### PR TITLE
language: fix: package db was always set to daml-lf 1.2 in tests

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -19,6 +19,7 @@ import DA.Daml.GHC.Compiler.Preprocessor
 
 import           Control.Monad.Reader
 import qualified Data.List.Extra as List
+import Data.Maybe (fromMaybe)
 import qualified "ghc-lib" GHC
 import "ghc-lib-parser" Module (moduleNameSlashes)
 import qualified System.Directory as Dir
@@ -105,11 +106,11 @@ mkOptions opts@Options{..} = do
             LF.VDev _ -> "dev"
             _ -> renderPretty optDamlLfVersion
 
--- | Default configuration for the compiler, in particular the standard library
---   and configuration directory `daml-stdlib`.
---   By default, the directories are expected in the executable's location under resources.
-defaultOptionsIO :: IO Options
-defaultOptionsIO = do
+-- | Default configuration for the compiler with package database set according to daml-lf version
+-- and located runfiles. If the version argument is Nothing it is set to the default daml-lf
+-- version.
+defaultOptionsIO :: Maybe LF.Version -> IO Options
+defaultOptionsIO mbVersion = do
     baseDir <- getBaseDir
     mkOptions Options
         { optImportPath = [baseDir </> "daml-stdlib-src"]
@@ -120,7 +121,7 @@ defaultOptionsIO = do
         , optPackageImports = []
         , optShakeProfiling = Nothing
         , optThreads = 1
-        , optDamlLfVersion = LF.versionDefault
+        , optDamlLfVersion = fromMaybe LF.versionDefault mbVersion
         , optDebug = False
         }
 

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -58,7 +58,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
                 concatMapM (either printAndExit pure) mbData
 
             InputDaml -> do
-                ghcOpts <- DGHC.defaultOptionsIO
+                ghcOpts <- DGHC.defaultOptionsIO Nothing
                 onErrorExit $ runExceptT
                             $ fmap (applyTransform options)
                             $ mkDocs (toCompileOpts ghcOpts) files

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Tests.hs
@@ -226,7 +226,7 @@ damldocExpect testname input check =
     -- write input to a file
     T.writeFileUtf8 testfile (T.unlines input)
 
-    opts <- defaultOptionsIO
+    opts <- defaultOptionsIO Nothing
 
     -- run the doc generator on that file
     mbResult <- runExceptT $ mkDocs (toCompileOpts opts) [testfile]

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -121,7 +121,7 @@ getIntegrationTests registerTODO scenarioService version = do
     let outdir = "daml-foundations/daml-ghc/output"
     createDirectoryIfMissing True outdir
 
-    opts <- fmap (\opts -> opts { optDamlLfVersion = version, optThreads = 0 } ) defaultOptionsIO
+    opts <- fmap (\opts ->  opts { optThreads = 0 }) $ defaultOptionsIO (Just version)
 
     -- initialise the compiler service
     pure $

--- a/daml-foundations/daml-ghc/src/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/src/Development/IDE/State/API/Testing.hs
@@ -100,7 +100,7 @@ newtype ShakeTest t = ShakeTest (ExceptT ShakeTestError (ReaderT ShakeTestEnv IO
 -- | Run shake test on freshly initialised shake service.
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
-    options <- defaultOptionsIO -- TODO: improve?
+    options <- defaultOptionsIO Nothing -- TODO: improve?
     virtualResources <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -181,7 +181,7 @@ execIde (Telemetry telemetry) (Debug debug) = NS.withSocketsDo $ Managed.runMana
       then Logger.GCP.gcpLogger (>= Logger.Warning) loggerH
       else pure loggerH
 
-    opts <- liftIO defaultOptionsIO
+    opts <- liftIO $ defaultOptionsIO Nothing
 
     Managed.liftIO $
       Daml.LanguageServer.runLanguageServer

--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -24,10 +24,10 @@ tests :: TestTree
 tests = testGroup
     "damlc test"
     [ testCase "Non-existent file" $ do
-        opts <- defaultOptionsIO
+        opts <- defaultOptionsIO Nothing
         shouldThrow (Damlc.execTest "foobar" Nothing opts)
     , testCase "File with compile error" $ do
-        opts <- defaultOptionsIO
+        opts <- defaultOptionsIO Nothing
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
               [ "daml 1.2"


### PR DESCRIPTION
The way the options were constructed in the ghc tests set the package
database always to the daml-lf 1.2 version.