### PR TITLE
Update rules_haskell

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -27,8 +27,8 @@
 # be resolvable from external workspaces otherwise.
 
 rules_scala_version = "6f8ee3d951d2ac6154356314600f6edb4eb5df8b"
-rules_haskell_version = "dfff93e145f33aa0b448033aec42cc034d883f5d"
-rules_haskell_sha256 = "fb5d9089d547a89bbe530df926ec233d96c6c571e9928da81e9f92edec77fcfe"
+rules_haskell_version = "7a306841b0fcca41c9fd62b3f7033fbd67d50e22"
+rules_haskell_sha256 = "55badbdc193a47c693ac94f33aa14f8fa5b8a5c9828e9e0a065a1c1280d4a3f5"
 rules_nixpkgs_version = "40b5a9f23abca57f364c93245c7451206ef1a855"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
We need the latest improvements to rules_haskell to build more Windows targets.