### PR TITLE
Simplify profile_zsh.sh

### DIFF
--- a/dev-env/profile_zsh.sh
+++ b/dev-env/profile_zsh.sh
@@ -3,5 +3,4 @@
 
 # DADE shell profile compatible with zsh.
 
-export DADE_REPO_ROOT="$(cd $(dirname "${(%):-%N}")/.. > /dev/null && pwd)"
-source /dev/stdin <<< "$(${DADE_REPO_ROOT}/dev-env/bin/dade assist)"
+source <("${0:A:h}"/bin/dade assist)


### PR DESCRIPTION
Rely on zsh features to simplify profile_zsh.sh file.

- Remove `DADE_REPO_ROOT` as it is not needed anywhere, `dade-assist` redefines
  it already.
- `${0:A:h}` gives the absolute path of the folder *this* file resides in, no
  need for `cd`, `dirname`, and `pwd` combo.
- Use simple process redirection (`<`), as it is more robust than the one in
  bash, and works better than `<<<`