### PR TITLE
Add verbosity option for Java codegen

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -3,23 +3,23 @@
 
 .. _daml-codegen-java:
 
-Generating Java code from DAML
-##############################
+Generate Java code from DAML
+############################
 
 Introduction
 ============
 
 When writing applications for the ledger in Java, you want to work with a representation of DAML templates and data types in Java that closely resemble the original DAML code while still being as true to the native types in Java as possible. To achieve this, you can use DAML to Java code generator ("Java codegen") to generate Java types based on a DAML model. You can then use these types in your Java code when reading information from and sending data to the ledger.
 
-Downloading
-===========
+Download
+========
 
 You can download the `latest version <https://bintray.com/api/v1/content/digitalassetsdk/DigitalAssetSDK/com/daml/java/codegen/$latest/codegen-$latest.jar?bt_package=sdk-components>`__  of the Java codegen.
 
 .. _daml-codegen-java-running:
 
-Running the Java codegen
-========================
+Run the Java codegen
+====================
 
 The Java codegen takes DAML archive (DAR) files as input and generates Java files for DAML templates, records, and variants. For information on creating DAR files see :ref:`assistant-manual-building-dars`. To use the Java codegen, run this command in a terminal:
 
@@ -27,14 +27,14 @@ The Java codegen takes DAML archive (DAR) files as input and generates Java file
   
   java -jar <path-to-codegen-jar>
 
-Use this command to display the helptext:
+Use this command to display the help text:
 
 .. code-block:: none
   
   java -jar codegen.jar --help
 
-Generating Java code from DAR files
------------------------------------
+Generate Java code from DAR files
+---------------------------------
 
 Pass one or more DAR files as arguments to the Java codegen. Use the ``-o`` or ``--output-directory`` parameter for specifying the directory for the generated Java files.
 
@@ -53,8 +53,8 @@ To avoid possible name clashes in the generated Java sources, you should specify
       daml/project2.dar=com.example.daml.project2
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Generating the decoder utility class
-------------------------------------
+Generate the decoder utility class
+----------------------------------
 
 When reading transactions from the ledger, you typically want to convert a `CreatedEvent <https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/CreatedEvent.html>`__ from the Ledger API to the corresponding generated ``Contract`` class. The Java codegen can optionally generate a decoder class based on the input DAR files that calls the ``fromIdAndRecord`` method of the respective generated ``Contract`` class (see :ref:`daml-codegen-java-templates`). The decoder class can do this for all templates in the input DAR files. 
 
@@ -66,8 +66,22 @@ To generate such a decoder class, provide the command line parameter ``-d`` or `
       -d com.myproject.DamModelDecoder daml/my-project.dar
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Integration with build tools
-----------------------------
+Receive feedback
+----------------
+
+By default, the logging is configured so that you'll only see error messages.
+
+If you want to change this behavior, you can ask to receive more extensive feedback using the ``-V`` or ``--verbosity`` command-line option. This option takes a numeric parameter from 0 to 4, where 0 corresponds to the default quiet behavior and 4 represents the most verbose output possible.
+
+In the following example the logging is set to print most of the output with detailed debugging information:
+
+.. code-block:: none
+
+  java -jar java-codegen.jar -o target/generated-sources/daml -V 3
+                                                              ^^^^
+
+Integrate with build tools
+--------------------------
 
 While we currently don’t provide direct integration with Maven, Groovy, SBT, etc., you can run the Java codegen as described in :ref:`daml-codegen-java-running` just like any other external process (for example the protobuf compiler). Alternatively you can integrate it as a runnable dependency in your ``pom.xml`` file for Maven.
 
@@ -78,14 +92,13 @@ The following snippet is an excerpt from the ``pom.xml`` that is part of the :re
     :lines: 73-105,121-122
     :dedent: 12
 
+Understand the generated Java model
+===================================
 
-Generated Java model
-====================
+The Java codegen generates source files in a directory tree under the output directory specified on the command line.
 
-The Java codegen generates Java source files in a directory tree under the output directory specified on the command line.
-
-How DAML built-in types map to Java types
------------------------------------------
+Map DAML primitives to Java types
+---------------------------------
 
 DAML built-in types are translated to the following equivalent types in
 Java:
@@ -125,12 +138,12 @@ Java:
 
 .. _com.daml.ledger.javaapi.data.Unit: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
 
-Generated class details
------------------------
+Understand the generated classes
+--------------------------------
 
 Every user-defined data type in DAML (template, record, and variant) is represented by one or more Java classes as described in this section.
 
-The java package for the generated classes is the equivalent of the lowercase DAML module name.
+The Java package for the generated classes is the equivalent of the lowercase DAML module name.
 
 .. code-block:: daml
   :caption: DAML
@@ -142,8 +155,8 @@ The java package for the generated classes is the equivalent of the lowercase DA
 
   package foo.bar.baz;
 
-Records or product types
-~~~~~~~~~~~~~~~~~~~~~~~~
+Records (a.k.a product types)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A :ref:`DAML record <daml-ref-record-types>` is represented by a Java class with fields that have the same name as the DAML record fields. A DAML field having the type of another record is represented as a field having the type of the generated class for that record.
 
@@ -155,7 +168,6 @@ A :ref:`DAML record <daml-ref-record-types>` is represented by a Java class with
 
   data Person = Person with name : Name; age : Decimal
   data Name = Name with firstName : Text; lastName : Text
-
 
 A Java file is generated that defines the class for the type ``Person``:
 
@@ -175,7 +187,6 @@ A Java file is generated that defines the class for the type ``Person``:
   }
 
 A Java file is generated that defines the class for the type ``Name``:
-
 
   .. code-block:: java
     :caption: com/acme/Name.java
@@ -227,7 +238,7 @@ The Java codegen generates three classes for a DAML template:
           aName: Text
         do return True
 
-A file Java file is generated that defines three Java classes:
+A file is generated that defines three Java classes:
 
 #. ``Bar``
 #. ``Bar.ContractId``
@@ -264,8 +275,8 @@ A file Java file is generated that defines three Java classes:
     }
   }
 
-Variants or sum types
-~~~~~~~~~~~~~~~~~~~~~
+Variants (a.k.a sum types)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A :ref:`variant or sum type <daml-ref-sum-types>` is a type with multiple constructors, where each constructor wraps a value of another type. The generated code is comprised of an abstract class for the variant type itself and a subclass thereof for each constructor. Classes for variant constructors are similar to classes for records.
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -6,6 +6,8 @@ Release notes
 
 This page contains release notes for the SDK.
 
+- Java Codegen: Leaner log output and flag for log verbosity ``-V LEVEL`` or ``--verbosity LEVEL``, where ``LEVEL`` is a number between ``0`` (least verbose) and ``4`` (most verbose).
+
 0.12.0
 ------
 

--- a/language-support/java/codegen/src/main/resources/logback.xml
+++ b/language-support/java/codegen/src/main/resources/logback.xml
@@ -1,19 +1,25 @@
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <appender name="STDOUT-SIMPLE" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [ %X{packageIdShort} %X{moduleName}:%X{entityName} - %X{entityType} ] - %msg%n</pattern>
+            <pattern>[%highlight(%-5level)] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT-BACKEND" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>[%highlight(%-5level)] %msg \(%X{entityType} %X{moduleName}:%X{entityName}, package %X{packageIdShort}\)%n</pattern>
         </encoder>
     </appender>
 
     <root level="ERROR">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDOUT-SIMPLE" />
     </root>
 
-    <!--<logger level="DEBUG" name="com.digitalasset.daml.lf.codegen.backend">-->
-        <!--<appender-ref ref="STDOUT" />-->
-    <!--</logger>-->
+    <logger level="ERROR" name="com.digitalasset.daml.lf.codegen.backend.java.inner" additivity="false">
+        <appender-ref ref="STDOUT-BACKEND" />
+    </logger>
 
 </configuration>

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -15,6 +15,7 @@ import com.digitalasset.daml.lf.iface.reader.{Interface, InterfaceReader}
 import com.digitalasset.daml.lf.iface.{Type => _, _}
 import com.digitalasset.daml_lf.DamlLf
 import com.typesafe.scalalogging.StrictLogging
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -22,6 +23,16 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 private[codegen] object CodeGenRunner extends StrictLogging {
 
   def run(conf: Conf): Unit = {
+
+    LoggerFactory
+      .getLogger(Logger.ROOT_LOGGER_NAME)
+      .asInstanceOf[ch.qos.logback.classic.Logger]
+      .setLevel(conf.verbosity)
+    LoggerFactory
+      .getLogger("com.digitalasset.daml.lf.codegen.backend.java.inner")
+      .asInstanceOf[ch.qos.logback.classic.Logger]
+      .setLevel(conf.verbosity)
+
     conf.darFiles.foreach {
       case (path, _) =>
         assertInputFileExists(path)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -120,7 +120,7 @@ private[codegen] object CodeGenRunner extends StrictLogging {
       interfaces: Seq[Interface],
       conf: Conf,
       pkgPrefixes: Map[PackageId, String])(implicit ec: ExecutionContext): Unit = {
-    logger.warn(
+    logger.info(
       s"Start processing packageIds '${interfaces.map(_.packageId.underlyingString).mkString(", ")}' in directory '${conf.outputDirectory}'")
 
     // TODO (mp): pre-processing and escaping
@@ -137,7 +137,7 @@ private[codegen] object CodeGenRunner extends StrictLogging {
 
     // TODO (mp): make the timeout configurable
     val _ = Await.result(future, Duration.create(10l, TimeUnit.MINUTES))
-    logger.warn(
+    logger.info(
       s"Finish processing packageIds ''${interfaces.map(_.packageId.underlyingString).mkString(", ")}''")
   }
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
@@ -81,7 +81,7 @@ object Conf {
     case "4" => Level.TRACE
     case _ =>
       throw new IllegalArgumentException(
-        "Expected a verbosity value between 0 (quieter) and 4 (louder)")
+        "Expected a verbosity value between 0 (least verbose) and 4 (most verbose)")
   }
 
   private[conf] def optTupleRead[A: Read, B: Read]: Read[(A, Option[B])] =


### PR DESCRIPTION
Moreover (yes, moreover):
- makes codegen docs titles more assertive
- fixes typos in codegen docs