### PR TITLE
Bump timeout of daml-ref-daml-test

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -272,7 +272,8 @@ daml_test(
 
 daml_test(
     name = "daml-ref-daml-test",
-    srcs = glob(["source/daml/code-snippets/**/*.daml"])
+    srcs = glob(["source/daml/code-snippets/**/*.daml"]),
+    timeout = "long",
 )
 
 daml_test(


### PR DESCRIPTION
This tests seems to timeout on CI sometimes so let’s increase the timeout.