### PR TITLE
Fix IS_FORK variable

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -18,7 +18,7 @@ steps:
   - bash: ci/build.sh
     displayName: 'Build'
     env:
-      IS_FORK: variables['System.PullRequest.IsFork']
+      IS_FORK: $(System.PullRequest.IsFork)
       # to upload to the bazel cache
       GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 


### PR DESCRIPTION
Without this PR, this variable ends up being set to the string
"variables['System.PullRequest.IsFork']" which meant that we never
uploaded to the Bazel cache.