### PR TITLE
Stop using Template Haskell to derive type class instances

### DIFF
--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -7,7 +7,6 @@ da_haskell_library(
     name = "daml-lf-ast",
     srcs = glob(["src/**/*.hs"]),
     hazel_deps = [
-        "aeson",
         "base",
         "containers",
         "deepseq",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -788,7 +788,7 @@ instance NM.Named Module where
   type Name Module = ModuleName
   name = moduleName
 
-concatSequenceA $
+concatSequenceA
   [ makePrisms ''Kind
   , makePrisms ''Type
   , makePrisms ''Expr

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -2,6 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -12,7 +14,7 @@ import DA.Prelude
 
 import           Control.DeepSeq
 import           Control.Lens
-import           Data.Aeson (FromJSON)
+import           Data.Aeson
 import qualified Data.NameMap as NM
 import qualified Data.Text          as T
 import Data.Fixed
@@ -106,6 +108,7 @@ data PackageRef
     -- ^ Reference to the package being currently handled.
   | PRImport !PackageId
     -- ^ Reference to the package with the given id.
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Something qualified by a package and a module within that package.
 data Qualified a = Qualified
@@ -113,6 +116,7 @@ data Qualified a = Qualified
   , qualModule  :: !ModuleName
   , qualObject  :: !a
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Source location annotation.
 data SourceLoc = SourceLoc
@@ -125,16 +129,19 @@ data SourceLoc = SourceLoc
   , slocEndLine :: !Int
   , slocEndCol :: !Int
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Kinds.
 data Kind
   = KStar
   | KArrow Kind Kind
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Enumeration types like Bool and Unit.
 data EnumType
   = ETUnit
   | ETBool
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Builtin type.
 data BuiltinType
@@ -152,6 +159,7 @@ data BuiltinType
   | BTOptional
   | BTMap
   | BTArrow
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Type as used in typed binders.
 data Type
@@ -174,6 +182,7 @@ data Type
   -- | Type for tuples aka structural records. Parameterized by the names of the
   -- fields and their types.
   | TTuple      ![(FieldName, Type)]
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Fully applied qualified type constructor.
 data TypeConApp = TypeConApp
@@ -182,12 +191,14 @@ data TypeConApp = TypeConApp
   , tcaArgs    :: ![Type]
     -- ^ Type arguments which are applied to the type constructor.
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Constructors of builtin 'EnumType's.
 data EnumCon
   = ECUnit   -- ∷ Unit
   | ECFalse  -- ∷ Bool
   | ECTrue   -- ∷ Bool
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 data E10
 instance HasResolution E10 where
@@ -261,12 +272,14 @@ data BuiltinExpr
 
   | BETrace                      -- :: forall a. Text -> a -> a
   | BEEqualContractId            -- :: forall a. ContractId a -> ContractId a -> Bool
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 
 data Binding = Binding
   { bindingBinder :: !(ExprVarName, Type)
   , bindingBound  :: !Expr
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression.
 data Expr
@@ -414,6 +427,7 @@ data Expr
   | EScenario !Scenario
   -- | An expression annotated with a source location.
   | ELocation !SourceLoc !Expr
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Pattern matching alternative.
 data CaseAlternative = CaseAlternative
@@ -422,6 +436,7 @@ data CaseAlternative = CaseAlternative
   , altExpr    :: !Expr
     -- ^ Expression to evaluate in case of a match.
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 data CasePattern
   -- | Match on constructor of variant type.
@@ -450,6 +465,7 @@ data CasePattern
   -- | Match on anything. Should be the last alternative. Also note that 'ECase'
   -- bind the value of the scrutinee to a variable.
   | CPDefault
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression in the update monad.
 data Update
@@ -505,6 +521,7 @@ data Update
     }
   | ULookupByKey !RetrieveByKey
   | UFetchByKey !RetrieveByKey
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression in the scenario monad
 data Scenario
@@ -567,13 +584,17 @@ data Scenario
     { scenarioEmbedType :: !Type
     , scenarioEmbedExpr :: !Expr
     }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 data RetrieveByKey = RetrieveByKey
   { retrieveByKeyTemplate :: !(Qualified TypeConName)
   , retrieveByKeyKey :: !Expr
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 newtype IsSerializable = IsSerializable{getIsSerializable :: Bool}
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (NFData, ToJSON)
 
 -- | Definition of a data type.
 data DefDataType = DefDataType
@@ -588,6 +609,7 @@ data DefDataType = DefDataType
   , dataCons    :: !DataCons
     -- ^ Data constructor of the type.
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Data constructors for a data type definition.
 data DataCons
@@ -595,10 +617,15 @@ data DataCons
   = DataRecord  ![(FieldName, Type)]
   -- | A variant type given by its construtors and their payload types.
   | DataVariant ![(VariantConName, Type)]
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 newtype HasNoPartyLiterals = HasNoPartyLiterals{getHasNoPartyLiterals :: Bool}
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (NFData, ToJSON)
 
 newtype IsTest = IsTest{getIsTest :: Bool}
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (NFData, ToJSON)
 
 -- | Definition of a value.
 data DefValue = DefValue
@@ -614,6 +641,7 @@ data DefValue = DefValue
   , dvalBody   :: !Expr
     -- ^ Expression whose value to bind to the name.
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 data TemplateKey = TemplateKey
   { tplKeyType :: !Type
@@ -624,6 +652,7 @@ data TemplateKey = TemplateKey
   -- of that fragment in DAML-LF directly.
   , tplKeyMaintainers :: !Expr
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Definition of a contract template.
 data Template = Template
@@ -650,6 +679,7 @@ data Template = Template
   , tplKey             :: !(Maybe TemplateKey)
     -- ^ Template key definition, if any.
   }
+  deriving (Eq, Generic, NFData, Show, ToJSON)
 
 -- | Single choice of a contract template.
 data TemplateChoice = TemplateChoice
@@ -674,6 +704,7 @@ data TemplateChoice = TemplateChoice
     -- ^ Follow-up update of the choice. It has type @Update <ret_type>@ and
     -- both the template parameter and the choice parameter in scope.
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Feature flags for a module.
 data FeatureFlags = FeatureFlags
@@ -689,6 +720,7 @@ data FeatureFlags = FeatureFlags
   -- and controllers of the target contract/choice and not to the observers of the target contract.
   -}
   }
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 defaultFeatureFlags :: FeatureFlags
 defaultFeatureFlags = FeatureFlags
@@ -717,12 +749,14 @@ data Module = Module
   , moduleTemplates :: !(NM.NameMap Template)
     -- ^ Template definitions.
   }
+  deriving (Eq, Generic, NFData, Show, ToJSON)
 
 -- | A package.
 data Package = Package
     { packageLfVersion :: Version
     , packageModules :: NM.NameMap Module
     }
+  deriving (Eq, Generic, NFData, Show, ToJSON)
 
 -- | Type synonym for a reference to an LF value.
 type ValueRef = Qualified ExprValName
@@ -730,56 +764,6 @@ type ValueRef = Qualified ExprValName
 deriving instance Foldable    Qualified
 deriving instance Functor     Qualified
 deriving instance Traversable Qualified
-
-concatSequenceA $
-  [ makePrisms ''Kind
-  , makePrisms ''Type
-  , makePrisms ''Expr
-  , makePrisms ''Update
-  , makePrisms ''Scenario
-  , makePrisms ''DataCons
-  , makePrisms ''Package
-  , makeUnderscoreLenses ''DefDataType
-  , makeUnderscoreLenses ''DefValue
-  , makeUnderscoreLenses ''TemplateChoice
-  , makeUnderscoreLenses ''Template
-  , makeUnderscoreLenses ''Module
-  , makeUnderscoreLenses ''Package
-  , makeUnderscoreLenses ''TemplateKey
-  ] ++
-  map (makeInstancesExcept [''FromJSON])
-  [ ''PackageRef
-  , ''Qualified
-  , ''SourceLoc
-  , ''Kind
-  , ''EnumType
-  , ''BuiltinType
-  , ''Type
-  , ''TypeConApp
-  , ''EnumCon
-  , ''BuiltinExpr
-  , ''Binding
-  , ''Expr
-  , ''CaseAlternative
-  , ''CasePattern
-  , ''RetrieveByKey
-  , ''Update
-  , ''Scenario
-  , ''IsSerializable
-  , ''DefDataType
-  , ''DataCons
-  , ''HasNoPartyLiterals
-  , ''IsTest
-  , ''DefValue
-  , ''TemplateChoice
-  , ''FeatureFlags
-  , ''TemplateKey
-  ] ++
-  map (makeInstancesExcept [''Ord, ''FromJSON])
-  [ ''Template
-  , ''Module
-  , ''Package
-  ]
 
 instance Hashable PackageRef
 instance Hashable a => Hashable (Qualified a)
@@ -804,33 +788,19 @@ instance NM.Named Module where
   type Name Module = ModuleName
   name = moduleName
 
-instance NFData Binding
-instance NFData BuiltinExpr
-instance NFData BuiltinType
-instance NFData CaseAlternative
-instance NFData CasePattern
-instance NFData DataCons
-instance NFData DefDataType
-instance NFData DefValue
-instance NFData EnumCon
-instance NFData EnumType
-instance NFData Expr
-instance NFData FeatureFlags
-instance NFData HasNoPartyLiterals
-instance NFData IsSerializable
-instance NFData IsTest
-instance NFData Kind
-instance NFData Module
-instance NFData Package
-instance NFData PackageRef
-instance NFData Scenario
-instance NFData SourceLoc
-instance NFData TemplateKey
-instance NFData Template
-instance NFData TemplateChoice
-instance NFData Type
-instance NFData TypeConApp
-instance NFData RetrieveByKey
-instance NFData Update
-
-instance NFData a => NFData (Qualified a)
+concatSequenceA $
+  [ makePrisms ''Kind
+  , makePrisms ''Type
+  , makePrisms ''Expr
+  , makePrisms ''Update
+  , makePrisms ''Scenario
+  , makePrisms ''DataCons
+  , makePrisms ''Package
+  , makeUnderscoreLenses ''DefDataType
+  , makeUnderscoreLenses ''DefValue
+  , makeUnderscoreLenses ''TemplateChoice
+  , makeUnderscoreLenses ''Template
+  , makeUnderscoreLenses ''Module
+  , makeUnderscoreLenses ''Package
+  , makeUnderscoreLenses ''TemplateKey
+  ]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -108,7 +108,7 @@ data PackageRef
     -- ^ Reference to the package being currently handled.
   | PRImport !PackageId
     -- ^ Reference to the package with the given id.
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Something qualified by a package and a module within that package.
 data Qualified a = Qualified
@@ -116,7 +116,7 @@ data Qualified a = Qualified
   , qualModule  :: !ModuleName
   , qualObject  :: !a
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Source location annotation.
 data SourceLoc = SourceLoc
@@ -129,19 +129,19 @@ data SourceLoc = SourceLoc
   , slocEndLine :: !Int
   , slocEndCol :: !Int
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Kinds.
 data Kind
   = KStar
   | KArrow Kind Kind
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Enumeration types like Bool and Unit.
 data EnumType
   = ETUnit
   | ETBool
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Builtin type.
 data BuiltinType
@@ -159,7 +159,7 @@ data BuiltinType
   | BTOptional
   | BTMap
   | BTArrow
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Type as used in typed binders.
 data Type
@@ -182,7 +182,7 @@ data Type
   -- | Type for tuples aka structural records. Parameterized by the names of the
   -- fields and their types.
   | TTuple      ![(FieldName, Type)]
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Fully applied qualified type constructor.
 data TypeConApp = TypeConApp
@@ -191,14 +191,14 @@ data TypeConApp = TypeConApp
   , tcaArgs    :: ![Type]
     -- ^ Type arguments which are applied to the type constructor.
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Constructors of builtin 'EnumType's.
 data EnumCon
   = ECUnit   -- ∷ Unit
   | ECFalse  -- ∷ Bool
   | ECTrue   -- ∷ Bool
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 data E10
 instance HasResolution E10 where
@@ -272,14 +272,14 @@ data BuiltinExpr
 
   | BETrace                      -- :: forall a. Text -> a -> a
   | BEEqualContractId            -- :: forall a. ContractId a -> ContractId a -> Bool
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 
 data Binding = Binding
   { bindingBinder :: !(ExprVarName, Type)
   , bindingBound  :: !Expr
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression.
 data Expr
@@ -427,7 +427,7 @@ data Expr
   | EScenario !Scenario
   -- | An expression annotated with a source location.
   | ELocation !SourceLoc !Expr
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Pattern matching alternative.
 data CaseAlternative = CaseAlternative
@@ -436,7 +436,7 @@ data CaseAlternative = CaseAlternative
   , altExpr    :: !Expr
     -- ^ Expression to evaluate in case of a match.
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 data CasePattern
   -- | Match on constructor of variant type.
@@ -465,7 +465,7 @@ data CasePattern
   -- | Match on anything. Should be the last alternative. Also note that 'ECase'
   -- bind the value of the scrutinee to a variable.
   | CPDefault
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression in the update monad.
 data Update
@@ -521,7 +521,7 @@ data Update
     }
   | ULookupByKey !RetrieveByKey
   | UFetchByKey !RetrieveByKey
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Expression in the scenario monad
 data Scenario
@@ -584,16 +584,16 @@ data Scenario
     { scenarioEmbedType :: !Type
     , scenarioEmbedExpr :: !Expr
     }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 data RetrieveByKey = RetrieveByKey
   { retrieveByKeyTemplate :: !(Qualified TypeConName)
   , retrieveByKeyKey :: !Expr
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 newtype IsSerializable = IsSerializable{getIsSerializable :: Bool}
-  deriving stock (Eq, Generic, Ord, Show)
+  deriving stock (Eq, Data, Generic, Ord, Show)
   deriving anyclass (NFData, ToJSON)
 
 -- | Definition of a data type.
@@ -609,7 +609,7 @@ data DefDataType = DefDataType
   , dataCons    :: !DataCons
     -- ^ Data constructor of the type.
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Data constructors for a data type definition.
 data DataCons
@@ -617,14 +617,14 @@ data DataCons
   = DataRecord  ![(FieldName, Type)]
   -- | A variant type given by its construtors and their payload types.
   | DataVariant ![(VariantConName, Type)]
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 newtype HasNoPartyLiterals = HasNoPartyLiterals{getHasNoPartyLiterals :: Bool}
-  deriving stock (Eq, Generic, Ord, Show)
+  deriving stock (Eq, Data, Generic, Ord, Show)
   deriving anyclass (NFData, ToJSON)
 
 newtype IsTest = IsTest{getIsTest :: Bool}
-  deriving stock (Eq, Generic, Ord, Show)
+  deriving stock (Eq, Data, Generic, Ord, Show)
   deriving anyclass (NFData, ToJSON)
 
 -- | Definition of a value.
@@ -641,7 +641,7 @@ data DefValue = DefValue
   , dvalBody   :: !Expr
     -- ^ Expression whose value to bind to the name.
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 data TemplateKey = TemplateKey
   { tplKeyType :: !Type
@@ -652,7 +652,7 @@ data TemplateKey = TemplateKey
   -- of that fragment in DAML-LF directly.
   , tplKeyMaintainers :: !Expr
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Definition of a contract template.
 data Template = Template
@@ -679,7 +679,7 @@ data Template = Template
   , tplKey             :: !(Maybe TemplateKey)
     -- ^ Template key definition, if any.
   }
-  deriving (Eq, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
 
 -- | Single choice of a contract template.
 data TemplateChoice = TemplateChoice
@@ -704,7 +704,7 @@ data TemplateChoice = TemplateChoice
     -- ^ Follow-up update of the choice. It has type @Update <ret_type>@ and
     -- both the template parameter and the choice parameter in scope.
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | Feature flags for a module.
 data FeatureFlags = FeatureFlags
@@ -720,7 +720,7 @@ data FeatureFlags = FeatureFlags
   -- and controllers of the target contract/choice and not to the observers of the target contract.
   -}
   }
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 defaultFeatureFlags :: FeatureFlags
 defaultFeatureFlags = FeatureFlags
@@ -749,14 +749,14 @@ data Module = Module
   , moduleTemplates :: !(NM.NameMap Template)
     -- ^ Template definitions.
   }
-  deriving (Eq, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
 
 -- | A package.
 data Package = Package
     { packageLfVersion :: Version
     , packageModules :: NM.NameMap Module
     }
-  deriving (Eq, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
 
 -- | Type synonym for a reference to an LF value.
 type ValueRef = Qualified ExprValName

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -14,7 +14,6 @@ import DA.Prelude
 
 import           Control.DeepSeq
 import           Control.Lens
-import           Data.Aeson
 import qualified Data.NameMap as NM
 import qualified Data.Text          as T
 import Data.Fixed
@@ -108,7 +107,7 @@ data PackageRef
     -- ^ Reference to the package being currently handled.
   | PRImport !PackageId
     -- ^ Reference to the package with the given id.
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Something qualified by a package and a module within that package.
 data Qualified a = Qualified
@@ -116,7 +115,7 @@ data Qualified a = Qualified
   , qualModule  :: !ModuleName
   , qualObject  :: !a
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Source location annotation.
 data SourceLoc = SourceLoc
@@ -129,19 +128,19 @@ data SourceLoc = SourceLoc
   , slocEndLine :: !Int
   , slocEndCol :: !Int
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Kinds.
 data Kind
   = KStar
   | KArrow Kind Kind
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Enumeration types like Bool and Unit.
 data EnumType
   = ETUnit
   | ETBool
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Builtin type.
 data BuiltinType
@@ -159,7 +158,7 @@ data BuiltinType
   | BTOptional
   | BTMap
   | BTArrow
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Type as used in typed binders.
 data Type
@@ -182,7 +181,7 @@ data Type
   -- | Type for tuples aka structural records. Parameterized by the names of the
   -- fields and their types.
   | TTuple      ![(FieldName, Type)]
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Fully applied qualified type constructor.
 data TypeConApp = TypeConApp
@@ -191,14 +190,14 @@ data TypeConApp = TypeConApp
   , tcaArgs    :: ![Type]
     -- ^ Type arguments which are applied to the type constructor.
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Constructors of builtin 'EnumType's.
 data EnumCon
   = ECUnit   -- ∷ Unit
   | ECFalse  -- ∷ Bool
   | ECTrue   -- ∷ Bool
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 data E10
 instance HasResolution E10 where
@@ -272,14 +271,14 @@ data BuiltinExpr
 
   | BETrace                      -- :: forall a. Text -> a -> a
   | BEEqualContractId            -- :: forall a. ContractId a -> ContractId a -> Bool
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 
 data Binding = Binding
   { bindingBinder :: !(ExprVarName, Type)
   , bindingBound  :: !Expr
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Expression.
 data Expr
@@ -427,7 +426,7 @@ data Expr
   | EScenario !Scenario
   -- | An expression annotated with a source location.
   | ELocation !SourceLoc !Expr
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Pattern matching alternative.
 data CaseAlternative = CaseAlternative
@@ -436,7 +435,7 @@ data CaseAlternative = CaseAlternative
   , altExpr    :: !Expr
     -- ^ Expression to evaluate in case of a match.
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 data CasePattern
   -- | Match on constructor of variant type.
@@ -465,7 +464,7 @@ data CasePattern
   -- | Match on anything. Should be the last alternative. Also note that 'ECase'
   -- bind the value of the scrutinee to a variable.
   | CPDefault
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Expression in the update monad.
 data Update
@@ -521,7 +520,7 @@ data Update
     }
   | ULookupByKey !RetrieveByKey
   | UFetchByKey !RetrieveByKey
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Expression in the scenario monad
 data Scenario
@@ -584,17 +583,17 @@ data Scenario
     { scenarioEmbedType :: !Type
     , scenarioEmbedExpr :: !Expr
     }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 data RetrieveByKey = RetrieveByKey
   { retrieveByKeyTemplate :: !(Qualified TypeConName)
   , retrieveByKeyKey :: !Expr
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 newtype IsSerializable = IsSerializable{getIsSerializable :: Bool}
   deriving stock (Eq, Data, Generic, Ord, Show)
-  deriving anyclass (NFData, ToJSON)
+  deriving anyclass (NFData)
 
 -- | Definition of a data type.
 data DefDataType = DefDataType
@@ -609,7 +608,7 @@ data DefDataType = DefDataType
   , dataCons    :: !DataCons
     -- ^ Data constructor of the type.
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Data constructors for a data type definition.
 data DataCons
@@ -617,15 +616,15 @@ data DataCons
   = DataRecord  ![(FieldName, Type)]
   -- | A variant type given by its construtors and their payload types.
   | DataVariant ![(VariantConName, Type)]
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 newtype HasNoPartyLiterals = HasNoPartyLiterals{getHasNoPartyLiterals :: Bool}
   deriving stock (Eq, Data, Generic, Ord, Show)
-  deriving anyclass (NFData, ToJSON)
+  deriving anyclass (NFData)
 
 newtype IsTest = IsTest{getIsTest :: Bool}
   deriving stock (Eq, Data, Generic, Ord, Show)
-  deriving anyclass (NFData, ToJSON)
+  deriving anyclass (NFData)
 
 -- | Definition of a value.
 data DefValue = DefValue
@@ -641,7 +640,7 @@ data DefValue = DefValue
   , dvalBody   :: !Expr
     -- ^ Expression whose value to bind to the name.
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 data TemplateKey = TemplateKey
   { tplKeyType :: !Type
@@ -652,7 +651,7 @@ data TemplateKey = TemplateKey
   -- of that fragment in DAML-LF directly.
   , tplKeyMaintainers :: !Expr
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Definition of a contract template.
 data Template = Template
@@ -679,7 +678,7 @@ data Template = Template
   , tplKey             :: !(Maybe TemplateKey)
     -- ^ Template key definition, if any.
   }
-  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show)
 
 -- | Single choice of a contract template.
 data TemplateChoice = TemplateChoice
@@ -704,7 +703,7 @@ data TemplateChoice = TemplateChoice
     -- ^ Follow-up update of the choice. It has type @Update <ret_type>@ and
     -- both the template parameter and the choice parameter in scope.
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Feature flags for a module.
 data FeatureFlags = FeatureFlags
@@ -720,7 +719,7 @@ data FeatureFlags = FeatureFlags
   -- and controllers of the target contract/choice and not to the observers of the target contract.
   -}
   }
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 defaultFeatureFlags :: FeatureFlags
 defaultFeatureFlags = FeatureFlags
@@ -749,14 +748,14 @@ data Module = Module
   , moduleTemplates :: !(NM.NameMap Template)
     -- ^ Template definitions.
   }
-  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show)
 
 -- | A package.
 data Package = Package
     { packageLfVersion :: Version
     , packageModules :: NM.NameMap Module
     }
-  deriving (Eq, Data, Generic, NFData, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Show)
 
 -- | Type synonym for a reference to an LF value.
 type ValueRef = Qualified ExprValName

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -11,7 +11,6 @@ import DA.Prelude
 
 import           Control.Lens
 import           Control.Lens.Ast
-import           Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Graph as G
 import           Data.List.Extra (nubSort)
 import qualified Data.NameMap as NM
@@ -291,4 +290,3 @@ _moduleDefinitions f mod0@(Module name path flags _ _ _) =
   moduleFromDefinitions name path flags <$> f (moduleDefinitions mod0)
 
 makePrisms ''Definition
-makeInstancesExcept [''Ord, ''FromJSON, ''ToJSON] ''Definition

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as T
 data Version
   = V1{versionMinor :: Int}
   | VDev T.Text
-  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
 
 -- | DAML-LF version 1.0.
 version1_0 :: Version

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 module DA.Daml.LF.Ast.Version where
 
 import           DA.Prelude

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module DA.Daml.LF.Ast.Version where
@@ -8,13 +9,14 @@ module DA.Daml.LF.Ast.Version where
 import           DA.Prelude
 import           DA.Pretty
 import           Control.DeepSeq
-import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Aeson
 import qualified Data.Text as T
 
 -- | DAML-LF version of an archive payload.
 data Version
   = V1{versionMinor :: Int}
   | VDev T.Text
+  deriving (Eq, Generic, NFData, Ord, Show, ToJSON)
 
 -- | DAML-LF version 1.0.
 version1_0 :: Version
@@ -83,16 +85,7 @@ featurePartyFromText = Feature "partyFromText function" version1_2
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 
-concatSequenceA $
-  map (makeInstancesExcept [''FromJSON, ''ToJSON])
-  [ ''Version
-  ]
-
-instance NFData Version
-
 instance Pretty Version where
   pPrint = \case
     V1 minor -> "1." <> pretty minor
     VDev hash -> "dev-" <> pretty hash
-
-instance ToJSON Version

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -8,14 +8,13 @@ module DA.Daml.LF.Ast.Version where
 import           DA.Prelude
 import           DA.Pretty
 import           Control.DeepSeq
-import           Data.Aeson
 import qualified Data.Text as T
 
 -- | DAML-LF version of an archive payload.
 data Version
   = V1{versionMinor :: Int}
   | VDev T.Text
-  deriving (Eq, Data, Generic, NFData, Ord, Show, ToJSON)
+  deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | DAML-LF version 1.0.
 version1_0 :: Version

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -103,9 +103,6 @@ lookupChoice (tplRef, chName) world = do
     Nothing -> Left (LEChoice tplRef chName)
     Just choice -> Right choice
 
-deriving instance Eq World
-deriving instance Show World
-
 instance Pretty LookupError where
   pPrint = \case
     LEPackage pkgId -> "unknown package:" <-> prettyName pkgId

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
@@ -43,10 +43,7 @@ import           Data.Ratio((%))
 -- | A decimal `d` is represented as a tuple `(n :: Integer, k :: Natural)`
 -- such that `d = n / 10 ^^ k = n * 10 ^^ -k`.
 data Decimal = Decimal {_mantissa :: Integer, _exponent :: Integer}
-  deriving (Read)
-
-makeInstancesExcept [''Ord, ''Eq, ''Aeson.FromJSON, ''Aeson.ToJSON] ''Decimal
-deriving instance NFData Decimal
+  deriving (Generic, NFData, Show)
 
 
 instance Num Decimal where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE MultiWayIf         #-}
-{-# LANGUAGE TemplateHaskell    #-}
 
 -- | The model of our floating point decimal numbers.
 module DA.Daml.LF.Decimal

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Decimal.hs
@@ -32,7 +32,6 @@ where
 import           Control.Lens       (Iso', Prism', from, iso, prism')
 import           Control.DeepSeq    (NFData(..))
 
-import qualified Data.Aeson         as Aeson
 import qualified Data.Scientific    as Scientific
 
 import           DA.Prelude
@@ -70,16 +69,6 @@ instance Ord Decimal where
       then n <= m * 10^diff
       else n * 10^(-diff) <= m
 
-
--- | JSON encoding compatible with Apollo (expecting an array)
-instance Aeson.ToJSON Decimal where
-    toJSON (Decimal m e) = Aeson.toJSON [m, e]
-
-
-instance Aeson.FromJSON Decimal where
-    parseJSON jsn = do
-        [m, e] <- Aeson.parseJSON jsn
-        return $ Decimal m e
 
 -- The following are needed by core package
 -------------------------------------------

--- a/libs-haskell/da-hs-base/src/DA/Prelude.hs
+++ b/libs-haskell/da-hs-base/src/DA/Prelude.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE TemplateHaskell #-}
-
 -- | Custom Prelude without partial functions and a more extensive default
 -- export list.
 module DA.Prelude


### PR DESCRIPTION
Template Haskell is notorious for causing slow build times. That's why we
remove the `makeInstances*` family of functions and use proper `deriving`
clauses instead.