### PR TITLE
language: fix: redundant glob in BAZEL rule

### DIFF
--- a/daml-foundations/daml-ghc/daml-prim-and-stdlib-src/BUILD.bazel
+++ b/daml-foundations/daml-ghc/daml-prim-and-stdlib-src/BUILD.bazel
@@ -4,6 +4,6 @@
 
 filegroup(
   name = "daml-prim-and-stdlib-src",
-  srcs = glob(["*.daml", "**/*.daml"]),
+  srcs = glob(["**/*.daml"]),
   visibility = ["//visibility:public"]
 )


### PR DESCRIPTION
We remove a redundant glob pattern in a bazel rule.