### PR TITLE
Fixes the missing margin between codeblocks and headings

### DIFF
--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -571,6 +571,10 @@ body
       &:last-child
         margin-bottom: 35px
 
+    blockquote
+      &:last-child
+        margin-bottom: 35px
+
     a
       position: relative
       font-weight: bold


### PR DESCRIPTION
## Before the fix
![image](https://user-images.githubusercontent.com/29121423/55719202-f72c8a00-59fd-11e9-8c65-c5a9d1cbaeeb.png)

## After the fix

![image](https://user-images.githubusercontent.com/29121423/55719214-01e71f00-59fe-11e9-81de-99e8a374fd13.png)


Contributes to #147.