### PR TITLE
Build gRPC on Windows with GHC's internal Mingw toolchain

### DIFF
--- a/bazel_tools/grpc-bazel-mingw.patch
+++ b/bazel_tools/grpc-bazel-mingw.patch
@@ -1,0 +1,22 @@
+diff --git a/include/grpc/impl/codegen/port_platform.h b/include/grpc/impl/codegen/port_platform.h
+index 0349e31bb3..d2e7408dbf 100644
+--- a/include/grpc/impl/codegen/port_platform.h
++++ b/include/grpc/impl/codegen/port_platform.h
+@@ -39,15 +39,9 @@
+ #define NOMINMAX
+ #endif /* NOMINMAX */
+ 
+-#ifndef _WIN32_WINNT
+-#error \
+-    "Please compile grpc with _WIN32_WINNT of at least 0x600 (aka Windows Vista)"
+-#else /* !defined(_WIN32_WINNT) */
+-#if (_WIN32_WINNT < 0x0600)
+-#error \
+-    "Please compile grpc with _WIN32_WINNT of at least 0x600 (aka Windows Vista)"
+-#endif /* _WIN32_WINNT < 0x0600 */
+-#endif /* defined(_WIN32_WINNT) */
++/* FIXME: Force-define Windows version to Windows 10 before including windows.h */
++#define WINVER 0x0A00
++#define _WIN32_WINNT 0x0A00
+ 
+ #include <windows.h>

--- a/build.ps1
+++ b/build.ps1
@@ -31,6 +31,9 @@ bazel build //pipeline/samples/bazel/haskell/...
 bazel build //compiler/haskell-ide-core/...
 bazel build //compiler/daml-lf-ast/...
 
+# build gRPC
+bazel build @com_github_grpc_grpc//:grpc
+
 # node / npm / yarn test
 bazel build //daml-foundations/daml-tools/daml-extension:daml_extension_lib
 bazel build //daml-foundations/daml-tools/language-server-tests:lib-js

--- a/deps.bzl
+++ b/deps.bzl
@@ -154,6 +154,10 @@ def daml_deps():
         strip_prefix = "grpc-1.19.0",
         urls = ["https://github.com/grpc/grpc/archive/v1.19.0.tar.gz"],
         sha256 = "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73",
+        patches = [
+          "@com_github_digital_asset_daml//bazel_tools:grpc-bazel-mingw.patch",
+        ],
+        patch_args = ["-p1"],
      )
 
   if "io_grpc_grpc_java" not in native.existing_rules():


### PR DESCRIPTION
This PR builds gRPC on Windows with GHC's internal CC toolchain. This requires a minor patch, as `WINVER` and `_WIN32_WINNT` are not automatically defined by GCC. For now, we fix those to `0xA00`, which corresponds to Windows 10.