### PR TITLE
Rewrite integration tests in Haskell

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -4,9 +4,9 @@
 load('//bazel_tools:haskell.bzl', 'da_haskell_binary', 'da_haskell_library', 'da_haskell_test')
 load('//bazel_tools:packaging/packaging.bzl', 'package_app')
 
-da_haskell_binary(
-    name = "daml-helper",
-    srcs = ["DamlHelper.hs"],
+da_haskell_library(
+    name = "daml-helper-lib",
+    srcs = glob(["src/**/*.hs"], exclude = ["src/Main.hs"]),
     deps = [
         "//daml-assistant:daml-project-config",
     ],
@@ -25,6 +25,17 @@ da_haskell_binary(
         "process",
         "safe-exceptions",
         "text",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+da_haskell_binary(
+    name = "daml-helper",
+    srcs = ["src/Main.hs"],
+    deps = [":daml-helper-lib"],
+    hazel_deps = [
+        "base",
+        "optparse-applicative",
     ],
     visibility = ["//visibility:public"],
 )

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE OverloadedStrings #-}
-module DAMLHelper
+module DamlHelper
     ( runDamlStudio
     , runNew
     , runJar
@@ -10,6 +10,7 @@ module DAMLHelper
     , runStart
 
     , withJar
+    , withSandbox
     , withNavigator
 
     , waitForConnectionOnPort

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -1,0 +1,55 @@
+module Main (main) where
+
+import Data.Foldable
+import Options.Applicative
+
+import DAMLHelper
+
+main :: IO ()
+main = runCommand =<< execParser (info (commandParser <**> helper) idm)
+
+data Command
+    = DamlStudio { overwriteExtension :: Bool, remainingArguments :: [String] }
+    | RunJar { jarPath :: FilePath, remainingArguments :: [String] }
+    | New { targetFolder :: FilePath, templateName :: String }
+    | ListTemplates
+    | Sandbox { port :: SandboxPort, remainingArguments :: [String] }
+    | Start { darPath :: FilePath }
+
+commandParser :: Parser Command
+commandParser =
+    subparser $ foldMap
+         (\(name, opts) -> command name (info (opts <**> helper) idm))
+         [ ("studio", damlStudioCmd)
+         , ("run-jar", runJarCmd)
+         , ("new", newCmd)
+         , ("sandbox", sandboxCmd)
+         , ("start", startCmd)
+         ]
+    where damlStudioCmd = DamlStudio
+              <$> switch (long "overwrite" <> help "Overwrite the VSCode extension if it already exists")
+              <*> many (argument str (metavar "ARG"))
+          runJarCmd = RunJar
+              <$> argument str (metavar "JAR" <> help "Path to JAR relative to SDK path")
+              <*> many (argument str (metavar "ARG"))
+          newCmd = asum
+              [ ListTemplates <$ flag' () (long "list" <> help "List the available project templates.")
+              , New
+                  <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
+                  <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: quickstart-java)" <> value "quickstart-java")
+              ]
+          sandboxCmd = Sandbox
+              <$> option sandboxPortReader (long "port" <> help "Port used by the sandbox")
+              <*> many (argument str (metavar "ARG"))
+          startCmd = Start <$> argument str (metavar "DAR_PATH" <> help "Path to DAR that should be loaded")
+
+runCommand :: Command -> IO ()
+runCommand DamlStudio {..} = runDamlStudio overwriteExtension remainingArguments
+runCommand RunJar {..} = runJar jarPath remainingArguments
+runCommand New {..} = runNew targetFolder templateName
+runCommand ListTemplates = runListTemplates
+runCommand Sandbox {..} = runSandbox port remainingArguments
+runCommand Start {..} = runStart darPath
+
+sandboxPortReader :: ReadM SandboxPort
+sandboxPortReader = SandboxPort <$> auto

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -1,3 +1,5 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 module Main (main) where
 
 import Data.Foldable

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import Data.Foldable
 import Options.Applicative
 
-import DAMLHelper
+import DamlHelper
 
 main :: IO ()
 main = runCommand =<< execParser (info (commandParser <**> helper) idm)

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -1,14 +1,29 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+load("//bazel_tools:haskell.bzl", "da_haskell_test")
 
-sh_test(
+da_haskell_test(
     name = "integration-tests",
-    srcs = ["run-test.sh"],
-    args = [
-        "$(location //release:sdk-release-tarball)",
+    srcs = ["src/Main.hs"],
+    deps = [
+        "//libs-haskell/bazel-runfiles",
+        "//daml-assistant/daml-helper:daml-helper-lib",
+    ],
+    hazel_deps = [
+        "async",
+        "base",
+        "directory",
+        "extra",
+        "filepath",
+        "main-tester",
+        "network",
+        "process",
+        "tasty",
+        "tasty-hunit",
     ],
     data = [
         "//release:sdk-release-tarball",
+        "@local_jdk//:bin/java",
     ],
     timeout = "long",
 )

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -1,0 +1,119 @@
+module Main (main) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception
+import Control.Monad
+import Data.Typeable
+import Network.Socket
+import System.Directory.Extra
+import System.Environment
+import System.FilePath
+import System.IO.Extra
+import System.Process
+import Test.Main
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import DA.Bazel.Runfiles
+import DamlHelper
+
+main :: IO ()
+main =
+    withTempDir $ \tmpDir -> do
+    -- We manipulate global state via the working directory and
+    -- the environment so running tests in parallel will cause trouble.
+    setEnv "TASTY_NUM_THREADS" "1"
+    oldPath <- getEnv "PATH"
+    javaPath <- locateRunfiles "local_jdk/bin"
+    let damlDir = tmpDir </> "daml"
+    withEnv
+        [ ("DAML_HOME", Just damlDir)
+        , ("PATH", Just $ (damlDir </> "bin") <> ":" <> javaPath <> ":" <> oldPath)
+        ] $ defaultMain (tests tmpDir)
+
+tests :: FilePath -> TestTree
+tests tmpDir = testGroup "Integration tests"
+    [ testCase "install" $ do
+          releaseTarball <- locateRunfiles (mainWorkspace </> "release" </> "sdk-release-tarball.tar.gz")
+          createDirectory tarballDir
+          callProcessQuiet "tar" ["xf", releaseTarball, "--strip-components=1", "-C", tarballDir]
+          callProcessQuiet (tarballDir </> "install.sh") []
+    , testCase "daml version" $ callProcessQuiet "daml" ["version"]
+    , testCase "daml --help" $ callProcessQuiet "daml" ["--help"]
+    , testCase "daml new --list" $ callProcessQuiet "daml" ["new", "--list"]
+    , quickstartTests quickstartDir
+    ]
+    where quickstartDir = tmpDir </> "quickstart"
+          tarballDir = tmpDir </> "tarball"
+
+quickstartTests :: FilePath -> TestTree
+quickstartTests quickstartDir = testGroup "quickstart"
+    [ testCase "daml new" $
+          callProcessQuiet "daml" ["new", quickstartDir]
+    , testCase "daml package" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet "daml" ["package", "daml/Main.daml", "target/daml/iou"]
+    , testCase "daml test" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet "daml" ["test", "daml/Main.daml"]
+    , testCase "sandbox startup" $
+      withCurrentDirectory quickstartDir $
+      withDevNull $ \devNull -> do
+          p :: Int <- fromIntegral <$> getFreePort
+          withCreateProcess ((proc "daml" ["sandbox", "--port", show p, "target/daml/iou.dar"]) { std_out = UseHandle devNull }) $
+              \_ _ _ ph -> race_ (waitForProcess' "sandbox" [] ph) $ do
+              waitForConnectionOnPort (threadDelay 100000) p
+              addr : _ <- getAddrInfo
+                  (Just socketHints)
+                  (Just "127.0.0.1")
+                  (Just $ show p)
+              bracket
+                  (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+                  close
+                  (\s -> connect s (addrAddress addr))
+    ]
+
+-- | Like call process but hides stdout.
+callProcessQuiet :: FilePath -> [String] -> IO ()
+callProcessQuiet cmd args = do
+    (exit, _out, err) <- readProcessWithExitCode cmd args ""
+    hPutStr stderr err
+    unless (exit == ExitSuccess) $ throwIO $ ProcessExitFailure exit cmd args
+
+data ProcessExitFailure = ProcessExitFailure !ExitCode !FilePath ![String]
+    deriving (Show, Typeable)
+
+instance Exception ProcessExitFailure
+
+-- This is slightly hacky: we need to find a free port but pass it to an
+-- external process. Technically this port could be reused between us
+-- getting it from the kernel and the external process listening
+-- on that port but ports are usually not reused aggressively so this should
+-- be fine and is certainly better than hardcoding the port.
+getFreePort :: IO PortNumber
+getFreePort = do
+    addr : _ <- getAddrInfo
+        (Just socketHints)
+        (Just "127.0.0.1")
+        (Just "0")
+    bracket
+        (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+        close
+        (\s -> do bind s (addrAddress addr)
+                  name <- getSocketName s
+                  case name of
+                      SockAddrInet p _ -> pure p
+                      _ -> fail $ "Expected a SockAddrInet but got " <> show name)
+
+socketHints :: AddrInfo
+socketHints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
+
+-- | Like waitForProcess' but throws ProcessExitFailure if the process fails to start.
+waitForProcess' :: String -> [String] -> ProcessHandle -> IO ()
+waitForProcess' cmd args ph = do
+    e <- waitForProcess ph
+    unless (e == ExitSuccess) $ throwIO $ ProcessExitFailure e cmd args
+
+-- | Getting a dev-null handle in a cross-platform way seems to be somewhat tricky so we instead
+-- use a temporary file.
+withDevNull :: (Handle -> IO a) -> IO a
+withDevNull a = withTempFile $ \f -> withFile f WriteMode a

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -1,3 +1,5 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 module Main (main) where
 
 import Control.Concurrent


### PR DESCRIPTION
Once we need to do things like wait for a server to have started (this PR does that for the sandbox), writing the tests in bash becomes a giant pain so this PR changes the integration test suite to this PR rewrites the integration tests in Haskell.