### PR TITLE
Fix #152 java-codegen: Document parameterized types.

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -297,3 +297,8 @@ daml_test(
     name = "ledger-model-daml-test",
     srcs = glob(["source/concepts/ledger-model/daml/**/*.daml"])
 )
+
+daml_test(
+    name = "java-bindings-docs-daml-test",
+    srcs = glob(["source/app-dev/bindings-java/daml/**/*.daml"])
+)

--- a/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
@@ -12,4 +12,4 @@ data BookAttributes = BookAttributes with
    pages : (Attribute Int)
    authors : (Attribute [Text])
    title : (Attribute Text)
--- start snippet: parameterized types example
+-- end snippet: parameterized types example

--- a/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 daml 1.2
 module Com.Acme where
 

--- a/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- start snippet: parameterized types example
 daml 1.2
 module Com.Acme where
 
@@ -11,3 +12,4 @@ data BookAttributes = BookAttributes with
    pages : (Attribute Int)
    authors : (Attribute [Text])
    title : (Attribute Text)
+-- start snippet: parameterized types example

--- a/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/ParameterizedTypes.daml
@@ -1,0 +1,10 @@
+daml 1.2
+module Com.Acme where
+
+data Attribute a = Attribute
+    with v : a
+
+data BookAttributes = BookAttributes with
+   pages : (Attribute Int)
+   authors : (Attribute [Text])
+   title : (Attribute Text)

--- a/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 daml 1.2
 module Com.Acme where
 

--- a/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
@@ -1,0 +1,7 @@
+daml 1.2
+module Com.Acme where
+
+data BookAttribute = Pages Int
+                   | Authors [Text]
+                   | Title Text
+                   | Published with year: Int; publisher Text

--- a/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/Variants.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- start snippet: variant example
 daml 1.2
 module Com.Acme where
 
@@ -8,3 +9,4 @@ data BookAttribute = Pages Int
                    | Authors [Text]
                    | Title Text
                    | Published with year: Int; publisher Text
+-- end snippet: variant example

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -467,7 +467,7 @@ converted to the Java Binding Java Types before the creating the product type.
 
   Value serializedAuthors = authorsAttribute.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
 
-The deserialization to the Java ``List`` and ``Optional`` types similarly require that the Java Bindings product type is converted to it's Java
+The deserialization to the Java ``List`` and ``Optional`` types similarly require that the Java Bindings types ``DamlList`` and ``DamlOptional``  are converted to it's Java
 equivalent and then all the contained elements are converted to Java types.
 
 .. code-block:: java

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -455,7 +455,7 @@ Non-exposed parameterized types
 If the parameterized type is contained in a type where the *actual* type is specified (as in the ``BookAttributes`` type above), then the serialization
 and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
 
-DAML List and DAML Optional
+Converting List and Optional
 """"""""""""""""""""""""""""
 
 The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -456,7 +456,7 @@ If the parameterized type is contained in a type where the *actual* type is spec
 and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
 
 DAML List and DAML Optional
-"""""""""""""""""""""""""""
+""""""""""""""""""""""""""""
 
 The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be
 converted to the Java Binding Java Types before the creating the product type.

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -430,7 +430,7 @@ Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` 
 
   Value serializedPages = pagesAttribute.toValue(Int64::new);
 
-See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the `fromValue`` method.
+See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the ``fromValue`` method.
 
 Note: If the DAML type is a record that has more than one parameterized type, a function for creating the
 Java Binding values must be supplied for *each* such type.

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -387,7 +387,13 @@ The Java code generated for this variant is:
 Parameterized types
 ~~~~~~~~~~~~~~~~~~~
 
-The Java Code Generator uses Java Generic types to represent :ref:`DAML parameterized types <daml-ref-parameterized-types>`.
+The following section describes the mechanism that the generated sources used to represent
+:ref:`DAML parameterized types <daml-ref-parameterized-types>` using Java Generic types.
+
+**Note:**
+The intended audience for this section are only those requiring a detailed understanding of how the
+generated Java parameterized types are serialized and deserialized. Application developers will not generally handle
+parameterized types directly, but only as fields of non-parameterized types so therefore may want to skip this section.
 
 Below is a DAML fragment defining the parameterized type ``Attribute`` for use by the ``BookAttribute`` type for modeling
 the characteristics of the book.
@@ -418,8 +424,11 @@ The Java codegen generates a Java file with a generic class for  the ``Attribute
 Serializing
 """""""""""
 
-To serialize an instance of the ``Attribute<a>`` data type, a function for creating the Ledger API equivalent of the attribute value
-is passed to the ``toValue`` method as the ``fromValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
+To serialize an instance of the ``Attribute<a>`` data type, pass a function for creating the Ledger API equivalent of the attribute value
+is passed to the ``toValue`` method as the ``toValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
+
+**Note:** The ``toValue`` method has the same number of arguments as the type has parameters. The arguments names are ``toValue`` suffixed with
+the type parameter name, for example the argument to serialize type ``a`` is called ``toValuea``.
 
 Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` value to the Ledger API representation using the *method reference*
 ``Int64::new`` to create a new instance of the Java Bindings value type.
@@ -448,12 +457,6 @@ Analogous to the generated ``toValue`` method, the deserialization method ``from
 See Java Bindings `Value`_ class for the methods to transform the Java Bindings types into corresponding Java types.
 
 .. _Value: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
-
-Non-exposed parameterized types
-"""""""""""""""""""""""""""""""
-
-If the parameterized type is contained in a type where the *actual* type is specified (as in the ``BookAttributes`` type above), then the serialization
-and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
 
 Converting List and Optional
 """"""""""""""""""""""""""""

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -183,7 +183,7 @@ The Java package for the generated classes is the equivalent of the lowercase DA
   package foo.bar.baz;
 
 Records (a.k.a product types)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A :ref:`DAML record <daml-ref-record-types>` is represented by a Java class with fields that have the same name as the DAML record fields. A DAML field having the type of another record is represented as a field having the type of the generated class for that record.
 
@@ -233,7 +233,7 @@ A Java file is generated that defines the class for the type ``Name``:
 .. _daml-codegen-java-templates:
 
 Templates
-~~~~~~~~~
+^^^^^^^^^
 
 The Java codegen generates three classes for a DAML template:
 
@@ -303,13 +303,14 @@ A file is generated that defines three Java classes:
   }
 
 Variants (a.k.a sum types)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A :ref:`variant or sum type <daml-ref-sum-types>` is a type with multiple constructors, where each constructor wraps a value of another type. The generated code is comprised of an abstract class for the variant type itself and a subclass thereof for each constructor. Classes for variant constructors are similar to classes for records.
 
 .. literalinclude:: ./code-snippets/Variants.daml
    :language: daml
-   :lines: 3-10
+   :start-after: -- start snippet: variant example
+   :end-before: -- end snippet: variant example
    :caption: Com/Acme.daml
 
 The Java code generated for this variant is:
@@ -385,22 +386,20 @@ The Java code generated for this variant is:
   }
 
 Parameterized types
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
-The following section describes the mechanism that the generated sources used to represent
-:ref:`DAML parameterized types <daml-ref-parameterized-types>` using Java Generic types.
+.. note::
 
-**Note:**
-The intended audience for this section are only those requiring a detailed understanding of how the
-generated Java parameterized types are serialized and deserialized. Application developers will not generally handle
-parameterized types directly, but only as fields of non-parameterized types so therefore may want to skip this section.
+   This section is only included for completeness: we don't expect users to make use of the ``fromValue`` and ``toValue methods``, because they would typically come from a template that doesn't have any unbound type parameters.
 
-Below is a DAML fragment defining the parameterized type ``Attribute`` for use by the ``BookAttribute`` type for modeling
-the characteristics of the book.
+The Java codegen uses Java Generic types to represent :ref:`DAML parameterized types <daml-ref-parameterized-types>`.
+
+This DAML fragment defines the parameterized type ``Attribute``, used by the ``BookAttribute`` type for modeling the characteristics of the book:
 
 .. literalinclude:: ./code-snippets/ParameterizedTypes.daml
    :language: daml
-   :lines: 3-11
+   :start-after: -- start snippet: parameterized types example
+   :end-before: -- end snippet: parameterized types example
    :caption: Com/Acme.daml
 
 The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -394,7 +394,6 @@ The Java code generated for this variant is:
 Parameterized types
 ~~~~~~~~~~~~~~~~~~~
 
-A :ref:`parameterized type <daml-ref-parameterized-types>` is where the actual type is specified at instantiation as *type parameters* and not as part of type definition.
 The Java Code Generator uses Java Generic types to represent the DAML parameterized type.
 
 Below is a DAML fragment defining the parameterized type `Attribute` for use by the `

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -397,7 +397,7 @@ the characteristics of the book.
    :lines: 3-11
    :caption: Com/Acme.daml
 
-A file Java file is generated for the ``Attribute`` data type that defines the Java Generic class:
+The Java codegen generates a Java file with a generic class for  the ``Attribute a`` data type:
 
 .. code-block:: java
   :caption: com/acme/Attribute.java

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -432,7 +432,7 @@ Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` 
 
 See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the `fromValue`` method.
 
-Note: That if the DAML type is a record that has more that one parameterized type, then a function for creating the
+Note: If the DAML type is a record that has more than one parameterized type, a function for creating the
 Java Binding values must be supplied for *each* such type.
 
 Deserializing

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -97,11 +97,7 @@ Understand the generated Java model
 
 The Java codegen generates source files in a directory tree under the output directory specified on the command line.
 
-<<<<<<< Updated upstream
 .. _daml-codegen-java-primitive-types:
-=======
-.. _daml-codegen-java-types:
->>>>>>> Stashed changes
 
 Map DAML primitives to Java types
 ---------------------------------
@@ -134,7 +130,7 @@ Java:
 +--------------------------------+--------------------------------------------+------------------------+
 | ``Optional``                   | ``java.util.Optional``                     | `DamlOptional`_        |
 +--------------------------------+--------------------------------------------+------------------------+
-| ``()`` (Unit)                  | **None** since the Java language doesn’t   | `DamlUnit`_            |
+| ``()`` (Unit)                  | **None** since the Java language doesn’t   | `Unit`_                |
 |                                | have a direct equivalent of DAML’s Unit    |                        |
 |                                | type ``()``, the generated code uses the   |                        |
 |                                | Java Bindings value type.                  |                        |
@@ -452,7 +448,7 @@ Below is a Java fragment to serialize an attribute with a `java.lang.Long` value
 
   Value serializedPages = pagesAttribute.toValue(Int64::new);
 
-See :ref:`daml-codegen-java-types` for the Java Bindings value types need to be created in the `fromValue` method.
+See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the `fromValue` method.
 
 Note: That if the DAML type is a record that has more that one parameterized field, then a function for creating the
 Java Binding values must be supplied for *each* such fields.

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -309,6 +309,7 @@ A :ref:`variant or sum type <daml-ref-sum-types>` is a type with multiple constr
 
 .. literalinclude:: ./code-snippets/Variants.daml
    :language: daml
+   :lines: 3-10
    :caption: Com/Acme.daml
 
 The Java code generated for this variant is:
@@ -393,6 +394,7 @@ the characteristics of the book.
 
 .. literalinclude:: ./code-snippets/ParameterizedTypes.daml
    :language: daml
+   :lines: 3-11
    :caption: Com/Acme.daml
 
 A file Java file is generated for the ``Attribute`` data type that defines the Java Generic class:

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -423,14 +423,9 @@ The Java codegen generates a Java file with a generic class for  the ``Attribute
 Serializing
 """""""""""
 
-To serialize an instance of the ``Attribute<a>`` data type, pass a function for creating the Ledger API equivalent of the attribute value
-is passed to the ``toValue`` method as the ``toValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
+To serialize an instance of the ``Attribute<a>`` data type, a function for creating the Ledger API equivalent of the attribute value is passed to the ``toValue`` method as the ``fromValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
 
-**Note:** The ``toValue`` method has the same number of arguments as the type has parameters. The arguments names are ``toValue`` suffixed with
-the type parameter name, for example the argument to serialize type ``a`` is called ``toValuea``.
-
-Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` value to the Ledger API representation using the *method reference*
-``Int64::new`` to create a new instance of the Java Bindings value type.
+Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` value to the Ledger API representation using the *method reference* ``Int64::new`` to create a new instance of the Java Bindings value type.
 
 .. code-block:: java
 
@@ -440,8 +435,7 @@ Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` 
 
 See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the ``fromValue`` method.
 
-Note: If the DAML type is a record that has more than one parameterized type, a function for creating the
-Java Binding values must be supplied for *each* such type.
+Note: If the DAML type is a record that has more than one parameterized type, a function for creating the Java Binding values must be supplied for *each* such type.
 
 Deserializing
 """""""""""""
@@ -457,11 +451,15 @@ See Java Bindings `Value`_ class for the methods to transform the Java Bindings 
 
 .. _Value: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
 
+Non-exposed parameterized types
+"""""""""""""""""""""""""""""""
+
+If the parameterized type is contained in a type where the *actual* type is specified (as in the ``BookAttributes`` type above), then the serialization and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
+
 Converting List and Optional
 """"""""""""""""""""""""""""
 
-The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be
-converted to the Java Binding Java Types before the creating the ``DamlList`` or ``DamlOptional``.
+The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be converted to the Java Binding Java Types before the creating the ``DamlList`` or ``DamlOptional``.
 
 .. code-block:: java
 
@@ -469,8 +467,7 @@ converted to the Java Binding Java Types before the creating the ``DamlList`` or
 
   Value serializedAuthors = authorsAttribute.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
 
-The deserialization to the Java ``List`` and ``Optional`` types similarly require that the Java Bindings types ``DamlList`` and ``DamlOptional``  are converted to it's Java
-equivalent and then all the contained elements are converted to Java types.
+The deserialization to the Java ``List`` and ``Optional`` types similarly require that the Java Bindings types ``DamlList`` and ``DamlOptional``  are converted to it's Java equivalent and then all the contained elements are converted to Java types.
 
 .. code-block:: java
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -454,7 +454,7 @@ Java Binding values must be supplied for *each* such fields.
 
 **Deserializing**
 
-The deserialization method `fromValue` requires in a similar manner, a function to convert the Java Bindings value types to it's corresponding Java type.
+Analogous to the generated ``toValue`` method, the deserialization method ``fromValue`` takes a function to convert a Java Bindings ``Value`` type to the expected Java type.
 
 .. code-block:: java
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -459,7 +459,7 @@ Converting List and Optional
 """"""""""""""""""""""""""""
 
 The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be
-converted to the Java Binding Java Types before the creating the product type.
+converted to the Java Binding Java Types before the creating the ``DamlList`` or ``DamlOptional``.
 
 .. code-block:: java
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -140,18 +140,18 @@ Java:
 |                                | respective template ``X``.                 |                        |
 +--------------------------------+--------------------------------------------+------------------------+
 
-.. _Int64: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Int64.html
-.. _Decimal: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Decimal.html
-.. _Text: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Text.html
-.. _Bool: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Bool.html
-.. _Party: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Party.html
-.. _Date: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Date.html
-.. _Timestamp: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Timestamp.html
-.. _DamlList: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlList.html
-.. _TextMap: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/TextMap.html
-.. _DamlOptional: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
-.. _Unit: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
-.. _ContractId: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html
+.. _Int64: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Int64.html
+.. _Decimal: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Decimal.html
+.. _Text: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Text.html
+.. _Bool: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Bool.html
+.. _Party: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Party.html
+.. _Date: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Date.html
+.. _Timestamp: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Timestamp.html
+.. _DamlList: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlList.html
+.. _TextMap: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/TextMap.html
+.. _DamlOptional: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
+.. _Unit: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
+.. _ContractId: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html
 
 Understand escaping rules
 -------------------------
@@ -396,7 +396,8 @@ Parameterized types
 
 The Java Code Generator uses Java Generic types to represent :ref:`DAML parameterized types <daml-ref-parameterized-types>`.
 
-Below is a DAML fragment defining the parameterized type `Attribute` for use by the `
+Below is a DAML fragment defining the parameterized type ``Attribute`` for use by the ``BookAttribute`` type for modeling
+the characteristics of the book.
 
 .. code-block:: daml
   :caption: Com/Acme.daml
@@ -412,10 +413,7 @@ Below is a DAML fragment defining the parameterized type `Attribute` for use by 
      authors : (Attribute [Text])
      title : (Attribute Text)
 
-A file Java file is generated for the `Attribute` data type that defines the Java Generic class:
-
-Note: If the parameterized type is contained in a type where the *actual* type is specified (as in the `BookAttributes` type above), then the serialization
-and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
+A file Java file is generated for the ``Attribute`` data type that defines the Java Generic class:
 
 .. code-block:: java
   :caption: com/acme/Attribute.java
@@ -433,13 +431,14 @@ and deserialization of the enclosing type provides the necessary methods for ser
     public static <a> Attribute<a> fromValue(Value value$, Function<Value, a> fromValuea) { /* ... */ }
   }
 
-**Serializing**
+Serializing
+"""""""""""
 
-To serialize an instance of the `Attribute<a>` data type function for creating the Ledger API equivalent of the attribute value
-is passed to the `toValue` method as the `fromValuea` argument (see the above `com/acme/Attribute.java` source extract).
+To serialize an instance of the ``Attribute<a>`` data type function for creating the Ledger API equivalent of the attribute value
+is passed to the ``toValue`` method as the ``fromValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
 
-Below is a Java fragment to serialize an attribute with a `java.lang.Long` value to Ledger API representation using the *method reference*
-`Int64::new` to create a new instance of the Java Bindings value type.
+Below is a Java fragment to serialize an attribute with a ``java.lang.Long`` value to Ledger API representation using the *method reference*
+``Int64::new`` to create a new instance of the Java Bindings value type.
 
 .. code-block:: java
 
@@ -447,12 +446,13 @@ Below is a Java fragment to serialize an attribute with a `java.lang.Long` value
 
   Value serializedPages = pagesAttribute.toValue(Int64::new);
 
-See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the `fromValue` method.
+See :ref:`DAML To Java Type Mapping <daml-codegen-java-primitive-types>` for the Java Bindings value types need to be created in the `fromValue`` method.
 
-Note: That if the DAML type is a record that has more that one parameterized field, then a function for creating the
-Java Binding values must be supplied for *each* such fields.
+Note: That if the DAML type is a record that has more that one parameterized type, then a function for creating the
+Java Binding values must be supplied for *each* such type.
 
-**Deserializing**
+Deserializing
+"""""""""""""
 
 Analogous to the generated ``toValue`` method, the deserialization method ``fromValue`` takes a function to convert a Java Bindings ``Value`` type to the expected Java type.
 
@@ -463,11 +463,18 @@ Analogous to the generated ``toValue`` method, the deserialization method ``from
 
 See Java Bindings `Value`_ class for the methods to transform the Java Bindings types into corresponding Java types.
 
-.. _Value: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
+.. _Value: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
 
-**Parameterized product types**
+Non-exposed parameterized types
+"""""""""""""""""""""""""""""""
 
-The serialization of parameterized product types require a multiple stage conversion function where the elements must be
+If the parameterized type is contained in a type where the *actual* type is specified (as in the ``BookAttributes`` type above), then the serialization
+and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
+
+DAML List and DAML Optional
+"""""""""""""""""""""""""""
+
+The serialization of the Java ``List`` and ``Optional`` types require a multiple stage conversion function where the elements must be
 converted to the Java Binding Java Types before the creating the product type.
 
 .. code-block:: java
@@ -476,7 +483,7 @@ converted to the Java Binding Java Types before the creating the product type.
 
   Value serializedAuthors = authorsAttribute.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
 
-The deserialization of parameterized product types similarly require that the Java Bindings product type is converted to it's Java
+The deserialization to the Java ``List`` and ``Optional`` types similarly require that the Java Bindings product type is converted to it's Java
 equivalent and then all the contained elements are converted to Java types.
 
 .. code-block:: java

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -97,7 +97,11 @@ Understand the generated Java model
 
 The Java codegen generates source files in a directory tree under the output directory specified on the command line.
 
+<<<<<<< Updated upstream
 .. _daml-codegen-java-primitive-types:
+=======
+.. _daml-codegen-java-types:
+>>>>>>> Stashed changes
 
 Map DAML primitives to Java types
 ---------------------------------
@@ -105,43 +109,53 @@ Map DAML primitives to Java types
 DAML built-in types are translated to the following equivalent types in
 Java:
 
-+-----------------------------------+---------------------------------------+
-| DAML type                         | Java type                             |
-+===================================+=======================================+
-| ``Int``                           | ``java.lang.Long``                    |
-+-----------------------------------+---------------------------------------+
-| ``Decimal``                       | ``java.math.BigDecimal``              |
-+-----------------------------------+---------------------------------------+
-| ``Text``                          | ``java.lang.String``                  |
-+-----------------------------------+---------------------------------------+
-| ``Bool``                          | ``java.util.Boolean``                 |
-+-----------------------------------+---------------------------------------+
-| ``Party``                         | ``java.lang.String``                  |
-+-----------------------------------+---------------------------------------+
-| ``Date``                          | ``java.time.LocalDate``               |
-+-----------------------------------+---------------------------------------+
-| ``Time``                          | ``java.time.Instant``                 |
-+-----------------------------------+---------------------------------------+
-| ``List`` or ``[]``                | ``java.util.List``                    |
-+-----------------------------------+---------------------------------------+
-| ``TextMap``                       | ``java.util.Map``                     |
-|                                   | Restricted to using ``String`` keys.  |
-+-----------------------------------+---------------------------------------+
-| ``Optional``                      | ``java.util.Optional``                |
-+-----------------------------------+---------------------------------------+
-| ``()`` (Unit)                     | Since Java doesn’t have an            |
-|                                   | equivalent of DAML’s Unit type        |
-|                                   | ``()`` in the standard library,       |
-|                                   | the generated code uses               |
-|                                   | `com.daml.ledger.javaapi.data.Unit`_  |
-|                                   | from the Java Bindings library.       |
-+-----------------------------------+---------------------------------------+
-| ``ContractId``                    | Fields of type ``ContractId X`` refer |
-|                                   | to the generated ``ContractId`` class |
-|                                   | of the respective template ``X``.     |
-+-----------------------------------+---------------------------------------+
++--------------------------------+--------------------------------------------+------------------------+
+| DAML type                      | Java type                                  | Java Bindings          |
+|                                |                                            | Value Type             |
++================================+============================================+========================+
+| ``Int``                        | ``java.lang.Long``                         | `Int64`_               |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Decimal``                    | ``java.math.BigDecimal``                   | `Decimal`_             |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Text``                       | ``java.lang.String``                       | `Text`_                |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Bool``                       | ``java.util.Boolean``                      | `Bool`_                |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Party``                      | ``java.lang.String``                       | `Party`_               |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Date``                       | ``java.time.LocalDate``                    | `Date`_                |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Time``                       | ``java.time.Instant``                      | `Timestamp`_           |
++--------------------------------+--------------------------------------------+------------------------+
+| ``List`` or ``[]``             | ``java.util.List``                         | `DamlList`_            |
++--------------------------------+--------------------------------------------+------------------------+
+| ``TextMap``                    | ``java.util.Map``                          | `TextMap`_             |
+|                                | Restricted to using ``String`` keys.       |                        |
++--------------------------------+--------------------------------------------+------------------------+
+| ``Optional``                   | ``java.util.Optional``                     | `DamlOptional`_        |
++--------------------------------+--------------------------------------------+------------------------+
+| ``()`` (Unit)                  | **None** since the Java language doesn’t   | `DamlUnit`_            |
+|                                | have a direct equivalent of DAML’s Unit    |                        |
+|                                | type ``()``, the generated code uses the   |                        |
+|                                | Java Bindings value type.                  |                        |
++--------------------------------+--------------------------------------------+------------------------+
+| ``ContractId``                 | Fields of type ``ContractId X`` refer to   | `ContractId`_          |
+|                                | the generated ``ContractId`` class of the  |                        |
+|                                | respective template ``X``.                 |                        |
++--------------------------------+--------------------------------------------+------------------------+
 
-.. _com.daml.ledger.javaapi.data.Unit: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
+.. _Int64: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Int64.html
+.. _Decimal: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Decimal.html
+.. _Text: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Text.html
+.. _Bool: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Bool.html
+.. _Party: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Party.html
+.. _Date: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Date.html
+.. _Timestamp: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Timestamp.html
+.. _DamlList: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlList.html
+.. _TextMap: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/TextMap.html
+.. _DamlOptional: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
+.. _Unit: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
+.. _ContractId: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html
 
 Understand escaping rules
 -------------------------
@@ -380,3 +394,99 @@ The Java code generated for this variant is:
     public Published(Long year, String publisher) { /* ... */ }
     public Record toValue() { /* ... */ }
   }
+
+Parameterized types
+~~~~~~~~~~~~~~~~~~~
+
+A :ref:`parameterized type <daml-ref-parameterized-types>` is where the actual type is specified at instantiation as *type parameters* and not as part of type definition.
+The Java Code Generator uses Java Generic types to represent the DAML parameterized type.
+
+Below is a DAML fragment defining the parameterized type `Attribute` for use by the `
+
+.. code-block:: daml
+  :caption: Com/Acme.daml
+
+  daml 1.2
+  module Com.Acme where
+
+  data Attribute a = Attribute
+      with v : a
+
+  data BookAttributes = BookAttributes with
+     pages : (Attribute Int)
+     authors : (Attribute [Text])
+     title : (Attribute Text)
+
+A file Java file is generated for the `Attribute` data type that defines the Java Generic class:
+
+Note: If the parameterized type is contained in a type where the *actual* type is specified (as in the `BookAttributes` type above), then the serialization
+and deserialization of the enclosing type provides the necessary methods for serialization and deserialization.
+
+.. code-block:: java
+  :caption: com/acme/Attribute.java
+  :emphasize-lines: 3,8,10
+
+  package com.acme;
+
+  public class Attribute<a> {
+    public final a value;
+
+    public Attribute(a value) { /* ... */  }
+
+    public Record toValue(Function<a, Value> toValuea) { /* ... */ }
+
+    public static <a> Attribute<a> fromValue(Value value$, Function<Value, a> fromValuea) { /* ... */ }
+  }
+
+**Serializing**
+
+To serialize an instance of the `Attribute<a>` data type function for creating the Ledger API equivalent of the attribute value
+is passed to the `toValue` method as the `fromValuea` argument (see the above `com/acme/Attribute.java` source extract).
+
+Below is a Java fragment to serialize an attribute with a `java.lang.Long` value to Ledger API representation using the *method reference*
+`Int64::new` to create a new instance of the Java Bindings value type.
+
+.. code-block:: java
+
+  Attribute<Long> pagesAttribute = new Attributes<>(42L);
+
+  Value serializedPages = pagesAttribute.toValue(Int64::new);
+
+See :ref:`daml-codegen-java-types` for the Java Bindings value types need to be created in the `fromValue` method.
+
+Note: That if the DAML type is a record that has more that one parameterized field, then a function for creating the
+Java Binding values must be supplied for *each* such fields.
+
+**Deserializing**
+
+The deserialization method `fromValue` requires in a similar manner, a function to convert the Java Bindings value types to it's corresponding Java type.
+
+.. code-block:: java
+
+  Attribute<Long> pagesAttribute = Attribute.<Long>fromValue(serializedPages,
+      f -> f.asInt64().getOrElseThrow(() -> throw new IllegalArgumentException("Expected Int field").getValue());
+
+See Java Bindings `Value`_ class for the methods to transform the Java Bindings types into corresponding Java types.
+
+.. _Value: https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
+
+**Parameterized product types**
+
+The serialization of parameterized product types require a multiple stage conversion function where the elements must be
+converted to the Java Binding Java Types before the creating the product type.
+
+.. code-block:: java
+
+  Attribute<List<String>> authorsAttribute = new Attribute<List<String>>(Arrays.asList("Homer", "Ovid", "Vergil"));
+
+  Value serializedAuthors = authorsAttribute.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
+
+The deserialization of parameterized product types similarly require that the Java Bindings product type is converted to it's Java
+equivalent and then all the contained elements are converted to Java types.
+
+.. code-block:: java
+
+  Attribute<List<String>> authorsAttribute = Attribute.<List<String>>fromValue(serializedAuthors,
+      f0 -> f0.asList().orElseThrow(() -> new IllegalArgumentException("Expected DamlList field")).getValues().stream()
+          .map(f1 -> f1.asText().orElseThrow(() -> new IllegalArgumentException("Expected Text element")).getValue())
+              .collect(Collectors.toList()));

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -102,8 +102,7 @@ The Java codegen generates source files in a directory tree under the output dir
 Map DAML primitives to Java types
 ---------------------------------
 
-DAML built-in types are translated to the following equivalent types in
-Java:
+DAML built-in types are translated to the following equivalent types in Java:
 
 +--------------------------------+--------------------------------------------+------------------------+
 | DAML type                      | Java type                                  | Java Bindings          |
@@ -308,16 +307,9 @@ Variants (a.k.a sum types)
 
 A :ref:`variant or sum type <daml-ref-sum-types>` is a type with multiple constructors, where each constructor wraps a value of another type. The generated code is comprised of an abstract class for the variant type itself and a subclass thereof for each constructor. Classes for variant constructors are similar to classes for records.
 
-.. code-block:: daml
-  :caption: Com/Acme.daml
-
-  daml 1.2
-  module Com.Acme where
-
-  data BookAttribute = Pages Int
-                     | Authors [Text]
-                     | Title Text
-                     | Published with year: Int; publisher Text
+.. literalinclude:: ./code-snippets/Variants.daml
+   :language: daml
+   :caption: Com/Acme.daml
 
 The Java code generated for this variant is:
 
@@ -399,19 +391,9 @@ The Java Code Generator uses Java Generic types to represent :ref:`DAML paramete
 Below is a DAML fragment defining the parameterized type ``Attribute`` for use by the ``BookAttribute`` type for modeling
 the characteristics of the book.
 
-.. code-block:: daml
-  :caption: Com/Acme.daml
-
-  daml 1.2
-  module Com.Acme where
-
-  data Attribute a = Attribute
-      with v : a
-
-  data BookAttributes = BookAttributes with
-     pages : (Attribute Int)
-     authors : (Attribute [Text])
-     title : (Attribute Text)
+.. literalinclude:: ./code-snippets/ParameterizedTypes.daml
+   :language: daml
+   :caption: Com/Acme.daml
 
 A file Java file is generated for the ``Attribute`` data type that defines the Java Generic class:
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -418,7 +418,7 @@ A file Java file is generated for the ``Attribute`` data type that defines the J
 Serializing
 """""""""""
 
-To serialize an instance of the ``Attribute<a>`` data type function for creating the Ledger API equivalent of the attribute value
+To serialize an instance of the ``Attribute<a>`` data type, a function for creating the Ledger API equivalent of the attribute value
 is passed to the ``toValue`` method as the ``fromValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
 
 Below is a Java fragment to serialize an attribute with a ``java.lang.Long`` value to Ledger API representation using the *method reference*

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -421,7 +421,7 @@ Serializing
 To serialize an instance of the ``Attribute<a>`` data type, a function for creating the Ledger API equivalent of the attribute value
 is passed to the ``toValue`` method as the ``fromValuea`` argument (see the above ``com/acme/Attribute.java`` source extract).
 
-Below is a Java fragment to serialize an attribute with a ``java.lang.Long`` value to Ledger API representation using the *method reference*
+Below is a Java fragment that serializes an attribute with a ``java.lang.Long`` value to the Ledger API representation using the *method reference*
 ``Int64::new`` to create a new instance of the Java Bindings value type.
 
 .. code-block:: java

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -394,7 +394,7 @@ The Java code generated for this variant is:
 Parameterized types
 ~~~~~~~~~~~~~~~~~~~
 
-The Java Code Generator uses Java Generic types to represent the DAML parameterized type.
+The Java Code Generator uses Java Generic types to represent :ref:`DAML parameterized types <daml-ref-parameterized-types>`.
 
 Below is a DAML fragment defining the parameterized type `Attribute` for use by the `
 

--- a/docs/source/daml/reference/data-types.rst
+++ b/docs/source/daml/reference/data-types.rst
@@ -209,6 +209,7 @@ If you have a variable with the same name as the label, DAML lets you use this w
 
 .. note:: The ``with`` keyword binds more strongly than function application. So for a function, say ``return``, either write ``return IntegerCoordinate with first = 1; second = 5`` or ``return (IntegerCoordinate {first = 1; second = 5})``, where the latter expression is enclosed in parentheses.
 
+.. _daml-ref-parameterized-types:
 
 Parameterized data types
 ========================

--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -2210,6 +2210,7 @@ body
 
       thead
         th
+          white-space: pre
           border: none
           text-transform: uppercase
           border-bottom: 1px solid #dddddd


### PR DESCRIPTION
Explain the sources that the Java Code Generator creates for
parameterized DAML types including the implications for converting
between Java Bindings Value types and Java native types.

First version!