### PR TITLE
language: fix: Include the main file in dar sources.

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -15,7 +15,6 @@ import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import           System.FilePath
-import           System.Directory
 import qualified Codec.Archive.Zip          as Zip
 
 ------------------------------------------------------------------------------
@@ -54,11 +53,9 @@ buildDar dalf modRoot dalfDependencies fileDependencies name = do
     -- Reads all module source files, and pairs paths (with changed prefix)
     -- with contents as BS. The path must be within the module root path, and
     -- is modified to have prefix <name> instead of the original root path.
-    absModRoot <- makeAbsolute modRoot
     mbSrcFiles <- forM fileDependencies $ \mPath -> do
-      absPath <- makeAbsolute mPath
-      contents <- BSL.readFile absPath
-      let mbNewPath = (name </>) <$> stripPrefix (addTrailingPathSeparator absModRoot) absPath
+      contents <- BSL.readFile mPath
+      let mbNewPath = (name </>) <$> stripPrefix (addTrailingPathSeparator modRoot) mPath
       return $ fmap (, contents) mbNewPath
 
     let dalfName = name <> ".dalf"

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -302,7 +302,7 @@ buildDar service file pkgName dalfInput = do
               dalf
               (takeDirectory file)
               dalfDependencies
-              fileDependencies
+              (file:fileDependencies)
               pkgName
 
 -- | Get the transitive package dependencies on other dalfs.


### PR DESCRIPTION
This adds the main daml file to the file dependencies packaged in the
dar. In addition, we now only use relative file paths in the dar
packaging.