### PR TITLE
Change contract key maintainers to have template argument in scope

### DIFF
--- a/daml-foundations/daml-ghc/daml-prim-src/GHC/Types.daml
+++ b/daml-foundations/daml-ghc/daml-prim-src/GHC/Types.daml
@@ -22,7 +22,6 @@ module GHC.Types (
         Opaque,
         ifThenElse,
         primitive, magic,
-        Proxy(..)
     ) where
 
 import GHC.Prim
@@ -149,5 +148,3 @@ data Text =
 data Decimal =
   -- | HIDE
   Decimal Opaque
-
-data Proxy a = Proxy

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -9,6 +9,7 @@ daml 1.2
 module DA.Internal.Desugar (
     concat,
     Template(ensure, signatory, observer, agreement),
+    TemplateKey(key, maintainer),
     Choice(consuming, choiceController, choice), nonconsuming, NoEvent(..),
     IsParties(toParties),
     Eq(..),

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -22,7 +22,7 @@ import GHC.Num as GHC
 import GHC.Real as GHC (fromRational)
 import GHC.Show as GHC
 import GHC.Tuple()
-import GHC.Types as GHC (Bool (..), Int, Ordering (..), Text, Decimal, ifThenElse, primitive, Proxy (..))
+import GHC.Types as GHC (Bool (..), Int, Ordering (..), Text, Decimal, ifThenElse, primitive)
 
 infixr 0 $
 ($) : (a -> b) -> a -> b

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -14,7 +14,7 @@ module DA.Internal.Template(
     lookupByKey, fetchByKey,
     exerciseExplicit,
     IsParties(toParties),
-    Key(..)
+    TemplateKey(key, maintainer)
     ) where
 
 import GHC.Types (magic)
@@ -50,11 +50,11 @@ stakeholder : Template c => c -> [Party]
 stakeholder c = signatory c ++ observer c
 
 -- | HIDE pass the @c@ using type applications, otherwise it's ambiguous
-lookupByKey : forall c k. Key c k => k -> Update (Optional (ContractId c))
+lookupByKey : forall c k. TemplateKey c k => k -> Update (Optional (ContractId c))
 lookupByKey = internalLookupByKey
 
 -- | HIDE pass the @c@ using type applications, otherwise it's ambiguous
-fetchByKey : Key c k => k -> Update (ContractId c, c)
+fetchByKey : TemplateKey c k => k -> Update (ContractId c, c)
 fetchByKey = internalFetchByKey
 
 class Template c where
@@ -132,10 +132,10 @@ instance IsParties [Party] where
   toParties ps = ps
 
 -- | HIDE
-class Template c => Key c k | c -> k where
+class Template c => TemplateKey c k | c -> k where
     key : c -> k
 
-    keyMaintainers : Proxy c -> k -> [Party]
+    maintainer : c -> [Party]
 
     -- | HIDE
     internalFetchByKey : k -> Update (ContractId c, c)

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -1203,7 +1203,7 @@ rewriteMaintainer key maintainer = do
             keyMaps <- forM fields $ \(fieldName, fieldExpr) ->
                 MS.map (ERecProj typ fieldName) <$> buildKeyMap fieldExpr
             pure $ MS.unions keyMaps
-        expr@ERecProj{}
+        expr
             | (EVar "this", fields) <- unwindProjections expr -> pure $ MS.singleton fields (EVar "$key")
         o -> unhandled "Template key expression" o
 

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -1196,7 +1196,7 @@ rewriteMaintainer key maintainer = do
             ERecProj _typ field expr -> go (field : fields) expr
             expr -> (expr, fields)
 
-    -- TODO(MH): The error messages here and below are pretty bad.
+    -- TODO(#299): The error messages are pretty bad.
     buildKeyMap :: LF.Expr -> ConvertM (MS.Map [FieldName] LF.Expr)
     buildKeyMap = \case
         ERecCon typ fields -> do
@@ -1207,9 +1207,7 @@ rewriteMaintainer key maintainer = do
             | (EVar "this", fields) <- unwindProjections expr -> pure $ MS.singleton fields (EVar "$key")
         o -> unhandled "Template key expression" o
 
-    -- TODO(MH): Currently, we fail when 'maintainer' references 'this.foo.bar'
-    -- and 'key' contains only 'this.foo' but not 'this.foo.bar'.
-    -- This should be improved.
+    -- TODO(#299): The error messages are pretty bad.
     rewriteThisProjections :: MS.Map [FieldName] LF.Expr -> LF.Expr -> ConvertM LF.Expr
     rewriteThisProjections keyMap expr = case unwindProjections expr of
         (EVar "this", fields)

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilLF.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilLF.hs
@@ -3,17 +3,20 @@
 
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- | DAML-LF utility functions, may move to the LF utility if they are generally useful
 module DA.Daml.GHC.Compiler.UtilLF where
 
 import           DA.Daml.LF.Ast
 import qualified DA.Daml.LF.Proto3.Archive  as Archive
+import           DA.Pretty (renderPretty)
 
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.NameMap               as NM
 import           Data.Tagged
 import qualified Data.Text                  as T
 import           GHC.Stack                  (HasCallStack)
+import           Outputable
 
 mkVar :: String -> ExprVarName
 mkVar = Tagged . T.pack
@@ -160,3 +163,5 @@ ghcTypes = Module
           (ERecCon (TypeConApp (qual (dataTypeCon dataProxy)) [TVar (Tagged "a")]) [])
       }
 
+instance Outputable Expr where
+    ppr = text . renderPretty

--- a/daml-foundations/daml-ghc/tests/ContractKeys.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeys.daml
@@ -21,9 +21,9 @@ template Account with
   where
     signatory [bank, accountHolder]
 
-instance Key Account (Party, Text, Int) where
+instance TemplateKey Account (Party, Text, Int) where
     key acc = (acc.bank, acc.accountNumber._1, acc.accountNumber._2)
-    keyMaintainers Proxy (bank, _, _) = [bank]
+    maintainer acc = [acc.bank]
 
 test = scenario do
     bank <- getParty "Bank"

--- a/daml-lf/tests/scenario/daml-1.3/contract-keys/Test.daml
+++ b/daml-lf/tests/scenario/daml-1.3/contract-keys/Test.daml
@@ -16,10 +16,10 @@ template TextKey
         do
           return ()
 
-instance Key TextKey (Party, Text) where
+instance TemplateKey TextKey (Party, Text) where
   key tk = (tk.p, tk.tkKey)
 
-  keyMaintainers _ (p, _) = [p]
+  maintainer tk = [tk.p]
 
 run = scenario do
   alice <- getParty "Alice"

--- a/ledger/sandbox/src/test/resources/damls/Test.daml
+++ b/ledger/sandbox/src/test/resources/damls/Test.daml
@@ -303,10 +303,10 @@ template TextKey
         do
           return ()
 
-instance Key TextKey TextKey where
+instance TemplateKey TextKey TextKey where
   key tk = tk
 
-  keyMaintainers _ tk = [tkParty tk]
+  maintainer tk = [tk.tkParty]
 
 template TextKeyOperations
   with


### PR DESCRIPTION
More precisely, change the contract key type class we desugar the surface
syntax to such that the maintainers function has the template argument
in scope instead of the key. The compiler rewrites all references to the
template argument into references to the key and fails whenever that is
not possible.