### PR TITLE
Move daml-assistant logic out of daml-project-config.

### DIFF
--- a/daml-assistant/daml-project-config/DAML/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Config.hs
@@ -25,70 +25,73 @@ import DAML.Project.Consts
 import DAML.Project.Types
 import DAML.Project.Util
 import qualified Data.Text as T
+import Data.Text (Text)
 import qualified Data.Yaml as Y
 import Data.Yaml ((.:?))
 import Data.Either.Extra
 import Data.Foldable
 import System.FilePath
+import Control.Exception.Safe
 
 -- | Read daml config file.
--- Throws an assistant error if reading or parsing fails.
+-- Throws a ConfigError if reading or parsing fails.
 readDamlConfig :: DamlPath -> IO DamlConfig
 readDamlConfig (DamlPath path) = readConfig "daml" (path </> damlConfigName)
 
 -- | Read project config file.
--- Throws an assistant error if reading or parsing fails.
+-- Throws a ConfigError if reading or parsing fails.
 readProjectConfig :: ProjectPath -> IO ProjectConfig
 readProjectConfig (ProjectPath path) = readConfig "project" (path </> projectConfigName)
 
 -- | Read sdk config file.
--- Throws an assistant error if reading or parsing fails.
+-- Throws a ConfigError if reading or parsing fails.
 readSdkConfig :: SdkPath -> IO SdkConfig
 readSdkConfig (SdkPath path) = readConfig "SDK" (path </> sdkConfigName)
 
 -- | (internal) Helper function for defining 'readXConfig' functions.
+-- Throws a ConfigError if reading or parsing fails.
 readConfig :: Y.FromJSON b => Text -> FilePath -> IO b
 readConfig name path = do
     configE <- Y.decodeFileEither path
-    requiredE ("Failed to read " <> name <> " config file " <> pack path) configE
+    fromRightM (throwIO . ConfigFileInvalid name) configE
 
 -- | Determine pinned sdk version from project config, if it exists.
-sdkVersionFromProjectConfig :: ProjectConfig -> Either AssistantError (Maybe SdkVersion)
+sdkVersionFromProjectConfig :: ProjectConfig -> Either ConfigError (Maybe SdkVersion)
 sdkVersionFromProjectConfig = queryProjectConfig ["project", "sdk-version"]
 
 -- | Determine sdk version from project config, if it exists.
-sdkVersionFromSdkConfig :: SdkConfig -> Either AssistantError SdkVersion
+sdkVersionFromSdkConfig :: SdkConfig -> Either ConfigError SdkVersion
 sdkVersionFromSdkConfig = querySdkConfigRequired ["version"]
 
 -- | Read sdk config to get list of sdk commands.
-listSdkCommands :: SdkConfig -> Either AssistantError [SdkCommandInfo]
+listSdkCommands :: SdkConfig -> Either ConfigError [SdkCommandInfo]
 listSdkCommands = querySdkConfigRequired ["commands"]
 
 -- | Query the daml config by passing a path to the desired property.
 -- See 'queryConfig' for more details.
-queryDamlConfig :: Y.FromJSON t => [Text] -> DamlConfig -> Either AssistantError (Maybe t)
+queryDamlConfig :: Y.FromJSON t => [Text] -> DamlConfig -> Either ConfigError (Maybe t)
 queryDamlConfig path = queryConfig "daml" "DamlConfig" path . unwrapDamlConfig
 
 -- | Query the project config by passing a path to the desired property.
 -- See 'queryConfig' for more details.
-queryProjectConfig :: Y.FromJSON t => [Text] -> ProjectConfig -> Either AssistantError (Maybe t)
+queryProjectConfig :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError (Maybe t)
 queryProjectConfig path = queryConfig "project" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Query the sdk config by passing a list of members to the desired property.
 -- See 'queryConfig' for more details.
-querySdkConfig :: Y.FromJSON t => [Text] -> SdkConfig -> Either AssistantError (Maybe t)
+querySdkConfig :: Y.FromJSON t => [Text] -> SdkConfig -> Either ConfigError (Maybe t)
 querySdkConfig path = queryConfig "SDK" "SdkConfig" path . unwrapSdkConfig
 
 -- | Like 'queryDamlConfig' but returns an error if the property is missing.
-queryDamlConfigRequired :: Y.FromJSON t => [Text] -> DamlConfig -> Either AssistantError t
+queryDamlConfigRequired :: Y.FromJSON t => [Text] -> DamlConfig -> Either ConfigError t
 queryDamlConfigRequired path = queryConfigRequired "daml" "DamlConfig" path . unwrapDamlConfig
 
 -- | Like 'queryProjectConfig' but returns an error if the property is missing.
-queryProjectConfigRequired :: Y.FromJSON t => [Text] -> ProjectConfig -> Either AssistantError t
+queryProjectConfigRequired :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError t
 queryProjectConfigRequired path = queryConfigRequired "project" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Like 'querySdkConfig' but returns an error if the property is missing.
-querySdkConfigRequired :: Y.FromJSON t => [Text] -> SdkConfig -> Either AssistantError t
+querySdkConfigRequired :: Y.FromJSON t => [Text] -> SdkConfig -> Either ConfigError t
 querySdkConfigRequired path = queryConfigRequired "SDK" "SdkConfig" path . unwrapSdkConfig
 
 -- | (internal) Helper function for querying config data. The 'path' argument
@@ -105,23 +108,22 @@ querySdkConfigRequired path = queryConfigRequired "SDK" "SdkConfig" path . unwra
 -- This distinguishes between a missing property and a poorly formed property:
 --    * If the property is missing, this returns (Right Nothing).
 --    * If the property is poorly formed, this returns (Left ...).
-queryConfig :: Y.FromJSON t => Text -> Text -> [Text] -> Y.Value -> Either AssistantError (Maybe t)
+queryConfig :: Y.FromJSON t => Text -> Text -> [Text] -> Y.Value -> Either ConfigError (Maybe t)
 queryConfig name root path cfg
-    = mapLeft (assistantErrorBecause ("Invalid " <> name <> " config file.") . pack)
+    = mapLeft (ConfigFieldInvalid name path)
     . flip Y.parseEither cfg
     $ \v0 -> do
         let initial = (root, Just v0)
             step (p, Nothing) _ = pure (p, Nothing)
             step (p, Just v) n = do
-                v' <- Y.withObject (unpack p) (.:? n) v
+                v' <- Y.withObject (T.unpack p) (.:? n) v
                 pure (p <> "." <> n, v')
 
         (_,v1) <- foldlM step initial path
         mapM Y.parseJSON v1
 
 -- | (internal) Like 'queryConfig' but returns an error if property is missing.
-queryConfigRequired :: Y.FromJSON t => Text -> Text -> [Text] -> Y.Value -> Either AssistantError t
+queryConfigRequired :: Y.FromJSON t => Text -> Text -> [Text] -> Y.Value -> Either ConfigError t
 queryConfigRequired name root path cfg = do
     resultM <- queryConfig name root path cfg
-    fromMaybeM (Left $ assistantErrorBecause ("Invalid " <> name <> " config file.")
-        ("Missing required property: " <> T.intercalate "." (root:path))) resultM
+    fromMaybeM (Left $ ConfigFieldMissing name path) resultM

--- a/daml-assistant/daml-project-config/DAML/Project/Util.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Util.hs
@@ -3,75 +3,6 @@
 
 module DAML.Project.Util where
 
-import DAML.Project.Types
-import System.FilePath
-import Control.Exception.Safe
-import Control.Applicative
-import Control.Monad.Extra
-
--- | Calculate the ascendants of a path, i.e. the successive parents of a path,
--- including the path itself, all the way to its root. For example:
---
---     ascendants "/foo/bar/baz" == ["/foo/bar/baz", "/foo/bar", "/foo", "/"]
---     ascendants "~/foo/bar/baz" == ["~/foo/bar/baz", "~/foo/bar", "~/foo", "~"]
---     ascendants "./foo/bar/baz" == ["./foo/bar/baz", "./foo/bar", "./foo", "."]
---     ascendants "../foo/bar/baz" == ["../foo/bar/baz", "../foo/bar", "../foo", ".."]
---     ascendants "foo/bar/baz"  == ["foo/bar/baz", "foo/bar", "foo", "."]
---
-ascendants :: FilePath -> [FilePath]
-ascendants "" = ["."]
-ascendants "~" = ["~"]
-ascendants ".." = [".."]
-ascendants p =
-    let p' = takeDirectory (dropTrailingPathSeparator p)
-        ps = if p == p' then [] else ascendants p'
-    in p : ps
-
--- | Throw an assistant error.
-throwErr :: Text -> IO a
-throwErr msg = throwIO (assistantError msg)
-
--- | Handle IOExceptions by wrapping them in an AssistantError, and
--- add context to any assistant errors that are missing context.
-wrapErr :: Text -> (IO a -> IO a)
-wrapErr ctx = handleIO (throwIO . wrapIOException)
-            . handle   (throwIO . addErrorContext)
-
-    where
-        wrapIOException :: IOException -> AssistantError
-        wrapIOException ioErr =
-            AssistantError
-                { errContext  = Just ctx
-                , errMessage  = Nothing
-                , errInternal = Just (pack (show ioErr))
-                }
-
-        addErrorContext :: AssistantError -> AssistantError
-        addErrorContext err =
-            err { errContext = errContext err <|> Just ctx }
-
-
--- | Throw an assistant error if the passed value is Nothing.
--- Otherwise return the underlying value.
---
---     required msg Nothing == throwErr msg
---     required msg . Just  == pure
---
-required :: Text -> Maybe t -> IO t
-required msg = maybe (throwErr msg) pure
-
--- | Same as 'required' but operates over Either values.
---
---     requiredE msg (Left e) = throwErr (msg <> "\nInternal error: " <> show e)
---     requiredE msg . Right  = pure
---
-requiredE :: Exception e => Text -> Either e t -> IO t
-requiredE msg = fromRightM (throwIO . assistantErrorBecause msg . pack . displayException)
-
--- | Catch IOExceptions and re-throw them as AssistantError with a helpful message.
-requiredIO :: Text -> IO t -> IO t
-requiredIO msg m = requiredE msg =<< tryIO m
-
 -- | Same as 'fromRight' but monadic in the applied function.
 fromRightM :: Applicative m => (a -> m b) -> Either a b -> m b
 fromRightM f = either f pure
@@ -79,7 +10,3 @@ fromRightM f = either f pure
 -- | Same as 'fromMaybe' but monadic in the default.
 fromMaybeM :: Applicative m => m a -> Maybe a -> m a
 fromMaybeM d = maybe d pure
-
--- | Like 'whenMaybeM' but only returns a 'Just' value if the test is false.
-unlessMaybeM :: Monad m => m Bool -> m t -> m (Maybe t)
-unlessMaybeM = whenMaybeM . fmap not

--- a/daml-assistant/src/DAML/Assistant.hs
+++ b/daml-assistant/src/DAML/Assistant.hs
@@ -8,12 +8,12 @@ module DAML.Assistant
     , runTests
     ) where
 
-import DAML.Project.Util
 import DAML.Project.Config
 import DAML.Assistant.Env
 import DAML.Assistant.Tests
 import DAML.Assistant.Command
 import DAML.Assistant.Install
+import DAML.Assistant.Util
 import qualified Data.Text.IO as T
 import System.FilePath
 import System.Process

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -14,7 +14,7 @@ module DAML.Assistant.Command
     , getCommand
     ) where
 
-import DAML.Project.Types
+import DAML.Assistant.Types
 import Data.List
 import Data.Maybe
 import Data.Foldable

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -17,10 +17,10 @@ module DAML.Assistant.Env
     , getDispatchEnv
     ) where
 
+import DAML.Assistant.Types
+import DAML.Assistant.Util
 import DAML.Project.Config
 import DAML.Project.Consts hiding (getDamlPath, getProjectPath)
-import DAML.Project.Types
-import DAML.Project.Util
 import System.Directory
 import System.FilePath
 import System.Environment
@@ -125,7 +125,7 @@ getSdk damlPath projectPathM =
         fromConfig :: Text
                    -> IO (Maybe path)
                    -> (path -> IO config)
-                   -> (config -> Either AssistantError (Maybe SdkVersion))
+                   -> (config -> Either ConfigError (Maybe SdkVersion))
                    -> IO (Maybe SdkVersion)
         fromConfig name lookupPath readConfig parseVersion =
             wrapErr ("Determining SDK version from " <> name <> " config.") $ do

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -15,9 +15,9 @@ module DAML.Assistant.Install
     , install
     ) where
 
-import DAML.Project.Types
+import DAML.Assistant.Types
+import DAML.Assistant.Util
 import DAML.Project.Consts
-import DAML.Project.Util
 import DAML.Project.Config
 import Safe
 import Conduit

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -9,9 +9,9 @@ module DAML.Assistant.Tests
 
 import DAML.Assistant.Env
 import DAML.Assistant.Install
+import DAML.Assistant.Types
+import DAML.Assistant.Util
 import DAML.Project.Consts hiding (getDamlPath, getProjectPath)
-import DAML.Project.Types
-import DAML.Project.Util
 import System.Directory
 import System.Environment
 import System.FilePath

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -1,0 +1,82 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module DAML.Assistant.Types
+    ( module DAML.Assistant.Types
+    , module DAML.Project.Types
+    , Text, pack, unpack -- convenient re-exports
+    ) where
+
+import DAML.Project.Types
+import qualified Data.Text as T
+import Data.Text (Text, pack, unpack)
+import Data.Maybe
+import Control.Exception.Safe
+
+data AssistantError = AssistantError
+    { errContext  :: Maybe Text -- ^ Context in which error occurs.
+    , errMessage  :: Maybe Text -- ^ User-friendly error message.
+    , errInternal :: Maybe Text -- ^ Internal error message, i.e. what actually happened.
+    } deriving (Eq, Show)
+
+instance Exception AssistantError where
+    displayException AssistantError {..} = unpack . T.unlines . catMaybes $
+        [ Just ("daml: " <> fromMaybe "An unknown error has occured" errMessage)
+        , fmap ("   context: " <>) errContext
+        , fmap ("   reason:  " <>) errInternal
+        ]
+
+-- | Standard error message.
+assistantError :: Text -> AssistantError
+assistantError msg = AssistantError
+    { errContext = Nothing
+    , errMessage = Just msg
+    , errInternal = Nothing
+    }
+
+-- | Standard error message with additional internal cause.
+assistantErrorBecause ::  Text -> Text -> AssistantError
+assistantErrorBecause msg e = (assistantError msg) { errInternal = Just e }
+
+data Env = Env
+    { envDamlPath      :: DamlPath
+    , envProjectPath   :: Maybe ProjectPath
+    , envSdkPath       :: Maybe SdkPath
+    , envSdkVersion    :: Maybe SdkVersion
+    } deriving (Eq, Show)
+
+data BuiltinCommand
+    = Version
+    | Install InstallOptions
+    deriving (Eq, Show)
+
+data Command
+    = Builtin BuiltinCommand
+    | Dispatch SdkCommandInfo UserCommandArgs
+    deriving (Eq, Show)
+
+newtype UserCommandArgs = UserCommandArgs
+    { unwrapUserCommandArgs :: [String]
+    } deriving (Eq, Show)
+
+data InstallOptions = InstallOptions
+    { iTargetM :: Maybe RawInstallTarget
+    , iActivate :: ActivateInstall
+    , iInitial :: InitialInstall
+    , iForce :: ForceInstall
+    , iQuiet :: QuietInstall
+    } deriving (Eq, Show)
+
+newtype RawInstallTarget = RawInstallTarget String deriving (Eq, Show)
+newtype ForceInstall = ForceInstall Bool deriving (Eq, Show)
+newtype QuietInstall = QuietInstall Bool deriving (Eq, Show)
+newtype ActivateInstall = ActivateInstall Bool deriving (Eq, Show)
+newtype InitialInstall = InitialInstall Bool deriving (Eq, Show)
+
+data InstallTarget
+    = InstallChannel SdkChannel
+    | InstallVersion SdkVersion
+    | InstallPath FilePath
+    deriving (Eq, Show)

--- a/daml-assistant/src/DAML/Assistant/Util.hs
+++ b/daml-assistant/src/DAML/Assistant/Util.hs
@@ -1,0 +1,82 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DAML.Assistant.Util
+    ( module DAML.Assistant.Util
+    , fromRightM
+    , fromMaybeM
+    ) where
+
+import DAML.Assistant.Types
+import DAML.Project.Util
+import System.FilePath
+import Control.Exception.Safe
+import Control.Applicative
+import Control.Monad.Extra
+
+-- | Calculate the ascendants of a path, i.e. the successive parents of a path,
+-- including the path itself, all the way to its root. For example:
+--
+--     ascendants "/foo/bar/baz" == ["/foo/bar/baz", "/foo/bar", "/foo", "/"]
+--     ascendants "~/foo/bar/baz" == ["~/foo/bar/baz", "~/foo/bar", "~/foo", "~"]
+--     ascendants "./foo/bar/baz" == ["./foo/bar/baz", "./foo/bar", "./foo", "."]
+--     ascendants "../foo/bar/baz" == ["../foo/bar/baz", "../foo/bar", "../foo", ".."]
+--     ascendants "foo/bar/baz"  == ["foo/bar/baz", "foo/bar", "foo", "."]
+--
+ascendants :: FilePath -> [FilePath]
+ascendants "" = ["."]
+ascendants "~" = ["~"]
+ascendants ".." = [".."]
+ascendants p =
+    let p' = takeDirectory (dropTrailingPathSeparator p)
+        ps = if p == p' then [] else ascendants p'
+    in p : ps
+
+-- | Throw an assistant error.
+throwErr :: Text -> IO a
+throwErr msg = throwIO (assistantError msg)
+
+-- | Handle IOExceptions by wrapping them in an AssistantError, and
+-- add context to any assistant errors that are missing context.
+wrapErr :: Text -> (IO a -> IO a)
+wrapErr ctx = handleIO (throwIO . wrapIOException)
+            . handle   (throwIO . addErrorContext)
+
+    where
+        wrapIOException :: IOException -> AssistantError
+        wrapIOException ioErr =
+            AssistantError
+                { errContext  = Just ctx
+                , errMessage  = Nothing
+                , errInternal = Just (pack (show ioErr))
+                }
+
+        addErrorContext :: AssistantError -> AssistantError
+        addErrorContext err =
+            err { errContext = errContext err <|> Just ctx }
+
+
+-- | Throw an assistant error if the passed value is Nothing.
+-- Otherwise return the underlying value.
+--
+--     required msg Nothing == throwErr msg
+--     required msg . Just  == pure
+--
+required :: Text -> Maybe t -> IO t
+required msg = maybe (throwErr msg) pure
+
+-- | Same as 'required' but operates over Either values.
+--
+--     requiredE msg (Left e) = throwErr (msg <> "\nInternal error: " <> show e)
+--     requiredE msg . Right  = pure
+--
+requiredE :: Exception e => Text -> Either e t -> IO t
+requiredE msg = fromRightM (throwIO . assistantErrorBecause msg . pack . displayException)
+
+-- | Catch IOExceptions and re-throw them as AssistantError with a helpful message.
+requiredIO :: Text -> IO t -> IO t
+requiredIO msg m = requiredE msg =<< tryIO m
+
+-- | Like 'whenMaybeM' but only returns a 'Just' value if the test is false.
+unlessMaybeM :: Monad m => m Bool -> m t -> m (Maybe t)
+unlessMaybeM = whenMaybeM . fmap not


### PR DESCRIPTION
Take daml-assistant-specific logic and types out of daml-project-config.

Introduces a ConfigError type to replace the AssistantError type in daml-project-config, giving config-specific errors.