### PR TITLE
Prevent crash when .daml/sdk is missing.

### DIFF
--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -141,16 +141,16 @@ getLatestInstalledSdkVersion :: DamlPath -> IO (Maybe SdkVersion)
 getLatestInstalledSdkVersion (DamlPath path) = do
     let dpath = path </> "sdk"
     wrapErr "Determining latest installed sdk version." $ do
-        versionMM <- whenMaybeM (doesDirectoryExist path) $ do
-            dirlistE <- tryIO $ listDirectory dpath
-            dirlist <- requiredE ("Failed to list daml home sdk directory " <> pack dpath) dirlistE
-            subdirs <- filterM (doesDirectoryExist . (dpath </>)) dirlist
-            -- TODO (FAFM): warn if subdirs /= dirlist
-            --  (i.e. $DAML_HOME/sdk is polluted with non-dirs).
-            let versions = filter ("nightly-" `isPrefixOf`) subdirs
-                -- TODO (FAFM): configurable channels
-            pure $ fmap (SdkVersion . pack) (maximumMay versions)
-        pure (join versionMM)
+        dirlistE <- tryIO $ listDirectory dpath
+        case dirlistE of
+            Left _ -> pure Nothing
+            Right dirlist -> do
+                subdirs <- filterM (doesDirectoryExist . (dpath </>)) dirlist
+                -- TODO (FAFM): warn if subdirs /= dirlist
+                --  (i.e. $DAML_HOME/sdk is polluted with non-dirs).
+                let versions = filter ("nightly-" `isPrefixOf`) subdirs
+                    -- TODO (FAFM): configurable channels
+                pure $ fmap (SdkVersion . pack) (maximumMay versions)
 
 -- | Calculate the environment for dispatched commands (i.e. the environment
 -- with updated DAML_HOME, DAML_PROJECT, DAML_SDK, etc).

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -240,7 +240,16 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             Tasty.assertEqual "sdk version" expected1 (unpack got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
-    -- TODO (FAFM): Add test cases for using latest available version.
+    , Tasty.testCase "getSdk: Returns Nothings if .daml/sdk is missing." $ do
+        withSystemTempDirectory "test-getSdk" $ \base -> do
+            let damlPath = DamlPath (base </> "daml")
+                projPath = Nothing
+            createDirectoryIfMissing True (base </> "daml")
+            (Nothing, Nothing) <- withEnv
+                [ (sdkVersionEnvVar, Nothing)
+                , (sdkPathEnvVar, Nothing)
+                ] (getSdk damlPath projPath)
+            pure ()
     ]
 
 


### PR DESCRIPTION
Fixes #287