### PR TITLE
Fix proto3-suite on Windows

### DIFF
--- a/nix/third-party/proto3-suite/BUILD.bazel
+++ b/nix/third-party/proto3-suite/BUILD.bazel
@@ -16,6 +16,8 @@ da_haskell_library(
     'bytestring',
     'containers',
     'deepseq',
+    'directory',
+    'filepath',
     'foldl',
     'haskell-src',
     'lens',

--- a/nix/third-party/proto3-suite/proto3-suite.cabal
+++ b/nix/third-party/proto3-suite/proto3-suite.cabal
@@ -51,6 +51,7 @@ library
                        transformers >=0.4 && <0.6,
                        turtle,
                        filepath,
+                       directory,
                        vector >=0.11 && < 0.13
 
   hs-source-dirs:      src
@@ -83,7 +84,6 @@ test-suite tests
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
                        turtle,
-                       filepath,
                        vector >=0.11 && < 0.13
 
 executable compile-proto-file
@@ -95,5 +95,4 @@ executable compile-proto-file
                        , proto3-suite
                        , system-filepath
                        , text
-                       , filepath
                        , turtle

--- a/nix/third-party/proto3-suite/proto3-suite.cabal
+++ b/nix/third-party/proto3-suite/proto3-suite.cabal
@@ -50,6 +50,7 @@ library
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
                        turtle,
+                       filepath,
                        vector >=0.11 && < 0.13
 
   hs-source-dirs:      src
@@ -82,6 +83,7 @@ test-suite tests
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
                        turtle,
+                       filepath,
                        vector >=0.11 && < 0.13
 
 executable compile-proto-file
@@ -93,4 +95,5 @@ executable compile-proto-file
                        , proto3-suite
                        , system-filepath
                        , text
+                       , filepath
                        , turtle

--- a/nix/third-party/proto3-suite/src/Proto3/Suite/DotProto/Internal.hs
+++ b/nix/third-party/proto3-suite/src/Proto3/Suite/DotProto/Internal.hs
@@ -13,6 +13,7 @@ import           Control.Lens.Cons         (_head)
 import           Data.Char                 (toUpper)
 import           Data.Maybe                (fromMaybe)
 import qualified Data.Text                 as T
+import           System.FilePath           (isPathSeparator)
 import qualified Filesystem.Path.CurrentOS as FP
 import           Filesystem.Path.CurrentOS ((</>))
 import qualified NeatInterpolation         as Neat
@@ -101,7 +102,7 @@ toModulePath fp0@(fromMaybe fp0 . FP.stripPrefix "./" -> fp)
                               -- want to ignore. E.g. ".foo.proto" => ["","Foo"].
              . fmap (T.unpack . over _head toUpper)
              . concatMap (T.splitOn ".")
-             . T.splitOn "/"
+             . T.split isPathSeparator
              . Turtle.format F.fp
              . FP.collapse
              . Turtle.dropExtension


### PR DESCRIPTION
On Windows proto3-suite turned Turtle FilePath's (which contain `\\` and normalises all `/` to `\\`) into `Path` via a `T.splitOn "/"`. That didn't work, and then meant that protobuf generated wrong files, which had the wrong case, and where imports didn't have the right dots in the right places. This code fixes up the code by using the trusty `filepath` library.

I did first try and use the Turtle FilePath library to undo the madness, but it lacks the necessary functionality.