### PR TITLE
Allow for record wildcards in key expression

### DIFF
--- a/daml-foundations/daml-ghc/tests/ContractKeys.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeys.daml
@@ -22,7 +22,7 @@ template Account with
     signatory [bank, accountHolder]
 
 instance TemplateKey Account (Party, Text, Int) where
-    key acc = (acc.bank, acc.accountNumber._1, acc.accountNumber._2)
+    key this@Account{..} = (bank, accountNumber._1, this.accountNumber._2)
     maintainer acc = [acc.bank]
 
 test = scenario do


### PR DESCRIPTION
Right now, instances of `TemplateKey` must define `key` to be something like
```
key this = ...
```
With this change, we can also write
```
key Foo{..} = ...
```
and even
```
key this@Foo{..} = ...
```

This is required for the desugaring of the surface syntax for contract keys.

### Pull Request Checklist

[ ] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
[ ] Include appropriate tests
[ ] Set a descriptive title and thorough description
[ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
[ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
