### PR TITLE
Do not divulge contracts to observers in nonconsuming exercises

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -679,27 +679,26 @@ data TemplateChoice = TemplateChoice
 data FeatureFlags = FeatureFlags
   { forbidPartyLiterals :: !Bool
   -- ^ If set to true, party literals are forbidden to appear in daml-lf packages.
+  {-
+  DAML-LF has these but our ecosystem does not support them anymore, see #157
   , dontDivulgeContractIdsInCreateArguments :: !Bool
   -- ^ If set to true, arguments to creates are not divulged. Instead target contract id's of
   -- exercises are divulged and fetch is checked for authorization.
   , dontDiscloseNonConsumingChoicesToObservers :: !Bool
   -- ^ If set to true, exercise nodes of non-consuming choices are only disclosed to the signatories
   -- and controllers of the target contract/choice and not to the observers of the target contract.
+  -}
   }
 
 defaultFeatureFlags :: FeatureFlags
 defaultFeatureFlags = FeatureFlags
   { forbidPartyLiterals = False
-  , dontDivulgeContractIdsInCreateArguments = False
-  , dontDiscloseNonConsumingChoicesToObservers = False
   }
 
 -- | Feature flags for DAML 1.2.
 daml12FeatureFlags :: FeatureFlags
 daml12FeatureFlags = FeatureFlags
   { forbidPartyLiterals = True
-  , dontDivulgeContractIdsInCreateArguments = True
-  , dontDiscloseNonConsumingChoicesToObservers = True
   }
 
 -- | A module.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -467,13 +467,9 @@ prettyTemplate modName (Template mbLoc tpl param precond signatories observers a
 prettyFeatureFlags :: FeatureFlags -> Doc ann
 prettyFeatureFlags
   FeatureFlags
-  { forbidPartyLiterals
-  , dontDivulgeContractIdsInCreateArguments
-  , dontDiscloseNonConsumingChoicesToObservers } =
+  { forbidPartyLiterals } =
   fcommasep $ catMaybes
     [ optionalFlag forbidPartyLiterals "+ForbidPartyLiterals"
-    , optionalFlag dontDivulgeContractIdsInCreateArguments "+DontDivulgeContractIdsInCreateArguments"
-    , optionalFlag dontDiscloseNonConsumingChoicesToObservers "+DontDiscloseNonConsumingChoicesToObservers"
     ]
   where
     optionalFlag flag name

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -54,12 +54,13 @@ decodeModule (LF1.Module name flags dataTypes values templates) =
     <*> decodeNM EDuplicateTemplate decodeDefTemplate templates
 
 decodeFeatureFlags :: LF1.FeatureFlags -> Decode FeatureFlags
-decodeFeatureFlags LF1.FeatureFlags{..} =  pure $
-  FeatureFlags
-    { forbidPartyLiterals = featureFlagsForbidPartyLiterals
-    , dontDivulgeContractIdsInCreateArguments = featureFlagsDontDivulgeContractIdsInCreateArguments
-    , dontDiscloseNonConsumingChoicesToObservers = featureFlagsDontDiscloseNonConsumingChoicesToObservers
-    }
+decodeFeatureFlags LF1.FeatureFlags{..} =
+  if not featureFlagsDontDivulgeContractIdsInCreateArguments || not featureFlagsDontDiscloseNonConsumingChoicesToObservers
+    -- We do not support these anymore -- see #157
+    then Left (ParseError "Package uses unsupported flags dontDivulgeContractIdsInCreateArguments or dontDiscloseNonConsumingChoicesToObservers")
+    else Right FeatureFlags
+      { forbidPartyLiterals = featureFlagsForbidPartyLiterals
+      }
 
 decodeDefDataType :: LF1.DefDataType -> Decode DefDataType
 decodeDefDataType LF1.DefDataType{..} =

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeVDev.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeVDev.hs
@@ -48,8 +48,6 @@ decodeFeatureFlags :: LF1.FeatureFlags -> Decode FeatureFlags
 decodeFeatureFlags LF1.FeatureFlags{..} =  pure $
   FeatureFlags
     { forbidPartyLiterals = featureFlagsForbidPartyLiterals
-    , dontDivulgeContractIdsInCreateArguments = featureFlagsDontDivulgeContractIdsInCreateArguments
-    , dontDiscloseNonConsumingChoicesToObservers = featureFlagsDontDiscloseNonConsumingChoicesToObservers
     }
 
 decodeDefDataType :: LF1.DefDataType -> Decode DefDataType

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -525,8 +525,9 @@ instance Encode TemplateChoice P.TemplateChoice where
 instance Encode FeatureFlags P.FeatureFlags where
   encode _version FeatureFlags{..} =  P.FeatureFlags
     { P.featureFlagsForbidPartyLiterals = forbidPartyLiterals
-    , P.featureFlagsDontDivulgeContractIdsInCreateArguments = dontDivulgeContractIdsInCreateArguments
-    , P.featureFlagsDontDiscloseNonConsumingChoicesToObservers = dontDiscloseNonConsumingChoicesToObservers
+    -- We only support packages with these enabled -- see #157
+    , P.featureFlagsDontDivulgeContractIdsInCreateArguments = True
+    , P.featureFlagsDontDiscloseNonConsumingChoicesToObservers = True
     }
 
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeVDev.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeVDev.hs
@@ -511,8 +511,6 @@ instance Encode TemplateChoice P.TemplateChoice where
 instance Encode FeatureFlags P.FeatureFlags where
   encode FeatureFlags{..} =  P.FeatureFlags
     { P.featureFlagsForbidPartyLiterals = forbidPartyLiterals
-    , P.featureFlagsDontDivulgeContractIdsInCreateArguments = dontDivulgeContractIdsInCreateArguments
-    , P.featureFlagsDontDiscloseNonConsumingChoicesToObservers = dontDiscloseNonConsumingChoicesToObservers
     }
 
 

--- a/daml-lf/archive/da/daml_lf_dev.proto
+++ b/daml-lf/archive/da/daml_lf_dev.proto
@@ -722,8 +722,6 @@ message DefValue {
 
 message FeatureFlags {
   bool forbidPartyLiterals = 1;
-  bool dontDivulgeContractIdsInCreateArguments = 2;
-  bool dontDiscloseNonConsumingChoicesToObservers = 3;
 }
 
 message Module {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -20,11 +20,10 @@ import scala.annotation.tailrec
 object Blinding {
 
   private[this] def maybeAuthorizeAndBlind(
-      ledgerFlags: LedgerFeatureFlags,
       tx: Transaction.Transaction,
       authorization: Authorization): Either[AuthorizationError, BlindingInfo] = {
     val enrichedTx =
-      enrichTransaction(authorization, ledgerFlags, tx)
+      enrichTransaction(authorization, tx)
     def authorizationErrors(failures: Map[Transaction.NodeId, FailedAuthorization]) = {
       failures
         .map {
@@ -78,16 +77,15 @@ object Blinding {
     *  @param initialAuthorizers set of parties claimed to be authorizers of the transaction
     */
   def checkAuthorizationAndBlind(
-      ledgerFlags: LedgerFeatureFlags,
       tx: Transaction.Transaction,
       initialAuthorizers: Set[Party]): Either[AuthorizationError, BlindingInfo] =
-    maybeAuthorizeAndBlind(ledgerFlags, tx, Authorize(initialAuthorizers))
+    maybeAuthorizeAndBlind(tx, Authorize(initialAuthorizers))
 
   /**
     * Like checkAuthorizationAndBlind, but does not authorize the transaction, just blinds it.
     */
-  def blind(ledgerFeatureFlags: LedgerFeatureFlags, tx: Transaction.Transaction): BlindingInfo =
-    maybeAuthorizeAndBlind(ledgerFeatureFlags, tx, DontAuthorize) match {
+  def blind(tx: Transaction.Transaction): BlindingInfo =
+    maybeAuthorizeAndBlind(tx, DontAuthorize) match {
       case Left(err) =>
         throw new RuntimeException(
           s"Impossible: got authorization exception even if we're not authorizing: $err")

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -14,7 +14,6 @@ import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.{Transaction => Tx}
 import com.digitalasset.daml.lf.types.Ledger
-import com.digitalasset.daml.lf.types.Ledger.LedgerFeatureFlags
 import com.digitalasset.daml.lf.value.Value._
 
 import scala.annotation.tailrec
@@ -216,10 +215,7 @@ final class Engine {
     for {
       recreatedTx <- incrementalRunInterpreter()
       authorizerSet = submitter.map(s => Set(s)).getOrElse(Set.empty[Party])
-      enrichment = Ledger.enrichTransaction(
-        Ledger.Authorize(authorizerSet),
-        compiledPackages.ledgerFlags,
-        recreatedTx)
+      enrichment = Ledger.enrichTransaction(Ledger.Authorize(authorizerSet), recreatedTx)
       comparableTx = recreatedTx.mapContractIdAndValue(contractIdMaping, valMapping)
       _ <- Result.assert(!enrichment.failedAuthorizations.exists(checkedFailures))(
         Error("Post-commit validation failure: unauthorized transaction"))
@@ -407,9 +403,6 @@ final class Engine {
       case Right(t) => ResultDone(t)
     }
   }
-
-  def ledgerFeatureFlags(): LedgerFeatureFlags =
-    compiledPackages.ledgerFlags
 
   def clearPackages(): Unit = compiledPackages.clear()
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -415,7 +415,7 @@ class EngineTest extends WordSpec with Matchers {
 
     "events are collected" in {
       val Right(blindingInfo) =
-        Blinding.checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(party))
+        Blinding.checkAuthorizationAndBlind(tx, Set(party))
       val events = Event.collectEvents(tx, blindingInfo.explicitDisclosure)
       val partyEvents = events.events.values.toList.filter(_.witnesses contains party)
       partyEvents.size shouldBe 1
@@ -601,7 +601,7 @@ class EngineTest extends WordSpec with Matchers {
 
     val Right(tx) = interpretResult
     val Right(blindingInfo) =
-      Blinding.checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(bob))
+      Blinding.checkAuthorizationAndBlind(tx, Set(bob))
 
     "reinterpret to the same result" in {
       val txRoots = tx.roots.map(id => tx.nodes.get(id).get).toSeq
@@ -752,7 +752,7 @@ class EngineTest extends WordSpec with Matchers {
     "events generated correctly" in {
       val Right(tx) = interpretResult
       val Right(blindingInfo) =
-        Blinding.checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(bob))
+        Blinding.checkAuthorizationAndBlind(tx, Set(bob))
       val events = Event.collectEvents(tx, blindingInfo.explicitDisclosure)
       val partyEvents = events.filter(_.witnesses contains bob)
       partyEvents.roots.length shouldBe 1

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -6,7 +6,6 @@ package com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.data.Ref.{DefinitionRef, PackageId}
 import com.digitalasset.daml.lf.lfpackage.Ast.Package
 import com.digitalasset.daml.lf.speedy.{Compiler, SExpr}
-import com.digitalasset.daml.lf.types.Ledger.LedgerFeatureFlags
 
 /** Trait to abstract over a collection holding onto DAML-LF package definitions + the
   * compiled speedy expressions.
@@ -14,49 +13,18 @@ import com.digitalasset.daml.lf.types.Ledger.LedgerFeatureFlags
 trait CompiledPackages {
   def getPackage(pkgId: PackageId): Option[Package]
   def getDefinition(dref: DefinitionRef[PackageId]): Option[SExpr]
-  def ledgerFlags(): LedgerFeatureFlags
 
   def packages: PartialFunction[PackageId, Package] = Function.unlift(this.getPackage)
   def definitions: PartialFunction[DefinitionRef[PackageId], SExpr] =
     Function.unlift(this.getDefinition)
 }
 
-object CompiledPackages {
-  def newLedgerFlags(
-      pkgId: PackageId,
-      pkg: Package,
-      mbPrevFlags: Option[LedgerFeatureFlags]): Either[String, LedgerFeatureFlags] = {
-    val flagsList = pkg.modules.values.toList
-      .map(_.featureFlags)
-      .map(LedgerFeatureFlags.projectToUniqueFlags)
-      .distinct
-    if (flagsList.size > 1) {
-      Left(s"Mixed feature flags in package $pkgId")
-    } else {
-      val newFlags = flagsList.headOption.getOrElse(LedgerFeatureFlags.default)
-      mbPrevFlags match {
-        case Some(prevFlags) if (prevFlags != newFlags) =>
-          Left(s"Mixed feature flags across imported packages when importing $pkgId.")
-        case _ =>
-          // NOTE(JM, #157): We disallow loading of packages with deprecated flag
-          // settings as these are no longer supported.
-          if (newFlags != LedgerFeatureFlags.default)
-            Left(s"Deprecated ledger feature flag settings in loaded packages: $newFlags")
-          else
-            Right(LedgerFeatureFlags.default)
-      }
-    }
-  }
-}
-
 final class PureCompiledPackages private (
     packages: Map[PackageId, Package],
-    defns: Map[DefinitionRef[PackageId], SExpr],
-    _ledgerFlags: LedgerFeatureFlags)
+    defns: Map[DefinitionRef[PackageId], SExpr])
     extends CompiledPackages {
   override def getPackage(pkgId: PackageId): Option[Package] = packages.get(pkgId)
   override def getDefinition(dref: DefinitionRef[PackageId]): Option[SExpr] = defns.get(dref)
-  override def ledgerFlags(): LedgerFeatureFlags = _ledgerFlags
 }
 
 object PureCompiledPackages {
@@ -67,15 +35,7 @@ object PureCompiledPackages {
   def apply(
       packages: Map[PackageId, Package],
       defns: Map[DefinitionRef[PackageId], SExpr]): Either[String, PureCompiledPackages] = {
-    var mbPrevFlags: Option[LedgerFeatureFlags] = None
-    for (pkg <- packages) {
-      CompiledPackages.newLedgerFlags(pkg._1, pkg._2, mbPrevFlags) match {
-        case Left(err) => return Left(err)
-        case Right(newFlags) => mbPrevFlags = Some(newFlags)
-      }
-    }
-    Right(
-      new PureCompiledPackages(packages, defns, mbPrevFlags.getOrElse(LedgerFeatureFlags.default)))
+    Right(new PureCompiledPackages(packages, defns))
   }
 
   def apply(packages: Map[PackageId, Package]): Either[String, PureCompiledPackages] = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -124,8 +124,14 @@ object Ledger {
         .distinct
       if (flags.size > 1)
         Left(s"Mixed occurence of ledger feature flags in loaded packages")
-      else
-        Right(flags.headOption.getOrElse(LedgerFeatureFlags.default))
+      else {
+        // NOTE(JM, #157): We disallow loading of packages with deprecated flag
+        // settings as these are no longer supported.
+        if (flags.headOption.fold(false)(_ != LedgerFeatureFlags.default))
+          Left(s"Deprecated ledger feature flag settings in loaded packages: ${flags.head}")
+        else
+          Right(LedgerFeatureFlags.default)
+      }
     }
   }
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
@@ -543,8 +543,11 @@ object Ast {
   object FeatureFlags {
     val default = FeatureFlags(
       forbidPartyLiterals = false,
-      dontDivulgeContractIdsInCreateArguments = false,
-      dontDiscloseNonConsumingChoicesToObservers = false)
+
+      // NOTE(JM, #157): These are the only allowed settings for
+      // these flags.
+      dontDivulgeContractIdsInCreateArguments = true,
+      dontDiscloseNonConsumingChoicesToObservers = true)
   }
 
   //

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
@@ -529,7 +529,9 @@ object Ast {
   )
 
   case class FeatureFlags(
-      forbidPartyLiterals: Boolean, // If set to true, party literals are not allowed to appear in daml-lf packages.
+      forbidPartyLiterals: Boolean // If set to true, party literals are not allowed to appear in daml-lf packages.
+      /*
+      These flags are present in DAML-LF, but our ecosystem does not support them anymore:
       dontDivulgeContractIdsInCreateArguments: Boolean, // If set to true, arguments to creates are not divulged.
       // Instead target contract id's of exercises are divulged
       // and fetches are authorized.
@@ -538,16 +540,13 @@ object Ast {
       // disclosed to the signatories and
       // controllers of the target contract/choice
       // and not to the observers of the target contract.
+   */
   )
 
   object FeatureFlags {
     val default = FeatureFlags(
       forbidPartyLiterals = false,
-
-      // NOTE(JM, #157): These are the only allowed settings for
-      // these flags.
-      dontDivulgeContractIdsInCreateArguments = true,
-      dontDiscloseNonConsumingChoicesToObservers = true)
+    )
   }
 
   //

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -78,13 +78,16 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
 
     // -----------------------------------------------------------------------
 
-    private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags =
+    private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags = {
+      if (!flags.getDontDivulgeContractIdsInCreateArguments || !flags.getDontDiscloseNonConsumingChoicesToObservers) {
+        throw new ParseError("Deprecated feature flag settings detected, refusing to parse package")
+      }
       FeatureFlags(
         forbidPartyLiterals = flags.getForbidPartyLiterals,
-        dontDivulgeContractIdsInCreateArguments = flags.getDontDivulgeContractIdsInCreateArguments,
-        dontDiscloseNonConsumingChoicesToObservers =
-          flags.getDontDiscloseNonConsumingChoicesToObservers
+        dontDivulgeContractIdsInCreateArguments = true,
+        dontDiscloseNonConsumingChoicesToObservers = true,
       )
+    }
 
     private[this] def decodeDefDataType(lfDataType: PLF.DefDataType): DDataType = {
       DDataType(

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -79,13 +79,13 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
     // -----------------------------------------------------------------------
 
     private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags = {
+      // NOTE(JM, #157): We disallow loading packages with these flags because they impact the Ledger API in
+      // ways that would currently make it quite complicated to support them.
       if (!flags.getDontDivulgeContractIdsInCreateArguments || !flags.getDontDiscloseNonConsumingChoicesToObservers) {
         throw new ParseError("Deprecated feature flag settings detected, refusing to parse package")
       }
       FeatureFlags(
         forbidPartyLiterals = flags.getForbidPartyLiterals,
-        dontDivulgeContractIdsInCreateArguments = true,
-        dontDiscloseNonConsumingChoicesToObservers = true,
       )
     }
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeVDev.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeVDev.scala
@@ -71,13 +71,8 @@ private[lf] object DecodeVDev extends Decode.OfPackage[PLF.Package] {
     // -----------------------------------------------------------------------
 
     private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags = {
-      if (!flags.getDontDivulgeContractIdsInCreateArguments || !flags.getDontDiscloseNonConsumingChoicesToObservers) {
-        throw new ParseError("Deprecated feature flag settings detected, refusing to parse package")
-      }
       FeatureFlags(
         forbidPartyLiterals = flags.getForbidPartyLiterals,
-        dontDivulgeContractIdsInCreateArguments = true,
-        dontDiscloseNonConsumingChoicesToObservers = true
       )
     }
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeVDev.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeVDev.scala
@@ -70,13 +70,16 @@ private[lf] object DecodeVDev extends Decode.OfPackage[PLF.Package] {
 
     // -----------------------------------------------------------------------
 
-    private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags =
+    private[this] def decodeFeatureFlags(flags: PLF.FeatureFlags): FeatureFlags = {
+      if (!flags.getDontDivulgeContractIdsInCreateArguments || !flags.getDontDiscloseNonConsumingChoicesToObservers) {
+        throw new ParseError("Deprecated feature flag settings detected, refusing to parse package")
+      }
       FeatureFlags(
         forbidPartyLiterals = flags.getForbidPartyLiterals,
-        dontDivulgeContractIdsInCreateArguments = flags.getDontDivulgeContractIdsInCreateArguments,
-        dontDiscloseNonConsumingChoicesToObservers =
-          flags.getDontDiscloseNonConsumingChoicesToObservers
+        dontDivulgeContractIdsInCreateArguments = true,
+        dontDiscloseNonConsumingChoicesToObservers = true
       )
+    }
 
     private[this] def decodeDefDataType(lfDataType: PLF.DefDataType): DDataType = {
       DDataType(

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -36,9 +36,7 @@ private[parser] object ModParser {
       case _ ~ modTag ~ modName ~ _ ~ defs =>
         val (definitions, templates) = split(defs)
         val flags = FeatureFlags(
-          forbidPartyLiterals = modTag(noPartyLitsTag),
-          dontDivulgeContractIdsInCreateArguments = false,
-          dontDiscloseNonConsumingChoicesToObservers = false
+          forbidPartyLiterals = modTag(noPartyLitsTag)
         )
         Module(modName, definitions, templates, defaultLanguageVersion, flags)
     }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -97,7 +97,6 @@ final case class ScenarioRunner(machine: Speedy.Machine) {
           committer = committer,
           effectiveAt = ledger.currentTime,
           optLocation = machine.commitLocation,
-          flags = machine.compiledPackages.ledgerFlags,
           tr = tx,
           l = ledger)
         .isRight) {
@@ -111,7 +110,6 @@ final case class ScenarioRunner(machine: Speedy.Machine) {
       committer = committer,
       effectiveAt = ledger.currentTime,
       optLocation = machine.commitLocation,
-      flags = machine.compiledPackages.ledgerFlags,
       tr = tx,
       l = ledger
     ) match {

--- a/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
+++ b/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
@@ -418,7 +418,7 @@ object SemanticTester {
       val tx = consumeResult(cmds.commandsReference, engine.submit(cmds))
       val blindingInfo =
         Blinding
-          .checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(submitterName))
+          .checkAuthorizationAndBlind(tx, Set(submitterName))
           .toOption
           .getOrElse(sys.error(s"authorization failed for ${cmds.commandsReference}"))
       val absTx = tx.mapContractIdAndValue(makeAbsoluteContractId, makeValueWithAbsoluteContractId)

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -14,6 +14,7 @@ This page contains release notes for the SDK.
   to ``java.lang.String`` instances.
 - Java Codegen: Leaner log output and flag for log verbosity ``-V LEVEL`` or ``--verbosity LEVEL``, where ``LEVEL`` is a number between ``0`` (least verbose) and ``4`` (most verbose).
   to ``java.lang.String`` instances.
+- Removed support for DAML 1.0 packages in the engine, and thus the sandbox. Note that the SDK has removed support for _compiling_ DAML 1.0 months ago.
 
 0.12.0
 ------

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
@@ -87,7 +87,11 @@ object TransactionFiltration {
     private def explicitWitnessesForNode(node: GenNode[_, _, _]): Set[LfParty] = node match {
       case n: Node.NodeCreate[_, _] => n.signatories union n.stakeholders
       case n: Node.NodeFetch[_] => n.signatories union n.stakeholders
-      case n: Node.NodeExercises[_, _, _] => n.signatories union n.stakeholders
+      case n: Node.NodeExercises[_, _, _] =>
+        if (n.consuming)
+          n.signatories union n.stakeholders
+        else
+          n.signatories
       case _: Node.NodeLookupByKey[_, _] => Set.empty
     }
   }

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -27,11 +27,6 @@ class SandboxSemanticTestsLfRunner
 
   private val darFile = new File("ledger/ledger-api-integration-tests/SemanticTests.dalf")
 
-  // a blacklist of tests that are currently failing
-  val knownFailures = Set(
-    "Test:test_divulgence_of_token" // FIXME https://github.com/digital-asset/daml/issues/157
-  )
-
   override protected lazy val config: Config = Config.default
     .withDarFile(darFile.toPath)
     .withTimeProvider(TimeProviderType.StaticAllowBackwards)
@@ -43,7 +38,6 @@ class SandboxSemanticTestsLfRunner
     for {
       (pkgId, names) <- SemanticTester.scenarios(packages)
       name <- names
-      if !knownFailures.contains(name.toString)
     } {
       s"run scenario: $name" in allFixtures { ledger =>
         for {

--- a/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Validation.scala
+++ b/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Validation.scala
@@ -67,10 +67,7 @@ object Validation {
       result <- stepResult(
         engine.validate(tx, Timestamp.assertFromInstant(submission.ledgerEffectiveTime)))
       // check transaction is well-authorized
-      blinding <- Blinding.checkAuthorizationAndBlind(
-        engine.ledgerFeatureFlags(),
-        tx,
-        Set(submitter))
+      blinding <- Blinding.checkAuthorizationAndBlind(tx, Set(submitter))
     } yield (blinding, result)
 
     result match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutorImpl.scala
@@ -33,10 +33,7 @@ class CommandExecutorImpl(engine: Engine, packageContainer: DamlPackageContainer
         Left(ErrorCause.DamlLf(err))
       case Right(updateTx) =>
         Blinding
-          .checkAuthorizationAndBlind(
-            engine.ledgerFeatureFlags(),
-            updateTx,
-            Set(Ref.Party.assertFromString(submitter.unwrap)))
+          .checkAuthorizationAndBlind(updateTx, Set(Ref.Party.assertFromString(submitter.unwrap)))
           .fold(
             e => Left(ErrorCause.DamlLf(e)),
             blindingInfo =>

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
@@ -122,7 +122,7 @@ class EventConverterSpec
                 5.seconds
               )
               blinding <- Blinding
-                .checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(commands.party))
+                .checkAuthorizationAndBlind(tx, Set(commands.party))
             } yield {
               val txId = "testTx"
               val absCoid: Lf.ContractId => Lf.AbsoluteContractId =
@@ -161,7 +161,7 @@ class EventConverterSpec
               5.seconds
             )
             blinding <- Blinding
-              .checkAuthorizationAndBlind(engine.ledgerFeatureFlags(), tx, Set(commands.party))
+              .checkAuthorizationAndBlind(tx, Set(commands.party))
           } yield {
             val txId = "testTx"
             val absCoid: Lf.ContractId => Lf.AbsoluteContractId =
@@ -251,7 +251,7 @@ class EventConverterSpec
           Lf.VersionedValue[Lf.AbsoluteContractId]]] =
         Seq(nod0, node1).toMap
       val tx: LfTx = GenTransaction(nodes, ImmArray(Transaction.NodeId.unsafeFromIndex(0)))
-      val blinding = Blinding.blind(engine.ledgerFeatureFlags(), tx)
+      val blinding = Blinding.blind(tx)
       val absCoid: Lf.ContractId => Lf.AbsoluteContractId =
         SandboxEventIdFormatter.makeAbsCoid("transactionId")
       val recordTx = tx


### PR DESCRIPTION
Disables support for non-default ledger feature flags, as they
are meaningless since ledger server logic does not respect the flags.
Instead of large refactoring to add support for the old flag settings,
it is best to disallow the deprecated flags, and later on phase out the
flags completely.

Re-enables test_divulgence_of_token in sandbox semantic tests.

Fixes #157.

### Pull Request Checklist

[x] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
[x] Include appropriate tests
[x] Set a descriptive title and thorough description
[x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
[x] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
