### PR TITLE
Update wget dadew manifest

### DIFF
--- a/dev-env/windows/manifests/wget-1.19.4.json
+++ b/dev-env/windows/manifests/wget-1.19.4.json
@@ -5,7 +5,7 @@
   "architecture": {
     "64bit": {
       "url": [
-        "https://eternallybored.org/misc/wget/releases/wget-1.19.4-win64.zip"
+        "https://eternallybored.org/misc/wget/releases/old/wget-1.19.4-win64.zip"
       ],
       "hash": [
         "3e370410a7818076a5ee30867a9966098dee5de2a94793e574d2531a6c95f5b9"
@@ -13,7 +13,7 @@
     },
     "32bit": {
       "url": [
-        "https://eternallybored.org/misc/wget/releases/wget-1.19.4-win32.zip"
+        "https://eternallybored.org/misc/wget/releases/old/wget-1.19.4-win32.zip"
       ],
       "hash": [
         "b1a7e4ba4ab7f78e588c1186f2a5d7e1726628a5a66c645e41f8105b7cf5f61c"


### PR DESCRIPTION
The upstream URL has changed and the previous URL is no longer available, causing `dadew.ps1 sync` to fail.

### Pull Request Checklist

[x] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
[ ] Include appropriate tests
[x] Set a descriptive title and thorough description
[ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
[ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
