### PR TITLE
build with full history

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -1,6 +1,5 @@
 steps:
   - checkout: self
-    fetchDepth: 2 # speed up checkout from 30sec to 7sec
 
   - bash: ci/dev-env-install.sh
     displayName: 'Build/Install the Developer Environment'

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -1,6 +1,5 @@
 steps:
   - checkout: self
-    fetchDepth: 1 # speed up checkout from 30sec to 7sec
   - powershell: '.\dev-env\windows\dadew-installer.ps1'
     displayName: 'Install dev-env'
     #- script: ./ci/configure-bazel.ps1


### PR DESCRIPTION
[3h]
Gary Verhaegen   It looks like we're only fetching two commits of hisotry when cloning the repo, so building older commits fails
[3h]
Gary Verhaegen   (because we're merging stuff too fast for Azure to catch up)
[2h]
Brian Healey   hmm okay so maybe this was because of the 4 merges in quick succession
[2h]
Brian Healey   slow pipeline leads to many batched merges
[2h]
Gary Verhaegen   Yes. Also consistent with the first failure in that series being "I can't find my parent commit" and then the next ones being "I can't find myself"
[2h]
Gary Verhaegen   I'm struggling a bit to find the parameter to change that though :confused:
[2h]
Gary Verhaegen   https://github.com/digital-asset/daml/pull/333 (edited)
[2h]
Moritz Kiefer   `fetchDepth` in `build-unix.yml`
[1h]
Brian Healey   @gary.verhaegen can we do interim of 5 or so rather than full history?
[1h]
Moritz Kiefer   I don’t think it matters. That’s not the bottleneck in our builds
[1h]
Brian Healey   sure, what is 20s if the build is taking 35min :slightly_smiling_face:
[1h]
Gary Verhaegen   The 30s comment dates back to the old repo
[1h]
Gary Verhaegen   when we had 40k commits of history
[1h]
Gary Verhaegen   We have 112 now