### PR TITLE
Inline all aliasing let bindings generated during conversion to DAML-LF

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -781,13 +781,10 @@ convertExpr env0 e = do
         fmap (, args) $ convertLet env name x (\env -> convertExpr env y)
     go env (Case scrutinee bind _ [(DEFAULT, [], x)]) args =
         go env (Let (NonRec bind scrutinee) x) args
-    go env (Case scrutinee bind t [(DataAlt con, [v], x)]) args | is con == "I#" = fmap (, args) $ do
-        -- we pretend Int and Int# are the same, so a case statement becomes a Let
-        scrutinee' <- convertExpr env scrutinee
-        x' <- convertExpr env x
-        pure $
-            ELet (Binding (convVar bind, TInt64) scrutinee') $
-            ELet (Binding (convVar v, TInt64) (EVar (convVar bind))) x'
+    go env (Case scrutinee bind t [(DataAlt con, [v], x)]) args | is con == "I#" = do
+        -- We pretend Int and Int# are the same, so a case-expression becomes a let-expression.
+        let letExpr = Let (NonRec bind scrutinee) $ Let (NonRec v (Var bind)) x
+        go env letExpr args
     -- NOTE(MH): This is DICTIONARY SANITIZATION step (2).
     go env (Case scrutinee bind _ [(DataAlt con, vs, Var x)]) args
         | tyConFlavour (dataConTyCon con) == ClassFlavour
@@ -799,7 +796,6 @@ convertExpr env0 e = do
             recTyp <- convertType env (varType bind)
             pure $ ERecProj (fromTCon recTyp) fldName scrutinee' `ETmApp` EUnit
     go env o@(Case scrutinee bind _ [alt@(DataAlt con, vs, x)]) args = fmap (, args) $ do
-        scrutinee' <- convertExpr env scrutinee
         convertType env (varType bind) >>= \case
           TText -> asLet
           TDecimal -> asLet
@@ -809,31 +805,24 @@ convertExpr env0 e = do
           TContractId{} -> asLet
           TUpdate{} -> asLet
           TScenario{} -> asLet
-          tcon0 -> do
-              ctor <- toCtor env con
+          tcon -> do
+              ctor@(Ctor _ fldNames fldTys) <- toCtor env con
               if not (isRecordCtor ctor)
-                then do
+                then convertLet env bind scrutinee $  \env -> do
+                  bind' <- convertExpr env (Var bind)
                   ty <- convertType env $ varType bind
                   alt' <- convertAlt env ty alt
-                  bind' <- convVarWithType env bind
-                  pure $
-                    ELet (Binding bind' scrutinee') $
-                    ECase (EVar $ convVar bind) [alt']
-                else mkProj ctor tcon0 scrutinee'
+                  pure $ ECase bind' [alt']
+                -- NOTE(MH): The 'zipExact' below fails for pattern matches on constructors with existentials.
+                else case zipExactMay vs (zipExact fldNames fldTys) of
+                    Nothing -> unsupported "Pattern match with existential type" alt
+                    Just vsFlds -> convertLet env bind scrutinee $ \env -> do
+                        bindRef <- convertExpr env (Var bind)
+                        x' <- convertExpr env x
+                        projBinds <- mkProjBindings env bindRef (fromTCon tcon) vsFlds x'
+                        pure projBinds
       where
-        asLet = do
-            scrutinee' <- convertExpr env scrutinee
-            x' <- convertExpr env x
-            bind' <- convVarWithType env bind
-            pure $ ELet (Binding bind' scrutinee') x'
-        -- NOTE(MH): The 'zipExact' below fails for pattern matches on constructors with existentials.
-        mkProj (Ctor _ fldNames fldTys) tcon bound = case zipExactMay vs (zipExact fldNames fldTys) of
-          Nothing -> unsupported "Pattern match with existential type" alt
-          Just vsFlds -> do
-              x' <- convertExpr env x
-              projBinds <- mkProjBindings env (convVar bind) (fromTCon tcon) vsFlds x'
-              pure $
-                ELet (Binding (convVar bind, tcon) bound) projBinds
+        asLet = convertLet env bind scrutinee $ \env -> convertExpr env x
     go env (Case scrutinee bind typ []) args = fmap (, args) $ do
         -- GHC only generates empty case alternatives if it is sure the scrutinee will fail, LF doesn't support empty alternatives
         scrutinee' <- convertExpr env scrutinee
@@ -916,7 +905,7 @@ convertAlt env (TConApp tcon targs) alt@(DataAlt con, vs, x) = do
             let patBinder = vArg
             in  do
               x' <- convertExpr env x
-              projBinds <- mkProjBindings env vArg (TypeConApp (synthesizeVariantRecord variantName <$> tcon) targs) vsFlds x'
+              projBinds <- mkProjBindings env (EVar vArg) (TypeConApp (synthesizeVariantRecord variantName <$> tcon) targs) vsFlds x'
               pure $ CaseAlternative CPVariant{..} projBinds
     where
         -- TODO(MH): We need to generate fresh names.
@@ -924,10 +913,10 @@ convertAlt env (TConApp tcon targs) alt@(DataAlt con, vs, x) = do
         patTypeCon = tcon
 convertAlt _ _ x = unsupported "Case alternative of this form" x
 
-mkProjBindings :: Env -> ExprVarName -> TypeConApp -> [(Var, (FieldName, LF.Type))] -> LF.Expr -> ConvertM LF.Expr
-mkProjBindings env recVar recTyp vsFlds e =
+mkProjBindings :: Env -> LF.Expr -> TypeConApp -> [(Var, (FieldName, LF.Type))] -> LF.Expr -> ConvertM LF.Expr
+mkProjBindings env recExpr recTyp vsFlds e =
   fmap (\bindings -> mkELets bindings e) $ sequence
-    [ Binding <$> convVarWithType env v <*> pure (ERecProj recTyp fld (EVar recVar))
+    [ Binding <$> convVarWithType env v <*> pure (ERecProj recTyp fld recExpr)
     | (v, (fld, _typ)) <- vsFlds
     , not (isDeadOcc (occInfo (idInfo v)))
     ]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -808,12 +808,11 @@ convertExpr env0 e = do
           tcon -> do
               ctor@(Ctor _ fldNames fldTys) <- toCtor env con
               if not (isRecordCtor ctor)
-                then convertLet env bind scrutinee $  \env -> do
+                then convertLet env bind scrutinee $ \env -> do
                   bind' <- convertExpr env (Var bind)
                   ty <- convertType env $ varType bind
                   alt' <- convertAlt env ty alt
                   pure $ ECase bind' [alt']
-                -- NOTE(MH): The 'zipExact' below fails for pattern matches on constructors with existentials.
                 else case zipExactMay vs (zipExact fldNames fldTys) of
                     Nothing -> unsupported "Pattern match with existential type" alt
                     Just vsFlds -> convertLet env bind scrutinee $ \env -> do

--- a/daml-foundations/daml-ghc/tests/ContractKeys.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeys.daml
@@ -23,7 +23,8 @@ template Account with
 
 instance TemplateKey Account (Party, Text, Int) where
     key this@Account{..} = (bank, accountNumber._1, this.accountNumber._2)
-    maintainer acc = [acc.bank]
+    -- NOTE(MH): Thus duplication is intended to test both `this.bank` and `bank`.
+    maintainer this@Account{..} = [this.bank, bank]
 
 test = scenario do
     bank <- getParty "Bank"


### PR DESCRIPTION
Inlining the aliases generated for record wildcards is a prerequisite for
the maintainer clauses of our contract keys syntax to work.

Inlining all other aliases doesn't seem to be a bad idea as well.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
