### PR TITLE
Amend the Node.js bindings Ledger API values representation

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -6,6 +6,9 @@ Release notes
 
 This page contains release notes for the SDK.
 
+- Node.js Bindings: fixed validation for Ledger API timestamp values
+- Node.js Bindings: drops support for identifier names, replacing them with separated module and entity names
+- Node.js Bindings: use strings instead of numbers to represent Ledger API timestamps and dates
 - Node.js Bindings: use strings instead of numbers to represent Protobuf 64-bit precision integers to avoid a loss of precision
 - Java Code Generator: Supports DAML TextMap primitive which is mapped to ``java.util.Map`` type with keys restricted
   to ``java.lang.String`` instances.

--- a/language-support/js/daml-ledger/src/mapping/identifier.ts
+++ b/language-support/js/daml-ledger/src/mapping/identifier.ts
@@ -9,13 +9,15 @@ export const Identifier: mapping.Mapping<grpc.Identifier, ledger.Identifier> = {
     toObject(identifier: grpc.Identifier): ledger.Identifier {
         return {
             packageId: identifier.getPackageId(),
-            name: identifier.getName()
+            moduleName: identifier.getModuleName(),
+            entityName: identifier.getEntityName()
         };
     },
     toMessage(identifier: ledger.Identifier): grpc.Identifier {
         const value = new grpc.Identifier();
         value.setPackageId(identifier.packageId);
-        value.setName(identifier.name);
+        value.setModuleName(identifier.moduleName);
+        value.setEntityName(identifier.entityName);
         return value;
     }
 };

--- a/language-support/js/daml-ledger/src/mapping/value.ts
+++ b/language-support/js/daml-ledger/src/mapping/value.ts
@@ -15,7 +15,7 @@ export const Value: mapping.Mapping<grpc.Value, ledger.Value> = {
         } else if (value.hasContractId()) {
             return { contractId: value.getContractId() }
         } else if (value.hasDate()) {
-            return { date: value.getDate() }
+            return { date: '' + value.getDate() }
         } else if (value.hasDecimal()) {
             return { decimal: value.getDecimal() }
         } else if (value.hasInt64()) {
@@ -61,7 +61,7 @@ export const Value: mapping.Mapping<grpc.Value, ledger.Value> = {
         } else if (value.contractId !== undefined) {
             result.setContractId(value.contractId);
         } else if (value.date !== undefined) {
-            result.setDate(value.date);
+            result.setDate(parseInt(value.date));
         } else if (value.decimal !== undefined) {
             result.setDecimal(value.decimal);
         } else if (value.int64 !== undefined) {

--- a/language-support/js/daml-ledger/src/model/identifier.ts
+++ b/language-support/js/daml-ledger/src/model/identifier.ts
@@ -13,9 +13,15 @@ export interface Identifier {
      */
     packageId: string
     /**
-     * @member {string} name
+     * @member {string} moduleName
      * @memberof ledger.Identifier
      * @instance
      */
-    name: string
+    moduleName: string
+    /**
+     * @member {string} entityName
+     * @memberof ledger.Identifier
+     * @instance
+     */
+    entityName: string
 }

--- a/language-support/js/daml-ledger/src/model/value.ts
+++ b/language-support/js/daml-ledger/src/model/value.ts
@@ -43,6 +43,8 @@ export interface Value {
      * @member {string} decimal
      * @memberof ledger.Value
      * @instance
+     *
+     * Represented as a {string} to avoid losing precision
      */
     decimal?: string
     /**
@@ -52,11 +54,13 @@ export interface Value {
      */
     text?: string
     /**
-     * @member {number} timestamp
+     * @member {string} timestamp
      * @memberof ledger.Value
      * @instance
+     *
+     * Represented as a {string} to avoid losing precision
      */
-    timestamp?: number
+    timestamp?: string
     /**
      * @member {string} party
      * @memberof ledger.Value
@@ -76,11 +80,17 @@ export interface Value {
      */
     unit?: ledger.Empty
     /**
-     * @member {number} date
+     * @member {string} date
      * @memberof ledger.Value
      * @instance
+     *
+     * Represented as a {string} for consistency with
+     * other numeric types in this union. This also
+     * allows the type to remain stable in the face
+     * of prospective expansions of the underlying
+     * type to a 64-bit encoding.
      */
-    date?: number
+    date?: string
     /**
      * @member {ledger.Optional} optional
      * @memberof ledger.Value

--- a/language-support/js/daml-ledger/src/validation/identifier.ts
+++ b/language-support/js/daml-ledger/src/validation/identifier.ts
@@ -7,8 +7,9 @@ import { RequiredValidation } from "./base/typelevel";
 
 function required(): RequiredValidation<ledger.Identifier> {
     return {
-        name: native('string'),
         packageId: native('string'),
+        moduleName: native('string'),
+        entityName: native('string')
     };
 }
 

--- a/language-support/js/daml-ledger/src/validation/value.ts
+++ b/language-support/js/daml-ledger/src/validation/value.ts
@@ -13,14 +13,14 @@ function values(): Record<keyof ledger.Value, Validation> {
     return {
         bool: native('boolean'),
         contractId: native('string'),
-        date: native('number'),
+        date: native('string'),
         decimal: native('string'),
         int64: native('string'),
         list: array(Value),
         party: native('string'),
         record: Record,
         text: native('string'),
-        timestamp: Timestamp,
+        timestamp: native('string'),
         unit: Empty,
         variant: Variant,
         optional: Optional

--- a/language-support/js/daml-ledger/tests/active_contracts_client.spec.ts
+++ b/language-support/js/daml-ledger/tests/active_contracts_client.spec.ts
@@ -32,7 +32,7 @@ describe("ActiveContractClient", () => {
             verbose: false,
             filter: {
                 filtersByParty: {
-                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', name: 'tid1' }] } }
+                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', moduleName: 'mod1', entityName: 'ent1' }] } }
                 }
             }
         };
@@ -59,7 +59,7 @@ describe("ActiveContractClient", () => {
         const request = {
             filter: {
                 filtersByParty: {
-                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', name: 'tid1' }] } }
+                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', moduleName: 'mod1', entityName: 'ent1' }] } }
                 }
             }
         };
@@ -88,7 +88,7 @@ describe("ActiveContractClient", () => {
             verbose: true,
             filter: {
                 filtersByParty: {
-                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', name: 'tid1' }] } }
+                    alice: { inclusive: { templateIds: [{ packageId: 'packageId', moduleName: 'mod1', entityName: 'ent1' }] } }
                 }
             }
         };

--- a/language-support/js/daml-ledger/tests/arbitrary/identifier.ts
+++ b/language-support/js/daml-ledger/tests/arbitrary/identifier.ts
@@ -5,14 +5,15 @@ import * as jsc from 'jsverify';
 import * as ledger from '../../src';
 
 export const Identifier: jsc.Arbitrary<ledger.Identifier> =
-    jsc.pair(jsc.string, jsc.string).smap<ledger.Identifier>(
-        ([name, packageId]) => {
+    jsc.tuple([jsc.string, jsc.string, jsc.string]).smap<ledger.Identifier>(
+        ([packageId, moduleName, entityName]) => {
             return {
-                name: name,
-                packageId: packageId
+                packageId: packageId,
+                moduleName: moduleName,
+                entityName: entityName
             }
         },
         (identifier) => {
-            return [identifier.name, identifier.packageId]
+            return [identifier.packageId, identifier.moduleName, identifier.entityName]
         }
     );

--- a/language-support/js/daml-ledger/tests/arbitrary/record_value_variant.ts
+++ b/language-support/js/daml-ledger/tests/arbitrary/record_value_variant.ts
@@ -22,7 +22,7 @@ const ContractIdValue: jsc.Arbitrary<ledger.Value> =
         value => value.contractId
     );
 const DateValue: jsc.Arbitrary<ledger.Value> =
-    jsc.number.smap<{ date: number }>(
+    jsc.string.smap<{ date: string }>(
         number => ({ date: number }),
         value => value.date
     );
@@ -45,6 +45,11 @@ const TextValue: jsc.Arbitrary<ledger.Value> =
     jsc.string.smap<{ text: string }>(
         string => ({ text: string }),
         value => value.text
+    );
+const TimestampValue: jsc.Arbitrary<ledger.Value> =
+    jsc.string.smap<{ timestamp: string }>(
+        string => ({ timestamp: string }),
+        value => value.timestamp
     );
 const UnitValue: jsc.Arbitrary<ledger.Value> =
     Empty.smap<{ unit: ledger.Empty }>(
@@ -90,6 +95,7 @@ const { Record: record, Value: value, Variant: variant }: { [key: string]: jsc.A
             PartyValue,
             tie('RecordValue'),
             TextValue,
+            TimestampValue,
             UnitValue,
             tie('VariantValue')
         ]),

--- a/language-support/js/daml-ledger/tests/client_readable_object_stream.spec.ts
+++ b/language-support/js/daml-ledger/tests/client_readable_object_stream.spec.ts
@@ -29,10 +29,12 @@ describe("ClientReadableObjectStream", () => {
     it("should read the expected items out of the wrapped stream", (done) => {
 
         const id1 = new grpc.Identifier();
-        id1.setName('firstName');
+        id1.setModuleName('firstModuleName');
+        id1.setEntityName('firstEntityName');
         id1.setPackageId('firstPackageId');
         const id2 = new grpc.Identifier();
-        id2.setName('secondName');
+        id2.setModuleName('secondModuleName');
+        id2.setEntityName('secondEntityName');
         id2.setPackageId('secondPackageId');
 
         const fixture = [id1, id2];
@@ -42,7 +44,8 @@ describe("ClientReadableObjectStream", () => {
 
         let counter = 0;
         wrapper.on('data', (id) => {
-            expect(id).to.haveOwnProperty('name');
+            expect(id).to.haveOwnProperty('moduleName');
+            expect(id).to.haveOwnProperty('entityName');
             expect(id).to.haveOwnProperty('packageId');
             expect(id).to.deep.equal(mapping.Identifier.toObject(fixture[counter]));
             counter = counter + 1;

--- a/language-support/js/daml-ledger/tests/command_client.spec.ts
+++ b/language-support/js/daml-ledger/tests/command_client.spec.ts
@@ -40,9 +40,9 @@ describe("CommandClient", () => {
             list: [
                 {
                     create: {
-                        templateId: { packageId: 'tmplt', name: 'cpluspls' },
+                        templateId: { packageId: 'tmplt', moduleName: 'cpluspls', entityName: 'ent' },
                         arguments: {
-                            recordId: { packageId: 'pkg', name: 'fernando' },
+                            recordId: { packageId: 'pkg', moduleName: 'fernando', entityName: 'ent' },
                             fields: {
                                 someValue: { bool: true }
                             }

--- a/language-support/js/daml-ledger/tests/command_submission_client.spec.ts
+++ b/language-support/js/daml-ledger/tests/command_submission_client.spec.ts
@@ -29,9 +29,9 @@ describe('CommandSubmissionClient', () => {
             list: [
                 {
                     create: {
-                        templateId: { packageId: 'fgdfg', name: 'dwgwdfg' },
+                        templateId: { packageId: 'fgdfg', moduleName: 'dwgwdfg', entityName: 'alkhksjhd' },
                         arguments: {
-                            recordId: { name: '314tgg5', packageId: 'g3g42' },
+                            recordId: { packageId: 'g3g42', moduleName: '314tgg5', entityName: '235lkj23' },
                             fields: {
                                 contract: { contractId: 'sdg4tr34' },
                                 someFlag: { bool: true }
@@ -45,7 +45,7 @@ describe('CommandSubmissionClient', () => {
                             decimal: '999'
                         },
                         contractId: 'f4f34f34f',
-                        templateId: { packageId: 'f1234f34f', name: '341f43f3' }
+                        templateId: { packageId: 'f1234f34f', moduleName: '341f43f3', entityName: '239874hb' }
                     }
                 }
             ]

--- a/language-support/js/daml-ledger/tests/mapping/mapping.spec.ts
+++ b/language-support/js/daml-ledger/tests/mapping/mapping.spec.ts
@@ -15,11 +15,13 @@ import { Any } from 'google-protobuf/google/protobuf/any_pb';
 describe("Mapping", () => {
 
     const packageId = 'packageId';
-    const templateName = 'templateName';
+    const moduleName = 'moduleName';
+    const entityName = 'entityName';
 
     const identifierObject: ledger.Identifier = {
         packageId: packageId,
-        name: templateName
+        moduleName: moduleName,
+        entityName: entityName,
     }
 
     const inclusiveFiltersObject: ledger.InclusiveFilters = {
@@ -39,7 +41,8 @@ describe("Mapping", () => {
 
     const identifierMessage = new grpc.Identifier();
     identifierMessage.setPackageId(packageId);
-    identifierMessage.setName(templateName);
+    identifierMessage.setModuleName(moduleName);
+    identifierMessage.setEntityName(entityName);
 
     const inclusiveFiltersMessage = new grpc.InclusiveFilters();
     inclusiveFiltersMessage.setTemplateIdsList([identifierMessage]);
@@ -82,7 +85,7 @@ describe("Mapping", () => {
         recordId: identifierObject,
         fields: {
             textLabel: { text: 'text' },
-            dateLabel: { date: 40 },
+            dateLabel: { date: '40' },
             nestedLabel: {
                 record: {
                     recordId: identifierObject,
@@ -223,7 +226,7 @@ describe("Mapping", () => {
     itShouldConvert('Value(Date)', () => {
         const dateMessage = new grpc.Value();
         dateMessage.setDate(1);
-        const dateObject: ledger.Value = { date: 1 }
+        const dateObject: ledger.Value = { date: '1' }
         mappingCheck(mapping.Value, dateMessage, dateObject);
     });
 
@@ -255,7 +258,7 @@ describe("Mapping", () => {
         singletonList.setElementsList([dateMessage]);
         const singletonListMessage = new grpc.Value();
         singletonListMessage.setList(singletonList);
-        const singletonListObject: ledger.Value = { list: [{ date: 2 }] };
+        const singletonListObject: ledger.Value = { list: [{ date: '2' }] };
         mappingCheck(mapping.Value, singletonListMessage, singletonListObject);
     });
 
@@ -282,8 +285,8 @@ describe("Mapping", () => {
 
     itShouldConvert('Value(Timestamp)', () => {
         const timestampMessage = new grpc.Value();
-        timestampMessage.setTimestamp(50);
-        const timestampObject: ledger.Value = { timestamp: 50 };
+        timestampMessage.setTimestamp('50');
+        const timestampObject: ledger.Value = { timestamp: '50' };
         mappingCheck(mapping.Value, timestampMessage, timestampObject);
     });
 
@@ -755,7 +758,8 @@ describe("Mapping", () => {
         const message = new grpc.ArchivedEvent();
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         message.setTemplateId(templateId);
         message.setContractId('some-contract-id');
         message.setEventId('some-event-id');
@@ -763,7 +767,7 @@ describe("Mapping", () => {
         const object: ledger.ArchivedEvent = {
             contractId: 'some-contract-id',
             eventId: 'some-event-id',
-            templateId: { packageId: 'pkg', name: 'alejandro' },
+            templateId: { packageId: 'pkg', moduleName: 'alejandro', entityName: 'roberto' },
             witnessParties: ['birthday', 'pool', 'house-warming']
         }
         mappingCheck(mapping.ArchivedEvent, message, object);
@@ -773,7 +777,8 @@ describe("Mapping", () => {
         const message = new grpc.ExercisedEvent();
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         message.setTemplateId(templateId);
         message.setContractId('some-contract-id');
         message.setEventId('some-event-id');
@@ -794,7 +799,7 @@ describe("Mapping", () => {
         const object: ledger.ExercisedEvent = {
             contractId: 'some-contract-id',
             eventId: 'some-event-id',
-            templateId: { packageId: 'pkg', name: 'alejandro' },
+            templateId: { packageId: 'pkg', moduleName: 'alejandro', entityName: 'roberto' },
             actingParties: ['birthday'],
             argument: { list: [{ party: 'patricians' }] },
             childEventIds: ['event'],
@@ -811,12 +816,14 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.Event();
         const archived = new grpc.ArchivedEvent();
         const archivedTemplateId = new grpc.Identifier();
         archivedTemplateId.setPackageId('pkg');
-        archivedTemplateId.setName('alejandro');
+        archivedTemplateId.setModuleName('alejandro');
+        archivedTemplateId.setEntityName('roberto');
         archived.setTemplateId(templateId);
         archived.setContractId('some-contract-id');
         archived.setEventId('some-event-id');
@@ -827,7 +834,7 @@ describe("Mapping", () => {
             archived: {
                 contractId: 'some-contract-id',
                 eventId: 'some-event-id',
-                templateId: { packageId: 'pkg', name: 'alejandro' },
+                templateId: { packageId: 'pkg', moduleName: 'alejandro', entityName: 'roberto' },
                 witnessParties: ['pool']
             }
         };
@@ -840,7 +847,8 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.TreeEvent();
         const created = new grpc.CreatedEvent()
         const createdTemplateId = new grpc.Identifier();
@@ -852,7 +860,8 @@ describe("Mapping", () => {
         createdArgsField.setValue(createdArgsFieldValue);
         createdArgs.setFieldsList([createdArgsField]);
         createdTemplateId.setPackageId('pkg');
-        createdTemplateId.setName('alejandro');
+        createdTemplateId.setModuleName('alejandro');
+        createdTemplateId.setEntityName('roberto');
         created.setTemplateId(templateId);
         created.setContractId('some-contract-id');
         created.setEventId('some-event-id');
@@ -880,8 +889,9 @@ describe("Mapping", () => {
                 someId: {
                     created: {
                         templateId: {
-                            name: 'alejandro',
-                            packageId: 'pkg'
+                            packageId: 'pkg',
+                            moduleName: 'alejandro',
+                            entityName: 'roberto'
                         },
                         contractId: 'some-contract-id',
                         eventId: 'some-event-id',
@@ -908,7 +918,8 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.TreeEvent();
         const created = new grpc.CreatedEvent()
         const createdTemplateId = new grpc.Identifier();
@@ -920,7 +931,8 @@ describe("Mapping", () => {
         createdArgsField.setValue(createdArgsFieldValue);
         createdArgs.setFieldsList([createdArgsField]);
         createdTemplateId.setPackageId('pkg');
-        createdTemplateId.setName('alejandro');
+        createdTemplateId.setModuleName('alejandro');
+        createdTemplateId.setEntityName('roberto');
         created.setTemplateId(templateId);
         created.setContractId('some-contract-id');
         created.setEventId('some-event-id');
@@ -952,8 +964,9 @@ describe("Mapping", () => {
                     someId: {
                         created: {
                             templateId: {
-                                name: 'alejandro',
-                                packageId: 'pkg'
+                                packageId: 'pkg',
+                                moduleName: 'alejandro',
+                                entityName: 'roberto'
                             },
                             contractId: 'some-contract-id',
                             eventId: 'some-event-id',
@@ -981,12 +994,14 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.Event();
         const archived = new grpc.ArchivedEvent();
         const archivedTemplateId = new grpc.Identifier();
         archivedTemplateId.setPackageId('pkg');
-        archivedTemplateId.setName('alejandro');
+        archivedTemplateId.setModuleName('alejandro');
+        archivedTemplateId.setEntityName('roberto');
         archived.setTemplateId(templateId);
         archived.setContractId('some-contract-id');
         archived.setEventId('some-event-id');
@@ -1011,7 +1026,7 @@ describe("Mapping", () => {
                 archived: {
                     contractId: 'some-contract-id',
                     eventId: 'some-event-id',
-                    templateId: { packageId: 'pkg', name: 'alejandro' },
+                    templateId: { packageId: 'pkg', moduleName: 'alejandro', entityName: 'roberto' },
                     witnessParties: ['pool']
                 }
             }],
@@ -1028,12 +1043,14 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.Event();
         const archived = new grpc.ArchivedEvent();
         const archivedTemplateId = new grpc.Identifier();
         archivedTemplateId.setPackageId('pkg');
-        archivedTemplateId.setName('alejandro');
+        archivedTemplateId.setModuleName('alejandro');
+        archivedTemplateId.setEntityName('roberto');
         archived.setTemplateId(templateId);
         archived.setContractId('some-contract-id');
         archived.setEventId('some-event-id');
@@ -1062,7 +1079,7 @@ describe("Mapping", () => {
                     archived: {
                         contractId: 'some-contract-id',
                         eventId: 'some-event-id',
-                        templateId: { packageId: 'pkg', name: 'alejandro' },
+                        templateId: { packageId: 'pkg', moduleName: 'alejandro', entityName: 'roberto' },
                         witnessParties: ['pool']
                     }
                 }],
@@ -1080,7 +1097,8 @@ describe("Mapping", () => {
 
         const templateId = new grpc.Identifier();
         templateId.setPackageId('pkg');
-        templateId.setName('alejandro');
+        templateId.setModuleName('alejandro');
+        templateId.setEntityName('roberto');
         const event = new grpc.TreeEvent();
         const created = new grpc.CreatedEvent()
         const createdTemplateId = new grpc.Identifier();
@@ -1092,7 +1110,8 @@ describe("Mapping", () => {
         createdArgsField.setValue(createdArgsFieldValue);
         createdArgs.setFieldsList([createdArgsField]);
         createdTemplateId.setPackageId('pkg');
-        createdTemplateId.setName('alejandro');
+        createdTemplateId.setModuleName('alejandro');
+        createdTemplateId.setEntityName('roberto');
         created.setTemplateId(templateId);
         created.setContractId('some-contract-id');
         created.setEventId('some-event-id');
@@ -1124,8 +1143,9 @@ describe("Mapping", () => {
                     someId: {
                         created: {
                             templateId: {
-                                name: 'alejandro',
-                                packageId: 'pkg'
+                                packageId: 'pkg',
+                                moduleName: 'alejandro',
+                                entityName: 'roberto'
                             },
                             contractId: 'some-contract-id',
                             eventId: 'some-event-id',

--- a/language-support/js/daml-ledger/tests/mapping/mapping_reference.spec.ts
+++ b/language-support/js/daml-ledger/tests/mapping/mapping_reference.spec.ts
@@ -13,7 +13,7 @@ describe('Reference Mapping (InclusiveFilters)', () => {
     it('should not throw an error with a valid input', () => {
         const object = {
             templateIds: [
-                { name: 'foo', packageId: 'bar' }
+                { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
             ]
         };
         expect(() => mapping.InclusiveFilters.toMessage(object)).to.not.throw(Error);
@@ -22,7 +22,7 @@ describe('Reference Mapping (InclusiveFilters)', () => {
     it('should push the right number of items into the populated array', () => {
         const object = {
             templateIds: [
-                { name: 'foo', packageId: 'bar' }
+                { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
             ]
         };
         const result = mapping.InclusiveFilters.toMessage(object);
@@ -32,36 +32,40 @@ describe('Reference Mapping (InclusiveFilters)', () => {
     it('should push the correctly built items to the array', () => {
         const object = {
             templateIds: [
-                { name: 'foo', packageId: 'bar' }
+                { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
             ]
         };
         const result = mapping.InclusiveFilters.toMessage(object);
         const identifier = result.getTemplateIdsList()[0];
-        expect(identifier.getName()).to.equal('foo');
+        expect(identifier.getModuleName()).to.equal('foo');
+        expect(identifier.getEntityName()).to.equal('baz');
         expect(identifier.getPackageId()).to.equal('bar');
     });
 
     it('should work for more than one item as well', () => {
         const object = {
             templateIds: [
-                { name: 'foo', packageId: 'bar' },
-                { name: 'baz', packageId: 'quux' },
+                { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
             ]
         };
         const result = mapping.InclusiveFilters.toMessage(object);
         const identifier1 = result.getTemplateIdsList()[0];
         const identifier2 = result.getTemplateIdsList()[1];
-        expect(identifier1.getName()).to.equal('foo');
-        expect(identifier1.getPackageId()).to.equal('bar');
-        expect(identifier2.getName()).to.equal('baz');
-        expect(identifier2.getPackageId()).to.equal('quux');
+        expect(identifier1.getPackageId()).to.equal('bar1');
+        expect(identifier1.getModuleName()).to.equal('foo1');
+        expect(identifier1.getEntityName()).to.equal('baz1');
+        expect(identifier2.getPackageId()).to.equal('bar2');
+        expect(identifier2.getModuleName()).to.equal('foo2');
+        expect(identifier2.getEntityName()).to.equal('baz2');
     });
 
     it('should not throw exception with a valid "bean"', () => {
         const message = new grpc.InclusiveFilters();
         const identifier = new grpc.Identifier();
-        identifier.setName('foo');
         identifier.setPackageId('bar');
+        identifier.setModuleName('foo');
+        identifier.setEntityName('baz');
         message.setTemplateIdsList([identifier]);
         expect(() => mapping.InclusiveFilters.toObject(message)).to.not.throw(Error);
     });
@@ -69,25 +73,28 @@ describe('Reference Mapping (InclusiveFilters)', () => {
     it('should map array items with the correct values from beans to objects', () => {
         const message = new grpc.InclusiveFilters();
         const identifier = new grpc.Identifier();
-        identifier.setName('foo');
         identifier.setPackageId('bar');
+        identifier.setModuleName('foo');
+        identifier.setEntityName('baz');
         message.setTemplateIdsList([identifier]);
-        expect(mapping.InclusiveFilters.toObject(message).templateIds[0]).to.deep.equal({ name: 'foo', packageId: 'bar' });
+        expect(mapping.InclusiveFilters.toObject(message).templateIds[0]).to.deep.equal({ packageId: 'bar', moduleName: 'foo', entityName: 'baz' });
     });
 
     it('should map array items with the correct values from beans to objects with multiple items', () => {
         const message = new grpc.InclusiveFilters();
         const identifier1 = new grpc.Identifier();
-        identifier1.setName('foo');
-        identifier1.setPackageId('bar');
+        identifier1.setPackageId('bar1');
+        identifier1.setModuleName('foo1');
+        identifier1.setEntityName('baz1');
         const identifier2 = new grpc.Identifier();
-        identifier2.setName('baz');
-        identifier2.setPackageId('quux');
+        identifier2.setPackageId('bar2');
+        identifier2.setModuleName('foo2');
+        identifier2.setEntityName('baz2');
         message.setTemplateIdsList([identifier1, identifier2]);
         expect(mapping.InclusiveFilters.toObject(message)).to.deep.equal({
             templateIds: [
-                { name: 'foo', packageId: 'bar' },
-                { name: 'baz', packageId: 'quux' },
+                { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
             ]
         });
     });
@@ -115,7 +122,7 @@ describe('Reference Mapping (Filters)', () => {
         const conversion = () => mapping.Filters.toMessage({
             inclusive: {
                 templateIds: [
-                    { name: 'foo', packageId: 'bar' }
+                    { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
                 ]
             }
         });
@@ -126,7 +133,7 @@ describe('Reference Mapping (Filters)', () => {
         const result = mapping.Filters.toMessage({
             inclusive: {
                 templateIds: [
-                    { name: 'foo', packageId: 'bar' }
+                    { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
                 ]
             }
         });
@@ -137,20 +144,21 @@ describe('Reference Mapping (Filters)', () => {
         const result = mapping.Filters.toMessage({
             inclusive: {
                 templateIds: [
-                    { name: 'foo', packageId: 'bar' }
+                    { packageId: 'bar', moduleName: 'foo', entityName: 'baz' }
                 ]
             }
         });
-        expect(result.getInclusive()!.getTemplateIdsList()[0].getName()).to.equal('foo');
         expect(result.getInclusive()!.getTemplateIdsList()[0].getPackageId()).to.equal('bar');
+        expect(result.getInclusive()!.getTemplateIdsList()[0].getModuleName()).to.equal('foo');
+        expect(result.getInclusive()!.getTemplateIdsList()[0].getEntityName()).to.equal('baz');
     });
 
     it('should not throw an error when converting an array with two items', () => {
         const conversion = () => mapping.Filters.toMessage({
             inclusive: {
                 templateIds: [
-                    { name: 'foo', packageId: 'bar' },
-                    { name: 'baz', packageId: 'quux' }
+                    { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                    { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
                 ]
             }
         });
@@ -161,8 +169,8 @@ describe('Reference Mapping (Filters)', () => {
         const result = mapping.Filters.toMessage({
             inclusive: {
                 templateIds: [
-                    { name: 'foo', packageId: 'bar' },
-                    { name: 'baz', packageId: 'quux' }
+                    { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                    { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
                 ]
             }
         });
@@ -244,11 +252,13 @@ describe('Reference Mapping (TransactionFilter)', () => {
         const filters = new grpc.Filters();
         const inclusive = new grpc.InclusiveFilters();
         const identifier1 = new grpc.Identifier();
-        identifier1.setName('foo');
-        identifier1.setPackageId('bar');
+        identifier1.setPackageId('bar1');
+        identifier1.setModuleName('foo1');
+        identifier1.setEntityName('baz1');
         const identifier2 = new grpc.Identifier();
-        identifier2.setName('baz');
-        identifier2.setPackageId('quux');
+        identifier2.setPackageId('bar2');
+        identifier2.setModuleName('foo2');
+        identifier2.setEntityName('baz2');
         inclusive.setTemplateIdsList([identifier1, identifier2]);
         filters.setInclusive(inclusive);
         map.set('someKey', filters);
@@ -258,8 +268,8 @@ describe('Reference Mapping (TransactionFilter)', () => {
                 someKey: {
                     inclusive: {
                         templateIds: [
-                            { name: 'foo', packageId: 'bar' },
-                            { name: 'baz', packageId: 'quux' }
+                            { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                            { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
                         ]
                     }
                 }
@@ -273,11 +283,13 @@ describe('Reference Mapping (TransactionFilter)', () => {
         const filters = new grpc.Filters();
         const inclusive = new grpc.InclusiveFilters();
         const identifier1 = new grpc.Identifier();
-        identifier1.setName('foo');
-        identifier1.setPackageId('bar');
+        identifier1.setPackageId('bar1');
+        identifier1.setModuleName('foo1');
+        identifier1.setEntityName('baz1');
         const identifier2 = new grpc.Identifier();
-        identifier2.setName('baz');
-        identifier2.setPackageId('quux');
+        identifier2.setPackageId('bar2');
+        identifier2.setModuleName('foo2');
+        identifier2.setEntityName('baz2');
         inclusive.setTemplateIdsList([identifier1, identifier2]);
         filters.setInclusive(inclusive);
         map.set('someKey', filters);
@@ -289,8 +301,8 @@ describe('Reference Mapping (TransactionFilter)', () => {
                 someKey: {
                     inclusive: {
                         templateIds: [
-                            { name: 'foo', packageId: 'bar' },
-                            { name: 'baz', packageId: 'quux' }
+                            { packageId: 'bar1', moduleName: 'foo1', entityName: 'baz1' },
+                            { packageId: 'bar2', moduleName: 'foo2', entityName: 'baz2' },
                         ]
                     }
                 }
@@ -305,11 +317,13 @@ describe('Reference Mapping (SubmitRequest)', () => {
     const command = new grpc.Command();
 
     const templateId = new grpc.Identifier();
-    templateId.setName('templateId-name');
+    templateId.setModuleName('templateId-moduleName');
+    templateId.setEntityName('templateId-entityName');
     templateId.setPackageId('templateId-packageId');
 
     const recordId = new grpc.Identifier();
-    recordId.setName('recordId-name');
+    recordId.setModuleName('recordId-moduleName');
+    recordId.setEntityName('recordId-entityName');
     recordId.setPackageId('recordId-packageId');
 
     const create = new grpc.CreateCommand();
@@ -376,9 +390,9 @@ describe('Reference Mapping (SubmitRequest)', () => {
             list: [
                 {
                     create: {
-                        templateId: { packageId: 'templateId-packageId', name: 'templateId-name' },
+                        templateId: { packageId: 'templateId-packageId', moduleName: 'templateId-moduleName', entityName: 'templateId-entityName' },
                         arguments: {
-                            recordId: { packageId: 'recordId-packageId', name: 'recordId-name' },
+                            recordId: { packageId: 'recordId-packageId', moduleName: 'recordId-moduleName', entityName: 'recordId-entityName' },
                             fields: {
                                 sender: { party: 'sender-party' },
                                 receiver: { party: 'receiver-party' },
@@ -410,7 +424,8 @@ describe('Reference Mapping (SubmitRequest/Pvp)', () => {
     const command = new grpc.Command();
 
     const pvpId = new grpc.Identifier();
-    pvpId.setName('Pvp');
+    pvpId.setModuleName('mod1');
+    pvpId.setEntityName('PvP');
     pvpId.setPackageId('934023fa9c89e8f89b8a');
 
     const create = new grpc.CreateCommand();
@@ -439,7 +454,8 @@ describe('Reference Mapping (SubmitRequest/Pvp)', () => {
     const baseIouCidVariant = new grpc.Variant();
     baseIouCidVariant.setConstructor('Maybe');
     const baseIouCidVariantId = new grpc.Identifier();
-    baseIouCidVariantId.setName('Maybe');
+    baseIouCidVariantId.setModuleName('mod2');
+    baseIouCidVariantId.setEntityName('Maybe');
     baseIouCidVariantId.setPackageId('ba777d8d7c88e87f7');
     baseIouCidVariant.setVariantId(baseIouCidVariantId);
     const baseIouCidVariantValue = new grpc.Value();
@@ -483,7 +499,8 @@ describe('Reference Mapping (SubmitRequest/Pvp)', () => {
     const quoteIouCidVariant = new grpc.Variant();
     quoteIouCidVariant.setConstructor('Maybe');
     const quoteIouCidVariantId = new grpc.Identifier();
-    quoteIouCidVariantId.setName('Maybe');
+    quoteIouCidVariantId.setModuleName('mod2');
+    quoteIouCidVariantId.setEntityName('Maybe');
     quoteIouCidVariantId.setPackageId('ba777d8d7c88e87f7');
     quoteIouCidVariant.setVariantId(quoteIouCidVariantId);
     const quoteIouCidVariantValue = new grpc.Value();
@@ -510,7 +527,7 @@ describe('Reference Mapping (SubmitRequest/Pvp)', () => {
     const settleTimeField = new grpc.RecordField();
     settleTimeField.setLabel('settleTime');
     const settleTimeValue = new grpc.Value();
-    settleTimeValue.setTimestamp(93641099000000000);
+    settleTimeValue.setTimestamp('93641099000000000');
     settleTimeField.setValue(settleTimeValue);
     record.addFields(settleTimeField);
 
@@ -552,21 +569,21 @@ describe('Reference Mapping (SubmitRequest/Pvp)', () => {
             list: [
                 {
                     create: {
-                        templateId: { packageId: '934023fa9c89e8f89b8a', name: 'Pvp' },
+                        templateId: { packageId: '934023fa9c89e8f89b8a', moduleName: 'mod1', entityName: 'PvP' },
                         arguments: {
-                            recordId: { packageId: '934023fa9c89e8f89b8a', name: 'Pvp' },
+                            recordId: { packageId: '934023fa9c89e8f89b8a', moduleName: 'mod1', entityName: 'PvP' },
                             fields: {
                                 buyer        : { party: 'some-buyer' },
                                 seller       : { party: 'some-seller' },
                                 baseIssuer   : { party: 'some-base-issuer' },
                                 baseCurrency : { text: 'CHF' },
                                 baseAmount   : { decimal: '1000000.00' },
-                                baseIouCid   : { variant: { variantId: { packageId: 'ba777d8d7c88e87f7', name: 'Maybe' }, constructor: 'Maybe', value: { contractId: '76238b8998a98d98e978f' } } },
+                                baseIouCid   : { variant: { variantId: { packageId: 'ba777d8d7c88e87f7', moduleName: 'mod2', entityName: 'Maybe' }, constructor: 'Maybe', value: { contractId: '76238b8998a98d98e978f' } } },
                                 quoteIssuer  : { party: 'some-quote-issuer' },
                                 quoteCurrency: { text: 'USD' },
                                 quoteAmount  : { decimal: '1000001.00' },
-                                quoteIouCid  : { variant: { variantId: { packageId: 'ba777d8d7c88e87f7', name: 'Maybe' }, constructor: 'Maybe', value: { contractId: '76238b8998a98d98e978f' } } },
-                                settleTime   : { timestamp: 93641099000000000 }
+                                quoteIouCid  : { variant: { variantId: { packageId: 'ba777d8d7c88e87f7', moduleName: 'mod2', entityName: 'Maybe' }, constructor: 'Maybe', value: { contractId: '76238b8998a98d98e978f' } } },
+                                settleTime   : { timestamp: '93641099000000000' }
                             }
                         }
                     }

--- a/language-support/js/daml-ledger/tests/transaction_client.spec.ts
+++ b/language-support/js/daml-ledger/tests/transaction_client.spec.ts
@@ -22,8 +22,8 @@ describe('TransactionClient', () => {
                 someParty: {
                     inclusive: {
                         templateIds: [
-                            { name: 'foobar', packageId: 'foo' },
-                            { name: 'fooquux', packageId: 'quux' }
+                            { packageId: 'foo1', moduleName: 'bar1', entityName: 'baz1' },
+                            { packageId: 'foo2', moduleName: 'bar2', entityName: 'baz2' },
                         ]
                     }
                 },

--- a/language-support/js/daml-ledger/tests/validation/base/array.spec.ts
+++ b/language-support/js/daml-ledger/tests/validation/base/array.spec.ts
@@ -94,12 +94,14 @@ describe('Validation: Array', () => {
     it('should validate an array with two objects', () => {
         const identifiers: ledger.Identifier[] = [
             {
-                name: 'foo',
-                packageId: 'bar'
+                packageId: 'bar1',
+                moduleName: 'foo1',
+                entityName: 'baz1'
             },
             {
-                name: 'baz',
-                packageId: 'quux'
+                packageId: 'bar2',
+                moduleName: 'foo2',
+                entityName: 'baz2'
             }
         ]
         const expected: Tree = {
@@ -108,7 +110,11 @@ describe('Validation: Array', () => {
                 '0': {
                     errors: [],
                     children: {
-                        name: {
+                        moduleName: {
+                            errors: [],
+                            children: {}
+                        },
+                        entityName: {
                             errors: [],
                             children: {}
                         },
@@ -121,7 +127,11 @@ describe('Validation: Array', () => {
                 '1': {
                     errors: [],
                     children: {
-                        name: {
+                        moduleName: {
+                            errors: [],
+                            children: {}
+                        },
+                        entityName: {
                             errors: [],
                             children: {}
                         },
@@ -136,11 +146,12 @@ describe('Validation: Array', () => {
         expect(array(Identifier).validate(identifiers)).to.deep.equal(expected);
     });
 
-    it('should correcly report errors in an array with invalid objects', () => {
+    it('should correctly report errors in an array with invalid objects', () => {
         const invalidIdentifiers = [
             'not-an-identifier :(',
             {
-                name: 'baz'
+                moduleName: 'foo',
+                entityName: 'baz'
             }
         ]
         const expected: Tree = {
@@ -161,10 +172,14 @@ describe('Validation: Array', () => {
                             expectedType: 'string'
                         }],
                         children: {
-                            name: {
+                            moduleName: {
                                 errors: [],
                                 children: {}
-                            }
+                            },
+                            entityName: {
+                                errors: [],
+                                children: {}
+                            },
                         }
                     }
                 }
@@ -191,8 +206,9 @@ describe('Validation: Array', () => {
     it('should validate an set of filters with one identifier', () => {
         const inclusiveFilters: ledger.InclusiveFilters = {
             templateIds: [{
-                name: 'foo',
-                packageId: 'bar'
+                packageId: 'bar',
+                moduleName: 'foo',
+                entityName: 'baz',
             }]
         };
         const expected: Tree = {
@@ -204,7 +220,11 @@ describe('Validation: Array', () => {
                         '0': {
                             errors: [],
                             children: {
-                                name: {
+                                moduleName: {
+                                    errors: [],
+                                    children: {}
+                                },
+                                entityName: {
                                     errors: [],
                                     children: {}
                                 },
@@ -224,11 +244,13 @@ describe('Validation: Array', () => {
     it('should validate an set of filters with two identifiers', () => {
         const inclusiveFilters: ledger.InclusiveFilters = {
             templateIds: [{
-                name: 'foo',
-                packageId: 'bar'
+                packageId: 'bar1',
+                moduleName: 'foo1',
+                entityName: 'baz1',
             }, {
-                name: 'baz',
-                packageId: 'quux'
+                packageId: 'bar2',
+                moduleName: 'foo2',
+                entityName: 'baz2',
             }]
         };
         const expected: Tree = {
@@ -240,7 +262,11 @@ describe('Validation: Array', () => {
                         '0': {
                             errors: [],
                             children: {
-                                name: {
+                                moduleName: {
+                                    errors: [],
+                                    children: {}
+                                },
+                                entityName: {
                                     errors: [],
                                     children: {}
                                 },
@@ -253,7 +279,11 @@ describe('Validation: Array', () => {
                         '1': {
                             errors: [],
                             children: {
-                                name: {
+                                moduleName: {
+                                    errors: [],
+                                    children: {}
+                                },
+                                entityName: {
                                     errors: [],
                                     children: {}
                                 },
@@ -286,11 +316,13 @@ describe('Validation: Array', () => {
     it('should provide precise feedback about a single mistake', () => {
         const invalidInclusiveFilters = {
             templateIds: [{
-                name: 'foo',
-                packageId: 'bar'
+                packageId: 'bar1',
+                moduleName: 'foo1',
+                entityName: 'baz1',
             }, {
-                name: 'baz',
-                packageId: 42
+                packageId: 42,
+                moduleName: 'foo2',
+                entityName: 'baz2',
             }]
         };
         const expected: Tree = {
@@ -302,10 +334,15 @@ describe('Validation: Array', () => {
                         '0': {
                             errors: [],
                             children: {
-                                name: {
+                                moduleName: {
                                     errors: [],
                                     children: {}
-                                }, packageId: {
+                                },
+                                entityName: {
+                                    errors: [],
+                                    children: {}
+                                },
+                                packageId: {
                                     errors: [],
                                     children: {}
                                 }
@@ -314,10 +351,15 @@ describe('Validation: Array', () => {
                         '1': {
                             errors: [],
                             children: {
-                                name: {
+                                moduleName: {
                                     errors: [],
                                     children: {}
-                                }, packageId: {
+                                },
+                                entityName: {
+                                    errors: [],
+                                    children: {}
+                                },
+                                packageId: {
                                     errors: [{
                                         kind: 'type-error',
                                         expectedType: 'string',
@@ -337,7 +379,7 @@ describe('Validation: Array', () => {
     it('should provide thorough feedback about extensive mistakes', () => {
         const invalidInclusiveFilters = {
             templateIds: [{
-                name: false
+                moduleName: false
             },
                 42
             ]
@@ -353,9 +395,13 @@ describe('Validation: Array', () => {
                                 kind: 'missing-key',
                                 expectedKey: 'packageId',
                                 expectedType: 'string'
+                            },{
+                                kind: 'missing-key',
+                                expectedKey: 'entityName',
+                                expectedType: 'string'
                             }],
                             children: {
-                                name: {
+                                moduleName: {
                                     errors: [{
                                         kind: 'type-error',
                                         expectedType: 'string',

--- a/language-support/js/daml-ledger/tests/validation/base/object.spec.ts
+++ b/language-support/js/daml-ledger/tests/validation/base/object.spec.ts
@@ -9,13 +9,18 @@ describe('Validation: Object', () => {
 
     it('should report a correct tree as such', () => {
         const identifier: ledger.Identifier = {
-            name: 'foo',
-            packageId: 'bar'
+            packageId: 'bar',
+            moduleName: 'foo',
+            entityName: 'baz',
         };
         const expected: validation.Tree = {
             errors: [],
             children: {
-                name: {
+                moduleName: {
+                    errors: [],
+                    children: {}
+                },
+                entityName: {
                     errors: [],
                     children: {}
                 },
@@ -35,7 +40,11 @@ describe('Validation: Object', () => {
         const expected: validation.Tree = {
             errors: [{
                 kind: 'missing-key',
-                expectedKey: 'name',
+                expectedKey: 'moduleName',
+                expectedType: 'string'
+            },{
+                kind: 'missing-key',
+                expectedKey: 'entityName',
                 expectedType: 'string'
             }],
             children: {
@@ -50,13 +59,14 @@ describe('Validation: Object', () => {
 
     it('should correctly report a type error in a child', () => {
         const invalidIdentifier = {
-            name: 42,
-            packageId: 'bar'
+            packageId: 'bar',
+            moduleName: 42,
+            entityName: 'baz',
         };
         const expected: validation.Tree = {
             errors: [],
             children: {
-                name: {
+                moduleName: {
                     errors: [
                         {
                             kind: 'type-error',
@@ -69,7 +79,11 @@ describe('Validation: Object', () => {
                 packageId: {
                     errors: [],
                     children: {}
-                }
+                },
+                entityName: {
+                    errors: [],
+                    children: {}
+                },
             }
         };
         expect(validation.Identifier.validate(invalidIdentifier)).to.deep.equal(expected);
@@ -77,13 +91,14 @@ describe('Validation: Object', () => {
 
     it('should correctly report multiple type errors in the children', () => {
         const invalidIdentifier = {
-            name: 42,
-            packageId: true
+            packageId: true,
+            moduleName: 42,
+            entityName: false,
         };
         const expected: validation.Tree = {
             errors: [],
             children: {
-                name: {
+                moduleName: {
                     errors: [
                         {
                             kind: 'type-error',
@@ -102,7 +117,17 @@ describe('Validation: Object', () => {
                         }
                     ],
                     children: {}
-                }
+                },
+                entityName: {
+                    errors: [
+                        {
+                            kind: 'type-error',
+                            expectedType: 'string',
+                            actualType: 'boolean'
+                        }
+                    ],
+                    children: {}
+                },
             }
         };
         expect(validation.Identifier.validate(invalidIdentifier)).to.deep.equal(expected);
@@ -174,8 +199,9 @@ describe('Validation: Object', () => {
         const filters: ledger.Filters = {
             inclusive: {
                 templateIds: [{
-                    name: 'foo',
-                    packageId: 'bar'
+                    packageId: 'bar',
+                    moduleName: 'foo',
+                    entityName: 'baz',
                 }]
             }
         }
@@ -191,7 +217,11 @@ describe('Validation: Object', () => {
                                 '0': {
                                     errors: [],
                                     children: {
-                                        name: {
+                                        moduleName: {
+                                            errors: [],
+                                            children: {}
+                                        },
+                                        entityName: {
                                             errors: [],
                                             children: {}
                                         },
@@ -226,11 +256,13 @@ describe('Validation: Object', () => {
     it('should report in case of a crass mistake', () => {
         const actuallyInclusiveFilters: ledger.InclusiveFilters = {
             templateIds: [{
-                name: 'foo',
-                packageId: 'bar'
+                packageId: 'bar1',
+                moduleName: 'foo1',
+                entityName: 'baz1',
             }, {
-                name: 'baz',
-                packageId: 'quux'
+                packageId: 'bar2',
+                moduleName: 'foo2',
+                entityName: 'baz2',
             }]
         };
         const expected: validation.Tree = {

--- a/language-support/js/daml-ledger/tests/validation/base/record.spec.ts
+++ b/language-support/js/daml-ledger/tests/validation/base/record.spec.ts
@@ -30,8 +30,9 @@ describe('Validation: Record', () => {
                     inclusive: {
                         templateIds: [
                             {
-                                name: 'digital',
-                                packageId: 'asset'
+                                packageId: 'pkg',
+                                moduleName: 'mdl',
+                                entityName: 'ent',
                             }
                         ]
                     }
@@ -56,7 +57,11 @@ describe('Validation: Record', () => {
                                                 '0': {
                                                     errors: [],
                                                     children: {
-                                                        name: {
+                                                        moduleName: {
+                                                            errors: [],
+                                                            children: {}
+                                                        },
+                                                        entityName: {
                                                             errors: [],
                                                             children: {}
                                                         },

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/value.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/value.proto
@@ -44,7 +44,7 @@ message Value {
     // epoch is greater than that. Range: 0001-01-01T00:00:00Z to
     // 9999-12-31T23:59:59.999999Z, so that we can convert to/from
     // https://www.ietf.org/rfc/rfc3339.txt
-    sfixed64 timestamp = 9;
+    sfixed64 timestamp = 9 [jstype = JS_STRING];
 
     // An agent operating on the ledger.
     string party = 11;


### PR DESCRIPTION
Finishes the work started in #324:

- drops deprecated `name` in identifiers, adopting `moduleName` and `entityName`
- use string to represent `timestamp`s to avoid a loss of precision
- use string for `date`s too for consistency and future-proofness

The work unconvered a quite serious bug caused by the lack of coverage
on the validation of timestamps: the model was expecting timestamps to
be of type timestamp, whereas in Ledger API values they are represented
by numbers.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
