### PR TITLE
new ghc-lib : contract key syntax

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,8 +382,8 @@ hazel_repositories(
       extra =
         [ # Read [Working on ghc-lib] for ghc-lib update instructions at
           # https://github.com/DACH-NY/daml/blob/master/ghc-lib/working-on-ghc-lib.md
-          ("ghc-lib-parser", {"url": "https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-0.20190405.tar.gz", "stripPrefix": "ghc-lib-parser-0.20190405", "sha256": "61bb998ea10a8189b5f5cdae41e7ee6c6329bd8f7f81276e65d0d592b5a69b79"})
-        , ("ghc-lib", {"url": "https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-0.20190405.tar.gz", "stripPrefix": "ghc-lib-0.20190405", "sha256": "d656919c8c6f6e0c4d6307ef51f89b44d7c218b8261b750bbe8e73127865a6f5"})
+          ("ghc-lib-parser", {"url": "https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-0.20190409.tar.gz", "stripPrefix": "ghc-lib-parser-0.20190409", "sha256": "53d86b741a64c6ef41fe2635583bf3bdf288aee22006cb0e0395a955650f1d6e"})
+        , ("ghc-lib", {"url": "https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-0.20190409.tar.gz", "stripPrefix": "ghc-lib-0.20190409", "sha256": "803ba87198191114ad6ef7b61e9ff5bd7cfc43feb9ee978207d281bf6f38d024"})
         , ("bytestring-nums", {"version": "0.3.6", "sha256": "bdca97600d91f00bb3c0f654784e3fbd2d62fcf4671820578105487cdf39e7cd"})
         , ("unix-time", {"version": "0.4.5", "sha256": "fe7805c62ad682589567afeee265e6e230170c3941cdce479a2318d1c5088faf"})
         , ("zip-archive", {"version": "0.3.3", "sha256": "988adee77c806e0b497929b24d5526ea68bd3297427da0d0b30b99c094efc84d"})


### PR DESCRIPTION
This PR adds experimental support for contract key syntax. It is conditional on https://github.com/digital-asset/ghc/pull/8. Tests for contract keys to come in a follow up PR. 