### PR TITLE
HOTFIX damlc: allow for passing options to the underlying GHC

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -29,7 +29,7 @@ import qualified "ghc-lib-parser" StringBuffer                as SB
 import qualified "ghc-lib-parser" EnumSet
 
 import           Control.DeepSeq
-import           Control.Monad (unless)
+import           Control.Monad
 import           Data.IORef
 import           Data.List
 import qualified Data.Text as T
@@ -201,7 +201,7 @@ setupDamlGHC importPaths mbPackageName packageState customOpts = do
   (dflags', leftover, warns) <- parseDynamicFilePragma damlDFlags $ map noLoc customOpts
 
   let leftoverError = CmdLineError $
-        (unlines . ("Unable to parse custom flags:":) . map unLoc) $ leftover
+        (unlines . ("Unable to parse custom flags:":) . map unLoc) leftover
   unless (null leftover) $ liftIO $ throwGhcExceptionIO leftoverError
 
   unless (null warns) $

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -14,6 +14,8 @@
 module Development.IDE.UtilGHC where
 
 import           "ghc-lib-parser" Config
+import qualified "ghc-lib-parser" CmdLineParser as Cmd (warnMsg)
+import           "ghc-lib-parser" DynFlags (parseDynamicFilePragma)
 import           "ghc-lib-parser" Fingerprint
 import           "ghc-lib" GHC                         hiding (convertLit)
 import           "ghc-lib-parser" GHC.LanguageExtensions.Type
@@ -21,11 +23,13 @@ import           "ghc-lib-parser" GhcMonad
 import           "ghc-lib" GhcPlugins                  as GHC hiding (PackageState, fst3, (<>))
 import           "ghc-lib" HscMain
 import qualified "ghc-lib-parser" Packages
+import           "ghc-lib-parser" Panic (throwGhcExceptionIO)
 import           "ghc-lib-parser" Platform
 import qualified "ghc-lib-parser" StringBuffer                as SB
 import qualified "ghc-lib-parser" EnumSet
 
 import           Control.DeepSeq
+import           Control.Monad (unless)
 import           Data.IORef
 import           Data.List
 import qualified Data.Text as T
@@ -185,9 +189,26 @@ instance NFData PackageState where
 --     * Installs a custom log action;
 --     * Sets up the package databases;
 --     * Sets the import paths to the given list of 'FilePath'.
-setupDamlGHC :: GhcMonad m => [FilePath] -> Maybe String -> PackageState -> m ()
-setupDamlGHC importPaths mbPackageName packageState = do
+--     * if present, parses and applies custom options for GHC
+--       (may fail if the custom options are inconsistent with std DAML ones)
+setupDamlGHC :: GhcMonad m => [FilePath] -> Maybe String -> PackageState -> [String] -> m ()
+setupDamlGHC importPaths mbPackageName packageState [] =
   modifyDynFlags $ adjustDynFlags importPaths packageState mbPackageName
+-- if custom options are given, add them after the standard DAML flag setup
+setupDamlGHC importPaths mbPackageName packageState customOpts = do
+  setupDamlGHC importPaths mbPackageName packageState []
+  damlDFlags <- getSessionDynFlags
+  (dflags', leftover, warns) <- parseDynamicFilePragma damlDFlags $ map noLoc customOpts
+
+  let leftoverError = CmdLineError $
+        (unlines . ("Unable to parse custom flags:":) . map unLoc) $ leftover
+  unless (null leftover) $ liftIO $ throwGhcExceptionIO leftoverError
+
+  unless (null warns) $
+    liftIO $ putStrLn $ unlines $ "Warnings:" : map (unLoc . Cmd.warnMsg) warns
+
+  modifySession $ \h ->
+    h { hsc_dflags = dflags', hsc_IC = (hsc_IC h) {ic_dflags = dflags' } }
 
 -- | A version of `showSDoc` that uses default flags (to avoid uses of
 -- `showSDocUnsafe`).

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -28,7 +28,6 @@ import DA.Pretty (renderPretty)
 
 -- | Compiler run configuration for DAML-GHC.
 data Options = Options
-  -- TODO (JB) add custom flags as a field [String] here
   { optImportPath :: [FilePath]
     -- ^ import path for both user modules and standard library
   , optPackageDbs :: [FilePath]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -28,6 +28,7 @@ import DA.Pretty (renderPretty)
 
 -- | Compiler run configuration for DAML-GHC.
 data Options = Options
+  -- TODO (JB) add custom flags as a field [String] here
   { optImportPath :: [FilePath]
     -- ^ import path for both user modules and standard library
   , optPackageDbs :: [FilePath]
@@ -50,6 +51,8 @@ data Options = Options
     -- ^ The target DAML LF version
   , optDebug :: Bool
     -- ^ Whether to enable debugging output
+  , optGhcCustomOpts :: [String]
+    -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   } deriving Show
 
 -- | Convert to the DAML-independent CompileOpts type.
@@ -60,7 +63,7 @@ toCompileOpts Options{..} =
       { optPreprocessor = damlPreprocessor
       , optRunGhcSession = \mbMod packageState m -> runGhcFast $ do
             let importPaths = maybe [] moduleImportPaths mbMod <> optImportPath
-            setupDamlGHC importPaths optMbPackageName packageState
+            setupDamlGHC importPaths optMbPackageName packageState optGhcCustomOpts
             m
       , optWriteIface = optWriteInterface
       , optMbPackageName = optMbPackageName
@@ -125,6 +128,7 @@ defaultOptionsIO mbVersion = do
         , optThreads = 1
         , optDamlLfVersion = fromMaybe LF.versionDefault mbVersion
         , optDebug = False
+        , optGhcCustomOpts = []
         }
 
 getBaseDir :: IO FilePath

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -475,6 +475,7 @@ optionsParser numProcessors parsePkgName = Compiler.Options
     <*> optShakeThreads
     <*> lfVersionOpt
     <*> optDebugLog
+    <*> many optGhcCustomOption
   where
     optImportPath :: Parser [FilePath]
     optImportPath =
@@ -537,6 +538,14 @@ optionsParser numProcessors parsePkgName = Compiler.Options
             , "Use --jobs=N to explicitely set the number of threads to N."
             , "Note that the output is not deterministic for > 1 job."
             ]
+
+    optGhcCustomOption :: Parser String
+    optGhcCustomOption =
+        strOption $
+        long "ghc-option" <>
+        metavar "CUSTOM_OPTION" <>
+        help "custom option to pass to the underlying GHC" <>
+        internal
 
 options :: Int -> Parser Command
 options numProcessors =


### PR DESCRIPTION
As `damlc` is based on GHC, it "understands" all options that GHC understands.
This PR introduces a way to use GHC options that are not exposed by the `damlc`
driver, by passing any number of `--ghc-option CUSTOM_OPTION` on the command line.

The code uses the GHC function which parses options inside files, so
prohibiting a few options that we would not want to expose (package db, output
file, etc).

All warnings that GHC emits during flag processing are presented to the user.

If an option contradicts a DAML compiler setting, the compilation will be
aborted with a GHC exception (calls makeDynFlagsConsistent internally).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [-] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
