### PR TITLE
fmt.sh: format and lint checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,17 +11,6 @@ execution_log_postfix=${1:-}
 
 export LC_ALL=en_US.UTF-8
 
-# check for scala code style
-scalafmt_ret=0
-./scalafmt.sh --test --quiet || scalafmt_ret=$?
-if [[ scalafmt_ret -ne 0 ]]; then
-  echo "scalafmt returned ${scalafmt_ret}. Please run ./scalafmt.sh to fix the formatting of your code."
-  exit $scalafmt_ret
-fi
-
-# Check for correct copyrights
-dade-copyright-headers check .
-
 EXEC_LOG_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 
 # Bazel test only builds targets that are dependencies of a test suite
@@ -44,16 +33,3 @@ fi
 
 # Check that we can load damlc in ghci
 da-ghci damlc -e '()'
-
-# We have a Bazel test that is meant to run HLint, but we're a little sceptical of it
-# If we get this far, but hlint fails, that's a problem we should fix
-function bad_hlint() {
-  echo "UNEXPECTED HLINT FAILURE: The Bazel rules should have spotted this, please raise a GitHub issue"
-}
-trap bad_hlint EXIT
-for dir in daml-foundations da-assistant daml-assistant libs-haskell compiler; do
-    pushd $dir
-    hlint --git -j4
-    popd
-done
-trap - EXIT

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@
 
 set -euxo pipefail
 
+eval "$($(dirname "$0")/dev-env/bin/dade-assist)"
+
 execution_log_postfix=${1:-}
 
 export LC_ALL=en_US.UTF-8

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -14,6 +14,10 @@ steps:
       GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       NIX_SECRET_KEY_CONTENT: $(NIX_SECRET_KEY_CONTENT)
 
+  - bash: ./fmt.sh --test
+    displayName: 'Platform-agnostic lints and checks'
+    condition: eq(variables['Agent.OS'], 'Linux')
+
   - bash: ci/build.sh
     displayName: 'Build'
     env:

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -20,10 +20,6 @@ to_lower() {
 kernel=$(to_lower "$(uname)")
 cd "$(dirname "$0")"/..
 
-step "loading dev-env"
-
-eval "$(dev-env/bin/dade assist)"
-
 step "configuring bazel"
 
 # sets up write access to the shared remote cache if the branch is not a fork

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run formatters and linter, anything platform-independent and quick
+#
+# Usage: ./fmt.sh [--test]
+set -euo pipefail
+
+cd "$(dirname "$0")"
+# load the dev-env
+eval "$(dev-env/bin/dade-assist)"
+
+## Config ##
+is_test=
+scalafmt_args=()
+dade_copyright_arg=update
+
+## Functions ##
+
+log() {
+  echo "fmt.sh: $*" >&2
+}
+
+run() {
+  echo "$ ${*%Q}"
+  "$@"
+  ret=$?
+  if [[ $is_test = 1 && $ret -gt 0 ]]; then
+    log "command failed with return $ret"
+    log
+    log "run ./fmt.sh to fix the issue"
+    exit 1
+  fi
+  return 0
+}
+
+## Main ##
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      cat <<USAGE
+Usage: ./fmt.sh [options]
+
+Options:
+  -h, --help: shows this help
+  --test:     only test for formatting changes, used by CI
+USAGE
+      exit
+      ;;
+    --test)
+      shift
+      is_test=1
+      scalafmt_args+=(--test)
+      dade_copyright_arg=check
+      ;;
+    *)
+      echo "fmt.sh: unknown argument $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Check for correct copyrights
+run dade-copyright-headers "$dade_copyright_arg" .
+
+# We have a Bazel test that is meant to run HLint, but we're a little sceptical of it
+# If we get this far, but hlint fails, that's a problem we should fix
+function bad_hlint() {
+  echo "UNEXPECTED HLINT FAILURE: The Bazel rules should have spotted this, please raise a GitHub issue"
+}
+trap bad_hlint EXIT
+for dir in daml-foundations da-assistant daml-assistant libs-haskell compiler; do
+  run pushd "$dir"
+  run hlint --git -j4
+  run popd
+done
+trap - EXIT
+
+# check for scala code style
+run ./scalafmt.sh "${scalafmt_args[@]}"
+


### PR DESCRIPTION
Split out the formatting and lint checks from ./build.sh.

On CI, only run ./fmt.sh on Linux where it's faster. Since those tests are platform-agnostic it's not necessary to run them on the other platforms.

This saves ~30s of execution on the macOS jobs

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
