### PR TITLE
pull-request template: fix link to CONTRIBUTING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Pull Request Checklist
 
-- [ ] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
+- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
 - [ ] Include appropriate tests
 - [ ] Set a descriptive title and thorough description
 - [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
-- [ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
+- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate


### PR DESCRIPTION
the relative link was being resolved to
https://github.com/digital-asset/daml/pull/CONTRIBUTING.md on the new
pull request. Point to the absolute URL instead.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
