### PR TITLE
Build grpc fat_cc_library on Windows

### DIFF
--- a/bazel_tools/fat_cc_library.bzl
+++ b/bazel_tools/fat_cc_library.bzl
@@ -1,19 +1,25 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@os_info//:os_info.bzl", "is_darwin")
+load("@os_info//:os_info.bzl", "is_darwin", "is_windows")
 
 def _fat_cc_library_impl(ctx):
     input_lib = ctx.attr.input_lib
     cc_info = input_lib[CcInfo]
-    pic_static_libs = []
+    static_libs = []
     # For now we assume that we have static PIC libs for all libs.
     # It should be possible to extend this but we do not have a need
     # for it so far and it would complicate things.
     for lib in cc_info.linking_context.libraries_to_link:
-        if not lib.pic_static_library:
-            fail("No PIC static lib for: " + lib)
-        pic_static_libs += [lib.pic_static_library]
+        static_lib = None
+        if lib.pic_static_library:
+            static_lib = lib.pic_static_library
+        elif is_windows and lib.static_library:
+            # On Windows we don't seem to have `pic_static_library`s available.
+            static_lib = lib.static_library
+        else:
+            fail("No (PIC) static library found.")
+        static_libs += [static_lib]
 
     dyn_lib = ctx.outputs.dynamic_library
     static_lib = ctx.outputs.static_library
@@ -21,24 +27,34 @@ def _fat_cc_library_impl(ctx):
     toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
     feature_configuration = cc_common.configure_features(cc_toolchain = toolchain)
 
+    compiler = None
+    if is_darwin:
+        # toolchain.compiler_executable() fails on MacOS, see https://github.com/bazelbuild/bazel/issues/7105
+        compiler = ctx.executable._cc_compiler
+    elif is_windows:
+        compiler = toolchain.compiler_executable() + ".exe"
+    else:
+        compiler = toolchain.compiler_executable()
     ctx.actions.run(
         mnemonic = "CppLinkFatDynLib",
         outputs = [dyn_lib],
-        # toolchain.compiler_executable() fails on MacOS, see https://github.com/bazelbuild/bazel/issues/7105
-        executable = ctx.executable.cc_compiler,
+        executable = compiler,
         arguments =
             ["-o", dyn_lib.path, "-shared"] +
+            ctx.attr.whole_archive_flag +
+            [f.path for f in static_libs] +
+            ctx.attr.no_whole_archive_flag +
             # Some libs seems to depend on libstdc++ implicitely
             ["-lstdc++"] +
-            ctx.attr.whole_archive_flag +
-            [f.path for f in pic_static_libs] +
-            ctx.attr.no_whole_archive_flag,
-        inputs = pic_static_libs,
+            # On Windows some libs seems to depend on Windows sockets
+            (["-lws2_32"] if is_windows else []),
+        inputs = static_libs,
+	env = {"PATH": ""},
     )
 
     mri_script_content = "\n".join(
         ["create {}".format(static_lib.path)] +
-        ["addlib {}".format(lib.path) for lib in pic_static_libs] +
+        ["addlib {}".format(lib.path) for lib in static_libs] +
         ["save", "end"]
     ) + "\n"
 
@@ -54,16 +70,16 @@ def _fat_cc_library_impl(ctx):
             mnemonic = "CppLinkFatStaticLib",
             outputs = [static_lib],
             executable = ar,
-            inputs = pic_static_libs,
+            inputs = static_libs,
             arguments =
                 ["-no_warning_for_no_symbols", "-static", "-o", static_lib.path] +
-                [f.path for f in pic_static_libs]
+                [f.path for f in static_libs]
         )
     else:
         ctx.actions.run_shell(
             mnemonic = "CppLinkFatStaticLib",
             outputs = [static_lib],
-            inputs = [mri_script] + pic_static_libs,
+            inputs = [mri_script] + static_libs,
             command = "{ar} -M < {mri_script}".format(ar = ar, mri_script = mri_script.path),
         )
 
@@ -103,14 +119,14 @@ fat_cc_library = rule(
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
-        "cc_compiler": attr.label(
+        "_cc_compiler": attr.label(
             allow_files = True,
             executable =True,
             cfg = "host",
             default =
                 # bin/cc is gcc on Darwin which fails to find libc++
-                Label("@nixpkgs_cc_toolchain//:bin/clang")
-                if is_darwin else Label("@nixpkgs_cc_toolchain//:bin/cc"),
+                Label("@nixpkgs_cc_toolchain//:bin/clang") if is_darwin
+                else None,
         ),
         "whole_archive_flag": attr.string_list(
             # ld on MacOS doesn’t understand --whole-archive
@@ -121,7 +137,7 @@ fat_cc_library = rule(
         ),
     }),
     outputs = {
-        "dynamic_library": "lib%{name}.so",
+        "dynamic_library": "lib%{name}.dll" if is_windows else "lib%{name}.so",
         "static_library": "lib%{name}.a",
     },
 )

--- a/bazel_tools/fat_cc_library.bzl
+++ b/bazel_tools/fat_cc_library.bzl
@@ -18,7 +18,9 @@ def _fat_cc_library_impl(ctx):
             # On Windows we don't seem to have `pic_static_library`s available.
             static_lib = lib.static_library
         else:
-            fail("No (PIC) static library found.")
+            fail("No (PIC) static library found for '{}'.".format(
+                str(lib.dynamic_library.path)
+            ))
         static_libs += [static_lib]
 
     dyn_lib = ctx.outputs.dynamic_library

--- a/build.ps1
+++ b/build.ps1
@@ -33,6 +33,7 @@ bazel build //compiler/daml-lf-ast/...
 
 # build gRPC
 bazel build @com_github_grpc_grpc//:grpc
+bazel build //nix/third-party/gRPC-haskell/core:fat_cbits
 
 # node / npm / yarn test
 bazel build //daml-foundations/daml-tools/daml-extension:daml_extension_lib


### PR DESCRIPTION
- Modify `fat_cc_library` rule to support Windows.
  - Had to move `-lstdc++` to the end, so that when linked statically (as on Windows) the symbols are know to be required.
  - Had to add `-lws2_32` on Windows.
  - Had to adapt the compiler executable on Windows.
  - Choose to use the `cc_toolchain` `cc` executable on Linux as well, as it is only problematic on Darwin.
  - Use `static_library` instead of `pic_static_library` on Windows, as the former is not available.
- Add grpc `fat_cbits` to Windows CI. (Currently disabled)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](./CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](./docs/source/support/release-notes.rst), if appropriate
