### PR TITLE
Turn off -Woverlowed-literals in damlc

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -94,7 +94,6 @@ wOptsSet =
 wOptsSetFatal :: [ WarningFlag ]
 wOptsSetFatal =
   [ Opt_WarnMissingFields
-  , Opt_WarnOverflowedLiterals
   ]
 
 -- | Warning options unset for DAML compilation. Note that these can be modified
@@ -103,6 +102,7 @@ wOptsSetFatal =
 wOptsUnset :: [ WarningFlag ]
 wOptsUnset =
   [ Opt_WarnMissingMonadFailInstances -- failable pattern plus RebindableSyntax raises this error
+  , Opt_WarnOverflowedLiterals -- this does not play well with -ticky and the error message is misleading
   ]
 
 

--- a/daml-foundations/daml-ghc/tests/IntBoundsLower.daml
+++ b/daml-foundations/daml-ghc/tests/IntBoundsLower.daml
@@ -2,13 +2,9 @@
 -- All rights reserved.
 
 -- Test that overflowing integer literals are detected at compile time.
--- @ ERROR Literal 9223372036854775808
--- @ ERROR Literal -9223372036854775809
+-- @ ERROR Int literal out of bounds
 daml 1.2
-module IntBoundsStatic where
-
-tooBig : Int
-tooBig = 9223372036854775808
+module IntBoundsLower where
 
 tooSmall : Int
 tooSmall = -9223372036854775809

--- a/daml-foundations/daml-ghc/tests/IntBoundsUpper.daml
+++ b/daml-foundations/daml-ghc/tests/IntBoundsUpper.daml
@@ -4,7 +4,7 @@
 -- Test that overflowing integer literals are detected at compile time.
 -- @ ERROR Int literal out of bounds
 daml 1.2
-module IntBoundsLower where
+module IntBoundsUpper where
 
 tooBig : Int
 tooBig = 9223372036854775808

--- a/daml-foundations/daml-ghc/tests/IntBoundsUpper.daml
+++ b/daml-foundations/daml-ghc/tests/IntBoundsUpper.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Test that overflowing integer literals are detected at compile time.
+-- @ ERROR Int literal out of bounds
+daml 1.2
+module IntBoundsLower where
+
+tooBig : Int
+tooBig = 9223372036854775808


### PR DESCRIPTION
This flag does not play well with location information obtained via `-ticky`.
Also, the error message you get from overflowed literals suggests to use
`-XNegativeLiterals`, which is a bad idea since it changes the meaning of
`(-1)` from `\x -> x - 1` to `negate 1`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate
