### PR TITLE
Switch to unix-compat for now in daml-assistant.

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -27,7 +27,7 @@ deps = [
     'temporary',
     'terminal-progress-bar',
     'text',
-    'unix',
+    'unix-compat',
     'utf8-string',
     'yaml',
 ]

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -28,13 +28,28 @@ import System.Directory
 import Control.Monad.Extra
 import Control.Exception.Safe
 import System.ProgressBar
-import System.Posix.Types
-import System.Posix.Files -- forget windows for now
 import qualified System.Info
 import qualified Data.Text as T
 import Data.Maybe
 import qualified Data.SemVer as V
 import qualified Control.Lens as L
+
+-- unix specific
+import System.PosixCompat.Types ( FileMode )
+import System.PosixCompat.Files
+    ( removeLink
+    , createSymbolicLink
+    , fileMode
+    , getFileStatus
+    , setFileMode
+    , intersectFileModes
+    , unionFileModes
+    , ownerReadMode
+    , ownerExecuteMode
+    , groupReadMode
+    , groupExecuteMode
+    , otherReadMode
+    , otherExecuteMode)
 
 displayInstallTarget :: InstallTarget -> Text
 displayInstallTarget = \case

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -29,10 +29,12 @@ import Data.Maybe
 import Control.Exception.Safe
 import Control.Monad
 import Conduit
-import System.Posix.Files
 import qualified Data.Conduit.Zlib as Zlib
 import qualified Data.Conduit.Tar as Tar
 import qualified Data.SemVer as V
+
+-- unix specific
+import System.PosixCompat.Files (createSymbolicLink)
 
 runTests :: IO ()
 runTests = do


### PR DESCRIPTION
unix-compat is supposedly available on Windows.

Clearly not a long term solution, but to get windows builds going.