### PR TITLE
Avoid symbolic links altogether on windows.

### DIFF
--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -323,7 +323,7 @@ extractAndInstall env source =
                         liftIO $ setFileMode targetPath (Tar.fileMode info)
                     Tar.FTDirectory -> do
                         liftIO $ createDirectoryIfMissing True targetPath
-                    Tar.FTSymbolicLink bs -> do
+                    Tar.FTSymbolicLink bs | Unix <- getPlatform -> do
                         let path = Tar.decodeFilePath bs
                         unless (isRelative path) $
                             liftIO $ throwIO $ assistantErrorBecause

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -202,27 +202,48 @@ installExtracted env@InstallEnv{..} sourcePath =
         requiredIO "Failed to set file mode of installed SDK directory." $
             setSdkFileMode (unwrapSdkPath targetPath)
 
-        whenActivate env $ do
-            let damlBinarySourcePath = unwrapSdkPath targetPath </> "daml" </> "daml"
-                damlBinaryTargetDir  = unwrapDamlPath damlPath </> "bin"
-                damlBinaryTargetPath = damlBinaryTargetDir </> "daml"
+        whenActivate env $ activateDaml env targetPath
 
-            unlessM (doesFileExist damlBinarySourcePath) $
-                throwIO $ assistantErrorBecause
-                    "daml binary is missing from SDK release."
-                    ("expected path = " <> pack damlBinarySourcePath)
+activateDaml :: InstallEnv -> SdkPath -> IO ()
+activateDaml env@InstallEnv{..} targetPath = do
 
-            whenM (doesFileExist damlBinaryTargetPath) $
-                requiredIO "Failed to delete existing daml binary symbolic link." $
-                    removeLink damlBinaryTargetPath
+    let damlSourceName =
+            case getPlatform of
+                Unix -> "daml"
+                Windows -> "daml.exe"
 
-            requiredIO ("Failed to link daml binary in " <> pack damlBinaryTargetDir) $
-                createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
+        damlTargetName =
+            case getPlatform of
+                Unix -> "daml"
+                Windows -> "daml.cmd"
 
-            unlessQuiet env $ do -- Ask user to add .daml/bin to PATH if it is absent.
-                searchPaths <- map dropTrailingPathSeparator <$> getSearchPath
-                when (damlBinaryTargetDir `notElem` searchPaths) $ do
-                    putStrLn ("Please add " <> damlBinaryTargetDir <> " to your PATH.")
+        damlBinarySourcePath = unwrapSdkPath targetPath </> "daml" </> damlSourceName
+        damlBinaryTargetDir  = unwrapDamlPath damlPath </> "bin"
+        damlBinaryTargetPath = damlBinaryTargetDir </> damlTargetName
+
+    unlessM (doesFileExist damlBinarySourcePath) $
+        throwIO $ assistantErrorBecause
+            "daml binary is missing from SDK release."
+            ("expected path = " <> pack damlBinarySourcePath)
+
+    whenM (doesFileExist damlBinaryTargetPath) $
+        requiredIO "Failed to delete existing daml binary link." $
+            case getPlatform of
+                Unix -> removeLink damlBinaryTargetPath
+                Windows -> removePathForcibly damlBinaryTargetPath
+
+    requiredIO ("Failed to link daml binary in " <> pack damlBinaryTargetDir) $
+        case getPlatform of
+            Unix -> createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
+            Windows -> do
+                let runnerScript = "START " <> damlBinarySourcePath <> " %*"
+                writeFile damlBinaryTargetPath runnerScript
+
+    unlessQuiet env $ do -- Ask user to add .daml/bin to PATH if it is absent.
+        searchPaths <- map dropTrailingPathSeparator <$> getSearchPath
+        when (damlBinaryTargetDir `notElem` searchPaths) $ do
+            putStrLn ("Please add " <> damlBinaryTargetDir <> " to your PATH.")
+
 
 data WalkCallbacks = WalkCallbacks
     { walkOnFile :: FilePath -> IO ()

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -318,9 +318,14 @@ testInstall = Tasty.testGroup "DAML.Assistant.Install"
                 .| sinkFile "source.tar.gz"
 
             install options damlPath
+    , case getPlatform of
+        Unix -> testInstallUnix
+        Windows -> testInstallWindows
+    ]
 
-
-    , Tasty.testCase "reject an absolute symlink in a tarball" $ do
+testInstallUnix :: Tasty.TestTree
+testInstallUnix = Tasty.testGroup "unix-specific tests"
+    [ Tasty.testCase "reject an absolute symlink in a tarball" $ do
         withSystemTempDirectory "test-install" $ \ base -> do
             let damlPath = DamlPath (base </> "daml")
                 options = InstallOptions
@@ -373,6 +378,7 @@ testInstall = Tasty.testGroup "DAML.Assistant.Install"
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target escapes tarball."
                 (install options damlPath)
-
-
     ]
+
+testInstallWindows :: Tasty.TestTree
+testInstallWindows = Tasty.testGroup "windows-specific tests" []

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -14,6 +14,7 @@ import qualified Data.Text as T
 import Data.Text (Text, pack, unpack)
 import Data.Maybe
 import Control.Exception.Safe
+import System.Info (os)
 
 data AssistantError = AssistantError
     { errContext  :: Maybe Text -- ^ Context in which error occurs.
@@ -80,3 +81,14 @@ data InstallTarget
     | InstallVersion SdkVersion
     | InstallPath FilePath
     deriving (Eq, Show)
+
+data Platform
+    = Unix
+    | Windows
+
+getPlatform :: Platform
+getPlatform = case os of
+    "darwin"  -> Unix
+    "linux"   -> Unix
+    "mingw32" -> Windows
+    _ -> error ("Unsupported operating system: " <> os)


### PR DESCRIPTION
Two changes:

- Don't handle symbolic links in tarballs, and don't test this, on windows.
- When "linking" the daml binary on windows, create a .cmd script to run the binary instead of a symbolic link. We'll have to test if this actually works & is upgradeable.
 
I pilfered the ".cmd" logic from the old assistant.