### PR TITLE
Simplify daml install & some refactoring.

### DIFF
--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -56,6 +56,27 @@ instance Y.FromJSON SdkVersion where
             Left e -> fail ("Invalid SDK version: " <> e)
             Right v -> pure (SdkVersion v)
 
+versionToString :: SdkVersion -> String
+versionToString = V.toString . unwrapSdkVersion
+
+versionToText :: SdkVersion -> Text
+versionToText = V.toText . unwrapSdkVersion
+
+data InvalidVersion = InvalidVersion
+    { ivSource :: !Text -- ^ invalid version
+    , ivMessage :: !String -- ^ error message
+    } deriving (Show, Eq)
+
+instance Exception InvalidVersion where
+    displayException (InvalidVersion bad msg) =
+        "Invalid SDK version  " <> show bad <> ": " <> msg
+
+parseVersion :: Text -> Either InvalidVersion SdkVersion
+parseVersion src =
+    case V.fromText src of
+        Left msg -> Left (InvalidVersion src msg)
+        Right v -> Right (SdkVersion v)
+
 isStableVersion :: SdkVersion -> Bool
 isStableVersion = (== []) . L.view V.release . unwrapSdkVersion
 

--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -78,7 +78,7 @@ parseVersion src =
         Right v -> Right (SdkVersion v)
 
 isStableVersion :: SdkVersion -> Bool
-isStableVersion = (== []) . L.view V.release . unwrapSdkVersion
+isStableVersion = null . L.view V.release . unwrapSdkVersion
 
 -- | File path of daml installation root (by default ~/.daml on unix, %APPDATA%/daml on windows).
 newtype DamlPath = DamlPath

--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -56,22 +56,8 @@ instance Y.FromJSON SdkVersion where
             Left e -> fail ("Invalid SDK version: " <> e)
             Right v -> pure (SdkVersion v)
 
-data SdkChannel
-    = Stable
-    | Unstable
-    | Custom [V.Identifier]
-    deriving (Eq, Ord, Show)
-
-versionChannel :: SdkVersion -> SdkChannel
-versionChannel (SdkVersion v) =
-    let ch = v L.^. V.release in
-    case ch of
-        [] -> Stable
-        [u] | Just u == V.textual "unstable" -> Unstable
-        _ -> Custom ch
-
 isStableVersion :: SdkVersion -> Bool
-isStableVersion = (== Stable) . versionChannel
+isStableVersion = (== []) . L.view V.release . unwrapSdkVersion
 
 -- | File path of daml installation root (by default ~/.daml on unix, %APPDATA%/daml on windows).
 newtype DamlPath = DamlPath

--- a/daml-assistant/src/DAML/Assistant.hs
+++ b/daml-assistant/src/DAML/Assistant.hs
@@ -9,6 +9,7 @@ module DAML.Assistant
     ) where
 
 import DAML.Project.Config
+import DAML.Project.Types
 import DAML.Assistant.Env
 import DAML.Assistant.Tests
 import DAML.Assistant.Command
@@ -19,7 +20,6 @@ import System.Process
 import System.Exit
 import Control.Exception.Safe
 import Data.Maybe
-import qualified Data.SemVer as V
 
 -- | Run the assistant and exit.
 main :: IO ()
@@ -32,7 +32,7 @@ main = do
 
         Builtin Version -> do
             version <- required "Could not determine SDK version." envSdkVersion
-            putStrLn (V.toString (unwrapSdkVersion version))
+            putStrLn (versionToString version)
 
         Builtin (Install options) -> wrapErr "Installing the SDK." $ do
             install options envDamlPath

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -59,7 +59,6 @@ installParser :: Parser InstallOptions
 installParser = InstallOptions
     <$> optional (RawInstallTarget <$> argument str (metavar "CHANNEL|VERSION|PATH"))
     <*> iflag ActivateInstall "activate" mempty "Activate installed version of daml"
-    <*> iflag InitialInstall "initial" mempty "Create daml home folder as well"
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
     <*> iflag QuietInstall "quiet" (short 'q') "Quiet verbosity"
     where

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -150,7 +150,7 @@ installExtracted env@InstallEnv{..} sourcePath =
             unless (versionMatchesTarget sourceVersion target) $
                 throwIO (assistantErrorBecause "SDK release version mismatch."
                     ("Expected " <> displayInstallTarget target
-                    <> " but got version " <> V.toText (unwrapSdkVersion sourceVersion)))
+                    <> " but got version " <> versionToText sourceVersion))
 
         -- Set file mode of files to install.
         requiredIO "Failed to set file modes for extracted SDK files." $
@@ -399,9 +399,9 @@ decideInstallTarget (RawInstallTarget arg) = do
     testF <- doesFileExist arg
     if testD || testF then
         pure (InstallPath arg)
-    else
-        fromRightM (throwIO . assistantErrorBecause "Invalid SDK version." . pack) $
-            InstallVersion . SdkVersion <$> V.fromText (pack arg)
+    else do
+        v <- requiredE "Invalid SDK version" (parseVersion (pack arg))
+        pure (InstallVersion v)
 
 -- | Run install command.
 install :: InstallOptions -> DamlPath -> IO ()

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -32,7 +32,6 @@ import Control.Monad
 import Conduit
 import qualified Data.Conduit.Zlib as Zlib
 import qualified Data.Conduit.Tar as Tar
-import qualified Data.SemVer as V
 
 -- unix specific
 import System.PosixCompat.Files (createSymbolicLink)
@@ -150,11 +149,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
                 expected2 = base </> "sdk"
 
             createDirectory expected2
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Just expected2)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
     , Tasty.testCase "getSdk determines DAML_SDK from DAML_SDK_VERSION" $ do
@@ -166,11 +165,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
 
             createDirectoryIfMissing True (base </> "daml" </> "sdk")
             createDirectory expected2
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Nothing)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
     , Tasty.testCase "getSdk determines DAML_SDK_VERSION from DAML_SDK" $ do
@@ -182,11 +181,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
 
             createDirectory expected2
             writeFileUTF8 (expected2 </> sdkConfigName) ("version: " <> expected1 <> "\n")
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Just expected2)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
     , Tasty.testCase "getSdk determines DAML_SDK and DAML_SDK_VERSION from project config" $ do
@@ -202,11 +201,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             writeFileUTF8 (base </> "project" </> projectConfigName)
                 ("project:\n  sdk-version: " <> expected1)
             createDirectory expected2
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Nothing)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
 
@@ -224,11 +223,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
                 ("project:\n  sdk-version: " <> projVers)
             createDirectory expected2
             writeFileUTF8 (expected2 </> sdkConfigName) ("version: " <> expected1 <> "\n")
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Just expected2)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
     , Tasty.testCase "getSdk: DAML_SDK_VERSION overrides project config version" $ do
@@ -244,11 +243,11 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             writeFileUTF8 (base </> "project" </> projectConfigName)
                 ("project:\n  sdk-version: " <> projVers)
             createDirectory expected2
-            (Just (SdkVersion got1), Just (SdkPath got2)) <-
+            (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Nothing)
                         ] (getSdk damlPath projectPath)
-            Tasty.assertEqual "sdk version" expected1 (V.toString got1)
+            Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
     , Tasty.testCase "getSdk: Returns Nothings if .daml/sdk is missing." $ do

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -298,7 +298,6 @@ testInstall = Tasty.testGroup "DAML.Assistant.Install"
                 options = InstallOptions
                     { iTargetM = Just (RawInstallTarget "source.tar.gz")
                     , iActivate = ActivateInstall True
-                    , iInitial = InitialInstall True
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     }
@@ -331,7 +330,6 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                 options = InstallOptions
                     { iTargetM = Just (RawInstallTarget "source.tar.gz")
                     , iActivate = ActivateInstall False
-                    , iInitial = InitialInstall True
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     }
@@ -358,7 +356,6 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                 options = InstallOptions
                     { iTargetM = Just (RawInstallTarget "source.tar.gz")
                     , iActivate = ActivateInstall False
-                    , iInitial = InitialInstall True
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     }

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -64,7 +64,6 @@ newtype UserCommandArgs = UserCommandArgs
 data InstallOptions = InstallOptions
     { iTargetM :: Maybe RawInstallTarget
     , iActivate :: ActivateInstall
-    , iInitial :: InitialInstall
     , iForce :: ForceInstall
     , iQuiet :: QuietInstall
     } deriving (Eq, Show)
@@ -73,4 +72,3 @@ newtype RawInstallTarget = RawInstallTarget String deriving (Eq, Show)
 newtype ForceInstall = ForceInstall Bool deriving (Eq, Show)
 newtype QuietInstall = QuietInstall Bool deriving (Eq, Show)
 newtype ActivateInstall = ActivateInstall Bool deriving (Eq, Show)
-newtype InitialInstall = InitialInstall Bool deriving (Eq, Show)

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -74,9 +74,3 @@ newtype ForceInstall = ForceInstall Bool deriving (Eq, Show)
 newtype QuietInstall = QuietInstall Bool deriving (Eq, Show)
 newtype ActivateInstall = ActivateInstall Bool deriving (Eq, Show)
 newtype InitialInstall = InitialInstall Bool deriving (Eq, Show)
-
-data InstallTarget
-    = InstallChannel SdkChannel
-    | InstallVersion SdkVersion
-    | InstallPath FilePath
-    deriving (Eq, Show)

--- a/release/install.sh
+++ b/release/install.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 DIR="$(cd $(dirname $(readlink -f "$BASH_SOURCE[0]")); pwd)"
-"$DIR/daml/daml" install --initial --activate "$DIR"
+"$DIR/daml/daml" install "$DIR" --activate $@


### PR DESCRIPTION
- Remove `--initial` flag, since it did barely anything and it makes sense to always create the `.daml` directory if it's missing, when it's time to install the sdk.
- Get rid of the concept of channels, which was premature. We need to move away from da-assistant before we can make a meaningful distinction between stable/nightly/unstable etc releases.
- Provide some convenient functions to deal with SDK versions so we don't have to import SemVer everywhere. 