### PR TITLE
Drop DA src_strip_prefix

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -5,7 +5,6 @@ load ("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
 
 da_haskell_library (
     name = "da-hs-daml-cli"
-  , src_strip_prefix = "DA"
   , extra_srcs = [
     "//daml-foundations/daml-tools/docs/daml-licenses/licenses:licensing.md"
   ]


### PR DESCRIPTION
This prefix, used in da-hs-daml-cli, should not be needed. As it happens
I am surprised it doesn't break the build.
