### PR TITLE
Add location information to DAML-LF produced by damlc

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -65,6 +65,10 @@ data Arg
   = TmArg Expr
   | TyArg Type
 
+mkEApp :: Expr -> Arg -> Expr
+mkEApp e (TmArg a) = ETmApp e a
+mkEApp e (TyArg t) = ETyApp e t
+
 _EApp :: Prism' Expr (Expr, Arg)
 _EApp = prism' inj proj
   where

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -496,6 +496,8 @@ instance Encode KeyExpr P.KeyExprSum where
 
 encodeKeyExpr ::  Version -> ExprVarName -> Expr -> Either String KeyExpr
 encodeKeyExpr version tplParameter = \case
+  ELocation _loc expr ->
+    encodeKeyExpr version tplParameter expr
   EVar var -> if var == tplParameter
     then Right (KeyExprProjections [])
     else Left ("Expecting variable " ++ show tplParameter ++ " in key expression, got " ++ show var)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -526,6 +526,8 @@ checkTemplate m t@(Template _loc tpl param precond signatories observers text ch
 
 checkValidKeyExpr :: MonadGamma m => Expr -> m ()
 checkValidKeyExpr = \case
+  ELocation _loc expr ->
+    checkValidKeyExpr expr
   ERecCon _typ recordExpr -> do
       traverse_ (checkValidKeyExpr . snd) recordExpr
   expr ->
@@ -533,6 +535,8 @@ checkValidKeyExpr = \case
 
 checkValidProjectionsKey :: MonadGamma m => Expr -> m ()
 checkValidProjectionsKey = \case
+  ELocation _loc expr ->
+    checkValidProjectionsKey expr
   EVar _var ->
     pure ()
   ERecProj _typ _field rec ->

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -77,6 +77,7 @@ xExtensionsUnset = [  ]
 xFlagsSet :: [ GeneralFlag ]
 xFlagsSet = [
    Opt_Haddock
+ , Opt_Ticky
  ]
 
 -- | Warning options set for DAML compilation. Note that these can be modified
@@ -121,6 +122,7 @@ adjustDynFlags paths packageState mbPackageName dflags
   $ apply gopt_set xFlagsSet
   dflags{
     mainModIs = mkModule primUnitId (mkModuleName "NotAnExistingName"), -- avoid DEL-6770
+    debugLevel = 1,
     ghcLink = NoLink, hscTarget = HscNothing -- avoid generating .o or .hi files
     {-, dumpFlags = Opt_D_ppr_debug `EnumSet.insert` dumpFlags dflags -- turn on debug output from GHC-}
   }

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -94,6 +94,7 @@ import           Control.Monad.Reader
 import           Control.Monad.State.Strict
 import           DA.Daml.LF.Ast as LF
 import           Data.Data hiding (TyCon)
+import           Data.Foldable (foldlM)
 import           Data.Functor.Foldable
 import           Data.Int
 import           Data.List.Extra
@@ -344,6 +345,7 @@ convertChoice env (VarIs "C:Choice" `App` Type tmpl `App` Type (TypeCon chc []) 
         argVar = EVar (mkVar "arg")
 
         f i (App a _) = f i a
+        f i (Tick _ e) = f i e
         f i (VarIs "nonconsuming") = pure False
         f i (VarIs "$dmconsuming") = pure True -- the default is consuming
         f i (Var x) | i > 0 = f (i-1) =<< envFindBind env x -- only required to see through the automatic default
@@ -368,7 +370,7 @@ convertKey _ o = unhandled "Template key definition" o
 
 convertKeyExpr :: Env -> Var -> GHC.Expr Var -> ConvertM LF.Expr
 convertKeyExpr env keyBinder keyExpr
-    | Case (Var caseScrut) caseBinder _ [(DataAlt con, vs, body)] <- keyExpr
+    | Case (Var caseScrut) caseBinder _ [(DataAlt con, vs, body)] <- untick keyExpr
     , keyBinder == caseScrut = do
         ctor@(Ctor _ fldNames _) <- toCtor env con
         if  | isRecordCtor ctor
@@ -498,42 +500,49 @@ internalFunctions = MS.fromList $ map (first mkModuleName)
 convertExpr :: Env -> GHC.Expr Var -> ConvertM LF.Expr
 convertExpr env0 e = do
     (e, args) <- go env0 e []
-    args <- mapM (convertArg env0) args
-    pure $ mkEApps e args
+    let appArg e (mbSrcSpan, arg) =
+            mkEApp (maybe id (ELocation . convRealSrcSpan) mbSrcSpan e) <$> convertArg env0 arg
+    foldlM appArg e args
   where
     -- NOTE(MH): We collect all arguments to functions in a list such that
     -- we have access to them when converting functions. This is necessary to
     -- inline fully applied record constructors instead of going through a
     -- record constructor function, which is required for contract keys.
-    go :: Env -> GHC.Expr Var -> [GHC.Arg Var] -> ConvertM (LF.Expr, [GHC.Expr Var])
+    go :: Env -> GHC.Expr Var -> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])
+    go env (Tick (SourceNote srcSpan _) x) args = case args of
+        [] -> do
+            x <- convertExpr env x
+            pure (ELocation (convRealSrcSpan srcSpan) x, [])
+        (_, arg):args -> go env x ((Just srcSpan, arg):args)
+    go env (Tick _ x) args = go env x args
     go env (x `App` y) args
-        = go env x (y : args)
+        = go env x ((Nothing, y) : args)
     -- see through $ to give better matching power
-    go env (VarIs "$") (Type _ : Type _ : x : y : args)
+    go env (VarIs "$") (LType _ : LType _ : LExpr x : y : args)
         = go env x (y : args)
 
-    go env (VarIs "$dminternalCreate") (Type t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
+    go env (VarIs "$dminternalCreate") (LType t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
         t' <- convertType env t
         tmpl' <- convertQualified env tmpl
         pure $ ETmLam (varV1, t') $ EUpdate $ UCreate tmpl' $ EVar varV1
-    go env (VarIs "$dminternalFetch") (Type t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
+    go env (VarIs "$dminternalFetch") (LType t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
         t' <- convertType env t
         tmpl' <- convertQualified env tmpl
         pure . ETmLam (varV1, TContractId t') $ EUpdate $ UFetch tmpl' $ EVar varV1
-    go env (VarIs "$dminternalExercise") (Type t@(TypeCon tmpl []) : Type c@(TypeCon chc []) : Type _result : _dict : args) = fmap (, args) $ do
+    go env (VarIs "$dminternalExercise") (LType t@(TypeCon tmpl []) : LType c@(TypeCon chc []) : LType _result : _dict : args) = fmap (, args) $ do
         t' <- convertType env t
         c' <- convertType env c
         tmpl' <- convertQualified env tmpl
         pure $
             ETmLam (varV1, TList TParty) $ ETmLam (varV2, TContractId t') $ ETmLam (varV3, c') $
             EUpdate $ UExercise tmpl' (mkChoiceName $ is chc) (EVar varV2) (EVar varV1) (EVar varV3)
-    go env (VarIs "$dminternalArchive") (Type t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
+    go env (VarIs "$dminternalArchive") (LType t@(TypeCon tmpl []) : _dict : args) = fmap (, args) $ do
         t' <- convertType env t
         tmpl' <- convertQualified env tmpl
         pure $
             ETmLam (varV1, TList TParty) $ ETmLam (varV2, TContractId t') $
             EUpdate $ UExercise tmpl' (mkChoiceName "Archive") (EVar varV2) (EVar varV1) mkEUnit
-    go env (VarIs "$dminternalFetchByKey") (Type t@(TypeCon tmpl []) : Type key : _dict : args)
+    go env (VarIs "$dminternalFetchByKey") (LType t@(TypeCon tmpl []) : LType key : _dict : args)
         = fmap (, args) $ do
         key' <- convertType env key
         tmpl' <- convertQualified env tmpl
@@ -553,7 +562,7 @@ convertExpr env0 e = do
               [ (Tagged "_1", ETupleProj (Tagged "contractId") (EVar varV2))
               , (Tagged "_2", ETupleProj (Tagged "contract") (EVar varV2))
               ])))
-    go env (VarIs "$dminternalLookupByKey") (Type t@(TypeCon tmpl []) : Type key : _dict : args)
+    go env (VarIs "$dminternalLookupByKey") (LType t@(TypeCon tmpl []) : LType key : _dict : args)
         = fmap (, args) $ do
         key' <- convertType env key
         tmpl' <- convertQualified env tmpl
@@ -562,40 +571,40 @@ convertExpr env0 e = do
             { retrieveByKeyTemplate = tmpl'
             , retrieveByKeyKey = EVar varV1
             }
-    go env (VarIs "primitive") (Type (isStrLitTy -> Just y) : Type t : args)
+    go env (VarIs "primitive") (LType (isStrLitTy -> Just y) : LType t : args)
         = fmap (, args) $ convertPrim (envLfVersion env) (unpackFS y) <$> convertType env t
-    go env (VarIs "getFieldPrim") (Type (isStrLitTy -> Just name) : Type record : Type _field : args) = fmap (, args) $ do
+    go env (VarIs "getFieldPrim") (LType (isStrLitTy -> Just name) : LType record : LType _field : args) = fmap (, args) $ do
         record' <- convertType env record
         pure $ ETmLam (varV1, record') $ ERecProj (fromTCon record') (mkField $ unpackFS name) $ EVar varV1
     -- NOTE(MH): We only inline `getField` for record types. This is required
     -- for contract keys. Projections on sum-of-records types have to through
     -- the type class for `getField`.
-    go env (VarIs "getField") (Type (isStrLitTy -> Just name) : Type recordType@(TypeCon recordTyCon _) : Type _fieldType : _dict : record : args)
+    go env (VarIs "getField") (LType (isStrLitTy -> Just name) : LType recordType@(TypeCon recordTyCon _) : LType _fieldType : _dict : LExpr record : args)
         | Just [_] <- tyConDataCons_maybe recordTyCon = fmap (, args) $ do
             recordType <- convertType env recordType
             record <- convertExpr env record
             pure $ ERecProj (fromTCon recordType) (mkField $ unpackFS name) record
-    go env (VarIs "setFieldPrim") (Type (isStrLitTy -> Just name) : Type record : Type field : args) = fmap (, args) $ do
+    go env (VarIs "setFieldPrim") (LType (isStrLitTy -> Just name) : LType record : LType field : args) = fmap (, args) $ do
         record' <- convertType env record
         field' <- convertType env field
         pure $
             ETmLam (varV1, field') $ ETmLam (varV2, record') $
             ERecUpd (fromTCon record') (mkField $ unpackFS name) (EVar varV2) (EVar varV1)
-    go env (VarIs "fromRational") ((VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+    go env (VarIs "fromRational") (LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ pure $ EBuiltin $ BEDecimal $ fromRational $ top % bot
-    go env (VarIs "negate") (tyInt : VarIs "$fAdditiveInt" : (VarIs "fromInteger" `App` Lit (LitNumber _ x _)) : args)
+    go env (VarIs "negate") (tyInt : LExpr (VarIs "$fAdditiveInt") : LExpr (untick -> VarIs "fromInteger" `App` Lit (LitNumber _ x _)) : args)
         = fmap (, args) $ convertInt64 (negate x)
-    go env (VarIs "fromInteger") (Lit (LitNumber _ x _) : args)
+    go env (VarIs "fromInteger") (LExpr (Lit (LitNumber _ x _)) : args)
         = fmap (, args) $ convertInt64 x
     go env (Lit (LitNumber LitNumInt x _)) args
         = fmap (, args) $ convertInt64 x
-    go env (VarIs "fromString") (x : args)
+    go env (VarIs "fromString") (LExpr x : args)
         = fmap (, args) $ convertExpr env x
-    go env (VarIs "unpackCString#") (Lit (LitString x) : args)
+    go env (VarIs "unpackCString#") (LExpr (Lit (LitString x)) : args)
         = fmap (, args) $ pure $ EBuiltin $ BEText $ T.decodeLatin1 x
-    go env (VarIs "unpackCStringUtf8#") (Lit (LitString x) : args)
+    go env (VarIs "unpackCStringUtf8#") (LExpr (Lit (LitString x)) : args)
         = fmap (, args) $ pure $ EBuiltin $ BEText $ T.decodeUtf8 x
-    go env x@(Var f) (Type t1 : Type t2 : Lit (LitString s) : args)
+    go env x@(Var f) (LType t1 : LType t2 : LExpr (untick -> Lit (LitString s)) : args)
         | Just m <- nameModule_maybe (getName f)
         , moduleNameString (GHC.moduleName m) == "Control.Exception.Base"
         = fmap (, args) $ do
@@ -605,7 +614,7 @@ convertExpr env0 e = do
         pure (x' `ETyApp` t1' `ETyApp` t2' `ETmApp` EBuiltin (BEText (T.decodeUtf8 s)))
 
     -- conversion of bodies of $con2tag functions
-    go env (VarIs "getTag") (Type (TypeCon t _) : x : args) = fmap (, args) $ do
+    go env (VarIs "getTag") (LType (TypeCon t _) : LExpr x : args) = fmap (, args) $ do
         Ctors _ _ cs <- toCtors env t
         x' <- convertExpr env x
         t' <- convertQualified env t
@@ -613,7 +622,7 @@ convertExpr env0 e = do
             [ CaseAlternative (CPVariant t' (mkVariantCon (getOccString variantName)) (mkVar "_")) (EBuiltin $ BEInt64 i)
             | (Ctor variantName _ _, i) <- zip cs [0..]
             ]
-    go env (VarIs "tagToEnum#") (Type (TypeCon (Is "Bool") []) : (op0 `App` x `App` y) : args)
+    go env (VarIs "tagToEnum#") (LType (TypeCon (Is "Bool") []) : LExpr (op0 `App` x `App` y) : args)
         | VarIs "==#" <- op0 = go BEEqual
         | VarIs "<#"  <- op0 = go BELess
         | VarIs ">#"  <- op0 = go BEGreater
@@ -622,10 +631,10 @@ convertExpr env0 e = do
               x' <- convertExpr env x
               y' <- convertExpr env y
               pure (EBuiltin (op1 BTInt64) `ETmApp` x' `ETmApp` y')
-    go env (VarIs "tagToEnum#") (Type (TypeCon (Is "Bool") []) : x : args) = fmap (, args) $ do
+    go env (VarIs "tagToEnum#") (LType (TypeCon (Is "Bool") []) : LExpr x : args) = fmap (, args) $ do
         x' <- convertExpr env x
         pure $ EBuiltin (BEEqual BTInt64) `ETmApp` EBuiltin (BEInt64 1) `ETmApp` x'
-    go env (VarIs "tagToEnum#") (Type tt@(TypeCon t _) : x : args) = fmap (, args) $ do
+    go env (VarIs "tagToEnum#") (LType tt@(TypeCon t _) : LExpr x : args) = fmap (, args) $ do
         -- FIXME: Should generate a binary tree of eq and compare
         Ctors _ _ cs@(c1:_) <- toCtors env t
         tt' <- convertType env tt
@@ -635,37 +644,37 @@ convertExpr env0 e = do
         pure (foldr ($) (mkCtor c1) [mkIf (mkEqInt i) (mkCtor c) | (i,c) <- zipFrom 0 cs])
 
     -- built ins because they are lazy
-    go env (VarIs "ifThenElse") (Type tRes : cond : true : false : args)
+    go env (VarIs "ifThenElse") (LType tRes : LExpr cond : LExpr true : LExpr false : args)
         = fmap (, args) $ mkIf <$> convertExpr env cond <*> convertExpr env true <*> convertExpr env false
-    go env (VarIs "||") (x : y : args)
+    go env (VarIs "||") (LExpr x : LExpr y : args)
         = fmap (, args) $ mkIf <$> convertExpr env x <*> pure ETrue <*> convertExpr env y
-    go env (VarIs "&&") (x : y : args)
+    go env (VarIs "&&") (LExpr x : LExpr y : args)
         = fmap (, args) $ mkIf <$> convertExpr env x <*> convertExpr env y <*> pure EFalse
-    go env (VarIs "when") (Type monad : dict : x : y : args)
+    go env (VarIs "when") (LType monad : LExpr dict : LExpr x : LExpr y : args)
         = fmap (, args) $ mkIf <$> convertExpr env x <*> convertExpr env y <*> mkPure env monad dict TUnit EUnit
-    go env (VarIs "unless") (Type monad : dict : x : y : args)
+    go env (VarIs "unless") (LType monad : LExpr dict : LExpr x : LExpr y : args)
         = fmap (, args) $ mkIf <$> convertExpr env x <*> mkPure env monad dict TUnit EUnit <*> convertExpr env y
-    go env (VarIs "submit") (Type typ : pty : upd : args) = fmap (, args) $ do
+    go env (VarIs "submit") (LType typ : LExpr pty : LExpr upd : args) = fmap (, args) $ do
         pty' <- convertExpr env pty
         upd' <- convertExpr env upd
         typ' <- convertType env typ
         pure $
           EScenario (SCommit typ' pty' (EUpdate (UEmbedExpr typ' upd')))
-    go env (VarIs "submitMustFail") (Type typ : pty : upd : args) = fmap (, args) $ do
+    go env (VarIs "submitMustFail") (LType typ : LExpr pty : LExpr upd : args) = fmap (, args) $ do
         pty' <- convertExpr env pty
         upd' <- convertExpr env upd
         typ' <- convertType env typ
         pure $ EScenario (SMustFailAt typ' pty' (EUpdate (UEmbedExpr typ' upd')))
 
     -- custom conversion because they correspond to builtins in DAML-LF, so can make the output more readable
-    go env (VarIs "pure") (Type monad : dict : Type t : x : args)
+    go env (VarIs "pure") (LType monad : LExpr dict : LType t : LExpr x : args)
         -- This is generating the special UPure/SPure nodes when the monad is Update/Scenario.
         = fmap (, args) $ join $ mkPure env monad dict <$> convertType env t <*> convertExpr env x
-    go env (VarIs "return") (Type monad : Type t : dict : x : args)
+    go env (VarIs "return") (LType monad : LType t : LExpr dict : LExpr x : args)
         -- This is generating the special UPure/SPure nodes when the monad is Update/Scenario.
         -- In all other cases, 'return' is rewritten to 'pure'.
         = fmap (, args) $ join $ mkPure env monad dict <$> convertType env t <*> convertExpr env x
-    go env bind@(VarIs ">>=") allArgs@(Type monad : dict : Type _ : Type _ : x : lam@(Lam b y) : args) = do
+    go env bind@(VarIs ">>=") allArgs@(LType monad : LExpr dict : LType _ : LType _ : LExpr x : LExpr lam@(Lam b y) : args) = do
         monad' <- convertType env monad
         case monad' of
           TBuiltin BTUpdate -> mkBind EUpdate UBind
@@ -677,7 +686,7 @@ convertExpr env0 e = do
               y' <- convertExpr env y
               b' <- convVarWithType env b
               pure (inj (bind (Binding b' x') y'))
-    go env semi@(VarIs ">>") allArgs@(Type monad : Type t : Type _ : _dict : x : y : args) = do
+    go env semi@(VarIs ">>") allArgs@(LType monad : LType t : LType _ : LExpr _dict : LExpr x : LExpr y : args) = do
         monad' <- convertType env monad
         case monad' of
           TBuiltin BTUpdate -> mkSeq EUpdate UBind
@@ -690,28 +699,28 @@ convertExpr env0 e = do
               y' <- convertExpr env y
               pure $ inj (bind (Binding (mkVar "_", t') x') y')
 
-    go env (VarIs "[]") (Type (TypeCon (Is "Char") []) : args)
+    go env (VarIs "[]") (LType (TypeCon (Is "Char") []) : args)
         = fmap (, args) $ pure $ EBuiltin (BEText T.empty)
-    go env (VarIs "[]") (Type t : args)
+    go env (VarIs "[]") (LType t : args)
         = fmap (, args) $ ENil <$> convertType env t
     go env (VarIs "[]") args
         = fmap (, args) $ pure $ ETyLam varT1 $ ENil (TVar (fst varT1))
     -- TODO(MH): We should use the same technique as in GenDALF to avoid
     -- generating useless lambdas.
-    go env (VarIs ":") (Type t : args) = fmap (, args) $ do
+    go env (VarIs ":") (LType t : args) = fmap (, args) $ do
         t' <- convertType env t
         pure $ mkETmLams [(varV1, t'), (varV2, TList t')] $ ECons t' (EVar varV1) (EVar varV2)
     go env (VarIs ":") args
         = fmap (, args) $ do
             let t' = TVar (fst varT1)
             pure $ ETyLam varT1 $ mkETmLams [(varV1, t'), (varV2, TList t')] $ ECons t' (EVar varV1) (EVar varV2)
-    go env (Var v) (Type t : args)
+    go env (Var v) (LType t : args)
         | isBuiltinNone env v
         = fmap (, args) $ ENone <$> convertType env t
     go env (Var v) args
         | isBuiltinNone env v
         = fmap (, args) $ pure $ ETyLam varT1 $ ENone (TVar (fst varT1))
-    go env (Var v) (Type t : args)
+    go env (Var v) (LType t : args)
         | isBuiltinSome env v
         = fmap (, args) $ do
             t' <- convertType env t
@@ -746,7 +755,7 @@ convertExpr env0 e = do
             if  | let tycon = dataConTyCon con
                 , tyConFlavour tycon /= ClassFlavour && isRecordCtor ctor && isSingleConType tycon
                 , let n = length (dataConUnivTyVars con)
-                , let (tyArgs, tmArgs) = splitAt n args
+                , let (tyArgs, tmArgs) = splitAt n (map snd args)
                 , length tyArgs == n && length tmArgs == length fldNames
                 , Just tyArgs <- mapM isType_maybe tyArgs
                 , all (isNothing . isType_maybe) tmArgs
@@ -842,7 +851,6 @@ convertExpr env0 e = do
           else pure $
             ELet (Binding bind' scrutinee') $
             ECase (EVar $ convVar bind) alts'
-    go env (Tick _ x) args = go env x args
     go env (Let (Rec xs) _) args = unsupported "Local variables defined recursively - recursion can only happen at the top level" $ map fst xs
     go env o@(Coercion _) args = unhandled "Coercion" o
     go _ x args = unhandled "Expression" x
@@ -1094,14 +1102,17 @@ convNameLoc :: NamedThing a => a -> Maybe LF.SourceLoc
 convNameLoc n = case nameSrcSpan (getName n) of
   -- NOTE(MH): Locations are 1-based in GHC and 0-based in DAML-LF.
   -- Hence all the @- 1@s below.
-  RealSrcSpan srcSpan -> Just SourceLoc
+  RealSrcSpan srcSpan -> Just (convRealSrcSpan srcSpan)
+  UnhelpfulSpan{} -> Nothing
+
+convRealSrcSpan :: RealSrcSpan -> LF.SourceLoc
+convRealSrcSpan srcSpan = SourceLoc
     { slocModuleRef = Nothing
     , slocStartLine = srcSpanStartLine srcSpan - 1
     , slocStartCol = srcSpanStartCol srcSpan - 1
     , slocEndLine = srcSpanEndLine srcSpan - 1
     , slocEndCol = srcSpanEndCol srcSpan - 1
     }
-  UnhelpfulSpan{} -> Nothing
 
 ---------------------------------------------------------------------
 -- SMART CONSTRUCTORS
@@ -1193,12 +1204,14 @@ rewriteMaintainer key maintainer = do
     unwindProjections = go []
       where
         go fields = \case
+            ELocation _ expr -> go fields expr
             ERecProj _typ field expr -> go (field : fields) expr
             expr -> (expr, fields)
 
     -- TODO(#299): The error messages are pretty bad.
     buildKeyMap :: LF.Expr -> ConvertM (MS.Map [FieldName] LF.Expr)
     buildKeyMap = \case
+        ELocation _ expr -> buildKeyMap expr
         ERecCon typ fields -> do
             keyMaps <- forM fields $ \(fieldName, fieldExpr) ->
                 MS.map (ERecProj typ fieldName) <$> buildKeyMap fieldExpr

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -81,3 +81,18 @@ defaultMethods core = Set.fromList
   | ATyCon (tyConClass_maybe -> Just class_) <- nameEnvElts (cm_types core)
   , (_id, Just (name, VanillaDM)) <- classOpItems class_
   ]
+
+untick :: GHC.Expr b -> GHC.Expr b
+untick = \case
+    Tick _ e -> untick e
+    e -> e
+
+-- | An argument to a function together with the location information of the
+-- _function_.
+type LArg b = (Maybe RealSrcSpan, Arg b)
+
+pattern LType :: Type -> LArg b
+pattern LType x <- (_, Type x)
+
+pattern LExpr :: GHC.Expr b -> LArg b
+pattern LExpr x <- (_, x)

--- a/daml-foundations/daml-ghc/tests/RightOfUse.daml
+++ b/daml-foundations/daml-ghc/tests/RightOfUse.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR exercise of Accept in RightOfUse:RightOfUseOffer at unknown source failed due to a missing authorization from 'Betina Beakley'
+-- @ERROR exercise of Accept in RightOfUse:RightOfUseOffer at RightOfUse:35:16 failed due to a missing authorization from 'Betina Beakley'
 daml 1.2
 
 module RightOfUse where

--- a/daml-foundations/daml-ghc/tests/RightOfUse.daml
+++ b/daml-foundations/daml-ghc/tests/RightOfUse.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR exercise of Accept in RightOfUse:RightOfUseOffer at RightOfUse:35:16 failed due to a missing authorization from 'Betina Beakley'
+-- @ERROR Scenario execution failed on commit at RightOfUse:56:5:
 daml 1.2
 
 module RightOfUse where

--- a/daml-foundations/daml-ghc/tests/UseInteger.daml
+++ b/daml-foundations/daml-ghc/tests/UseInteger.daml
@@ -2,10 +2,10 @@
 -- All rights reserved.
 
 -- Test that foo is not overflowed
--- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]? == "foo") | .dvalBody.EBuiltin.BEInt64 == "1.0"
+-- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]? == "foo") | .dvalBody.ELocation | .[1] | .EBuiltin.BEInt64 == "1.0"
 
 -- Test that we daml-lf can hold maxBound :: Int64
--- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]?=="bar") | .dvalBody.EBuiltin.BEInt64 == "9.223372036854775807e18"
+-- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]?=="bar") | .dvalBody.ELocation | .[1] | .EBuiltin.BEInt64 == "9.223372036854775807e18"
 
 daml 1.2 module UseInteger where
 

--- a/daml-foundations/daml-tools/language-server-tests/tests/diagnostics/scenario-error/EXPECTED.json
+++ b/daml-foundations/daml-tools/language-server-tests/tests/diagnostics/scenario-error/EXPECTED.json
@@ -13,11 +13,11 @@
         }
       },
       "source": "Scenario",
-      "message": "Scenario execution failed:\n  #0: create of Main:Agree at unknown source\n      failed due to a missing authorization from 'Alice'\n\nLedger time: 1970-01-01T00:00:00Z\n\nPartial transaction:\n  Sub-transactions:\n     #0\n     └─> create Main:Agree\n         with\n           p1 = 'Foo'; p2 = 'Alice'"
+      "message": "Scenario execution failed on commit at Main:28:5:\n  #0: create of Main:Agree at DA.Internal.Prelude:388:1\n      failed due to a missing authorization from 'Alice'\n\nLast source location: DA.Internal.Prelude:388:1\n\nLedger time: 1970-01-01T00:00:00Z\n\nPartial transaction:\n  Sub-transactions:\n     #0\n     └─> create Main:Agree\n         with\n           p1 = 'Foo'; p2 = 'Alice'"
     }
   ],
   "file:/tests/diagnostics/scenario-error/Prelude.daml": [],
-  "file:/tests/diagnostics/scenario-error/DA/Internal/Desugar.daml": [],
   "file:/tests/diagnostics/scenario-error/DA/Internal/Record.daml": [],
+  "file:/tests/diagnostics/scenario-error/DA/Internal/Desugar.daml": [],
   "file:/tests/diagnostics/scenario-error/DA/Internal/RebindableSyntax.daml": []
 }

--- a/daml-lf/tests/scenario/daml-1.3/contract-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.3/contract-keys/EXPECTED.ledger
@@ -1,5 +1,5 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [unknown source]
+TX #0 1970-01-01T00:00:00Z [Test:28]
 #0:0
 │   archived by #8:1
 │   referenced by #4:0, #5:0, #8:0, #8:1
@@ -8,35 +8,35 @@ TX #0 1970-01-01T00:00:00Z [unknown source]
     with: { p = 'Alice', tkKey = "some-key" } value-version: 1
 key { _1 = 'Alice', _2 = "some-key" } value-version: 1
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:34]
 
-mustFailAt 'Bob' [unknown source]
+mustFailAt 'Bob' [Test:40]
 
-mustFailAt 'Bob' [unknown source]
+mustFailAt 'Bob' [Test:42]
 
-TX #4 1970-01-01T00:00:00Z [unknown source]
+TX #4 1970-01-01T00:00:00Z [Test:45]
 #4:0
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" } value-version: 1
 found #0:0
 
-TX #5 1970-01-01T00:00:00Z [unknown source]
+TX #5 1970-01-01T00:00:00Z [Test:49]
 #5:0
 └─> ensure active #0:0
 
-TX #6 1970-01-01T00:00:00Z [unknown source]
+TX #6 1970-01-01T00:00:00Z [Test:53]
 #6:0
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "blah" } value-version: 1
 not found
 
-TX #7 1970-01-01T00:00:00Z [unknown source]
+TX #7 1970-01-01T00:00:00Z [Test:57]
 #7:0
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Bob', _2 = "some-key" } value-version: 1
 not found
 
-TX #8 1970-01-01T00:00:00Z [unknown source]
+TX #8 1970-01-01T00:00:00Z [Test:61]
 #8:0
 └─> ensure active #0:0
 
@@ -46,13 +46,13 @@ TX #8 1970-01-01T00:00:00Z [unknown source]
     with {  } value-version: 1
     
 
-TX #9 1970-01-01T00:00:00Z [unknown source]
+TX #9 1970-01-01T00:00:00Z [Test:64]
 #9:0
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" } value-version: 1
 not found
 
-TX #10 1970-01-01T00:00:00Z [unknown source]
+TX #10 1970-01-01T00:00:00Z [Test:70]
 #10:0
 │   archived by #11:1
 │   referenced by #11:0, #11:1
@@ -61,7 +61,7 @@ TX #10 1970-01-01T00:00:00Z [unknown source]
     with: { p = 'Alice', tkKey = "some-key-2" } value-version: 1
 key { _1 = 'Alice', _2 = "some-key-2" } value-version: 1
 
-TX #11 1970-01-01T00:00:00Z [unknown source]
+TX #11 1970-01-01T00:00:00Z [Test:74]
 #11:0
 └─> ensure active #10:0
 

--- a/daml-lf/tests/scenario/daml-1.3/divulge-iou/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.3/divulge-iou/EXPECTED.ledger
@@ -1,19 +1,19 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [unknown source]
+TX #0 1970-01-01T00:00:00Z [Test:12]
 #0:0
 │   referenced by #2:2
 │   known to (since): Alice (#0), AlicesBank (#0), Bob (#2)
 └─> create Test:Iou@XXXXXXXX
     with: { payer = 'AlicesBank', owner = 'Alice', amount = Test:Amount@XXXXXXXX{ value = 1.0000000000, currency = "USD" } } value-version: 1
 
-TX #1 1970-01-01T00:00:00Z [unknown source]
+TX #1 1970-01-01T00:00:00Z [Test:17]
 #1:0
 │   referenced by #2:0, #2:1
 │   known to (since): AlicesBank (#1), Bob (#1)
 └─> create Test:DivulgeIouByExercise@XXXXXXXX
     with: { payer = 'AlicesBank', divulgee = 'Bob' } value-version: 1
 
-TX #2 1970-01-01T00:00:00Z [unknown source]
+TX #2 1970-01-01T00:00:00Z [Test:20]
 #2:0
 └─> ensure active #1:0
 

--- a/daml-lf/tests/scenario/daml-1.3/embed-abort/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.3/embed-abort/EXPECTED.ledger
@@ -1,8 +1,8 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [unknown source]
+TX #0 1970-01-01T00:00:00Z [Test:20]
 
 
-TX #1 1970-01-01T00:00:00Z [unknown source]
+TX #1 1970-01-01T00:00:00Z [Test:21]
 
 
 active contracts:

--- a/daml-lf/tests/scenario/daml-1.3/mustfails/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.3/mustfails/EXPECTED.ledger
@@ -1,13 +1,13 @@
 transactions:
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:88]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:92]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:96]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:100]
 
-TX #4 1970-01-01T00:00:00Z [unknown source]
+TX #4 1970-01-01T00:00:00Z [Test:108]
 #4:0
 │   known to (since): Alice (#4), Bob (#4)
 └─> create Test:X@XXXXXXXX
@@ -15,19 +15,19 @@ TX #4 1970-01-01T00:00:00Z [unknown source]
 
 pass -100000000
 
-mustFailAt 'Bob' [unknown source]
+mustFailAt 'Bob' [Test:110]
 
-TX #7 1969-12-31T23:58:20Z [unknown source]
+TX #7 1969-12-31T23:58:20Z [Test:115]
 #7:0
 │   known to (since): Alice (#7)
 └─> create Test:TwoParties@XXXXXXXX
     with: { p = 'Alice', p2 = 'Alice' } value-version: 1
 
-mustFailAt 'Bob' [unknown source]
+mustFailAt 'Bob' [Test:116]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:123]
 
-TX #10 1969-12-31T23:58:20Z [unknown source]
+TX #10 1969-12-31T23:58:20Z [Test:128]
 #10:0
 │   archived by #11:1
 │   referenced by #11:0, #11:1
@@ -35,7 +35,7 @@ TX #10 1969-12-31T23:58:20Z [unknown source]
 └─> create Test:ToTwoParties@XXXXXXXX
     with: { p = 'Alice', p2 = 'Bob' } value-version: 1
 
-TX #11 1969-12-31T23:58:20Z [unknown source]
+TX #11 1969-12-31T23:58:20Z [Test:129]
 #11:0
 └─> ensure active #10:0
 
@@ -49,43 +49,43 @@ TX #11 1969-12-31T23:58:20Z [unknown source]
     └─> create Test:TwoParties@XXXXXXXX
         with: { p = 'Alice', p2 = 'Bob' } value-version: 1
 
-mustFailAt 'Bob' [unknown source]
+mustFailAt 'Bob' [Test:130]
 
-TX #13 1969-12-31T23:58:20Z [unknown source]
+TX #13 1969-12-31T23:58:20Z [Test:134]
 #13:0
 │   known to (since): Alice (#13)
 └─> create Test:NoCtrls@XXXXXXXX
     with: { p = 'Alice', xs = [] } value-version: 1
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:135]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:139]
 
-TX #16 1969-12-31T23:58:20Z [unknown source]
+TX #16 1969-12-31T23:58:20Z [Test:144]
 #16:0
 │   known to (since): Alice (#16), Bob (#16)
 └─> create Test:X@XXXXXXXX
     with: { p = 'Alice', p2 = 'Bob' } value-version: 1
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:145]
 
-TX #18 1969-12-31T23:58:20Z [unknown source]
+TX #18 1969-12-31T23:58:20Z [Test:151]
 #18:0
 │   known to (since): Alice (#18)
 └─> create Test:Recursive@XXXXXXXX
     with: { p = 'Alice' } value-version: 1
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:154]
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:340]
 
-TX #21 1969-12-31T23:58:20Z [unknown source]
+TX #21 1969-12-31T23:58:20Z [Test:345]
 #21:0
 │   known to (since): Alice (#21)
 └─> create Test:NestingLimitExercise@XXXXXXXX
     with: { p = 'Alice' } value-version: 1
 
-mustFailAt 'Alice' [unknown source]
+mustFailAt 'Alice' [Test:346]
 
 active contracts:
    #4:0, #7:0, #11:2, #13:0, #16:0, #18:0, #21:0

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandClientIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandClientIT.scala
@@ -359,7 +359,7 @@ class CommandClientIT
         // Note: we only check that the beginning of the error matches otherwise every time the package id
         // changes this test fails.
         val expectedMessageSubstring =
-          "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [unknown source], partial transaction: root node"
+          "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:19], partial transaction: root node"
         val command = c.createCommand(
           "Dummy for failing assert",
           templateIds.dummy,


### PR DESCRIPTION
This is required to get error locations in the scenario view. Rigth now,
the location information for `create`/`exercise` still points to the
template/choice. I'll fix that in a separate PR.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate
