### PR TITLE
Sandbox Postgres support with passing api integration tests

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -6,6 +6,7 @@ Release notes
 
 This page contains release notes for the SDK.
 
+- introducing experimental support for using Postgres as a backend for the Sandbox. The optional CLI argument for it named ``--jdbcurl`` is still hidden. 
 - Node.js Bindings: fixed validation for Ledger API timestamp values
 - Node.js Bindings: drops support for identifier names, replacing them with separated module and entity names
 - Node.js Bindings: use strings instead of numbers to represent Ledger API timestamps and dates

--- a/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
+++ b/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
@@ -63,7 +63,7 @@ import scala.concurrent.Future
   * the newly committed transaction.
   *
   */
-trait LedgerBackend {
+trait LedgerBackend extends AutoCloseable {
 
   /** Return the identifier of the Participant node's state that this
     * [[LedgerBackend]] reads from and writes to.

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -72,7 +72,7 @@ class TransactionServiceIT
     Config
       .defaultWithTimeProvider(TimeProviderType.WallClock)
 
-  override val timeLimit: Span = 60.seconds
+  override val timeLimit: Span = 300.seconds
 
   private def newClient(stub: TransactionService, ledgerId: String): TransactionClient =
     new TransactionClient(ledgerId, stub)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -39,7 +39,7 @@ import com.digitalasset.platform.api.v1.event.EventOps._
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestTemplateIds}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
-import com.digitalasset.platform.participant.util.ValueConversions._
+import com.digitalasset.platform.participant.x§util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
 import com.google.rpc.code.Code
 import io.grpc.{Status, StatusRuntimeException}

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -39,7 +39,7 @@ import com.digitalasset.platform.api.v1.event.EventOps._
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestTemplateIds}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
-import com.digitalasset.platform.participant.x§util.ValueConversions._
+import com.digitalasset.platform.participant.util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
 import com.google.rpc.code.Code
 import io.grpc.{Status, StatusRuntimeException}

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
@@ -56,7 +56,8 @@ class TransactionBackpressureIT
 
       def sendCommands() =
         Source(1 to noOfCommands)
-          .mapAsync(20)(i =>
+          .throttle(10, 1.second)
+          .mapAsync(10)(i =>
             commandClient.submitSingleCommand(oneKbCommandRequest(ctx.ledgerId, s"command-$i")))
           .runWith(Sink.ignore)
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -31,6 +31,7 @@ import com.digitalasset.ledger.api.v1.value.{
   Variant
 }
 import com.digitalasset.ledger.client.services.commands.CompletionStreamElement
+import com.digitalasset.platform.apitesting.LedgerBackend.SandboxInMemory
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.google.rpc.code.Code
@@ -521,9 +522,14 @@ abstract class CommandTransactionChecks
         }.map(_ => succeed)
       }
 
+
+    
+
       // this is basically a port of
       // `daml-lf/tests/scenario/daml-1.3/contract-keys/Test.daml`.
-      "process contract keys" in allFixtures { ctx =>
+      //TODO: enable this for all fixtures when we support contract keys in Postgres
+      "process contract keys" in forAllMatchingFixtures {
+        case TestFixture(SandboxInMemory, ctx) =>
         // TODO currently we run multiple suites with the same sandbox, therefore we must generate
         // unique keys. This is not so great though, it'd be better to have a clean environment.
         val keyPrefix = UUID.randomUUID.toString

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiFixtureBase.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiFixtureBase.scala
@@ -98,13 +98,10 @@ trait MultiFixtureBase[FixtureId, TestContext]
     forAllFixtures(fixture => runTest(fixture.context))
 
   protected def forAllFixtures(runTest: TestFixture => Future[Assertion]): Future[Assertion] = {
-    allMatchingFixtures { case f => runTest(f) }
+    forAllMatchingFixtures { case f => runTest(f) }
   }
 
-  // TODO: this method will be useful once we differentiate parity and non-parity instances on the TestContext level.
-  // Since the current TestContext in MultiLedgerTest is a Channel, this is not possible, and I'd change the context in
-  // a follow-up PR
-  protected def allMatchingFixtures(
+  protected def forAllMatchingFixtures(
       runTest: PartialFunction[TestFixture, Future[Assertion]]): Future[Assertion] = {
     @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))
     implicit val ec = global

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiLedgerFixture.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiLedgerFixture.scala
@@ -24,7 +24,7 @@ trait MultiLedgerFixture
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[LedgerBackend] =
-    Set(LedgerBackend.SandboxSql) //TODO: enable the SQL one as well once we have all ITs working with it
+    Set(LedgerBackend.SandboxInMemory, LedgerBackend.SandboxSql)
 
   override protected def constructResource(
       index: Int,

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiLedgerFixture.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/MultiLedgerFixture.scala
@@ -24,7 +24,7 @@ trait MultiLedgerFixture
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[LedgerBackend] =
-    Set(LedgerBackend.SandboxInMemory) //TODO: enable the SQL one as well once we have all ITs working with it
+    Set(LedgerBackend.SandboxSql) //TODO: enable the SQL one as well once we have all ITs working with it
 
   override protected def constructResource(
       index: Int,

--- a/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Backend.scala
+++ b/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Backend.scala
@@ -91,6 +91,9 @@ class Backend(
     logger.debug("shutdownTasks called.")
     ledger.shutdownTasks()
   }
+
+  override def close(): Unit = {} //TODO: Jussi, is there anything to free up here?
+
 }
 
 class Handle(ledger: Ledger, ledgerSyncOffset: LedgerSyncOffset, ec: ExecutionContext)
@@ -125,4 +128,5 @@ class Handle(ledger: Ledger, ledgerSyncOffset: LedgerSyncOffset, ec: ExecutionCo
 
   override def lookupContractKey(key: Node.GlobalKey): Future[Option[Value.AbsoluteContractId]] =
     sys.error("contract keys not implemented in example backend")
+
 }

--- a/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Backend.scala
+++ b/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Backend.scala
@@ -92,7 +92,7 @@ class Backend(
     ledger.shutdownTasks()
   }
 
-  override def close(): Unit = {} //TODO: Jussi, is there anything to free up here?
+  override def close(): Unit = {}
 
 }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
@@ -52,7 +52,7 @@ object LedgerApiServer {
       implicit materializer: ActorMaterializer): LedgerApiServer = {
 
     new LedgerApiServer(
-      { (mat, esf) =>
+      ledgerBackend, { (mat, esf) =>
         services(config, ledgerBackend, timeProvider, optTimeServiceBackend)(mat, esf)
       },
       optResetService,
@@ -182,6 +182,7 @@ object LedgerApiServer {
 }
 
 class LedgerApiServer(
+    ledgerBackend: LedgerBackend,
     services: (ActorMaterializer, ExecutionSequencerFactory) => Iterable[BindableService],
     optResetService: Option[SandboxResetService],
     addressOption: Option[String],
@@ -265,6 +266,7 @@ class LedgerApiServer(
 
   override def close(): Unit = {
     closeAllServices()
+    ledgerBackend.close()
     Option(server).foreach { s =>
       s.shutdownNow()
       s.awaitTermination(10, TimeUnit.SECONDS)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
 
 object SandboxApplication {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -86,11 +87,11 @@ object SandboxApplication {
       val (ledgerType, ledger) = config.jdbcUrl match {
         case None => ("in-memory", Ledger.inMemory(ledgerId, timeProvider, acs, records))
         case Some(jdbcUrl) =>
-          sys.error("Postgres persistence is not supported yet.") //TODO: remove this when we do
-        //          val ledgerF = Ledger.postgres(jdbcUrl, ledgerId, timeProvider, records)
-        //          val ledger = Try(Await.result(ledgerF, asyncTolerance))
-        //            .getOrElse(sys.error("Could not start PostgreSQL persistence layer"))
-        //          (s"sql", ledger)
+          //    sys.error("Postgres persistence is not supported yet.") //TODO: remove this when we do
+          val ledgerF = Ledger.postgres(jdbcUrl, ledgerId, timeProvider, records)
+          val ledger = Try(Await.result(ledgerF, asyncTolerance))
+            .getOrElse(sys.error("Could not start PostgreSQL persistence layer"))
+          (s"sql", ledger)
       }
 
       val ledgerBackend = new SandboxLedgerBackend(ledger)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
@@ -87,7 +87,6 @@ object SandboxApplication {
       val (ledgerType, ledger) = config.jdbcUrl match {
         case None => ("in-memory", Ledger.inMemory(ledgerId, timeProvider, acs, records))
         case Some(jdbcUrl) =>
-          //    sys.error("Postgres persistence is not supported yet.") //TODO: remove this when we do
           val ledgerF = Ledger.postgres(jdbcUrl, ledgerId, timeProvider, records)
           val ledger = Try(Await.result(ledgerF, asyncTolerance))
             .getOrElse(sys.error("Could not start PostgreSQL persistence layer"))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -103,6 +103,7 @@ object Cli {
 
     opt[String]("jdbcurl")
       .optional()
+      .hidden()
       .text("The JDBC connection URL to a Postgres database containing the username and password as well. If missing the Sandbox will use an in memory store.")
       .action((url, config) => config.copy(jdbcUrl = Some(url)))
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -21,7 +21,7 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlLedger
 import scala.collection.immutable
 import scala.concurrent.Future
 
-trait Ledger {
+trait Ledger extends AutoCloseable {
 
   def ledgerId: String
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxLedgerBackend.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxLedgerBackend.scala
@@ -116,4 +116,8 @@ class SandboxLedgerBackend(ledger: Ledger)(implicit mat: Materializer) extends L
         )
     }
   }
+
+  override def close(): Unit = {
+    ledger.close()
+  }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -140,4 +140,6 @@ class InMemoryLedger(
     ()
   }
 
+  override def close(): Unit = ()
+
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -63,8 +63,7 @@ private class SqlLedger(
     headAtInitialization: Long,
     ledgerDao: LedgerDao,
     timeProvider: TimeProvider)(implicit mat: Materializer)
-    extends Ledger
-    with AutoCloseable {
+    extends Ledger {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -107,7 +106,10 @@ private class SqlLedger(
       .run()
   }
 
-  override def close(): Unit = persistenceQueue.complete()
+  override def close(): Unit = {
+    persistenceQueue.complete()
+    ledgerDao.close()
+  }
 
   private def loadStartingState(ledgerEntries: immutable.Seq[LedgerEntry]): Future[Unit] =
     if (ledgerEntries.nonEmpty) {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -182,7 +182,7 @@ private class SqlLedger(
           tx.submitter,
           tx.workflowId,
           tx.ledgerEffectiveTime,
-          Instant.now(),
+          timeProvider.getCurrentTime,
           mappedTx,
           mappedDisclosure
         )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
@@ -44,7 +44,7 @@ object PersistenceResponse {
 
 }
 
-trait LedgerDao {
+trait LedgerDao extends AutoCloseable {
 
   /** Looks up the ledger id */
   def lookupLedgerId(): Future[Option[String]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/PostgresLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/PostgresLedgerDao.scala
@@ -559,6 +559,10 @@ private class PostgresLedgerDao(
         DirectExecutionContext)
   }
 
+  override def close(): Unit = {
+    dbDispatcher.close()
+  }
+
 }
 
 object PostgresLedgerDao {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/HikariJdbcConnectionProvider.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/HikariJdbcConnectionProvider.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.control.NonFatal
 
 /** A helper to run JDBC queries using a pool of managed connections */
-trait JdbcConnectionProvider {
+trait JdbcConnectionProvider extends AutoCloseable {
 
   /** Blocks are running in a single transaction as the commit happens when the connection
     * is returned to the pool.
@@ -83,6 +83,11 @@ class HikariJdbcConnectionProvider(
 
   override def getStreamingConnection(): Connection =
     streamingDataSource.getConnection()
+
+  override def close(): Unit = {
+    shortLivedDataSource.close()
+    streamingDataSource.close()
+  }
 
 }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -6,13 +6,20 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundEach
+import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.duration._
 
 class SqlLedgerSpec
     extends AsyncWordSpec
+    with AsyncTimeLimitedTests
     with Matchers
     with PostgresAroundEach
     with AkkaBeforeAndAfterAll {
+
+  override val timeLimit: Span = 60.seconds
 
   "SQL Ledger" should {
     "be able to be created from scratch with a random ledger id" in {


### PR DESCRIPTION
- fixes all issues found during running api integration tests using a ledger on Postgres
- enables the PostgresSQL test fixture -> all tests need to pass with it too from now on
- enables Postgres support 
- making CLI arg for `jdbcurl` hidden

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate
