### PR TITLE
language: new package command for damlc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -180,6 +180,7 @@ filegroup(
     name = "bin",
     srcs = ["bin/c2hs"],
 )
+exports_files(["bin/ghc-pkg"])
   ''',
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps + [

--- a/daml-assistant/daml-project-config/DAML/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Config.hs
@@ -57,7 +57,7 @@ readConfig name path = do
 
 -- | Determine pinned sdk version from project config, if it exists.
 sdkVersionFromProjectConfig :: ProjectConfig -> Either ConfigError (Maybe SdkVersion)
-sdkVersionFromProjectConfig = queryProjectConfig ["project", "sdk-version"]
+sdkVersionFromProjectConfig = queryProjectConfig ["sdk-version"]
 
 -- | Determine sdk version from project config, if it exists.
 sdkVersionFromSdkConfig :: SdkConfig -> Either ConfigError SdkVersion
@@ -75,7 +75,7 @@ queryDamlConfig path = queryConfig "daml" "DamlConfig" path . unwrapDamlConfig
 -- | Query the project config by passing a path to the desired property.
 -- See 'queryConfig' for more details.
 queryProjectConfig :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError (Maybe t)
-queryProjectConfig path = queryConfig "project" "ProjectConfig" path . unwrapProjectConfig
+queryProjectConfig path = queryConfig "" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Query the sdk config by passing a list of members to the desired property.
 -- See 'queryConfig' for more details.
@@ -88,7 +88,7 @@ queryDamlConfigRequired path = queryConfigRequired "daml" "DamlConfig" path . un
 
 -- | Like 'queryProjectConfig' but returns an error if the property is missing.
 queryProjectConfigRequired :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError t
-queryProjectConfigRequired path = queryConfigRequired "project" "ProjectConfig" path . unwrapProjectConfig
+queryProjectConfigRequired path = queryConfigRequired "" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Like 'querySdkConfig' but returns an error if the property is missing.
 querySdkConfigRequired :: Y.FromJSON t => [Text] -> SdkConfig -> Either ConfigError t

--- a/daml-assistant/daml-project-config/DAML/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Config.hs
@@ -75,7 +75,7 @@ queryDamlConfig path = queryConfig "daml" "DamlConfig" path . unwrapDamlConfig
 -- | Query the project config by passing a path to the desired property.
 -- See 'queryConfig' for more details.
 queryProjectConfig :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError (Maybe t)
-queryProjectConfig path = queryConfig "" "ProjectConfig" path . unwrapProjectConfig
+queryProjectConfig path = queryConfig "project" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Query the sdk config by passing a list of members to the desired property.
 -- See 'queryConfig' for more details.
@@ -88,7 +88,7 @@ queryDamlConfigRequired path = queryConfigRequired "daml" "DamlConfig" path . un
 
 -- | Like 'queryProjectConfig' but returns an error if the property is missing.
 queryProjectConfigRequired :: Y.FromJSON t => [Text] -> ProjectConfig -> Either ConfigError t
-queryProjectConfigRequired path = queryConfigRequired "" "ProjectConfig" path . unwrapProjectConfig
+queryProjectConfigRequired path = queryConfigRequired "project" "ProjectConfig" path . unwrapProjectConfig
 
 -- | Like 'querySdkConfig' but returns an error if the property is missing.
 querySdkConfigRequired :: Y.FromJSON t => [Text] -> SdkConfig -> Either ConfigError t

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -57,6 +57,8 @@ quickstartTests quickstartDir = testGroup "quickstart"
           callProcessQuiet "daml" ["init"]
     , testCase "daml package" $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["package"]
+    , testCase "daml build " $ withCurrentDirectory quickstartDir $
+          callProcessQuiet "daml" ["build"]
     , testCase "daml test" $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["test", "daml/Main.daml"]
     , testCase "sandbox startup" $

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -65,7 +65,7 @@ quickstartTests quickstartDir = testGroup "quickstart"
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do
           p :: Int <- fromIntegral <$> getFreePort
-          withCreateProcess ((proc "daml" ["sandbox", "--port", show p, "target/daml/iou.dar"]) { std_out = UseHandle devNull }) $
+          withCreateProcess ((proc "daml" ["sandbox", "--port", show p, "quickstart.dar"]) { std_out = UseHandle devNull }) $
               \_ _ _ ph -> race_ (waitForProcess' "sandbox" [] ph) $ do
               waitForConnectionOnPort (threadDelay 100000) p
               addr : _ <- getAddrInfo

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -53,8 +53,10 @@ quickstartTests :: FilePath -> TestTree
 quickstartTests quickstartDir = testGroup "quickstart"
     [ testCase "daml new" $
           callProcessQuiet "daml" ["new", quickstartDir]
+    , testCase "daml init" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet "daml" ["init"]
     , testCase "daml package" $ withCurrentDirectory quickstartDir $
-          callProcessQuiet "daml" ["package", "daml/Main.daml", "target/daml/iou"]
+          callProcessQuiet "daml" ["package"]
     , testCase "daml test" $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["test", "daml/Main.daml"]
     , testCase "sandbox startup" $

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -199,7 +199,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             createDirectoryIfMissing True (base </> "daml" </> "sdk")
             createDirectory (base </> "project")
             writeFileUTF8 (base </> "project" </> projectConfigName)
-                ("project:\n  sdk-version: " <> expected1)
+                ("sdk-version: " <> expected1)
             createDirectory expected2
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -8,6 +8,8 @@ module DA.Daml.GHC.Compiler.Options
     , mkOptions
     , getBaseDir
     , toCompileOpts
+    , projectPackageDatabase
+    , basePackages
     ) where
 
 
@@ -87,6 +89,13 @@ moduleImportPaths pm =
         | rootModDir == "." = Just rootPathDir
         | otherwise = dropTrailingPathSeparator <$> List.stripSuffix rootModDir rootPathDir
 
+-- | The project package database path relative to the project root.
+projectPackageDatabase :: FilePath
+projectPackageDatabase = ".package-database"
+
+-- | Packages that we ship with the compiler.
+basePackages :: [String]
+basePackages = ["daml-prim", "daml-stdlib"]
 
 -- | Check that import paths and package db directories exist
 -- and add the default package db if it exists
@@ -101,8 +110,7 @@ mkOptions opts@Options {..} = do
     let defaultPkgDb
           | deprecatedPkgDbExists = deprecatedPkgDb
           | otherwise = baseDir </> "package-database"
-    let projectPkgDb = ".package-database"
-    pkgDbs <- filterM Dir.doesDirectoryExist [projectPkgDb, defaultPkgDb]
+    pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDb, projectPackageDatabase]
     pure opts {optPackageDbs = map (</> versionSuffix) $ pkgDbs ++ optPackageDbs}
   where checkDirExists f =
           Dir.doesDirectoryExist f >>= \ok ->

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -31,6 +31,7 @@ A (fat) dar file is a zip file containing
      - all these files _must_ reside in the same directory 'topdir'
      - the 'topdir' in the absolute path is replaced by 'name'
 * all dalf dependencies
+* additional data files under the data/ directory.
 
 'topdir' is the path prefix of the top module that is _not_ part of the
 qualified module name.

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -15,6 +15,7 @@ import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import           System.FilePath
+import System.Directory
 import qualified Codec.Archive.Zip          as Zip
 
 ------------------------------------------------------------------------------
@@ -47,13 +48,19 @@ buildDar ::
   -> FilePath
   -> [(T.Text, BS.ByteString)]
   -> [FilePath]
+  -> [(String, BS.ByteString)]
   -> String
   -> IO BS.ByteString
-buildDar dalf modRoot dalfDependencies fileDependencies name = do
+buildDar dalf modRoot dalfDependencies fileDependencies dataFiles name = do
+    -- Take all source file dependencies and produced interface files. Only the new package command
+    -- produces interface files per default, hence we filter for existent files.
+    fileDeps <-
+        filterM doesFileExist $
+        concat [[dep, replaceExtension dep "hi"] | dep <- fileDependencies]
     -- Reads all module source files, and pairs paths (with changed prefix)
     -- with contents as BS. The path must be within the module root path, and
     -- is modified to have prefix <name> instead of the original root path.
-    mbSrcFiles <- forM fileDependencies $ \mPath -> do
+    mbSrcFiles <- forM fileDeps $ \mPath -> do
       contents <- BSL.readFile mPath
       let mbNewPath = (name </>) <$> stripPrefix (addTrailingPathSeparator modRoot) mPath
       return $ fmap (, contents) mbNewPath
@@ -61,12 +68,14 @@ buildDar dalf modRoot dalfDependencies fileDependencies name = do
     let dalfName = name <> ".dalf"
     let dependencies = [(T.unpack pkgName <> ".dalf", BSC.fromStrict bs)
                           | (pkgName, bs) <- dalfDependencies]
+    let dataFiles' = [("data" </> n, BSC.fromStrict bs) | (n, bs) <- dataFiles]
 
     -- construct a zip file from all required files
     let allFiles = ("META-INF/MANIFEST.MF", manifestHeader dalfName $ dalfName:map fst dependencies)
                     : (dalfName, dalf)
                     : catMaybes mbSrcFiles
                     ++ dependencies
+                    ++ dataFiles'
 
         mkEntry (filePath, content) = Zip.toEntry filePath 0 content
         zipArchive = foldr (Zip.addEntryToArchive . mkEntry) Zip.emptyArchive allFiles

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -271,9 +271,10 @@ buildDar ::
      IdeState
   -> FilePath
   -> String
+  -> [(String, BS.ByteString)]
   -> UseDalf
   -> ExceptT [Diagnostic] IO BS.ByteString
-buildDar service file pkgName dalfInput = do
+buildDar service file pkgName dataFiles dalfInput = do
   liftIO $
     CompilerService.logDebug service $
     "Creating dar: " <> T.pack file
@@ -285,6 +286,7 @@ buildDar service file pkgName dalfInput = do
         (takeDirectory file)
         []
         []
+        dataFiles
         pkgName
     else do
       dalf <- encodeArchiveLazy <$> compileFile service file
@@ -308,6 +310,7 @@ buildDar service file pkgName dalfInput = do
               (takeDirectory file)
               dalfDependencies
               (file:fileDependencies)
+              dataFiles
               pkgName
 
 -- | Get the transitive package dependencies on other dalfs.

--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -31,6 +31,7 @@ da_haskell_library(
         "network",
         "optparse-applicative",
         "prettyprinter",
+        "process",
         "safe-exceptions",
         "shake",
         "split",

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -129,6 +129,14 @@ cmdInspect =
     cmd = execInspect <$> inputFileOpt <*> outputFileOpt <*> jsonOpt
 
 
+cmdBuild :: Int -> Mod CommandFields Command
+cmdBuild numProcessors =
+    command "build" $
+    info (helper <*> cmd) $
+    progDesc "Initialize, build and package the DAML project" <> fullDesc
+  where
+    cmd = pure $ execBuild numProcessors
+
 cmdPackageNew :: Int -> Mod CommandFields Command
 cmdPackageNew numProcessors =
     command "package-new" $
@@ -385,6 +393,11 @@ createProjectPackageDb lfVersion fps = do
             , "--package-db=" ++ dbPath
             , "--expand-pkgroot"
             ]
+
+execBuild :: Int -> IO ()
+execBuild numProcessors = do
+  execInit
+  execPackageNew numProcessors Nothing
 
 lfVersionString :: LF.Version -> String
 lfVersionString lfVersion =
@@ -753,6 +766,7 @@ options numProcessors =
         <> cmdInspect
         <> cmdPackageNew numProcessors
         <> cmdInit
+        <> cmdBuild numProcessors
       )
 
 parserInfo :: Int -> ParserInfo Command

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -11,6 +11,7 @@ module DA.Cli.Damlc (main, execTest) where
 
 import Control.Monad.Except
 import qualified Control.Monad.Managed             as Managed
+import Control.Exception (throwIO)
 import qualified "cryptonite" Crypto.Hash as Crypto
 import Codec.Archive.Zip
 import qualified Da.DamlLf as PLF
@@ -22,6 +23,7 @@ import           DA.Cli.Args
 import           DA.Prelude
 import qualified DA.Pretty
 import           DA.Service.Daml.Compiler.Impl.Handle as Compiler
+import DA.Daml.GHC.Compiler.Options (projectPackageDatabase, basePackages)
 import qualified DA.Service.Daml.LanguageServer    as Daml.LanguageServer
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Proto3.Archive as Archive
@@ -32,11 +34,14 @@ import qualified DA.Service.Logger.Impl.IO         as Logger.IO
 import qualified DA.Service.Logger.Impl.GCP        as Logger.GCP
 import qualified DA.Service.Logger.Impl.Pure as Logger.Pure
 import DAML.Project.Consts
+import DAML.Project.Config
+import DAML.Project.Types (ProjectPath(..))
 import qualified Data.Aeson.Encode.Pretty as Aeson.Pretty
 import Data.ByteArray.Encoding (Base (Base16), convertToBase)
 import qualified Data.ByteString                   as B
 import qualified Data.ByteString.Lazy as BSL
 import Data.Either
+import qualified Data.ByteString.Char8 as BSC
 import Data.FileEmbed (embedFile)
 import Data.Functor
 import qualified Data.Set as Set
@@ -59,7 +64,8 @@ import qualified ScenarioService as SS
 import System.Directory (createDirectoryIfMissing)
 import System.Environment (withProgName)
 import System.Exit (exitFailure)
-import System.FilePath (takeDirectory, (<.>), (</>), isExtensionOf, takeFileName, dropExtension)
+import System.FilePath (takeDirectory, (<.>), (</>), isExtensionOf, takeFileName, dropExtension, takeBaseName)
+import System.Process(callCommand)
 import           System.IO                         (stderr, hPutStrLn)
 import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 import qualified Text.XML.Light as XML
@@ -122,6 +128,14 @@ cmdInspect =
     jsonOpt = switch $ long "json" <> help "Output the raw Protocol Buffer structures as JSON"
     cmd = execInspect <$> inputFileOpt <*> outputFileOpt <*> jsonOpt
 
+
+cmdPackageNew :: Int -> Mod CommandFields Command
+cmdPackageNew numProcessors =
+    command "package-new" $
+    info (helper <*> cmd) $
+    progDesc "Compile the DAML project into a DAML ARchive (DAR)" <> fullDesc
+  where
+    cmd = execPackageNew numProcessors <$> optionalOutputFileOpt
 
 cmdPackage :: Int -> Mod CommandFields Command
 cmdPackage numProcessors =
@@ -208,7 +222,152 @@ execCompile inputFile outputFile opts = withProjectRoot $ \relativize -> do
 
 newtype DumpPom = DumpPom{unDumpPom :: Bool}
 
-execPackage :: FilePath -- ^ input file
+execPackageNew :: Int -> Maybe FilePath -> IO ()
+execPackageNew numProcessors mbOutFile =
+    withProjectRoot $ \_relativize -> do
+        project <- readProjectConfig $ ProjectPath "."
+        case parseProjectConfig project of
+            Left err -> throwIO err
+            Right (name, main, exposedModules, version, dependencies) -> do
+                createProjectPackageDb LF.versionDefault dependencies
+                defaultOpts <- Compiler.defaultOptionsIO Nothing
+                let opts =
+                        defaultOpts
+                            { optMbPackageName = Just name
+                            , optThreads = numProcessors
+                            , optWriteInterface = True
+                            }
+                loggerH <- getLogger opts "package"
+                let confFile =
+                        mkConfFile
+                            name
+                            version
+                            LF.versionDefault
+                            exposedModules
+                            dependencies
+                Managed.with (Compiler.newIdeState opts Nothing loggerH) $ \compilerH -> do
+                    darOrErr <-
+                        runExceptT $
+                        Compiler.buildDar
+                            compilerH
+                            main
+                            name
+                            [confFile]
+                            (UseDalf False)
+                    case darOrErr of
+                        Left errs ->
+                            ioError $
+                            userError $
+                            unlines
+                                [ "Creation of DAR file failed:"
+                                , T.unpack $
+                                  Pretty.renderColored $
+                                  Pretty.vcat $
+                                  map prettyDiagnostic $
+                                  Set.toList $ Set.fromList errs
+                                ]
+                        Right dar -> do
+                            let fp = targetFilePath name
+                            createDirectoryIfMissing True $ takeDirectory fp
+                            B.writeFile fp dar
+                            putStrLn $ "Created " <> fp <> "."
+  where
+    parseProjectConfig project = do
+        name <- queryProjectConfigRequired ["project", "name"] project
+        main <- queryProjectConfigRequired ["project", "source"] project
+        exposedModules <-
+            queryProjectConfigRequired ["project", "exposed-modules"] project
+        version <- queryProjectConfigRequired ["project", "version"] project
+        dependencies <-
+            queryProjectConfigRequired ["project", "dependencies"] project
+        Right (name, main, exposedModules, version, dependencies)
+
+    mkConfFile ::
+           String
+        -> String
+        -> LF.Version
+        -> [String]
+        -> [FilePath]
+        -> (String, B.ByteString)
+    mkConfFile name version lfVersion exposedMods deps = (confName, bs)
+      where
+        confName = name ++ ".conf"
+        lfVersionStr = lfVersionString lfVersion
+        bs =
+            BSC.pack $
+            unlines
+                [ "name: " ++ name
+                , "id: " ++ name
+                , "key: " ++ name
+                , "version: " ++ version
+                , "exposed: True"
+                , "exposed-modules: " ++ unwords exposedMods
+                , "import-dirs: ${pkgroot}" </> lfVersionStr </> name
+                , "library-dirs: ${pkgroot}" </> lfVersionStr </> name
+                , "data-dir: ${pkgroot}" </> lfVersionStr </> name
+                , "depends: " ++
+                  unwords [dropExtension $ takeFileName dep | dep <- deps]
+                ]
+
+    -- The default output filename is based on Maven coordinates if
+    -- the package name is specified via them, otherwise we use the
+    -- name.
+    defaultDarFile name =
+        case Split.splitOn ":" name of
+            [_g, a, v] -> a <> "-" <> v <> ".dar"
+            _otherwise -> name <> ".dar"
+    targetFilePath name = fromMaybe (defaultDarFile name) mbOutFile
+
+-- | Create the project package database containing the given dar packages.
+createProjectPackageDb :: LF.Version -> [FilePath] -> IO ()
+createProjectPackageDb lfVersion fps = do
+    let dbPath = projectPackageDatabase </> lfVersionString lfVersion
+    createDirectoryIfMissing True dbPath
+    let fps0 = filter (`notElem` basePackages) fps
+    forM_ fps0 $ \fp -> do
+        bs <- BSL.readFile fp
+        let pkgName = takeBaseName fp
+        let archive = toArchive bs
+        let confFiles =
+                [ e
+                | e <- zEntries archive
+                , ".conf" `isExtensionOf` eRelativePath e
+                ]
+        let dalfs =
+                [ e
+                | e <- zEntries archive
+                , ".dalf" `isExtensionOf` eRelativePath e
+                ]
+        let srcs =
+                [ e
+                | e <- zEntries archive
+                , pkgName `isPrefixOf` eRelativePath e
+                ]
+        forM_ dalfs $ \dalf ->
+            BSL.writeFile (dbPath </> eRelativePath dalf) (fromEntry dalf)
+        forM_ confFiles $ \conf ->
+            BSL.writeFile
+                (dbPath </> (takeFileName $ eRelativePath conf))
+                (fromEntry conf)
+        createDirectoryIfMissing True $ dbPath </> pkgName
+        forM_ srcs $ \src ->
+            BSL.writeFile (dbPath </> eRelativePath src) (fromEntry src)
+    sdkRoot <- getSdkPath
+    callCommand $
+        unwords
+            [ sdkRoot </> "damlc/resources/ghc-pkg"
+            , "recache"
+            , "--package-db=" ++ dbPath
+            , "--expand-pkgroot"
+            ]
+
+lfVersionString :: LF.Version -> String
+lfVersionString lfVersion =
+    case lfVersion of
+        LF.VDev _ -> "dev"
+        _ -> DA.Pretty.renderPretty lfVersion
+
+execPackage:: FilePath -- ^ input file
             -> Compiler.Options
             -> Maybe FilePath
             -> DumpPom
@@ -226,7 +385,7 @@ execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relat
     -- but I don’t think that is worth the complexity of carrying around a type parameter.
     name = fromMaybe (error "Internal error: Package name was not present") (Compiler.optMbPackageName opts)
     buildDar path compilerH = do
-        darOrErr <- runExceptT $ Compiler.buildDar compilerH path name dalfInput
+        darOrErr <- runExceptT $ Compiler.buildDar compilerH path name [] dalfInput
         case darOrErr of
           Left errs
            -> ioError $ userError $ unlines
@@ -567,6 +726,7 @@ options numProcessors =
     <|> subparser
       (internal -- internal commands
         <> cmdInspect
+        <> cmdPackageNew numProcessors
       )
 
 parserInfo :: Int -> ParserInfo Command

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -229,6 +229,7 @@ execCompile inputFile outputFile opts = withProjectRoot $ \relativize -> do
 
 newtype DumpPom = DumpPom{unDumpPom :: Bool}
 
+-- | daml.yaml config fields specific to packaging.
 data PackageConfigFields = PackageConfigFields
     { pName :: String
     , pMain :: String
@@ -237,17 +238,19 @@ data PackageConfigFields = PackageConfigFields
     , pDependencies :: [String]
     }
 
+-- | Parse the daml.yaml for package specific config fields.
 parseProjectConfig :: ProjectConfig -> Either ConfigError PackageConfigFields
 parseProjectConfig project = do
-    name <- queryProjectConfigRequired ["project", "name"] project
-    main <- queryProjectConfigRequired ["project", "source"] project
+    name <- queryProjectConfigRequired ["name"] project
+    main <- queryProjectConfigRequired ["source"] project
     exposedModules <-
-        queryProjectConfigRequired ["project", "exposed-modules"] project
-    version <- queryProjectConfigRequired ["project", "version"] project
+        queryProjectConfigRequired ["exposed-modules"] project
+    version <- queryProjectConfigRequired ["version"] project
     dependencies <-
-        queryProjectConfigRequired ["project", "dependencies"] project
+        queryProjectConfigRequired ["dependencies"] project
     Right $ PackageConfigFields name main exposedModules version dependencies
 
+-- | Package command that takes all arguments of daml.yaml.
 execPackageNew :: Int -> Maybe FilePath -> IO ()
 execPackageNew numProcessors mbOutFile =
     withProjectRoot $ \_relativize -> do

--- a/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
@@ -60,7 +60,7 @@ package_app(
         "//compiler/scenario-service/server:scenario_service_jar",
         "//daml-foundations/daml-ghc/package-database:gen-daml-prim.dar",
         "//daml-foundations/daml-ghc/package-database:package-db",
-        "@c2hs//:bin/ghc-pkg"
+        "@c2hs//:bin/ghc-pkg",
     ],
     tags = ["no-cache"],
     visibility = ["//visibility:public"],

--- a/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
@@ -60,6 +60,7 @@ package_app(
         "//compiler/scenario-service/server:scenario_service_jar",
         "//daml-foundations/daml-ghc/package-database:gen-daml-prim.dar",
         "//daml-foundations/daml-ghc/package-database:package-db",
+        "@c2hs//:bin/ghc-pkg"
     ],
     tags = ["no-cache"],
     visibility = ["//visibility:public"],

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -13,7 +13,7 @@ fi
 # This is where we install the head version. Clean it up before we start.
 readonly DAML_HEAD="$HOME/.daml-head"
 if [ -d $DAML_HEAD ] ; then
-  chmod -R -P u+w $DAML_HEAD
+  chmod -R  u+w $DAML_HEAD
   rm -rf $DAML_HEAD
 fi
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -127,15 +127,23 @@ genrule(
       # Once da-assistant is dead, the quickstart-java rule should produce the final version.
       rm $$OUT/templates/quickstart-java/da-skeleton.yaml
       cat > $$OUT/templates/quickstart-java/daml.yaml << EOF
-sdk-version: $$VERSION
-name: quickstart
-source: daml/Main.daml
-scenario: Main:setup
-parties:
-  - Alice
-  - Bob
-  - USD_Bank
-  - EUR_Bank
+project:
+  sdk-version: $$VERSION
+  name: quickstart
+  source: daml/Main.daml
+  scenario: Main:setup
+  parties:
+    - Alice
+    - Bob
+    - USD_Bank
+    - EUR_Bank
+  version: 1.0.0
+  exposed-modules:
+    - Main
+  dependencies:
+    - daml-prim
+    - daml-stdlib
+version: 2
 EOF
 
       tar zcf $(location sdk-release-tarball.tar.gz) --format=ustar $$OUT

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -127,23 +127,21 @@ genrule(
       # Once da-assistant is dead, the quickstart-java rule should produce the final version.
       rm $$OUT/templates/quickstart-java/da-skeleton.yaml
       cat > $$OUT/templates/quickstart-java/daml.yaml << EOF
-project:
-  sdk-version: $$VERSION
-  name: quickstart
-  source: daml/Main.daml
-  scenario: Main:setup
-  parties:
-    - Alice
-    - Bob
-    - USD_Bank
-    - EUR_Bank
-  version: 1.0.0
-  exposed-modules:
-    - Main
-  dependencies:
-    - daml-prim
-    - daml-stdlib
-version: 2
+sdk-version: $$VERSION
+name: quickstart
+source: daml/Main.daml
+scenario: Main:setup
+parties:
+  - Alice
+  - Bob
+  - USD_Bank
+  - EUR_Bank
+version: 1.0.0
+exposed-modules:
+  - Main
+dependencies:
+  - daml-prim
+  - daml-stdlib
 EOF
 
       tar zcf $(location sdk-release-tarball.tar.gz) --format=ustar $$OUT

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -6,8 +6,8 @@ commands:
   desc: "Compile a DAML file"
 - name: package
   path: damlc/da-hs-damlc-app
-  args: ["package"]
-  desc: "Compile a DAML file into a DAR"
+  args: ["package-new"]
+  desc: "Compile a DAML project into a DAR"
 - name: test
   path: damlc/da-hs-damlc-app
   args: ["test"]

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -8,6 +8,10 @@ commands:
   path: damlc/da-hs-damlc-app
   args: ["package-new"]
   desc: "Compile a DAML project into a DAR"
+- name: init
+  path: damlc/da-hs-damlc-app
+  args: ["init"]
+  desc: "Initialize a DAML project"
 - name: test
   path: damlc/da-hs-damlc-app
   args: ["test"]

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -12,6 +12,10 @@ commands:
   path: damlc/da-hs-damlc-app
   args: ["init"]
   desc: "Initialize a DAML project"
+- name: build
+  path: damlc/da-hs-damlc-app
+  args: ["build"]
+  desc: "Initialize, build and package a DAML project"
 - name: test
   path: damlc/da-hs-damlc-app
   args: ["test"]


### PR DESCRIPTION
We introduce a new package command that allows users to depend on other DAML packages they have locally.

The (internal) package-new command reads all information from the daml.yaml file of a DAML project and also creates the .conf file for the package database and packs it with the dar. We replace the package command in the new daml-assistant with this command. Note that there are still a couple of rough edges: 1) We produce the interface files when packaging, 2) error messages. This solves the first point of issue #125.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
