### PR TITLE
Make records with less fields still use abstract projections

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Records.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Records.hs
@@ -105,7 +105,7 @@ instanceTemplate abstract selector record field = ClsInstD noE $ ClsInstDecl noE
 
 onDecl :: LHsDecl GhcPs -> [LHsDecl GhcPs]
 onDecl o@(L _ (GHC.TyClD _ x)) = o :
-    [ noL $ InstD noE $ instanceTemplate (length fields >= 3 && length ctors == 1) field (unLoc record) typ
+    [ noL $ InstD noE $ instanceTemplate (length ctors == 1) field (unLoc record) typ
     | let fields = nubOrdOn (\(_,_,x,_) -> GHC.occNameFS $ GHC.rdrNameOcc $ unLoc $ rdrNameFieldOcc x) $ getFields x
     , (record, _, field, typ) <- fields]
     where ctors = dd_cons $ tcdDataDefn x


### PR DESCRIPTION
Before if you had a record with less than 3 fields, we'd make a case statement, so GHC could optimise it. We don't turn on the optimiser though, so we'd turn that case statement back into a projection and hopefully shake out the resulting mess. With this change we switch to always creating the projection directly, unless it's a sum type (but see #396 for potential solutions to that part).