### PR TITLE
windows: fixed SHA256_TEXT daml-lf/interpreter test; less tools in dadew

### DIFF
--- a/.dadew
+++ b/.dadew
@@ -11,8 +11,6 @@
         "vcredist-14.0.23026",
         "bazel",
         "nodejs-10.12.0",
-        "pester-4.4.2",
-        "python-3.6.7",
-        "pipenv-2018.11.26"
+        "python-3.6.7"
     ]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -77,6 +77,7 @@ function build-full() {
     bazel test `
         //daml-lf/data/... `
         //daml-lf/interface/... `
+        //daml-lf/interpreter/... `
         //daml-lf/lfpackage/... `
         //daml-lf/parser/... `
         //daml-lf/validation/... `
@@ -88,9 +89,6 @@ function build-full() {
         //pipeline/samples/bazel/java/... `
         //pipeline/samples/bazel/haskell/...
 }
-
-# FIXME: one of tests fails
-#bazel test //daml-lf/interpreter/...
 
 # FIXME:
 # @haskell_c2hs//... `

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -321,7 +321,9 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
             |aliquip ex ea commodo consequat. Duis aute irure dolor in
             |reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
             |pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            |culpa qui officia deserunt mollit anim id est laborum...""".stripMargin ->
+            |culpa qui officia deserunt mollit anim id est laborum..."""
+            .replaceAll("\r", "")
+            .stripMargin ->
             "c045064089460b634bb47e71d2457cd0e8dbc1327aaf9439c275c9796c073620",
           "a¶‱😂" ->
             "8f1cc14a85321115abcd2854e34f9ca004f4f199d367c3c9a84a355f287cec2e"


### PR DESCRIPTION
- on Windows extra `\r` are added to the input of tested sha256_text causing test failure (`//daml-lf/interpreter/...`).
- removed pester and pipenv as these are not used in the bazel build

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
