### PR TITLE
CI: Add script to purge old agents

### DIFF
--- a/ci/azure-cleanup/azure-devops.nix
+++ b/ci/azure-cleanup/azure-devops.nix
@@ -1,0 +1,31 @@
+{ pkgs, python3 }:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "azure-devops";
+  version = "5.0.0b4";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "azure-devops-python-api";
+    rev = version;
+    sha256 = "0g6p839ssn75ly4n4a2vdjfivb37yfv1328k28azm0r4grz3l694";
+  };
+
+  postUnpack = ''
+    rm -R source/scripts
+    mv source/azure-devops/* source
+    rmdir source/azure-devops
+  '';
+
+  propagatedBuildInputs = [
+    python3.pkgs.msrest
+  ];
+
+  doCheck = false;
+
+  meta = with pkgs.stdenv.lib; {
+    description = "Azure DevOps Python API";
+    homepage = "https://github.com/Microsoft/azure-devops-python-api";
+    license = licenses.mit;
+  };
+}

--- a/ci/azure-cleanup/default.nix
+++ b/ci/azure-cleanup/default.nix
@@ -1,0 +1,14 @@
+{ system ? builtins.currentSystem }:
+
+let
+  pkgs = import (import ../../nix/nixpkgs/nixos-19.03) {
+    inherit system;
+    config = {};
+    overlays = [];
+  };
+
+  azure-devops = pkgs.callPackage ./azure-devops.nix { };
+in
+pkgs.mkShell {
+  buildInputs = [ azure-devops ];
+}

--- a/ci/azure-cleanup/purge_old_agents.py
+++ b/ci/azure-cleanup/purge_old_agents.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 .
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script purges agents older than 25 hours in a given pool
+# Pass VSTS_{ACCOUNT,POOL,TOKEN} as environment variables to it
+import datetime
+import os
+import sys
+
+from azure.devops.connection import Connection
+from msrest.authentication import BasicAuthentication
+
+CUTOFF_HOURS=25
+
+VSTS_ACCOUNT = os.environ["VSTS_ACCOUNT"]
+VSTS_POOL = os.environ["VSTS_POOL"]
+VSTS_TOKEN = os.environ["VSTS_TOKEN"]
+
+credentials = BasicAuthentication('', VSTS_TOKEN)
+connection = Connection(base_url="https://dev.azure.com/" + VSTS_ACCOUNT,
+                        creds=credentials)
+
+agent_client = connection.clients_v5_1.get_task_agent_client()
+
+# retrieve pool id from name
+pool_id = next(filter(lambda x: x.name == VSTS_POOL, agent_client.get_agent_pools())).id
+
+for agent in agent_client.get_agents(pool_id):
+    # agents should be killed after 24 hours max
+    cutoff_time = datetime.datetime.now(datetime.timezone.utc)\
+                  - datetime.timedelta(hours=CUTOFF_HOURS)
+    if agent.created_on < cutoff_time:
+        if agent.status == 'offline':
+            print("cleaning up agent #{} ({})".format(agent.id, agent.name))
+            agent_client.delete_agent(pool_id, agent.id)
+        else:
+            print("agent still online: #{} ({})".format(agent.id, agent.name),
+                  file=sys.stderr)
+    else:
+        print("skipping agent #{} ({}), too new".format(agent.id, agent.name))

--- a/nix/nixpkgs/nixos-19.03/default.src.json
+++ b/nix/nixpkgs/nixos-19.03/default.src.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixos-19.03",
-  "rev": "5f3be9bc4b45f9da2d7c6768c0d187ef3f2643f7",
-  "sha256": "107j2j56n5h1xb9wf6j2qxsn5xmjmyj75rr8dzns0chrxqs7xddy"
+  "rev": "5c52b25283a6cccca443ffb7a358de6fe14b4a81",
+  "sha256": "0fhbl6bgabhi1sw1lrs64i0hibmmppy1bh256lq8hxy3a2p1haip"
 }


### PR DESCRIPTION
This adds `ci/azure-cleanup`, containing a script that talks to azure pipelines, removing agents older than 25 hours in a specific pool.
Machines are meant to be killed after 24 hours anyway, make sure they're properly unregistered from Azure Pipelines, too.
By doing this, we don't need to unregister nodes manually on shutdown.

Idea is to execute this every time a new agent is provisioned, it has cloned the repo. We intend to clone the repo and pre-warm the caches there anyhow.

WIP until the repo fetching and cache pre-warming is present, too.

cc @zimbatm 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
