### PR TITLE
Add a daml-sdk-head script.

### DIFF
--- a/dev-env/bin/daml-head
+++ b/dev-env/bin/daml-head
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+DAML_HEAD="$HOME/.daml-head"
+if [ -d $DAML_HEAD ] ; then
+    DAML_HOME=$DAML_HEAD $DAML_HEAD/bin/daml $@
+else
+    echo "daml-head is not installed"
+    echo "please run daml-sdk-head to install"
+fi

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eu
+
+# Make sure they are in the right repo
+readonly REPO_ROOT=$(bazel info workspace)
+if [[ "${REPO_ROOT}/dev-env/bin/daml-sdk-head" != "${BASH_SOURCE}" ]];
+then
+  echo "Repo root does not match the script being run."
+  echo "Make sure you run this script from a directory within the 'daml' repository "
+  exit 1
+fi
+
+# This is where we install the head version. Clean it up before we start.
+readonly DAML_HEAD="$HOME/.daml-head"
+if [ -d $DAML_HEAD ] ; then
+  chmod -R -P u+w $DAML_HEAD
+  rm -rf $DAML_HEAD
+fi
+
+echo "$(tput setaf 3)Building version 0.0.0 - this may take a while ...$(tput sgr 0)"
+echo ""
+
+function cleanup() {
+  echo "SDK 0.0.0 failed to build/install - if you need help ask on #team-daml"
+  echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
+}
+trap cleanup EXIT
+
+# Building here separately so the user can see the build process which could take a while
+bazel build //release:sdk-head-tarball.tar.gz
+
+readonly TARBALL=$(bazel info bazel-genfiles)/release/sdk-head-tarball.tar.gz
+readonly TMPDIR=$(mktemp -d)
+mkdir -p $TMPDIR/sdk-head
+
+tar xzf $TARBALL -C $TMPDIR/sdk-head --strip-components 1
+echo $DAML_HEAD
+DAML_HOME=$DAML_HEAD $TMPDIR/sdk-head/install.sh --quiet
+
+trap - EXIT
+echo "$(tput setaf 3)Successfully installed DA SDK HEAD as version 0.0.0.$(tput sgr 0)"
+echo "Now use daml-head to use it."

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -139,3 +139,39 @@ EOF
     """,
     visibility = ["//visibility:public"],
 )
+
+# Same as the above, but with head version 0.0.0.
+genrule(
+    name = "sdk-head-tarball",
+    srcs = [
+        ":config.yaml.tmpl",
+        ":sdk-release-tarball.tar.gz",
+    ],
+    outs = ["sdk-head-tarball.tar.gz"],
+    cmd = """
+
+      VERSION=0.0.0
+      OUT=sdk-head
+      mkdir -p $$OUT
+      tar xf $(location sdk-release-tarball.tar.gz) --strip-components=1 -C $$OUT
+
+      cp $(location :config.yaml.tmpl) $$OUT/config.yaml
+      sed -i "s/__VERSION__/$$VERSION/" $$OUT/config.yaml
+
+      rm $$OUT/templates/quickstart-java/daml.yaml
+      cat > $$OUT/templates/quickstart-java/daml.yaml << EOF
+sdk-version: $$VERSION
+name: quickstart
+source: daml/Main.daml
+scenario: Main:setup
+parties:
+  - Alice
+  - Bob
+  - USD_Bank
+  - EUR_Bank
+EOF
+
+      tar zcf $(location sdk-head-tarball.tar.gz) --format=ustar $$OUT
+    """,
+    visibility = ["//visibility:public"],
+)

--- a/release/install.sh
+++ b/release/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-DIR="$(cd $(dirname $(readlink -f "$BASH_SOURCE[0]")); pwd)"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 "$DIR/daml/daml" install "$DIR" --activate $@


### PR DESCRIPTION
Added a `daml-sdk-head` so we can test from head. The head distribution is installed in `~/.daml-head` and can be invoked with `daml-head`. 

One thing this experience points out to me is that it is super awkward for daml-assistant to rely on DAML_HOME being set when it is invoked outside of the default location. It should make an effort to ascertain if it is being run from an installed release, and go with that instead of using the default location right away. So expect a near future PR to change this.

Another thing is that `daml new` should get the version from `DAML_SDK_VERSION` variable, not have it be hardcoded in the template as is currently done.

(Also the install.sh script in the release was not working on my mac, so I changed the way it calculates the directory it is running from.)