### PR TITLE
Move tuple repacking in conversion to DAML-LF into separate function

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -546,22 +546,19 @@ convertExpr env0 e = do
         = fmap (, args) $ do
         key' <- convertType env key
         tmpl' <- convertQualified env tmpl
-        tuple2Typ <- qGHC_Tuple env (mkTypeCon ["Tuple2"])
         let contractType = TConApp tmpl' []
         let cidType = TContractId contractType
+        let fields = [("contractId", cidType), ("contract", contractType)]
+        (repackTuple, tupleType) <- mkRepackTuple env fields varV2
         pure $ ETmLam (varV1, key') $
           EUpdate $ UBind
             (Binding
-              (varV2, TTuple [(Tagged "contractId", cidType), (Tagged "contract", contractType)])
+              (varV2, TTuple fields)
               (EUpdate (UFetchByKey RetrieveByKey
                 { retrieveByKeyTemplate = tmpl'
                 , retrieveByKeyKey = EVar varV1
                 })))
-            (EUpdate (UPure (TConApp tuple2Typ [cidType, contractType]) (ERecCon
-              (TypeConApp tuple2Typ [cidType, contractType])
-              [ (Tagged "_1", ETupleProj (Tagged "contractId") (EVar varV2))
-              , (Tagged "_2", ETupleProj (Tagged "contract") (EVar varV2))
-              ])))
+            (EUpdate (UPure tupleType repackTuple))
     go env (VarIs "$dminternalLookupByKey") (LType t@(TypeCon tmpl []) : LType key : _dict : args)
         = fmap (, args) $ do
         key' <- convertType env key
@@ -1269,6 +1266,14 @@ mkPure env monad dict t x = do
           `ETmApp` dict'
           `ETyApp` t
           `ETmApp` x
+
+mkRepackTuple :: Env -> [(FieldName, LF.Type)] -> ExprVarName -> ConvertM (LF.Expr, LF.Type)
+mkRepackTuple env fields x = do
+    tupleTyCon <- qGHC_Tuple env (mkTypeCon ["Tuple" ++ show (length fields)])
+    let tupleType = TypeConApp tupleTyCon (map snd fields)
+    pure (ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields, typeConAppToType tupleType)
+  where
+    mkFieldProj i (name, _typ) = (mkField ("_" ++ show i), ETupleProj name (EVar x))
 
 sourceLocToRange :: SourceLoc -> Range
 sourceLocToRange (SourceLoc _ slin scol elin ecol) =


### PR DESCRIPTION
I need to use the same logic for implementing the `TextMap.toList` function.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
