### PR TITLE
Implement TextMap.toList

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Private/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Private/TextMap.daml
@@ -31,9 +31,7 @@ fromList list = foldl (\acc (key, value) -> (insert key value acc)) empty list
 -- | Convert the map to a list of key/value pairs where the keys are
 -- in ascending order.
 toList : TextMap a -> [(Text, a)]
-toList textMap =
- -- FixMe: implement toList
- error "not yet implemented"
+toList = primitive @"BEMapToList"
 
 -- | The empty map.
 empty : TextMap a
@@ -80,9 +78,7 @@ instance (Show a) => Show (TextMap a) where
 
 
 instance (Eq a) => Eq (TextMap a) where
-  (==) m1 m2 =
--- FixMe should use (toList m1 == toList m2)
-     False
+  x == y = toList x == toList y
 
 instance (Ord a) => Ord (TextMap a) where
   compare = \m1 m2 -> compare (toList m1) (toList m2)
@@ -92,4 +88,3 @@ instance Semigroup (TextMap b) where
 
 instance Monoid (TextMap b) where
   mempty = empty
-

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Primitives.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Primitives.hs
@@ -171,9 +171,9 @@ convertPrim _ "BEMapDelete" (TText :-> TMap a1 :-> TMap a2) | a1 == a2 =
   EBuiltin BEMapDelete `ETyApp` a1
 convertPrim _ "BEMapDelete" t@(TText :-> TextMap_ _ a1 :-> TextMap_ _ a2) | a1 == a2 =
   runtimeUnsupported "BAMapDelete" "1.3" t
-convertPrim _ "BEMapToList" (TMap a1 :-> TList (TMapEntry a2)) | a1 == a2  =
+convertPrim _ "BEMapToList" (TMap a1 :-> TList _) =
   EBuiltin BEMapToList `ETyApp` a1
-convertPrim _ "BEMapToList" t@(TextMap_ _ a1 :-> TList (TMapEntry a2)) | a1 == a2 =
+convertPrim _ "BEMapToList" t@(TextMap_ _ _ :-> TList _) =
   runtimeUnsupported "BEMapToList" "1.3" t
 convertPrim _ "BEMapSize" (TMap a :-> TInt64) =
   EBuiltin BEMapSize `ETyApp` a

--- a/daml-foundations/daml-ghc/tests/TextMap.daml
+++ b/daml-foundations/daml-ghc/tests/TextMap.daml
@@ -12,19 +12,19 @@ import DA.Assert
 
 testEmpty = scenario do
   0 === size TM.empty
-  -- [] === toList (TM.empty : TextMap Decimal)
+  [] === toList (TM.empty : TextMap Decimal)
 
 testSize = scenario do
   0 === size (fromList ([] : [(Text, Decimal)]))
   3 === size (fromList [("1", 2.0), ("2", 9.0), ("3", 2.2)])
 
--- testToList = scenario do
---  [("1", "c"), ("2", "a"), ("5", "b")] === toList (fromList [("2", "a"), ("5", "b"), ("1", "c")])
+testToList = scenario do
+  [("1", "c"), ("2", "a"), ("5", "b")] === toList (fromList [("2", "a"), ("5", "b"), ("1", "c")])
 
 testFromList = scenario do
   False === member "2" (fromList [("1", "a"), ("3", "b"), ("4", "c")])
   True === member "3" (fromList [("1", "a"), ("3", "b"), ("4", "c")])
---  fromList [("1", "b")] === fromList [("1", "a"), ("1", "c"), ("1", "b")]
+  fromList [("1", "b")] === fromList [("1", "a"), ("1", "c"), ("1", "b")]
 
 testMember = scenario do
   False === member "a" (fromList [("", 1.0), ("b", 2.0), ("c", 3.0)])
@@ -42,37 +42,25 @@ testNull = scenario do
   False === TM.null (fromList [("1", "a"), ("2", "b"), ("3", "c")])
   True === TM.null (fromList ([] : [(Text, Party)]))
 
--- testEq = scenario do
---  (TM.empty : TextMap Int) === (TM.empty : TextMap Int)
---  assert (not (TM.empty == (TM.fromList [("1", 1)])))
---  (TM.fromList [("1", 1), ("2", 2), ("3", 3)]) === (TM.fromList [("1", 1), ("2", 2), ("3", 3)])
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2)])))
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("3", 4)])))
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("4", 3)])))
+testEq = scenario do
+  (TM.empty : TextMap Int) === (TM.empty : TextMap Int)
+  assert (not (TM.empty == (TM.fromList [("1", 1)])))
+  (TM.fromList [("1", 1), ("2", 2), ("3", 3)]) === (TM.fromList [("1", 1), ("2", 2), ("3", 3)])
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2)])))
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("3", 4)])))
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("4", 3)])))
 
--- testInsert = scenario do
---  [("1", True), ("2", False), ("3", True), ("4", False), ("5", False)]
---    ===
---    toList (foldl (\a b -> (uncurry TM.insert) b a) TM.empty [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)])
+testInsert = scenario do
+  [("1", True), ("2", False), ("3", True), ("4", False), ("5", False)]
+    ===
+    toList (foldl (\a b -> (uncurry TM.insert) b a) TM.empty [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)])
 
--- testFilter = scenario do
---  (fromList [("1", True), ("2", False), ("3", True)])
---    ===
---    (TM.filter (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
+testFilter = scenario do
+  (fromList [("1", True), ("2", False), ("3", True)])
+    ===
+    (TM.filter (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
 
--- testDelete = scenario do
---  (fromList [("2", False), ("3", True), ("4", False), ("5", False)])
---    ===
---    (delete "1" (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
-
-main = scenario do
-  testEmpty
-  testSize
-  --testToList
-  testFromList
-  testMember
-  testNull
-  --tesstInsert
-  --testFilter
-  --testDelete
-
+testDelete = scenario do
+  (fromList [("2", False), ("3", True), ("4", False), ("5", False)])
+    ===
+    (delete "1" (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))


### PR DESCRIPTION
Implement the compiler logic needed to expose DAML-LF's `MAP_TO_LIST` as
`TextMap.toList` in the surface language.

This is part of #409. The type definition and module need to be put in the right place before I consider this done. Once it's done, I'll add it to the release notes.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
