### PR TITLE
language-support: more ScalaCodeGenIT coverage for Maps

### DIFF
--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -468,20 +468,24 @@ template Maybes
 template OptTextMapInt
    with
       party: Party
--- (RH) the two next lines are too slow.
--- In the engine the maps send from the ledger API go thought several passes:
---   1 Proto to Value conversion
---   2 Value to AST expression conversion
---   3 Speedy compilation
---   4 Program interpretation
--- Those phases are pretty slow on big nested map.
--- See <https://github.com/digital-asset/daml/issues/313>
-
---      intPlusTwo: TextMap (TextMap Int)
---      listOfEm: List (TextMap Int)
       optMap: Optional (TextMap Int)
     where
       signatory party
+
+template ListTextMapInt
+   with
+      party: Party
+      listMap: List (TextMap Int)
+    where
+      signatory party
+
+template TextMapTextMapInt
+   with
+      party: Party
+      mapMap: TextMap (TextMap Int)
+    where
+      signatory party
+
 
 template TextMapInt
    with

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
@@ -40,6 +40,9 @@ import com.digitalasset.sample.MyMain.{
   CallablePayout,
   Maybes,
   TextMapInt,
+  OptTextMapInt,
+  TextMapTextMapInt,
+  ListTextMapInt,
   MkListExample,
   MyRecord,
   MyVariant,
@@ -328,9 +331,30 @@ class ScalaCodeGenIT
     testCreateContractAndReceiveEvent(contract copy (party = alice), alice)
   }
 
-  "alice creates TextMaybes contract and receives corresponding event" in {
+  "alice creates TextMapInt contract and receives corresponding event" in {
     import com.digitalasset.ledger.client.binding.encoding.GenEncoding.Implicits._
     val contract = arbitrary[TextMapInt].sample getOrElse sys.error("random TexMap failed")
+    testCreateContractAndReceiveEvent(contract copy (party = alice), alice)
+  }
+
+  "alice creates OptTextMapInt contract and receives corresponding event" in {
+    import com.digitalasset.ledger.client.binding.encoding.GenEncoding.Implicits._
+    val contract = arbitrary[OptTextMapInt].sample getOrElse sys.error(
+      "random OptTextMapInt failed")
+    testCreateContractAndReceiveEvent(contract copy (party = alice), alice)
+  }
+
+  "alice creates TextMapTextMapInt contract and receives corresponding event" in {
+    import com.digitalasset.ledger.client.binding.encoding.GenEncoding.Implicits._
+    val contract = arbitrary[TextMapTextMapInt].sample getOrElse sys.error(
+      "random TextMapTextMapInt failed")
+    testCreateContractAndReceiveEvent(contract copy (party = alice), alice)
+  }
+
+  "alice creates ListTextMapInt contract and receives corresponding event" in {
+    import com.digitalasset.ledger.client.binding.encoding.GenEncoding.Implicits._
+    val contract = arbitrary[ListTextMapInt].sample getOrElse sys.error(
+      "random TListTextMapInt failed")
     testCreateContractAndReceiveEvent(contract copy (party = alice), alice)
   }
 


### PR DESCRIPTION
Add a few templates for the Scala codegen test to run on, and some unit tests that exercise the emitted classes.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
