### PR TITLE
Make daml-head work outside of devenv.

### DIFF
--- a/daml-assistant/daml-project-config/DAML/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Consts.hs
@@ -55,7 +55,7 @@ sdkVersionEnvVar = "DAML_SDK_VERSION"
 
 -- | File name of config file in DAML_HOME (~/.daml).
 damlConfigName :: FilePath
-damlConfigName = "config.yaml"
+damlConfigName = "daml-config.yaml"
 
 -- | File name of config file in DAML_PROJECT (the project path).
 projectConfigName :: FilePath

--- a/dev-env/bin/daml-head
+++ b/dev-env/bin/daml-head
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-DAML_HEAD="$HOME/.daml-head"
-if [ -d $DAML_HEAD ] ; then
-    DAML_HOME=$DAML_HEAD $DAML_HEAD/bin/daml $@
-else
-    echo "daml-head is not installed"
-    echo "please run daml-sdk-head to install"
-fi

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -34,9 +34,8 @@ readonly TMPDIR=$(mktemp -d)
 mkdir -p $TMPDIR/sdk-head
 
 tar xzf $TARBALL -C $TMPDIR/sdk-head --strip-components 1
-echo $DAML_HEAD
-DAML_HOME=$DAML_HEAD $TMPDIR/sdk-head/install.sh --quiet
+DAML_HOME=$DAML_HEAD $TMPDIR/sdk-head/install.sh
+mv $DAML_HEAD/bin/{daml,daml-head}
 
 trap - EXIT
-echo "$(tput setaf 3)Successfully installed DA SDK HEAD as version 0.0.0.$(tput sgr 0)"
-echo "Now use daml-head to use it."
+echo "$(tput setaf 3)Successfully installed daml-head command.$(tput sgr 0)"


### PR DESCRIPTION
- Changed the damlpath config file name to `daml-config.yaml`.
- Make daml-assistant auto-detect that it is being run from an installed distribution, so you don't have to pass DAML_HOME when running daml-assistant outside of the default directory. It does this by going up the tree from the executable path and finding the directory that contains `daml-config.yaml`. (Relevant for daml-head).
- Make the `daml-head` command run outside of devenv, as part of the `daml-sdk-head` release.