### PR TITLE
require manual publication of GitHub releases

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -61,6 +61,7 @@ steps:
       assets: './daml-sdk-$(release_tag)-${{ parameters.name }}.tar.gz'
       assetUploadMode: 'replace'
       addChangeLog: false
+      isDraft: true
   - bash: |
       rm ./daml-sdk-$(release_tag)-${{ parameters.name }}.tar.gz
     condition: eq(variables['has_released'], 'true')

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -23,3 +23,7 @@
       https://circleci.com/gh/DACH-NY/workflows/damlc-docker/tree/master
       and click "rerun" on "master / Main Variant" and on "master / CircleCI Variant".
       Once the jobs have passed, you should see two new images on https://hub.docker.com/r/digitalasset/daml-sdk/tags.
+
+   1. Publish the draft release on GitHub by going to [the releases
+      page](https://github.com/digital-asset/daml/releases) and clicking the
+      Edit button for the relevant release.


### PR DESCRIPTION
Because automated testing is not yet part of our release pipeline, we
need to manually publish releases after manual testing.