### PR TITLE
Accept multiple files in damlc test

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -32,7 +32,7 @@ tests :: TestTree
 tests = testGroup
     "damlc test"
     [ testCase "Non-existent file" $ do
-        shouldThrow (Damlc.execTest "foobar" Nothing opts)
+        shouldThrow (Damlc.execTest ["foobar"] Nothing opts)
     , testCase "File with compile error" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -40,7 +40,7 @@ tests = testGroup
               , "module Foo where"
               , "abc"
               ]
-            shouldThrow (Damlc.execTest path Nothing opts)
+            shouldThrow (Damlc.execTest [path] Nothing opts)
     , testCase "File with failing scenario" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -48,7 +48,7 @@ tests = testGroup
               , "module Foo where"
               , "x = scenario $ assert False"
               ]
-            shouldThrowExitFailure (Damlc.execTest path Nothing opts)
+            shouldThrowExitFailure (Damlc.execTest [path] Nothing opts)
     ]
 
 shouldThrowExitFailure :: IO () -> IO ()

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -155,12 +155,7 @@ daml_compile = rule(
 
 def _daml_test_impl(ctx):
     script = """
-      set -e
-      for f in {files}
-      do
-      echo "running damlc test on " $PWD/$f
-      {damlc} test $PWD/$f
-      done
+      {damlc} test {files}
     """.format(damlc = ctx.executable.damlc.short_path, files = " ".join([f.short_path for f in ctx.files.srcs]))
 
     ctx.actions.write(


### PR DESCRIPTION
Since damlc test also runs tests in transitive dependencies, this can
be significantly faster than running "damlc test" individually on
a set of files as you will end up recompiling and rerunning tests
multiple times if those files depend on each other.

For //docs:daml-ref-daml-test This is roughly a 10x improvement from
~70s to ~7s.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
