### PR TITLE
Remove pandoc from dev-env

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -330,15 +330,6 @@ nixpkgs_package(
     repositories = dev_env_nix_repos,
 )
 
-#Pandoc
-nixpkgs_package(
-    name = "pandoc_nix",
-    attribute_path = "pandoc",
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
-)
-
 #Javadoc
 nixpkgs_package(
     name = "jdk_nix",

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -18,7 +18,6 @@ rec {
     jq
     libffi
     nodejs
-    pandoc
     patchelf
     protobuf3_5
     zip

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -164,8 +164,6 @@ in rec {
     cqlsh     = cassandra;
     nodetool  = cassandra;
 
-    pandoc = bazel_dependencies.pandoc;
-
     sphinx            = pkgs.python36.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]);
     sphinx-build      = sphinx;
     sphinx-quickstart = sphinx;


### PR DESCRIPTION
We used to use this for generating documentation but we no longer
do. Removing it should slim down dev-env and make GHC upgrades less painful.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
