### PR TITLE
Add support for contract keys in the sandbox SQL backend

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -30,7 +30,7 @@ import com.digitalasset.ledger.api.v1.value.{
   Value,
   Variant
 }
-import com.digitalasset.ledger.client.services.commands.CompletionStreamElementp
+import com.digitalasset.ledger.client.services.commands.CompletionStreamElement
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.google.rpc.code.Code

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -30,7 +30,7 @@ import com.digitalasset.ledger.api.v1.value.{
   Value,
   Variant
 }
-import com.digitalasset.ledger.client.services.commands.CompletionStreamElement
+import com.digitalasset.ledger.client.services.commands.CompletionStreamElementp
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.google.rpc.code.Code

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -31,7 +31,6 @@ import com.digitalasset.ledger.api.v1.value.{
   Variant
 }
 import com.digitalasset.ledger.client.services.commands.CompletionStreamElement
-import com.digitalasset.platform.apitesting.LedgerBackend.SandboxInMemory
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.google.rpc.code.Code
@@ -527,9 +526,7 @@ abstract class CommandTransactionChecks
 
       // this is basically a port of
       // `daml-lf/tests/scenario/daml-1.3/contract-keys/Test.daml`.
-      //TODO: enable this for all fixtures when we support contract keys in Postgres
-      "process contract keys" in forAllMatchingFixtures {
-        case TestFixture(SandboxInMemory, ctx) =>
+      "process contract keys" in allFixtures { ctx =>
         // TODO currently we run multiple suites with the same sandbox, therefore we must generate
         // unique keys. This is not so great though, it'd be better to have a clean environment.
         val keyPrefix = UUID.randomUUID.toString

--- a/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
+++ b/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
@@ -89,7 +89,7 @@ CREATE TABLE parameters (
 -- and relies for the hash to be collision free
 CREATE TABLE contract_keys (
   package_id   varchar                           not null,
-  name         varchar                           not null,
+  name         varchar                           not null, -- using the QualifiedName#toString format
   value_hash   varchar                           not null, -- SHA256 of the protobuf serialized key value
   -- TODO: depending on outcome of https://github.com/digital-asset/daml/issues/497, update the above comment,
   -- or add a new column describing the algorithm used to compute the value hash.

--- a/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
+++ b/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
@@ -49,7 +49,8 @@ CREATE TABLE contracts (
   entity_name    varchar                                            not null,
   create_offset  bigint references ledger_entries (ledger_offset)   not null,--TODO this is also denormalisation, as we could get this data from ledger_entries table too. We might not need this, this should be reviewed later.
   archive_offset bigint references ledger_entries (ledger_offset),
-  contract       bytea                                              not null --this will be changed to a json representation later with flattened args
+  contract       bytea                                              not null,--this will be changed to a json representation later with flattened args
+  key            bytea
 );
 -- These two indices below could be a source performance bottleneck. Every additional index slows
 -- down insertion. The contracts table will grow endlessly and the sole purpose of these indices is
@@ -68,8 +69,28 @@ CREATE TABLE contract_witnesses (
 CREATE UNIQUE INDEX contract_witnesses_idx
   ON contract_witnesses (contract_id, witness);
 
+CREATE TABLE contract_key_maintainers (
+  contract_id varchar references contracts (id) not null,
+  maintainer  varchar                           not null
+);
+
+CREATE UNIQUE INDEX contract_key_maintainers_idx
+  ON contract_key_maintainers (contract_id, maintainer);
+
 -- a generic table to store meta information such as: ledger id and ledger end
 CREATE TABLE parameters (
   key   varchar primary key not null,
   value varchar             not null
+);
+
+
+-- table to store a mapping from (template_id, contract value) to contract id
+-- contract values are binary blobs of unbounded size, the table therefore only stores a hash of the value
+-- and relies for the hash to be collision free
+CREATE TABLE contract_keys (
+  module_name varchar                           not null,
+  entity_name varchar                           not null,
+  value_hash  varchar                           not null,
+  contract_id varchar references contracts (id) not null,
+  PRIMARY KEY (module_name, entity_name, value_hash)
 );

--- a/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
+++ b/ledger/sandbox/src/main/resources/db/migration/V1__Init.sql
@@ -84,13 +84,15 @@ CREATE TABLE parameters (
 );
 
 
--- table to store a mapping from (template_id, contract value) to contract id
+-- table to store a mapping from (template_id, contract value) to contract_id
 -- contract values are binary blobs of unbounded size, the table therefore only stores a hash of the value
 -- and relies for the hash to be collision free
 CREATE TABLE contract_keys (
-  module_name varchar                           not null,
-  entity_name varchar                           not null,
-  value_hash  varchar                           not null,
-  contract_id varchar references contracts (id) not null,
-  PRIMARY KEY (module_name, entity_name, value_hash)
+  package_id   varchar                           not null,
+  name         varchar                           not null,
+  value_hash   varchar                           not null, -- SHA256 of the protobuf serialized key value
+  -- TODO: depending on outcome of https://github.com/digital-asset/daml/issues/497, update the above comment,
+  -- or add a new column describing the algorithm used to compute the value hash.
+  contract_id  varchar references contracts (id) not null,
+  PRIMARY KEY (package_id, name, value_hash)
 );

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/ValueSerializer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/ValueSerializer.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation
+
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
+import com.digitalasset.daml.lf.value.ValueCoder.DecodeError
+import com.digitalasset.daml.lf.value.{ValueCoder, ValueOuterClass}
+
+trait ValueSerializer {
+  def serialiseValue(
+      value: VersionedValue[AbsoluteContractId]): Either[ValueCoder.EncodeError, Array[Byte]]
+
+  def deserialiseValue(blob: Array[Byte]): Either[DecodeError, VersionedValue[AbsoluteContractId]]
+}
+
+/**
+  * This is a preliminary serializer using protobuf as a payload type. Our goal on the long run is to use JSON as a payload.
+  */
+object ValueSerializer extends ValueSerializer {
+
+  override def serialiseValue(
+      value: VersionedValue[AbsoluteContractId]): Either[ValueCoder.EncodeError, Array[Byte]] =
+    ValueCoder
+      .encodeVersionedValueWithCustomVersion(defaultCidEncode, value)
+      .map(_.toByteArray())
+
+  override def deserialiseValue(
+      blob: Array[Byte]): Either[DecodeError, VersionedValue[AbsoluteContractId]] =
+    ValueCoder
+      .decodeVersionedValue(defaultCidDecode, ValueOuterClass.VersionedValue.parseFrom(blob))
+
+  val defaultCidEncode: ValueCoder.EncodeCid[AbsoluteContractId] = ValueCoder.EncodeCid(
+    _.coid,
+    acid => (acid.coid, false)
+  )
+
+  val defaultCidDecode: ValueCoder.DecodeCid[AbsoluteContractId] = ValueCoder.DecodeCid(
+    { i: String =>
+      Right(AbsoluteContractId(i))
+    }, { (i, r) =>
+      if (r)
+        sys.error("found relative contract id in stored contract instance")
+      else Right(AbsoluteContractId(i))
+    }
+  )
+
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -104,7 +104,7 @@ class PostgresDaoSpec
               None,
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
-              None
+              Some(keyWithMaintainers)
             )),
           ImmArray("event1")
         ),
@@ -190,7 +190,7 @@ class PostgresDaoSpec
       )
 
       val keyWithMaintainers = KeyWithMaintainers(
-        VersionedValue(ValueVersions.acceptedVersions.head, ValueText("key")),
+        VersionedValue(ValueVersions.acceptedVersions.head, ValueText("key2")),
         Set(Ref.Party.assertFromString("Alice"))
       )
 
@@ -220,7 +220,7 @@ class PostgresDaoSpec
               None,
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
-              None
+              Some(keyWithMaintainers)
             )),
           ImmArray("event1")
         ),


### PR DESCRIPTION
This PR implements support for contract keys in the sandbox SQL backend, and enables the `CommandTransactionChecks` test for the SQL backend.