### PR TITLE
Check for VERSION and release-notes.rst in the same commit

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -1,10 +1,9 @@
 # Making a Release
 
-1. Update https://github.com/digital-asset/daml/docs/source/support/release-notes.rst
-   by adding a new header for the new version above any changes since the last
-   version.
-1. Make a PR that only bumps the version number in the VERSION
-   file. It is important that the PR only changes the VERSION file.
+1. Make a PR that bumps the version number in the `VERSION`
+   file and adds a new header for the new version in
+   `docs/source/support/release-notes.rst`.
+   It is important that the PR only changes `VERSION` and `release-notes.rst`.
 1. Squash the PR.
 1. Once CI has passed for the corresponding master build, the release should be
    available on bintray and GitHub, as well as properly tagged.


### PR DESCRIPTION
That should make the release process a bit less painful as it requires one less PR. The check only checks that the release notes have been modified not that the changes include the correct header. I don’t think that’s worth it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
