### PR TITLE
fix GitHub tag conflict on release

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -46,7 +46,7 @@ steps:
       JFROG_CONFIG_CONTENT: $(JFROG_CONFIG_CONTENT)
   - bash: |
       set -euxo pipefail
-      git tag -a v$(release_tag) -m "SDK $(release_tag)"
+      git tag v$(release_tag)
       git push origin v$(release_tag)
       cp bazel-genfiles/release/sdk-release-tarball.tar.gz ./daml-sdk-$(release_tag)-${{ parameters.name }}.tar.gz
     condition: eq(variables['has_released'], 'true')


### PR DESCRIPTION
As multiple platforms will create different annotated tags (because an
annotated tag includes a tag time), they will conflict on trying to
push. Therefore, we go for a lightweight tag for now, as those are
simple pointers to a commit and git will recognize that they are the
same and there is no conflict.