### PR TITLE
Install from GitHub releases!

### DIFF
--- a/da-assistant/release-scripts/make-capsule.sh
+++ b/da-assistant/release-scripts/make-capsule.sh
@@ -43,7 +43,10 @@ echo "Running da setup."
 ~/.da/bin/da setup >> out.log
 
 echo "Setting script mode."
-sed -e 's/script-mode: false/script-mode: true/g' -i .backup ~/.da/da.yaml
+sed -i -e 's/script-mode: false/script-mode: true/g' ~/.da/da.yaml
+
+echo "Preparing da link."
+sed -i -e "s/$HOME/__HOME__/g" ~/.da/bin/da
 
 echo "Packaging everything up."
 cp -r ~/.da da-data
@@ -60,6 +63,7 @@ cd $DIR
 tar xf da-data.tar da-data
 rm -rf ~/.da
 mv da-data ~/.da
+sed -i -e "s/__HOME__/$HOME/g" ~/.da/bin/da
 if [[ $PATH == *"$HOME/.da/bin"* ]] ; then
   echo "DAML SDK Assistant da is installed."
 else

--- a/da-assistant/release-scripts/make-capsule.sh
+++ b/da-assistant/release-scripts/make-capsule.sh
@@ -43,10 +43,7 @@ echo "Running da setup."
 ~/.da/bin/da setup >> out.log
 
 echo "Setting script mode."
-sed -i -e 's/script-mode: false/script-mode: true/g' ~/.da/da.yaml
-
-echo "Preparing da link."
-sed -i -e "s/$HOME/__HOME__/g" ~/.da/bin/da
+sed -e 's/script-mode: false/script-mode: true/g' -i .backup ~/.da/da.yaml
 
 echo "Packaging everything up."
 cp -r ~/.da da-data
@@ -63,7 +60,6 @@ cd $DIR
 tar xf da-data.tar da-data
 rm -rf ~/.da
 mv da-data ~/.da
-sed -i -e "s/__HOME__/$HOME/g" ~/.da/bin/da
 if [[ $PATH == *"$HOME/.da/bin"* ]] ; then
   echo "DAML SDK Assistant da is installed."
 else

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -32,6 +32,7 @@ da_haskell_binary(
     name = "daml",
     srcs = native.glob(["src/**/*.hs"]),
     hazel_deps = [
+        "aeson",
         "base",
         "bytestring",
         "conduit",
@@ -77,6 +78,7 @@ da_haskell_test(
     name = "test",
     srcs = native.glob(["src/**/*.hs"]),
     hazel_deps = [
+        "aeson",
         "base",
         "bytestring",
         "conduit",

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -65,8 +65,6 @@ versionMatchesTarget version = \case
     InstallVersion v -> v == version
     InstallPath _ -> True -- tarball path could be any version
 
-newtype InstallURL = InstallURL { unwrapInstallURL :: Text }
-
 data InstallEnv = InstallEnv
     { options :: InstallOptions
     , targetM :: Maybe InstallTarget
@@ -377,11 +375,11 @@ install options damlPath = do
 
     case targetM of
         Nothing ->
-            httpInstall env . InstallURL =<< Github.latestURL
+            httpInstall env =<< Github.latestURL
             -- TODO replace with installing project version
 
         Just (InstallPath tarballPath) ->
             pathInstall env tarballPath
 
         Just (InstallVersion version) -> do
-            httpInstall env . InstallURL =<< Github.versionURL version
+            httpInstall env =<< Github.versionURL version

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -5,7 +5,9 @@
 
 -- | Discover releases from the digital-asset/daml github.
 module DAML.Assistant.Install.Github
-    where
+    ( latestURL
+    , versionURL
+    ) where
 
 import DAML.Assistant.Types
 import DAML.Assistant.Util
@@ -18,7 +20,14 @@ import Data.Either.Extra
 import qualified System.Info
 import qualified Data.Text as T
 
+-- | General git tag. We only care about the tags of the form "v<VERSION>"
+-- where <VERSION> is an SDK version. For example, "v0.11.1".
 newtype Tag = Tag Text deriving (Eq, Show, FromJSON)
+
+-- | Name of asset in a github release. We only care about assets
+-- with the name "sdk-<VERSION>-<OS>.tar.gz" where <VERSION> is an
+-- SDK version and <OS> is "linux", "macos", or "win". For example,
+-- "sdk-0.11.1-linux.tar.gz".
 newtype AssetName = AssetName { unAssetName :: Text } deriving (Eq, Show, FromJSON)
 
 data Release = Release
@@ -64,11 +73,6 @@ makeAPIRequest path = do
     when (getResponseStatusCode response /= 200) $
         throwString . show $ getResponseStatus response
     pure (getResponseBody response)
-
-getReleases :: IO [Release]
-getReleases =
-    requiredIO "Failed to get list of SDK releases from github." $
-        makeAPIRequest "/releases"
 
 getLatestRelease :: IO Release
 getLatestRelease =

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -36,7 +36,7 @@ instance FromJSON Release where
 
 data Asset = Asset
     { assetName :: AssetName
-    , assetDownloadURL :: Text
+    , assetDownloadURL :: InstallURL
     } deriving (Eq, Show)
 
 instance FromJSON Asset where
@@ -81,7 +81,7 @@ getVersionRelease v = do
     requiredIO ("Failed to get SDK release " <> versionToText v <> " from github.") $
         makeAPIRequest ("/releases/tags/" <> t)
 
-getReleaseURL :: Release -> Either AssistantError Text
+getReleaseURL :: Release -> Either AssistantError InstallURL
 getReleaseURL Release{..} = do
     version <- tagToVersion releaseTag
     let target = versionToAssetName version
@@ -105,8 +105,8 @@ osName = case System.Info.os of
     "mingw32" -> "win"
     p -> error ("daml: Unknown operating system " ++ p)
 
-versionURL :: SdkVersion -> IO Text
+versionURL :: SdkVersion -> IO InstallURL
 versionURL v = getVersionRelease v >>= fromRightM throwIO . getReleaseURL
 
-latestURL :: IO Text
+latestURL :: IO InstallURL
 latestURL = getLatestRelease >>= fromRightM throwIO . getReleaseURL

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -1,0 +1,113 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Discover releases from the digital-asset/daml github.
+module DAML.Assistant.Install.Github
+    where
+
+import DAML.Assistant.Types
+import DAML.Assistant.Util
+import Data.Aeson
+import Network.HTTP.Simple
+import Control.Exception.Safe
+import Control.Monad
+import Data.List
+import Data.Either.Extra
+import qualified System.Info
+import qualified Data.Text as T
+
+newtype Tag = Tag Text deriving (Eq, Show, FromJSON)
+newtype AssetName = AssetName { unAssetName :: Text } deriving (Eq, Show, FromJSON)
+
+data Release = Release
+    { releaseTag          :: Tag
+    , releaseIsPrerelease :: Bool
+    , releaseAssets       :: [Asset]
+    } deriving (Eq, Show)
+
+instance FromJSON Release where
+    parseJSON = withObject "Release" $ \r ->
+        Release
+        <$> r .: "tag_name"
+        <*> r .: "prerelease"
+        <*> r .: "assets"
+
+data Asset = Asset
+    { assetName :: AssetName
+    , assetDownloadURL :: Text
+    } deriving (Eq, Show)
+
+instance FromJSON Asset where
+    parseJSON = withObject "Asset" $ \r ->
+        Asset
+        <$> r .: "name"
+        <*> r .: "browser_download_url"
+
+versionToTag :: SdkVersion -> Tag
+versionToTag v = Tag ("v" <> versionToText v)
+
+tagToVersion :: Tag -> Either AssistantError SdkVersion
+tagToVersion (Tag t) =
+    mapLeft (assistantErrorBecause ("Tag " <> t <> "does not represent a valid SDK version.")) $
+        if T.take 1 t == "v" then
+            mapLeft (pack . displayException) $ parseVersion (T.drop 1 t)
+        else
+            Left "Tag must start with v followed by semantic version."
+
+
+makeAPIRequest :: FromJSON t => Text -> IO t
+makeAPIRequest path = do
+    request <- parseRequest (unpack ("GET https://api.github.com/repos/digital-asset/daml" <> path))
+    response <- httpJSON (setRequestHeader "User-Agent" ["daml"] request)
+    when (getResponseStatusCode response /= 200) $
+        throwString . show $ getResponseStatus response
+    pure (getResponseBody response)
+
+getReleases :: IO [Release]
+getReleases =
+    requiredIO "Failed to get list of SDK releases from github." $
+        makeAPIRequest "/releases"
+
+getLatestRelease :: IO Release
+getLatestRelease =
+    requiredIO "Failed to get latest SDK release from github." $
+        makeAPIRequest "/releases/latest"
+
+getVersionRelease :: SdkVersion -> IO Release
+getVersionRelease v = do
+    let Tag t = versionToTag v
+    requiredIO ("Failed to get SDK release " <> versionToText v <> " from github.") $
+        makeAPIRequest ("/releases/tags/" <> t)
+
+
+getReleaseURL :: Release -> Either AssistantError Text
+getReleaseURL Release{..} = do
+    version <- tagToVersion releaseTag
+    let target = versionToAssetName version
+    asset <- fromMaybeM
+        (Left (assistantErrorBecause "Could not find required SDK distribution in github release."
+            ("Looked for " <> unAssetName target <> " but got [" <>
+                T.intercalate ", " (map (unAssetName . assetName) releaseAssets) <> "].")))
+        (find ((== target) . assetName) releaseAssets)
+    pure (assetDownloadURL asset)
+
+versionToAssetName :: SdkVersion -> AssetName
+versionToAssetName v =
+    AssetName
+        ("daml-sdk-" <> versionToText v
+        <> "-" <> osName <> ".tar.gz")
+
+osName :: Text
+osName = case System.Info.os of
+    "darwin"  -> "macos"
+    "linux"   -> "linux"
+    "mingw32" -> "win"
+    p -> error ("daml: Unknown operating system " ++ p)
+
+versionURL :: SdkVersion -> IO Text
+versionURL v = getVersionRelease v >>= fromRightM throwIO . getReleaseURL
+
+latestURL :: IO Text
+latestURL = getLatestRelease >>= fromRightM throwIO . getReleaseURL

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -81,7 +81,6 @@ getVersionRelease v = do
     requiredIO ("Failed to get SDK release " <> versionToText v <> " from github.") $
         makeAPIRequest ("/releases/tags/" <> t)
 
-
 getReleaseURL :: Release -> Either AssistantError Text
 getReleaseURL Release{..} = do
     version <- tagToVersion releaseTag

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -11,6 +11,7 @@ module DAML.Assistant.Types
 
 import DAML.Project.Types
 import qualified Data.Text as T
+import Data.Aeson (FromJSON)
 import Data.Text (Text, pack, unpack)
 import Data.Maybe
 import Control.Exception.Safe
@@ -67,6 +68,10 @@ data InstallOptions = InstallOptions
     , iForce :: ForceInstall
     , iQuiet :: QuietInstall
     } deriving (Eq, Show)
+
+newtype InstallURL = InstallURL
+    { unwrapInstallURL :: Text
+    } deriving (Eq, Show, FromJSON)
 
 newtype RawInstallTarget = RawInstallTarget String deriving (Eq, Show)
 newtype ForceInstall = ForceInstall Bool deriving (Eq, Show)

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -69,6 +69,8 @@ data InstallOptions = InstallOptions
     , iQuiet :: QuietInstall
     } deriving (Eq, Show)
 
+-- | An install URL is a fully qualified HTTP[S] URL to an SDK release tarball. For example:
+-- "https://github.com/digital-asset/daml/releases/download/v0.11.1/daml-sdk-0.11.1-macos.tar.gz"
 newtype InstallURL = InstallURL
     { unwrapInstallURL :: Text
     } deriving (Eq, Show, FromJSON)


### PR DESCRIPTION
Replaces the bintray backend with a github backend for `daml install`.