### PR TITLE
HOTFIX: increasing 30.sec timeout to 300.sec

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
@@ -11,6 +11,7 @@ import scala.util.control.NoStackTrace
 
 trait FutureTimeouts {
 
+  // TODO get rid of the default timeout, see issue: #464
   protected def timeout[T](f: Future[T], opName: String, duration: FiniteDuration = 300.seconds)(
       implicit system: ActorSystem): Future[T] = {
     val promise: Promise[T] = Promise[T]()

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
@@ -11,7 +11,7 @@ import scala.util.control.NoStackTrace
 
 trait FutureTimeouts {
 
-  protected def timeout[T](f: Future[T], opName: String, duration: FiniteDuration = 30.seconds)(
+  protected def timeout[T](f: Future[T], opName: String, duration: FiniteDuration = 300.seconds)(
       implicit system: ActorSystem): Future[T] = {
     val promise: Promise[T] = Promise[T]()
 


### PR DESCRIPTION
this to fix SQL-backed ledger tests that currently keep timing out.
It is NOT really a fix, but a temp work-around. Tried to get rid of
this timeout, but it propogates all over the place. Need a separate
story to address this

Here is an issue: https://github.com/digital-asset/daml/issues/464

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
