### PR TITLE
Reuse the same Engine object between ledger resets

### DIFF
--- a/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Application.scala
+++ b/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Application.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.daml.lf.engine.Engine
 import com.digitalasset.ledger.client.configuration.TlsConfiguration
 import com.digitalasset.ledger.server.LedgerApiServer.LedgerApiServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
@@ -95,6 +96,7 @@ object Application {
       server = LedgerApiServer(
         ledgerBackend,
         timeProvider,
+        Engine(),
         config,
         port,
         timeServiceBackendO,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
@@ -45,6 +45,7 @@ object LedgerApiServer {
   def apply(
       ledgerBackend: LedgerBackend,
       timeProvider: TimeProvider,
+      engine: Engine,
       config: => SandboxConfig,
       serverPort: Int, //TODO: why do we need this if we already have a SandboxConfig?
       optTimeServiceBackend: Option[TimeServiceBackend],
@@ -53,7 +54,7 @@ object LedgerApiServer {
 
     new LedgerApiServer(
       ledgerBackend, { (mat, esf) =>
-        services(config, ledgerBackend, timeProvider, optTimeServiceBackend)(mat, esf)
+        services(config, ledgerBackend, engine, timeProvider, optTimeServiceBackend)(mat, esf)
       },
       optResetService,
       config.addressOption,
@@ -85,6 +86,7 @@ object LedgerApiServer {
   private def services(
       config: SandboxConfig,
       ledgerBackend: LedgerBackend,
+      engine: Engine,
       timeProvider: TimeProvider,
       optTimeServiceBackend: Option[TimeServiceBackend])(
       implicit mat: ActorMaterializer,
@@ -105,7 +107,7 @@ object LedgerApiServer {
         ledgerBackend,
         config.timeModel,
         timeProvider,
-        new CommandExecutorImpl(Engine(), context.packageContainer)
+        new CommandExecutorImpl(engine, context.packageContainer)
       )
 
     logger.info(EngineInfo.show)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
@@ -52,6 +52,7 @@ object SandboxApplication {
     // We memoize the engine between resets so we avoid the expensive
     // repeated validation of the sames packages after each reset
     private val engine = Engine()
+
     /** the reset service is special, since it triggers a server shutdown */
     private val resetService: SandboxResetService = new SandboxResetService(
       () => ledgerId,


### PR DESCRIPTION
Compared to older versions of the Engine, we do A LOT more validation
now. So when starting with a fresh engine after each reset (via
the ResetService), we also repeat the validation of the loaded packages
again and again. This is VERY expensive, especially for large DAML
packages.

Luckily, the specification of the ResetService states the following:
// Resets the ledger state. Note that loaded DARs won't be removed --
// this only rolls back the ledger to genesis.
This means that we can re-use the same Engine object and benefit from
not having "re-compile" packages via
ConcurrentCompiledPackages#addPackage, more specifically we can avoid
executing this line by having retained all compiled packages in the engine:
https://github.com/digital-asset/daml/blob/1f2246c822acd1d44a6b0ed223f0b063f4a4e2cf/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala#L56

Fixes #178

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
