### PR TITLE
ci: publish the bazel test logs

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -33,9 +33,17 @@ steps:
 
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()
+    displayName: 'Publish the bazel execution logs'
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'Bazel execution logs'
+
+  - task: PublishBuildArtifacts@1
+    condition: failed()
+    displayName: 'Publish the bazel test logs'
+    inputs:
+      pathtoPublish: 'bazel-testlogs/'
+      artifactName: 'Bazel test logs'
 
   - bash: ci/release.sh
     displayName: 'Release'


### PR DESCRIPTION
As a developer I want to be able to inspect the detailed test logs when those are
failing.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
