### PR TITLE
Include google/rpc/*.proto into ledger-api-scalapb

### DIFF
--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -49,7 +49,11 @@ pkg_tar(
 
 proto_gen(
     name = "ledger-api-scalapb-sources",
-    srcs = [":protos"],
+    srcs = [
+        ":protos",
+        "@com_github_googleapis_googleapis//google/rpc:code_proto",
+        "@com_github_googleapis_googleapis//google/rpc:status_proto",
+    ],
     plugin_exec = "//scala-protoc-plugins/scalapb:protoc-gen-scalapb",
     plugin_name = "scalapb",
     plugin_options = ["grpc"],
@@ -57,8 +61,6 @@ proto_gen(
         "//visibility:public",
     ],
     deps = [
-        "@com_github_googleapis_googleapis//google/rpc:code_proto",
-        "@com_github_googleapis_googleapis//google/rpc:status_proto",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
@@ -82,45 +84,15 @@ scala_library(
     srcs = [":ledger-api-scalapb-sources"],
     tags = [
         "maven_coordinates=com.digitalasset.ledger-api.grpc-definitions:ledger-api-scalapb:__VERSION__",
-        # the bazel rules depend on the source .proto files, which we do not release.
-        # rely on the fact that we know the generated code only relies on external
-        # deps.
-        "only_external_deps",
     ],
     visibility = ["//visibility:public"],
-    exports = scalapb_deps + [":google-rpc-scalapb"],
-    deps = scalapb_deps + [":google-rpc-scalapb"],
+    exports = scalapb_deps,
+    deps = scalapb_deps,
 )
 
 pom_file(
     name = "ledger-api-scalapb_pom",
     target = ":ledger-api-scalapb",
-)
-
-proto_gen(
-    name = "google-rpc-sources",
-    srcs = [
-        "@com_github_googleapis_googleapis//google/rpc:code_proto",
-        "@com_github_googleapis_googleapis//google/rpc:status_proto",
-    ],
-    plugin_exec = "//scala-protoc-plugins/scalapb:protoc-gen-scalapb",
-    plugin_name = "scalapb",
-    plugin_options = ["grpc"],
-    visibility = [
-        "//visibility:public",
-    ],
-    deps = [
-        "@com_google_protobuf//:any_proto",
-    ],
-)
-
-scala_library(
-    name = "google-rpc-scalapb",
-    srcs = [":google-rpc-sources"],
-    tags = ["maven_coordinates=com.digitalasset.ledger-api.grpc-definitions:ledger-api-scalapb:__VERSION__"],
-    visibility = ["//visibility:public"],
-    exports = scalapb_deps,
-    deps = scalapb_deps,
 )
 
 proto_gen(


### PR DESCRIPTION
Considering that there is no canonical source for status.proto generated
for scalapb (for java it is pulled in via a transitive dependency of
grpc-protobuf), we should rather compile and include it in the
ledger-api-scalapb artefact.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
