### PR TITLE
make reference index service stop repeating last event indefinitely + refactoring

### DIFF
--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXActiveContractsService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXActiveContractsService.scala
@@ -18,15 +18,13 @@ import com.digitalasset.ledger.api.v1.active_contracts_service._
 import com.digitalasset.ledger.api.v1.event.Event.Event.Created
 import com.digitalasset.ledger.api.v1.event.{CreatedEvent, Event}
 import com.digitalasset.ledger.api.validation.TransactionFilterValidator
-import com.digitalasset.platform.api.grpc.GrpcApiService
-import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.participant.util.{EventFilter, LfEngineToApi}
 import com.digitalasset.platform.server.api.validation.{
   ActiveContractsServiceValidation,
   ErrorFactories,
   IdentifierResolver
 }
-import io.grpc.{BindableService, ServerServiceDefinition}
+import io.grpc.{BindableService}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
@@ -40,7 +38,6 @@ class DamlOnXActiveContractsService private (
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory)
     extends ActiveContractsServiceAkkaGrpc
-    with GrpcApiService
     with ErrorFactories
     with DamlOnXServiceUtils {
 
@@ -111,9 +108,6 @@ class DamlOnXActiveContractsService private (
         a.stakeholders.map(_.underlyingString)
       ))
   }
-
-  override def bindService(): ServerServiceDefinition =
-    ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)
 }
 
 object DamlOnXActiveContractsService {
@@ -129,9 +123,6 @@ object DamlOnXActiveContractsService {
     new ActiveContractsServiceValidation(
       new DamlOnXActiveContractsService(indexService, identifierResolver)(ec, mat, esf),
       ledgerId.underlyingString
-    ) with BindableService with ActiveContractsServiceLogging {
-      override def bindService(): ServerServiceDefinition =
-        ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)
-    }
+    ) with ActiveContractsServiceLogging
   }
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
@@ -32,7 +32,6 @@ class DamlOnXCommandCompletionService private (indexService: IndexService)(
     protected val esf: ExecutionSequencerFactory)
     extends CommandCompletionServiceAkkaGrpc
     with ErrorFactories
-
     with DamlOnXServiceUtils {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -144,7 +143,6 @@ object DamlOnXCommandCompletionService {
     val ledgerId = Await.result(indexService.getLedgerId(), 5.seconds)
     new CommandCompletionServiceValidation(
       new DamlOnXCommandCompletionService(indexService),
-      ledgerId.underlyingString)
-      with CommandCompletionServiceLogging
+      ledgerId.underlyingString) with CommandCompletionServiceLogging
   }
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXLedgerConfigurationService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXLedgerConfigurationService.scala
@@ -16,6 +16,7 @@ import com.digitalasset.ledger.api.v1.ledger_configuration_service._
 import com.digitalasset.platform.api.grpc.{GrpcApiService, GrpcApiUtil}
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import io.grpc.{BindableService, ServerServiceDefinition}
+import org.slf4j.{Logger,LoggerFactory}
 
 import scala.concurrent.ExecutionContext
 
@@ -26,6 +27,8 @@ class DamlOnXLedgerConfigurationService private (indexService: IndexService)(
     extends LedgerConfigurationServiceAkkaGrpc
     with GrpcApiService
     with DamlOnXServiceUtils {
+
+  protected val logger: Logger = LoggerFactory.getLogger(this.getClass.getName)
 
   override protected def getLedgerConfigurationSource(
       request: GetLedgerConfigurationRequest): Source[GetLedgerConfigurationResponse, NotUsed] = {
@@ -55,6 +58,6 @@ object DamlOnXLedgerConfigurationService {
   def apply(indexService: IndexService)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
-      mat: Materializer): LedgerConfigurationService with BindableService =
-    new DamlOnXLedgerConfigurationService(indexService) with BindableService
+      mat: Materializer): LedgerConfigurationService with BindableService with LedgerConfigurationServiceLogging =
+    new DamlOnXLedgerConfigurationService(indexService) with LedgerConfigurationServiceLogging
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXLedgerConfigurationService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXLedgerConfigurationService.scala
@@ -16,7 +16,7 @@ import com.digitalasset.ledger.api.v1.ledger_configuration_service._
 import com.digitalasset.platform.api.grpc.{GrpcApiService, GrpcApiUtil}
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import io.grpc.{BindableService, ServerServiceDefinition}
-import org.slf4j.{Logger,LoggerFactory}
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.ExecutionContext
 
@@ -58,6 +58,7 @@ object DamlOnXLedgerConfigurationService {
   def apply(indexService: IndexService)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
-      mat: Materializer): LedgerConfigurationService with BindableService with LedgerConfigurationServiceLogging =
+      mat: Materializer)
+    : LedgerConfigurationService with BindableService with LedgerConfigurationServiceLogging =
     new DamlOnXLedgerConfigurationService(indexService) with LedgerConfigurationServiceLogging
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXPackageService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXPackageService.scala
@@ -78,5 +78,5 @@ object DamlOnXPackageService {
   def apply(indexService: IndexService, ledgerId: String)(implicit ec: ExecutionContext)
     : PackageService with BindableService with PackageServiceLogging =
     new PackageServiceValidation(new DamlOnXPackageService(indexService), ledgerId)
-      with PackageServiceLogging
+    with PackageServiceLogging
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXPackageService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXPackageService.scala
@@ -18,19 +18,16 @@ import com.digitalasset.ledger.api.v1.package_service.{
   HashFunction => APIHashFunction,
   _
 }
-import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.server.api.validation.PackageServiceValidation
-import io.grpc.{BindableService, ServerServiceDefinition, Status}
+import io.grpc.{BindableService, Status}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class DamlOnXPackageService private (indexService: IndexService)
     extends PackageService
-    with GrpcApiService
+    with AutoCloseable
     with DamlOnXServiceUtils {
-  override def bindService(): ServerServiceDefinition =
-    PackageServiceGrpc.bindService(this, DirectExecutionContext)
 
   override def close(): Unit = ()
 
@@ -81,8 +78,5 @@ object DamlOnXPackageService {
   def apply(indexService: IndexService, ledgerId: String)(implicit ec: ExecutionContext)
     : PackageService with BindableService with PackageServiceLogging =
     new PackageServiceValidation(new DamlOnXPackageService(indexService), ledgerId)
-    with BindableService with PackageServiceLogging {
-      override def bindService(): ServerServiceDefinition =
-        PackageServiceGrpc.bindService(this, DirectExecutionContext)
-    }
+      with PackageServiceLogging
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXSubmissionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXSubmissionService.scala
@@ -8,7 +8,16 @@ import com.daml.ledger.participant.state.index.v1.IndexService
 import com.daml.ledger.participant.state.v1.{LedgerId, SubmitterInfo, TransactionMeta, WriteService}
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.engine.{Engine, Result, ResultDone, ResultError, ResultNeedContract, ResultNeedKey, ResultNeedPackage, Error => DamlLfError}
+import com.digitalasset.daml.lf.engine.{
+  Engine,
+  Result,
+  ResultDone,
+  ResultError,
+  ResultNeedContract,
+  ResultNeedKey,
+  ResultNeedPackage,
+  Error => DamlLfError
+}
 import com.digitalasset.daml.lf.lfpackage.{Ast, Decode}
 import com.digitalasset.daml.lf.transaction.Transaction.{Value => TxValue}
 import com.digitalasset.daml.lf.value.Value
@@ -19,7 +28,10 @@ import com.digitalasset.platform.participant.util.ApiToLfEngine.apiCommandsToLfC
 import com.digitalasset.platform.server.api.services.domain.CommandSubmissionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandSubmissionService
 import com.digitalasset.platform.server.api.validation.{ErrorFactories, IdentifierResolver}
-import com.digitalasset.ledger.api.v1.command_submission_service.{CommandSubmissionServiceGrpc, CommandSubmissionServiceLogging}
+import com.digitalasset.ledger.api.v1.command_submission_service.{
+  CommandSubmissionServiceGrpc,
+  CommandSubmissionServiceLogging
+}
 import io.grpc.BindableService
 import org.slf4j.LoggerFactory
 import scalaz.syntax.tag._

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXSubmissionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXSubmissionService.scala
@@ -8,16 +8,7 @@ import com.daml.ledger.participant.state.index.v1.IndexService
 import com.daml.ledger.participant.state.v1.{LedgerId, SubmitterInfo, TransactionMeta, WriteService}
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.engine.{
-  Engine,
-  Result,
-  ResultDone,
-  ResultError,
-  ResultNeedContract,
-  ResultNeedKey,
-  ResultNeedPackage,
-  Error => DamlLfError
-}
+import com.digitalasset.daml.lf.engine.{Engine, Result, ResultDone, ResultError, ResultNeedContract, ResultNeedKey, ResultNeedPackage, Error => DamlLfError}
 import com.digitalasset.daml.lf.lfpackage.{Ast, Decode}
 import com.digitalasset.daml.lf.transaction.Transaction.{Value => TxValue}
 import com.digitalasset.daml.lf.value.Value
@@ -28,7 +19,7 @@ import com.digitalasset.platform.participant.util.ApiToLfEngine.apiCommandsToLfC
 import com.digitalasset.platform.server.api.services.domain.CommandSubmissionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandSubmissionService
 import com.digitalasset.platform.server.api.validation.{ErrorFactories, IdentifierResolver}
-import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceLogging
+import com.digitalasset.ledger.api.v1.command_submission_service.{CommandSubmissionServiceGrpc, CommandSubmissionServiceLogging}
 import io.grpc.BindableService
 import org.slf4j.LoggerFactory
 import scalaz.syntax.tag._
@@ -44,7 +35,7 @@ object DamlOnXSubmissionService {
       indexService: IndexService,
       writeService: WriteService,
       engine: Engine)(implicit ec: ExecutionContext, mat: ActorMaterializer)
-    : GrpcCommandSubmissionService with BindableService with CommandSubmissionServiceLogging =
+    : CommandSubmissionServiceGrpc.CommandSubmissionService with BindableService with CommandSubmissionServiceLogging =
     new GrpcCommandSubmissionService(
       new DamlOnXSubmissionService(indexService, writeService, engine),
       ledgerId.underlyingString,

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -19,10 +19,7 @@ import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain._
 import com.digitalasset.ledger.api.messages.transaction._
 import com.digitalasset.ledger.api.v1.transaction.{Transaction => PTransaction}
-import com.digitalasset.ledger.api.v1.transaction_service.{
-  GetTransactionsResponse,
-  TransactionServiceLogging
-}
+import com.digitalasset.ledger.api.v1.transaction_service.{GetTransactionsResponse, TransactionServiceGrpc, TransactionServiceLogging}
 import com.digitalasset.ledger.api.validation.PartyNameChecker
 import com.digitalasset.platform.participant.util.EventFilter
 import com.digitalasset.platform.server.api._
@@ -48,7 +45,7 @@ object DamlOnXTransactionService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory)
-    : GrpcTransactionService with BindableService with TransactionServiceLogging =
+    : TransactionServiceGrpc.TransactionService with BindableService with TransactionServiceLogging =
     new GrpcTransactionService(
       new DamlOnXTransactionService(indexService),
       ledgerId.underlyingString,
@@ -62,6 +59,7 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
     materializer: Materializer,
     esf: ExecutionSequencerFactory)
     extends TransactionService
+    with AutoCloseable
     with ErrorFactories
     with DamlOnXServiceUtils {
 
@@ -303,4 +301,7 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
       trans.recordTime.toInstant,
       None
     )
+
+  override def close(): Unit = ()
+
 }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -19,7 +19,11 @@ import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain._
 import com.digitalasset.ledger.api.messages.transaction._
 import com.digitalasset.ledger.api.v1.transaction.{Transaction => PTransaction}
-import com.digitalasset.ledger.api.v1.transaction_service.{GetTransactionsResponse, TransactionServiceGrpc, TransactionServiceLogging}
+import com.digitalasset.ledger.api.v1.transaction_service.{
+  GetTransactionsResponse,
+  TransactionServiceGrpc,
+  TransactionServiceLogging
+}
 import com.digitalasset.ledger.api.validation.PartyNameChecker
 import com.digitalasset.platform.participant.util.EventFilter
 import com.digitalasset.platform.server.api._

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
@@ -11,15 +11,24 @@ import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.domain.PartyTag
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.TransactionTree
-import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.{TransactionService => ApiTransactionService}
+import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.{
+  TransactionService => ApiTransactionService
+}
 import com.digitalasset.ledger.api.v1.transaction_service._
 import com.digitalasset.ledger.api.validation.{PartyNameChecker, TransactionServiceRequestValidator}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.server.api.{ApiException, ProxyCloseable}
 import com.digitalasset.platform.server.api.services.domain.TransactionService
-import com.digitalasset.platform.server.api.validation.{ErrorFactories, FieldValidations, IdentifierResolver}
-import com.digitalasset.platform.server.services.transaction.{TransactionConversion, VisibleTransaction}
+import com.digitalasset.platform.server.api.validation.{
+  ErrorFactories,
+  FieldValidations,
+  IdentifierResolver
+}
+import com.digitalasset.platform.server.services.transaction.{
+  TransactionConversion,
+  VisibleTransaction
+}
 import io.grpc.{ServerServiceDefinition, Status}
 import org.slf4j.{Logger, LoggerFactory}
 import scalaz.Tag

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
@@ -11,24 +11,15 @@ import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.domain.PartyTag
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.TransactionTree
-import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.{
-  TransactionService => ApiTransactionService
-}
+import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.{TransactionService => ApiTransactionService}
 import com.digitalasset.ledger.api.v1.transaction_service._
 import com.digitalasset.ledger.api.validation.{PartyNameChecker, TransactionServiceRequestValidator}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
-import com.digitalasset.platform.server.api.ApiException
+import com.digitalasset.platform.server.api.{ApiException, ProxyCloseable}
 import com.digitalasset.platform.server.api.services.domain.TransactionService
-import com.digitalasset.platform.server.api.validation.{
-  ErrorFactories,
-  FieldValidations,
-  IdentifierResolver
-}
-import com.digitalasset.platform.server.services.transaction.{
-  TransactionConversion,
-  VisibleTransaction
-}
+import com.digitalasset.platform.server.api.validation.{ErrorFactories, FieldValidations, IdentifierResolver}
+import com.digitalasset.platform.server.services.transaction.{TransactionConversion, VisibleTransaction}
 import io.grpc.{ServerServiceDefinition, Status}
 import org.slf4j.{Logger, LoggerFactory}
 import scalaz.Tag
@@ -37,7 +28,7 @@ import scalaz.syntax.tag._
 import scala.concurrent.Future
 
 class GrpcTransactionService(
-    protected val service: TransactionService,
+    protected val service: TransactionService with AutoCloseable,
     val ledgerId: String,
     partyNameChecker: PartyNameChecker,
     identifierResolver: IdentifierResolver)(
@@ -45,6 +36,7 @@ class GrpcTransactionService(
     protected val mat: Materializer)
     extends ApiTransactionService
     with TransactionServiceAkkaGrpc
+    with ProxyCloseable
     with GrpcApiService
     with ErrorFactories
     with FieldValidations {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ActiveContractsServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ActiveContractsServiceValidation.scala
@@ -17,7 +17,7 @@ import io.grpc.stub.StreamObserver
 import org.slf4j.{Logger, LoggerFactory}
 
 class ActiveContractsServiceValidation(
-    protected val service: ActiveContractsService with GrpcApiService,
+    protected val service: ActiveContractsService with AutoCloseable,
     val ledgerId: String)
     extends ActiveContractsService
     with ProxyCloseable

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandServiceValidation.scala
@@ -7,6 +7,7 @@ import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.Command
 import com.digitalasset.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
+import com.digitalasset.platform.server.api.ProxyCloseable
 import com.google.protobuf.empty.Empty
 import io.grpc.ServerServiceDefinition
 import org.slf4j.{Logger, LoggerFactory}
@@ -14,10 +15,11 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.Future
 
 class CommandServiceValidation(
-    protected val service: CommandService with GrpcApiService,
+    protected val service: CommandService with AutoCloseable,
     val ledgerId: String)
     extends CommandService
     with GrpcApiService
+    with ProxyCloseable
     with CommandValidations
     with ErrorFactories
     with CommandPayloadValidations {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/PackageServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/PackageServiceValidation.scala
@@ -15,7 +15,7 @@ import scala.Function.const
 import scala.concurrent.Future
 
 class PackageServiceValidation(
-    protected val service: PackageService with GrpcApiService,
+    protected val service: PackageService with AutoCloseable,
     val ledgerId: String)
     extends PackageService
     with ProxyCloseable
@@ -50,4 +50,6 @@ class PackageServiceValidation(
       )
   override def bindService(): ServerServiceDefinition =
     PackageServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
@@ -10,7 +10,6 @@ import akka.stream.scaladsl.{Flow, Keep, Source}
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionService
 import com.digitalasset.ledger.api.v1.command_completion_service.{
-  CommandCompletionServiceGrpc,
   CompletionEndResponse,
   CompletionStreamRequest,
   CompletionStreamResponse
@@ -18,7 +17,6 @@ import com.digitalasset.ledger.api.v1.command_completion_service.{
 import com.digitalasset.ledger.api.v1.command_service._
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
 import com.digitalasset.ledger.api.v1.command_submission_service.{
-  CommandSubmissionServiceGrpc,
   SubmitRequest
 }
 import com.digitalasset.ledger.client.configuration.CommandClientConfiguration
@@ -27,7 +25,6 @@ import com.digitalasset.ledger.client.services.commands.{
   CommandCompletionSource,
   CommandTrackerFlow
 }
-import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.server.api.ApiException
 import com.digitalasset.platform.server.api.validation.CommandServiceValidation
 import com.digitalasset.platform.server.services.command.ReferenceCommandService.LowLevelCommandServiceAccess
@@ -143,42 +140,19 @@ class ReferenceCommandService private (
     }
   }
 
+  override def toString: String = ReferenceCommandService.getClass.getSimpleName
+
 }
 
 object ReferenceCommandService {
-
-  def apply(
-      configuration: Configuration,
-      submissionChannel: ManagedChannel,
-      completionsChannel: ManagedChannel)(
-      implicit grpcExecutionContext: ExecutionContext,
-      actorMaterializer: ActorMaterializer,
-      esf: ExecutionSequencerFactory
-  ): CommandServiceGrpc.CommandService with GrpcApiService = {
-
-    val submissionStub = CommandSubmissionServiceGrpc.stub(submissionChannel)
-    val completionStub = CommandCompletionServiceGrpc.stub(completionsChannel)
-
-    new CommandServiceValidation(
-      ReferenceCommandService(
-        configuration,
-        LowLevelCommandServiceAccess.RemoteServices(submissionStub, completionStub)),
-      configuration.ledgerId)
-  }
 
   def apply(configuration: Configuration, svcAccess: LowLevelCommandServiceAccess)(
       implicit grpcExecutionContext: ExecutionContext,
       actorMaterializer: ActorMaterializer,
       esf: ExecutionSequencerFactory
-  ): CommandServiceGrpc.CommandService with GrpcApiService with CommandServiceLogging =
+  ): CommandServiceGrpc.CommandService with BindableService with CommandServiceLogging =
     new CommandServiceValidation(
-      new ReferenceCommandService(svcAccess, configuration) with GrpcApiService {
-
-        override def bindService(): ServerServiceDefinition =
-          CommandServiceGrpc.bindService(this, grpcExecutionContext)
-
-        override def toString: String = ReferenceCommandService.getClass.getSimpleName
-      },
+      new ReferenceCommandService(svcAccess, configuration),
       configuration.ledgerId
     ) with CommandServiceLogging
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
@@ -16,9 +16,7 @@ import com.digitalasset.ledger.api.v1.command_completion_service.{
 }
 import com.digitalasset.ledger.api.v1.command_service._
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
-import com.digitalasset.ledger.api.v1.command_submission_service.{
-  SubmitRequest
-}
+import com.digitalasset.ledger.api.v1.command_submission_service.{SubmitRequest}
 import com.digitalasset.ledger.client.configuration.CommandClientConfiguration
 import com.digitalasset.ledger.client.services.commands.{
   CommandClient,

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/identity/LedgerIdentityServiceImpl.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/identity/LedgerIdentityServiceImpl.scala
@@ -4,16 +4,11 @@
 package com.digitalasset.platform.server.services.identity
 
 import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
-import com.digitalasset.ledger.api.v1.ledger_identity_service.{
-  GetLedgerIdentityRequest,
-  GetLedgerIdentityResponse,
-  LedgerIdentityServiceGrpc,
-  LedgerIdentityServiceLogging
-}
+import com.digitalasset.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, GetLedgerIdentityResponse, LedgerIdentityServiceGrpc, LedgerIdentityServiceLogging}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.server.api.ApiException
 import com.digitalasset.platform.common.util.DirectExecutionContext
-import io.grpc.{ServerServiceDefinition, Status}
+import io.grpc.{BindableService, ServerServiceDefinition, Status}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.Future
@@ -37,12 +32,12 @@ abstract class LedgerIdentityServiceImpl private (val ledgerId: String)
       Future.successful(GetLedgerIdentityResponse(ledgerId))
 
   override def close(): Unit = closed = true
+
+  override def bindService(): ServerServiceDefinition =
+    LedgerIdentityServiceGrpc.bindService(this, DirectExecutionContext)
 }
 
 object LedgerIdentityServiceImpl {
-  def apply(ledgerId: String): LedgerIdentityServiceImpl with LedgerIdentityServiceLogging =
-    new LedgerIdentityServiceImpl(ledgerId) with LedgerIdentityServiceLogging {
-      override def bindService(): ServerServiceDefinition =
-        LedgerIdentityServiceGrpc.bindService(this, DirectExecutionContext)
-    }
+  def apply(ledgerId: String): LedgerIdentityService with BindableService with LedgerIdentityServiceLogging =
+    new LedgerIdentityServiceImpl(ledgerId) with LedgerIdentityServiceLogging
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/identity/LedgerIdentityServiceImpl.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/identity/LedgerIdentityServiceImpl.scala
@@ -4,7 +4,12 @@
 package com.digitalasset.platform.server.services.identity
 
 import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
-import com.digitalasset.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, GetLedgerIdentityResponse, LedgerIdentityServiceGrpc, LedgerIdentityServiceLogging}
+import com.digitalasset.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  GetLedgerIdentityResponse,
+  LedgerIdentityServiceGrpc,
+  LedgerIdentityServiceLogging
+}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.server.api.ApiException
 import com.digitalasset.platform.common.util.DirectExecutionContext
@@ -38,6 +43,7 @@ abstract class LedgerIdentityServiceImpl private (val ledgerId: String)
 }
 
 object LedgerIdentityServiceImpl {
-  def apply(ledgerId: String): LedgerIdentityService with BindableService with LedgerIdentityServiceLogging =
+  def apply(ledgerId: String)
+    : LedgerIdentityService with BindableService with LedgerIdentityServiceLogging =
     new LedgerIdentityServiceImpl(ledgerId) with LedgerIdentityServiceLogging
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ReferenceTimeService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ReferenceTimeService.scala
@@ -10,6 +10,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.digitalasset.api.util.TimestampConversion._
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
+import com.digitalasset.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService
 import com.digitalasset.ledger.api.v1.testing.time_service._
 import com.digitalasset.platform.akkastreams.SignalDispatcher
 import com.digitalasset.platform.api.grpc.GrpcApiService
@@ -31,8 +32,6 @@ class ReferenceTimeService private (
     protected val esf: ExecutionSequencerFactory)
     extends TimeServiceAkkaGrpc
     with FieldValidations
-    with BindableService
-    with AutoCloseable
     with GrpcApiService {
 
   protected val logger = LoggerFactory.getLogger(TimeServiceGrpc.TimeService.getClass)
@@ -133,6 +132,6 @@ object ReferenceTimeService {
       allowSettingTimeBackwards: Boolean = false)(
       implicit grpcExecutionContext: ExecutionContext,
       mat: Materializer,
-      esf: ExecutionSequencerFactory): ReferenceTimeService with TimeServiceLogging =
+      esf: ExecutionSequencerFactory): TimeService with BindableService with TimeServiceLogging =
     new ReferenceTimeService(ledgerId, backend, allowSettingTimeBackwards) with TimeServiceLogging
 }

--- a/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
+++ b/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
@@ -273,8 +273,13 @@ final case class ReferenceIndexService(participantReadService: participant.state
             currentOffset
               .fold(state.txs)(state.txs.from)
               .take(100) /* produce in chunks of 100 */
+          val toDrop = currentOffset
           currentOffset = txs.lastOption.map(_._1)
           txs
+            .dropWhile{
+              //_ => false
+              case (offset,_) => toDrop.fold(false)(_.eq(offset))
+            }
       }
       // Complete the stream once end (if given) has been reached.
       .takeWhile {

--- a/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
+++ b/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
@@ -272,13 +272,12 @@ final case class ReferenceIndexService(participantReadService: participant.state
           val txs =
             currentOffset
               .fold(state.txs)(state.txs.from)
-              .take(100) /* produce in chunks of 100 */
+              .take(100) // produce in chunks of 100
           val toDrop = currentOffset
           currentOffset = txs.lastOption.map(_._1)
           txs
-            .dropWhile{
-              //_ => false
-              case (offset,_) => toDrop.fold(false)(_.eq(offset))
+            .dropWhile {
+              case (offset, _) => toDrop.fold(false)(_.eq(offset))
             }
       }
       // Complete the stream once end (if given) has been reached.

--- a/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Ledger.scala
+++ b/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Ledger.scala
@@ -202,9 +202,10 @@ class Ledger(timeModel: TimeModel, timeProvider: TimeProvider)(implicit mat: Act
       txDelta: TxDelta,
       recordedAt: Instant,
       ledgerState: LedgerState): Either[v1.Update, Unit] = {
-    
+
     checkSubmission(submitterInfo, transactionMeta, txDelta, recordedAt, ledgerState)
-      .flatMap(_ => runPreCommitValidation(submitterInfo, transactionMeta, transaction, ledgerState))
+      .flatMap(_ =>
+        runPreCommitValidation(submitterInfo, transactionMeta, transaction, ledgerState))
   }
 
   private def runPreCommitValidation(
@@ -241,14 +242,15 @@ class Ledger(timeModel: TimeModel, timeProvider: TimeProvider)(implicit mat: Act
       .flatMap(_ => checkLet(submitterInfo, transactionMeta, ledgerState))
       .flatMap(_ => checkActiveness(submitterInfo, txDelta, ledgerState))
   }
-  
-          // check for and ignore duplicates
+
+  // check for and ignore duplicates
   private def checkDuplicates(
       submitterInfo: SubmitterInfo,
       ledgerState: LedgerState): Either[Update, Unit] = {
-    
-    Either.cond (
-      !ledgerState.duplicationCheck.contains(submitterInfo.applicationId->submitterInfo.commandId),
+
+    Either.cond(
+      !ledgerState.duplicationCheck.contains(
+        submitterInfo.applicationId -> submitterInfo.commandId),
       (),
       mkRejectedCommand(DuplicateCommand, submitterInfo)
     )
@@ -274,10 +276,9 @@ class Ledger(timeModel: TimeModel, timeProvider: TimeProvider)(implicit mat: Act
         transactionMeta.ledgerEffectiveTime.toInstant,
         submitterInfo.maxRecordTime.toInstant,
         submitterInfo.commandId,
-        submitterInfo.applicationId)
-      .fold(
-        t => Left(mkRejectedCommand(MaximumRecordTimeExceeded, submitterInfo)), 
-        _ => Right(()))
+        submitterInfo.applicationId
+      )
+      .fold(t => Left(mkRejectedCommand(MaximumRecordTimeExceeded, submitterInfo)), _ => Right(()))
   }
 
   // check for consistency
@@ -288,11 +289,11 @@ class Ledger(timeModel: TimeModel, timeProvider: TimeProvider)(implicit mat: Act
       txDelta: TxDelta,
       ledgerState: LedgerState): Either[Update, Unit] = {
 
-      Either.cond(
-        txDelta.inputs.subsetOf(ledgerState.activeContracts.keySet) &&
-          txDelta.inputs_nc.subsetOf(ledgerState.activeContracts.keySet),
-        (),
-        mkRejectedCommand(Inconsistent, submitterInfo)
+    Either.cond(
+      txDelta.inputs.subsetOf(ledgerState.activeContracts.keySet) &&
+        txDelta.inputs_nc.subsetOf(ledgerState.activeContracts.keySet),
+      (),
+      mkRejectedCommand(Inconsistent, submitterInfo)
     )
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
@@ -55,6 +55,7 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
     materializer: Materializer,
     esf: ExecutionSequencerFactory)
     extends TransactionService
+    with AutoCloseable
     with ErrorFactories {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -251,4 +252,7 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
       trans.recordTime,
       None
     )
+
+  override def close(): Unit = ()
+
 }


### PR DESCRIPTION
* make reference index service stop repeating last event indefinitely
Fixes #473 
* remove early returns in the reference ledger implementation
Fixes #403 
* make all services follow more consistent design, without unnecessary inherits and without unnecessary methods that do nothing (bindService)