### PR TITLE
Make install target explicit in daml install.

### DIFF
--- a/daml-assistant/src/DAML/Assistant.hs
+++ b/daml-assistant/src/DAML/Assistant.hs
@@ -35,7 +35,7 @@ main = do
             putStrLn (versionToString version)
 
         Builtin (Install options) -> wrapErr "Installing the SDK." $ do
-            install options envDamlPath
+            install options envDamlPath envProjectPath
 
         Dispatch SdkCommandInfo{..} cmdArgs ->
             wrapErr ("Running " <> unwrapSdkCommandName sdkCommandName <> " command.") $ do

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -57,7 +57,7 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions
-    <$> optional (RawInstallTarget <$> argument str (metavar "CHANNEL|VERSION|PATH"))
+    <$> optional (RawInstallTarget <$> argument str (metavar "TARGET"))
     <*> iflag ActivateInstall "activate" mempty "Activate installed version of daml"
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
     <*> iflag QuietInstall "quiet" (short 'q') "Quiet verbosity"

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -316,7 +316,7 @@ testInstall = Tasty.testGroup "DAML.Assistant.Install"
                 .| Zlib.gzip
                 .| sinkFile "source.tar.gz"
 
-            install options damlPath
+            install options damlPath Nothing
     , if isWindows
         then testInstallWindows
         else testInstallUnix
@@ -348,7 +348,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
 
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target is absolute."
-                (install options damlPath)
+                (install options damlPath Nothing)
 
     , Tasty.testCase "reject an escaping symlink in a tarball" $ do
         withSystemTempDirectory "test-install" $ \ base -> do
@@ -374,7 +374,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
 
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target escapes tarball."
-                (install options damlPath)
+                (install options damlPath Nothing)
     ]
 
 testInstallWindows :: Tasty.TestTree


### PR DESCRIPTION
Added functionality to install SDK version of current project. Slight interface change to accomodate that by making the install target explicit for `daml install`. There are four options:

- `daml install latest` which will install the latest stable SDK version (i.e. it skips pre-release versions)
- `daml install project` which will install the SDK version specified in the project config 
- `daml install VERSION` which will install a specific SDK version, as before
- `daml install PATH` which will install an SDK release from a tarball or directory, as before