### PR TITLE
Fix the DAML-LF Archive package structure

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -193,6 +193,6 @@ pkg_tar(
     name = "daml_lf_archive_protos_tarball",
     srcs = [":proto_srcs"],
     extension = "tar.gz",
-    package_dir = "daml-lf-archive-protos/protobuf/com/digitalasset/daml_lf",
+    package_dir = "daml-lf-archive-protos/protobuf/da",
     visibility = ["//visibility:public"],
 )

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,9 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- DAML-LF Archive packaging: the DAML-LF Archive Protobuf definitions are now
+  packaged so that it's possible to use them without mangling the path.
+
 0.12.4 — 2019-04-15
 -------------------
 


### PR DESCRIPTION
The DAML-LF Archive Protobuf definitions, as packaged and distributed
via Bintray and the SDK, currently packages the files in a directory
structure that does not match with the actual one, causing the usage of
`protoc` on the packaged definitions to raise errors. This commit fixes
it by packaging the files in the same directory structure as the one
found in the repository.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
