### PR TITLE
Implement TextMap.toList (2nd attempt)

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/LF.daml
@@ -30,9 +30,12 @@ module DA.Internal.LF
 
   , CanAbort
   , abort
+
+  , Pair
+  , unpackPair
   ) where
 
-import GHC.Types (Opaque)
+import GHC.Types (Opaque, Symbol, magic)
 import DA.Internal.Prelude
 
 -- | The `Party` type represents a party to a contract.
@@ -180,3 +183,11 @@ submitMustFail = primitive @"SMustFailAt"
 -- | Declare you are building a scenario.
 scenario : Scenario a -> Scenario a
 scenario = identity
+
+-- | HIDE A dummy type for the DAML-LF structural record type
+-- `<f1: a1, f2: a2>`.
+data Pair (f1 : Symbol) (f2 : Symbol) a1 a2 = Pair Opaque
+
+-- | HIDE Function to turn a DAML-LF structural record type into a DAML pair.
+unpackPair : forall f1 f2 a1 a2. Pair f1 f2 a1 a2 -> (a1, a2)
+unpackPair = magic @"unpackPair"

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Private/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Private/TextMap.daml
@@ -21,6 +21,7 @@ module DA.Private.TextMap
   ) where
 
 import Prelude hiding (lookup, null, filter, empty)
+import DA.Internal.LF (Pair, unpackPair)
 import DA.List qualified as L
 import DA.Optional qualified as M
 
@@ -31,9 +32,7 @@ fromList list = foldl (\acc (key, value) -> (insert key value acc)) empty list
 -- | Convert the map to a list of key/value pairs where the keys are
 -- in ascending order.
 toList : TextMap a -> [(Text, a)]
-toList textMap =
- -- FixMe: implement toList
- error "not yet implemented"
+toList x = map (unpackPair @"key" @"value") (primitive @"BEMapToList" x)
 
 -- | The empty map.
 empty : TextMap a
@@ -80,9 +79,7 @@ instance (Show a) => Show (TextMap a) where
 
 
 instance (Eq a) => Eq (TextMap a) where
-  (==) m1 m2 =
--- FixMe should use (toList m1 == toList m2)
-     False
+  x == y = toList x == toList y
 
 instance (Ord a) => Ord (TextMap a) where
   compare = \m1 m2 -> compare (toList m1) (toList m2)
@@ -92,4 +89,3 @@ instance Semigroup (TextMap b) where
 
 instance Monoid (TextMap b) where
   mempty = empty
-

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -23,13 +23,13 @@ isInternal (GHC.moduleNameString -> x)
     "GHC." `isPrefixOf` x ||
     x `elem` ["Control.Exception.Base", "Data.String", "LibraryModules"]
 
-mayImportInternal :: GHC.ModuleName -> Bool
-mayImportInternal (GHC.moduleNameString -> x) = x == "Prelude" || x == "DA.Time" || x == "DA.Date" || x == "DA.Record"
+mayImportInternal :: [GHC.ModuleName]
+mayImportInternal = map GHC.mkModuleName ["Prelude", "DA.Time", "DA.Date", "DA.Record", "DA.Private.TextMap"]
 
 -- | Apply all necessary preprocessors
 damlPreprocessor :: GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
 damlPreprocessor x
-    | maybe False (isInternal ||^ mayImportInternal) name = ([], x)
+    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], x)
     | otherwise = (checkImports x ++ checkDataTypes x, recordDotPreprocessor $ importDamlPreprocessor x)
     where name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -38,6 +38,9 @@ pattern TypeCon :: TyCon -> [GHC.Type] -> GHC.Type
 pattern TypeCon c ts <- (splitTyConApp_maybe -> Just (c, ts))
   where TypeCon = mkTyConApp
 
+pattern StrLitTy :: String -> Type
+pattern StrLitTy x <- (fmap unpackFS . isStrLitTy -> Just x)
+
 subst :: [(TyVar, GHC.Type)] -> GHC.Type -> GHC.Type
 subst env = transform $ \t ->
     case getTyVar_maybe t of

--- a/daml-foundations/daml-ghc/tests/TextMap.daml
+++ b/daml-foundations/daml-ghc/tests/TextMap.daml
@@ -12,19 +12,19 @@ import DA.Assert
 
 testEmpty = scenario do
   0 === size TM.empty
-  -- [] === toList (TM.empty : TextMap Decimal)
+  [] === toList (TM.empty : TextMap Decimal)
 
 testSize = scenario do
   0 === size (fromList ([] : [(Text, Decimal)]))
   3 === size (fromList [("1", 2.0), ("2", 9.0), ("3", 2.2)])
 
--- testToList = scenario do
---  [("1", "c"), ("2", "a"), ("5", "b")] === toList (fromList [("2", "a"), ("5", "b"), ("1", "c")])
+testToList = scenario do
+  [("1", "c"), ("2", "a"), ("5", "b")] === toList (fromList [("2", "a"), ("5", "b"), ("1", "c")])
 
 testFromList = scenario do
   False === member "2" (fromList [("1", "a"), ("3", "b"), ("4", "c")])
   True === member "3" (fromList [("1", "a"), ("3", "b"), ("4", "c")])
---  fromList [("1", "b")] === fromList [("1", "a"), ("1", "c"), ("1", "b")]
+  fromList [("1", "b")] === fromList [("1", "a"), ("1", "c"), ("1", "b")]
 
 testMember = scenario do
   False === member "a" (fromList [("", 1.0), ("b", 2.0), ("c", 3.0)])
@@ -42,37 +42,25 @@ testNull = scenario do
   False === TM.null (fromList [("1", "a"), ("2", "b"), ("3", "c")])
   True === TM.null (fromList ([] : [(Text, Party)]))
 
--- testEq = scenario do
---  (TM.empty : TextMap Int) === (TM.empty : TextMap Int)
---  assert (not (TM.empty == (TM.fromList [("1", 1)])))
---  (TM.fromList [("1", 1), ("2", 2), ("3", 3)]) === (TM.fromList [("1", 1), ("2", 2), ("3", 3)])
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2)])))
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("3", 4)])))
---  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("4", 3)])))
+testEq = scenario do
+  (TM.empty : TextMap Int) === (TM.empty : TextMap Int)
+  assert (not (TM.empty == (TM.fromList [("1", 1)])))
+  (TM.fromList [("1", 1), ("2", 2), ("3", 3)]) === (TM.fromList [("1", 1), ("2", 2), ("3", 3)])
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2)])))
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("3", 4)])))
+  assert (not ((TM.fromList [("1", 1), ("2", 2), ("3", 3)]) == (TM.fromList [("1", 2), ("2", 2), ("4", 3)])))
 
--- testInsert = scenario do
---  [("1", True), ("2", False), ("3", True), ("4", False), ("5", False)]
---    ===
---    toList (foldl (\a b -> (uncurry TM.insert) b a) TM.empty [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)])
+testInsert = scenario do
+  [("1", True), ("2", False), ("3", True), ("4", False), ("5", False)]
+    ===
+    toList (foldl (\a b -> (uncurry TM.insert) b a) TM.empty [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)])
 
--- testFilter = scenario do
---  (fromList [("1", True), ("2", False), ("3", True)])
---    ===
---    (TM.filter (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
+testFilter = scenario do
+  (fromList [("1", True), ("2", False), ("3", True)])
+    ===
+    (TM.filter (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
 
--- testDelete = scenario do
---  (fromList [("2", False), ("3", True), ("4", False), ("5", False)])
---    ===
---    (delete "1" (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
-
-main = scenario do
-  testEmpty
-  testSize
-  --testToList
-  testFromList
-  testMember
-  testNull
-  --tesstInsert
-  --testFilter
-  --testDelete
-
+testDelete = scenario do
+  (fromList [("2", False), ("3", True), ("4", False), ("5", False)])
+    ===
+    (delete "1" (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))


### PR DESCRIPTION
Implement the compiler logic needed to expose DAML-LF's `MAP_TO_LIST` as
`TextMap.toList` in the surface language.

This is part of #409. The type definition and module need to be put in the
right place before I consider this done. Once it's done, I'll add it to the
release notes.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/508)
<!-- Reviewable:end -->
