### PR TITLE
Fix codegen integration tests

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -64,7 +64,8 @@ quickstartTests compVersion quickstartDir mvnDir = testGroup "quickstart"
     , testCase "daml init" $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["init"]
     , testCase "daml package" $ withCurrentDirectory quickstartDir $
-          callProcessQuiet "daml" ["package"]
+          -- This location is assumed by the codegen in the quickstart example.
+          callProcessQuiet "daml" ["package", "-o", "target/daml/iou.dar"]
     , testCase "daml build " $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["build"]
     , testCase "daml test" $ withCurrentDirectory quickstartDir $


### PR DESCRIPTION
The codegen integration tests assume a specific location atm so we
need to specify that explicitely (eventually we might want to change
them to use the default location but not for now). The reason why we
didn’t catch this before merging the package-new command is that the
PR was not rebased on top of the changes that added the codegen
integration tests.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
