### PR TITLE
Downgrade nix from 2.2.2 to 2.2.1

### DIFF
--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -23,7 +23,8 @@ if [[ ! -e /nix ]]; then
   sudo mkdir -m 0755 /nix
   sudo chown "$(id -u):$(id -g)" /nix
 
-  curl -sfL https://nixos.org/nix/install | bash
+  # 2.2.2 seems to segfault on MacOS in CI so for now we use 2.2.1.
+  curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
 fi
 
 # shellcheck source=../dev-env/lib/ensure-nix


### PR DESCRIPTION
The newer version seems to segfault on MacOS quite often so let’s
downgrade for now. We should also try to see if we can find a
reasonable way of reproducing this and report it upstream.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
