### PR TITLE
Improve error message for ambiguous data types

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -16,6 +16,7 @@ import Outputable
 
 import           Control.Monad.Extra
 import           Data.List
+import           Data.Maybe
 
 
 isInternal :: GHC.ModuleName -> Bool

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -86,7 +86,7 @@ checkAmbiguousDataTypes (GHC.L _ m) =
       = Nothing
       where
         message =
-          "Ambiguous data type declaration. " ++ "Write " ++
+          "Ambiguous data type declaration. Write " ++
           baseDeclStr ++ " {} for a record or " ++
           baseDeclStr ++ " () for a variant."
         baseDeclStr = showSDocUnsafe (ppr decl)

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -81,14 +81,14 @@ checkAmbiguousDataTypes (GHC.L _ m) =
       | GHC.TyClD _ GHC.DataDecl{tcdDataDefn=GHC.HsDataDefn{dd_cons=[con]}} <- decl -- single con data type
       , GHC.PrefixCon [] <- GHC.con_args (GHC.unLoc con) -- zero arguments
       = Just (ss, message)
+      | otherwise
+      = Nothing
       where
         message =
           "Ambiguous data type declaration. " <> "Write " <>
           baseDeclStr <> " {} for a record or " <>
           baseDeclStr <> " () for a variant."
         baseDeclStr = showSDocUnsafe (ppr decl)
-      | otherwise
-      = Nothing
 
 
 checkUnlabelledConArgs :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -84,11 +84,11 @@ checkAmbiguousDataTypes (GHC.L _ m) =
       | otherwise
       = Nothing
       where
-        message =
+        message :: String =
           "Ambiguous data type declaration. " <> "Write " <>
           baseDeclStr <> " {} for a record or " <>
           baseDeclStr <> " () for a variant."
-        baseDeclStr = showSDocUnsafe (ppr decl)
+        baseDeclStr :: String = showSDocUnsafe (ppr decl)
 
 
 checkUnlabelledConArgs :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -12,6 +12,7 @@ import           DA.Daml.GHC.Compiler.Records
 import Development.IDE.UtilGHC
 
 import qualified "ghc-lib" GHC
+import Outputable
 
 import           Control.Monad.Extra
 import           Data.List
@@ -71,17 +72,23 @@ checkDataTypes m = checkAmbiguousDataTypes m ++ checkUnlabelledConArgs m
 
 
 checkAmbiguousDataTypes :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
-checkAmbiguousDataTypes m =
-    [ (ss, "Ambiguous data type. Please disambiguate, e.g. data Foo = Foo {} for a record type or data Foo = Foo () for a variant type.")
-    | GHC.L ss decl <- GHC.hsmodDecls (GHC.unLoc m), isBad decl ]
-    where
-        isBad :: GHC.HsDecl GHC.GhcPs -> Bool
-        -- Is the declaration a data type with one constructor and zero arguments?
-        isBad decl
-          | GHC.TyClD _ GHC.DataDecl{tcdDataDefn=GHC.HsDataDefn{dd_cons=[con]}} <- decl -- single con data type
-          , GHC.PrefixCon [] <- GHC.con_args (GHC.unLoc con) -- zero arguments
-          = True
-        isBad _ = False
+checkAmbiguousDataTypes (GHC.L _ m) =
+    mapMaybe getAmbiguousError (GHC.hsmodDecls m)
+  where
+    getAmbiguousError :: GHC.LHsDecl GHC.GhcPs -> Maybe (GHC.SrcSpan, String)
+    -- Generate an error if the declaration is a data type with one constructor and zero arguments
+    getAmbiguousError (GHC.L ss decl)
+      | GHC.TyClD _ GHC.DataDecl{tcdDataDefn=GHC.HsDataDefn{dd_cons=[con]}} <- decl -- single con data type
+      , GHC.PrefixCon [] <- GHC.con_args (GHC.unLoc con) -- zero arguments
+      = Just (ss, message)
+      where
+        message =
+          "Ambiguous data type declaration. " <> "Write " <>
+          baseDeclStr <> " {} for a record or " <>
+          baseDeclStr <> " () for a variant."
+        baseDeclStr = showSDocUnsafe (ppr decl)
+      | otherwise
+      = Nothing
 
 
 checkUnlabelledConArgs :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -84,11 +84,11 @@ checkAmbiguousDataTypes (GHC.L _ m) =
       | otherwise
       = Nothing
       where
-        message :: String =
-          "Ambiguous data type declaration. " <> "Write " <>
-          baseDeclStr <> " {} for a record or " <>
-          baseDeclStr <> " () for a variant."
-        baseDeclStr :: String = showSDocUnsafe (ppr decl)
+        message =
+          "Ambiguous data type declaration. " ++ "Write " ++
+          baseDeclStr ++ " {} for a record or " ++
+          baseDeclStr ++ " () for a variant."
+        baseDeclStr = showSDocUnsafe (ppr decl)
 
 
 checkUnlabelledConArgs :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/daml-foundations/daml-ghc/tests/AmbiguousDataType.daml
+++ b/daml-foundations/daml-ghc/tests/AmbiguousDataType.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:1-9:15; Ambiguous data type. Write data Foo = Bar {} for a record or data Foo = Bar () for a variant.
+-- @ERROR range=9:1-9:15; Ambiguous data type declaration. Write data Foo = Bar {} for a record or data Foo = Bar () for a variant.
 
 daml 1.2
 module AmbiguousDataType where

--- a/daml-foundations/daml-ghc/tests/AmbiguousDataType.daml
+++ b/daml-foundations/daml-ghc/tests/AmbiguousDataType.daml
@@ -1,11 +1,9 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:1-9:15; Ambiguous data type. Please disambiguate
+-- @ERROR range=9:1-9:15; Ambiguous data type. Write data Foo = Bar {} for a record or data Foo = Bar () for a variant.
 
 daml 1.2
 module AmbiguousDataType where
 
-data Foo = Foo
-
-main = scenario do return ()
+data Foo = Bar


### PR DESCRIPTION
Use the type and data constructor names that the user actually wrote in the error message, instead of using the `data Foo = Foo` example.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
