### PR TITLE
Remove blocking call in Bot.wire

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,9 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- RxJava Bindings: remove blocking call inside Bot.wire, which could lead to an
+  application not making progress in certain situations.
+
 0.12.5 — 2019-04-15
 -------------------
 


### PR DESCRIPTION
The call to blockingGet can lead to no progress being made in certain
scenarios. Therefore I am removing the blocking call and replacing it
with a regular "doOnSuccess".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
