### PR TITLE
Navigator: Print important messages to stderr

### DIFF
--- a/navigator/backend/src/main/resources/logback.xml
+++ b/navigator/backend/src/main/resources/logback.xml
@@ -25,8 +25,13 @@
         <appender-ref ref="FILE"/>
     </appender>
 
+    <!-- Some important messages are written to stderr -->
+    <logger name="user-facing-logs" level="INFO" additivity="true">
+        <appender-ref ref="STDERR"/>
+    </logger>
+
+    <!-- All log messages are written asynchronously to a file -->
     <root level="INFO">
-        <!-- <appender-ref ref="STDERR"/> -->
         <appender-ref ref="ASYNC"/>
     </root>
 </configuration>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -286,7 +286,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
       case DumpGraphQLSchema =>
         dumpGraphQLSchema()
       case RunServer if !Files.exists(configFile) =>
-        val message = "No configuration file found! A a configuration template file will be created at " +
+        val message = "No configuration file found! A configuration template file will be created at " +
           s"$configFile, please edit it and restart ${applicationInfo.name}"
         userFacingLogger.error(message)
         Config.writeTemplateToPath(configFile, args.useDatabase)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -24,6 +24,7 @@ import com.digitalasset.navigator.model.{Ledger, PackageRegistry}
 import com.digitalasset.navigator.store.Store.Subscribe
 import com.digitalasset.navigator.store.platform.PlatformStore
 import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
 import pureconfig.error.ConfigReaderException
 import sangria.schema._
 import spray.json._
@@ -49,6 +50,8 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
   def customRoutes: List[Route]
   def applicationInfo: ApplicationInfo
   def banner: Option[String] = None
+
+  private[this] def userFacingLogger = LoggerFactory.getLogger("user-facing-logs")
 
   /** Allow subclasses to customize config file name, but don't require it
     * (supply a default)
@@ -283,9 +286,9 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
       case DumpGraphQLSchema =>
         dumpGraphQLSchema()
       case RunServer if !Files.exists(configFile) =>
-        logger.error(
-          s"No configuration file found! A a configuration template file will be created at " +
-            s"${configFile}, please edit it and restart the UI backend")
+        val message = "No configuration file found! A a configuration template file will be created at " +
+          s"$configFile, please edit it and restart ${applicationInfo.name}"
+        userFacingLogger.error(message)
         Config.writeTemplateToPath(configFile, args.useDatabase)
       case RunServer =>
         Config.load(configFile, args.useDatabase) match {
@@ -295,7 +298,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
             throw exception
           case Right(config) if config.users.isEmpty =>
             logger.error("No users found in the configuration file!")
-            throw new RuntimeException("No users found in the configuration file!")
+            sys.error("No users found in the configuration file!")
           case Right(config) =>
             runServer(args, config)
         }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -30,6 +30,7 @@ import com.digitalasset.navigator.ApplicationInfo
 import io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 import io.grpc.{ManagedChannel, Status}
 import io.netty.handler.ssl.SslContext
+import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Random, Success, Try}
 import scala.concurrent.Future
@@ -96,6 +97,8 @@ class PlatformStore(
     .nextLong()
     .toHexString
 
+  private[this] def userFacingLogger = LoggerFactory.getLogger("user-facing-logs")
+
   import PlatformStore._
 
   // ----------------------------------------------------------------------------------------------
@@ -124,7 +127,9 @@ class PlatformStore(
 
     case Connected(Failure(e)) =>
       // Connection failed even after several retries - not sure how to recover from this
-      log.error("Giving up. Please fix any issues and restart this application.")
+      val message = s"Permanently failed to connect to the ledger at $platformHost:$platformPort. " +
+        "Please fix any issues and restart this application."
+      userFacingLogger.error(message)
       context.become(failed(StateFailed(e)))
 
     case GetApplicationStateInfo =>


### PR DESCRIPTION
All messages that users need to act on are now printed to stderr, in addition to the log file.

Fixes #112 
