### PR TITLE
Update rules_haskell and don't use nixpkgs c2hs

### DIFF
--- a/3rdparty/haskell/BUILD.c2hs
+++ b/3rdparty/haskell/BUILD.c2hs
@@ -1,9 +1,14 @@
+# vim: ft=python
+
 load("@ai_formation_hazel//third_party/cabal2bazel:bzl/cabal_package.bzl",
      "cabal_haskell_package",
      "hazel_symlink")
 load("@hazel_base_repository//:extra-libs.bzl",
   "extra_libs",
 )
+
+load("@os_info//:os_info.bzl", "is_windows")
+
 load("@com_github_digital_asset_daml//3rdparty/haskell:c2hs-package.bzl", "package")
 # Make a buildable target for easier debugging of the package.bzl file
 hazel_symlink(
@@ -11,10 +16,13 @@ hazel_symlink(
   src = "@com_github_digital_asset_daml//3rdparty/haskell:c2hs-package.bzl",
   out = "package-bzl",
 )
+
+
+ghc_workspace = "@io_tweag_rules_haskell_ghc_windows_amd64" if is_windows else "@io_tweag_rules_haskell_ghc-nixpkgs"
+
 cabal_haskell_package(
   package,
-  "8.6.4
-",
-  "@io_tweag_rules_haskell_ghc_windows_amd64",
+  "8.6.4",
+  ghc_workspace,
   extra_libs,
 )

--- a/BUILD
+++ b/BUILD
@@ -47,7 +47,7 @@ load(
 
 c2hs_toolchain(
     name = "c2hs-toolchain",
-    c2hs = "@c2hs//:bin",
+    c2hs = "@haskell_c2hs//:c2hs_bin",
 )
 
 filegroup(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,32 +169,6 @@ dev_env_tool(
     win_tool = "msys2-20180531",
 )
 
-# c2hs
-nixpkgs_package(
-    name = "c2hs",
-    attribute_path = "ghcWithC2hs",
-    build_file_content = '''
-
-package(default_visibility = [ "//visibility:public" ])
-
-filegroup(
-    name = "bin",
-    srcs = ["bin/c2hs"],
-)
-exports_files(["bin/ghc-pkg"])
-  ''',
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps + [
-        "//nix:ghc.nix",
-        "//nix:with-packages-wrapper.nix",
-        "//nix:overrides/ghc-8.6.4.nix",
-        "//nix:overrides/c2hs-0.28.6.nix",
-        "//nix:overrides/ghc-8.6.3-binary.nix",
-        "//nix:overrides/language-c-0.8.2.nix",
-    ],
-    repositories = dev_env_nix_repos,
-)
-
 load(
     "@io_tweag_rules_haskell//haskell:haskell.bzl",
     "haskell_register_ghc_bindists",

--- a/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
@@ -4,6 +4,8 @@
 load("//bazel_tools:haskell.bzl", "da_haskell_binary")
 load("//bazel_tools:packaging/packaging.bzl", "package_app")
 
+load("@os_info//:os_info.bzl", "is_windows")
+
 da_haskell_binary(
     name = "da-hs-damlc-app",
     srcs = ["src/Main.hs"],
@@ -60,7 +62,7 @@ package_app(
         "//compiler/scenario-service/server:scenario_service_jar",
         "//daml-foundations/daml-ghc/package-database:gen-daml-prim.dar",
         "//daml-foundations/daml-ghc/package-database:package-db",
-        "@c2hs//:bin/ghc-pkg",
+        "@io_tweag_rules_haskell_ghc_windows_amd64//:bin/ghc-pkg.exe" if is_windows else "@io_tweag_rules_haskell_ghc-nixpkgs//:bin/ghc-pkg",
     ],
     tags = ["no-cache"],
     visibility = ["//visibility:public"],

--- a/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-damlc-app/BUILD.bazel
@@ -3,7 +3,6 @@
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary")
 load("//bazel_tools:packaging/packaging.bzl", "package_app")
-
 load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_binary(

--- a/deps.bzl
+++ b/deps.bzl
@@ -27,8 +27,8 @@
 # be resolvable from external workspaces otherwise.
 
 rules_scala_version = "6f8ee3d951d2ac6154356314600f6edb4eb5df8b"
-rules_haskell_version = "4bebd7a72daf56a0f2859599741050d80bf179dc"
-rules_haskell_sha256 = "c62d44c2d78125ac972b50811b1c21096c37399efb75d31ea454ad52d76830a2"
+rules_haskell_version = "ac1d2c17d873d48dde9d307b7b8913cd1d2970ec"
+rules_haskell_sha256 = "e2a9315a46f5edd099880c804e13dd8a743e02495eada02a885b2817f4d9ed8d"
 rules_nixpkgs_version = "40b5a9f23abca57f364c93245c7451206ef1a855"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
* We need the rules_haskell update on Windows, because it flags kernel32 as a system lib.
* We use c2hs from hazel because we can't use nixpkgs' on Windows.