### PR TITLE
language: don't check for deprecated pkgDb anymore

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -103,14 +103,8 @@ mkOptions :: Options -> IO Options
 mkOptions opts@Options {..} = do
     baseDir <- getBaseDir
     mapM_ checkDirExists $ optImportPath <> optPackageDbs
-    let deprecatedPkgDb = baseDir </> "package-database" </> "deprecated"
-    deprecatedPkgDbExists <- Dir.doesDirectoryExist deprecatedPkgDb
-    when deprecatedPkgDbExists $
-      putStrLn "DEPRECATED: Please use fat dars instead of dalfs in tests"
-    let defaultPkgDb
-          | deprecatedPkgDbExists = deprecatedPkgDb
-          | otherwise = baseDir </> "package-database"
-    pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDb, projectPackageDatabase]
+    let defaultPkgDb = baseDir </> "package-database"
+    pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDb]
     pure opts {optPackageDbs = map (</> versionSuffix) $ pkgDbs ++ optPackageDbs}
   where checkDirExists f =
           Dir.doesDirectoryExist f >>= \ok ->


### PR DESCRIPTION
This removes a left over check in Compiler/Options for the deprecated
package db that has been removed.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
