### PR TITLE
Added daml assistant exec command.

### DIFF
--- a/daml-assistant/src/DAML/Assistant.hs
+++ b/daml-assistant/src/DAML/Assistant.hs
@@ -16,6 +16,7 @@ import DAML.Assistant.Command
 import DAML.Assistant.Install
 import DAML.Assistant.Util
 import System.FilePath
+import System.Directory
 import System.Process
 import System.Exit
 import Control.Exception.Safe
@@ -37,13 +38,21 @@ main = do
         Builtin (Install options) -> wrapErr "Installing the SDK." $ do
             install options envDamlPath envProjectPath
 
+        Builtin (Exec cmd args) ->
+            wrapErr "Running executable in daml environment." $ do
+                path <- fromMaybe cmd <$> findExecutable cmd
+                exitWith =<< dispatch env path args
+
         Dispatch SdkCommandInfo{..} cmdArgs ->
             wrapErr ("Running " <> unwrapSdkCommandName sdkCommandName <> " command.") $ do
                 sdkPath <- required "Could not determine SDK path." envSdkPath
-                dispatchEnv <- getDispatchEnv env
                 let path = unwrapSdkPath sdkPath </> unwrapSdkCommandPath sdkCommandPath
                     args = unwrapSdkCommandArgs sdkCommandArgs ++ unwrapUserCommandArgs cmdArgs
-                    process = (proc path args) { env = Just dispatchEnv }
-                exitCodeE <- tryIO $ withCreateProcess process (\ _ _ _ -> waitForProcess)
-                exitCode <- requiredE "Failed to spawn command subprocess." exitCodeE
-                exitWith exitCode
+                exitWith =<< dispatch env path args
+
+dispatch :: Env -> FilePath -> [String] -> IO ExitCode
+dispatch env path args = do
+    dispatchEnv <- getDispatchEnv env
+    requiredIO "Failed to spawn command subprocess." $
+        withCreateProcess (proc path args) { env = Just dispatchEnv }
+            (\ _ _ _ -> waitForProcess)

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -30,7 +30,7 @@ subcommand name desc infoMod parser =
 
 builtin :: Text -> Text -> InfoMod Command -> Parser BuiltinCommand -> Mod CommandFields Command
 builtin name desc mod parser =
-    subcommand name desc mod (Builtin <$> parser <**> helper)
+    subcommand name desc mod (Builtin <$> parser)
 
 isHidden :: SdkCommandInfo -> Bool
 isHidden = isNothing . sdkCommandDesc
@@ -46,8 +46,8 @@ dispatch info = subcommand
 commandParser :: [SdkCommandInfo] -> Parser Command
 commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
     [ subparser -- visible commands
-        $  builtin "version" "Display SDK version" mempty (pure Version)
-        <> builtin "install" "Install SDK version" mempty (Install <$> installParser)
+        $  builtin "version" "Display SDK version" mempty (pure Version <**> helper)
+        <> builtin "install" "Install SDK version" mempty (Install <$> installParser <**> helper)
         <> builtin "exec" "Execute command with daml environment." forwardOptions
             (Exec <$> strArgument (metavar "CMD") <*> many (strArgument (metavar "ARGS")))
         <> foldMap dispatch visible

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -28,9 +28,9 @@ subcommand :: Text -> Text -> InfoMod Command -> Parser Command -> Mod CommandFi
 subcommand name desc infoMod parser =
     command (unpack name) (info parser (infoMod <> progDesc (unpack desc)))
 
-builtin :: Text -> Text -> Parser BuiltinCommand -> Mod CommandFields Command
-builtin name desc parser =
-    subcommand name desc mempty (Builtin <$> parser <**> helper)
+builtin :: Text -> Text -> InfoMod Command -> Parser BuiltinCommand -> Mod CommandFields Command
+builtin name desc mod parser =
+    subcommand name desc mod (Builtin <$> parser <**> helper)
 
 isHidden :: SdkCommandInfo -> Bool
 isHidden = isNothing . sdkCommandDesc
@@ -46,8 +46,10 @@ dispatch info = subcommand
 commandParser :: [SdkCommandInfo] -> Parser Command
 commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
     [ subparser -- visible commands
-        $  builtin "version" "Display SDK version" (pure Version)
-        <> builtin "install" "Install SDK version" (Install <$> installParser)
+        $  builtin "version" "Display SDK version" mempty (pure Version)
+        <> builtin "install" "Install SDK version" mempty (Install <$> installParser)
+        <> builtin "exec" "Execute command with daml environment." forwardOptions
+            (Exec <$> (strArgument (metavar "CMD")) <*> many (strArgument (metavar "ARGS")))
         <> foldMap dispatch visible
     , subparser -- hidden commands
         $  internal

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -49,7 +49,7 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
         $  builtin "version" "Display SDK version" mempty (pure Version)
         <> builtin "install" "Install SDK version" mempty (Install <$> installParser)
         <> builtin "exec" "Execute command with daml environment." forwardOptions
-            (Exec <$> (strArgument (metavar "CMD")) <*> many (strArgument (metavar "ARGS")))
+            (Exec <$> strArgument (metavar "CMD") <*> many (strArgument (metavar "ARGS")))
         <> foldMap dispatch visible
     , subparser -- hidden commands
         $  internal

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -50,6 +50,7 @@ data Env = Env
 
 data BuiltinCommand
     = Version
+    | Exec String [String]
     | Install InstallOptions
     deriving (Eq, Show)
 


### PR DESCRIPTION
Implements a `daml exec` command that executes a command in the environment given by the daml assistant. For example, running `daml exec env | grep DAML_` gives me:

```
DAML_HOME=/Users/fmota/.daml
DAML_PROJECT=
DAML_SDK=/Users/fmota/.daml/sdk/0.12.3
DAML_SDK_VERSION=0.12.3
```