### PR TITLE
Stable hashing for SQL contract keys

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -29,6 +29,7 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.PersistenceRespon
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{LedgerDao, PostgresLedgerDao}
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   ContractSerializer,
+  KeyHasher,
   TransactionSerializer,
   ValueSerializer
 }
@@ -69,7 +70,12 @@ object SqlLedger {
 
     val dbDispatcher = DbDispatcher(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
     val ledgerDao = LedgerDao.metered(
-      PostgresLedgerDao(dbDispatcher, ContractSerializer, TransactionSerializer, ValueSerializer))
+      PostgresLedgerDao(
+        dbDispatcher,
+        ContractSerializer,
+        TransactionSerializer,
+        ValueSerializer,
+        KeyHasher))
 
     val sqlLedgerFactory = SqlLedgerFactory(ledgerDao)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
@@ -1,0 +1,155 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation
+
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+
+import com.digitalasset.daml.lf.transaction.Node.GlobalKey
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+
+trait KeyHasher {
+
+  /** Returns the hash of the given DAML-LF value */
+  def hashKey(key: GlobalKey): Array[Byte]
+
+  /** Returns a string representation of the hash of the given DAML-LF value */
+  def hashKeyString(key: GlobalKey): String = hashKey(key).map("%02x" format _).mkString
+}
+
+/**
+  * ADT for data elements that appear in the input stream of the hash function
+  * used to hash DAML-LF values.
+  */
+sealed abstract class HashToken extends Product with Serializable
+final case class HashTokenText(value: String) extends HashToken
+final case class HashTokenByte(value: Byte) extends HashToken
+final case class HashTokenInt(value: Int) extends HashToken
+final case class HashTokenLong(value: Long) extends HashToken
+final case class HashTokenBigDecimal(value: BigDecimal) extends HashToken
+final case class HashTokenCollectionBegin(length: Int) extends HashToken
+final case class HashTokenCollectionEnd() extends HashToken
+
+object KeyHasher extends KeyHasher {
+
+  /**
+    * Traverses the given value in a stable way, producing "hash tokens" for any encountered primitive values.
+    * These tokens can be used as the input to a hash function.
+    *
+    * @param value the DAML-LF value to hash
+    * @param z initial hash value
+    * @param op operation to append a hash token
+    * @return the final hash value
+    */
+  def foldLeft[T](value: Value[AbsoluteContractId], z: T, op: (T, HashToken) => T): T = {
+    import com.digitalasset.daml.lf.value.Value._
+
+    value match {
+      case ValueContractId(v) => op(z, HashTokenText(v.coid))
+      case ValueInt64(v) => op(z, HashTokenLong(v))
+      case ValueDecimal(v) => op(z, HashTokenBigDecimal(v))
+      case ValueText(v) => op(z, HashTokenText(v))
+      case ValueTimestamp(v) => op(z, HashTokenLong(v.micros))
+      case ValueParty(v) => op(z, HashTokenText(v.underlyingString))
+      case ValueBool(v) => op(z, HashTokenByte(if (v) 1.toByte else 0.toByte))
+      case ValueDate(v) => op(z, HashTokenInt(v.days))
+      case ValueUnit => op(z, HashTokenByte(0))
+
+      // Record: [CollectionBegin(), Token(value)*, CollectionEnd()]
+      case ValueRecord(_, fs) =>
+        val z1 = op(z, HashTokenCollectionBegin(fs.length))
+        val z2 = fs.foldLeft[T](z1)((t, v) => foldLeft(v._2, t, op))
+        op(z2, HashTokenCollectionEnd())
+
+      // Optional: [CollectionBegin(), Token(value), CollectionEnd()]
+      case ValueOptional(Some(v)) =>
+        val z1 = op(z, HashTokenCollectionBegin(1))
+        val z2 = foldLeft(v, z1, op)
+        op(z2, HashTokenCollectionEnd())
+      case ValueOptional(None) =>
+        val z1 = op(z, HashTokenCollectionBegin(0))
+        op(z1, HashTokenCollectionEnd())
+
+      // Variant: [CollectionBegin(), Text(variant), Token(value), CollectionEnd()]
+      case ValueVariant(_, variant, v) =>
+        val z1 = op(z, HashTokenCollectionBegin(1))
+        val z2 = op(z1, HashTokenText(variant))
+        val z3 = foldLeft(v, z2, op)
+        op(z3, HashTokenCollectionEnd())
+
+      // List: [CollectionBegin(), Token(value)*, CollectionEnd()]
+      case ValueList(xs) =>
+        val arr = xs.toImmArray
+        val z1 = op(z, HashTokenCollectionBegin(xs.length))
+        val z2 = arr.foldLeft[T](z1)((t, v) => foldLeft(v, t, op))
+        op(z2, HashTokenCollectionEnd())
+
+      // Map: [CollectionBegin(), (Text(key), Token(value))*, CollectionEnd()]
+      case ValueMap(xs) =>
+        val arr = xs.toImmArray
+        val z1 = op(z, HashTokenCollectionBegin(arr.length))
+        val z2 = arr.foldLeft[T](z1)((t, v) => {
+          val zz1 = op(t, HashTokenText(v._1))
+          foldLeft(v._2, zz1, op)
+        })
+        op(z2, HashTokenCollectionEnd())
+
+      // Tuple: should never be encountered
+      case ValueTuple(xs) =>
+        sys.error("Hashing of tuple values is not supported")
+    }
+  }
+
+  private[this] def putInt(digest: MessageDigest, value: Int): Unit =
+    digest.update(ByteBuffer.allocate(4).putInt(value).array())
+
+  private[this] def putLong(digest: MessageDigest, value: Long): Unit =
+    digest.update(ByteBuffer.allocate(8).putLong(value).array())
+
+  private[this] def putStringContent(digest: MessageDigest, value: String): Unit =
+    digest.update(value.getBytes("UTF8"))
+
+  private[this] def putString(digest: MessageDigest, value: String): Unit = {
+    putInt(digest, value.length)
+    putStringContent(digest, value)
+  }
+
+  override def hashKey(key: GlobalKey): Array[Byte] = {
+    val digest = MessageDigest.getInstance("SHA-256")
+
+    // First, write the template ID
+    putString(digest, key.templateId.packageId.underlyingString)
+    putString(digest, key.templateId.qualifiedName.toString())
+
+    // Note: We do not emit the value or language version, as both are
+    // implied by the template ID.
+
+    // Then, write the value
+    foldLeft[MessageDigest](
+      key.key.value,
+      digest,
+      (d, token) => {
+        // Append bytes:
+        // - Fixed-width values are appended as-is
+        // - Variable-width values are prefixed with their length
+        // - Collections are prefixed with their size
+        token match {
+          case HashTokenByte(v) => d.update(v)
+          case HashTokenInt(v) => putInt(d, v)
+          case HashTokenLong(v) => putLong(d, v)
+          case HashTokenText(v) => putString(d, v)
+          // Java docs: "The toString() method provides a canonical representation of a BigDecimal."
+          case HashTokenBigDecimal(v) => putString(d, v.toString)
+          case HashTokenCollectionBegin(length) => putInt(d, length)
+          case HashTokenCollectionEnd() => // no-op
+        }
+
+        // MessageDigest is a mutable object modified above
+        d
+      }
+    ).digest()
+  }
+
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
@@ -1,0 +1,343 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.stores.ledger.sql
+
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.daml.lf.data._
+import com.digitalasset.daml.lf.transaction.Node.GlobalKey
+import com.digitalasset.daml.lf.value.Value._
+import com.digitalasset.daml.lf.value.{Value, ValueVersion}
+import org.scalatest.{Matchers, WordSpec}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.KeyHasher
+
+class KeyHasherSpec extends WordSpec with Matchers {
+  private[this] def templateId(module: String, name: String) = Identifier(
+    PackageId.assertFromString("package"),
+    QualifiedName(
+      ModuleName(ImmArray(module)),
+      DottedName(ImmArray(name))
+    )
+  )
+
+  private[this] def complexValue = {
+    val builder = ImmArray.newBuilder[(Option[String], Value[AbsoluteContractId])]
+    builder += None -> ValueInt64(0)
+    builder += None -> ValueInt64(123456)
+    builder += None -> ValueInt64(-1)
+    builder += None -> ValueDecimal(BigDecimal(0))
+    builder += None -> ValueDecimal(BigDecimal(1) / BigDecimal(3))
+    builder += None -> ValueBool(true)
+    builder += None -> ValueBool(false)
+    builder += None -> ValueDate(Time.Date.assertFromDaysSinceEpoch(0))
+    builder += None -> ValueDate(Time.Date.assertFromDaysSinceEpoch(123456))
+    builder += None -> ValueTimestamp(Time.Timestamp.assertFromLong(0))
+    builder += None -> ValueTimestamp(Time.Timestamp.assertFromLong(123456))
+    builder += None -> ValueText("")
+    builder += None -> ValueText("abcd-äöü€")
+    builder += None -> ValueParty(SimpleString.assertFromString("Alice"))
+    builder += None -> ValueUnit
+    builder += None -> ValueOptional(None)
+    builder += None -> ValueOptional(Some(ValueText("Some")))
+    builder += None -> ValueList(FrontStack(ValueText("A"), ValueText("B"), ValueText("C")))
+    builder += None -> ValueVariant(None, "Variant", ValueInt64(0))
+    builder += None -> ValueRecord(
+      None,
+      ImmArray(
+        None -> ValueText("field1"),
+        None -> ValueText("field2")
+      ))
+    builder += None -> ValueMap(
+      SortedLookupList(
+        Map(
+          "keyA" -> ValueText("valueA"),
+          "keyB" -> ValueText("valueB")
+        )))
+    val fields = builder.result()
+
+    ValueRecord(None, fields)
+  }
+
+  "KeyHasher" should {
+
+    "be stable" in {
+      // Hashing function must not change
+      val value = VersionedValue(ValueVersion("4"), complexValue)
+      val hash = "4f44a1674ef37e1019fcfd1c74047aef97a4cf34991bb9ee3368166254b7c77c"
+
+      KeyHasher.hashKeyString(GlobalKey(templateId("module", "name"), value)) shouldBe hash
+    }
+
+    "be deterministic and thread safe" in {
+      // Compute many hashes in parallel, check that they are all equal
+      // Note: intentionally does not reuse value instances
+      val hashes = Vector
+        .range(0, 1000)
+        .map(_ =>
+          GlobalKey(templateId("module", "name"), VersionedValue(ValueVersion("4"), complexValue)))
+        .par
+        .map(key => KeyHasher.hashKeyString(key))
+
+      hashes.toSet.size shouldBe 1
+    }
+
+    "not produce collision in template id" in {
+      // Same value but different template ID should produce a different hash
+      val value = VersionedValue(ValueVersion("4"), ValueText("A"))
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(templateId("AA", "A"), value))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(templateId("A", "AA"), value))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    // Note: value version is given by the template ID, this check is not necessary
+    /*
+    "not produce collision in value version" in {
+      // Same value but different value version should produce a different hash
+      val value1 = VersionedValue(ValueVersion("3"), ValueText("A"))
+      val value2 = VersionedValue(ValueVersion("4"), ValueText("A"))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+     */
+
+    "not produce collision in list of text" in {
+      // Testing whether strings are delimited: ["AA", "A"] vs ["A", "AA"]
+      val value1 =
+        VersionedValue(ValueVersion("4"), ValueList(FrontStack(ValueText("AA"), ValueText("A"))))
+      val value2 =
+        VersionedValue(ValueVersion("4"), ValueList(FrontStack(ValueText("A"), ValueText("AA"))))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in list of decimals" in {
+      // Testing whether decimals are delimited: [10, 10] vs [101, 0]
+      val value1 =
+        VersionedValue(ValueVersion("4"), ValueList(FrontStack(ValueDecimal(10), ValueDecimal(10))))
+      val value2 =
+        VersionedValue(ValueVersion("4"), ValueList(FrontStack(ValueDecimal(101), ValueDecimal(0))))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in list of lists" in {
+      // Testing whether lists are delimited: [[()], [(), ()]] vs [[(), ()], [()]]
+      val value1 = VersionedValue(
+        ValueVersion("4"),
+        ValueList(
+          FrontStack(
+            ValueList(FrontStack(ValueUnit)),
+            ValueList(FrontStack(ValueUnit, ValueUnit))
+          )))
+      val value2 = VersionedValue(
+        ValueVersion("4"),
+        ValueList(
+          FrontStack(
+            ValueList(FrontStack(ValueUnit, ValueUnit)),
+            ValueList(FrontStack(ValueUnit))
+          )))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Variant constructor" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueVariant(None, "A", ValueUnit))
+      val value2 = VersionedValue(ValueVersion("4"), ValueVariant(None, "B", ValueUnit))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Variant value" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueVariant(None, "A", ValueInt64(0L)))
+      val value2 = VersionedValue(ValueVersion("4"), ValueVariant(None, "A", ValueInt64(1L)))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Map keys" in {
+      val value1 = VersionedValue(
+        ValueVersion("4"),
+        ValueMap(
+          SortedLookupList(
+            Map(
+              "A" -> ValueInt64(0),
+              "B" -> ValueInt64(0)
+            ))))
+      val value2 = VersionedValue(
+        ValueVersion("4"),
+        ValueMap(
+          SortedLookupList(
+            Map(
+              "A" -> ValueInt64(0),
+              "C" -> ValueInt64(0)
+            ))))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Map values" in {
+      val value1 = VersionedValue(
+        ValueVersion("4"),
+        ValueMap(
+          SortedLookupList(
+            Map(
+              "A" -> ValueInt64(0),
+              "B" -> ValueInt64(0)
+            ))))
+      val value2 = VersionedValue(
+        ValueVersion("4"),
+        ValueMap(
+          SortedLookupList(
+            Map(
+              "A" -> ValueInt64(0),
+              "B" -> ValueInt64(1)
+            ))))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Bool" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueBool(true))
+      val value2 = VersionedValue(ValueVersion("4"), ValueBool(false))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Int64" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueInt64(0L))
+      val value2 = VersionedValue(ValueVersion("4"), ValueInt64(1L))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Decimal" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueDecimal(0))
+      val value2 = VersionedValue(ValueVersion("4"), ValueDecimal(1))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Date" in {
+      val value1 =
+        VersionedValue(ValueVersion("4"), ValueDate(Time.Date.assertFromDaysSinceEpoch(0)))
+      val value2 =
+        VersionedValue(ValueVersion("4"), ValueDate(Time.Date.assertFromDaysSinceEpoch(1)))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Timestamp" in {
+      val value1 =
+        VersionedValue(ValueVersion("4"), ValueTimestamp(Time.Timestamp.assertFromLong(0)))
+      val value2 =
+        VersionedValue(ValueVersion("4"), ValueTimestamp(Time.Timestamp.assertFromLong(1)))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Optional" in {
+      val value1 = VersionedValue(ValueVersion("4"), ValueOptional(None))
+      val value2 = VersionedValue(ValueVersion("4"), ValueOptional(Some(ValueUnit)))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+
+    "not produce collision in Record" in {
+      val value1 = VersionedValue(
+        ValueVersion("4"),
+        ValueRecord(
+          None,
+          ImmArray(
+            None -> ValueText("A"),
+            None -> ValueText("B")
+          )))
+      val value2 = VersionedValue(
+        ValueVersion("4"),
+        ValueRecord(
+          None,
+          ImmArray(
+            None -> ValueText("A"),
+            None -> ValueText("C")
+          )))
+
+      val tid = templateId("module", "name")
+
+      val hash1 = KeyHasher.hashKeyString(GlobalKey(tid, value1))
+      val hash2 = KeyHasher.hashKeyString(GlobalKey(tid, value2))
+
+      hash1.equals(hash2) shouldBe false
+    }
+  }
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -27,7 +27,8 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{Contract, Postgr
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   ContractSerializer,
   TransactionSerializer,
-  ValueSerializer
+  ValueSerializer,
+  KeyHasher
 }
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher
 import org.scalacheck.{Arbitrary, Gen}
@@ -47,7 +48,12 @@ class PostgresDaoSpec
   private lazy val dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4)
 
   private lazy val ledgerDao =
-    PostgresLedgerDao(dbDispatcher, ContractSerializer, TransactionSerializer, ValueSerializer)
+    PostgresLedgerDao(
+      dbDispatcher,
+      ContractSerializer,
+      TransactionSerializer,
+      ValueSerializer,
+      KeyHasher)
 
   private val nextOffset: () => Long = {
     val counter = new AtomicLong(0)


### PR DESCRIPTION
Previously contract keys were hashed by hashing the protobuf serialization of the key value. This is not good, because protobuf does not have a canonical representation.

This PR implements a stable hashing of contract keys by traversing the DAML-LF value and emiting bytes for any encountered primitive.

Fixes #497
