### PR TITLE
Remove compiler option that turned off fatal-warnings

### DIFF
--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -14,11 +14,8 @@ da_scala_library(
         "//external:jar/org/spire_math/kind_projector_2_12",
         "//external:jar/com/github/ghik/silencer_plugin_2_12",
     ],
-    # NOTE(JM): commented out deprecation warnings to get this to compile with the
-    # versions matching sbt. Please remove when deprecations are fixed.
     scalacopts = [
         "-deprecation",
-        "-Xfatal-warnings:false",
         "-Xsource:2.13",
     ],
     tags = ["maven_coordinates=com.daml.scala:bindings:__VERSION__"],
@@ -43,11 +40,8 @@ da_scala_test_suite(
     plugins = [
         "//external:jar/org/spire_math/kind_projector_2_12",
     ],
-    # NOTE(JM): commented out deprecation warnings to get this to compile with the
-    # versions matching sbt. Please remove when deprecations are fixed.
     scalacopts = [
         "-deprecation",
-        "-Xfatal-warnings:false",
         "-Xsource:2.13",
     ],
     deps = [

--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -15,7 +15,6 @@ da_scala_library(
         "//external:jar/com/github/ghik/silencer_plugin_2_12",
     ],
     scalacopts = [
-        "-deprecation",
         "-Xsource:2.13",
     ],
     tags = ["maven_coordinates=com.daml.scala:bindings:__VERSION__"],
@@ -41,7 +40,6 @@ da_scala_test_suite(
         "//external:jar/org/spire_math/kind_projector_2_12",
     ],
     scalacopts = [
-        "-deprecation",
         "-Xsource:2.13",
     ],
     deps = [


### PR DESCRIPTION
The deprecated calls have been already addressed by someone
else.
Closes: #111 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
