### PR TITLE
Update Scala Codegen SBT Example

### DIFF
--- a/language-support/scala/codegen-sbt-example/README.md
+++ b/language-support/scala/codegen-sbt-example/README.md
@@ -1,5 +1,5 @@
 # Mock scala/codegen example (does not send any commands just prints them to STD OUT)
-$ sbt -DDA.sdkVersion=100.12.6 compile "mock-example/runMain com.digitalasset.example.ExampleMain"
+$ sbt -DDA.sdkVersion=100.12.6 mock-example/run
 
 # Sandbox scala/codegen example (sends commands to sandbox and receives transactions)
-$ sbt -DDA.sdkVersion=100.12.6 "sandbox-example/runMain com.digitalasset.example.ExampleMain ./scala-codegen/target/repository/daml-codegen/Main.dar"
+$ sbt -DDA.sdkVersion=100.12.6 sandbox-example/run

--- a/language-support/scala/codegen-sbt-example/README.md
+++ b/language-support/scala/codegen-sbt-example/README.md
@@ -1,5 +1,5 @@
 # Mock scala/codegen example (does not send any commands just prints them to STD OUT)
-$ sbt "mock-example/runMain com.digitalasset.example.ExampleMain"
+$ sbt -DDA.sdkVersion=100.12.6 compile "mock-example/runMain com.digitalasset.example.ExampleMain"
 
 # Sandbox scala/codegen example (sends commands to sandbox and receives transactions)
-$ sbt "sandbox-example/runMain com.digitalasset.example.ExampleMain ./scala-codegen/target/repository/daml-codegen/Main.dar"
+$ sbt -DDA.sdkVersion=100.12.6 "sandbox-example/runMain com.digitalasset.example.ExampleMain ./scala-codegen/target/repository/daml-codegen/Main.dar"

--- a/language-support/scala/codegen-sbt-example/project/Versions.scala
+++ b/language-support/scala/codegen-sbt-example/project/Versions.scala
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 object Versions {
-  lazy val sdkVersion: String = "100.12.6"
+  val sdkVersion: String = sdkVersionFromSysProps().getOrElse("100.12.6")
+
+  println(s"DA sdkVersion: $sdkVersion")
 
   lazy val detectedOs: String = sys.props("os.name") match {
     case "Mac OS X" => "osx"
     case _ => "linux"
   }
+
+  private def sdkVersionFromSysProps(): Option[String] =
+    sys.props.get("DA.sdkVersion").map(_.toString)
 }

--- a/language-support/scala/codegen-sbt-example/project/Versions.scala
+++ b/language-support/scala/codegen-sbt-example/project/Versions.scala
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 object Versions {
-  lazy val sdkVersion: String = "100.11.25"
+  lazy val sdkVersion: String = "100.12.6"
 
   lazy val detectedOs: String = sys.props("os.name") match {
     case "Mac OS X" => "osx"

--- a/language-support/scala/codegen-sbt-example/sandbox-example/src/main/scala/com/digitalasset/example/ExampleMain.scala
+++ b/language-support/scala/codegen-sbt-example/sandbox-example/src/main/scala/com/digitalasset/example/ExampleMain.scala
@@ -40,20 +40,16 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 
 object ExampleMain extends App {
-  if (args.length == 0)
-    throw new IllegalArgumentException(
-      "Expected at least one DAR or DALF file passed as an argument")
+
+  private val dar = new File("./scala-codegen/target/repository/daml-codegen/Main.dar")
 
   private val ledgerId = "codegen-sbt-example-with-sandbox"
 
   private val port: Int = findOpenPort().fold(e => throw new IllegalStateException(e), identity)
 
-  private def archives(fileNames: List[String]): List[File] =
-    toFiles(args.toList).fold(e => throw new IllegalStateException(e), identity)
-
   private val serverConfig = SandboxConfig.default.copy(
     port = port,
-    damlPackageContainer = DamlPackageContainer(archives(args.toList)),
+    damlPackageContainer = DamlPackageContainer(List(dar)),
     timeProviderType = TimeProviderType.WallClock,
     ledgerIdMode = LedgerIdMode.HardCoded(ledgerId),
   )


### PR DESCRIPTION
- Update scala codegen sbt example to use the latest codegen binaries
- Use DAR to generate Scala code, no reason to unzip DALFs
- Allow to override the default sdkVersion: `sbt -DDA.sdkVersion=100.12.6 compile`
- Simplify the way examples run

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
