### PR TITLE
Add CreateAndExercise command throughout the stack

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Command.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Command.scala
@@ -8,9 +8,9 @@ import com.digitalasset.daml.lf.value.Value._
 
 import com.digitalasset.daml.lf.data.Time
 
-// --------------------------------
-// Accepted commads coming from API
-// --------------------------------
+// ---------------------------------
+// Accepted commands coming from API
+// ---------------------------------
 sealed trait Command extends Product with Serializable
 
 /** Command for creating a contract
@@ -35,6 +35,23 @@ final case class ExerciseCommand(
     choiceId: String,
     submitter: SimpleString,
     argument: VersionedValue[AbsoluteContractId])
+    extends Command
+
+/** Command for creating a contract and exercising a choice
+  * on that existing contract within the same transaction
+  *
+  *  @param templateId identifier of the original contract
+  *  @param createArgument value passed to the template
+  *  @param choiceId identifier choice
+  *  @param choiceArgument value passed for the choice
+  *  @param submitter party submitting the choice
+  */
+final case class CreateAndExerciseCommand(
+    templateId: Identifier,
+    createArgument: VersionedValue[AbsoluteContractId],
+    choiceId: String,
+    choiceArgument: VersionedValue[AbsoluteContractId],
+    submitter: SimpleString)
     extends Command
 
 /** Commands input adapted from ledger-api

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -85,7 +85,7 @@ final class Engine {
     *   tx === tx' if tx and tx' are equivalent modulo a renaming of node and relative contract IDs
     *
     * In addition to the errors returned by `submit`, reinterpretation fails with a `ValidationError` whenever `nodes`
-    * contain a relative contract ID, either as the target contract of an exercise or a fetch, or as an argument to a
+    * contain a relative contract ID, either as the target contract of a fetch, or as an argument to a
     * create or an exercise choice.
     */
   def reinterpret(
@@ -129,7 +129,7 @@ final class Engine {
 
   /**
     * Post-commit validation
-    * we damand that validatable transactions only contain AbsoluteContractIds in root nodes
+    * we demand that validatable transactions only contain AbsoluteContractIds in root nodes
     *
     * @param tx a transaction to be validated
     * @param submitter party name if known who originally submitted the transaction
@@ -265,7 +265,7 @@ final class Engine {
         )
 
       case NodeExercises(
-          target,
+          coid,
           template,
           choice,
           optLoc @ _,
@@ -277,11 +277,10 @@ final class Engine {
           controllers @ _,
           children @ _) =>
         val templateId = template
-        asAbsoluteContractId(target).flatMap(
-          acoid =>
-            asValueWithAbsoluteContractIds(chosenVal).flatMap(absChosenVal =>
-              commandPreprocessor
-                .preprocessExercise(templateId, acoid, choice, actingParties, absChosenVal)))
+        asValueWithAbsoluteContractIds(chosenVal).flatMap(
+          absChosenVal =>
+            commandPreprocessor
+              .preprocessExercise(templateId, coid, choice, actingParties, absChosenVal))
 
       case NodeFetch(coid, templateId, _, _, _, _) =>
         asAbsoluteContractId(coid)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -32,4 +32,12 @@ object Command {
       coid: SContractId
   ) extends Command
 
+  final case class CreateAndExercise(
+      templateId: Identifier,
+      createArgument: SValue,
+      choiceId: String,
+      choiceArgument: SValue,
+      submitter: ImmArray[SParty]
+  ) extends Command
+
 }

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -10,6 +10,10 @@ HEAD — ongoing
 --------------
 
 - Addition of ``DA.Math`` library containing exponentiation, logarithms and trig functions
+- Add CreateAndExerciseCommand to Ledger API and DAMLe for creating a contract
+  and exercising a choice on it within the same transaction. This can be used to
+  implement "callable updates" (aka functions of type ``Update a`` that can be
+  called from the Ledger API via a contract).
 
 0.12.7 — 2019-04-17
 -------------------

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreateAndExerciseCommand.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreateAndExerciseCommand.java
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.digitalasset.ledger.api.v1.CommandsOuterClass;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Objects;
+
+public class CreateAndExerciseCommand extends Command {
+    private final Identifier templateId;
+
+    private final Record createArguments;
+
+    private final String choice;
+
+    private final Value choiceArgument;
+
+    public CreateAndExerciseCommand(@NonNull Identifier templateId, @NonNull Record createArguments, @NonNull String choice, @NonNull Value choiceArgument) {
+        this.templateId = templateId;
+        this.createArguments = createArguments;
+        this.choice = choice;
+        this.choiceArgument = choiceArgument;
+    }
+
+    public static CreateAndExerciseCommand fromProto(CommandsOuterClass.CreateAndExerciseCommand command) {
+        Identifier templateId = Identifier.fromProto(command.getTemplateId());
+        Record createArguments = Record.fromProto(command.getCreateArguments());
+        String choice = command.getChoice();
+        Value choiceArgument = Value.fromProto(command.getChoiceArgument());
+        return new CreateAndExerciseCommand(templateId, createArguments, choice, choiceArgument);
+    }
+
+    public CommandsOuterClass.CreateAndExerciseCommand toProto() {
+        return CommandsOuterClass.CreateAndExerciseCommand.newBuilder()
+                .setTemplateId(this.templateId.toProto())
+                .setCreateArguments(this.createArguments.toProtoRecord())
+                .setChoice(this.choice)
+                .setChoiceArgument(this.choiceArgument.toProto())
+                .build();
+    }
+
+    @Override
+    Identifier getTemplateId() {
+        return templateId;
+    }
+
+    public Record getCreateArguments() {
+        return createArguments;
+    }
+
+    public String getChoice() {
+        return choice;
+    }
+
+    public Value getChoiceArgument() {
+        return choiceArgument;
+    }
+
+    @Override
+    public String toString() {
+        return "CreateAndExerciseCommand{" +
+                "templateId=" + templateId +
+                ", createArguments=" + createArguments +
+                ", choice='" + choice + '\'' +
+                ", choiceArgument=" + choiceArgument +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateAndExerciseCommand that = (CreateAndExerciseCommand) o;
+        return templateId.equals(that.templateId) &&
+                createArguments.equals(that.createArguments) &&
+                choice.equals(that.choice) &&
+                choiceArgument.equals(that.choiceArgument);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(templateId, createArguments, choice, choiceArgument);
+    }
+}

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/commands.proto
@@ -58,6 +58,7 @@ message Command {
   oneof command {
     CreateCommand create = 1;
     ExerciseCommand exercise = 2;
+    CreateAndExerciseCommand createAndExercise = 3;
   }
 }
 
@@ -83,6 +84,25 @@ message ExerciseCommand {
   // The ID of the contract the client wants to exercise upon.
   // Required
   string contract_id = 2;
+
+  // The name of the choice the client wants to exercise.
+  // Required
+  string choice = 3;
+
+  // The argument for this choice.
+  // Required
+  Value choice_argument = 4;
+}
+
+// Create a contract and exercise a choice on it in the same transaction.
+message CreateAndExerciseCommand {
+  // The template of the contract the client wants to create
+  // Required
+  Identifier template_id = 1;
+
+  // The arguments required for creating a contract from this template.
+  // Required
+  Record create_arguments = 2;
 
   // The name of the choice the client wants to exercise.
   // Required

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -11,14 +11,16 @@ import com.digitalasset.daml.lf.engine.{
   Commands,
   CreateCommand,
   DeprecatedIdentifier,
-  ExerciseCommand
+  ExerciseCommand,
+  CreateAndExerciseCommand
 }
 import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.ledger.api.v1.commands.{
   Command => ApiCommand,
   Commands => ApiCommands,
   CreateCommand => ApiCreateCommand,
-  ExerciseCommand => ApiExerciseCommand
+  ExerciseCommand => ApiExerciseCommand,
+  CreateAndExerciseCommand => ApiCreateAndExerciseCommand
 }
 import com.digitalasset.ledger.api.v1.value.{
   Optional,
@@ -191,6 +193,14 @@ object LfEngineToApi {
               contractId,
               choiceId,
               LfEngineToApi.lfValueToApiValue(verbose = true, argument.value).toOption)))
+      case CreateAndExerciseCommand(templateId, createArgument, choiceId, choiceArgument, _) =>
+        ApiCommand(
+          ApiCommand.Command.CreateAndExercise(ApiCreateAndExerciseCommand(
+            Some(toApiIdentifier(templateId)),
+            LfEngineToApi.lfVersionedValueToApiRecord(verbose = true, createArgument).toOption,
+            choiceId,
+            LfEngineToApi.lfVersionedValueToApiValue(verbose = true, choiceArgument).toOption
+          )))
     }
 
     ApiCommands(

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandPayloadValidations.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandPayloadValidations.scala
@@ -35,6 +35,14 @@ trait CommandPayloadValidations extends CommandValidations with ErrorFactories {
         _ <- requirePresence(ex.choiceArgument, "choice_argument")
         _ <- requirePresence(ex.templateId, "template_id")
       } yield ()
+
+    case Command.Command.CreateAndExercise(ce) =>
+      for {
+        _ <- requirePresence(ce.templateId, "template_id")
+        _ <- requirePresence(ce.createArguments, "create_arguments")
+        _ <- requireNonEmptyString(ce.choice, "choice")
+        _ <- requirePresence(ce.choiceArgument, "choice_argument")
+      } yield ()
     case _ => Left(missingField("command"))
   }
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -302,4 +302,11 @@ object domain {
       choiceArgument: Value)
       extends Command
 
+  final case class CreateAndExerciseCommand(
+      templateId: Ref.Identifier,
+      createArgument: RecordValue,
+      choice: Choice,
+      choiceArgument: Value)
+      extends Command
+
 }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionServiceIT.scala
@@ -34,7 +34,7 @@ class CommandSubmissionServiceIT
 
   private def client(channel: Channel) = CommandSubmissionServiceGrpc.stub(channel)
 
-  "Command Service" when {
+  "Command Submission Service" when {
 
     "commands arrive with extreme TTLs" should {
 
@@ -45,7 +45,6 @@ class CommandSubmissionServiceIT
             succeed
         }
       }
-
     }
   }
 }


### PR DESCRIPTION
The CreateAndExerciseCommand allows users to create a contract and
exercise a choice on it within the same transaction. Users can use this
method to implement "callable update functions" by creating a template
that calls the update function in a choice body.

This PR also makes relative contract IDs in transaction root nodes valid again.

Fixes #382.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
