### PR TITLE
Update to Bazel 0.24

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,4 +89,10 @@ build:darwin --protocopt=--include_source_info
 # https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/command_line_interface.cc#L1363
 #build:windows --protocopt=--include_source_info
 
+# To fix the following error on Windows
+# LAUNCHER ERROR: Cannot find key "escape_jvmflags" from launch data.
+# See https://github.com/bazelbuild/bazel/pull/7490
+# The flag does not seem to be supported in rules_scala, yet.
+build:windows --noincompatible_windows_escape_jvm_flags
+
 try-import %workspace%/.bazelrc.local

--- a/.bazelrc
+++ b/.bazelrc
@@ -89,10 +89,13 @@ build:darwin --protocopt=--include_source_info
 # https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/command_line_interface.cc#L1363
 #build:windows --protocopt=--include_source_info
 
-# To fix the following error on Windows
-# LAUNCHER ERROR: Cannot find key "escape_jvmflags" from launch data.
+# Bazel 0.24 introduced the new flag --incompatible_windows_escape_jvm_flags
+# and modified its Java launcher mechanism. rules_scala needs to be patched
+# to support this. See `bazel_tools/scala-escape-jvmflags.patch`.
+# Without this patch we get the following error on Windows:
+# `LAUNCHER ERROR: Cannot find key "escape_jvmflags" from launch data.`
+# This patch assumes `--noincompatible_windows_escape_jvm_flags`.
 # See https://github.com/bazelbuild/bazel/pull/7490
-# The flag does not seem to be supported in rules_scala, yet.
 build:windows --noincompatible_windows_escape_jvm_flags
 
 try-import %workspace%/.bazelrc.local

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -417,6 +417,7 @@ bind(
 load("@ai_formation_hazel//:hazel.bzl", "hazel_custom_package_github", "hazel_custom_package_hackage", "hazel_default_extra_libs", "hazel_repositories")
 load("//hazel:packages.bzl", "core_packages", "packages")
 load("//bazel_tools:haskell.bzl", "add_extra_packages")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 # XXX: We do not have access to an integer-simple version of GHC on Windows.
 # For the time being we build with GMP. See https://github.com/digital-asset/daml/issues/106
@@ -427,13 +428,16 @@ HASKELL_LSP_COMMIT = "15096280b3542d56d8df728d3bce9ea34141debd"
 HASKELL_LSP_HASH = "170de7aeb1da63198139a667c074a05f7ecd30017d54c78569a6aa1cc565be89"
 
 hazel_repositories(
-    core_packages = core_packages + {
-        "integer-simple": "0.1.1.1",
+    core_packages = dicts.add(
+        core_packages,
+        {
+            "integer-simple": "0.1.1.1",
 
-        # this is a core package, but not reflected in hazel/packages.bzl.
-        "haskeline": "0.7.4.2",
-        "Win32": "2.6.1.0",
-    },
+            # this is a core package, but not reflected in hazel/packages.bzl.
+            "haskeline": "0.7.4.2",
+            "Win32": "2.6.1.0",
+        },
+    ),
     exclude_packages = [
         "arx",
         "clock",
@@ -449,10 +453,13 @@ hazel_repositories(
         "text": {"integer-simple": use_integer_simple},
         "scientific": {"integer-simple": use_integer_simple},
     },
-    extra_libs = hazel_default_extra_libs + {
-        "z": "@com_github_madler_zlib//:z",
-        "ffi": "@com_github_digital_asset_daml//3rdparty/haskell/ffi_windows:ffi" if is_windows else "@libffi_nix//:ffi",
-    },
+    extra_libs = dicts.add(
+        hazel_default_extra_libs,
+        {
+            "z": "@com_github_madler_zlib//:z",
+            "ffi": "@com_github_digital_asset_daml//3rdparty/haskell/ffi_windows:ffi" if is_windows else "@libffi_nix//:ffi",
+        },
+    ),
     ghc_workspaces = {
         "k8": "@io_tweag_rules_haskell_ghc-nixpkgs",
         "darwin": "@io_tweag_rules_haskell_ghc-nixpkgs",

--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -296,4 +296,6 @@ def c2hs_suite(name, hazel_deps, deps = [], srcs = [], c2hs_srcs = [], c2hs_src_
 # Add extra packages, e.g., packages that are on Hackage but not in Stackage.
 # This cannot be inlined since it is impossible to create a struct in WORKSPACE.
 def add_extra_packages(pkgs, extra):
-    return pkgs + {k: struct(**v) for (k, v) in extra}
+    result = dict(pkgs)
+    result.update({k: struct(**v) for (k, v) in extra})
+    return result

--- a/bazel_tools/scala-escape-jvmflags.patch
+++ b/bazel_tools/scala-escape-jvmflags.patch
@@ -1,0 +1,12 @@
+diff --git a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+index f54a578..533e813 100644
+--- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
++++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+@@ -36,6 +36,7 @@ public class LauncherFileWriter {
+             .addKeyValuePair("jar_bin_path", jarBinPath)
+             .addKeyValuePair("java_start_class", javaStartClass)
+             .addKeyValuePair("classpath", classpath)
++            .addKeyValuePair("escape_jvmflags", "0")
+             .addJoinedValues("jvm_flags", " ", jvmFlags)
+             .build();
+ 

--- a/bazel_tools/scala-escape-jvmflags.patch
+++ b/bazel_tools/scala-escape-jvmflags.patch
@@ -1,12 +1,14 @@
 diff --git a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
-index f54a578..533e813 100644
+index f54a578..0d871ef 100644
 --- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
 +++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
-@@ -36,6 +36,7 @@ public class LauncherFileWriter {
+@@ -36,7 +36,8 @@ public class LauncherFileWriter {
              .addKeyValuePair("jar_bin_path", jarBinPath)
              .addKeyValuePair("java_start_class", javaStartClass)
              .addKeyValuePair("classpath", classpath)
+-            .addJoinedValues("jvm_flags", " ", jvmFlags)
 +            .addKeyValuePair("escape_jvmflags", "0")
-             .addJoinedValues("jvm_flags", " ", jvmFlags)
++            .addJoinedValues("jvm_flags", "\t", jvmFlags)
              .build();
- 
+
+     Path launcher = Paths.get(Runfiles.create().rlocation("bazel_tools/tools/launcher/launcher.exe"));

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -212,7 +212,7 @@ def da_scala_library(name, **kwargs):
     [rules_scala_docs]: https://github.com/bazelbuild/rules_scala#scala_library
     """
     _wrap_rule(scala_library, name, **kwargs)
-    _create_scala_source_jar(**(kwargs + {"name": name}))
+    _create_scala_source_jar(name = name, **kwargs)
 
     if "tags" in kwargs:
         for tag in kwargs["tags"]:

--- a/deps.bzl
+++ b/deps.bzl
@@ -88,6 +88,10 @@ def daml_deps():
             type = "zip",
             strip_prefix = "rules_scala-%s" % rules_scala_version,
             sha256 = "2b39ea3eba5ce86126980fa2bf20db9e0896b75aec23f0c639d9bb47dd9914b9",
+            patches = [
+                "@com_github_digital_asset_daml//bazel_tools:scala-escape-jvmflags.patch",
+            ],
+            patch_args = ["-p1"],
         )
 
     if "com_google_protobuf" not in native.existing_rules():

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -1,12 +1,12 @@
 {
   "homepage": "https://bazel.build",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "license": "Apache-2.0",
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/bazelbuild/bazel/releases/download/0.23.2/bazel-0.23.2-windows-x86_64.zip",
-      "hash": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe"
+      "url": "https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-windows-x86_64.zip",
+      "hash": "d444a319320c0d788bf36c19816235636f8ad7b49b8bc5fad32daf7ae4e7aefa"
     }
   },
   "depends": [

--- a/language-support/scala/sandbox-control/BUILD.bazel
+++ b/language-support/scala/sandbox-control/BUILD.bazel
@@ -29,11 +29,13 @@ java_test_suite(
     strip = "src/test/java/",
     deps = [
         ":sandbox-control",
-        "//3rdparty/jvm/com/github/stefanbirkner:system_rules",
+        # junit needs to be listed before system_rules to avoid failure due to
+        # classpath pollution.
         "//3rdparty/jvm/junit",
-        "//3rdparty/jvm/org/hamcrest:hamcrest_all",
         "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_api",
         "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_engine",
         "//3rdparty/jvm/org/junit/platform:junit_platform_runner",
+        "//3rdparty/jvm/com/github/stefanbirkner:system_rules",
+        "//3rdparty/jvm/org/hamcrest:hamcrest_all",
     ],
 )

--- a/nix/overrides/bazel/default.nix
+++ b/nix/overrides/bazel/default.nix
@@ -6,18 +6,24 @@
 # Allow to independently override the jdks used to build and run respectively
 , buildJdk, runJdk
 , buildJdkName
+, runtimeShell
 # Always assume all markers valid (don't redownload dependencies).
 # Also, don't clean up environment variables.
 , enableNixHacks ? false
 }:
 
 let
-  srcDeps = lib.singleton (
-    fetchurl {
+  srcDeps = [
+    (fetchurl {
       url = "https://github.com/google/desugar_jdk_libs/archive/915f566d1dc23bc5a8975320cd2ff71be108eb9c.zip";
       sha256 = "0b926df7yxyyyiwm9cmdijy6kplf0sghm23sf163zh8wrk87wfi7";
-    }
-  );
+    })
+
+    (fetchurl {
+        url = "https://mirror.bazel.build/bazel_java_tools/java_tools_pkg-0.5.1.tar.gz";
+        sha256 = "1ld8m5cj9j0r474f56pixcfi0xvx3w7pzwahxngs8f6ns0yimz5w";
+    })
+  ];
 
   distDir = runCommand "bazel-deps" {} ''
     mkdir -p $out
@@ -60,7 +66,7 @@ let
 in
 stdenv.mkDerivation rec {
 
-  version = "0.23.1";
+  version = "0.24.0";
 
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -84,8 +90,12 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/${name}-dist.zip";
-    sha256 = "07a9l20rsi0khxpap5k15jplwma3f55ssq2x5ixzcas5jagijiyx";
+    sha256 = "11gsc00ghxqkbci8nrflkwq1lcvqawlgkaryj458b24si6bjl7b2";
   };
+
+  # Necessary for the tests to pass on Darwin with sandbox enabled.
+  # Bazel starts a local server and needs to bind a local address.
+  __darwinAllowLocalNetworking = true;
 
   sourceRoot = ".";
 
@@ -176,6 +186,10 @@ stdenv.mkDerivation rec {
           --replace "/usr/bin/env python" "${python}/bin/python" \
           --replace "NIX_STORE_PYTHON_PATH" "${python}/bin/python" \
 
+      # md5sum is part of coreutils
+      sed -i 's|/sbin/md5|md5sum|' \
+        src/BUILD
+
       # substituteInPlace is rather slow, so prefilter the files with grep
       grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
         # If you add more replacements here, you must change the grep above!
@@ -219,8 +233,17 @@ stdenv.mkDerivation rec {
         src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
         --replace /bin:/usr/bin ${defaultShellPath}
 
+      # This is necessary to avoid:
+      # "error: no visible @interface for 'NSDictionary' declares the selector
+      # 'initWithContentsOfURL:error:'"
+      # This can be removed when the apple_sdk is upgraded beyond 10.13+
+      sed -i '/initWithContentsOfURL:versionPlistUrl/ {
+        N
+        s/error:nil\];/\];/
+      }' tools/osx/xcode_locator.m
+
       # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
-      echo "PATH=$PATH:${defaultShellPath}" >> runfiles.bash.tmp
+      echo "PATH=\$PATH:${defaultShellPath}" >> runfiles.bash.tmp
       cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
       mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
 
@@ -244,17 +267,27 @@ stdenv.mkDerivation rec {
     customBash
   ] ++ lib.optionals (stdenv.isDarwin) [ cctools clang libcxx CoreFoundation CoreServices Foundation ];
 
-  # If TMPDIR is in the unpack dir we run afoul of blaze's infinite symlink
-  # detector (see com.google.devtools.build.lib.skyframe.FileFunction).
-  # Change this to $(mktemp -d) as soon as we figure out why.
+  # Bazel makes extensive use of symlinks in the WORKSPACE.
+  # This causes problems with infinite symlinks if the build output is in the same location as the
+  # Bazel WORKSPACE. This is why before executing the build, the source code is moved into a
+  # subdirectory.
+  # Failing to do this causes "infinite symlink expansion detected"
+  preBuildPhases = ["preBuildPhase"];
+  preBuildPhase = ''
+    mkdir bazel_src
+    shopt -s dotglob extglob
+    mv !(bazel_src) bazel_src
+  '';
 
   buildPhase = ''
-    export TMPDIR=/tmp/.bazel-$UID
-    ./compile.sh
-    scripts/generate_bash_completion.sh \
-        --bazel=./output/bazel \
-        --output=output/bazel-complete.bash \
-        --prepend=scripts/bazel-complete-template.bash
+    # Increasing memory during compilation might be necessary.
+    # export BAZEL_JAVAC_OPTS="-J-Xmx2g -J-Xms200m"
+    ./bazel_src/compile.sh
+    ./bazel_src/scripts/generate_bash_completion.sh \
+        --bazel=./bazel_src/output/bazel \
+        --output=./bazel_src/output/bazel-complete.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-header.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-template.bash
   '';
 
   installPhase = ''
@@ -262,15 +295,15 @@ stdenv.mkDerivation rec {
 
     # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel
     # if it can’t find something in tools, it calls $out/bin/bazel-real
-    cp scripts/packages/bazel.sh $out/bin/bazel
-    mv output/bazel $out/bin/bazel-real
+    cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
+    mv ./bazel_src/output/bazel $out/bin/bazel-real
 
     wrapProgram "$out/bin/bazel" --add-flags --server_javabase="${runJdk}"
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
-    mv output/bazel-complete.bash $out/share/bash-completion/completions/bazel
-    cp scripts/zsh_completion/_bazel $out/share/zsh/site-functions/
+    mv ./bazel_src/output/bazel-complete.bash $out/share/bash-completion/completions/bazel
+    cp ./bazel_src/scripts/zsh_completion/_bazel $out/share/zsh/site-functions/
   '';
 
   doInstallCheck = true;
@@ -285,11 +318,13 @@ stdenv.mkDerivation rec {
         examples/java-native/src/test/java/com/example/myproject:hello
     }
 
+    cd ./bazel_src
+
     # test whether $WORKSPACE_ROOT/tools/bazel works
 
     mkdir -p tools
     cat > tools/bazel <<"EOF"
-    #!${stdenv.shell} -e
+    #!${runtimeShell} -e
     exit 1
     EOF
     chmod +x tools/bazel
@@ -298,7 +333,7 @@ stdenv.mkDerivation rec {
     ! hello_test
 
     cat > tools/bazel <<"EOF"
-    #!${stdenv.shell} -e
+    #!${runtimeShell} -e
     exec "$BAZEL_REAL" "$@"
     EOF
 

--- a/nix/tools/bazel-cc-toolchain/default.nix
+++ b/nix/tools/bazel-cc-toolchain/default.nix
@@ -32,7 +32,7 @@ let cc-darwin =
 
     makeWrapper ${stdenv.cc}/bin/clang $out/bin/clang \
       --add-flags "-Wno-unused-command-line-argument \
-                   -mmacosx-version-min=10.13 \
+                   -mmacosx-version-min=10.14 \
                    -isystem ${llvmPackages.libcxx}/include/c++/v1 \
                    -F${CoreFoundation}/Library/Frameworks \
                    -F${CoreServices}/Library/Frameworks \

--- a/nix/tools/bazel-deps/default.nix
+++ b/nix/tools/bazel-deps/default.nix
@@ -74,7 +74,7 @@ buildBazelPackage rec {
       find . -type d -empty -delete
     '';
 
-    sha256 = "0m36zfrbwxzjm5vpvrjgs3vmgk90x010wiki5aspjxs0n8l9dxvh";
+    sha256 = "0kxb8xh9lqf2b3fx5ln3dm7dbs2min172xa6rdpvqmcl4vy73vcp";
   };
 
   buildAttrs = {

--- a/util.bzl
+++ b/util.bzl
@@ -28,7 +28,9 @@ def hazel_ghclibs(version, shaParser, shaLibrary):
 
 # Things we override from Hackage
 def hazel_hackage(name, version, sha, **kwargs):
-    return [(name, {"version": version, "sha256": sha} + kwargs)]
+    args = {"version": version, "sha256": sha}
+    args.update(kwargs)
+    return [(name, args)]
 
 # Things we override from GitHub
 def hazel_github_external(project, repoName, commit, sha, directory = "", name = None):


### PR DESCRIPTION
- Update the Nix expression for Bazel based on upstream nixpkgs.
- Update scoop manifest for Bazel.
- Update the Nix expressions for bazel-deps and bazel-watcher.
- Bazel no longer supports `+` on `dict`s. Replace by `dict.update`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
