### PR TITLE
Reorganize damlc to put the test stuff in a separate module

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -7,32 +7,27 @@
 {-# LANGUAGE ApplicativeDo       #-}
 
 -- | Main entry-point of the DAML compiler
-module DA.Cli.Damlc (main, execTest) where
+module DA.Cli.Damlc (main) where
 
 import Control.Monad.Except
 import qualified Control.Monad.Managed             as Managed
+import DA.Cli.Damlc.Base
 import Control.Exception (throwIO)
 import qualified "cryptonite" Crypto.Hash as Crypto
 import Codec.Archive.Zip
 import qualified Da.DamlLf as PLF
 import           DA.Cli.Damlc.BuildInfo
 import           DA.Cli.Damlc.Command.Damldoc      (cmdDamlDoc)
-import           DA.Cli.Options
-import DA.Cli.Output
 import           DA.Cli.Args
-import           DA.Prelude
 import qualified DA.Pretty
 import           DA.Service.Daml.Compiler.Impl.Handle as Compiler
 import DA.Daml.GHC.Compiler.Options (projectPackageDatabase, basePackages)
 import qualified DA.Service.Daml.LanguageServer    as Daml.LanguageServer
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Proto3.Archive as Archive
-import qualified DA.Daml.LF.PrettyScenario as SS
-import qualified DA.Daml.LF.ScenarioServiceClient as SSC
 import qualified DA.Service.Logger                 as Logger
 import qualified DA.Service.Logger.Impl.IO         as Logger.IO
 import qualified DA.Service.Logger.Impl.GCP        as Logger.GCP
-import qualified DA.Service.Logger.Impl.Pure as Logger.Pure
 import DAML.Project.Consts
 import DAML.Project.Config
 import DAML.Project.Types (ProjectPath(..), ConfigError)
@@ -40,7 +35,6 @@ import qualified Data.Aeson.Encode.Pretty as Aeson.Pretty
 import Data.ByteArray.Encoding (Base (Base16), convertToBase)
 import qualified Data.ByteString                   as B
 import qualified Data.ByteString.Lazy as BSL
-import Data.Either
 import qualified Data.ByteString.Char8 as BSC
 import Data.FileEmbed (embedFile)
 import Data.Functor
@@ -49,18 +43,12 @@ import qualified Data.List.Split as Split
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
-import qualified Data.Vector as V
-import qualified Development.Shake as Shake
-import qualified Development.IDE.State.API as CompilerService
-import qualified Development.IDE.State.Rules.Daml as CompilerService
 import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.LSP
 import GHC.Conc
 import qualified Network.Socket                    as NS
 import           Options.Applicative
 import qualified Proto3.Suite as PS
 import qualified Proto3.Suite.JSONPB as Proto.JSONPB
-import qualified ScenarioService as SS
 import System.Directory (createDirectoryIfMissing)
 import System.Environment (withProgName)
 import System.Exit (exitFailure)
@@ -68,13 +56,11 @@ import System.FilePath (takeDirectory, (<.>), (</>), isExtensionOf, takeFileName
 import System.Process(callCommand)
 import           System.IO                         (stderr, hPutStrLn)
 import qualified Text.PrettyPrint.ANSI.Leijen      as PP
-import qualified Text.XML.Light as XML
+import DA.Cli.Damlc.Test
 
 --------------------------------------------------------------------------------
 -- Commands
 --------------------------------------------------------------------------------
-
-type Command = IO ()
 
 cmdIde :: Mod CommandFields Command
 cmdIde =
@@ -487,120 +473,6 @@ execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relat
 
     putErrLn = hPutStrLn System.IO.stderr
 
-
--- | Test a DAML file.
-execTest :: [FilePath] -> Maybe FilePath -> Compiler.Options -> IO ()
-execTest inFiles mbJUnitOutput cliOptions = do
-    loggerH <- getLogger cliOptions "test"
-    opts <- Compiler.mkOptions cliOptions
-    -- TODO (MK): For now the scenario service is only started if we have an event logger
-    -- so we insert a dummy event logger.
-    let eventLogger _ = pure ()
-    Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \hDamlGhc -> do
-        liftIO $ Compiler.setFilesOfInterest hDamlGhc inFiles
-        mbDeps <- liftIO $ CompilerService.runAction hDamlGhc $ fmap sequence $ mapM CompilerService.getDependencies inFiles
-        depFiles <- maybe (reportDiagnostics hDamlGhc "Failed get dependencies") pure mbDeps
-        let files = Set.toList $ Set.fromList inFiles `Set.union`  Set.fromList (concat depFiles)
-        let lfVersion = Compiler.optDamlLfVersion cliOptions
-        case mbJUnitOutput of
-            Nothing -> testStdio lfVersion hDamlGhc files
-            Just junitOutput -> testJUnit lfVersion hDamlGhc files junitOutput
-
-prettyErr :: LF.Version -> SSC.Error -> DA.Pretty.Doc Pretty.SyntaxClass
-prettyErr lfVersion err = case err of
-    SSC.BackendError berr ->
-        DA.Pretty.string (show berr)
-    SSC.ScenarioError serr ->
-        SS.prettyBriefScenarioError
-          (LF.emptyWorld lfVersion)
-          serr
-    SSC.ExceptionError e -> DA.Pretty.string $ show e
-prettyResult :: LF.Version -> Either SSC.Error SS.ScenarioResult -> DA.Pretty.Doc Pretty.SyntaxClass
-prettyResult lfVersion errOrResult = case errOrResult of
-  Left err ->
-      DA.Pretty.error_ "fail. " DA.Pretty.$$
-      DA.Pretty.nest 2 (prettyErr lfVersion err)
-  Right result ->
-    let nTx = length (SS.scenarioResultScenarioSteps result)
-        isActive node =
-          case SS.nodeNode node of
-            Just SS.NodeNodeCreate{} ->
-              isNothing (SS.nodeConsumedBy node)
-            _otherwise -> False
-        nActive = length $ filter isActive (V.toList (SS.scenarioResultNodes result))
-    in DA.Pretty.typeDoc_ "ok, "
-    <> DA.Pretty.int nActive <> " active contracts, "
-    <> DA.Pretty.int nTx <> " transactions."
-
-testStdio :: LF.Version -> IdeState -> [FilePath] -> IO ()
-testStdio lfVersion hDamlGhc files = do
-    failed <- fmap or $ CompilerService.runAction hDamlGhc $
-        Shake.forP files $ \file -> do
-            mbScenarioResults <- CompilerService.runScenarios file
-            scenarioResults <- liftIO $ maybe (reportDiagnostics hDamlGhc "Failed to run scenarios") pure mbScenarioResults
-            liftIO $ forM_ scenarioResults $ \(VRScenario vrFile vrName, result) -> do
-                let doc = prettyResult lfVersion result
-                let name = DA.Pretty.string vrFile <> ":" <> DA.Pretty.pretty vrName
-                putStrLn $ DA.Pretty.renderPlain (name <> ": " <> doc)
-            pure $ any (isLeft . snd) scenarioResults
-    when failed exitFailure
-
-testJUnit :: LF.Version -> IdeState -> [FilePath] -> FilePath -> IO ()
-testJUnit lfVersion hDamlGhc files junitOutput = do
-    failed <- CompilerService.runAction hDamlGhc $ do
-        results <- Shake.forP files $ \file -> do
-            scenarios <- CompilerService.getScenarios file
-            mbScenarioResults <- CompilerService.runScenarios file
-            results <- case mbScenarioResults of
-                Nothing -> do
-                    -- If we don’t get scenario results, we use the diagnostics
-                    -- as the error message for each scenario.
-                    diagnostics <- liftIO $ CompilerService.getDiagnostics hDamlGhc
-                    let errMsg = T.unlines (map (Pretty.renderPlain . prettyDiagnostic) diagnostics)
-                    pure $ map (, Just errMsg) scenarios
-                Just scenarioResults -> pure $
-                    map (\(vr, res) -> (vr, either (Just . T.pack . DA.Pretty.renderPlainOneLine . prettyErr lfVersion) (const Nothing) res))
-                        scenarioResults
-            pure (file, results)
-        liftIO $ do
-            createDirectoryIfMissing True $ takeDirectory junitOutput
-            writeFile junitOutput $ XML.showTopElement $ toJUnit results
-        pure (any (any (isJust . snd) . snd) results)
-    when failed exitFailure
-
-
-toJUnit :: [(FilePath, [(VirtualResource, Maybe T.Text)])] -> XML.Element
-toJUnit results =
-    XML.node
-        (XML.unqual "testsuites")
-        ([ XML.Attr (XML.unqual "errors") "0"
-           -- For now we only have successful tests and falures
-         , XML.Attr (XML.unqual "failures") (show failures)
-         , XML.Attr (XML.unqual "tests") (show tests)
-         ],
-         map handleFile results)
-    where
-        tests = length $ concatMap snd results
-        failures = length $ concatMap (mapMaybe snd . snd) results
-        handleFile :: (FilePath, [(VirtualResource, Maybe T.Text)]) -> XML.Element
-        handleFile (f, vrs) =
-            XML.node
-                (XML.unqual "testsuite")
-                ([ XML.Attr (XML.unqual "name") f
-                 , XML.Attr (XML.unqual "tests") (show $ length vrs)
-                 ],
-                 map (handleVR f) vrs)
-        handleVR :: FilePath -> (VirtualResource, Maybe T.Text) -> XML.Element
-        handleVR f (vr, mbErr) =
-            XML.node
-                (XML.unqual "testcase")
-                ([ XML.Attr (XML.unqual "name") (T.unpack $ vrScenarioName vr)
-                 , XML.Attr (XML.unqual "classname") f
-                 ],
-                 maybe [] (\err -> [XML.node (XML.unqual "failure") (T.unpack err)]) mbErr
-                )
-
-
 execInspect :: FilePath -> FilePath -> Bool -> Command
 execInspect inFile outFile jsonOutput = do
     bytes <- B.readFile inFile
@@ -649,12 +521,6 @@ execInspectDar inFile = do
 --------------------------------------------------------------------------------
 -- main
 --------------------------------------------------------------------------------
-
-getLogger :: Compiler.Options -> T.Text -> IO (Logger.Handle IO)
-getLogger Compiler.Options {optDebug} name =
-    if optDebug
-        then Logger.IO.newStderrLogger name
-        else pure Logger.Pure.makeNopHandle
 
 optDebugLog :: Parser Bool
 optDebugLog = switch $ help "Enable debug output" <> long "debug"
@@ -784,23 +650,3 @@ main :: IO ()
 main = do
     numProcessors <- getNumProcessors
     withProgName "damlc" $ join $ execParserLax (parserInfo numProcessors)
-
-------------------
--- Error reporting
-------------------
-
-reportDiagnostics :: CompilerService.IdeState -> String -> IO a
-reportDiagnostics service err = do
-    diagnostic <- CompilerService.getDiagnostics service
-    reportErr err diagnostic
-
-reportErr :: String -> [Diagnostic] -> IO a
-reportErr msg errs =
-  ioError $
-  userError $
-  unlines
-    [ msg
-    , T.unpack $
-      Pretty.renderColored $
-      Pretty.vcat $ map prettyDiagnostic $ Set.toList $ Set.fromList errs
-    ]

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Base.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Base.hs
@@ -6,12 +6,26 @@ module DA.Cli.Damlc.Base
     , module DA.Cli.Output
     , module DA.Prelude
     , CommandM
-    , Command)
+    , Command
+    , getLogger
+    )
 where
 import           DA.Cli.Options
 import           DA.Cli.Output
 import           DA.Prelude
+import           DA.Service.Daml.Compiler.Impl.Handle as Compiler
+import qualified Data.Text as T
+import qualified DA.Service.Logger                 as Logger
+import qualified DA.Service.Logger.Impl.IO         as Logger.IO
+import qualified DA.Service.Logger.Impl.Pure as Logger.Pure
+
 
 type CommandM = IO
 type Command  = IO ()
 
+
+getLogger :: Compiler.Options -> T.Text -> IO (Logger.Handle IO)
+getLogger Compiler.Options {optDebug} name =
+    if optDebug
+        then Logger.IO.newStderrLogger name
+        else pure Logger.Pure.makeNopHandle

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -1,0 +1,174 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE ApplicativeDo       #-}
+
+-- | Main entry-point of the DAML compiler
+module DA.Cli.Damlc.Test (execTest) where
+
+import Control.Monad.Except
+import qualified Control.Monad.Managed             as Managed
+import           DA.Prelude
+import qualified DA.Pretty
+import DA.Cli.Damlc.Base
+import           DA.Service.Daml.Compiler.Impl.Handle as Compiler
+import qualified DA.Daml.LF.Ast as LF
+import qualified DA.Daml.LF.PrettyScenario as SS
+import qualified DA.Daml.LF.ScenarioServiceClient as SSC
+import Data.Either
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
+import qualified Data.Vector as V
+import qualified Development.Shake as Shake
+import qualified Development.IDE.State.API as CompilerService
+import qualified Development.IDE.State.Rules.Daml as CompilerService
+import Development.IDE.Types.Diagnostics
+import Development.IDE.Types.LSP
+import qualified ScenarioService as SS
+import System.Directory (createDirectoryIfMissing)
+import System.Exit (exitFailure)
+import System.FilePath
+import qualified Text.XML.Light as XML
+
+--------------------------------------------------------------------------------
+-- Commands
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Execution
+--------------------------------------------------------------------------------
+
+
+
+-- | Test a DAML file.
+execTest :: [FilePath] -> Maybe FilePath -> Compiler.Options -> IO ()
+execTest inFiles mbJUnitOutput cliOptions = do
+    loggerH <- getLogger cliOptions "test"
+    opts <- Compiler.mkOptions cliOptions
+    -- TODO (MK): For now the scenario service is only started if we have an event logger
+    -- so we insert a dummy event logger.
+    let eventLogger _ = pure ()
+    Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \hDamlGhc -> do
+        liftIO $ Compiler.setFilesOfInterest hDamlGhc inFiles
+        mbDeps <- liftIO $ CompilerService.runAction hDamlGhc $ fmap sequence $ mapM CompilerService.getDependencies inFiles
+        depFiles <- maybe (reportDiagnostics hDamlGhc "Failed get dependencies") pure mbDeps
+        let files = Set.toList $ Set.fromList inFiles `Set.union`  Set.fromList (concat depFiles)
+        let lfVersion = Compiler.optDamlLfVersion cliOptions
+        case mbJUnitOutput of
+            Nothing -> testStdio lfVersion hDamlGhc files
+            Just junitOutput -> testJUnit lfVersion hDamlGhc files junitOutput
+
+testStdio :: LF.Version -> IdeState -> [FilePath] -> IO ()
+testStdio lfVersion hDamlGhc files = do
+    failed <- fmap or $ CompilerService.runAction hDamlGhc $
+        Shake.forP files $ \file -> do
+            mbScenarioResults <- CompilerService.runScenarios file
+            scenarioResults <- liftIO $ maybe (reportDiagnostics hDamlGhc "Failed to run scenarios") pure mbScenarioResults
+            liftIO $ forM_ scenarioResults $ \(VRScenario vrFile vrName, result) -> do
+                let doc = prettyResult lfVersion result
+                let name = DA.Pretty.string vrFile <> ":" <> DA.Pretty.pretty vrName
+                putStrLn $ DA.Pretty.renderPlain (name <> ": " <> doc)
+            pure $ any (isLeft . snd) scenarioResults
+    when failed exitFailure
+
+testJUnit :: LF.Version -> IdeState -> [FilePath] -> FilePath -> IO ()
+testJUnit lfVersion hDamlGhc files junitOutput = do
+    failed <- CompilerService.runAction hDamlGhc $ do
+        results <- Shake.forP files $ \file -> do
+            scenarios <- CompilerService.getScenarios file
+            mbScenarioResults <- CompilerService.runScenarios file
+            results <- case mbScenarioResults of
+                Nothing -> do
+                    -- If we don’t get scenario results, we use the diagnostics
+                    -- as the error message for each scenario.
+                    diagnostics <- liftIO $ CompilerService.getDiagnostics hDamlGhc
+                    let errMsg = T.unlines (map (Pretty.renderPlain . prettyDiagnostic) diagnostics)
+                    pure $ map (, Just errMsg) scenarios
+                Just scenarioResults -> pure $
+                    map (\(vr, res) -> (vr, either (Just . T.pack . DA.Pretty.renderPlainOneLine . prettyErr lfVersion) (const Nothing) res))
+                        scenarioResults
+            pure (file, results)
+        liftIO $ do
+            createDirectoryIfMissing True $ takeDirectory junitOutput
+            writeFile junitOutput $ XML.showTopElement $ toJUnit results
+        pure (any (any (isJust . snd) . snd) results)
+    when failed exitFailure
+
+
+
+prettyErr :: LF.Version -> SSC.Error -> DA.Pretty.Doc Pretty.SyntaxClass
+prettyErr lfVersion err = case err of
+    SSC.BackendError berr ->
+        DA.Pretty.string (show berr)
+    SSC.ScenarioError serr ->
+        SS.prettyBriefScenarioError
+          (LF.emptyWorld lfVersion)
+          serr
+    SSC.ExceptionError e -> DA.Pretty.string $ show e
+
+prettyResult :: LF.Version -> Either SSC.Error SS.ScenarioResult -> DA.Pretty.Doc Pretty.SyntaxClass
+prettyResult lfVersion errOrResult = case errOrResult of
+  Left err ->
+      DA.Pretty.error_ "fail. " DA.Pretty.$$
+      DA.Pretty.nest 2 (prettyErr lfVersion err)
+  Right result ->
+    let nTx = length (SS.scenarioResultScenarioSteps result)
+        isActive node =
+          case SS.nodeNode node of
+            Just SS.NodeNodeCreate{} ->
+              isNothing (SS.nodeConsumedBy node)
+            _otherwise -> False
+        nActive = length $ filter isActive (V.toList (SS.scenarioResultNodes result))
+    in DA.Pretty.typeDoc_ "ok, "
+    <> DA.Pretty.int nActive <> " active contracts, "
+    <> DA.Pretty.int nTx <> " transactions."
+
+
+toJUnit :: [(FilePath, [(VirtualResource, Maybe T.Text)])] -> XML.Element
+toJUnit results =
+    XML.node
+        (XML.unqual "testsuites")
+        ([ XML.Attr (XML.unqual "errors") "0"
+           -- For now we only have successful tests and falures
+         , XML.Attr (XML.unqual "failures") (show failures)
+         , XML.Attr (XML.unqual "tests") (show tests)
+         ],
+         map handleFile results)
+    where
+        tests = length $ concatMap snd results
+        failures = length $ concatMap (mapMaybe snd . snd) results
+        handleFile :: (FilePath, [(VirtualResource, Maybe T.Text)]) -> XML.Element
+        handleFile (f, vrs) =
+            XML.node
+                (XML.unqual "testsuite")
+                ([ XML.Attr (XML.unqual "name") f
+                 , XML.Attr (XML.unqual "tests") (show $ length vrs)
+                 ],
+                 map (handleVR f) vrs)
+        handleVR :: FilePath -> (VirtualResource, Maybe T.Text) -> XML.Element
+        handleVR f (vr, mbErr) =
+            XML.node
+                (XML.unqual "testcase")
+                ([ XML.Attr (XML.unqual "name") (T.unpack $ vrScenarioName vr)
+                 , XML.Attr (XML.unqual "classname") f
+                 ],
+                 maybe [] (\err -> [XML.node (XML.unqual "failure") (T.unpack err)]) mbErr
+                )
+
+--------------------------------------------------------------------------------
+-- main
+--------------------------------------------------------------------------------
+
+
+------------------
+-- Error reporting
+------------------
+
+reportDiagnostics :: CompilerService.IdeState -> String -> IO a
+reportDiagnostics service err = do
+    diagnostic <- CompilerService.getDiagnostics service
+    reportErr err diagnostic

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -34,15 +34,6 @@ import System.Exit (exitFailure)
 import System.FilePath
 import qualified Text.XML.Light as XML
 
---------------------------------------------------------------------------------
--- Commands
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
--- Execution
---------------------------------------------------------------------------------
-
-
 
 -- | Test a DAML file.
 execTest :: [FilePath] -> Maybe FilePath -> Compiler.Options -> IO ()
@@ -97,7 +88,6 @@ testJUnit lfVersion hDamlGhc files junitOutput = do
             writeFile junitOutput $ XML.showTopElement $ toJUnit results
         pure (any (any (isJust . snd) . snd) results)
     when failed exitFailure
-
 
 
 prettyErr :: LF.Version -> SSC.Error -> DA.Pretty.Doc Pretty.SyntaxClass
@@ -159,14 +149,6 @@ toJUnit results =
                  maybe [] (\err -> [XML.node (XML.unqual "failure") (T.unpack err)]) mbErr
                 )
 
---------------------------------------------------------------------------------
--- main
---------------------------------------------------------------------------------
-
-
-------------------
--- Error reporting
-------------------
 
 reportDiagnostics :: CompilerService.IdeState -> String -> IO a
 reportDiagnostics service err = do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -1,10 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE ApplicativeDo       #-}
 
 -- | Main entry-point of the DAML compiler
 module DA.Cli.Damlc.Test (execTest) where

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
@@ -5,10 +5,15 @@
 module DA.Cli.Output
   ( writeOutput
   , writeOutputBSL
+  , reportErr
   ) where
 
 import qualified Data.ByteString.Lazy                           as BSL
 import           Data.String                                    (IsString)
+import qualified Data.Text as T
+import Development.IDE.Types.Diagnostics
+import Data.List.Extra
+import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
 import           System.IO                                      (Handle, hClose, hPutStr, stdout, openFile, IOMode (WriteMode))
 import           Control.Exception (bracket)
 
@@ -38,3 +43,15 @@ writeOutput = writeOutputWith hPutStr
 
 writeOutputBSL :: FilePath -> BSL.ByteString -> IO ()
 writeOutputBSL = writeOutputWith BSL.hPutStr
+
+
+reportErr :: String -> [Diagnostic] -> IO a
+reportErr msg errs =
+  ioError $
+  userError $
+  unlines
+    [ msg
+    , T.unpack $
+      Pretty.renderColored $
+      Pretty.vcat $ map prettyDiagnostic $ nubOrd errs
+    ]

--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -13,7 +13,7 @@ import System.IO.Extra
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import qualified DA.Cli.Damlc as Damlc
+import qualified DA.Cli.Damlc.Test as Damlc
 import DA.Daml.GHC.Compiler.Options
 
 main :: IO ()


### PR DESCRIPTION
We were verging towards a monster module. Now the test stuff is somewhere separate and we can see what it is. This PR deliberately doesn't change any of the code (that's coming next). I think there's still plenty of splitting that could be done in a future step.