### PR TITLE
Implement post-consuming choices

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -109,9 +109,6 @@ postconsuming _ = PostConsuming
 class Template c => Choice c e r | c e -> r where
     -- | HIDE
     consuming : NoEvent c e -> Consuming
-    -- Must be a lambda since otherwise the default-dictionary method
-    -- causes a runtime loop as the method exists in the dictionary,
-    -- takes the dictionary, and can't be eta expanded.
     consuming = preconsuming
 
     choiceController : c -> e -> [Party]

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -7,7 +7,7 @@ daml 1.2
 -- | MOVE Prelude DAML-LF primitives, just templates/contracts
 module DA.Internal.Template(
     Template(ensure, signatory, observer, agreement),
-    Choice(consuming, choiceController, choice), nonconsuming, NoEvent(..),
+    Choice(consuming, choiceController, choice), preconsuming, nonconsuming, postconsuming, NoEvent(..),
     stakeholder,
     create, exercise, fetch,
     archive, Archive(..),
@@ -89,12 +89,28 @@ class Template c where
     internalArchive = magic @"archive"
 
 
+-- Deliberately not exported.
+data Consuming = PreConsuming  -- Archive before executing exercise body.
+               | PostConsuming -- Execute exercise body then archive.
+               | NonConsuming  -- Don't archive.
+
+-- | HIDE
+nonconsuming : NoEvent c e -> Consuming
+nonconsuming _ = NonConsuming
+
+preconsuming : NoEvent c e -> Consuming
+preconsuming _ = PreConsuming
+
+postconsuming : NoEvent c e -> Consuming
+postconsuming _ = PostConsuming
+
 class Template c => Choice c e r | c e -> r where
     -- | HIDE
-    consuming : NoEvent c e -> ChoiceType
-    -- must be a lambda since otherwise the default-dictionary method causes a runtime loop as the method
-    -- exists in the dictionary, takes the dictionary, and can't be eta expanded.
-    consuming _ = Consuming
+    consuming : NoEvent c e -> Consuming
+    -- Must be a lambda since otherwise the default-dictionary method
+    -- causes a runtime loop as the method exists in the dictionary,
+    -- takes the dictionary, and can't be eta expanded.
+    consuming = preconsuming
 
     choiceController : c -> e -> [Party]
     choice : c -> ContractId c -> e -> Update r
@@ -110,14 +126,6 @@ instance Template c => Choice c Archive () where
     choice _ _ _ = return ()
 
     internalExercise p c _ = internalArchive p c
-
-
--- Deliberately not exported, they either have to use the default, or 'nonconsuming' below.
-data ChoiceType = Consuming | NonConsuming
-
--- | HIDE
-nonconsuming : NoEvent c e -> ChoiceType
-nonconsuming _ = NonConsuming
 
 -- | HIDE
 data NoEvent c e = NoEvent

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -109,7 +109,10 @@ postconsuming _ = PostConsuming
 class Template c => Choice c e r | c e -> r where
     -- | HIDE
     consuming : NoEvent c e -> Consuming
-    consuming = preconsuming
+    -- Must be a lambda since otherwise the default-dictionary method
+    -- causes a runtime loop as the method exists in the dictionary,
+    -- takes the dictionary, and can't be eta expanded.
+    consuming _ = PreConsuming
 
     choiceController : c -> e -> [Party]
     choice : c -> ContractId c -> e -> Update r

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -98,9 +98,11 @@ data Consuming = PreConsuming  -- Archive before executing exercise body.
 nonconsuming : NoEvent c e -> Consuming
 nonconsuming _ = NonConsuming
 
+-- | HIDE
 preconsuming : NoEvent c e -> Consuming
 preconsuming _ = PreConsuming
 
+-- | HIDE
 postconsuming : NoEvent c e -> Consuming
 postconsuming _ = PostConsuming
 

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -306,7 +306,7 @@ convertTemplate env (VarIs "C:Template" `App` Type (TypeCon ty [])
         `App` ensure `App` signatories `App` observer `App` agreement `App` _create `App` _fetch `App` _archive)
     = do
     tplSignatories <- applyTplParam <$> convertExpr env signatories
-    tplChoices <- fmap (\cs -> NM.fromList (archiveChoice tplSignatories : cs)) choices
+    tplChoices <- fmap (\cs -> NM.fromList (archiveChoice tplSignatories : cs)) (choices tplSignatories)
     tplObservers <- applyTplParam <$> convertExpr env observer
     tplPrecondition <- applyTplParam <$> convertExpr env ensure
     tplAgreement <- applyTplParam <$> convertExpr env agreement
@@ -317,7 +317,7 @@ convertTemplate env (VarIs "C:Template" `App` Type (TypeCon ty [])
     pure [DTemplate Template{..}]
     where
         applyTplParam e = e `ETmApp` EVar tplParam
-        choices = traverse (convertChoice env) $ envFindChoices env $ is ty
+        choices signatories = traverse (convertChoice env signatories) $ envFindChoices env $ is ty
         keys = mapM (convertKey env) $ envFindKeys env $ is ty
         tplLocation = Nothing
         tplTypeCon = mkTypeCon [is ty]
@@ -336,13 +336,21 @@ archiveChoice signatories = TemplateChoice{..}
         chcSelfBinder = mkVar "self"
         chcArgBinder = (mkVar "arg", TUnit)
 
-convertChoice :: Env -> GHC.Expr Var -> ConvertM TemplateChoice
-convertChoice env (VarIs "C:Choice" `App` Type tmpl `App` Type (TypeCon chc []) `App` Type result `App` _templateDict
-        `App` consuming `App` Var controller `App` choice `App` _exercise) = do
-    chcConsuming <- f (10 :: Int) consuming
+convertChoice :: Env -> LF.Expr -> GHC.Expr Var -> ConvertM TemplateChoice
+convertChoice env signatories
+  (VarIs "C:Choice" `App`
+     Type tmpl@(TypeCon tmplTyCon []) `App`
+       Type (TypeCon chc []) `App`
+         Type result `App`
+           _templateDict `App`
+             consuming `App`
+               Var controller `App`
+                 choice `App` _exercise) = do
+    (chcConsuming, postConsuming) <- f (10 :: Int) consuming
     argType <- convertType env $ TypeCon chc []
     let chcArgBinder = (mkVar "arg", argType)
     tmplType <- convertType env tmpl
+    tmplTyCon' <- convertQualified env tmplTyCon
     chcReturnType <- convertType env result
     controllerExpr <- envFindBind env controller >>= convertExpr env
     let chcControllers = case controllerExpr of
@@ -353,9 +361,30 @@ convertChoice env (VarIs "C:Choice" `App` Type tmpl `App` Type (TypeCon chc []) 
             ETmLam thisBndr (ETmLam argBndr body)
               | fst argBndr `Set.notMember` cata freeVarsStep body ->
                 ETmLam thisBndr body `ETmApp` thisVar
-            _ ->
-                controllerExpr `ETmApp` thisVar `ETmApp` argVar
-    chcUpdate <- fmap (\u -> u `ETmApp` thisVar `ETmApp` selfVar `ETmApp` argVar) (convertExpr env choice)
+            _ -> controllerExpr `ETmApp` thisVar `ETmApp` argVar
+    expr <- fmap (\u -> u `ETmApp` thisVar `ETmApp` selfVar `ETmApp` argVar) (convertExpr env choice)
+    chcUpdate <-
+      if not $ postConsuming
+        then
+          pure expr
+      else
+        do
+           -- NOTE(SF): Support for 'postconsuming' choices. The idea
+           -- is to evaluate the user provided choice body and
+           -- following that, archive. That is, in pseduo-code, we are
+           -- going for an expression like this:
+           --     expr this self arg >>= \res ->
+           --     archive signatories self >>= \_ -> return res
+          let archive =
+                EUpdate $
+                  UExercise tmplTyCon'
+                            (mkChoiceName "Archive")
+                            selfVar signatories mkEUnit
+              returnRes = EUpdate $ UPure chcReturnType (EVar $ mkVar "res")
+          pure $
+            EUpdate $
+              UBind (Binding (mkVar "res", chcReturnType) expr)
+                    (EUpdate $ UBind (Binding (mkVar "_", TUnit) archive) returnRes)
     pure TemplateChoice{..}
     where
         chcLocation = Nothing
@@ -367,11 +396,13 @@ convertChoice env (VarIs "C:Choice" `App` Type tmpl `App` Type (TypeCon chc []) 
 
         f i (App a _) = f i a
         f i (Tick _ e) = f i e
-        f i (VarIs "nonconsuming") = pure False
-        f i (VarIs "$dmconsuming") = pure True -- the default is consuming
+        f i (VarIs "$dmconsuming") = pure (True, False) -- the default is preconsuming
+        f i (VarIs "preconsuming") = pure (True, False)
+        f i (VarIs "nonconsuming") = pure (False, False)
+        f i (VarIs "postconsuming") = pure (False, True)
         f i (Var x) | i > 0 = f (i-1) =<< envFindBind env x -- only required to see through the automatic default
         f _ x = unsupported "Unexpected definition of 'consuming', expected either absent or 'nonconsuming'" x
-convertChoice _ x = unhandled "Choice body" x
+convertChoice _ _ x = unhandled "Choice body" x
 
 convertKey :: Env -> GHC.Expr Var -> ConvertM TemplateKey
 convertKey env o@(VarIs "C:TemplateKey" `App` Type tmpl `App` Type keyType `App` _templateDict `App` Var key `App` Var maintainer `App` _fetch `App` _lookup) = do

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -377,11 +377,12 @@ convertChoice env signatories
             -- following that, archive. That is, in pseduo-code, we are
             -- going for an expression like this:
             --     expr this self arg >>= \res ->
-            --     archive signatories self >>= \_ -> return res
+            --     archive signatories self >>= \_ ->
+            --     return res
             let archive = EUpdate $ UExercise tmplTyCon' (mkChoiceName "Archive") selfVar signatories mkEUnit
             in EUpdate $ UBind (Binding (mkVar "res", chcReturnType) expr) $
-                           EUpdate $ UBind (Binding (mkVar "_", TUnit) archive) $
-                           EUpdate $ UPure chcReturnType (EVar $ mkVar "res")
+               EUpdate $ UBind (Binding (mkVar "_", TUnit) archive) $
+               EUpdate $ UPure chcReturnType (EVar $ mkVar "res")
     pure TemplateChoice{..}
     where
         chcLocation = Nothing

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -364,7 +364,7 @@ convertChoice env signatories
             _ -> controllerExpr `ETmApp` thisVar `ETmApp` argVar
     expr <- fmap (\u -> u `ETmApp` thisVar `ETmApp` selfVar `ETmApp` argVar) (convertExpr env choice)
     chcUpdate <-
-      if not $ postConsuming
+      if not postConsuming
         then
           pure expr
       else

--- a/daml-foundations/daml-ghc/tests/ConsumingTests.daml
+++ b/daml-foundations/daml-ghc/tests/ConsumingTests.daml
@@ -1,0 +1,43 @@
+daml 1.2
+module ConsumingTests where
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+    nonconsuming choice NoConsume : Int
+      controller p
+      do
+        return 41
+
+    choice PreConsume : Int
+      controller p
+      do
+        return 42
+
+-- Temporary : Will replace with DAML syntax when it's implemented.
+
+data PostConsume = PostConsume {} deriving (Eq, Show)
+instance Choice T PostConsume Int where
+  consuming = postconsuming
+  choiceController (T{..}) _ = [p]
+  choice _ self _ =  do _ <- fetch self; return 43 -- Can fetch 'self' in choice body
+
+main = scenario do
+  p <- getParty "p"
+
+  noConsumeCid <- submit p $ create T with p
+  41 <- submit p $ exercise noConsumeCid NoConsume
+  _ <- submit p $ fetch noConsumeCid
+
+  preConsumeCid <- submit p $ create T with p
+  42 <- submit p $ exercise preConsumeCid PreConsume
+  submitMustFail p $ fetch preConsumeCid
+
+  postConsumeCid <- submit p $ create T with p
+  43 <- submit p $ exercise postConsumeCid PostConsume
+  submitMustFail p $ fetch postConsumeCid
+
+  return ()

--- a/daml-foundations/daml-ghc/tests/ConsumingTests.daml
+++ b/daml-foundations/daml-ghc/tests/ConsumingTests.daml
@@ -9,13 +9,15 @@ template T
 
     nonconsuming choice NoConsume : Int
       controller p
-      do
-        return 41
+      do return 41
 
     choice PreConsume : Int
       controller p
-      do
-        return 42
+      do return 42
+
+    choice PreConsumeBad : Int
+      controller p
+      do _ <- fetch self; return 44 -- No! Can't fetch self in a preconsuming choice.
 
 -- Temporary : Will replace with DAML syntax when it's implemented.
 
@@ -23,7 +25,7 @@ data PostConsume = PostConsume {} deriving (Eq, Show)
 instance Choice T PostConsume Int where
   consuming = postconsuming
   choiceController T{..} _ = [p]
-  choice _ self _ =  (+2) <$> exercise self NoConsume
+  choice _ self _ =  (+2) <$> exercise self NoConsume  -- Yes, fetching self in a postconsuming choice is ok.
 
 main = scenario do
   p <- getParty "p"
@@ -35,6 +37,9 @@ main = scenario do
   preConsumeCid <- submit p $ create T with p
   42 <- submit p $ exercise preConsumeCid PreConsume
   submitMustFail p $ fetch preConsumeCid
+
+  preConsumeBadCid <- submit p $ create T with p
+  submitMustFail p $ exercise preConsumeBadCid PreConsumeBad
 
   postConsumeCid <- submit p $ create T with p
   43 <- submit p $ exercise postConsumeCid PostConsume

--- a/daml-foundations/daml-ghc/tests/ConsumingTests.daml
+++ b/daml-foundations/daml-ghc/tests/ConsumingTests.daml
@@ -23,7 +23,7 @@ data PostConsume = PostConsume {} deriving (Eq, Show)
 instance Choice T PostConsume Int where
   consuming = postconsuming
   choiceController T{..} _ = [p]
-  choice _ self _ =  do _ <- fetch self; return 43 -- Can fetch 'self' in choice body
+  choice _ self _ =  (+2) <$> exercise self NoConsume
 
 main = scenario do
   p <- getParty "p"

--- a/daml-foundations/daml-ghc/tests/ConsumingTests.daml
+++ b/daml-foundations/daml-ghc/tests/ConsumingTests.daml
@@ -22,7 +22,7 @@ template T
 data PostConsume = PostConsume {} deriving (Eq, Show)
 instance Choice T PostConsume Int where
   consuming = postconsuming
-  choiceController (T{..}) _ = [p]
+  choiceController T{..} _ = [p]
   choice _ self _ =  do _ <- fetch self; return 43 -- Can fetch 'self' in choice body
 
 main = scenario do


### PR DESCRIPTION
In this PR, support is added for post-consuming choices as described in issue https://github.com/digital-asset/daml/issues/420 ("provide a way for a contract to be archived at the end of a consuming choice"). A test is provided. A follow up PR will implement DAML syntax for `preconsuming` and `postconsuming` keywords (complementing the existing `nonconsuming`). As before, default behavior is to pre-consume.