### PR TITLE
Fixes #479 - Add result of exercise to transaction.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -276,7 +276,8 @@ final class Engine {
           stakeholders @ _,
           signatories @ _,
           controllers @ _,
-          children @ _) =>
+          children @ _,
+          exerciseResult @ _) =>
         val templateId = template
         asValueWithAbsoluteContractIds(chosenVal).flatMap(
           absChosenVal =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -9,7 +9,7 @@ class EngineInfoTest extends WordSpec with Matchers {
   EngineInfo.getClass.getSimpleName should {
     "show supported LF, Transaction and Value versions" in {
       EngineInfo.show shouldBe
-        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6; Value versions: 1, 2, 3, 4"
+        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6, 7; Value versions: 1, 2, 3, 4"
     }
 
     "toString returns the same value as show" in {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -753,7 +753,7 @@ class EngineTest extends WordSpec with Matchers {
       postCommitForBob shouldBe 'right
 
       bobView.nodes(Tx.NodeId.unsafeFromIndex(0)) match {
-        case NodeExercises(coid, _, choice, _, consuming, actingParties, _, _, _, _, children) =>
+        case NodeExercises(coid, _, choice, _, consuming, actingParties, _, _, _, _, children, _) =>
           coid shouldBe AbsoluteContractId(originalCoid)
           consuming shouldBe true
           actingParties shouldBe Set(bob)
@@ -897,6 +897,9 @@ class EngineTest extends WordSpec with Matchers {
           children = ImmArray(Tx.NodeId.unsafeFromIndex(1)),
           stakeholders = Set(bob, alice),
           witnesses = Set(bob, alice),
+          exerciseResult = Some(
+            assertAsVersionedValue(
+              ValueContractId(RelativeContractId(Tx.NodeId.unsafeFromIndex(1)))))
         )
       val bobVisibleCreate = partyEvents.events(Tx.NodeId.unsafeFromIndex(1))
       bobVisibleCreate shouldBe

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -724,7 +724,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
               // stack: <actors> <cid> <choice arg> <token> <template arg> ()
               update(SEVar(3)),
               // stack: <actors> <cid> <choice arg> <token> <template arg> () <ret value>
-              SBUEndExercise(tmplId)(SEVar(4))
+              SBUEndExercise(tmplId)(SEVar(4), SEVar(1))
             ) in
               // stack: <actors> <cid> <choice arg> <token> <template arg> () <ret value> ()
               SEVar(2)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -735,11 +735,21 @@ object SBuiltin {
     }
   }
 
-  /** $endExercise[T] :: Token -> () */
-  final case class SBUEndExercise(templateId: TypeConName) extends SBuiltin(1) {
+  /** $endExercise[T]
+    *    :: Token
+    *    -> Value   (result of the exercise)
+    *    -> ()
+    */
+  final case class SBUEndExercise(templateId: TypeConName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(0))
-      machine.ptx = machine.ptx.endExercises._2
+      val exerciseResult = args.get(1).toValue
+      machine.ptx = machine.ptx
+        .endExercises(asVersionedValue(exerciseResult) match {
+          case Left(err) => crash(err)
+          case Right(x) => x
+        })
+        ._2
       machine.ctrl = CtrlValue(SUnit(()))
       checkAborted(machine.ptx)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -227,7 +227,8 @@ object Ledger {
           stakeholders = nex.stakeholders,
           signatories = nex.signatories,
           controllers = nex.controllers,
-          children = nex.children.map(NodeId(commitPrefix, _))
+          children = nex.children.map(NodeId(commitPrefix, _)),
+          exerciseResult = nex.exerciseResult.map(makeAbsolute(commitPrefix, _))
         )
       case nlbk: NodeLookupByKey.WithTxValue[ContractId] =>
         NodeLookupByKey(

--- a/daml-lf/spec/transaction.rst
+++ b/daml-lf/spec/transaction.rst
@@ -4,7 +4,7 @@
 DAML-LF Transaction Specification
 =================================
 
-**version 6, 29 April 2019**
+**version 7, 5 May 2019**
 
 This specification, in concert with the ``transaction.proto``
 machine-readable definition, defines a format for _transactions_, to be
@@ -156,6 +156,8 @@ This table lists every version of this specification in ascending order
 |                  5 |      2019-03-12 |
 +--------------------+-----------------+
 |                  6 |      2019-04-29 |
++--------------------+-----------------+
+|                  7 |      2019-05-06 |
 +--------------------+-----------------+
 
 message Transaction
@@ -485,6 +487,14 @@ If ``contract_id_struct``'s ``relative`` field is ``true``, then:
 The ``controllers`` field must be empty. Software needing to fill in
 data structures that demand both actors and controllers must use
 the ``actors`` field as the controllers.
+
+*since version 7*
+
+A new field ``result_value`` is required:
+
+* `message VersionedValue`_ result_value
+
+Containing the result of the exercised choice.
 
 message NodeLookupByKey
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -310,6 +310,7 @@ object ValueGenerators {
         .listOf(Arbitrary.arbInt.arbitrary)
         .map(_.map(Transaction.NodeId.unsafeFromIndex))
         .map(ImmArray(_))
+      exerciseResultValue <- versionedValueGen
     } yield
       NodeExercises(
         targetCoid,
@@ -322,7 +323,8 @@ object ValueGenerators {
         stakeholders,
         signatories,
         actingParties,
-        children
+        children,
+        Some(exerciseResultValue)
       )
   }
 

--- a/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
@@ -11,7 +11,7 @@
 // * 4: string contract_id replaced globally by ContractId message
 // * 5: new field actors in NodeFetch
 // * 6: removal of controllers in exercise nodes
-
+// * 7: new field exerciseResult in NodeExercise
 syntax = "proto3";
 
 package com.digitalasset.daml.lf.transaction;
@@ -87,6 +87,7 @@ message NodeExercise {
     repeated string signatories = 9;
     repeated string controllers = 10;
     com.digitalasset.daml.lf.value.ContractId contract_id_struct = 11;
+    com.digitalasset.daml.lf.value.VersionedValue return_value = 12;
 }
 
 message NodeLookupByKey {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -87,12 +87,16 @@ object Node {
         * is why we removed the controllers field in transaction version 6.
         */
       controllers: Set[Party],
-      children: ImmArray[Nid])
+      children: ImmArray[Nid],
+      exerciseResult: Option[Val])
       extends GenNode[Nid, Cid, Val] {
     override def mapContractIdAndValue[Cid2, Val2](
         f: Cid => Cid2,
         g: Val => Val2): NodeExercises[Nid, Cid2, Val2] =
-      copy(targetCoid = f(targetCoid), chosenValue = g(chosenValue))
+      copy(
+        targetCoid = f(targetCoid),
+        chosenValue = g(chosenValue),
+        exerciseResult = exerciseResult.map(g))
 
     override def mapNodeId[Nid2](f: Nid => Nid2): NodeExercises[Nid2, Cid, Val] =
       copy(
@@ -116,7 +120,8 @@ object Node {
         chosenValue: Val,
         stakeholders: Set[Party],
         signatories: Set[Party],
-        children: ImmArray[Nid]): NodeExercises[Nid, Cid, Val] =
+        children: ImmArray[Nid],
+        exerciseResult: Option[Val]): NodeExercises[Nid, Cid, Val] =
       NodeExercises(
         targetCoid,
         templateId,
@@ -128,7 +133,8 @@ object Node {
         stakeholders,
         signatories,
         actingParties,
-        children)
+        children,
+        exerciseResult)
   }
 
   final case class NodeLookupByKey[+Cid, +Val](
@@ -202,11 +208,13 @@ object Node {
               stakeholders2,
               signatories2,
               controllers2,
-              _) =>
+              _,
+              exerciseResult2) =>
             import ne._
             targetCoid === targetCoid2 && templateId == templateId2 && choiceId == choiceId2 &&
             consuming == consuming2 && actingParties == actingParties2 && chosenValue === chosenValue2 &&
-            stakeholders == stakeholders2 && signatories == signatories2 && controllers == controllers2
+            stakeholders == stakeholders2 && signatories == signatories2 && controllers == controllers2 &&
+            exerciseResult.fold(true)(_ => exerciseResult === exerciseResult2)
           case _ => false
         }
       case nl: NodeLookupByKey[Cid, Val] =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -471,7 +471,7 @@ object Transaction {
     private def computeRoots: Set[NodeId] = {
       val allChildNodeIds: Set[NodeId] = nodes.values.flatMap {
         case _: LeafOnlyNode[_, _] => Nil
-        case NodeExercises(_, _, _, _, _, _, _, _, _, _, children) => children.toSeq
+        case NodeExercises(_, _, _, _, _, _, _, _, _, _, children, _) => children.toSeq
       }(breakOut)
 
       nodes.keySet diff allChildNodeIds
@@ -683,7 +683,7 @@ object Transaction {
       }
     }
 
-    def endExercises: (Option[NodeId], PartialTransaction) = {
+    def endExercises(value: Value[ContractId]): (Option[NodeId], PartialTransaction) = {
       context match {
         case ContextRoot =>
           (None, noteAbort(EndExerciseInRootContext))
@@ -700,7 +700,8 @@ object Transaction {
             ec.stakeholders,
             ec.signatories,
             ec.controllers,
-            exercisesChildren
+            exercisesChildren,
+            Some(value)
           )
           val nodeId = ec.exercisesNodeId
           val ptx =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -49,6 +49,7 @@ private[lf] object VersionTimeline {
       That(LanguageVersion(LMV.V1, "2")),
       Both(This(ValueVersion("4")), LanguageVersion(LMV.V1, "3")),
       This(That(TransactionVersion("6"))),
+      This(That(TransactionVersion("7"))),
       That(LanguageVersion(LMV.V1, Dev)),
       // add new versions above this line
       // do *not* backfill to make more Boths, because such would

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -117,7 +117,9 @@ object TransactionSpec {
       nodes: Map[String, GenNode[String, String, Value[String]]],
       roots: ImmArray[String]): StringTransaction = GenTransaction(nodes, roots, Set.empty)
 
-  def dummyExerciseNode(children: ImmArray[String]): NodeExercises[String, String, Value[String]] =
+  def dummyExerciseNode(
+      children: ImmArray[String],
+      hasExerciseResult: Boolean = true): NodeExercises[String, String, Value[String]] =
     NodeExercises(
       "dummyCoid",
       Ref.Identifier(
@@ -131,7 +133,8 @@ object TransactionSpec {
       Set.empty,
       Set.empty,
       Set.empty,
-      children
+      children,
+      if (hasExerciseResult) Some(V.ValueUnit) else None
     )
 
   val dummyCreateNode: NodeCreate[String, Value[String]] =

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -25,6 +25,19 @@ class TransactionVersionSpec extends WordSpec with Matchers {
         ValueOptional(Some(v)): Value[String])
       assignVersion(assignValueVersions(usingOptional)) shouldBe TransactionVersion("2")
     }
+
+    "pick version 7 when confronted with exercise result" in {
+      val hasExerciseResult = dummyExerciseWithResultTransaction mapContractIdAndValue (identity, v =>
+        ValueOptional(Some(v)): Value[String])
+      assignVersion(assignValueVersions(hasExerciseResult)) shouldBe TransactionVersion("7")
+    }
+
+    "pick version 2 when confronted with exercise result" in {
+      val hasExerciseResult = dummyExerciseTransaction mapContractIdAndValue (identity, v =>
+        ValueOptional(Some(v)): Value[String])
+      assignVersion(assignValueVersions(hasExerciseResult)) shouldBe TransactionVersion("2")
+    }
+
   }
 
   private[this] def assignValueVersions[Nid, Cid, Cid2](
@@ -35,8 +48,13 @@ class TransactionVersionSpec extends WordSpec with Matchers {
 }
 
 object TransactionVersionSpec {
-  import TransactionSpec.{dummyCreateNode, StringTransaction}
+  import TransactionSpec.{dummyCreateNode, dummyExerciseNode, StringTransaction}
   private[this] val singleId = "a"
   private val dummyCreateTransaction =
     StringTransaction(Map((singleId, dummyCreateNode)), ImmArray(singleId))
+  private val dummyExerciseWithResultTransaction =
+    StringTransaction(Map((singleId, dummyExerciseNode(ImmArray.empty))), ImmArray(singleId))
+  private val dummyExerciseTransaction =
+    StringTransaction(Map((singleId, dummyExerciseNode(ImmArray.empty, false))), ImmArray(singleId))
+
 }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -213,6 +213,7 @@ object TransactionGenerator {
     consuming <- Arbitrary.arbBool.arbitrary
     (scalaChildren, javaChildren) <- eventsGen
     witnessParties <- Gen.listOf(nonEmptyId)
+    (scalaExerciseResult, javaExerciseResult) <- Gen.sized(valueGen)
   } yield
     (
       Exercised(
@@ -226,7 +227,9 @@ object TransactionGenerator {
           actingParties,
           consuming,
           witnessParties,
-          Nil)), //TODO DEL-6007
+          Nil, //TODO DEL-6007
+          Some(scalaExerciseResult)
+        )),
       new data.ExercisedEvent(
         witnessParties.asJava,
         eventId,
@@ -237,8 +240,10 @@ object TransactionGenerator {
         javaChoiceArgument,
         actingParties.asJava,
         consuming,
-        Collections.emptyList()
-      ) //TODO DEL-6007
+        Collections.emptyList(),
+        //TODO DEL-6007
+        javaExerciseResult
+      )
     )
 
   val eventGen: Gen[(Event, data.Event)] =

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Event.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Event.java
@@ -43,7 +43,7 @@ public abstract class Event {
                     exercisedEvent.getContractId(), exercisedEvent.getContractCreatingEventId(),
                     exercisedEvent.getChoice(), Value.fromProto(exercisedEvent.getChoiceArgument()),
                     exercisedEvent.getActingPartiesList(), exercisedEvent.getConsuming(),
-                    exercisedEvent.getChildEventIdsList());
+                    exercisedEvent.getChildEventIdsList(), Value.fromProto(exercisedEvent.getExerciseResult()));
         } else {
             throw new UnsupportedEventTypeException(event.toString());
         }
@@ -63,7 +63,7 @@ public abstract class Event {
                     exercisedEvent.getContractId(), exercisedEvent.getContractCreatingEventId(),
                     exercisedEvent.getChoice(), Value.fromProto(exercisedEvent.getChoiceArgument()),
                     exercisedEvent.getActingPartiesList(), exercisedEvent.getConsuming(),
-                    exercisedEvent.getChildEventIdsList());
+                    exercisedEvent.getChildEventIdsList(), Value.fromProto(exercisedEvent.getExerciseResult()));
         } else {
             throw new UnsupportedEventTypeException(event.toString());
         }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
@@ -32,6 +32,8 @@ public class ExercisedEvent extends Event {
 
     private final List<String> childEventIds;
 
+    private final Value exerciseResult;
+
     public ExercisedEvent(@NonNull List<@NonNull String> witnessParties,
                           @NonNull String eventId,
                           @NonNull Identifier templateId,
@@ -41,7 +43,8 @@ public class ExercisedEvent extends Event {
                           @NonNull Value choiceArgument,
                           @NonNull List<@NonNull String> actingParties,
                           boolean consuming,
-                          @NonNull List<@NonNull String> childEventIds) {
+                          @NonNull List<@NonNull String> childEventIds,
+                          @NonNull Value exerciseResult) {
         this.witnessParties = witnessParties;
         this.eventId = eventId;
         this.templateId = templateId;
@@ -52,6 +55,7 @@ public class ExercisedEvent extends Event {
         this.actingParties = actingParties;
         this.consuming = consuming;
         this.childEventIds = childEventIds;
+        this.exerciseResult = exerciseResult;
     }
 
     @NonNull
@@ -106,6 +110,11 @@ public class ExercisedEvent extends Event {
         return consuming;
     }
 
+    @NonNull
+    public Value getExerciseResult() {
+        return exerciseResult;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -119,13 +128,14 @@ public class ExercisedEvent extends Event {
                 Objects.equals(contractCreatingEventId, that.contractCreatingEventId) &&
                 Objects.equals(choice, that.choice) &&
                 Objects.equals(choiceArgument, that.choiceArgument) &&
-                Objects.equals(actingParties, that.actingParties);
+                Objects.equals(actingParties, that.actingParties) &&
+                Objects.equals(exerciseResult, that.exerciseResult);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(witnessParties, eventId, templateId, contractId, contractCreatingEventId, choice, choiceArgument, actingParties, consuming);
+        return Objects.hash(witnessParties, eventId, templateId, contractId, contractCreatingEventId, choice, choiceArgument, actingParties, consuming, exerciseResult);
     }
 
     @Override
@@ -141,6 +151,7 @@ public class ExercisedEvent extends Event {
                 ", actingParties=" + actingParties +
                 ", consuming=" + consuming +
                 ", childEventIds=" + childEventIds +
+                ", exerciseResult=" + exerciseResult +
                 '}';
     }
 
@@ -156,6 +167,7 @@ public class ExercisedEvent extends Event {
                 .addAllActingParties(getActingParties())
                 .addAllWitnessParties(getWitnessParties())
                 .addAllChildEventIds(getChildEventIds())
+                .setExerciseResult(getExerciseResult().toProto())
                 .build();
     }
 
@@ -170,6 +182,7 @@ public class ExercisedEvent extends Event {
                 Value.fromProto(exercisedEvent.getChoiceArgument()),
                 exercisedEvent.getActingPartiesList(),
                 exercisedEvent.getConsuming(),
-                exercisedEvent.getChildEventIdsList());
+                exercisedEvent.getChildEventIdsList(),
+                Value.fromProto(exercisedEvent.getExerciseResult()));
     }
 }

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -236,7 +236,7 @@ object Generators {
       isConsuming <- Arbitrary.arbBool.arbitrary
       contractCreatingEventId <- Arbitrary.arbString.arbitrary
       witnessParties <- Gen.listOf(Arbitrary.arbString.arbitrary)
-
+      exerciseResult <- valueGen
     } yield
       EventOuterClass.ExercisedEvent
         .newBuilder()
@@ -249,6 +249,7 @@ object Generators {
         .setContractCreatingEventId(contractCreatingEventId)
         .setEventId(eventId)
         .addAllWitnessParties(witnessParties.asJava)
+        .setExerciseResult(exerciseResult)
         .build()
 
   def transactionFilterGen: Gen[TransactionFilterOuterClass.TransactionFilter] =

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -146,4 +146,9 @@ message ExercisedEvent {
   // It contains only the immediate children of this event, not all members of the subtree rooted at this node.
   // Optional
   repeated string child_event_ids = 11;
+
+  // The result of exercising the choice
+  // Required
+  Value exercise_result = 12;
+
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionConversion.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionConversion.scala
@@ -134,7 +134,16 @@ trait TransactionConversion {
       convert(exercise.actingParties),
       exercise.isConsuming,
       convert(exercise.witnesses),
-      exercise.children.toSeq.sortBy(getEventIndex)
+      exercise.children.toSeq.sortBy(getEventIndex),
+      exercise.exerciseResult.map(
+        er =>
+          LfEngineToApi
+            .lfValueToApiValue(verbose, er.value)
+            .fold(
+              err =>
+                throw new RuntimeException(
+                  s"Unexpected error when converting stored contract: $err"),
+              identity)),
     )
   }
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/semantictest/ApiScenarioTransform.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/semantictest/ApiScenarioTransform.scala
@@ -109,7 +109,10 @@ class ApiScenarioTransform(ledgerId: String, packages: Map[Ref.PackageId, Ast.Pa
         convertEvId: String => EventId)
       : Either[StatusRuntimeException, P.ExerciseEvent[EventId, AbsoluteContractId]] = {
       val witnesses = P.parties(exercisedEvent.witnessParties)
-      toLfVersionedValue(exercisedEvent.getChoiceArgument).map { value =>
+      for {
+        value <- toLfVersionedValue(exercisedEvent.getChoiceArgument)
+        result <- toLfVersionedValue(exercisedEvent.getExerciseResult)
+      } yield {
         P.ExerciseEvent(
           AbsoluteContractId(exercisedEvent.contractId),
           Ref.Identifier(
@@ -126,7 +129,8 @@ class ApiScenarioTransform(ledgerId: String, packages: Map[Ref.PackageId, Ast.Pa
           ImmArray(exercisedEvent.childEventIds.map(convertEvId)),
           // conversion is imperfect as stakeholders are not determinable from events yet
           witnesses,
-          witnesses
+          witnesses,
+          Some(result)
         )
       }
     }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerTestingHelpers.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerTestingHelpers.scala
@@ -15,7 +15,7 @@ import com.digitalasset.ledger.api.v1.command_service.{
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.commands.{CreateCommand, ExerciseCommand}
 import com.digitalasset.ledger.api.v1.completion.Completion
-import com.digitalasset.ledger.api.v1.event.Event.Event.{Archived, Created}
+import com.digitalasset.ledger.api.v1.event.Event.Event.{Archived, Created, Exercised}
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event, ExercisedEvent}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService
@@ -282,6 +282,11 @@ class LedgerTestingHelpers(
       .collect {
         case TreeEvent.Kind.Exercised(exercisedEvent) => exercisedEvent
       }(breakOut)
+
+  def exercisedEventsIn(transaction: Transaction): Seq[ExercisedEvent] =
+    transaction.events.map(_.event).collect {
+      case Exercised(exercisedEvent) => exercisedEvent
+    }
 
   def archivedEventsIn(transaction: Transaction): Seq[ArchivedEvent] =
     transaction.events.map(_.event).collect {

--- a/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Transaction.scala
+++ b/ledger/ledger-api-server-example/src/main/scala/com/digitalasset/ledger/example/Transaction.scala
@@ -43,7 +43,7 @@ object Transaction {
                     .explicitDisclosure(nodeEntry._1)
                     .intersect(node.stakeholders)))
             )
-          case node @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _) =>
+          case node @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _) =>
             TxDelta(
               // get consumed external contracts
               if (node.consuming) node.targetCoid match {

--- a/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Transaction.scala
+++ b/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Transaction.scala
@@ -43,7 +43,7 @@ object Transaction {
               delta.outputs + (node.coid ->
                 Contract(node.coinst, node.stakeholders))
             )
-          case node @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _) =>
+          case node @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _) =>
             TxDelta(
               // get consumed external contracts
               if (node.consuming) node.targetCoid match {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
@@ -206,7 +206,8 @@ class EventConverterSpec
             Set("Alice"),
             Set("Alice"),
             Set("Alice"),
-            ImmArray(Transaction.NodeId.unsafeFromIndex(1))
+            ImmArray(Transaction.NodeId.unsafeFromIndex(1)),
+            Some(asVersionedValueOrThrow(Lf.ValueUnit))
           ))
 
       val node1 = (
@@ -306,7 +307,11 @@ class EventConverterSpec
         true,
         ImmArray("#txId:2"),
         Set("giver", "receiver"),
-        Set("giver", "receiver")
+        Set("giver", "receiver"),
+        Some(
+          asVersionedValueOrThrow(
+            Lf.ValueContractId(Lf.AbsoluteContractId("#txId:3"))
+          ))
       )
       val events: Events[EventId, Lf.AbsoluteContractId, Lf.VersionedValue[Lf.AbsoluteContractId]] =
         Events(
@@ -317,13 +322,17 @@ class EventConverterSpec
               Ref.Identifier(
                 "0d25e199ed26977b3082864c62f8d154ca6042ed521712e2b3eb172dc79c87a2",
                 "Test:TriProposal"),
-              "Accept",
+              "TriProposalAccept",
               asVersionedValueOrThrow(Lf.ValueUnit),
               Set("receiver", "giver"),
               true,
               ImmArray("#txId:3"),
               Set("receiver", "giver", "operator"),
-              Set("receiver", "giver", "operator")
+              Set("receiver", "giver", "operator"),
+              Some(
+                asVersionedValueOrThrow(
+                  Lf.ValueContractId(Lf.AbsoluteContractId("#txId:3"))
+                ))
             ),
             "#txId:3" -> CreateEvent(
               Lf.AbsoluteContractId("#txId:3"),
@@ -384,12 +393,13 @@ class EventConverterSpec
             moduleName = "Test",
             entityName = "TriProposal")),
         "#6:0",
-        "Accept",
+        "TriProposalAccept",
         Some(Value(Value.Sum.Unit(Empty()))),
         Vector("receiver", "giver"),
         consuming = true,
         Vector("receiver", "giver", "operator"),
-        List(created.eventId)
+        List(created.eventId),
+        Some(Value(ContractId("#txId:3")))
       )
       val topLevelExercise = ExercisedEvent(
         "#txId:0",
@@ -415,7 +425,8 @@ class EventConverterSpec
         Vector("giver"),
         consuming = true,
         Vector("giver", "receiver"),
-        List(nestedExercise.eventId)
+        List(nestedExercise.eventId),
+        Some(Value(ContractId("#txId:3")))
       )
 
       val expected = TransactionTreeNodes(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -323,7 +323,11 @@ class PostgresDaoSpec
                 VersionedValue(ValueVersions.acceptedVersions.head, ValueText("some choice value")),
                 Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
                 Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
-                ImmArray.empty
+                ImmArray.empty,
+                Some(
+                  VersionedValue(
+                    ValueVersions.acceptedVersions.head,
+                    ValueText("some exercise result"))),
               )),
             ImmArray(s"event$id"),
             Set.empty


### PR DESCRIPTION
Modify the DAML Engine, Ledger API and Sandbox to pass the result of the
exercise as a field of the Exercise Events.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
