### PR TITLE
Build //daml-assistant:daml on Windows

### DIFF
--- a/bazel_tools/haskell-static-linking.patch
+++ b/bazel_tools/haskell-static-linking.patch
@@ -1,9 +1,9 @@
 This is required to get the GHCi/TH linker to pick up static Haskell libs.
 Buck uses the same trick. On Windows we retain the original behavior.
 
-Moreover on Windows we add extra system dependencies for grpc. The solution is
-not ideal but works well; for a proper solution we need better system library
-support in rules_haskell: https://github.com/tweag/rules_haskell/issues/834
+Moreover on Windows we add extra system dependencies. The solution is not ideal
+but works well; for a proper solution we need better system library support in
+rules_haskell: https://github.com/tweag/rules_haskell/issues/834
 diff --git a/haskell/haskell.bzl b/haskell/haskell.bzl
 index 7d26a6d..e2a289b 100644
 --- a/haskell/haskell.bzl
@@ -36,7 +36,7 @@ index 2163c02..37a6d07 100644
  
 +    metadata_entries_extras = {
 +        "hs-libraries": pkg_id.library_name(hs, my_pkg_id),
-+        "extra-libraries": " ".join(extra_libs + (["stdc++", "crypt32", "ws2_32"] if my_pkg_id.name == "grpc-haskell-core" else [])),
++        "extra-libraries": " ".join(extra_libs + ["stdc++", "crypt32", "ws2_32"]),
 +        } if hs.toolchain.is_windows else {
 +        "extra-libraries": " ".join([pkg_id.library_name(hs, my_pkg_id)] + extra_libs),
 +    }

--- a/build.ps1
+++ b/build.ps1
@@ -45,6 +45,7 @@ function build-full() {
         //:git-revision `
         @com_github_grpc_grpc//:grpc `
         //nix/third-party/gRPC-haskell:grpc-haskell `
+        //daml-assistant:daml `
         //daml-foundations/daml-tools/daml-extension:daml_extension_lib `
         //daml-foundations/daml-tools/language-server-tests:lib-js `
         //daml-lf/archive:daml_lf_archive_scala `


### PR DESCRIPTION
- Fix linker errors by generally linking against Windows system libraries (`stdc++`, `crypt32`, `ws2_32`)
- Build `//daml-assistant:daml` on Windows CI

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
