### PR TITLE
run perf tests separately

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,32 @@ jobs:
     steps:
       - template: ci/build-windows.yml
 
+  - job: perf
+    timeoutInMinutes: 30
+    pool:
+      name: 'linux-pool'
+    steps:
+      - checkout: self
+      - bash: ci/dev-env-install.sh
+        displayName: 'Build/Install the Developer Environment'
+      - bash: ci/configure-bazel.sh
+        displayName: 'Configure Bazel'
+        env:
+          IS_FORK: $(System.PullRequest.IsFork)
+          # to upload to the bazel cache
+          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bazel run -- //ledger/sandbox-perf -foe true -i1 -f1 -wi 1 -bm avgt -rf csv -rff "$(Build.StagingDirectory)/sandbox-perf.csv"
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        inputs:
+          pathtoPublish: '$(Build.StagingDirectory)'
+          artifactName: 'Perf test logs'
+
   - job: release
-    dependsOn: [ "Linux", "macOS", "Windows"]
+    dependsOn: [ "linux", "macos", "windows", "perf"]
     pool:
       vmImage: "Ubuntu-16.04"
     condition: and(succeeded(),

--- a/build.sh
+++ b/build.sh
@@ -27,14 +27,5 @@ ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 bazel test -j 200 //... --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null
-# Execute Sandbox performance tests if on master
-# On Jenkins we never run them as BUILD_SOURCEBRANCHNAME isn’t set.
-# moreover, pass -foe true to make the benchmark fail with a proper
-# exit code if things go wrong, rather than pretend that everything is
-# fine.
-if [[ "${BUILD_SOURCEBRANCHNAME:-master}" = master ]]; then
-    bazel run -- //ledger/sandbox-perf -foe true -i1 -f1 -wi 1 -bm avgt -rf csv -rff "$ARTIFACT_DIRS/sandbox-perf.csv" # 1 warmup, 1 iterations in 1 fork
-fi
-
 # Check that we can load damlc in ghci
 da-ghci damlc -e '()'


### PR DESCRIPTION
Perf tests on macOS are taking too long and are deemed unnecessary by the DAML Language team (at least @bitonic and @gaboraranyossy-da). The Linux pool is under our control, can have more and beefier machines, and running perf in parallel should reduce its impact on overall build time.