### PR TITLE
Fix daml wrapper on Windows

### DIFF
--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -164,7 +164,7 @@ activateDaml env@InstallEnv{..} targetPath = do
 
     requiredIO ("Failed to link daml binary in " <> pack damlBinaryTargetDir) $
         if isWindows
-            then writeFile damlBinaryTargetPath ("START " <> damlBinarySourcePath <> " %*")
+            then writeFile damlBinaryTargetPath (damlBinarySourcePath <> " %*")
             else createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
 
     unlessQuiet env $ do -- Ask user to add .daml/bin to PATH if it is absent.


### PR DESCRIPTION
Apart from the fact that START was missing the windows title argument
it launches a new terminal window and then exits immediately (the
terminal windows is closed immediately as well) so it seems like the
wrong thing to use. Just calling the executable directly seems to work
fine both in cmd.exe and in powershell on my Windows 10 VM so
hopefully this is reasonably robust.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
