### PR TITLE
Fix termination of scenario service on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
       - template: ci/build-windows.yml
 
   - job: perf
-    timeoutInMinutes: 30
+    timeoutInMinutes: 60
     pool:
       name: 'linux-pool'
     steps:

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -118,7 +118,7 @@ javaProc :: [String] -> IO CreateProcess
 javaProc args =
   lookupEnv "JAVA_HOME" >>= return . \case
     Nothing ->
-      proc "/usr/bin/env" ("java" : args)
+      proc "java" args
     Just javaHome ->
       let javaExe = javaHome </> "bin" </> "java"
       in proc javaExe args
@@ -150,12 +150,6 @@ start opts@Options{..} = do
       liftIO $ throwIO (ScenarioServiceException (optServerJar <> " does not exist."))
   liftIO $ validateJava opts
   cp <- liftIO $ javaProc ["-jar" , optServerJar]
-  -- we create the stdin handle because the server uses the pipe to
-  -- detect when the client is dead to kill itself. we rely on this
-  -- for this function to terminate cleanly: after the continuation has
-  -- ran, we close the handle, and then @withCheckedProcessCleanup@
-  -- will wait for the server to have died before terminating itself.
-  --
   port <- managed $ \resume -> withCheckedProcessCleanup cp $ \(stdinHdl :: System.IO.Handle) stdoutSrc stderrSrc -> do
     let splitOutput = C.T.decode C.T.utf8 .| C.T.lines
     let printStderr line = liftIO (optLogError (T.unpack ("SCENARIO SERVICE STDERR: " <> line)))
@@ -174,12 +168,15 @@ start opts@Options{..} = do
                 _ -> do
                   liftIO (optLogError ("Expected PORT=<port> from scenario service, but got '" <> line <> "'. Ignoring it."))
                   handleStdout
-
-    bracket (pure stdinHdl) System.IO.hClose $ \_ ->
-      withAsync (runConduit (stderrSrc .| splitOutput .| C.awaitForever printStderr)) $ \_ ->
-      withAsync (runConduit (stdoutSrc .| splitOutput .| handleStdout)) $ \_ -> do
-        System.IO.hFlush System.IO.stdout
-        either error resume =<< takeMVar portMVar
+    withAsync (runConduit (stderrSrc .| splitOutput .| C.awaitForever printStderr)) $ \_ ->
+        withAsync (runConduit (stdoutSrc .| splitOutput .| handleStdout)) $ \_ ->
+        -- The scenario service will shut down cleanly when stdin is closed so we do this at the end of
+        -- the callback. Note that on Windows, killThread will not be able to kill the conduits
+        -- if they are blocked in hGetNonBlocking so it is crucial that we close stdin in the
+        -- callback or withAsync will block forever.
+        flip finally (System.IO.hClose stdinHdl) $ do
+            System.IO.hFlush System.IO.stdout
+            either error resume =<< takeMVar portMVar
   liftIO $ optLogInfo $ "Scenario service backend running on port " <> show port
   let grpcConfig = ClientConfig (Host "localhost") (Port port) [] Nothing
   client <- managed (withGRPCClient grpcConfig)

--- a/daml-foundations/daml-ghc/package-database/util.bzl
+++ b/daml-foundations/daml-ghc/package-database/util.bzl
@@ -76,11 +76,10 @@ def _daml_package_rule_impl(ctx):
         tools = [ctx.executable.damlc_bootstrap],
         progress_message = "Compiling " + name + ".daml to daml-lf " + ctx.attr.daml_lf_version,
         command = """
-      set -eoux pipefail
+      set -eou pipefail
       mkdir -p tmp_db
       tar xf {db_tar} -C tmp_db --strip-components 1
       mkdir -p tmp_db/{daml_lf_version}
-      ls -lR tmp_db
 
       # Compile the dalf file
       {damlc_bootstrap} compile \
@@ -160,7 +159,7 @@ def _daml_package_db_impl(ctx):
         outputs = [ctx.outputs.tar],
         command =
             """
-        set -eoux pipefail
+        set -eou pipefail
         shopt -s nullglob
         TMP_DIR=$(mktemp -d)
         PACKAGE_DB="$TMP_DIR/package_db"

--- a/daml-foundations/daml-ghc/package-database/util.bzl
+++ b/daml-foundations/daml-ghc/package-database/util.bzl
@@ -76,9 +76,11 @@ def _daml_package_rule_impl(ctx):
         tools = [ctx.executable.damlc_bootstrap],
         progress_message = "Compiling " + name + ".daml to daml-lf " + ctx.attr.daml_lf_version,
         command = """
+      set -eoux pipefail
       mkdir -p tmp_db
       tar xf {db_tar} -C tmp_db --strip-components 1
       mkdir -p tmp_db/{daml_lf_version}
+      ls -lR tmp_db
 
       # Compile the dalf file
       {damlc_bootstrap} compile \


### PR DESCRIPTION
The lack of a proper Windows IO manager resulted in us being unable to
kill the conduits reading the output of the scenario service so `damlc
test` and `damlc ide` blocked forever. This PR fixes the problem by
shutting down the scenario service (by closing its stdin) before
killing the conduits .

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
