### PR TITLE
Document flexible controllers...

### DIFF
--- a/docs/source/daml/code-snippets/Reference.daml
+++ b/docs/source/daml/code-snippets/Reference.daml
@@ -32,53 +32,33 @@ template NameOfTemplate
       ""
 -- end template agree snippet
 -- start template choice snippet
-    -- option 2 for specifying choices: controller first
-    controller exampleParty can
-      NameOfChoice
-          : () -- replace () with the actual return type
-        with
-          exampleParameter : Text -- parameters here
-        do
-          return () -- replace this line with the choice body
-      nonconsuming NameOfChoice2
-          : ()  -- replace () with the actual return type
-        with
-          exampleParameter : Text -- parameters here
-        do
-          return () -- replace this line with the choice body
-
     -- option 1 for specifying choices: choice name first
-    choice NameOfChoice3
+    choice NameOfChoice1
           : ()  -- replace () with the actual return type
         with
           exampleParameter : Text -- parameters here
       controller exampleParty
         do
           return () -- replace this line with the choice body
+
+    -- option 2 for specifying choices: controller first
+    controller exampleParty can
+      NameOfChoice2
+          : () -- replace () with the actual return type
+        with
+          exampleParameter : Text -- parameters here
+        do
+          return () -- replace this line with the choice body
+      nonconsuming NameOfChoice3
+          : ()  -- replace () with the actual return type
+        with
+          exampleParameter : Text -- parameters here
+        do
+          return () -- replace this line with the choice body
 -- end template choice snippet
 
--- start controller-first controller snippet
-    controller exampleParty can
--- end controller-first controller snippet
--- start controller-first choice name snippet
-      NameOfChoice4
-          : () -- replace () with the actual return type
--- end controller-first choice name snippet
--- start controller-first params snippet
-        with
-          exampleParameter : Text
--- end controller-first params snippet
-        do
-          return () -- replace () with the actual return type
--- start controller-first nonconsuming snippet
-      nonconsuming NameOfChoice5
-          : () -- replace () with the actual return type
--- end controller-first nonconsuming snippet
-        do
-          return () -- replace () with the actual return type
-
 -- start choice-first choice name snippet
-    choice NameOfChoice6
+    choice ExampleChoice1
           : () -- replace () with the actual return type
 -- end choice-first choice name snippet
 -- start choice-first params snippet
@@ -90,13 +70,31 @@ template NameOfTemplate
 -- end choice-first controller snippet
         do
           return () -- replace () with the actual return type
--- end template choice snippet
-
 -- start choice-first nonconsuming snippet
-    nonconsuming choice NameOfChoice7
+    nonconsuming choice ExampleChoice3
           : () -- replace () with the actual return type
 -- end choice-first nonconsuming snippet
         with -- params
         controller exampleParty
           do
             return ()
+
+-- start controller-first controller snippet
+    controller exampleParty can
+-- end controller-first controller snippet
+-- start controller-first choice name snippet
+      ExampleChoice2
+          : () -- replace () with the actual return type
+-- end controller-first choice name snippet
+-- start controller-first params snippet
+        with
+          exampleParameter : Text
+-- end controller-first params snippet
+        do
+          return () -- replace () with the actual return type
+-- start controller-first nonconsuming snippet
+      nonconsuming ExampleChoice4
+          : () -- replace () with the actual return type
+-- end controller-first nonconsuming snippet
+        do
+          return () -- replace () with the actual return type

--- a/docs/source/daml/code-snippets/Reference.daml
+++ b/docs/source/daml/code-snippets/Reference.daml
@@ -4,41 +4,96 @@
 daml 1.2
 module Reference where
 type ExampleReturnType = ()
+
+-- start template intro snippet
 template NameOfTemplate
+-- end template intro snippet
+-- start template params snippet
   with
     exampleParty : Party
     exampleParty2 : Party
     exampleParty3 : Party
     -- more parameters here
+-- end template params snippet
+-- start template sigs snippet
   where
     signatory exampleParty
+-- end template sigs snippet
+-- start template obs snippet
     observer exampleParty2
+-- end template obs snippet
+-- start template ensure snippet
     ensure
-      -- boolean condition
-      True
+      True -- a boolean condition goes here
+-- end template ensure snippet
+-- start template agree snippet
     agreement
       -- text representing the contract
       ""
+-- end template agree snippet
+-- start template choice snippet
     controller exampleParty can
-      -- a choice goes here; see next page
       NameOfChoice
-          : ()
-        do
-          return ()
-
-      nonconsuming NameOfChoice2
-          : ()
-        do
-          return ()
-
-
-      NameOfChoice3 : ExampleReturnType
+          : () -- replace () with the actual return type
         with
           exampleParameter : Text
         do
-          -- choice body goes here
-          return ()
-
-      NameOfChoice4 : ContractId NameOfTemplate
+          return () -- replace this line with the choice body
+      nonconsuming NameOfChoice2
+          : ()  -- replace () with the actual return type
+        with
+          exampleParameter : Text
         do
-          create NameOfTemplate with exampleParty; exampleParty2; exampleParty3
+          return () -- replace this line with the choice body
+    choice NameOfChoice3
+          : ()  -- replace () with the actual return type
+        with
+          exampleParameter : Text
+      controller exampleParty
+        do
+          return () -- replace this line with the choice body
+-- end template choice snippet
+
+-- start controller-first controller snippet
+    controller exampleParty can
+-- end controller-first controller snippet
+-- start controller-first choice name snippet
+      NameOfChoice4
+          : () -- replace () with the actual return type
+-- end controller-first choice name snippet
+-- start controller-first params snippet
+        with
+          exampleParameter : Text
+-- end controller-first params snippet
+        do
+          return () -- replace () with the actual return type
+-- start controller-first nonconsuming snippet
+      nonconsuming NameOfChoice5
+          : () -- replace () with the actual return type
+-- end controller-first nonconsuming snippet
+        do
+          return () -- replace () with the actual return type
+
+-- start choice-first choice name snippet
+    choice NameOfChoice6
+          : () -- replace () with the actual return type
+-- end choice-first choice name snippet
+-- start choice-first params snippet
+        with
+          exampleParameter : Text
+-- end choice-first params snippet
+-- start choice-first controller snippet
+      controller exampleParty
+-- end choice-first controller snippet
+        do
+          return () -- replace () with the actual return type
+-- end template choice snippet
+
+-- start choice-first nonconsuming snippet
+    nonconsuming choice NameOfChoice7
+          : () -- replace () with the actual return type
+-- end choice-first nonconsuming snippet
+        with -- params
+        controller exampleParty
+          do
+            return ()

--- a/docs/source/daml/code-snippets/Reference.daml
+++ b/docs/source/daml/code-snippets/Reference.daml
@@ -32,23 +32,26 @@ template NameOfTemplate
       ""
 -- end template agree snippet
 -- start template choice snippet
+    -- option 2 for specifying choices: controller first
     controller exampleParty can
       NameOfChoice
           : () -- replace () with the actual return type
         with
-          exampleParameter : Text
+          exampleParameter : Text -- parameters here
         do
           return () -- replace this line with the choice body
       nonconsuming NameOfChoice2
           : ()  -- replace () with the actual return type
         with
-          exampleParameter : Text
+          exampleParameter : Text -- parameters here
         do
           return () -- replace this line with the choice body
+
+    -- option 1 for specifying choices: choice name first
     choice NameOfChoice3
           : ()  -- replace () with the actual return type
         with
-          exampleParameter : Text
+          exampleParameter : Text -- parameters here
       controller exampleParty
         do
           return () -- replace this line with the choice body

--- a/docs/source/daml/code-snippets/Structure.daml
+++ b/docs/source/daml/code-snippets/Structure.daml
@@ -21,14 +21,26 @@ template NameOfTemplate
     ensure
       -- boolean condition
       True
-    controller exampleParty3 can
-      -- a choice goes here; see next section
-      -- end of template outline snippet
-      NameOfChoice : -- return type here
-          ()
+    -- a choice goes here; see next section
+    -- end of template outline snippet
+    -- start of choice snippet
+    -- option 1 for specifying choices: choice name first
+    choice NameOfChoice : 
+          () -- replace () with the actual return type
+        with
+        -- parameters here
+        party : Party
+      controller party
+        do
+          return () -- replace this line with the choice body
+
+    -- option 2 for specifying choices: controller first
+    controller exampleParty can
+      NameOfAnotherChoice :
+          () -- replace () with the actual return type
         with
           -- parameters here
           party : Party
         do
-          -- choice body; see next section
-          return ()
+          return () -- replace the line with the choice body
+      -- end of choice snippet

--- a/docs/source/daml/code-snippets/Structure.daml
+++ b/docs/source/daml/code-snippets/Structure.daml
@@ -25,11 +25,10 @@ template NameOfTemplate
     -- end of template outline snippet
     -- start of choice snippet
     -- option 1 for specifying choices: choice name first
-    choice NameOfChoice : 
+    choice NameOfChoice :
           () -- replace () with the actual return type
         with
-        -- parameters here
-        party : Party
+        party : Party -- parameters here
       controller party
         do
           return () -- replace this line with the choice body
@@ -39,8 +38,7 @@ template NameOfTemplate
       NameOfAnotherChoice :
           () -- replace () with the actual return type
         with
-          -- parameters here
-          party : Party
+          party : Party -- parameters here
         do
           return () -- replace the line with the choice body
       -- end of choice snippet

--- a/docs/source/daml/code-snippets/Structure.daml
+++ b/docs/source/daml/code-snippets/Structure.daml
@@ -26,7 +26,7 @@ template NameOfTemplate
     -- start of choice snippet
     -- option 1 for specifying choices: choice name first
     choice NameOfChoice :
-          () -- replace () with the actual return type
+          ReturnType -- replace ReturnType with the actual return type
         with
         party : Party -- parameters here
       controller party
@@ -36,7 +36,7 @@ template NameOfTemplate
     -- option 2 for specifying choices: controller first
     controller exampleParty can
       NameOfAnotherChoice :
-          () -- replace () with the actual return type
+          ReturnType -- replace ReturnType with the actual return type
         with
           party : Party -- parameters here
         do

--- a/docs/source/daml/code-snippets/Structure.daml
+++ b/docs/source/daml/code-snippets/Structure.daml
@@ -26,7 +26,7 @@ template NameOfTemplate
     -- start of choice snippet
     -- option 1 for specifying choices: choice name first
     choice NameOfChoice :
-          ReturnType -- replace ReturnType with the actual return type
+          () -- replace () with the actual return type
         with
         party : Party -- parameters here
       controller party
@@ -36,7 +36,7 @@ template NameOfTemplate
     -- option 2 for specifying choices: controller first
     controller exampleParty can
       NameOfAnotherChoice :
-          ReturnType -- replace ReturnType with the actual return type
+          () -- replace () with the actual return type
         with
           party : Party -- parameters here
         do

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -10,32 +10,22 @@ This page gives reference information on choices:
 
 For information on the high-level structure of a choice, see :doc:`structure`.
 
-There are two ways you can start a choice: choice-name-first or controller-first.
+``choice`` first or ``controller`` first
+****************************************
+
+There are two ways you can start a choice:
+
+- start with the ``choice`` keyword
+- start with the ``controller`` keyword
 
 .. literalinclude:: ../code-snippets/Structure.daml
    :language: daml
    :start-after: -- start of choice snippet
    :end-before: -- end of choice snippet
 
-.. _daml-ref-controllers:
+The main difference is that starting with ``choice`` means that you can pass in a ``Party`` to use as a controller. If you do this, you **must** make sure that you add that party as an ``observer``, otherwise they won't be able to see the contract (and therefore won't be able to exercise the choice).
 
-Controllers
-***********
-
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :start-after: -- start controller-first controller snippet
-   :end-before: -- end controller-first controller snippet
-
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :start-after: -- start choice-first controller snippet
-   :end-before: -- end choice-first controller snippet
-
-- ``controller`` keyword
-- The controller is a comma-separated list of values, where each value is either a party or a collection of parties.
-
-  The conjunction of **all** the parties are required to authorize when this choice is exercised.
+In contrast, if you start with ``controller``, the ``controller`` is automatically added as an observer when you compile your DAML files.
 
 .. _daml-ref-choice-name:
 
@@ -44,18 +34,43 @@ Choice name
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :start-after: -- start controller-first choice name snippet
-   :end-before: -- end controller-first choice name snippet
+   :start-after: -- start choice-first choice name snippet
+   :end-before: -- end choice-first choice name snippet
+   :caption: Option 1 for specifying choices: choice name first
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :start-after: -- start choice-first choice name snippet
-   :end-before: -- end choice-first choice name snippet
+   :start-after: -- start controller-first choice name snippet
+   :end-before: -- end controller-first choice name snippet
+   :caption: Option 2 for specifying choices: controller first
+
 
 - The name of the choice. Must begin with a capital letter.
-- TODO: if using choice-first, preface with ``choice``.
+- If you're using choice-first, preface with ``choice``. Otherwise, this isn't needed.
 - Must be unique in your project. Choices in different templates can't have the same name.
-- TODO: if using controller-first, you can have multiple choices after one ``can``, for tidiness.
+- If you're using controller-first, you can have multiple choices after one ``can``, for tidiness.
+
+.. _daml-ref-controllers:
+
+Controllers
+***********
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first controller snippet
+   :end-before: -- end choice-first controller snippet
+   :caption: Option 1 for specifying choices: choice name first
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start controller-first controller snippet
+   :end-before: -- end controller-first controller snippet
+   :caption: Option 2 for specifying choices: controller first
+
+- ``controller`` keyword
+- The controller is a comma-separated list of values, where each value is either a party or a collection of parties.
+
+  The conjunction of **all** the parties are required to authorize when this choice is exercised.
 
 .. _daml-ref-anytime:
 
@@ -64,13 +79,15 @@ Non-consuming choices
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :start-after: -- start controller-first nonconsuming snippet
-   :end-before: -- end controller-first nonconsuming snippet
+   :start-after: -- start choice-first nonconsuming snippet
+   :end-before: -- end choice-first nonconsuming snippet
+   :caption: Option 1 for specifying choices: choice name first
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :start-after: -- start choice-first nonconsuming snippet
-   :end-before: -- end choice-first nonconsuming snippet
+   :start-after: -- start controller-first nonconsuming snippet
+   :end-before: -- end controller-first nonconsuming snippet
+   :caption: Option 2 for specifying choices: controller first
 
 - ``nonconsuming`` keyword. Optional.
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
@@ -91,11 +108,6 @@ Return type
 
 Choice arguments
 ****************
-
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :start-after: -- start controller-first params snippet
-   :end-before: -- end controller-first params snippet
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -8,7 +8,14 @@ This page gives reference information on choices:
 
 .. contents:: :local:
 
-For the structure of a choice, see :doc:`structure`.
+For information on the high-level structure of a choice, see :doc:`structure`.
+
+There are two ways you can start a choice: choice-name-first or controller-first.
+
+.. literalinclude:: ../code-snippets/Structure.daml
+   :language: daml
+   :start-after: -- start of choice snippet
+   :end-before: -- end of choice snippet
 
 .. _daml-ref-controllers:
 
@@ -17,8 +24,13 @@ Controllers
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 22
-   :dedent: 4
+   :start-after: -- start controller-first controller snippet
+   :end-before: -- end controller-first controller snippet
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first controller snippet
+   :end-before: -- end choice-first controller snippet
 
 - ``controller`` keyword
 - The controller is a comma-separated list of values, where each value is either a party or a collection of parties.
@@ -32,22 +44,33 @@ Choice name
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 22,24
-   :dedent: 4
+   :start-after: -- start controller-first choice name snippet
+   :end-before: -- end controller-first choice name snippet
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first choice name snippet
+   :end-before: -- end choice-first choice name snippet
 
 - The name of the choice. Must begin with a capital letter.
+- TODO: if using choice-first, preface with ``choice``.
 - Must be unique in your project. Choices in different templates can't have the same name.
-- You can have multiple choices after one ``can``, for tidiness.
+- TODO: if using controller-first, you can have multiple choices after one ``can``, for tidiness.
 
 .. _daml-ref-anytime:
 
 Non-consuming choices
-*********************
+=====================
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 22,29
-   :dedent: 4
+   :start-after: -- start controller-first nonconsuming snippet
+   :end-before: -- end controller-first nonconsuming snippet
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first nonconsuming snippet
+   :end-before: -- end choice-first nonconsuming snippet
 
 - ``nonconsuming`` keyword. Optional.
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
@@ -58,12 +81,7 @@ Non-consuming choices
 .. _daml-ref-return-type:
 
 Return type
-***********
-
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :lines: 22,42
-   :dedent: 4
+===========
 
 - Return type is written immediately after choice name.
 - All choices have a return type. A contract returning nothing should be marked as returning a "unit", ie ``()``.
@@ -76,8 +94,13 @@ Choice arguments
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 22,35-37
-   :dedent: 4
+   :start-after: -- start controller-first params snippet
+   :end-before: -- end controller-first params snippet
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first params snippet
+   :end-before: -- end choice-first params snippet
 
 - ``with`` keyword.
 - Choice arguments are similar in structure to :ref:`daml-ref-template-parameters`: a :ref:`record type <daml-ref-record-types>`.
@@ -88,10 +111,6 @@ Choice arguments
 
 Choice body
 ***********
-
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :lines: 22,42-44
 
 - Introduced with ``do``
 - The logic in this section is what is executed when the choice gets exercised.

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -8,8 +8,6 @@ This page covers what a template looks like: what parts of a template there are,
 
 For the structure of a DAML file *outside* a template, see :doc:`file-structure`.
 
-.. contents:: :local:
-
 .. _daml-ref-template-structure:
 
 Template outline structure
@@ -35,12 +33,12 @@ template body
     :ref:`signatories <daml-ref-signatories>`
         ``signatory`` keyword
 
-        The parties (see the :ref:`Party <daml-ref-built-in-types>` type) who must consent to the creation of an instance of this contract.
+        The parties (see the :ref:`Party <daml-ref-built-in-types>` type) who must consent to the creation of an instance of this contract. You won't be able to create an instance of this contract until all of these parties have authorized it.
 
     :ref:`observers <daml-ref-observers>`
     	``observer`` keyword
 
-    	Parties that aren't signatories but can still see this contract.
+    	Parties that aren't signatories but who you still want to be able to see this contract.
 
     :ref:`an agreement <daml-ref-agreements>`
         ``agreement`` keyword
@@ -71,8 +69,6 @@ Here's the structure of a choice inside a template. There are two ways of specif
 - start with the ``choice`` keyword
 - start with the ``controller`` keyword
 
-TODO compare and contrast
-
 .. literalinclude:: ../code-snippets/Structure.daml
    :language: daml
    :start-after: -- start of choice snippet
@@ -82,12 +78,12 @@ TODO compare and contrast
 :ref:`a controller (or controllers) <daml-ref-controllers>`
     ``controller`` keyword
 
-    Who can exercise the choice. TODO explain flexible controllers
+    Who can exercise the choice.
 
 :ref:`consumability <daml-ref-anytime>`
     ``nonconsuming`` keyword
 
-    By default, contracts are archived when a choice on them is exercised. If you include ``nonconsuming``, this choice can be exercised over and over.
+    By default, contracts are archived when a choice on them is exercised, which means that choices can no longer be exercised on them. If you include ``nonconsuming``, this choice can be exercised over and over.
 
 :ref:`a name <daml-ref-choice-name>`
     Must begin with a capital letter. Must be unique - choices in different templates can't have the same name.
@@ -98,7 +94,7 @@ TODO compare and contrast
 :ref:`choice arguments <daml-ref-choice-arguments>`
     ``with`` keyword
 
-    TODO: explain about passing party in
+    If you start your choice with ``choice`` and include a ``Party`` as a parameter, you can make that ``Party`` the ``controller`` of the choice. This is a feature called "flexible controllers", and it means you don't have to specify the controller when you create the contract - you can specify it when you exercise the choice. The ``Party`` still needs to be a parameter to the contract as well, so that they can be added as an observer.
 
 :ref:`a choice body <daml-ref-choice-body>`
     After ``do`` keyword
@@ -147,14 +143,12 @@ The update expressions are:
 :ref:`return <daml-ref-return>`
     Explicitly return a value. By default, a choice returns the result of its last update expression. This means you only need to use ``return`` if you want to return something else.
 
-    ``return amount``
+    ``return ContractID ExampleTemplate``
 
 The choice body can also contain:
 
 :ref:`let <daml-ref-let-update>` keyword
     Used to assign values or functions.
-
-    .. Changes in DAML 1.2.
 
 assign a value to the result of an update statement
    For example: ``contractFetched <- fetch someContractId``

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -53,7 +53,11 @@ template body
         Only create the contract if the conditions after ``ensure`` evaluate to true.
 
     :ref:`choices <daml-ref-choice-structure>`
-    	``controller nameOfParty can nameOfChoice``
+    	``controller nameOfParty can nameOfChoice do``
+
+        or
+
+        ``choice : () controller do``
 
         Defines choices that can be exercised. See `Choice structure`_ for what can go in a choice.
 
@@ -62,17 +66,23 @@ template body
 Choice structure
 ****************
 
-Here's the structure of a choice inside a template:
+Here's the structure of a choice inside a template. There are two ways of specifying a choice:
+
+- start with the ``choice`` keyword
+- start with the ``controller`` keyword
+
+TODO compare and contrast
 
 .. literalinclude:: ../code-snippets/Structure.daml
    :language: daml
-   :lines: 24,27-34
+   :start-after: -- start of choice snippet
+   :end-before: -- end of choice snippet
    :dedent: 4
 
 :ref:`a controller (or controllers) <daml-ref-controllers>`
     ``controller`` keyword
 
-    Who can exercise the choice.
+    Who can exercise the choice. TODO explain flexible controllers
 
 :ref:`consumability <daml-ref-anytime>`
     ``nonconsuming`` keyword
@@ -87,6 +97,8 @@ Here's the structure of a choice inside a template:
 
 :ref:`choice arguments <daml-ref-choice-arguments>`
     ``with`` keyword
+
+    TODO: explain about passing party in
 
 :ref:`a choice body <daml-ref-choice-body>`
     After ``do`` keyword

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -51,11 +51,11 @@ template body
         Only create the contract if the conditions after ``ensure`` evaluate to true.
 
     :ref:`choices <daml-ref-choice-structure>`
-    	``controller nameOfParty can nameOfChoice do``
+        ``choice NameOfChoice : ReturnType controller nameOfParty do``
 
         or
 
-        ``choice : () controller do``
+    	``controller nameOfParty can NameOfChoice : ReturnType do``
 
         Defines choices that can be exercised. See `Choice structure`_ for what can go in a choice.
 
@@ -94,7 +94,7 @@ Here's the structure of a choice inside a template. There are two ways of specif
 :ref:`choice arguments <daml-ref-choice-arguments>`
     ``with`` keyword
 
-    If you start your choice with ``choice`` and include a ``Party`` as a parameter, you can make that ``Party`` the ``controller`` of the choice. This is a feature called "flexible controllers", and it means you don't have to specify the controller when you create the contract - you can specify it when you exercise the choice. The ``Party`` still needs to be a parameter to the contract as well, so that they can be added as an observer.
+    If you start your choice with ``choice`` and include a ``Party`` as a parameter, you can make that ``Party`` the ``controller`` of the choice. This is a feature called "flexible controllers", and it means you don't have to specify the controller when you create the contract - you can specify it when you exercise the choice. To exercise a choice, the party needs to be a signatory or an observer of the contract and must be explicitly declared as such.
 
 :ref:`a choice body <daml-ref-choice-body>`
     After ``do`` keyword

--- a/docs/source/daml/reference/templates.rst
+++ b/docs/source/daml/reference/templates.rst
@@ -6,8 +6,6 @@ Reference: templates
 
 This page gives reference information on templates:
 
-.. contents:: :local:
-
 For the structure of a template, see :doc:`structure`.
 
 .. _daml-ref-template-name:
@@ -37,12 +35,7 @@ Template parameters
 - ``with`` keyword. The parameters are in the form of a :ref:`record type <daml-ref-record-types>`.
 - Passed in when :ref:`creating <daml-ref-create>` a contract instance from this template. These are then in scope inside the template body.
 - A template parameter can't have the same name as any :ref:`choice arguments <daml-ref-choice-arguments>` inside the template.
-
-- You must pass in the parties as parameters to the contract.
-
-  This means isn't valid to replace the ``giver`` variable in the ``Payout`` template above directly with ``'Elizabeth'``.
-
-  Parties can only be named explicitly in scenarios.
+- For all parties involved in the contract (whether they're a ``signatory``, ``observer``, or ``controller``) you must pass them in as parameters to the contract, whether individually or as a list (``[Party]``).
 
 .. Template has an *associated* data type with the same name?
 
@@ -59,10 +52,12 @@ Signatory parties
 - ``signatory`` keyword. After ``where``. Followed by at least one ``Party``.
 - Signatories are the parties (see the ``Party`` type) who must consent to the creation of an instance of this contract. They are the parties who would be put into an *obligable position* when this contract is created.
 
-  DAML won't let you put someone into an obligable position without their consent. So if the contract will cause obligations for a party, they *must* be a signatory.
+  DAML won't let you put someone into an obligable position without their consent. So if the contract will cause obligations for a party, they *must* be a signatory. **If they haven't authorized it, you won't be able to create the contract.** In this situation, you may see errors like:
+
+  ``NameOfTemplate requires authorizers Party1,Party2,Party, but only Party1 were given.``
 - When a signatory consents to the contract creation, this means they also authorize the consequences of :ref:`choices <daml-ref-choices>` that can be exercised on this contract.
-- The contract instance is visible to all signatories (as well as the other stakeholders of the contract).
-- You must have least one signatory per template. You can have many, either as a comma-separated list or reusing the keyword.
+- The contract instance is visible to all signatories (as well as the other stakeholders of the contract). That is, the compiler automatically adds signatories as observers.
+- You **must** have least one signatory per template. You can have many, either as a comma-separated list or reusing the keyword. You could pass in a list (of type ``[Party]``).
 
 .. _daml-ref-observers:
 
@@ -76,10 +71,9 @@ Observers
 
 - ``observer`` keyword. After ``where``. Followed by at least one ``Party``.
 - Observers are additional stakeholders, so the contract instance is visible to these parties (see the ``Party`` type).
-- Optional. You can have many, either as a comma-separated list or reusing the keyword.
+- Optional. You can have many, either as a comma-separated list or reusing the keyword. You could pass in a list (of type ``[Party]``).
 - Use when a party needs visibility on a contract, or be informed or contract events, but is not a :ref:`signatory <daml-ref-signatories>` or :ref:`controller <daml-ref-controllers>`.
-- TODO observer observers
-- TODO flexible controllers vs automatic adding if other option
+- If you start your choice with ``choice`` rather than ``controller`` (see :ref:`daml-ref-choices` below), you must make sure to add the controller as an observer. Otherwise, they will not be able to exercise the choice, because they won't be able to see the contract.
 
 .. _daml-ref-choices:
 
@@ -94,7 +88,9 @@ Choices
 - A right that the contract gives the controlling party. Can be *exercised*.
 - This is essentially where all the logic of the template goes.
 - By default, choices are *consuming*: that is, exercising the choice archives the contract, so no further choices can be exercised on it. You can make a choice non-consuming using the ``nonconsuming`` keyword.
-- TODO: Two different ways of specifying - choice first or controller first
+- There are two ways of specifying a choice: start with the ``choice`` keyword or start with the ``controller`` keyword.
+
+  Starting with ``choice`` lets you pass in a ``Party`` to use as a controller. But you must make sure to add that party as an ``observer``.
 - See :doc:`choices` for full reference information.
 
 .. _daml-ref-agreements:

--- a/docs/source/daml/reference/templates.rst
+++ b/docs/source/daml/reference/templates.rst
@@ -89,7 +89,7 @@ Choices
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
    :start-after: -- start template choice snippet
-   :end-before: -- start template choice snippet
+   :end-before: -- end template choice snippet
 
 - A right that the contract gives the controlling party. Can be *exercised*.
 - This is essentially where all the logic of the template goes.

--- a/docs/source/daml/reference/templates.rst
+++ b/docs/source/daml/reference/templates.rst
@@ -17,7 +17,8 @@ Template name
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 7
+   :start-after: -- start template intro snippet
+   :end-before: -- end template intro snippet
 
 - This is the name of the template. It's preceded by ``template`` keyword. Must begin with a capital letter.
 - This is the highest level of nesting.
@@ -30,7 +31,8 @@ Template parameters
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 7-12
+   :start-after: -- start template params snippet
+   :end-before: -- end template params snippet
 
 - ``with`` keyword. The parameters are in the form of a :ref:`record type <daml-ref-record-types>`.
 - Passed in when :ref:`creating <daml-ref-create>` a contract instance from this template. These are then in scope inside the template body.
@@ -51,8 +53,8 @@ Signatory parties
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 13-14
-   :dedent: 2
+   :start-after: -- start template sigs snippet
+   :end-before: -- end template sigs snippet
 
 - ``signatory`` keyword. After ``where``. Followed by at least one ``Party``.
 - Signatories are the parties (see the ``Party`` type) who must consent to the creation of an instance of this contract. They are the parties who would be put into an *obligable position* when this contract is created.
@@ -69,15 +71,15 @@ Observers
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 13,15
-   :dedent: 2
+   :start-after: -- start template obs snippet
+   :end-before: -- end template obs snippet
 
 - ``observer`` keyword. After ``where``. Followed by at least one ``Party``.
 - Observers are additional stakeholders, so the contract instance is visible to these parties (see the ``Party`` type).
 - Optional. You can have many, either as a comma-separated list or reusing the keyword.
 - Use when a party needs visibility on a contract, or be informed or contract events, but is not a :ref:`signatory <daml-ref-signatories>` or :ref:`controller <daml-ref-controllers>`.
-
-.. TODO: what about observer observers?
+- TODO observer observers
+- TODO flexible controllers vs automatic adding if other option
 
 .. _daml-ref-choices:
 
@@ -86,12 +88,13 @@ Choices
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 13, 22-23
-   :dedent: 2
+   :start-after: -- start template choice snippet
+   :end-before: -- start template choice snippet
 
 - A right that the contract gives the controlling party. Can be *exercised*.
 - This is essentially where all the logic of the template goes.
 - By default, choices are *consuming*: that is, exercising the choice archives the contract, so no further choices can be exercised on it. You can make a choice non-consuming using the ``nonconsuming`` keyword.
+- TODO: Two different ways of specifying - choice first or controller first
 - See :doc:`choices` for full reference information.
 
 .. _daml-ref-agreements:
@@ -101,8 +104,8 @@ Agreements
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 13,19-20
-   :dedent: 2
+   :start-after: -- start template agree snippet
+   :end-before: -- end template agree snippet
 
 - ``agreement`` keyword, followed by text.
 - Represents what the contract means in text. They're usually the boundary between on-ledger and off-ledger rights and obligations.
@@ -117,8 +120,8 @@ Preconditions
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
-   :lines: 13,16-17
-   :dedent: 2
+   :start-after: -- start template ensure snippet
+   :end-before: -- end template ensure snippet
 
 - ``ensure`` keyword, followed by a boolean condition.
 - Used on contract creation. ``ensure`` limits the values on parameters that can be passed to the contract: the contract can only be created if the boolean condition is true.

--- a/docs/source/daml/reference/templates.rst
+++ b/docs/source/daml/reference/templates.rst
@@ -73,7 +73,7 @@ Observers
 - Observers are additional stakeholders, so the contract instance is visible to these parties (see the ``Party`` type).
 - Optional. You can have many, either as a comma-separated list or reusing the keyword. You could pass in a list (of type ``[Party]``).
 - Use when a party needs visibility on a contract, or be informed or contract events, but is not a :ref:`signatory <daml-ref-signatories>` or :ref:`controller <daml-ref-controllers>`.
-- If you start your choice with ``choice`` rather than ``controller`` (see :ref:`daml-ref-choices` below), you must make sure to add the controller as an observer. Otherwise, they will not be able to exercise the choice, because they won't be able to see the contract.
+- If you start your choice with ``choice`` rather than ``controller`` (see :ref:`daml-ref-choices` below), you must make sure to add any potential controller as an observer. Otherwise, they will not be able to exercise the choice, because they won't be able to see the contract.
 
 .. _daml-ref-choices:
 

--- a/docs/source/daml/reference/updates.rst
+++ b/docs/source/daml/reference/updates.rst
@@ -51,10 +51,9 @@ do
 create
 ******
 
-.. literalinclude:: ../code-snippets/Reference.daml
-   :language: daml
-   :lines: 44
-   :dedent: 8
+.. code-block:: daml
+
+   create NameOfTemplate with exampleParameters
 
 - ``create`` keyword.
 - Creates an instance of that contract on the ledger. When a contract is committed to the ledger, it is given a unique contract identifier of type ``ContractId <name of template>``.

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -10,6 +10,7 @@ HEAD — ongoing
 --------------
 
 - Node.js bindings have been moved `here <https://github.com/digital-asset/daml-js>``
+- Add documentation for flexible controllers.
 
 0.12.10 — 2019-04-25
 --------------------


### PR DESCRIPTION
Fixes #168.

In this PR, I've also made some small improvements to the reference docs as I went, and moved all the snippets to using `start-after` and `end-before`, because otherwise updating them would have been a nightmare.