### PR TITLE
Inline record projections on this in maintainer expression

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -411,8 +411,7 @@ convertKey env o@(VarIs "C:TemplateKey" `App` Type tmpl `App` Type keyType `App`
       (Lam keyBinder keyExpr, Lam maintainerBinder maintainerExpr) -> do
         keyType <- convertType env keyType
         keyExpr <- convertKeyExpr env keyBinder keyExpr
-        let maintainerEnv = envInsertAlias maintainerBinder (EVar "this") env
-        maintainerExpr <- convertExpr maintainerEnv maintainerExpr
+        maintainerExpr <- convertKeyExpr env maintainerBinder maintainerExpr
         maintainerExpr <- rewriteMaintainer keyExpr maintainerExpr
         pure $ TemplateKey keyType keyExpr (ETmLam ("$key", keyType) maintainerExpr)
       _ -> unhandled "Template key definition" o

--- a/daml-foundations/daml-ghc/tests/ContractKeyTests.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeyTests.daml
@@ -38,8 +38,7 @@ template T
   where
     signatory i
     key k.s : M
-    maintainer this.k.s.m -- This doesn't work without qualifying with
-                          -- `this`. Is that expected?
+    maintainer k.s.m
 
 -- (3)
 


### PR DESCRIPTION
If we don't inline let bindings of the form `x = this.f`, the rewriting of
the maintainer expression in terms of the key can fail when it shouldn't.
Usually, these bindings do not exist in the surface language but are produced
by the compiler. I think the performance penalty we might pay for this is
negligible.

This fixes #384.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/638)
<!-- Reviewable:end -->
