### PR TITLE
Check that contract keys are supported in DAML-LF type checker

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -68,8 +68,8 @@ supportsSha256Text v = v >= version1_2
 supportsDisjunctionChoices :: Version -> Bool
 supportsDisjunctionChoices v = v >= version1_2
 
-supportsRetrieveByKey :: Version -> Bool
-supportsRetrieveByKey v = v >= version1_3
+supportsContractKeys :: Version -> Bool
+supportsContractKeys v = v >= version1_3
 
 supportsPartyFromText :: Version -> Bool
 supportsPartyFromText v = v >= version1_2

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -389,9 +389,9 @@ instance Encode Update P.Update where
     UFetch{..} -> P.UpdateSumFetch $ P.Update_Fetch (encode' version fetTemplate) (encode' version fetContractId)
     UGetTime -> P.UpdateSumGetTime P.Unit
     UEmbedExpr typ e -> P.UpdateSumEmbedExpr $ P.Update_EmbedExpr (encode' version typ) (encode' version e)
-    UFetchByKey rbk -> checkRetrieveByKey version $
+    UFetchByKey rbk -> checkContractKeys version $
        P.UpdateSumFetchByKey (encode version rbk)
-    ULookupByKey rbk -> checkRetrieveByKey version $
+    ULookupByKey rbk -> checkContractKeys version $
        P.UpdateSumLookupByKey (encode version rbk)
 
 instance Encode RetrieveByKey P.Update_RetrieveByKey where
@@ -472,7 +472,7 @@ instance Encode Template P.DefTemplate where
     }
 
 encodeTemplateKey :: Version -> ExprVarName -> TemplateKey -> P.DefTemplate_DefKey
-encodeTemplateKey version templateVar TemplateKey{..} = P.DefTemplate_DefKey
+encodeTemplateKey version templateVar TemplateKey{..} = checkContractKeys version $ P.DefTemplate_DefKey
   { P.defTemplate_DefKeyType = encode' version tplKeyType
   , P.defTemplate_DefKeyKey = case encodeKeyExpr version templateVar tplKeyBody of
       Left err -> error err
@@ -573,8 +573,8 @@ checkOptional = checkFeature supportsOptional "Optional"
 checkArrowType :: Version -> a -> a
 checkArrowType = checkFeature supportsArrowType "Partial application of (->)"
 
-checkRetrieveByKey :: Version -> a -> a
-checkRetrieveByKey = checkFeature supportsRetrieveByKey "Retrieve by key" 
+checkContractKeys :: Version -> a -> a
+checkContractKeys = checkFeature supportsContractKeys "Contract keys"
 
 checkTextMap :: Version -> a -> a
 checkTextMap = checkFeature supportsTextMap "TextMap"

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -90,7 +90,7 @@ data Error
   | EContext               !Context !Error
   | ENonValueDefinition    ![(String, Expr)] -- contains the non-value subexpressions and why they're bad
   | EKeyOperationOnTemplateWithNoKey !(Qualified TypeConName)
-  | EUnsupportedBuiltin !BuiltinExpr !Version
+  | EUnsupportedFeature !T.Text !Version
   | EInvalidKeyExpression !Expr
 
 contextLocation :: Context -> Maybe SourceLoc
@@ -271,8 +271,8 @@ instance Pretty Error where
       ]
     EExpectedOptionalType typ -> do
       "expected list type, but found: " <> pretty typ
-    EUnsupportedBuiltin builtin version ->
-      "unsupported builtin:" <-> pretty builtin
+    EUnsupportedFeature feature version ->
+      "unsupported feature:" <-> pretty feature
       <-> "only supported in DAML-LF version" <-> pretty version <-> "and later"
 
 instance Pretty Context where


### PR DESCRIPTION
Add a check to the Haskell implementation of the DAML-LF type checker to
make sure that the current DAML-LF version supports contract keys when they
are encountered.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/639)
<!-- Reviewable:end -->
