### PR TITLE
Make daml new files writeable.

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -188,6 +188,8 @@ copyDirectory src target = do
         let targetFile = target </> baseName
         createDirectoryIfMissing True (takeDirectory targetFile)
         copyFile file targetFile
+        p <- getPermissions targetFile
+        setPermissions targetFile p { writable = True }
 
 installExtension :: FilePath -> FilePath -> IO ()
 installExtension src target =


### PR DESCRIPTION
Make the files output by `daml new` writable (the template was being copied over from the sdk directory with readonly permissions).