### PR TITLE
Simplify implementation of fetchByKey in compiler

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -56,8 +56,8 @@ lookupByKey : forall c k. TemplateKey c k => k -> Update (Optional (ContractId c
 lookupByKey = internalLookupByKey
 
 -- | HIDE pass the @c@ using type applications, otherwise it's ambiguous
-fetchByKey : TemplateKey c k => k -> Update (ContractId c, c)
-fetchByKey = internalFetchByKey
+fetchByKey : forall c k. TemplateKey c k => k -> Update (ContractId c, c)
+fetchByKey k = fmap unpackPair (internalFetchByKey k)
 
 class Template c where
 
@@ -147,7 +147,7 @@ class Template c => TemplateKey c k | c -> k where
     maintainer : c -> [Party]
 
     -- | HIDE
-    internalFetchByKey : k -> Update (ContractId c, c)
+    internalFetchByKey : k -> Update (Pair "contractId" "contract" (ContractId c) c)
     internalFetchByKey = magic @"fetchByKey"
 
     -- | HIDE


### PR DESCRIPTION
Currently, the structural record returned by DAML-LF's `fetchByKey` is
unpacked in the compiler. This is not very nice as it requires too much
code for my taste.

This PR shifts the unpacking into DAML land by means of the recently
introduced `unpackPair` function.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/647)
<!-- Reviewable:end -->
