### PR TITLE
Enable Bazel execution logs on Windows CI

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,6 +11,8 @@ if (!(Test-Path .\.bazelrc.local)) {
    Set-Content -Path .\.bazelrc.local -Value 'build --config windows'
 }
 
+$ARTIFACT_DIRS = if ("$env:BUILD_ARTIFACTSTAGINGDIRECTORY") { $env:BUILD_ARTIFACTSTAGINGDIRECTORY } else { Get-Location }
+
 function bazel() {
     Write-Output ">> bazel $args"
     $global:lastexitcode = 0
@@ -26,7 +28,7 @@ function bazel() {
 }
 
 function build-partial() {
-    bazel build `
+    bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_partial_execution_windows.log `
         //:git-revision `
         //compiler/daml-lf-ast/... `
         //compiler/haskell-ide-core/... `
@@ -45,7 +47,7 @@ function build-partial() {
 
 function build-full() {
     # FIXME: Until all bazel issues on Windows are resolved we will be testing only specific bazel targets
-    bazel build `
+    bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_full_execution_windows.log `
         //release:sdk-release-tarball `
         //:git-revision `
         @com_github_grpc_grpc//:grpc `

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -10,6 +10,14 @@ steps:
 
   - powershell: '.\build.ps1 full'
     displayName: 'Build'
+
+  - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
+    displayName: 'Publish the bazel execution logs'
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'Execution logs'
+
   - bash: |
       set -euo pipefail
       echo "Simulating release step..."


### PR DESCRIPTION
Enable Bazel execution logs for Windows CI builds.

Motivation: Debug Bazel remote caching for Windows.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
