### PR TITLE
language: change default output dir of `package` command

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -72,7 +72,7 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do
           p :: Int <- fromIntegral <$> getFreePort
-          withCreateProcess ((proc "daml" ["sandbox", "--port", show p, "quickstart.dar"]) { std_out = UseHandle devNull }) $
+          withCreateProcess ((proc "daml" ["sandbox", "--port", show p, "dist/quickstart.dar"]) { std_out = UseHandle devNull }) $
               \_ _ _ ph -> race_ (waitForProcess' "sandbox" [] ph) $ do
               waitForConnectionOnPort (threadDelay 100000) p
               addr : _ <- getAddrInfo

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -325,7 +325,9 @@ execPackageNew numProcessors mbOutFile =
         case Split.splitOn ":" name of
             [_g, a, v] -> a <> "-" <> v <> ".dar"
             _otherwise -> name <> ".dar"
-    targetFilePath name = fromMaybe (defaultDarFile name) mbOutFile
+    targetFilePath name = fromMaybe (defaultOutDir </> defaultDarFile name) mbOutFile
+
+    defaultOutDir = "dist"
 
 -- | Read the daml.yaml field and create the project local package database.
 execInit :: IO ()


### PR DESCRIPTION
This changes the default output path of the `package` and `build`
command from the project root to the `dist` directory relative to the project root.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
