### PR TITLE
Generate daml new config file from template

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -29,6 +29,7 @@ import Control.Monad.Loops (untilJust)
 import Data.Aeson
 import Data.Aeson.Text
 import Data.Maybe
+import Data.List.Extra
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as T (toStrict)
 import qualified Network.HTTP.Client as HTTP
@@ -108,6 +109,21 @@ runNew targetFolder templateName = do
             ]
         exitFailure
     copyDirectory templateFolder targetFolder
+
+    -- update daml.yaml
+    let configPath = targetFolder </> projectConfigName
+        configTemplatePath = configPath <.> "template"
+
+    whenM (doesFileExist configTemplatePath) $ do
+        configTemplate <- readFileUTF8 configTemplatePath
+        sdkVersion <- getSdkVersion
+        let projectName = takeFileName (dropTrailingPathSeparator targetFolder)
+            config = replace "__SDK_VERSION__"  sdkVersion
+                   . replace "__PROJECT_NAME__" projectName
+                   $ configTemplate
+        writeFileUTF8 configPath config
+        removeFile configTemplatePath
+
 
 runListTemplates :: IO ()
 runListTemplates = do

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -118,7 +118,7 @@ runNew targetFolder templateName = do
         configTemplate <- readFileUTF8 configTemplatePath
         sdkVersion <- getSdkVersion
         let projectName = takeFileName (dropTrailingPathSeparator targetFolder)
-            config = replace "__SDK_VERSION__"  sdkVersion
+            config = replace "__VERSION__"  sdkVersion
                    . replace "__PROJECT_NAME__" projectName
                    $ configTemplate
         writeFileUTF8 configPath config

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -127,7 +127,7 @@ genrule(
       # Once da-assistant is dead, the quickstart-java rule should produce the final version.
       rm $$OUT/templates/quickstart-java/da-skeleton.yaml
       cat > $$OUT/templates/quickstart-java/daml.yaml.template << EOF
-sdk-version: __SDK_VERSION__
+sdk-version: __VERSION__
 name: __PROJECT_NAME__
 source: daml/Main.daml
 scenario: Main:setup

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -126,9 +126,9 @@ genrule(
       # While we use this template for both da-assistant and daml-assistant we do some manual patching here.
       # Once da-assistant is dead, the quickstart-java rule should produce the final version.
       rm $$OUT/templates/quickstart-java/da-skeleton.yaml
-      cat > $$OUT/templates/quickstart-java/daml.yaml << EOF
-sdk-version: $$VERSION
-name: quickstart
+      cat > $$OUT/templates/quickstart-java/daml.yaml.template << EOF
+sdk-version: __SDK_VERSION__
+name: __PROJECT_NAME__
 source: daml/Main.daml
 scenario: Main:setup
 parties:
@@ -166,8 +166,6 @@ genrule(
 
       cp $(location :sdk-config.yaml.tmpl) $$OUT/sdk-config.yaml
       sed -i "s/__VERSION__/$$VERSION/" $$OUT/sdk-config.yaml
-
-      sed -i "s/sdk-version: .*/sdk-version: 0.0.0/" $$OUT/templates/quickstart-java/daml.yaml
 
       tar zcf $(location sdk-head-tarball.tar.gz) --format=ustar $$OUT
     """,


### PR DESCRIPTION
This solves problem 3 of #644 and improves the way we generate the `daml.yaml` config file from `daml new` templates in general.