### PR TITLE
Disable echo in daml wrapper script

### DIFF
--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -164,7 +164,10 @@ activateDaml env@InstallEnv{..} targetPath = do
 
     requiredIO ("Failed to link daml binary in " <> pack damlBinaryTargetDir) $
         if isWindows
-            then writeFile damlBinaryTargetPath (damlBinarySourcePath <> " %*")
+            then writeFile damlBinaryTargetPath $ unlines
+                     [ "@echo off"
+                     , damlBinarySourcePath <> " %*"
+                     ]
             else createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
 
     unlessQuiet env $ do -- Ask user to add .daml/bin to PATH if it is absent.

--- a/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Server.hs
+++ b/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Server.hs
@@ -51,6 +51,9 @@ runServer loggerH reqHandler notifHandler notifChan = do
     -- are not newline delimited.
     hSetBuffering stdin NoBuffering
     hSetBuffering newStdout NoBuffering
+    -- We don’t want any newline conversion or encoding on those handles.
+    hSetBinaryMode newStdout True
+    hSetBinaryMode stdin True
     JsonRpc.runServer
       loggerH
       (sink newStdout) source


### PR DESCRIPTION
When echo is enabled (which is the default), the IDE can get really
confused since it tries to interpret the commands as LSP messages
which obviously fails.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
