### PR TITLE
Fixes #659 build-system: Fix failure of ci/release.sh on unset variable

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -22,7 +22,7 @@ eval "$(dev-env/bin/dade assist)"
 step "build release script"
 bazel build //release:release
 
-if [[ "$BUILD_SOURCEBRANCHNAME" == "master" ]]; then
+if [[ "${BUILD_SOURCEBRANCHNAME:-}" == "master" ]]; then
     # set up bintray credentials
     mkdir -p ~/.jfrog
     echo "$JFROG_CONFIG_CONTENT" > ~/.jfrog/jfrog-cli.conf


### PR DESCRIPTION
The ci/release.sh fails if the BUILD_SOURCEBRANCHNAME environment
variable is not set. Although this variable is normally set by the
CI system, it is sometimes useful to run the script manually and
simply adding an 'invalid' default to the check of the env variable
means that the script still works if the variable is unbound.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
