### PR TITLE
Clean up how we check DAML-LF feature support in damlc

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -50,29 +50,38 @@ supportedInputVersions = [version1_0, version1_1, version1_2, version1_3]
 supportedOutputVersions :: [Version]
 supportedOutputVersions = supportedInputVersions
 
-supportsOptional :: Version -> Bool
-supportsOptional v = v >= version1_1
 
-supportsTextMap :: Version -> Bool
-supportsTextMap v = v >= version1_3
+data Feature = Feature
+    { featureName :: !T.Text
+    , featureMinVersion :: !Version
+    }
 
-supportsPartyOrd :: Version -> Bool
-supportsPartyOrd v = v >= version1_1
+featureOptional :: Feature
+featureOptional = Feature "Optional type" version1_1
 
-supportsArrowType :: Version -> Bool
-supportsArrowType v = v >= version1_1
+featureTextMap :: Feature
+featureTextMap = Feature "Map type" version1_3
 
-supportsSha256Text :: Version -> Bool
-supportsSha256Text v = v >= version1_2
+featurePartyOrd :: Feature
+featurePartyOrd = Feature "Party comparison" version1_1
 
-supportsDisjunctionChoices :: Version -> Bool
-supportsDisjunctionChoices v = v >= version1_2
+featureArrowType :: Feature
+featureArrowType = Feature "Arrow type" version1_1
 
-supportsContractKeys :: Version -> Bool
-supportsContractKeys v = v >= version1_3
+featureSha256Text :: Feature
+featureSha256Text = Feature "sha256 function" version1_2
 
-supportsPartyFromText :: Version -> Bool
-supportsPartyFromText v = v >= version1_2
+featureDisjunctionChoices :: Feature
+featureDisjunctionChoices = Feature "Flexible controllers" version1_2
+
+featureContractKeys :: Feature
+featureContractKeys = Feature "Contract keys" version1_3
+
+featurePartyFromText :: Feature
+featurePartyFromText = Feature "partyFromText function" version1_2
+
+supports :: Version -> Feature -> Bool
+supports version feature = version >= featureMinVersion feature
 
 concatSequenceA $
   map (makeInstancesExcept [''FromJSON, ''ToJSON])

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -71,8 +71,8 @@ featureArrowType = Feature "Arrow type" version1_1
 featureSha256Text :: Feature
 featureSha256Text = Feature "sha256 function" version1_2
 
-featureDisjunctionChoices :: Feature
-featureDisjunctionChoices = Feature "Flexible controllers" version1_2
+featureFlexibleControllers :: Feature
+featureFlexibleControllers = Feature "Flexible controllers" version1_2
 
 featureContractKeys :: Feature
 featureContractKeys = Feature "Contract keys" version1_3

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -565,4 +565,4 @@ encodeDefName version txt = case mangleIdentifier txt of
 checkFeature :: Feature -> Version -> a -> a
 checkFeature feature version x
     | version `supports` feature = x
-    | otherwise = error (error "DAML-LF " ++ renderPretty version ++ " cannot encode feature: " ++ T.unpack (featureName feature))
+    | otherwise = error $ "DAML-LF " ++ renderPretty version ++ " cannot encode feature: " ++ T.unpack (featureName feature)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -170,9 +170,9 @@ instance Encode BuiltinType P.PrimType where
     BTScenario -> P.PrimTypeSCENARIO
     BTDate -> P.PrimTypeDATE
     BTContractId -> P.PrimTypeCONTRACT_ID
-    BTOptional -> checkOptional version P.PrimTypeOPTIONAL
-    BTMap -> checkTextMap version P.PrimTypeMAP
-    BTArrow -> checkArrowType version P.PrimTypeARROW
+    BTOptional -> checkFeature featureOptional version P.PrimTypeOPTIONAL
+    BTMap -> checkFeature featureTextMap version P.PrimTypeMAP
+    BTArrow -> checkFeature featureArrowType version P.PrimTypeARROW
 
 instance Encode Type P.Type where
   encode version typ = P.Type . Just $
@@ -182,7 +182,7 @@ instance Encode Type P.Type where
       (TCon con, args) ->
         P.TypeSumCon (P.Type_Con (encode' version con) (encodeV version args))
       (TBuiltin BTArrow, args)
-        | not (supportsArrowType version) -> case args of
+        | not (version `supports` featureArrowType) -> case args of
             [param, result] ->
               P.TypeSumFun (P.Type_Fun (encodeV version [param]) (encode' version result))
             _ -> error "TArrow must be used with exactly two arguments"
@@ -240,7 +240,7 @@ instance Encode BuiltinExpr P.ExprSum where
       BTText -> builtin P.BuiltinFunctionLEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLEQ_DATE
-      BTParty | supportsPartyOrd version -> builtin P.BuiltinFunctionLEQ_PARTY
+      BTParty | version `supports` featurePartyOrd -> builtin P.BuiltinFunctionLEQ_PARTY
       other -> error $ "BELessEq unexpected type " <> show other
 
     BELess typ -> case typ of
@@ -249,7 +249,7 @@ instance Encode BuiltinExpr P.ExprSum where
       BTText -> builtin P.BuiltinFunctionLESS_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLESS_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLESS_DATE
-      BTParty | supportsPartyOrd version -> builtin P.BuiltinFunctionLESS_PARTY
+      BTParty | version `supports` featurePartyOrd -> builtin P.BuiltinFunctionLESS_PARTY
       other -> error $ "BELess unexpected type " <> show other
 
     BEGreaterEq typ -> case typ of
@@ -258,7 +258,7 @@ instance Encode BuiltinExpr P.ExprSum where
       BTText -> builtin P.BuiltinFunctionGEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGEQ_DATE
-      BTParty | supportsPartyOrd version -> builtin P.BuiltinFunctionGEQ_PARTY
+      BTParty | version `supports` featurePartyOrd -> builtin P.BuiltinFunctionGEQ_PARTY
       other -> error $ "BEGreaterEq unexpected type " <> show other
 
     BEGreater typ -> case typ of
@@ -267,7 +267,7 @@ instance Encode BuiltinExpr P.ExprSum where
       BTText -> builtin P.BuiltinFunctionGREATER_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGREATER_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGREATER_DATE
-      BTParty | supportsPartyOrd version -> builtin P.BuiltinFunctionGREATER_PARTY
+      BTParty | version `supports` featurePartyOrd -> builtin P.BuiltinFunctionGREATER_PARTY
       other -> error $ "BEGreater unexpected type " <> show other
 
     BEToText typ -> case typ of
@@ -371,9 +371,9 @@ encodeExpr version = \case
   ELocation loc e ->
     let (P.Expr _ esum) = encodeExpr version e
     in P.Expr (Just (encode version loc)) esum
-  ENone typ -> checkOptional version $
+  ENone typ -> checkFeature featureOptional version $
     expr (P.ExprSumNone (P.Expr_None (encode' version typ)))
-  ESome typ body -> checkOptional version $
+  ESome typ body -> checkFeature featureOptional version $
     expr (P.ExprSumSome (P.Expr_Some (encode' version typ) (encode' version body)))
   where
     expr = P.Expr Nothing . Just
@@ -389,9 +389,9 @@ instance Encode Update P.Update where
     UFetch{..} -> P.UpdateSumFetch $ P.Update_Fetch (encode' version fetTemplate) (encode' version fetContractId)
     UGetTime -> P.UpdateSumGetTime P.Unit
     UEmbedExpr typ e -> P.UpdateSumEmbedExpr $ P.Update_EmbedExpr (encode' version typ) (encode' version e)
-    UFetchByKey rbk -> checkContractKeys version $
+    UFetchByKey rbk -> checkFeature featureContractKeys version $
        P.UpdateSumFetchByKey (encode version rbk)
-    ULookupByKey rbk -> checkContractKeys version $
+    ULookupByKey rbk -> checkFeature featureContractKeys version $
        P.UpdateSumLookupByKey (encode version rbk)
 
 instance Encode RetrieveByKey P.Update_RetrieveByKey where
@@ -433,9 +433,9 @@ instance Encode CaseAlternative P.CaseAlt where
           CPEnumCon con -> P.CaseAltSumPrimCon (encodeE version con)
           CPNil         -> P.CaseAltSumNil P.Unit
           CPCons{..}    -> P.CaseAltSumCons $ P.CaseAlt_Cons (encode version patHeadBinder) (encode version patTailBinder)
-          CPNone        -> checkOptional version $
+          CPNone        -> checkFeature featureOptional version $
             P.CaseAltSumNone P.Unit
-          CPSome{..}    -> checkOptional version $
+          CPSome{..}    -> checkFeature featureOptional version $
             P.CaseAltSumSome $ P.CaseAlt_Some (encode version patBodyBinder)
     in P.CaseAlt (Just pat) (encode' version altExpr)
 
@@ -472,7 +472,7 @@ instance Encode Template P.DefTemplate where
     }
 
 encodeTemplateKey :: Version -> ExprVarName -> TemplateKey -> P.DefTemplate_DefKey
-encodeTemplateKey version templateVar TemplateKey{..} = checkContractKeys version $ P.DefTemplate_DefKey
+encodeTemplateKey version templateVar TemplateKey{..} = checkFeature featureContractKeys version $ P.DefTemplate_DefKey
   { P.defTemplate_DefKeyType = encode' version tplKeyType
   , P.defTemplate_DefKeyKey = case encodeKeyExpr version templateVar tplKeyBody of
       Left err -> error err
@@ -562,19 +562,7 @@ encodeDefName version txt = case mangleIdentifier txt of
 
 -- | NOTE(MH): This functions is used for sanity checking. The actual checks
 -- are done in the conversion to DAML-LF.
-checkFeature :: (Version -> Bool) -> String -> Version -> a -> a
-checkFeature hasFeature name version x
-    | hasFeature version = x
-    | otherwise = error (error "DAML-LF " ++ renderPretty version ++ " cannot encode feature: " ++ name)
-
-checkOptional :: Version -> a -> a
-checkOptional = checkFeature supportsOptional "Optional"
-
-checkArrowType :: Version -> a -> a
-checkArrowType = checkFeature supportsArrowType "Partial application of (->)"
-
-checkContractKeys :: Version -> a -> a
-checkContractKeys = checkFeature supportsContractKeys "Contract keys"
-
-checkTextMap :: Version -> a -> a
-checkTextMap = checkFeature supportsTextMap "TextMap"
+checkFeature :: Feature -> Version -> a -> a
+checkFeature feature version x
+    | version `supports` feature = x
+    | otherwise = error (error "DAML-LF " ++ renderPretty version ++ " cannot encode feature: " ++ T.unpack (featureName feature))

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -502,7 +502,7 @@ checkTemplateChoice tpl (TemplateChoice _loc _ _ actors selfBinder (param, param
   checkType retType KStar
   v <- view lfVersion
   let checkActors = checkExpr actors (TList TParty)
-  if v `supports` featureDisjunctionChoices
+  if v `supports` featureFlexibleControllers
     then introExprVar param paramType checkActors
     else checkActors
   introExprVar selfBinder (TContractId (TCon tpl)) $ introExprVar param paramType $

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -90,7 +90,7 @@ data Error
   | EContext               !Context !Error
   | ENonValueDefinition    ![(String, Expr)] -- contains the non-value subexpressions and why they're bad
   | EKeyOperationOnTemplateWithNoKey !(Qualified TypeConName)
-  | EUnsupportedFeature !T.Text !Version
+  | EUnsupportedFeature !Feature
   | EInvalidKeyExpression !Expr
 
 contextLocation :: Context -> Maybe SourceLoc
@@ -271,9 +271,9 @@ instance Pretty Error where
       ]
     EExpectedOptionalType typ -> do
       "expected list type, but found: " <> pretty typ
-    EUnsupportedFeature feature version ->
-      "unsupported feature:" <-> pretty feature
-      <-> "only supported in DAML-LF version" <-> pretty version <-> "and later"
+    EUnsupportedFeature Feature{..} ->
+      "unsupported feature:" <-> pretty featureName
+      <-> "only supported in DAML-LF version" <-> pretty featureMinVersion <-> "and later"
 
 instance Pretty Context where
   pPrint = \case

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -219,19 +219,19 @@ isBuiltinName expected a
 
 isBuiltinOptional :: NamedThing a => Env -> a -> Bool
 isBuiltinOptional env a =
-    supportsOptional (envLfVersion env) && isBuiltinName "Optional" a
+    envLfVersion env `supports` featureOptional && isBuiltinName "Optional" a
 
 isBuiltinSome :: NamedThing a => Env -> a -> Bool
 isBuiltinSome env a =
-    supportsOptional (envLfVersion env) && isBuiltinName "Some" a
+    envLfVersion env `supports` featureOptional && isBuiltinName "Some" a
 
 isBuiltinNone :: NamedThing a => Env -> a -> Bool
 isBuiltinNone env a =
-    supportsOptional (envLfVersion env) && isBuiltinName "None" a
+    envLfVersion env `supports` featureOptional && isBuiltinName "None" a
 
 isBuiltinTextMap :: NamedThing a => Env -> a -> Bool
 isBuiltinTextMap env a =
-    supportsTextMap (envLfVersion env) && isBuiltinName "TextMap" a
+    envLfVersion env `supports` featureTextMap && isBuiltinName "TextMap" a
 
 convertInt64 :: Integer -> ConvertM LF.Expr
 convertInt64 x
@@ -1115,7 +1115,7 @@ convertType env o@(TypeCon t ts)
     | t == listTyCon, ts `eqTypes` [charTy] = pure TText
     | t == anyTyCon, [_] <- ts = pure TUnit -- used for type-zonking
     | t == funTyCon, _:_:ts' <- ts =
-        if supportsArrowType (envLfVersion env) || length ts' == 2
+        if envLfVersion env `supports` featureArrowType || length ts' == 2
           then foldl TApp TArrow <$> traverse (convertType env) ts'
           else unsupported "Partial application of (->)" o
     | Just m <- nameModule_maybe (getName t)


### PR DESCRIPTION
Currently, we have a predicate that tells us whether a DAML-LF version
supports a specific feature. We replace this by a data type which captures
the name of a feature and the minimal DAML-LF version which supports it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/663)
<!-- Reviewable:end -->
