### PR TITLE
add Windows tarball to github releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,6 @@ jobs:
   - job: linux
     timeoutInMinutes: 360
     pool:
-      # vmImage: 'ubuntu-16.04'
       name: 'linux-pool'
     steps:
       - template: ci/build-unix.yml
@@ -73,12 +72,12 @@ jobs:
       vmImage: "Ubuntu-16.04"
     condition: and(succeeded(),
                    eq( dependencies.linux.outputs['release.has_released'], 'true' ),
-                   eq( dependencies.macos.outputs['release.has_released'], 'true' ))
-                   #eq( dependencies.windows.outputs['release.has_released'], 'true' ))
+                   eq( dependencies.macos.outputs['release.has_released'], 'true' ),
+                   eq( dependencies.windows.outputs['release.has_released'], 'true' ))
     variables:
       artifact-linux: $[ dependencies.linux.outputs['publish.artifact'] ]
       artifact-macos: $[ dependencies.macos.outputs['publish.artifact'] ]
-      #artifact-windows: $[ dependencies.windows.outputs['publish.artifact'] ]
+      artifact-windows: $[ dependencies.windows.outputs['publish.artifact'] ]
     steps:
       - checkout: self
         persistCredentials: true
@@ -95,10 +94,10 @@ jobs:
         inputs:
           artifactName: $(artifact-macos)
           targetPath: $(Build.StagingDirectory)/release
-      #- task: DownloadPipelineArtifact@0
-      #  inputs:
-      #    artifactName: $(artifact-windows)
-      #    targetPath: $(Build.StagingDirectory)/release
+      - task: DownloadPipelineArtifact@0
+        inputs:
+          artifactName: $(artifact-windows)
+          targetPath: $(Build.StagingDirectory)/release
       - task: GitHubRelease@0
         inputs:
           gitHubConnection: 'garyverhaegen-da'

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -10,3 +10,20 @@ steps:
 
   - powershell: '.\build.ps1 full'
     displayName: 'Build'
+  - bash: |
+      set -euo pipefail
+      echo "Simulating release step..."
+      echo "##vso[task.setvariable variable=has_released;isOutput=true]true"
+      echo "##vso[task.setvariable variable=release_tag]$(cat VERSION)"
+  - bash: |
+      set -euo pipefail
+      ARTIFACT=daml-sdk-$(release_tag)-windows.tar.gz
+      cp bazel-genfiles/release/sdk-release-tarball.tar.gz $(Build.StagingDirectory)/$ARTIFACT
+      echo "##vso[task.setvariable variable=artifact;isOutput=true]$ARTIFACT"
+    name: publish
+    condition: eq(variables['release.has_released'], 'true')
+  - task: PublishPipelineArtifact@0
+    condition: eq(variables['release.has_released'], 'true')
+    inputs:
+      targetPath: $(Build.StagingDirectory)/$(publish.artifact)
+      artifactName: $(publish.artifact)

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -80,7 +80,7 @@ osName :: Text
 osName = case System.Info.os of
     "darwin"  -> "macos"
     "linux"   -> "linux"
-    "mingw32" -> "win"
+    "mingw32" -> "windows"
     p -> error ("daml: Unknown operating system " ++ p)
 
 -- | Install URL for particular version.


### PR DESCRIPTION
I'm not sure what the plan is regarding Windows releases long-term, so for now I've gone with a simulation of the current release script, followed by a "normal" push to github.

Note: on non-release commits, this will do a little bit of extra work (mostly copying 300MB), but should be harmless as the "published" artifact is only published internally to the rest of the pipeline.