### PR TITLE
Navigator console: Fix documentation of contract arguments

### DIFF
--- a/docs/source/tools/navigator/console.rst
+++ b/docs/source/tools/navigator/console.rst
@@ -392,9 +392,9 @@ Creating contracts
 Contracts in a ledger can be created directly from a template, or when you exercise a choice. You can do both of these things using Navigator Console.
 
 To create a contract of a given template, use the ``create`` command.
-The contract argument is written using the same syntax as in the DAML language::
+The contract argument is written in JSON format (DAML primitives are strings, DAML records are objects, DAML lists are arrays)::
 
-    >create Main.RightOfUseOffer@07ca8611d05ec14ea4b973192ef6caa5d53323bba50720a8d7142c2a246cfb73 with {landlord="BANK1", tenant="BANK2", address="Example Street", expirationDate="2018-01-01T00:00:00Z"}
+    >create Main.RightOfUseOffer@07ca8611d05ec14ea4b973192ef6caa5d53323bba50720a8d7142c2a246cfb73 with {"landlord": "BANK1", "tenant": "BANK2", "address": "Example Street", "expirationDate": "2018-01-01T00:00:00Z"}
     CommandId: 1e4c1610eadba6b
     Status: Success
     TransactionId: 2005

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Contract.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Contract.scala
@@ -5,6 +5,7 @@ package com.digitalasset.navigator.console.commands
 
 import com.digitalasset.ledger.api.refinements.ApiTypes
 import com.digitalasset.navigator.console._
+import com.digitalasset.navigator.json.ApiCodecCompressed
 import com.digitalasset.navigator.model
 
 @SuppressWarnings(Array("org.wartremover.warts.Product", "org.wartremover.warts.Serializable"))
@@ -26,6 +27,7 @@ case object Contract extends SimpleCommand {
       PrettyField("Id", ApiTypes.ContractId.unwrap(c.id)),
       PrettyField("TemplateId", c.template.idString),
       PrettyField("Argument", Pretty.argument(c.argument)),
+      PrettyField("ArgumentJson", ApiCodecCompressed.apiValueToJsValue(c.argument).compactPrint),
       PrettyField(
         "Created",
         PrettyObject(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Event.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Event.scala
@@ -5,6 +5,7 @@ package com.digitalasset.navigator.console.commands
 
 import com.digitalasset.ledger.api.refinements.ApiTypes
 import com.digitalasset.navigator.console._
+import com.digitalasset.navigator.json.ApiCodecCompressed
 import com.digitalasset.navigator.model
 
 case object Event extends SimpleCommand {
@@ -29,7 +30,8 @@ case object Event extends SimpleCommand {
         PrettyField("Type", "Created"),
         PrettyField("Contract", ApiTypes.ContractId.unwrap(ev.contractId)),
         PrettyField("Template", Pretty.shortTemplateId(ev.templateId)),
-        PrettyField("Argument", Pretty.argument(ev.argument))
+        PrettyField("Argument", Pretty.argument(ev.argument)),
+        PrettyField("ArgumentJson", ApiCodecCompressed.apiValueToJsValue(ev.argument).compactPrint),
       )
     case ev: model.ChoiceExercised =>
       PrettyObject(
@@ -44,6 +46,7 @@ case object Event extends SimpleCommand {
         PrettyField("Contract", ApiTypes.ContractId.unwrap(ev.contractId)),
         PrettyField("Choice", ApiTypes.Choice.unwrap(ev.choice)),
         PrettyField("Argument", Pretty.argument(ev.argument)),
+        PrettyField("ArgumentJson", ApiCodecCompressed.apiValueToJsValue(ev.argument).compactPrint),
         PrettyField(
           "Children",
           PrettyArray(tx.events.filter(_.parentId.contains(ev.id)).map(prettyEvent(_, tx))))


### PR DESCRIPTION
In early Navigator console versions, arguments were entered using a DAML-like syntax. This later changed to a JSON-based syntax, but the documentation was not updated.

This PR also improves the output of the `contract` and `event` commands: they now additionally print their arguments in the JSON-based syntax, to allow for easy copy-pasting of arguments.