### PR TITLE
Forward sandbox arguments properly (and navigator & extractor).

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -6,7 +6,6 @@ module DamlHelper
     , runNew
     , runJar
     , runListTemplates
-    , runSandbox
     , runStart
 
     , withJar
@@ -154,11 +153,6 @@ withNavigator (SandboxPort sandboxPort) (NavigatorPort navigatorPort) config arg
         -- TODO We need to figure out a sane timeout for this step.
         waitForHttpServer (putStr "." *> threadDelay 500000) ("http://localhost:" <> show navigatorPort)
         a ph
-
-runSandbox :: SandboxPort -> [String] -> IO ()
-runSandbox port args = do
-    exitCode <- withSandbox port args waitForProcess
-    exitWith exitCode
 
 runStart :: IO ()
 runStart = withProjectRoot $ \_ -> do

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -31,15 +31,15 @@ commands:
 - name: sandbox
   path: daml-helper/daml-helper
   desc: "Start the sandbox"
-  args: ["sandbox"]
+  args: ["run-jar", "sandbox/sandbox.jar"]
 - name: navigator
   path: daml-helper/daml-helper
   desc: "Start the navigator"
-  args: ["run-jar", "navigator/navigator.jar", "--"]
+  args: ["run-jar", "navigator/navigator.jar"]
 - name: extractor
   path: daml-helper/daml-helper
   desc: "Start the extractor"
-  args: ["run-jar", "extractor/extractor.jar", "--"]
+  args: ["run-jar", "extractor/extractor.jar"]
 - name: new
   path: daml-helper/daml-helper
   desc: "Create a new project"


### PR DESCRIPTION
As discovered by @bame-da the command `daml sandbox` was not forwarding everything to the jar. This PR fixes this and makes it the same as the navigator and extractor commands.