### PR TITLE
Auto-installing requested SDK versions.

### DIFF
--- a/daml-assistant/daml-project-config/DAML/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Config.hs
@@ -59,7 +59,7 @@ readConfig name path = do
 sdkVersionFromProjectConfig :: ProjectConfig -> Either ConfigError (Maybe SdkVersion)
 sdkVersionFromProjectConfig = queryProjectConfig ["sdk-version"]
 
--- | Determine sdk version from project config, if it exists.
+-- | Determine sdk version from sdk config, if it exists.
 sdkVersionFromSdkConfig :: SdkConfig -> Either ConfigError SdkVersion
 sdkVersionFromSdkConfig = querySdkConfigRequired ["version"]
 

--- a/daml-assistant/daml-project-config/DAML/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Consts.hs
@@ -7,6 +7,7 @@ module DAML.Project.Consts
     , sdkPathEnvVar
     , sdkVersionEnvVar
     , damlAssistantEnvVar
+    , damlAssistantVersionEnvVar
     , damlConfigName
     , projectConfigName
     , sdkConfigName
@@ -58,6 +59,12 @@ sdkVersionEnvVar = "DAML_SDK_VERSION"
 -- | The absolute path to the daml assistant executable.
 damlAssistantEnvVar :: String
 damlAssistantEnvVar = "DAML_ASSISTANT"
+
+-- | The SDK version of the daml assistant. This does not necessarily equal
+-- the DAML_SDK_VERSION, e.g. when working with a project with an older
+-- pinned SDK version.
+damlAssistantVersionEnvVar :: String
+damlAssistantVersionEnvVar = "DAML_ASSISTANT_VERSION"
 
 -- | File name of config file in DAML_HOME (~/.daml).
 damlConfigName :: FilePath

--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -49,6 +49,10 @@ newtype SdkVersion = SdkVersion
     { unwrapSdkVersion :: V.Version
     } deriving (Eq, Ord, Show)
 
+newtype DamlAssistantSdkVersion = DamlAssistantSdkVersion
+    { unwrapDamlAssistantSdkVersion :: SdkVersion
+    } deriving (Eq, Ord, Show)
+
 instance Y.FromJSON SdkVersion where
     parseJSON y = do
         verE <- V.fromText <$> Y.parseJSON y

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -198,9 +198,8 @@ getDispatchEnv Env{..} = do
 autoInstall :: DamlPath -> Maybe SdkVersion -> IO (Maybe SdkPath)
 autoInstall damlPath sdkVersionM = do
     damlConfigE <- try $ readDamlConfig damlPath
-    let doAutoInstallME = queryDamlConfig ["auto-install"] =<< damlConfigE
-        doAutoInstallM  = either (const (Just True)) id doAutoInstallME
-        doAutoInstall   = fromMaybe True doAutoInstallM
+    let doAutoInstallE = queryDamlConfigRequired ["auto-install"] =<< damlConfigE
+        doAutoInstall = fromRight True doAutoInstallE
     whenMaybe (doAutoInstall && isJust sdkVersionM) $ do
         let sdkVersion = fromJust sdkVersionM
         -- sdk is missing, so let's install it!
@@ -219,7 +218,7 @@ autoInstall damlPath sdkVersionM = do
                 , damlPath = damlPath
                 , targetVersionM = Just sdkVersion
                 , projectPathM = Nothing
-                , out = stderr -- Print install messages to stderr.
+                , output = hPutStrLn stderr -- Print install messages to stderr.
                 }
         versionInstall env sdkVersion
         pure (defaultSdkPath damlPath sdkVersion)

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -218,7 +218,12 @@ autoInstall damlPath sdkVersionM = do
                 , damlPath = damlPath
                 , targetVersionM = Just sdkVersion
                 , projectPathM = Nothing
-                , output = hPutStrLn stderr -- Print install messages to stderr.
+                , output = hPutStrLn stderr
+                    -- Print install messages to stderr since the install
+                    -- is only happening because of some other command,
+                    -- and we don't want to mess up the other command's
+                    -- output / have the install messages be gobbled
+                    -- up by a pipe.
                 }
         versionInstall env sdkVersion
         pure (defaultSdkPath damlPath sdkVersion)

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -393,7 +393,7 @@ projectInstall env projectPath = do
 install :: InstallOptions -> DamlPath -> Maybe ProjectPath -> IO ()
 install options damlPath projectPathM = do
     let targetVersionM = Nothing -- determined later
-        output = hPutStrLn stdout -- output install messages to stdout
+        output = hPutStrLn stdout -- Output install messages to stdout.
         env = InstallEnv {..}
     case iTargetM options of
         Nothing -> do

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -393,7 +393,7 @@ projectInstall env projectPath = do
 install :: InstallOptions -> DamlPath -> Maybe ProjectPath -> IO ()
 install options damlPath projectPathM = do
     let targetVersionM = Nothing -- determined later
-        output = hPutStrLn stdout -- Output install messages to stdout.
+        output = putStrLn -- Output install messages to stdout.
         env = InstallEnv {..}
     case iTargetM options of
         Nothing -> do

--- a/daml-assistant/src/DAML/Assistant/Tests.hs
+++ b/daml-assistant/src/DAML/Assistant/Tests.hs
@@ -152,7 +152,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Just expected2)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -168,7 +168,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Nothing)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -184,7 +184,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Just expected2)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -204,7 +204,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Nothing)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -226,7 +226,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Nothing)
                         , (sdkPathEnvVar, Just expected2)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -246,7 +246,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Just got1, Just (SdkPath got2)) <-
                 withEnv [ (sdkVersionEnvVar, Just expected1)
                         , (sdkPathEnvVar, Nothing)
-                        ] (getSdk damlPath projectPath)
+                        ] (getSdk damlPath Nothing projectPath)
             Tasty.assertEqual "sdk version" expected1 (versionToString got1)
             Tasty.assertEqual "sdk path" expected2 got2
 
@@ -258,7 +258,7 @@ testGetSdk = Tasty.testGroup "DAML.Assistant.Env.getSdk"
             (Nothing, Nothing) <- withEnv
                 [ (sdkVersionEnvVar, Nothing)
                 , (sdkPathEnvVar, Nothing)
-                ] (getSdk damlPath projPath)
+                ] (getSdk damlPath Nothing projPath)
             pure ()
     ]
 

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -44,7 +44,7 @@ assistantErrorBecause msg e = (assistantError msg) { errInternal = Just e }
 data Env = Env
     { envDamlPath      :: DamlPath
     , envDamlAssistantPath :: DamlAssistantPath
-    , envDamlAssistantSdkVersion :: Maybe SdkVersion
+    , envDamlAssistantSdkVersion :: Maybe DamlAssistantSdkVersion
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -44,6 +44,7 @@ assistantErrorBecause msg e = (assistantError msg) { errInternal = Just e }
 data Env = Env
     { envDamlPath      :: DamlPath
     , envDamlAssistantPath :: DamlAssistantPath
+    , envDamlAssistantSdkVersion :: Maybe SdkVersion
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -37,5 +37,7 @@ tar xzf $TARBALL -C $TMPDIR/sdk-head --strip-components 1
 DAML_HOME=$DAML_HEAD $TMPDIR/sdk-head/install.sh
 mv $DAML_HEAD/bin/{daml,daml-head}
 
+echo "auto-install: false" > $DAML_HEAD/daml-config.yaml
+
 trap - EXIT
 echo "$(tput setaf 3)Successfully installed daml-head command.$(tput sgr 0)"


### PR DESCRIPTION
Implements A1 of #687, and fixes a bug where requesting an SDK version that is not installed would cause an error (so you couldn't even install the missing version manually).
