### PR TITLE
Fix `daml studio` on Windows

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -38,6 +38,7 @@ import Network.Socket
 import System.FilePath
 import System.Directory.Extra
 import System.Exit
+import System.Info.Extra
 import System.Process hiding (runCommand)
 import System.IO
 import System.IO.Error
@@ -75,7 +76,9 @@ runDamlStudio overwriteExtension remainingArguments = do
     let vscodeExtensionTargetDir = vscodeExtensionsDir </> vscodeExtensionName
     when overwriteExtension $ removePathForcibly vscodeExtensionTargetDir
     installExtension vscodeExtensionSrcDir vscodeExtensionTargetDir
-    exitCode <- withCreateProcess (proc "code" ("-w" : remainingArguments)) $ \_ _ _ -> waitForProcess
+    -- Note that it is important that we use `shell` rather than `proc` here as
+    -- `proc` will look for `code.exe` in PATH which does not exist.
+    exitCode <- withCreateProcess (shell $ unwords $ "code" : remainingArguments) $ \_ _ _ -> waitForProcess
     exitWith exitCode
 
 runJar :: FilePath -> [String] -> IO ()
@@ -211,11 +214,18 @@ installExtension :: FilePath -> FilePath -> IO ()
 installExtension src target =
     catchJust
         (guard . isAlreadyExistsError)
-        (createDirectoryLink src target)
+        install
         (-- We might want to emit a warning if the extension is for a different SDK version
          -- but medium term it probably makes more sense to add the extension to the marketplace
          -- and make it backwards compatible
          const $ pure ())
+     where
+         install
+             | isWindows = do
+                   -- We create the directory to throw an isAlreadyExistsError.
+                   createDirectory target
+                   copyDirectory src target
+             | otherwise = createDirectoryLink src target
 
 -- | `waitForConnectionOnPort sleep port` keeps trying to establish a TCP connection on the given port.
 -- Between each connection request it calls `sleep`.


### PR DESCRIPTION
There were two issues in `daml studio`:

1. We need to use `shell` instead of `proc` to launch VSCode.

2. Creating symlinks requires admin privileges on Windows so instead
we just copy the directory.

Note that `daml studio` will not install or upgrade the extension if
it is already installed (this fact is unchanged by this PR). We should
change this to upgrade to newer versions by default (and add an option
to not do this) but I’ll leave that for a separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
