### PR TITLE
Fix `daml start` on Windows

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -160,10 +160,14 @@ runStart = withProjectRoot $ \_ -> do
     projectName :: String <-
         requiredE "Project must have a name" $
         queryProjectConfigRequired ["name"] projectConfig
+    mbScenario :: Maybe String <-
+        requiredE "Failed to parse scenario" $
+        queryProjectConfig ["scenario"] projectConfig
     let darName = projectName <> ".dar"
     assistant <- getDamlAssistant
     callCommand (unwords $ assistant : ["build", "-o", darName])
-    withSandbox sandboxPort [darName] $ \sandboxPh -> do
+    let scenarioArgs = maybe [] (\scenario -> ["--scenario", scenario]) mbScenario
+    withSandbox sandboxPort (darName : scenarioArgs) $ \sandboxPh -> do
         parties <- getProjectParties
         withTempDir $ \confDir -> do
             -- Navigator determines the file format based on the extension so we need a .json file.

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -162,7 +162,7 @@ runStart = withProjectRoot $ \_ -> do
         queryProjectConfigRequired ["name"] projectConfig
     let darName = projectName <> ".dar"
     assistant <- getDamlAssistant
-    callProcess assistant ["build", "-o", darName]
+    callCommand (unwords $ assistant : ["build", "-o", darName])
     withSandbox sandboxPort [darName] $ \sandboxPh -> do
         parties <- getProjectParties
         withTempDir $ \confDir -> do


### PR DESCRIPTION
This fixes two issues in `daml start`:

1. For the same reason we need to use `shell` instead of `proc` to start `vscode` we also need to use `shell` to start the assistant on Windows.
2. `daml start` wasn’t running the scenario defined in the config.

With this change, the Navigator parts of the test plan now seem to pass :tada:

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
