### PR TITLE
Stop deriving ToJSON/FromJSON when using makeInstances

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -28,6 +28,7 @@ import           Control.Exception.Extra
 import           Control.Monad
 import           Control.Monad.IO.Class
 import Control.Monad.Managed
+import           DA.Daml.LF.Proto3.EncodeV1
 import           DA.Pretty hiding (first)
 import qualified DA.Service.Daml.Compiler.Impl.Scenario as SS
 import qualified DA.Service.Logger.Impl.Pure as Logger
@@ -60,6 +61,7 @@ import qualified Development.IDE.Types.Diagnostics as D
 import Development.IDE.UtilGHC
 import           Data.Tagged                  (Tagged (..))
 import qualified GHC
+import qualified Proto3.Suite.JSONPB as JSONPB
 
 import Test.Tasty
 import qualified Test.Tasty.HUnit as HUnit
@@ -175,7 +177,7 @@ runJqQuery log qs = do
     log $ "running jq query: " ++ q
 
     let jq = "external" </> "jq" </> "bin" </> "jq"
-    let json = unpack $ A.encode $ transformOn A._Value numToString $ A.toJSON pkg
+    let json = unpack $ A.encode $ transformOn A._Value numToString $ JSONPB.toJSONPB (encodePackage pkg) JSONPB.jsonPBOptions
     out <- readProcess jq [q] json
     case trim out of
       "true" -> pure Nothing

--- a/daml-foundations/daml-ghc/tests/SerializableAnnotation.daml
+++ b/daml-foundations/daml-ghc/tests/SerializableAnnotation.daml
@@ -1,12 +1,12 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["Unserializable" ]) | .dataSerializable["getIsSerializable"]) == false
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["UnserializableReferenced" ]) | .dataSerializable["getIsSerializable"]) == false
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["UnserializableImported" ]) | .dataSerializable["getIsSerializable"]) == false
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["Serializable" ]) | .dataSerializable["getIsSerializable"]) == true
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["SerializableReferenced" ]) | .dataSerializable["getIsSerializable"]) == true
--- @ QUERY-LF (.packageModules[] | .moduleDataTypes[] | select(.dataTypeCon == ["SerializableImported" ]) | .dataSerializable["getIsSerializable"]) == true
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Unserializable"]) | has("serializable") | not
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["UnserializableReferenced"]) | has("serializable") | not
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["UnserializableImported"]) | has("serializable") | not
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Serializable"]) | .serializable
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["SerializableReferenced"]) | .serializable
+-- @ QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["SerializableImported"]) | .serializable
 
 daml 1.2
 module SerializableAnnotation where

--- a/daml-foundations/daml-ghc/tests/SugarUnit.daml
+++ b/daml-foundations/daml-ghc/tests/SugarUnit.daml
@@ -4,7 +4,7 @@
 -- Test that the type `GHC.Tuple.Unit`, which is only produced by ghc's
 -- desugarer, works correctly (cf. DEL-6656).
 -- Test that the generated code actually uses `GHC.Tuple.Unit`.
--- @ QUERY-LF [.packageModules[] | .moduleValues[] | .dvalBody | .. | .TCon? | objects |select(.qualObject == ["Unit"]) | .qualModule == ["GHC", "Tuple"], length > 0] | all
+-- @ QUERY-LF [.modules[] | .values[] | .. | objects | select(has("tycon")) | .tycon | select(.name.segments == ["Unit"]) | .module.module_name.segments == ["GHC", "Tuple"]] | all
 
 daml 1.2
 module SugarUnit where

--- a/daml-foundations/daml-ghc/tests/UseInteger.daml
+++ b/daml-foundations/daml-ghc/tests/UseInteger.daml
@@ -2,10 +2,10 @@
 -- All rights reserved.
 
 -- Test that foo is not overflowed
--- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]? == "foo") | .dvalBody.ELocation | .[1] | .EBuiltin.BEInt64 == "1.0"
+-- @ QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["foo"]) | .expr.prim_lit.int64 == "1"
 
 -- Test that we daml-lf can hold maxBound :: Int64
--- @ QUERY-LF .packageModules[] | .moduleValues[] | .. | objects | select(.dvalBinder? | .[0]?=="bar") | .dvalBody.ELocation | .[1] | .EBuiltin.BEInt64 == "9.223372036854775807e18"
+-- @ QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["bar"]) | .expr.prim_lit.int64 == "9223372036854775807"
 
 daml 1.2 module UseInteger where
 

--- a/daml-foundations/daml-ghc/util.bzl
+++ b/daml-foundations/daml-ghc/util.bzl
@@ -63,6 +63,7 @@ def daml_ghc_integration_test(name, main_function):
         deps = [
             ":daml-ghc-lib",
             "//compiler/daml-lf-ast",
+            "//compiler/daml-lf-proto",
             "//daml-lf/archive:daml_lf_haskell_proto",
             "//libs-haskell/da-hs-pretty",
             "//libs-haskell/da-hs-base",
@@ -87,6 +88,7 @@ def daml_ghc_integration_test(name, main_function):
             "managed",
             "optparse-applicative",
             "process",
+            "proto3-suite",
             "shake",
             "tagged",
             "tasty",


### PR DESCRIPTION
This is mostly a preparation for dropping `makeInstances` entirely.

As a side effect we have to change how we test properties of the DAML-LF
generated by damlc. Previously, we turned the AST into JSON using its
`ToJSON` instances. Now, we turn the AST into JSON using the `ToJSONPB`
instances generated by `proto3-suite`. The resulting JSON is then
inspected using the `jq` tool in both cases. This change actually improves
our testing since we're now testing properties of the generated protobuf
encoding of the AST rather than of our pleasant Haskell representation of
the AST.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/695)
<!-- Reviewable:end -->
