### PR TITLE
Added colon to list of valid simple string characters

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -29,7 +29,8 @@ object Ref {
       ('a' <= c && c <= 'z') ||
         ('A' <= c && c <= 'Z') ||
         ('0' <= c && c <= '9') ||
-        c == ' ' || c == '-' || c == '_'
+        c == ' ' || c == '-' || 
+        c == '_' || c == ':'
 
     def fromString(string: String): Either[String, SimpleString] =
       if (string.isEmpty)

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -66,7 +66,7 @@ class RefTest extends FreeSpec with Matchers {
 
   "String" - {
 
-    val simpleChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ "
+    val simpleChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_: "
 
     "accepts simple characters" in {
       for (c <- simpleChars)


### PR DESCRIPTION
Before, simple string did only include A-Za-z0-9_- and space as valid characters. Now, also ':' is allowed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
