### PR TITLE
Autoupgrade to newer vscode extensions

### DIFF
--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -11,7 +11,7 @@ main :: IO ()
 main = runCommand =<< execParser (info (commandParser <**> helper) idm)
 
 data Command
-    = DamlStudio { overwriteExtension :: Bool, remainingArguments :: [String] }
+    = DamlStudio { replaceExtension :: ReplaceExtension, remainingArguments :: [String] }
     | RunJar { jarPath :: FilePath, remainingArguments :: [String] }
     | New { targetFolder :: FilePath, templateName :: String }
     | ListTemplates
@@ -20,13 +20,17 @@ data Command
 commandParser :: Parser Command
 commandParser =
     subparser $ fold
-         [ command "studio" (info (damlStudioCmd <**> helper) idm)
+         [ command "studio" (info (damlStudioCmd <**> helper) forwardOptions)
          , command "new" (info (newCmd <**> helper) idm)
          , command "start" (info (startCmd <**> helper) idm)
          , command "run-jar" (info runJarCmd forwardOptions)
          ]
     where damlStudioCmd = DamlStudio
-              <$> switch (long "overwrite" <> help "Overwrite the VSCode extension if it already exists")
+              <$> option readReplacement
+                  (long "replace" <>
+                   help "Whether an existing extension should be overwritten. ('never', 'newer' or 'always', defaults to newer)" <>
+                   value ReplaceExtNewer
+                  )
               <*> many (argument str (metavar "ARG"))
           runJarCmd = RunJar
               <$> argument str (metavar "JAR" <> help "Path to JAR relative to SDK path")
@@ -38,9 +42,16 @@ commandParser =
                   <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: quickstart-java)" <> value "quickstart-java")
               ]
           startCmd = pure Start
+          readReplacement :: ReadM ReplaceExtension
+          readReplacement = maybeReader $ \s -> case s of
+              "never" -> Just ReplaceExtNever
+              "newer" -> Just ReplaceExtNewer
+              "always" -> Just ReplaceExtAlways
+              _ -> Nothing
+
 
 runCommand :: Command -> IO ()
-runCommand DamlStudio {..} = runDamlStudio overwriteExtension remainingArguments
+runCommand DamlStudio {..} = runDamlStudio replaceExtension remainingArguments
 runCommand RunJar {..} = runJar jarPath remainingArguments
 runCommand New {..} = runNew targetFolder templateName
 runCommand ListTemplates = runListTemplates

--- a/daml-foundations/daml-tools/daml-extension/BUILD.bazel
+++ b/daml-foundations/daml-tools/daml-extension/BUILD.bazel
@@ -43,6 +43,7 @@ pkg_tar(
         "@daml_extension_deps//vscode-languageclient:vscode-languageclient",
         "@daml_extension_deps//vscode-languageserver-types:vscode-languageserver-types",
         "@daml_extension_deps//which:which",
+        "//:VERSION",
     ],
     extension = "tar.gz",
     mode = "0755",


### PR DESCRIPTION
This PR changes `daml studio` to automatically install newer SDK
versions by default. The behavior can be overwritten to either force
the current SDK version (which should only be necessary if we break
backwards compatibility) or to not touch existing installations at all.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
