### PR TITLE
Fix Navigator console issues

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
@@ -282,8 +282,9 @@ object Pretty {
       state: State,
       header: List[String],
       data: TraversableOnce[TraversableOnce[String]]): String = {
+    val width = state.reader.getTerminal.getWidth
     AsciiTable()
-      .width(state.reader.getTerminal.getWidth)
+      .width(if (width > 4) width else 80)
       .multiline(false)
       .columnMinWidth(4)
       .sampleAtMostRows(200)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
@@ -254,6 +254,8 @@ object Pretty {
         values
           .map(v => arrayIndent + go(v, i + 1))
           .mkString("\n" + indent * i)
+      case PrettyObject(fields) if fields.isEmpty =>
+        "{}"
       case PrettyObject(fields) =>
         val maxFieldLength = fields.map(_.name.length).max + 1
         fields

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Sql.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Sql.scala
@@ -23,8 +23,9 @@ case object Sql extends SimpleCommand {
       ps <- state.getPartyState ~> s"Unknown party ${state.party}"
       result <- ps.ledger.runQuery(query) ~> s"Error while running the query"
     } yield {
+      val width = state.reader.getTerminal.getWidth
       val table = AsciiTable()
-        .width(state.reader.getTerminal.getWidth)
+        .width(if (width > 4) width else 80)
         .multiline(true)
         .columnMinWidth(4)
         .sampleAtMostRows(100000)


### PR DESCRIPTION
This PR fixes two Navigator console issues:
- Crash when listing or inspecting templates with recursive types
  - Root cause was Navigator failing to pretty-print an empty object
- Crash when running Navigator console on a "dumb" terminal (e.g., inside IntelliJ)
  - Root cause was Navigator not handling the case where terminal width reports as 0