### PR TITLE
Do not pass --remote_http_cache to Bazel on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,8 @@
 # Bazel distributed cache, can be temporarily disabled by passing the following
 # flag: --noremote_accept_cached
-build --remote_http_cache=https://bazel-cache.da-ext.net
+build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
+build:linux --remote_http_cache=https://bazel-cache.da-ext.net
+build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net
 build --remote_upload_local_results=false
 # Enable the disk cache in addition to the http cache.
 # Requires nix/overrides/bazel/combined_cache.patch, so disabled for Windows!


### PR DESCRIPTION
This allows you to use the disk cache (e.g., add `build --disk_cache=.bazel-cache` to `.bazelrc.local`) (you cannot have both enabled at
the same time) locally and we disabled fetching from the cache on
Windows (outside of CI) anyway, so passing --remote_http_cache was a noop.

I’ll try to enable the disk cache by default outside of CI in a separate PR once I’ve tested it for a bit to make sure it doesn’t break things.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
