### PR TITLE
Add exerciseByKey to daml-stdlib

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 daml 1.2

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -59,6 +59,17 @@ lookupByKey = internalLookupByKey
 fetchByKey : forall c k. TemplateKey c k => k -> Update (ContractId c, c)
 fetchByKey k = fmap unpackPair (internalFetchByKey k)
 
+-- | Exercise a choice on a contract given by its key.
+--
+-- The `c` needs to be passed using an explicit type application. For
+-- instance, if you want to exercise a choice `Withdraw` on a contract of
+-- template `Account` given by its key `k`, you must call
+-- `exerciseByKey @Account k Withdraw`.
+exerciseByKey : forall c k e r. (TemplateKey c k, Choice c e r) => k -> e -> Update r
+exerciseByKey k e = do
+    (c, cc) <- fetchByKey @c k
+    exerciseExplicit (choiceController cc e) c e
+
 class Template c where
 
     -- | Predicate that must hold for the succesful creation of the contract.


### PR DESCRIPTION
While I wrote my first model using contract keys, the pattern captured by
`exerciseByKey` popped up three times. I think that's a good indicator that
we want it in the stdlib.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/719)
<!-- Reviewable:end -->
