### PR TITLE
Migrate quickstart guide to DAML assistant

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -27,7 +27,7 @@ Download the quickstart application
 
 You can get the quickstart application as an :ref:`SDK template <cli-managing-templates>`:
 
-#. Run ``da new quickstart``
+#. Run ``daml new quickstart``
 
    This loads the entire application into a folder called ``quickstart``.
 #. Run ``cd quickstart`` to change into the new directory.
@@ -40,7 +40,7 @@ The project contains the following files:
 .. code-block:: none
 
   .
-  ├── da.yaml
+  ├── daml.yaml
   ├── daml
   │   ├── Iou.daml
   │   ├── IouTrade.daml
@@ -57,11 +57,10 @@ The project contains the following files:
   │               └── digitalasset
   │                   └── quickstart
   │                       └── iou
-  │                           ├── Iou.java
   │                           └── IouMain.java
   └── ui-backend.conf
 
-- ``da.yaml`` is a DAML project definition file consumed by some CLI commands. It will not be used in this guide.
+- ``daml.yaml`` is a DAML project definition file consumed by some CLI commands. It will not be used in this guide.
 - ``daml`` contains the :ref:`DAML code <quickstart-daml>` specifying the contract model for the ledger.
 - ``daml/Tests`` contains :ref:`test scenarios <quickstart-scenarios>` for the DAML model.
 - ``frontend-config.js`` and ``ui-backend.conf`` are configuration files for the :ref:`Navigator <quickstart-navigator>` frontend.
@@ -114,7 +113,7 @@ Run the application using prototyping tools
 
 In this section, you will run the quickstart application and get introduced to the main tools for prototyping DAML:
 
-#. To compile the DAML model, run ``da run damlc -- package daml/Main.daml target/daml/iou``
+#. To compile the DAML model, run ``daml package -o target/daml/iou.dar``
 
    This creates a DAR package called ``target/daml/iou.dar``. The output should look like this:
 
@@ -124,7 +123,7 @@ In this section, you will run the quickstart application and get introduced to t
 
    .. _quickstart-sandbox:
 
-#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``da run sandbox -- --scenario Main:setup target/daml/*``
+#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``daml sandbox --scenario Main:setup target/daml/iou.dar``
 
    The output should look like this:
 
@@ -138,7 +137,7 @@ In this section, you will run the quickstart application and get introduced to t
       _\ \/ _ `/ _ \/ _  / _ \/ _ \\ \ /
       /___/\_,_/_//_/\_,_/_.__/\___/_\_\
 
-      Initialized sandbox version 100.12.1 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
+      Initialized sandbox version 100.12.10 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
 
    The sandbox is now running, and you can access its :ref:`ledger API <ledger-api-introduction>` on port ``6865``.
 
@@ -149,7 +148,7 @@ In this section, you will run the quickstart application and get introduced to t
    .. _quickstart-navigator:
 
 #. Open a new terminal window and navigate to your project directory.
-#. Start the :doc:`Navigator </tools/navigator/index>`, a browser-based leger front-end, by running ``da run navigator -- server``
+#. Start the :doc:`Navigator </tools/navigator/index>`, a browser-based leger front-end, by running ``daml navigator server``
 
    The Navigator automatically connects the sandbox. You can access it on port ``4000``.
 
@@ -264,7 +263,7 @@ Develop with DAML Studio
 
 Take a look at the DAML that specifies the contract model in the quickstart application. The core template is ``Iou``.
 
-#. Open :doc:`DAML Studio </daml/daml-studio>`, a DAML IDE based on VS Code, by running ``da studio`` from the root of your project.
+#. Open :doc:`DAML Studio </daml/daml-studio>`, a DAML IDE based on VS Code, by running ``daml studio`` from the root of your project.
 #. Using the explorer on the left, open ``daml/Iou.daml``.
 
 The first two lines specify language version and module name:

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -113,7 +113,7 @@ Run the application using prototyping tools
 
 In this section, you will run the quickstart application and get introduced to the main tools for prototyping DAML:
 
-#. To compile the DAML model, run ``daml package -o target/daml/iou.dar``
+#. To compile the DAML model, run ``daml build -o target/daml/iou.dar``
 
    This creates a DAR package called ``target/daml/iou.dar``. The output should look like this:
 


### PR DESCRIPTION
I just went through the quickstart guide on Windows with the new assistant and these are the changes that I had to make to get things working.

We need to figure out how exactly we want to handle the docs migration to the new assistant before merging this.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
