### PR TITLE
Add DA.Experimental.Map

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Map.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Map.daml
@@ -1,0 +1,136 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+daml 1.2
+-- | Map - A `Map` is an associative array data type composed of a
+-- collection of key/value pairs such that each possible key appears
+-- at most once in the collection.
+module DA.Experimental.Map
+  ( Map
+  , MapKey (..)
+  , empty
+  , size
+  , toList
+  , fromList
+  , null
+  , lookup
+  , member
+  , filterWithKey
+  , delete
+  , insert
+  , union
+  ) where
+
+import Prelude hiding (lookup, null, empty)
+import DA.Foldable qualified as Foldable
+import DA.Optional
+import DA.Text
+import DA.TextMap qualified as TextMap
+import DA.Traversable qualified as Traversable
+import DA.Tuple
+
+-- | A `Map k v` is an associative array data type composed of a
+-- collection of key/value pairs of key type `k` and value type `v`
+-- such that each possible key appears at most once in the collection.
+newtype Map k v = Map with textMap : TextMap v
+  deriving (Eq, Ord, Foldable.Foldable)
+
+-- | A class for types that can be used as keys for the `Map` type.
+-- All keys `k` must satisfy `keyFromText (keyToText k) == k`.
+class Eq k => MapKey k where
+  -- | Turn a key into its textual representation. This function must be
+  -- injective.
+  keyToText : k -> Text
+  -- | Recover a key from its textual representation. `keyFromText x` is
+  -- allowed to fail whenever there is _no_ key `k` with `keyToText k == x`.
+  -- Whenever such a `k` does exist, then it must satisfy
+  -- `keyFromText x == k`.
+  keyFromText : Text -> k
+
+instance MapKey Text where
+  keyToText x = x
+  keyFromText x = x
+
+instance MapKey Party where
+  keyToText = partyToText
+  keyFromText = fromSome . partyFromText
+
+instance MapKey Int where
+  keyToText = show
+  keyFromText = fromSome . parseInt
+
+instance MapKey Decimal where
+  keyToText = show
+  keyFromText = fromSome . parseDecimal
+
+-- | Create a map from a list of key/value pairs.
+fromList : MapKey k => [(k, v)] -> Map k v
+fromList kvs = Map $ TextMap.fromList $ map (first keyToText) kvs
+
+-- | Convert the map to a list of key/value pairs where the keys are
+-- in ascending order of their textual representation.
+toList : MapKey k => Map k v -> [(k, v)]
+toList (Map t) = map (first keyFromText) $ TextMap.toList t
+
+-- | Create a `Map` from a `TextMap`.
+fromTextMap : TextMap v -> Map Text v
+fromTextMap = Map
+
+-- | Convert a `Map` into a `TextMap`.
+toTextMap : MapKey k => Map k v -> TextMap v
+toTextMap (Map t) = t
+
+-- | The empty map.
+empty : MapKey k => Map k v
+empty = Map TextMap.empty
+
+-- | Number of elements in the map.
+size : Map k v -> Int
+size (Map t) = TextMap.size t
+
+-- | Is the map empty?
+null : Map k v -> Bool
+null m = size m == 0
+
+-- | Lookup the value at a key in the map.
+lookup : MapKey k => k -> Map k v -> Optional v
+lookup k (Map t) = TextMap.lookup (keyToText k) t
+
+-- | Is the key a member of the map?
+member : MapKey k => k -> Map k v -> Bool
+member k (Map t) = TextMap.member (keyToText k) t
+
+-- | Filter all values that satisfy some predicate.
+filterWithKey : MapKey k => (k -> v -> Bool) -> Map k v -> Map k v
+filterWithKey p (Map t) = Map $ TextMap.filterWithKey (p . keyFromText) t
+
+-- | Delete a key and its value from the map. When the key is not a
+-- member of the map, the original map is returned.
+delete : MapKey k => k -> Map k v -> Map k v
+delete k (Map t) = Map $ TextMap.delete (keyToText k) t
+
+-- | Insert a new key/value pair in the map. If the key is already
+-- present in the map, the associated value is replaced with the
+-- supplied value.
+insert : MapKey k => k -> v -> Map k v -> Map k v
+insert k v (Map t) = Map $ TextMap.insert (keyToText k) v t
+
+-- | The union of two maps, preferring the first map when equal
+-- keys are encountered.
+union : MapKey k => Map k v -> Map k v -> Map k v
+union (Map t1) (Map t2) = Map $ TextMap.union t1 t2
+
+instance (MapKey k, Show k, Show v) => Show (Map k v) where
+  show m = "Map " <> show (toList m)
+
+deriving instance MapKey k => Semigroup (Map k v)
+
+-- TODO(MH): The converter to DAML-LF can't handle deriving this right now.
+-- It fails with "Coercion with symco."
+-- deriving instance MapKey k => Monoid (Map k v)
+instance MapKey k => Monoid (Map k v) where
+  mempty = empty
+
+deriving instance MapKey k => Functor (Map k)
+
+instance MapKey k => Traversable.Traversable (Map k) where
+  mapA f (Map t) = fmap Map $ Traversable.mapA f t

--- a/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
@@ -13,6 +13,7 @@ import DA.Assert
 import DA.Bifunctor
 import DA.Date
 import DA.Either
+import DA.Experimental.Map
 import DA.Foldable
 import DA.Functor
 import DA.HKTemplate


### PR DESCRIPTION
This PR adds a key/value map type based on `DA.TextMap` for key types with a
(more or less) canonical mapping to `Text`. Ideally this would replace
`DA.Map` one day but I'd like to get some feedback before we do this.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/730)
<!-- Reviewable:end -->
