### PR TITLE
Rename DA.TextMap.filter into filterWithKey

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Map.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Map.daml
@@ -17,6 +17,7 @@ module DA.Map
   , lookup
   , member
   , filter
+  , filterWithKey
   , delete
   , insert
   , merge
@@ -82,9 +83,14 @@ lookup x m = L.lookup x (toList m)
 member : (Eq k, Ord k) => k -> Map k v -> Bool
 member x m = M.isSome $ lookup x m
 
--- | Filter all values that satisfy some predicate.
+{-# DEPRECATED filter "Use 'filterWithKey' instead of 'filter'" #-}
+-- | DEPRECATED: Use `filterWithKey` instead.
 filter : Eq k => (k -> v -> Bool) -> Map k v -> Map k v
-filter p m = Map_internal $ L.filter (uncurry p) (toList m)
+filter = filterWithKey
+
+-- | Filter all values that satisfy some predicate.
+filterWithKey : Eq k => (k -> v -> Bool) -> Map k v -> Map k v
+filterWithKey p m = Map_internal $ L.filter (uncurry p) (toList m)
 
 -- | Delete a key and its value from the map. When the key is not a
 -- member of the map, the original map is returned.

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
@@ -14,7 +14,7 @@ module DA.TextMap
   , null
   , lookup
   , member
-  , filter
+  , filterWithKey
   , delete
   , insert
   , union
@@ -56,8 +56,8 @@ member : Text -> TextMap v -> Bool
 member x m = isSome $ lookup x m
 
 -- | Filter all values that satisfy some predicate.
-filter : (Text -> v -> Bool) -> TextMap v -> TextMap v
-filter p m = fromList $ List.filter (uncurry p) (toList m)
+filterWithKey : (Text -> v -> Bool) -> TextMap v -> TextMap v
+filterWithKey p m = fromList $ List.filter (uncurry p) (toList m)
 
 -- | Delete a key and its value from the map. When the key is not a
 -- member of the map, the original map is returned.

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
@@ -14,6 +14,7 @@ module DA.TextMap
   , null
   , lookup
   , member
+  , filter
   , filterWithKey
   , delete
   , insert
@@ -54,6 +55,11 @@ lookup = primitive @"BEMapLookup"
 -- | Is the key a member of the map?
 member : Text -> TextMap v -> Bool
 member x m = isSome $ lookup x m
+
+{-# DEPRECATED filter "Use 'filterWithKey' instead of 'filter'" #-}
+-- | DEPRECATED: Use `filterWithKey` instead.
+filter : (Text -> v -> Bool) -> TextMap v -> TextMap v
+filter = filterWithKey
 
 -- | Filter all values that satisfy some predicate.
 filterWithKey : (Text -> v -> Bool) -> TextMap v -> TextMap v

--- a/daml-foundations/daml-ghc/tests/Map.daml
+++ b/daml-foundations/daml-ghc/tests/Map.daml
@@ -52,8 +52,8 @@ testInsert = scenario do
   [(1, True), (2, False), (3, True), (4, False), (5, False)] === toList
     (foldl (\a b -> (uncurry insert) b a) M.empty [(3, True), (1, False), (4, False), (2, True), (5, False), (2, False), (1, True)])
 
-testFilter = scenario do
-  [(1, True), (2, False), (3, True)] === toList (M.filter (\k v -> k < 3 || v) (fromList [(3, True), (1, False), (4, False), (2, True), (5, False), (2, False), (1, True)]))
+testFilterWithKey = scenario do
+  [(1, True), (2, False), (3, True)] === toList (M.filterWithKey (\k v -> k < 3 || v) (fromList [(3, True), (1, False), (4, False), (2, True), (5, False), (2, False), (1, True)]))
 
 testDelete = scenario do
   [(2, False), (3, True), (4, False), (5, False)] === toList (delete 1 (fromList [(3, True), (1, False), (4, False), (2, True), (5, False), (2, False), (1, True)]))
@@ -79,7 +79,7 @@ main = scenario do
   testMember
   testNull
   testInsert
-  testFilter
+  testFilterWithKey
   testDelete
   testMerge
 

--- a/daml-foundations/daml-ghc/tests/TextMap.daml
+++ b/daml-foundations/daml-ghc/tests/TextMap.daml
@@ -55,10 +55,10 @@ testInsert = scenario do
     ===
     toList (foldl (\a b -> (uncurry TM.insert) b a) TM.empty [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)])
 
-testFilter = scenario do
+testFilterWithKey = scenario do
   (fromList [("1", True), ("2", False), ("3", True)])
     ===
-    (TM.filter (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
+    (TM.filterWithKey (\k v -> k < "3" || v) (fromList [("3", True), ("1", False), ("4", False), ("2", True), ("5", False), ("2", False), ("1", True)]))
 
 testDelete = scenario do
   (fromList [("2", False), ("3", True), ("4", False), ("5", False)])

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -18,6 +18,7 @@ HEAD — ongoing
   option.  A "1.dev" target will handle the intended "Dev" use cases in a future release.
 - Include list of DAML packages used during interpretation in the produced transaction.
 - Release source jars for scala libraries.
+- Rename ``DA.TextMap.filter`` into ``filterWithKey``.
 
 0.12.11 - 2019-04-26
 --------------------

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -18,7 +18,7 @@ HEAD — ongoing
   option.  A "1.dev" target will handle the intended "Dev" use cases in a future release.
 - Include list of DAML packages used during interpretation in the produced transaction.
 - Release source jars for scala libraries.
-- Rename ``DA.TextMap.filter`` into ``filterWithKey``.
+- Rename ``DA.TextMap.filter`` and ``DA.Map.filter`` to ``filterWithKey``.
 
 0.12.11 - 2019-04-26
 --------------------


### PR DESCRIPTION
`filterWithKey` reflects better that the predicate used for filtering
takes the key as an argument.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/731)
<!-- Reviewable:end -->
