### PR TITLE
Track the packages used to produce a transaction

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -134,6 +134,10 @@ object Blinding {
       }
     }
 
-    GenTransaction(roots = go(BackStack.empty, FrontStack(tx.roots)), nodes = filteredNodes)
+    GenTransaction(
+      roots = go(BackStack.empty, FrontStack(tx.roots)),
+      nodes = filteredNodes,
+      usedPackages = tx.usedPackages
+    )
   }
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -381,6 +381,12 @@ class EngineTest extends WordSpec with Matchers {
         case Right(()) => ()
       }
     }
+
+    "cause used package to show up in transaction" in {
+      // NOTE(JM): Other packages are pulled in by BasicTests.daml, e.g. daml-prim, but we
+      // don't know the package ids here.
+      interpretResult.map(_.usedPackages.contains(basicTestsPkgId)) shouldBe Right(true)
+    }
   }
 
   "exercise command" should {
@@ -846,11 +852,13 @@ class EngineTest extends WordSpec with Matchers {
       val node2 = node1.copy(coid = AbsoluteContractId("0:1"))
 
       val tx = GenTx[NodeId, AbsoluteContractId, VersionedValue[AbsoluteContractId]](
-        Map(
+        nodes = Map(
           Tx.NodeId.unsafeFromIndex(0) -> node1,
           Tx.NodeId.unsafeFromIndex(1) -> node2
         ),
-        ImmArray(Tx.NodeId.unsafeFromIndex(0), Tx.NodeId.unsafeFromIndex(1)))
+        roots = ImmArray(Tx.NodeId.unsafeFromIndex(0), Tx.NodeId.unsafeFromIndex(1)),
+        usedPackages = Set.empty,
+      )
 
       val validationResult = engine
         .validatePartial(

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -45,6 +45,7 @@ da_scala_test_suite(
         "//daml-lf/data",
         "//daml-lf/lfpackage",
         "//daml-lf/parser",
+        "//daml-lf/transaction",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -91,7 +91,8 @@ object Speedy {
         false
     }
 
-    def lookupVal(eval: SEVal): Ctrl =
+    def lookupVal(eval: SEVal): Ctrl = {
+      ptx = ptx.markPackage(eval.ref.packageId)
       eval.cached match {
         case Some(v) =>
           CtrlValue(v.asInstanceOf[SValue])
@@ -127,6 +128,7 @@ object Speedy {
             }
           }
       }
+    }
 
     /** Returns true when the machine has finished evaluation.
       * The machine is considered final when the kont stack

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/interp/testing/InterpTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/interp/testing/InterpTest.scala
@@ -212,5 +212,22 @@ class InterpTest extends WordSpec with Matchers {
 
     }
 
+    "tracks packages" in {
+      val machine = Speedy.Machine.fromExpr(
+        EVal(ref),
+        pkgs1,
+        false
+      )
+      var result: SResult = SResultContinue
+      def run() = {
+        while (result == SResultContinue && !machine.isFinal) result = machine.step()
+      }
+
+      run()
+
+      machine.ptx.usedPackages shouldBe Set(dummyPkg)
+    }
+
   }
+
 }

--- a/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
+++ b/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
@@ -259,7 +259,7 @@ class SemanticTester(
                   checkEvents(
                     reference,
                     richTransaction.explicitDisclosure,
-                    GenTransaction(richTransaction.nodes, ImmArray(nodeId)),
+                    GenTransaction(richTransaction.nodes, ImmArray(nodeId), Set.empty),
                     events,
                     scenarioToLedgerCoidMap)
               }

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -361,7 +361,7 @@ object ValueGenerators {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(NodeId.unsafeFromIndex))
-    } yield GenTransaction(nodes.toMap, ImmArray(roots))
+    } yield GenTransaction(nodes.toMap, ImmArray(roots), Set.empty)
   }
 
   @deprecated("use malformedGenTransaction instead", since = "100.11.17")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -61,6 +61,13 @@ case class VersionedTransaction[Nid, Cid](
   *
   * @param nodes The nodes of this transaction.
   * @param roots References to the root nodes of the transaction.
+  * @param usedPackages The set of packages used during interpretation.
+  *                     This is a hint for what packages are required to validate
+  *                     the transaction using the current interpreter. This assumption
+  *                     may not hold if new DAML engine implementations are introduced
+  *                     as some packages may be only referenced during compilation to
+  *                     engine's internal form. The used packages are not serialized
+  *                     using [[TransactionCoder]].
   *
   * Users of this class may assume that all instances are well-formed, i.e., `isWellFormed.isEmpty`.
   * For performance reasons, users are not required to call `isWellFormed`.
@@ -68,7 +75,8 @@ case class VersionedTransaction[Nid, Cid](
   */
 case class GenTransaction[Nid, Cid, +Val](
     nodes: Map[Nid, GenNode[Nid, Cid, Val]],
-    roots: ImmArray[Nid]) {
+    roots: ImmArray[Nid],
+    usedPackages: Set[PackageId]) {
   import GenTransaction._
 
   def mapContractIdAndValue[Cid2, Val2](
@@ -86,9 +94,13 @@ case class GenTransaction[Nid, Cid, +Val](
 
   /** Note: the provided function must be injective, otherwise the transaction will be corrupted. */
   def mapNodeId[Nid2](f: Nid => Nid2): GenTransaction[Nid2, Cid, Val] =
-    transaction.GenTransaction(roots = roots.map(f), nodes = nodes.map {
-      case (nid, node) => (f(nid), node.mapNodeId(f))
-    })
+    transaction.GenTransaction(
+      roots = roots.map(f),
+      nodes = nodes.map {
+        case (nid, node) => (f(nid), node.mapNodeId(f))
+      },
+      usedPackages = usedPackages
+    )
 
   /**
     * This function traverses the roots in order, visiting children based on the traverse order provided.
@@ -438,6 +450,12 @@ object Transaction {
     *              we archive. This is not an optimization and is required for
     *              correct semantics, since otherwise lookups for keys for
     *              locally archived absolute contract ids will succeed wrongly.
+    * @param usedPackages The set of packages used during interpretation.
+    *                     This is a hint for what packages are required to validate
+    *                     the transaction using the current interpreter. This assumption
+    *                     may not hold if new DAML engine implementations are introduced
+    *                     as some packages may be only referenced during compilation to
+    *                     engine's internal form.
     */
   case class PartialTransaction(
       nextNodeId: NodeId,
@@ -446,7 +464,8 @@ object Transaction {
       consumedBy: Map[ContractId, NodeId],
       context: Context,
       aborted: Option[TransactionError],
-      keys: Map[GlobalKey, Option[ContractId]]
+      keys: Map[GlobalKey, Option[ContractId]],
+      usedPackages: Set[PackageId]
   ) {
 
     private def computeRoots: Set[NodeId] = {
@@ -483,7 +502,7 @@ object Transaction {
         // roots field is not initialized when this method is executed on a failed transaction,
         // so we need to compute them.
         val rootNodes = computeRoots
-        val tx = GenTransaction(nodes, ImmArray(rootNodes))
+        val tx = GenTransaction(nodes, ImmArray(rootNodes), usedPackages)
 
         tx.foreach(GenTransaction.TopDown, { (nid, node) =>
           val rootPrefix = if (rootNodes.contains(nid)) "root " else ""
@@ -513,7 +532,8 @@ object Transaction {
             Right(
               GenTransaction(
                 nodes = nodes,
-                roots = roots.toImmArray
+                roots = roots.toImmArray,
+                usedPackages = usedPackages
               ))
           case _ => Left(this)
         }
@@ -537,7 +557,7 @@ object Transaction {
     }
 
     /** Extend the 'PartialTransaction' with a node for creating a
-      *  contract instance.
+      * contract instance.
       */
     def create(
         coinst: ContractInst[Value[ContractId]],
@@ -566,6 +586,12 @@ object Transaction {
         Right(ntx.copy(_1 = nodeIdToContractId(ntx._1)))
       }
     }
+
+    /** Mark a package as being used in the process of preparing the
+      * transaction.
+      */
+    def markPackage(packageId: PackageId): PartialTransaction =
+      this.copy(usedPackages = usedPackages + packageId)
 
     def serializable(a: Value[ContractId]): ImmArray[String] = a.value.serializable()
 
@@ -744,7 +770,8 @@ object Transaction {
       consumedBy = Map.empty,
       context = ContextRoot,
       aborted = None,
-      keys = Map.empty
+      keys = Map.empty,
+      usedPackages = Set.empty
     )
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -445,7 +445,7 @@ object TransactionCoder {
     for {
       rs <- roots
       ns <- nodes
-    } yield GenTransaction(ns, rs)
+    } yield GenTransaction(ns, rs, Set.empty)
   }
 
   private def toPartySet(strList: ProtocolStringList): Either[DecodeError, Set[Party]] = {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -244,7 +244,11 @@ class TransactionCoderSpec
       val nodes = ImmArray((1 to 10000).map { nid =>
         (nid.toString, node)
       })
-      val tx = GenTransaction(Map(nodes.toSeq: _*), nodes.map(_._1))
+      val tx = GenTransaction(
+        nodes = Map(nodes.toSeq: _*),
+        roots = nodes.map(_._1),
+        usedPackages = Set.empty
+      )
       tx shouldEqual TransactionCoder
         .decodeVersionedTransaction(
           Right(_),

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -115,7 +115,7 @@ object TransactionSpec {
   type StringTransaction = GenTransaction[String, String, Value[String]]
   def StringTransaction(
       nodes: Map[String, GenNode[String, String, Value[String]]],
-      roots: ImmArray[String]): StringTransaction = GenTransaction(nodes, roots)
+      roots: ImmArray[String]): StringTransaction = GenTransaction(nodes, roots, Set.empty)
 
   def dummyExerciseNode(children: ImmArray[String]): NodeExercises[String, String, Value[String]] =
     NodeExercises(

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -14,6 +14,7 @@ HEAD — ongoing
   to evolve.
 - Remove DAML-LF Dev major version, ``--target dev`` option, and sandbox ``--allow-dev``
   option.  A "1.dev" target will handle the intended "Dev" use cases in a future release.
+- Include list of DAML packages used during interpretation in the produced transaction.
 
 0.12.11 - 2019-04-26
 --------------------

--- a/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
@@ -129,7 +129,7 @@ final case class BadReadService(ledger: Ledger) extends ReadService {
       case (updateId, update) =>
         val updatePrime = update match {
           case tx: Update.TransactionAccepted =>
-            tx.copy(transaction = GenTransaction(Map(), ImmArray.empty))
+            tx.copy(transaction = GenTransaction(Map(), ImmArray.empty, Set.empty))
           case _ => update
         }
         (updateId, updatePrime)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -172,7 +172,7 @@ object ScenarioLoader {
         val workflowId = s"scenario-workflow-$stepId"
         // note that it's important that we keep the event ids in line with the contract ids, since
         // the sandbox code assumes that in TransactionConversion.
-        val txNoHash = GenTransaction(richTransaction.nodes, richTransaction.roots)
+        val txNoHash = GenTransaction(richTransaction.nodes, richTransaction.roots, Set.empty)
         val tx = txNoHash.mapContractIdAndValue(absCidWithHash, _.mapContractId(absCidWithHash))
         import richTransaction.{explicitDisclosure, implicitDisclosure}
         // copies non-absolute-able node IDs, but IDs that don't match

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
@@ -243,7 +243,8 @@ class EventConverterSpec
           Lf.AbsoluteContractId,
           Lf.VersionedValue[Lf.AbsoluteContractId]]] =
         Seq(nod0, node1).toMap
-      val tx: LfTx = GenTransaction(nodes, ImmArray(Transaction.NodeId.unsafeFromIndex(0)))
+      val tx: LfTx =
+        GenTransaction(nodes, ImmArray(Transaction.NodeId.unsafeFromIndex(0)), Set.empty)
       val blinding = Blinding.blind(tx)
       val absCoid: Lf.ContractId => Lf.AbsoluteContractId =
         SandboxEventIdFormatter.makeAbsCoid("transactionId")

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -113,7 +113,8 @@ class PostgresDaoSpec
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
               Some(keyWithMaintainers)
             )),
-          ImmArray("event1")
+          ImmArray("event1"),
+          Set.empty
         ),
         Map("event1" -> Set("Alice", "Bob"), "event2" -> Set("Alice", "In", "Chains"))
       )
@@ -229,7 +230,8 @@ class PostgresDaoSpec
               Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
               Some(keyWithMaintainers)
             )),
-          ImmArray("event1")
+          ImmArray("event1"),
+          Set.empty
         ),
         Map("event1" -> Set("Alice", "Bob"), "event2" -> Set("Alice", "In", "Chains"))
       )
@@ -289,7 +291,8 @@ class PostgresDaoSpec
                 Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
                 None
               )),
-            ImmArray(s"event$id")
+            ImmArray(s"event$id"),
+            Set.empty
           ),
           Map(s"event$id" -> Set("Alice", "Bob"))
         )
@@ -322,7 +325,8 @@ class PostgresDaoSpec
                 Set(SimpleString.assertFromString("Alice"), SimpleString.assertFromString("Bob")),
                 ImmArray.empty
               )),
-            ImmArray(s"event$id")
+            ImmArray(s"event$id"),
+            Set.empty
           ),
           Map(s"event$id" -> Set("Alice", "Bob"))
         )


### PR DESCRIPTION
Add field 'pkgs' to Transaction to record the packages that were
used during interpretation to produce said transaction.

These are required for ledger implementations for which the
packages are tracked similarly to contract instances, and which
require that all inputs to their transaction must be declared
beforehand.

This work is required for the participant-state key-value utilities
described in issue #410 and implemented in PR #637.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
