### PR TITLE
Full documentation for the new assistant

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 da.yaml
+/source/app-dev/grpc/proto-docs.rst

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -18,7 +18,7 @@ You can download the `latest version <https://bintray.com/api/v1/content/digital
 
 * the downloaded Java codegen jar file, eg. 10x.y.z
 * the dependency to :ref:`bindings-java <daml-codegen-java-compiling>`, eg. 10x.y.z
-* the ``sdk-version`` attribute in the :ref:`da.yaml <da-yaml-configuration>` file, eg. x.y.z
+* the ``sdk-version`` attribute in the :ref:`da.yaml <daml-yaml-configuration>` file, eg. x.y.z
 
 .. _daml-codegen-java-running:
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -18,7 +18,7 @@ You can download the `latest version <https://bintray.com/api/v1/content/digital
 
 * the downloaded Java codegen jar file, eg. 10x.y.z
 * the dependency to :ref:`bindings-java <daml-codegen-java-compiling>`, eg. 10x.y.z
-* the ``sdk-version`` attribute in the :ref:`da.yaml <daml-yaml-configuration>` file, eg. x.y.z
+* the ``sdk-version`` attribute in the :ref:`daml.yaml <daml-yaml-configuration>` file, eg. x.y.z
 
 .. _daml-codegen-java-running:
 

--- a/docs/source/app-dev/grpc/index.rst
+++ b/docs/source/app-dev/grpc/index.rst
@@ -12,17 +12,15 @@ The Ledger API using gRPC
 
 If you want to write an application for the ledger API in other languages, you'll need to use `gRPC <https://grpc.io>`__ directly.
 
-If you're not familiar with gRPC, we strongly recommend following the `gRPC quickstart <https://grpc.io/docs/quickstart/>`__ and `gRPC tutorials <https://grpc.io/docs/tutorials/>`__. You need an understanding of gRPC before you can use this version of the Ledger API.
+If you're not familiar with gRPC and protobuf, we strongly recommend following the `gRPC quickstart <https://grpc.io/docs/quickstart/>`__ and `gRPC tutorials <https://grpc.io/docs/tutorials/>`__. This documentation is written assuming you already have an understanding of gRPC.
 
 Getting started
 ***************
 
-.. TODO: how to get protobufs in world of new assistant
+You can either get the protobufs `from Bintray here <https://bintray.com/digitalassetsdk/DigitalAssetSDK/sdk-components#files/com%2Fdigitalasset%2Fledger-api-protos>`__, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/master/ledger-api/grpc-definitions>`__.
 
 Protobuf reference documentation
 ********************************
-
-.. TODO brief explanation of protos.
 
 For full details of all of the Ledger API services and their RPC methods, see  :doc:`/app-dev/grpc/proto-docs`.
 

--- a/docs/source/app-dev/grpc/index.rst
+++ b/docs/source/app-dev/grpc/index.rst
@@ -17,7 +17,7 @@ If you're not familiar with gRPC, we strongly recommend following the `gRPC quic
 Getting started
 ***************
 
-To add all of the necessary protobuf files to a project, run ``da project add ledger-api-protos``.
+.. TODO: how to get protobufs in world of new assistant
 
 Protobuf reference documentation
 ********************************

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -14,7 +14,7 @@ To install DAML Studio, :doc:`install the SDK </getting-started/installation>`. 
 Creating your first DAML file
 *****************************
 
-1. Start Visual Studio Code. To start it in the current project, use the ``da studio`` command.
+1. Start Visual Studio Code. To start it in the current project, run ``daml studio``.
    Alternatively you can simply start VS Code as you would normally start any application.
 
 2. Check that the DAML Studio extension is installed by first clicking on

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -16,9 +16,12 @@ Creating your first DAML file
 
 1. Start DAML Studio by running ``daml studio`` in the current project.
 
-   This command will start Visual Studio Code and install the DAML Studio extension, or upgrade it to the latest version.
+   This command starts Visual Studio Code and (if needs be) installs the DAML Studio extension, or upgrades it to the latest version.
 
-2. Verify that the DAML Studio extension is installed by first clicking on the Extensions icon at the bottom of the VS Code sidebar, and then clicking on the DAML Studio extension that should be listed on the pane.
+2. Make sure the DAML Studio extension is installed:
+
+   1. Click on the Extensions icon at the bottom of the VS Code sidebar.
+   2. Click on the DAML Studio extension that should be listed on the pane.
 
    .. image:: daml-studio/images/daml_studio_extension_view.png
 

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -15,12 +15,10 @@ Creating your first DAML file
 *****************************
 
 1. Start DAML Studio by running ``daml studio`` in the current project.
-   This command will start Visual Studio Code and install the DAML Studio
-   extension, or upgrade it to the latest version.
 
-2. Verify that the DAML Studio extension is installed by first clicking on
-   the Extensions icon at the bottom of the VS Code sidebar, and
-   then clicking on the DAML Studio extension that should be listed on the pane.
+   This command will start Visual Studio Code and install the DAML Studio extension, or upgrade it to the latest version.
+
+2. Verify that the DAML Studio extension is installed by first clicking on the Extensions icon at the bottom of the VS Code sidebar, and then clicking on the DAML Studio extension that should be listed on the pane.
 
    .. image:: daml-studio/images/daml_studio_extension_view.png
 

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -14,10 +14,11 @@ To install DAML Studio, :doc:`install the SDK </getting-started/installation>`. 
 Creating your first DAML file
 *****************************
 
-1. Start Visual Studio Code. To start it in the current project, run ``daml studio``.
-   Alternatively you can simply start VS Code as you would normally start any application.
+1. Start DAML Studio by running ``daml studio`` in the current project.
+   This command will start Visual Studio Code and install the DAML Studio
+   extension, or upgrade it to the latest version.
 
-2. Check that the DAML Studio extension is installed by first clicking on
+2. Verify that the DAML Studio extension is installed by first clicking on
    the Extensions icon at the bottom of the VS Code sidebar, and
    then clicking on the DAML Studio extension that should be listed on the pane.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -17,10 +17,10 @@ You need to install:
 2. Install the SDK
 *******************
 
-Mac and Unix
+Mac and Linux
 ============
 
-To install the SDK on Mac or Unix, run::
+To install the SDK on Mac or Linux, run::
 
   curl -sSL https://get.daml.com/ | sh
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -17,13 +17,17 @@ You need to install:
 2. Install the SDK
 *******************
 
+Mac and Unix
+============
+
 To install the SDK on Mac or Unix, run::
 
   curl -sSL https://get.daml.com/ | sh
 
-.. Install the SDK on Windows
-.. ==========================
-.. TODO installer is coming
+Windows
+=======
+
+To install the SDK on Windows, download and run the installer from `github.com/digital-asset/daml/releases/latest <https://github.com/digital-asset/daml/releases/latest>`__.
 
 .. _setup-maven-project:
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -14,42 +14,16 @@ You need to install:
 1. `Visual Studio Code <https://code.visualstudio.com/download>`_.
 2. `JDK 8 or greater <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_.
 
-2. Set up the SDK Assistant
-***************************
+2. Install the SDK
+*******************
 
-The SDK is distributed via a command-line tool called the :doc:`SDK Assistant </tools/assistant>`. To install the SDK Assistant:
+To install the SDK on Mac or Unix, run::
 
-#. Download the latest installer for your platform:
+  curl https://get.daml.com/ | bash
 
-   - .. rst-class:: cta-alt
-   
-        `Linux installer <https://cta-redirect.hubspot.com/cta/redirect/5388578/05b2410e-fba4-4d42-b125-f7fd2dc3ba5d>`_
-     
-     .. raw:: html
-
-        <!--HubSpot Call-to-Action Code --><span class="hs-cta-wrapper" id="hs-cta-wrapper-05b2410e-fba4-4d42-b125-f7fd2dc3ba5d"><span class="hs-cta-node hs-cta-05b2410e-fba4-4d42-b125-f7fd2dc3ba5d" id="hs-cta-05b2410e-fba4-4d42-b125-f7fd2dc3ba5d"><!--[if lte IE 8]><div id="hs-cta-ie-element"></div><![endif]--><a href="https://cta-redirect.hubspot.com/cta/redirect/5388578/05b2410e-fba4-4d42-b125-f7fd2dc3ba5d"  target="_blank" ><img class="hs-cta-img" id="hs-cta-img-05b2410e-fba4-4d42-b125-f7fd2dc3ba5d" style="border-width:0px;" src="https://no-cache.hubspot.com/cta/default/5388578/05b2410e-fba4-4d42-b125-f7fd2dc3ba5d.png"  alt="Linux installer"/></a></span><script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script><script type="text/javascript"> hbspt.cta.load(5388578, '05b2410e-fba4-4d42-b125-f7fd2dc3ba5d', {}); </script></span><!-- end HubSpot Call-to-Action Code -->
-
-   - .. rst-class:: cta-alt
-   
-        `Mac installer <https://cta-redirect.hubspot.com/cta/redirect/5388578/1b93ea71-77c6-4e0e-adbb-de072226d474>`_
-     
-     .. raw:: html
-
-        <!--HubSpot Call-to-Action Code --><span class="hs-cta-wrapper" id="hs-cta-wrapper-1b93ea71-77c6-4e0e-adbb-de072226d474"><span class="hs-cta-node hs-cta-1b93ea71-77c6-4e0e-adbb-de072226d474" id="hs-cta-1b93ea71-77c6-4e0e-adbb-de072226d474"><!--[if lte IE 8]><div id="hs-cta-ie-element"></div><![endif]--><a href="https://cta-redirect.hubspot.com/cta/redirect/5388578/1b93ea71-77c6-4e0e-adbb-de072226d474"  target="_blank" ><img class="hs-cta-img" id="hs-cta-img-1b93ea71-77c6-4e0e-adbb-de072226d474" style="border-width:0px;" src="https://no-cache.hubspot.com/cta/default/5388578/1b93ea71-77c6-4e0e-adbb-de072226d474.png"  alt="Mac installer"/></a></span><script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script><script type="text/javascript"> hbspt.cta.load(5388578, '1b93ea71-77c6-4e0e-adbb-de072226d474', {}); </script></span><!-- end HubSpot Call-to-Action Code -->
-
-   - Windows installer coming soon - `sign up to be notified <https://hub.daml.com/sdk/windows>`_
-
-   The SDK is distributed under the :download:`Apache 2.0 license </LICENSE>` (:download:`NOTICES </NOTICES>`).
-
-#. Run the installer:
-
-   .. code::
-
-     sh ./da-cli-<version>.run
-
-#. Follow the instructions in the output to update your ``PATH``.
-
-#. Run ``da setup``, which will download and install the SDK.
+.. Install the SDK on Windows
+.. ==========================
+.. TODO installer is coming
 
 .. _setup-maven-project:
 
@@ -67,5 +41,5 @@ Next steps
 
 - Follow the :doc:`quickstart guide <quickstart>`.
 - Read the :doc:`introduction <introduction>` page.
-- Use ``da --help`` to see all the commands that the SDK Assistant provides.
+- Use ``daml --help`` to see all the commands that the DAML assistant (``daml``) provides.
 - If you run into any problems, :doc:`use the support page </support/support>` to get in touch with us.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -20,9 +20,12 @@ You need to install:
 Mac and Linux
 ============
 
-To install the SDK on Mac or Linux, run::
+To install the SDK on Mac or Linux:
 
-  curl -sSL https://get.daml.com/ | sh
+1. Run::
+
+     curl -sSL https://get.daml.com/ | sh
+2. If prompted, add ``~/.daml/bin`` to your PATH.
 
 Windows
 =======

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -19,7 +19,7 @@ You need to install:
 
 To install the SDK on Mac or Unix, run::
 
-  curl https://get.daml.com/ | bash
+  curl -sSL https://get.daml.com/ | sh
 
 .. Install the SDK on Windows
 .. ==========================

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -18,7 +18,7 @@ You need to install:
 *******************
 
 Mac and Linux
-============
+=============
 
 To install the SDK on Mac or Linux:
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -27,9 +27,9 @@ Download the quickstart application
 
 You can get the quickstart application using the DAML assistant (``daml``):
 
-#. Run ``daml new quickstart``
+#. Run ``daml new quickstart quickstart-java``
 
-   This loads the entire application into a folder called ``quickstart``.
+   This creates the ``quickstart=java`` application into a folder called ``quickstart``.
 #. Run ``cd quickstart`` to change into the new directory.
 
 Folder structure

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -25,7 +25,7 @@ On this page:
 Download the quickstart application
 ***********************************
 
-You can get the quickstart application as an :ref:`SDK template <cli-managing-templates>`:
+You can get the quickstart application using the DAML assistant (``daml``):
 
 #. Run ``da new quickstart``
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -29,7 +29,7 @@ You can get the quickstart application using the DAML assistant (``daml``):
 
 #. Run ``daml new quickstart quickstart-java``
 
-   This creates the ``quickstart-java`` application into a folder called ``quickstart``.
+   This creates the ``quickstart-java`` application into a new folder called ``quickstart``.
 #. Run ``cd quickstart`` to change into the new directory.
 
 Folder structure

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -139,7 +139,7 @@ In this section, you will run the quickstart application and get introduced to t
 
       Initialized sandbox version 100.12.10 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
 
-   The sandbox is now running, and you can access its :ref:`ledger API <ledger-api-introduction>` on port ``6865``.
+   The sandbox is now running, and you can access its :doc:`ledger API </app-dev/index>` on port ``6865``.
 
    .. note::
 
@@ -464,7 +464,7 @@ The ``submit`` function used in this scenario tries to perform a transaction and
 ..  Interact with the ledger through the command line
     *************************************************
 
-    All interaction with the DA ledger, be it sandbox or full ledger server, happens via the :doc:`Ledger API </app-dev/ledger-api-introduction/index>`. It is based on `gRPC <https://grpc.io/>`_.
+    All interaction with the DA ledger, be it sandbox or full ledger server, happens via the :doc:`Ledger API </app-dev/index>``. It is based on `gRPC <https://grpc.io/>`_.
 
     The Navigator uses this API, as will any :ref:`custom integration <quickstart-application>`.
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -29,7 +29,7 @@ You can get the quickstart application using the DAML assistant (``daml``):
 
 #. Run ``daml new quickstart quickstart-java``
 
-   This creates the ``quickstart=java`` application into a folder called ``quickstart``.
+   This creates the ``quickstart-java`` application into a folder called ``quickstart``.
 #. Run ``cd quickstart`` to change into the new directory.
 
 Folder structure

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -584,7 +584,7 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
 
 The rest of the application sets up the REST services using `Spark Java <http://sparkjava.com/>`_, and does dynamic package Id detection using the Package Service. The latter is useful during development when package Ids change frequently.
 
-For a discussion of ledger application design and architecture, take a look at :doc:`Application Architecture Guide </app-dev/app-arch/index>`.
+For a discussion of ledger application design and architecture, take a look at :doc:`Application Architecture Guide </app-dev/app-arch>`.
 
 Next steps
 **********
@@ -595,5 +595,5 @@ Some steps you could take next include:
 
 - Explore :doc:`examples </examples/examples>` for guidance and inspiration.
 - :doc:`Learn DAML </daml/reference/index>`.
-- Learn more about :doc:`application development </app-dev/app-arch/index>`.
+- Learn more about :doc:`application development </app-dev/app-arch>`.
 - Learn about the :doc:`conceptual models </concepts/ledger-model/index>` behind DAML and platform.

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -27,7 +27,7 @@ Download the quickstart application
 
 You can get the quickstart application using the DAML assistant (``daml``):
 
-#. Run ``da new quickstart``
+#. Run ``daml new quickstart``
 
    This loads the entire application into a folder called ``quickstart``.
 #. Run ``cd quickstart`` to change into the new directory.
@@ -40,7 +40,7 @@ The project contains the following files:
 .. code-block:: none
 
   .
-  ├── da.yaml
+  ├── daml.yaml
   ├── daml
   │   ├── Iou.daml
   │   ├── IouTrade.daml
@@ -57,11 +57,10 @@ The project contains the following files:
   │               └── digitalasset
   │                   └── quickstart
   │                       └── iou
-  │                           ├── Iou.java
   │                           └── IouMain.java
   └── ui-backend.conf
 
-- ``da.yaml`` is a DAML project definition file consumed by some CLI commands. It will not be used in this guide.
+- ``daml.yaml`` is a DAML project config file used by the SDK to find out how to build the DAML project and how to run it.
 - ``daml`` contains the :ref:`DAML code <quickstart-daml>` specifying the contract model for the ledger.
 - ``daml/Tests`` contains :ref:`test scenarios <quickstart-scenarios>` for the DAML model.
 - ``frontend-config.js`` and ``ui-backend.conf`` are configuration files for the :ref:`Navigator <quickstart-navigator>` frontend.
@@ -114,7 +113,7 @@ Run the application using prototyping tools
 
 In this section, you will run the quickstart application and get introduced to the main tools for prototyping DAML:
 
-#. To compile the DAML model, run ``da run damlc -- package daml/Main.daml target/daml/iou``
+#. To compile the DAML model, run ``daml build -o target/daml/iou.dar``
 
    This creates a DAR package called ``target/daml/iou.dar``. The output should look like this:
 
@@ -124,7 +123,7 @@ In this section, you will run the quickstart application and get introduced to t
 
    .. _quickstart-sandbox:
 
-#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``da run sandbox -- --scenario Main:setup target/daml/*``
+#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``daml sandbox --scenario Main:setup target/daml/iou.dar``
 
    The output should look like this:
 
@@ -138,14 +137,10 @@ In this section, you will run the quickstart application and get introduced to t
       _\ \/ _ `/ _ \/ _  / _ \/ _ \\ \ /
       /___/\_,_/_//_/\_,_/_.__/\___/_\_\
 
-      Initialized sandbox version 100.12.1 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
-      Initialized Static time provider, starting from 1970-01-01T00:00:00Z
-      DAML LF Engine supports LF versions: 1.0, 0; Transaction versions: 1; Value versions: 1
-      Starting plainText server
-      listening on localhost:6865
-   
-   The sandbox is now running, and you can access its :doc:`ledger API </app-dev/index>` on port ``6865``.
-   
+      Initialized sandbox version 100.12.10 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
+
+   The sandbox is now running, and you can access its :ref:`ledger API <ledger-api-introduction>` on port ``6865``.
+
    .. note::
 
       The parameter ``--scenario Main:setup`` loaded the sandbox ledger with some initial data. Only the sandbox has this prototyping feature - it's not available on the full ledger server. More on :ref:`scenarios <quickstart-scenarios>` later.
@@ -153,7 +148,7 @@ In this section, you will run the quickstart application and get introduced to t
    .. _quickstart-navigator:
 
 #. Open a new terminal window and navigate to your project directory.
-#. Start the :doc:`Navigator </tools/navigator/index>`, a browser-based leger front-end, by running ``da run navigator -- server``
+#. Start the :doc:`Navigator </tools/navigator/index>`, a browser-based leger front-end, by running ``daml navigator server``
 
    The Navigator automatically connects the sandbox. You can access it on port ``4000``.
 
@@ -268,7 +263,7 @@ Develop with DAML Studio
 
 Take a look at the DAML that specifies the contract model in the quickstart application. The core template is ``Iou``.
 
-#. Open :doc:`DAML Studio </daml/daml-studio>`, a DAML IDE based on VS Code, by running ``da studio`` from the root of your project.
+#. Open :doc:`DAML Studio </daml/daml-studio>`, a DAML IDE based on VS Code, by running ``daml studio`` from the root of your project.
 #. Using the explorer on the left, open ``daml/Iou.daml``.
 
 The first two lines specify language version and module name:
@@ -469,7 +464,7 @@ The ``submit`` function used in this scenario tries to perform a transaction and
 ..  Interact with the ledger through the command line
     *************************************************
 
-    All interaction with the DA ledger, be it sandbox or full ledger server, happens via the :doc:`Ledger API </app-dev/index>`. It is based on `gRPC <https://grpc.io/>`_.
+    All interaction with the DA ledger, be it sandbox or full ledger server, happens via the :doc:`Ledger API </app-dev/ledger-api-introduction/index>`. It is based on `gRPC <https://grpc.io/>`_.
 
     The Navigator uses this API, as will any :ref:`custom integration <quickstart-application>`.
 
@@ -589,7 +584,7 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
 
 The rest of the application sets up the REST services using `Spark Java <http://sparkjava.com/>`_, and does dynamic package Id detection using the Package Service. The latter is useful during development when package Ids change frequently.
 
-For a discussion of ledger application design and architecture, take a look at :doc:`Application Architecture Guide </app-dev/app-arch>`.
+For a discussion of ledger application design and architecture, take a look at :doc:`Application Architecture Guide </app-dev/app-arch/index>`.
 
 Next steps
 **********
@@ -600,5 +595,5 @@ Some steps you could take next include:
 
 - Explore :doc:`examples </examples/examples>` for guidance and inspiration.
 - :doc:`Learn DAML </daml/reference/index>`.
-- Learn more about :doc:`application development </app-dev/app-arch>`.
+- Learn more about :doc:`application development </app-dev/app-arch/index>`.
 - Learn about the :doc:`conceptual models </concepts/ledger-model/index>` behind DAML and platform.

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -78,12 +78,11 @@ Java Bindings
 
 - **SDK**: The Windows installer no longer requires elevated privileges.
 
-- **DAML Assistant**: The assistant handles network failures gracefully.
-
-.. _release-0-12-16:
-- We've built a new and improved version of the SDK assistant, replacing ``da`` commands with ``daml`` commands.
+- **DAML Assistant**: We've built a new and improved version of the SDK assistant, replacing ``da`` commands with ``daml`` commands.
 
   For a full guide to what's changed and how to migrate, see :doc:`/support/new-assistant`. To read about how to use the new ``daml`` Assistant, see :doc:`/tools/assistant`.
+
+.. _release-0-12-16:
 
 0.12.16 - 2019-05-07
 --------------------

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -81,6 +81,9 @@ Java Bindings
 - **DAML Assistant**: The assistant handles network failures gracefully.
 
 .. _release-0-12-16:
+- We've built a new and improved version of the SDK assistant, replacing ``da`` commands with ``daml`` commands.
+
+  For a full guide to what's changed and how to migrate, see :doc:`/support/new-assistant`. To read about how to use the new ``daml`` Assistant, see :doc:`/tools/assistant`.
 
 0.12.16 - 2019-05-07
 --------------------

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -12,12 +12,14 @@ DAML assistant (``daml``)
 - Launch the tools in the SDK:
 
   - Launch :doc:`DAML Studio </daml/daml-studio>`: ``daml studio``
-  - Launch :doc:`Sandbox </tools/sandbox>` and :doc:`Navigator <tools/navigator/index>` together: ``daml start``
+  - Launch :doc:`Sandbox </tools/sandbox>` and :doc:`Navigator </tools/navigator/index>` together: ``daml start``
   - Launch Sandbox: ``daml sandbox``
   - Launch Navigator: ``daml navigator``
   - Launch :doc:`Extractor </tools/extractor>`: ``daml extractor``
 - Compile a DAML project: ``daml build``
 - Create new project based off built-in template: ``daml new <path to create project in> <name of template>``
+
+.. _daml-yaml-configuration:
 
 Configuration files
 *******************

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -11,7 +11,7 @@ DAML assistant (``daml``)
   ``daml install <version>``
 - Launch the tools in the SDK:
 
-  - Launch :doc:`DAML Studio </daml/daml-studio>`: ``da studio``
+  - Launch :doc:`DAML Studio </daml/daml-studio>`: ``daml studio``
   - Launch :doc:`Sandbox </tools/sandbox>` and :doc:`Navigator <tools/navigator/index>` together: ``daml start``
   - Launch Sandbox: ``daml sandbox``
   - Launch Navigator: ``daml navigator``

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -1,312 +1,155 @@
 .. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-SDK Assistant
-#############
+DAML assistant (``daml``)
+#########################
 
-The SDK Assistant is a command-line tool designed to help you interact with the DAML SDK. It includes commands to help you create projects, run other SDK tools, install and upgrade SDK releases, and view documentation.
+``daml`` is a command-line tool that does a bunch of useful stuff with the SDK. Using ``daml``, you can:
 
-Installing the SDK Assistant
-****************************
+- Install new SDK versions (but you need to update your config file yourself)
 
-Refer to :doc:`/getting-started/installation` for instructions on how to install the SDK Assistant.
+  ``daml install <version>``
+- Launch the tools in the SDK:
 
-All general SDK Assistant files are stored in ``~/.da/``. This folder contains the ``da`` binary itself, a global
-SDK configuration file called ``da.yaml``, and the downloaded SDK releases and
-related packages. On installation, the SDK Assistant will attempt to set up a
-symlink in ``/usr/local/bin``.
+  - Launch :doc:`DAML Studio </daml/daml-studio>`: ``da studio``
+  - Launch :doc:`Sandbox </tools/sandbox>` and :doc:`Navigator <tools/navigator/index>` together: ``daml start``
+  - Launch Sandbox: ``daml sandbox``
+  - Launch Navigator: ``daml navigator``
+  - Launch :doc:`Extractor </tools/extractor>`: ``daml extractor``
+- Compile a DAML project: ``daml build``
+- Create new project based off built-in template: ``daml new <path to create project in> <name of template>``
 
-.. CARL: Do we want to add info on what happens if the symlink is not set up?
+Configuration files
+*******************
 
-Understanding the SDK Assistant
+Global config file
+==================
+
+The ``daml`` configuration file, ``daml.yaml`` is in TODO directory.
+
+Specifies global configuration options. TODO list.
+
+TODO example file.
+
+Project config file
+===================
+
+The project configuration file must be in the root of your project. Specifies project configuration and can override global configuration properties.
+
+.. Make sure to include this from old docs: Some tools, like the Navigator, require parties to be configured before they are started. Do this in the ``project.parties`` property of the ``daml.yaml`` file for the project.
+
+TODO example files.
+
+Full help for commands
 *******************************
 
-The SDK Assistant is designed to make DAML development as easy and
-enjoyable as possible by helping with two key tasks:
+Use ``--help`` with any command.
 
-* **Initializing DAML SDK projects so you can use development tools** for project-specific application code. All SDK development should be confined within a DAML SDK project.
+Comparing to the old SDK assistant
+**********************************
 
-* **Managing DAML SDK releases from Digital Asset** by periodically checking for updates. When an update is available, it is automatically downloaded and installed, keeping your SDK instance up to date. SDK releases contain development tools and libraries -- the DAML compiler, the DAML Studio IDE, and a DAML ledger, for example.
+Biggest change is that templates are gone. Moving to more standard mechanisms like git clone.
 
-.. note:: Because the SDK Assistant controls SDK releases and related tools, it can manage several versions of a tool and ensure that it uses the version compatible with the active project and other running tools. See :ref:`assistant-manual-managing-releases`.
+Plus components don't run in the background, so stop with ctrl+c.
 
-Using the SDK Assistant
-***********************
+.. list-table:: 
+   :header-rows: 1
 
-The SDK Assistant is invoked with the ``da`` command in a terminal. If you do not
-add any arguments to the command, it will default to display a status message.
-
-Use the ``da --help`` command to display a list of valid options and commands::
-
-  da --help
-
-  SDK Assistant - Version
-
-  Usage: da [-c|--config FILENAME] [-l|--log-level debug|info|warn|error]
-            [--script] [--term-width ARG] [COMMAND]
-    SDK Assistant. Use --help for help.
-
-  Available options:
-    -h,--help                Show this help text
-    -c,--config FILENAME     Specify what config file to use.
-    -l,--log-level debug|info|warn|error
-                             Set the log level. Default is 'warn'.
-    --script                 Script mode -- skip auto-upgrades and similar.
-    --term-width ARG         Rendering width of the terminal.
-    -v,--version             Show version and exit
-
-  Available commands:
-    status                   Show SDK environment overview
-    docs                     Show SDK documentation
-    new                      Create a new project from template
-    add                      Add a template to the current project
-    project                  Manage DAML SDK projects
-    template                 Manage DAML SDK templates
-    upgrade                  Upgrade to latest SDK version
-    list                     List installed SDK versions
-    use                      Set the default SDK version, downloading it if
-                             necessary
-    uninstall                Remove DAML SDK versions or the complete DAML SDK
-    start                    Start a given service
-    restart                  Restart a given service
-    stop                     Stop a given service
-    feedback                 Send us feedback!
-    studio                   Start DAML Studio in the current project
-    navigator                Start Navigator (also runs Sandbox if needed)
-    sandbox                  Start Sandbox process in current project
-    compile                  Compile a DAML project into a DAR package
-    path                     Show the filesystem path of an SDK component
-    run                      Run the main executable of a package
-    setup                    Set up SDK environment (e.g. on install or upgrade)
-    subscribe                Subscribe for a namespace (of the template
-                             repository).
-    unsubscribe              Unsubscribe from a namespace (of the template
-                             repository).
-    config-help              Show config-file help
-    config                   Query and manage configuration
-    changelog                Show the changelog of an SDK version
-    update-info              Show SDK Assistant update channel information
-
-To get help for a particular command, use this command::
-
-  da <command> --help
-
-**Example**::
-
-  da new --help
-
-  Usage: da new PROJECT_PATH
-    Create a new project
-
-  Available options:
-    -h,--help                Show this help text
-    PROJECT_PATH             Path to the new project. Name of the last folder will
-                             be the name of the new project.
-
-Developing with the SDK Assistant
-*********************************
-
-To begin, create a new DAML SDK project using the SDK Assistant. A project consists
-of a folder with a valid ``da.yaml`` file that, among other things, specifies
-which SDK release is being used. This is important because the release determines which
-versions of DAML and the DAML Sandbox the project code uses.
-
-In the SDK
-Assistant, create a DA project with this command::
-
-  da new <project_path>
-
-**Example**::
-
-  da new my-project
-
-This example creates a project folder called ``my-project`` folder that is seeded with a basic folder structure.
-
-Change to the new project directory.
-
-**Example**::
-
-  cd my-project
-
-In the project folder, use SDK Assistant functions. For example, if you have Visual Studio Code installed, open DAML Studio for your project using::
-
-  da studio
-
-Use the following command to start the DAML Sandbox and the Navigator against
-the current project's DAML code::
-
-  da start
-
-These services will run in the background. To see a list of running services, use this command::
-
-  da status
-
-To stop any running services of the current project::
-
-  da stop
-
-To restart::
-
-  da restart
-
-The current SDK functionality is still basic. Future releases will improve and extend the current functionality and features to help you develop
-automation, UIs, and other types of functionality on top of your DAML
-application.
+   * - Old ``da`` command
+     - Purpose
+     - New ``daml`` equivalent
+   * - ``da status``
+     - Show a list of running services
+     - No longer needed, as components no longer run in the background
+   * - ``da docs``
+     - Display the documentation
+     - No longer needed. You can access the docs at docs.daml.com, which includes a PDF download for offline use.
+   * - ``da new``
+     - Create a new project from template
+     - ``daml new  <path to create project in> <name of template>``
+   * - ``da project``
+     - Manage SDK projects
+     - No longer needed
+   * - ``da template``
+     - Manage SDK templates
+     - No longer needed
+   * - ``da upgrade``
+     - Upgrade SDK version
+     - ``daml install <version>``
+   * - ``da list``
+     - List installed SDK versions
+     - ``daml version`` prints the current SDK version in use.
+   * - ``da use``
+     - Set the default SDK version
+     - No direct equivalent; you now set the new SDK version (``sdk-version: X.Y.Z``) in your project config file (``daml.yaml``) manually.
+   * - ``da uninstall``
+     - Uninstall the SDK
+     - No direct equivalent
+   * - ``da start``
+     - Start Navigator and Sandbox
+     - ``daml start``. Now stops by ctrl+c, rather than a ``stop`` command.
+   * - ``da restart``
+     - Shut down and restart Navigator and Sandbox.
+     - ``ctrl+c`` and ``daml start``
+   * - ``da stop``
+     - Stop running Navigator and Sandbo
+     - ``ctrl+c``
+   * - ``da feedback``
+     - Send us feedback
+     - No longer needed. See :doc:`/support/support` for how to give feedback.
+   * - ``da studio``
+     - Launch DAML Studio
+     - ``daml studio``
+   * - ``da navigator``
+     - Launch Navigator
+     - ``daml navigator``
+   * - ``da sandbox``
+     - Launch Sandbox
+     - ``daml sandbox``
+   * - ``da compile``
+     - Compile a DAML project into a .dar file
+     - ``daml build``
+   * - ``da path <component>``
+     - Show the path to an SDK component
+     - No equivalent
+   * - ``da run``
+     - Run an SDK component
+     - ``daml studio``, ``daml navigator``, etc
+   * - ``da setup``
+     - Initialize the SDK
+     - No longer needed: this is handled by the installer
+   * - ``da subscribe``
+     - Subscribe to a template namespace
+     - No longer needed
+   * - ``da unsubscribe``
+     - Unsubscribe from a template namespace
+     - No longer needed
+   * - ``da config-help``
+     - Show help about config files
+     - No longer needed: config files are documented on this page
+   * - ``da config``
+     - Query and manage config
+     - No equivalent: view and edit your config files directly
+   * - ``da changelog``
+     - Show release notes
+     - No longer needed: see the :doc:`/support/release-notes`.
+   * - ``da update-info``
+     - Show assistant update channel information
+     - No longer needed
 
 .. _assistant-manual-building-dars:
 
-Building DAML archives
-**********************
+Building .dar files
+*******************
 
-The SDK Assistant can compile your DAML source code into a DAML archive (a
-``.dar`` file). To do this, run::
+Compiling your DAML source code into a DAML archive (a ``.dar`` file)::
 
-  da compile
-
-This will compile the source code file set in your ``da.yaml``
-configuration file (see :ref:`assistant-manual-configuring-compilation`) and
-generate a ``.dar`` file in the directory ``target`` with the same name as your
-project.
-
-.. _assistant-manual-managing-releases:
-
-Managing SDK releases
-*********************
-
-The SDK Assistant will automatically check for updates and upgrade itself if there is
-a new version. This means that you will always have the latest version.
-
-If you are working on several
-projects that have code that assumes different tool and component versions, you will need to have
-several SDK releases installed at the same time. Having different SDK releases available ensures all your projects will work without your having to
-upgrade all of them to use the
-latest libraries and tools. The SDK Assistant has commands for managing several SDK releases.
-
-- The *active* release is the one that is currently in use. For example, each DAML SDK project specifies the SDK release to use. When you
-  are in a project, the specified release is the active one.
-
-- The *default* release is the one that will be used when you start a new
-  project or in other cases when an SDK release is needed and you are not in a
-  project.
-
-To list all installed SDK releases and see which are active and which is the default, use this command::
-
-  da list
-
-To change the default release::
-
-  da use <release-version>
-
-To upgrade to the latest SDK release manually::
-
-  da upgrade
-
-To remove unused old releases::
-
-  da uninstall <release-version>
-
-.. _cli-managing-templates:
-
-Managing SDK templates
-**********************
-
-You can use the SDK Assistant to subscribe to templates, which are stored under a specific namespace. Often these are DAML templates, but not all of them are. There are two types of template:
-
-- Project templates, which are the starting point for a full project. These give you a folder with its own ``da.yaml`` file.
-- Add-on templates, which are the starting point for a sub-project. These give you a folder that lives inside a DAML SDK project folder. Add-on templates are not always DAML templates.
-
-The Assistant comes with several DAML templates that are pre-made example modules, which show advanced uses of DAML and provide useful library functions.
-
-To list available project templates, run::
-
-  da new
-
-To list available add-on templates, run::
-
-  da add
-
-.. note:: ``da new`` and ``da add`` may show undocumented or unsupported templates.
-
-To subscribe to a namespace (so you can access the template inside it), run::
-
-  da subscribe <namespace>
-
-To unsubscribe (remove from the list of namespaces which are checked if the listing commands are executed), run::
-
-  da unsubscribe <namespace>
-
-Once you've subscribed to a project template's namespace, you can start a new project from the project template::
-
-  da new <namespace>/<project-template-name> <project-path>
-
-Once you've subscribed to an add-on template's namespace, you can add the add-on template to your project::
-
-  da add <namespace>/<add-on-template-name> <target-folder>
-
-For DAML templates, the new DAML files are added to your project inside the ``daml`` folder. To use them in your project, you need to add references to these files in the ``daml/Main.daml`` file with ``import`` statements. This is not done automatically.
-
-Running SDK tools
-*****************
-
-The SDK also comes with some packages that you can run and that can serve as important tools in the development of the project. You can run an executable package with the following command::
-
-  da run <package> [-- ARGS]
-
-If you run the command above without the package argument, it will display a message saying that the package is missing and will show a list of all the available packages. The available packages currently are ``damlc`` and ``navigator``.
-
-The ``damlc`` package is a DAML compiler tool. The compiler functionality is currently intended only for internal use, so it is not described in this documentation.
-
-The ``navigator`` package contains a browser-based tool that can also be used to interact with the ledger and is described in :doc:`/tools/navigator/index`.
-
-.. _da-yaml-configuration:
-
-da.yaml configuration
-*********************
-
-The SDK Assistant uses a configuration file -- ``da.yaml``-- that includes both global configuration and project configuration information. The SDK
-Assistant global ``da.yaml`` file is located in the SDK Assistant home folder
-(``~/.da/``). Project configuration in this file is ignored. Each project also
-has a ``da.yaml`` file, which specifies project configuration and can also
-override global configuration properties. To list the properties that can be specified in the configuration file, use this command::
-
-  da config-help
-
-Configuring parties
-===================
-
-Some tools, like the Navigator, require parties to be configured before it is started.
-When using the SDK Assistant to start such services, configure parties in
-the ``da.yaml`` file for the project. The ``project.parties`` property takes a list of
-strings. For example::
-
-  ...
-  project:
-    sdk-version: '0.6.0'
-    scenario: Main:example
-    name: my-project
-    source: daml/Main.daml
-    parties:
-    - OPERATOR
-    - BANK1
-    - BANK2
-    - '007'
-
-This can also be formatted in YAML as::
-
-  ...
-  project:
-    sdk-version: '0.6.0'
-    scenario: Main:example
-    name: my-project
-    source: daml/Main.daml
-    parties: ["OPERATOR", "BANK1", "BANK2", "007"]
-
-.. _assistant-manual-configuring-compilation:
+  daml build
 
 Configuring compilation
 =======================
 
-DAML compilation is configured with the following ``project`` variables:
+In your project's ``daml.yaml``. The variables you can set are:
 
 ``project.name``
   The name of the project.
@@ -321,11 +164,11 @@ The generated ``.dar`` file will be stored in
 ``${project.output-path}/${project.name}.dar``.
 
 
-Uninstalling DAML SDK
+.. _assistant-manual-managing-releases:
+
+Managing SDK releases
 *********************
 
-If for any reason the DAML SDK needs to be removed use::
+``daml`` automatically checks for updates and notifies you if there is
+a new version. But when there's a new version, you need to specify that you want a project to use it in the project config file.
 
-  da uninstall all
-
-This command will ask for confirmation and remove the complete DAML SDK home folder (``~/.da/``) and the ``da`` symlink in ``/usr/local/bin`` created upon installation.

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -63,25 +63,23 @@ The project config file ``daml.yaml`` must be in the root of your DAML project d
 
 The existence of a ``daml.yaml`` file is what tells ``daml`` assistant that this directory contains a DAML project, and lets you use project-aware commands like ``daml build`` and ``daml start``.
 
-``daml new`` creates an example application in a new project folder, which includes a config file. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
+``daml new`` creates a skeleton application in a new project folder, which includes a config file. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
 
 .. code-block:: yaml
 
-   sdk-version: 0.13.0
-   name: my_project
-   source: daml/Main.daml
-   scenario: Main:setup
-   parties:
-     - Alice
-     - Bob
-     - USD_Bank
-     - EUR_Bank
-   version: 1.0.0
-   exposed-modules:
-     - Main
-   dependencies:
-     - daml-prim
-     - daml-stdlib
+    sdk-version: __VERSION__
+    name: __PROJECT_NAME__
+    source: daml/Main.daml
+    scenario: Main:setup
+    parties:
+      - Alice
+      - Bob
+    version: 1.0.0
+    exposed-modules:
+      - Main
+    dependencies:
+      - daml-prim
+      - daml-stdlib
 
 Here is what each field means:
 

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-DAML assistant (``daml``)
+DAML Assistant (``daml``)
 #########################
 
 ``daml`` is a command-line tool that does a lot of useful things related to the SDK. Using ``daml``, you can:
@@ -25,20 +25,30 @@ DAML assistant (``daml``)
 
    Note that you need to update your `project config file <#configuration-files>` to use the new version.
 
+Moving to the ``daml`` assistant
+********************************
+
+To move your projects to use ``daml``, and see the difference between ``da`` commands and ``daml`` commands, read the :doc:`/support/new-assistant`.
+
+Full help for commands
+**********************
+
+To see information about any command, run it with ``--help``.
+
 .. _daml-yaml-configuration:
 
 Configuration files
 *******************
 
-The DAML assistant and the DAML SDK are configured using two kinds of config files:
+The DAML assistant and the DAML SDK are configured using two files:
 
 - The global config file, one per installation, which controls some options regarding SDK installation and updates
 - The project config file, one per DAML project, which controls how the DAML SDK builds and interacts with the project
 
-Global config file: (``daml-config.yaml``)
-==========================================
+Global config file (``daml-config.yaml``)
+=========================================
 
-The global config file ``daml-config.yaml`` is in the ``daml`` home directory, which is ``~/.daml`` on Linux and Mac, and ``C:/Users/<user>/AppData/Roaming/daml`` on Windows. It controls options related to SDK version installation and upgrades.
+The global config file ``daml-config.yaml`` is in the ``daml`` home directory (``~/.daml`` on Linux and Mac, ``C:/Users/<user>/AppData/Roaming/daml`` on Windows). It controls options related to SDK version installation and upgrades.
 
 By default it's blank, and you usually won't need to edit it. It recognizes the following options:
 
@@ -49,19 +59,19 @@ By default it's blank, and you usually won't need to edit it. It recognizes the 
     
    Set ``update-check: <number>`` to check for new versions every N seconds. Set ``update-check: never`` to never check for new versions.
 
-Here is an example of the global config file ``daml-config.yaml``:
+Here is an example ``daml-config.yaml``:
 
 .. code-block:: yaml
 
    auto-install: true
    update-check: 86400
 
-Project config file: ``daml.yaml``
-==================================
+Project config file (``daml.yaml``)
+===================================
 
 The project config file ``daml.yaml`` must be in the root of your DAML project directory. It controls how the DAML project is built and how tools like Sandbox and Navigator interact with it.
 
-The existence of a ``daml.yaml`` file is what tells ``daml`` assistant that this directory contains a DAML project, and lets you use project-aware commands like ``daml build`` and ``daml start``.
+The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory contains a DAML project, and lets you use project-aware commands like ``daml build`` and ``daml start``.
 
 ``daml new`` creates a skeleton application in a new project folder, which includes a config file. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
 
@@ -98,99 +108,6 @@ Here is what each field means:
 
 ..  TODO (@robin-da) document the dependency syntax
 
-Full help for commands
-**********************
-
-Use ``--help`` with any command.
-
-Comparing to the old SDK assistant
-**********************************
-
-.. list-table:: 
-   :header-rows: 1
-
-   * - Old ``da`` command
-     - Purpose
-     - New ``daml`` equivalent
-   * - ``da status``
-     - Show a list of running services
-     - No longer needed, as components no longer run in the background
-   * - ``da docs``
-     - Display the documentation
-     - No longer needed. You can access the docs at docs.daml.com, which includes a PDF download for offline use.
-   * - ``da new``
-     - Create a new project from template
-     - ``daml new  <path to create project in> [<name of template>]``
-   * - ``da project``
-     - Manage SDK projects
-     - No longer needed
-   * - ``da template``
-     - Manage SDK templates
-     - No longer needed
-   * - ``da upgrade``
-     - Upgrade SDK version
-     - ``daml install latest --activate``
-   * - ``da list``
-     - List installed SDK versions
-     - ``daml version`` prints SDK version information.
-   * - ``da use``
-     - Set the default SDK version
-     - No direct equivalent; you now set the new SDK version (``sdk-version: X.Y.Z``) in your project config file (``daml.yaml``) manually.
-   * - ``da uninstall``
-     - Uninstall the SDK
-     - No direct equivalent
-   * - ``da start``
-     - Start Navigator and Sandbox
-     - ``daml build`` then ``daml start``. Now stops by ctrl+c, rather than a ``stop`` command.
-   * - ``da restart``
-     - Shut down and restart Navigator and Sandbox.
-     - ``ctrl+c`` and ``daml start``
-   * - ``da stop``
-     - Stop running Navigator and Sandbo
-     - ``ctrl+c``
-   * - ``da feedback``
-     - Send us feedback
-     - No longer needed. See :doc:`/support/support` for how to give feedback.
-   * - ``da studio``
-     - Launch DAML Studio
-     - ``daml studio``
-   * - ``da navigator``
-     - Launch Navigator
-     - No direct equivalent; ``daml navigator`` is equivalent to ``da run navigator``.
-   * - ``da sandbox``
-     - Launch Sandbox
-     - No direct equivalent; ``daml sandbox`` is equivalent to ``da run sandbox``.
-   * - ``da compile``
-     - Compile a DAML project into a .dar file
-     - ``daml build``
-   * - ``da path <component>``
-     - Show the path to an SDK component
-     - No equivalent
-   * - ``da run``
-     - Run an SDK component
-     - ``daml sandbox``, ``daml navigator``, ``daml damlc``, etc
-   * - ``da setup``
-     - Initialize the SDK
-     - No longer needed: this is handled by the installer
-   * - ``da subscribe``
-     - Subscribe to a template namespace
-     - No longer needed
-   * - ``da unsubscribe``
-     - Unsubscribe from a template namespace
-     - No longer needed
-   * - ``da config-help``
-     - Show help about config files
-     - No longer needed: config files are documented on this page
-   * - ``da config``
-     - Query and manage config
-     - No equivalent: view and edit your config files directly
-   * - ``da changelog``
-     - Show release notes
-     - No longer needed: see the :doc:`/support/release-notes`.
-   * - ``da update-info``
-     - Show assistant update channel information
-     - No longer needed
-
 .. _assistant-manual-building-dars:
 
 Building DAML projects
@@ -222,8 +139,6 @@ Managing SDK releases
 
 In general the ``daml`` assistant will install versions and guide you when you need to update SDK versions or project settings. If you disable ``auto-install`` and ``update-check`` in the global config file, you will have to manage SDK releases manually.
 
-.. To find out what version: TODO (@associahedron) Add output of revamped version command here.
-
 To download and install the latest stable SDK release and update the assistant, run::
 
   daml install latest --activate
@@ -238,11 +153,7 @@ To install a specific SDK version, for example version ``0.13.0``, run::
 
   daml install 0.13.0
 
-To install an SDK release from a downloaded SDK release tarball, run::
+Rarely, you might need to install an SDK release from a downloaded SDK release tarball. **This is an advanced feature**: you should only ever perform this on an SDK release tarball that is released through the official ``digital-asset/daml`` github repository. Otherwise your ``daml`` installation may become inconsistent with everyone else's. To do this, run::
 
   daml install path-to-tarball.tar.gz
-
-but beware, this is an advanced feature and you should only ever perform this on an SDK release tarball that is released through the official ``digital-asset/daml`` github repository. Otherwise your ``daml`` installation may become inconsistent with everyone elses.
-
-.. TODO (@associahedron) Add ``daml uninstall`` and ``daml version --list`` commands.
 

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -4,15 +4,14 @@
 DAML assistant (``daml``)
 #########################
 
-``daml`` is a command-line tool that does a bunch of useful stuff with the SDK. Using ``daml``, you can:
+``daml`` is a command-line tool that does a lot of useful things related to the SDK. Using ``daml``, you can:
 
 - Create new DAML projects: ``daml new <path to create project in>``
 - Compile a DAML project: ``daml build``
 
-  - This will build the DAML project according to the project config file ``daml.yaml`` (see below).
-  - In particular, it will download and install the specified version of the SDK (the ``sdk-version`` 
-    field in ``daml.yaml``) if missing, and use that SDK version to resolve dependencies and compile
-    the DAML project.
+  This builds the DAML project according to the project config file ``daml.yaml`` (see `Configuration files`_ below).
+
+  In particular, it will download and install the specified version of the SDK (the ``sdk-version`` field in ``daml.yaml``) if missing, and use that SDK version to resolve dependencies and compile the DAML project.
 
 - Launch the tools in the SDK:
 
@@ -24,6 +23,8 @@ DAML assistant (``daml``)
 
 - Install new SDK versions manually: ``daml install <version>``
 
+   Note that you need to update your `project config file <#configuration-files>` to use the new version.
+
 .. _daml-yaml-configuration:
 
 Configuration files
@@ -31,20 +32,22 @@ Configuration files
 
 The DAML assistant and the DAML SDK are configured using two kinds of config files:
 
-- the global config file, one per installation, controls some options regarding SDK installation and updates
-- the project config file, one per DAML project, controls how the DAML SDK builds and interacts with the project
+- The global config file, one per installation, which controls some options regarding SDK installation and updates
+- The project config file, one per DAML project, which controls how the DAML SDK builds and interacts with the project
 
-Global config file
-==================
+Global config file: (``daml-config.yaml``)
+==========================================
 
-The global config file ``daml-config.yaml`` is in the daml home directory, which is ``~/.daml`` on Linux and Mac, and ``C:/Users/<user>/AppData/Roaming/daml`` on Windows. It controls certain options related to SDK version installation and upgrades. By default it is blank, and you will probably not need to change it, but you can edit it to suit your needs. The assistant recognizes the following options:
+The global config file ``daml-config.yaml`` is in the ``daml`` home directory, which is ``~/.daml`` on Linux and Mac, and ``C:/Users/<user>/AppData/Roaming/daml`` on Windows. It controls options related to SDK version installation and upgrades.
 
-- ``auto-install`` controls whether ``daml`` will automatically install a missing SDK version when it is required (defaults to ``true``)
-- ``update-check`` controls how often ``daml`` will check for new versions of the SDK (default to ``86400``, i.e. once a day)
+By default it's blank, and you usually won't need to edit it. It recognizes the following options:
 
-  - This setting is only to inform the user when an update is available.
-  - ``update-check: <number>`` will check for new versions every N seconds.
-  - ``update-check: never`` will never check for new versions.
+- ``auto-install``: whether ``daml`` automatically installs a missing SDK version when it is required (defaults to ``true``)
+- ``update-check``: how often ``daml`` will check for new versions of the SDK, in seconds (default to ``86400``, i.e. once a day)
+
+   This setting is only used to inform you when an update is available.
+    
+   Set ``update-check: <number>`` to check for new versions every N seconds. Set ``update-check: never`` to never check for new versions.
 
 Here is an example of the global config file ``daml-config.yaml``:
 
@@ -53,12 +56,14 @@ Here is an example of the global config file ``daml-config.yaml``:
    auto-install: true
    update-check: 86400
 
-Project config file
-===================
+Project config file: ``daml.yaml``
+==================================
 
-The project config file ``daml.yaml``, at the root of your DAML project directory, controls how the DAML project is built and how tools like Sandbox and Navigator interact with it. The ``daml.yaml`` file is necessary for ``daml`` assistant to recognize a DAML project, and to use project-aware commands like ``daml build`` and ``daml start``.
+The project config file ``daml.yaml`` must be in the root of your DAML project directory. It controls how the DAML project is built and how tools like Sandbox and Navigator interact with it.
 
-The ``daml new`` command will create a config file for you, along with an example app in a new project folder. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
+The existence of a ``daml.yaml`` file is what tells ``daml`` assistant that this directory contains a DAML project, and lets you use project-aware commands like ``daml build`` and ``daml start``.
+
+``daml new`` creates an example application in a new project folder, which includes a config file. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
 
 .. code-block:: yaml
 
@@ -80,32 +85,28 @@ The ``daml new`` command will create a config file for you, along with an exampl
 
 Here is what each field means:
 
-- ``sdk-version`` specifies the SDK version to be used to build this project. The assistant will automatically download and install
-  this version if needed (see the ``auto-install`` setting in the global config). We recommend keeping this up to date with the 
-  latest stable release of the SDK. The assistant will warn you when it is time to update this setting (see the ``update-check`` setting
-  in the global config  to control how often it checks, or to disable this check entirely).
-- ``name`` is the name of the project.
-- ``source`` is the location of your main DAML source code file, relative to the project root
-- ``scenario`` is the name of the main scenario to run with ``daml start``
-- ``parties`` is the list of parties to display in the Navigator, when running with ``daml start``
-- ``version`` is the project version.
-- ``exposed-modules`` is the list of DAML modules that are exposed by this project, which can be imported in other projects
-- ``dependencies`` is the list of dependencies this module has
+- ``sdk-version``: the SDK version that this project uses.
+
+   The assistant automatically downloads and installs this version if needed (see the ``auto-install`` setting in the global config). We recommend keeping this up to date with the latest stable release of the SDK.
+
+   The assistant will warn you when it is time to update this setting (see the ``update-check`` setting in the global config  to control how often it checks, or to disable this check entirely).
+- ``name``: the name of the project. This determines the filename of the ``.dar`` file compiled by ``daml build``.
+- ``source``: the location of your main DAML source code file, relative to the project root.
+- ``scenario``: the name of the scenario to run when using ``daml start``.
+- ``parties``: the parties to display in the Navigator when using ``daml start``.
+- ``version``: the project version.
+- ``exposed-modules``: the DAML modules that are exposed by this project, which can be imported in other projects.
+- ``dependencies``: the dependencies of this project.
 
 ..  TODO (@robin-da) document the dependency syntax
 
-
 Full help for commands
-*******************************
+**********************
 
 Use ``--help`` with any command.
 
 Comparing to the old SDK assistant
 **********************************
-
-Biggest change is that templates are gone. Moving to more standard mechanisms like git clone.
-
-Plus components don't run in the background, so stop with ctrl+c.
 
 .. list-table:: 
    :header-rows: 1
@@ -142,7 +143,7 @@ Plus components don't run in the background, so stop with ctrl+c.
      - No direct equivalent
    * - ``da start``
      - Start Navigator and Sandbox
-     - ``daml start``. Now stops by ctrl+c, rather than a ``stop`` command.
+     - ``daml build`` then ``daml start``. Now stops by ctrl+c, rather than a ``stop`` command.
    * - ``da restart``
      - Shut down and restart Navigator and Sandbox.
      - ``ctrl+c`` and ``daml start``
@@ -194,10 +195,10 @@ Plus components don't run in the background, so stop with ctrl+c.
 
 .. _assistant-manual-building-dars:
 
-Building DAML Project
-*********************
+Building DAML projects
+**********************
 
-Compiling your DAML source code into a DAML archive (a ``.dar`` file)::
+To compile your DAML source code into a DAML archive (a ``.dar`` file), run::
 
   daml build
 
@@ -212,8 +213,7 @@ You can control the build by changing your project's ``daml.yaml``:
 ``source``
   The path to the source code.
 
-The generated ``.dar`` file will be stored in ``dist/${name}.dar`` by default. You can override the default location by
-passing the ``-o`` argument to ``daml build``::
+The generated ``.dar`` file is created in ``dist/${name}.dar`` by default. To override the default location, pass the ``-o`` argument to ``daml build``::
 
   daml build -o path/to/darfile.dar
 
@@ -222,24 +222,21 @@ passing the ``-o`` argument to ``daml build``::
 Managing SDK releases
 *********************
 
-In general the ``daml`` assistant will install versions and guide you when you need to update SDK versions or project settings. If you disable ``auto-install`` and ``update-check`` in the global config file you will have to manage SDK releases manually.
+In general the ``daml`` assistant will install versions and guide you when you need to update SDK versions or project settings. If you disable ``auto-install`` and ``update-check`` in the global config file, you will have to manage SDK releases manually.
 
-To find out what version
+.. To find out what version: TODO (@associahedron) Add output of revamped version command here.
 
-.. TODO (@associahedron) Add output of revamped version command here.
-
-To download and install the latest stable SDK release and update your ``daml`` assistant::
+To download and install the latest stable SDK release and update the assistant, run::
 
   daml install latest --activate
 
-Remove the ``--activate`` flag if you only want to install the latest release without updating the ``daml`` assistant in the process.
-If it is already installed, you can force reinstallation by passing the ``--force`` flag. See ``daml install --help`` for a full list of options.
+Remove the ``--activate`` flag if you only want to install the latest release without updating the ``daml`` assistant in the process. If it is already installed, you can force reinstallation by passing the ``--force`` flag. See ``daml install --help`` for a full list of options.
 
-To install the SDK release specified in the project config::
+To install the SDK release specified in the project config, run::
 
   daml install project
 
-To install a specific SDK version, for example version ``0.13.0``::
+To install a specific SDK version, for example version ``0.13.0``, run::
 
   daml install 0.13.0
 
@@ -247,7 +244,7 @@ To install an SDK release from a downloaded SDK release tarball, run::
 
   daml install path-to-tarball.tar.gz
 
-but beware, this is an advanced feature and you should only ever perform this on an SDK release tarball that is released through the official ``digital-asset/daml`` github repository, otherwise your ``daml`` installation may become inconsistent with everyone elses.
+but beware, this is an advanced feature and you should only ever perform this on an SDK release tarball that is released through the official ``digital-asset/daml`` github repository. Otherwise your ``daml`` installation may become inconsistent with everyone elses.
 
 .. TODO (@associahedron) Add ``daml uninstall`` and ``daml version --list`` commands.
 

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -59,7 +59,7 @@ Running the Extractor
 
 The basic command to run the Extractor is::
 
-  $ daml extractor -- [options]
+  $ daml extractor [options]
 
 For what options to use, see the next sections.
 

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -87,7 +87,7 @@ This example connects to a PostgreSQL instance running on ``localhost`` on the d
 
 .. code-block:: none
 
-  $ daml extractor -- postgres --connecturl jdbc:postgresql:daml_export --user postgres --party [party]
+  $ daml extractor postgres --connecturl jdbc:postgresql:daml_export --user postgres --party [party]
 
 This example connects to a database on host ``192.168.1.12``, listening on port ``5432``. The database is called ``daml_export``, and the user and password used for authentication are ``daml_exporter`` and ``ExamplePassword``
 

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -257,9 +257,7 @@ These types are translated to `JSON types <https://json-schema.org/understanding
 Examples of output
 ******************
 
-The following examples show you what output you should expect.
-
-The examples use the default built-in SDK project which you get by running ``$ da new [project_name]``. The Sandbox has already run the scenarios of the DAML model which created two transactions: one creating a ``Main:RightOfUseOffer`` and one accepting it, thus archiving the original contract and creating a new ``Main:RightOfUseAgreement`` contract. We also added a new offer manually.
+The following examples show you what output you should expect. The Sandbox has already run the scenarios of a DAML model that created two transactions: one creating a ``Main:RightOfUseOffer`` and one accepting it, thus archiving the original contract and creating a new ``Main:RightOfUseAgreement`` contract. We also added a new offer manually.
 
 This is how the ``transaction`` table looks after extracting data from the ledger:
 

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -32,7 +32,7 @@ Prerequisites:
 
 Once you have the prerequisites, you can start the Extractor like this::
 
-$ da run extractor -- --help
+$ daml extractor -- --help
 
 Trying it out
 *************
@@ -48,7 +48,7 @@ This example extracts:
 
   .. code-block:: none
 
-    $ da run extractor -- postgresql --user postgres --connecturl jdbc:postgresql:daml_export --party Scrooge_McDuck -h 192.168.1.12 -p 6865 --to head
+    $ daml extractor -- postgresql --user postgres --connecturl jdbc:postgresql:daml_export --party Scrooge_McDuck -h 192.168.1.12 -p 6865 --to head
 
 This terminates after reaching the transaction which was the latest at the time the Extractor started streaming. 
 
@@ -59,7 +59,7 @@ Running the Extractor
 
 The basic command to run the Extractor is::
 
-  $ da run extractor -- [options]
+  $ daml extractor -- [options]
 
 For what options to use, see the next sections.
 
@@ -87,13 +87,13 @@ This example connects to a PostgreSQL instance running on ``localhost`` on the d
 
 .. code-block:: none
 
-  $ da run extractor -- postgres --connecturl jdbc:postgresql:daml_export --user postgres --party [party]
+  $ daml extractor -- postgres --connecturl jdbc:postgresql:daml_export --user postgres --party [party]
 
 This example connects to a database on host ``192.168.1.12``, listening on port ``5432``. The database is called ``daml_export``, and the user and password used for authentication are ``daml_exporter`` and ``ExamplePassword``
 
 .. code-block:: none
 
-  $ da run extractor -- postgres --connecturl jdbc:postgresql://192.168.1.12:5432/daml_export --user daml_exporter --password ExamplePassword --party [party]
+  $ daml extractor -- postgres --connecturl jdbc:postgresql://192.168.1.12:5432/daml_export --user daml_exporter --password ExamplePassword --party [party]
 
 Full list of options
 ********************

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -32,7 +32,7 @@ Prerequisites:
 
 Once you have the prerequisites, you can start the Extractor like this::
 
-$ daml extractor -- --help
+$ daml extractor --help
 
 Trying it out
 *************
@@ -48,7 +48,7 @@ This example extracts:
 
   .. code-block:: none
 
-    $ daml extractor -- postgresql --user postgres --connecturl jdbc:postgresql:daml_export --party Scrooge_McDuck -h 192.168.1.12 -p 6865 --to head
+    $ daml extractor postgresql --user postgres --connecturl jdbc:postgresql:daml_export --party Scrooge_McDuck -h 192.168.1.12 -p 6865 --to head
 
 This terminates after reaching the transaction which was the latest at the time the Extractor started streaming. 
 
@@ -93,7 +93,7 @@ This example connects to a database on host ``192.168.1.12``, listening on port 
 
 .. code-block:: none
 
-  $ daml extractor -- postgres --connecturl jdbc:postgresql://192.168.1.12:5432/daml_export --user daml_exporter --password ExamplePassword --party [party]
+  $ daml extractor postgres --connecturl jdbc:postgresql://192.168.1.12:5432/daml_export --user daml_exporter --password ExamplePassword --party [party]
 
 Full list of options
 ********************

--- a/docs/source/tools/navigator/console.rst
+++ b/docs/source/tools/navigator/console.rst
@@ -23,7 +23,7 @@ Try out the Navigator Console on the Quickstart
 
 With the sandbox running the :doc:`quickstart application </getting-started/quickstart>`
 
-#. To start the shell, run ``daml run navigator -- console localhost 6865``
+#. To start the shell, run ``daml navigator console localhost 6865``
 
    This connects Navigator Console to the sandbox, which is still running.
 
@@ -128,7 +128,7 @@ To run Navigator Console:
 
    The sandbox prints out the port on which it is running - by default, port ``6865``.
 
-3. Run ``daml navigator -- console localhost 6865``.
+3. Run ``daml navigator console localhost 6865``.
    Replace ``6865`` by the port reported by the sandbox, if necessary.
 
 When Navigator Console starts, it displays a welcome message::
@@ -491,4 +491,4 @@ To run Navigator against a secured Digital Asset Ledger, configure TLS certifica
 
 Details of these parameters are explained in the command line help::
 
-  daml navigator -- --help
+  daml navigator --help

--- a/docs/source/tools/navigator/console.rst
+++ b/docs/source/tools/navigator/console.rst
@@ -23,7 +23,7 @@ Try out the Navigator Console on the Quickstart
 
 With the sandbox running the :doc:`quickstart application </getting-started/quickstart>`
 
-#. To start the shell, run ``da run navigator -- console localhost 6865``
+#. To start the shell, run ``daml run navigator -- console localhost 6865``
 
    This connects Navigator Console to the sandbox, which is still running.
 
@@ -124,11 +124,11 @@ To run Navigator Console:
 
 1. Open a terminal window and navigate to your DAML SDK project folder.
 
-2. If the Sandbox isn't already running, run it with the command ``da start``.
+2. If the Sandbox isn't already running, run it with the command ``daml start``.
 
    The sandbox prints out the port on which it is running - by default, port ``6865``.
 
-3. Run ``da run navigator -- console localhost 6865``.
+3. Run ``daml navigator -- console localhost 6865``.
    Replace ``6865`` by the port reported by the sandbox, if necessary.
 
 When Navigator Console starts, it displays a welcome message::
@@ -491,4 +491,4 @@ To run Navigator against a secured Digital Asset Ledger, configure TLS certifica
 
 Details of these parameters are explained in the command line help::
 
-  da run navigator -- --help
+  daml navigator -- --help

--- a/docs/source/tools/navigator/index.rst
+++ b/docs/source/tools/navigator/index.rst
@@ -28,7 +28,7 @@ Navigator ships with the DAML SDK. To launch it:
 2. The Navigator web-app is automatically started in your browser. If it fails to start,
    open a browser window and point it to the Navigator URL
 
-  When running ``daml start`` you will see the Navigator URL. By default it will be `<http://localhost:7500/>`_. However, if port ``7500`` is taken, a different port will be picked.
+  When running ``daml start`` you will see the Navigator URL. By default it will be `<http://localhost:7500/>`_.
 
 .. note:: Navigator is compatible with these browsers: Safari, Chrome, or
    Firefox.

--- a/docs/source/tools/navigator/index.rst
+++ b/docs/source/tools/navigator/index.rst
@@ -387,4 +387,4 @@ To run Navigator against a secured Digital Asset Ledger,
 configure TLS certificates using the ``--pem``, ``--crt``, and ``--cacrt`` command line parameters.
 Details of these parameters are explained in the command line help::
 
-  daml navigator -- --help
+  daml navigator --help

--- a/docs/source/tools/navigator/index.rst
+++ b/docs/source/tools/navigator/index.rst
@@ -23,12 +23,12 @@ Installing and starting Navigator
 
 Navigator ships with the DAML SDK. To launch it:
 
-1. Start Navigator via a terminal window running :doc:`SDK Assistant </tools/assistant>` by typing ``da start``
+1. Start Navigator via a terminal window running :doc:`SDK Assistant </tools/assistant>` by typing ``daml start``
 
 2. The Navigator web-app is automatically started in your browser. If it fails to start,
    open a browser window and point it to the Navigator URL
 
-  When running ``da start`` you will see the Navigator URL. By default it will be `<http://localhost:7500/>`_. However, if port ``7500`` is taken, a different port will be picked.
+  When running ``daml start`` you will see the Navigator URL. By default it will be `<http://localhost:7500/>`_. However, if port ``7500`` is taken, a different port will be picked.
 
 .. note:: Navigator is compatible with these browsers: Safari, Chrome, or
    Firefox.
@@ -387,4 +387,4 @@ To run Navigator against a secured Digital Asset Ledger,
 configure TLS certificates using the ``--pem``, ``--crt``, and ``--cacrt`` command line parameters.
 Details of these parameters are explained in the command line help::
 
-  da run navigator -- --help
+  daml navigator -- --help

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -14,7 +14,7 @@ It is possible to execute the Sandbox launching step in isolation by typing ``da
 
 Sandbox can also be run manually as in this example::
 
-  $ daml sandbox -- Main.dar --scenario Main:example
+  $ daml sandbox Main.dar --scenario Main:example
 
      ____             ____
     / __/__ ____  ___/ / /  ___ __ __
@@ -24,7 +24,7 @@ Sandbox can also be run manually as in this example::
   Initialized Static time provider, starting from 1970-01-01T00:00:00Z
   listening on localhost:6865
 
-Here, ``daml sandbox --`` tells the SDK Assistant to run ``sandbox`` from the active SDK release and pass it any arguments that follow. The example passes the DAR file to load (``Main.dar``) and the optional ``--scenario`` flag tells Sandbox to run the ``Main:example`` scenario on startup. The scenario must be fully qualified; here ``Main`` is the module and ``example`` is the name of the scenario, separated by a ``:``. The scenario is used for testing and development; it is not run in production.
+Here, ``daml sandbox `` tells the SDK Assistant to run ``sandbox`` from the active SDK release and pass it any arguments that follow. The example passes the DAR file to load (``Main.dar``) and the optional ``--scenario`` flag tells Sandbox to run the ``Main:example`` scenario on startup. The scenario must be fully qualified; here ``Main`` is the module and ``example`` is the name of the scenario, separated by a ``:``. The scenario is used for testing and development; it is not run in production.
 
 
 Running with persistence

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -8,13 +8,13 @@ DAML Sandbox
 
 The DAML Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating the Digital Asset Distributed Ledger. 
 
-You can start DAML Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``da start`` command in a DAML SDK project. This command will compile the DAML file and its dependencies as specified in the ``da.yaml``. It will then launch Sandbox passing the just obtained DAR packages. Sandbox will also be given the name of the startup scenario specified in the project's ``da.yaml``. Finally, it launches the navigator connecting it to the running Sandbox.
+You can start DAML Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``daml start`` command in a DAML SDK project. This command will compile the DAML file and its dependencies as specified in the ``da.yaml``. It will then launch Sandbox passing the just obtained DAR packages. Sandbox will also be given the name of the startup scenario specified in the project's ``da.yaml``. Finally, it launches the navigator connecting it to the running Sandbox.
 
-It is possible to execute the Sandbox launching step in isolation by typing ``da sandbox``.
+It is possible to execute the Sandbox launching step in isolation by typing ``daml sandbox``.
 
 Sandbox can also be run manually as in this example::
 
-  $ da run sandbox -- Main.dar --scenario Main:example
+  $ daml sandbox -- Main.dar --scenario Main:example
 
      ____             ____
     / __/__ ____  ___/ / /  ___ __ __
@@ -24,7 +24,7 @@ Sandbox can also be run manually as in this example::
   Initialized Static time provider, starting from 1970-01-01T00:00:00Z
   listening on localhost:6865
 
-Here, ``da run sandbox --`` tells the SDK Assistant to run ``sandbox`` from the active SDK release and pass it any arguments that follow. The example passes the DAR file to load (``Main.dar``) and the optional ``--scenario`` flag tells Sandbox to run the ``Main:example`` scenario on startup. The scenario must be fully qualified; here ``Main`` is the module and ``example`` is the name of the scenario, separated by a ``:``. The scenario is used for testing and development; it is not run in production.
+Here, ``daml sandbox --`` tells the SDK Assistant to run ``sandbox`` from the active SDK release and pass it any arguments that follow. The example passes the DAR file to load (``Main.dar``) and the optional ``--scenario`` flag tells Sandbox to run the ``Main:example`` scenario on startup. The scenario must be fully qualified; here ``Main`` is the module and ``example`` is the name of the scenario, separated by a ``:``. The scenario is used for testing and development; it is not run in production.
 
 
 Running with persistence

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -6,9 +6,9 @@
 DAML Sandbox
 ############
 
-The DAML Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating the Digital Asset Distributed Ledger. 
+The DAML Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating a Digital Asset Distributed Ledger. 
 
-You can start DAML Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``daml start`` command in a DAML SDK project. This command will compile the DAML file and its dependencies as specified in the ``da.yaml``. It will then launch Sandbox passing the just obtained DAR packages. Sandbox will also be given the name of the startup scenario specified in the project's ``da.yaml``. Finally, it launches the navigator connecting it to the running Sandbox.
+You can start Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``daml start`` command in a DAML SDK project. This command will compile the DAML file and its dependencies as specified in the ``daml.yaml``. It will then launch Sandbox passing the just obtained DAR packages. Sandbox will also be given the name of the startup scenario specified in the project's ``daml.yaml``. Finally, it launches the navigator connecting it to the running Sandbox.
 
 It is possible to execute the Sandbox launching step in isolation by typing ``daml sandbox``.
 


### PR DESCRIPTION
As a follow-up PR to #768, this PR moves all of the documentation to use the new `daml` assistant, including the quickstart guide. We should only merge this when we're happy to encourage users to make the switch from `da` to `daml`.