### PR TITLE
increase ledger-api IT timeout; daml-lf, language-support/scala: remove long-deprecated symbols

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -35,10 +35,6 @@ abstract class Reader[+Pkg] {
     readArchiveAndVersion(DamlLf.Archive.parser().parseFrom(cos))
   }
 
-  @deprecated("use decodeArchiveFromInputStream instead", since = "13.8.1")
-  @throws[ParseError]
-  final def readArchive(is: InputStream): Pkg = decodeArchiveFromInputStream(is)
-
   @throws[ParseError]
   final def decodeArchiveFromInputStream(is: InputStream): Pkg =
     readArchiveAndVersion(is)._1
@@ -64,10 +60,6 @@ abstract class Reader[+Pkg] {
         throw ParseError("Unrecognized hash function")
     }
   }
-
-  @deprecated("use decodeArchive instead", since = "13.8.1")
-  @throws[ParseError]
-  def readArchive(lf: DamlLf.Archive): Pkg = decodeArchive(lf)
 
   @throws[ParseError]
   final def decodeArchive(lf: DamlLf.Archive): Pkg =
@@ -107,13 +99,6 @@ abstract class Reader[+Pkg] {
 
 object Reader extends Reader[(SimpleString, DamlLf.ArchivePayload)] {
   final case class ParseError(error: String) extends RuntimeException(error)
-
-  @deprecated("use lf.archive.LanguageMajorVersion instead", since = "47.0.0")
-  type DamlLfMajorVersion = LanguageMajorVersion
-  @deprecated("use lf.archive.LanguageMajorVersion.V0 instead", since = "47.0.0")
-  val DamlLfVersion0 = LanguageMajorVersion.V0
-  @deprecated("use lf.archive.LanguageMajorVersion.V1 instead", since = "47.0.0")
-  val DamlLfVersion1 = LanguageMajorVersion.V1
 
   def damlLfCodedInputStreamFromBytes(
       payload: Array[Byte],

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -15,16 +15,6 @@ object Ref {
 
   object SimpleString {
 
-    /** Crashes if the string is not a valid [[SimpleString]]. We provide this for
-      * backwards compat, but generally we prefer `assertX` methods for other
-      * similar classes.
-      */
-    @deprecated(
-      "use SimpleString.fromString, SimpleString.assertFromString, Party.fromString, or Party.assertFromString",
-      since = "44.0.1")
-    @throws[IllegalArgumentException]
-    def apply(s: String): Party = assertFromString(s)
-
     private def valid(c: Char) =
       ('a' <= c && c <= 'z') ||
         ('A' <= c && c <= 'Z') ||
@@ -42,6 +32,7 @@ object Ref {
             Left(s"""Invalid character ${c.toInt.formatted("%#x")} found in "$string"""")
         }
 
+    /** Crashes if the string is not a valid [[SimpleString]]. */
     @throws[IllegalArgumentException]
     def assertFromString(s: String): SimpleString =
       assert(fromString(s))

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -54,10 +54,6 @@ object Time {
       else
         Left(s"out of bound Date $days")
 
-    @deprecated("use fromDaysSinceEpoch instead", since = "44.0.1")
-    def fromLong(days: Long): Either[String, Date] =
-      asInt(days) flatMap fromDaysSinceEpoch
-
     def fromString(str: String): Either[String, Date] =
       Try(assertDaysFromString(str)).toEither.left
         .map(_ => s"cannot interpret $str as Date")
@@ -65,11 +61,6 @@ object Time {
 
     def assertFromDaysSinceEpoch(days: Int): Date =
       assert(fromDaysSinceEpoch(days))
-
-    @deprecated("use assertFromDaysSinceEpoch instead", since = "44.0.1")
-    @throws[IllegalArgumentException]
-    def assertFromLong(days: Long): Date =
-      assert(fromLong(days))
 
     @throws[IllegalArgumentException]
     def assertFromString(str: String): Date =

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -14,14 +14,6 @@ da_scala_library(
         "//external:jar/org/spire_math/kind_projector_2_12",
     ],
     resources = glob(["src/main/resources/**/*"]),
-    # TODO SC DEL-6727 for old Identifier field, to be removed when TemplateId.unapply changes back
-    # NOTE(JM): commented out deprecation warnings to get this to compile with the
-    # versions matching sbt. Please reenable when deprecations are fixed.
-    # scalacopts = ['-deprecation', '-Xfatal-warnings'],
-    scalacopts = [
-        "-deprecation:false",
-        "-Xfatal-warnings",
-    ],
     tags = ["maven_coordinates=com.daml.scala:bindings-akka:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -91,9 +83,6 @@ da_scala_test_suite(
         ],
         exclude = testing_utils,
     ),
-    # NOTE(JM): commented out deprecation warnings to get this to compile with the
-    # versions matching sbt. Please remove when deprecations are fixed.
-    scalacopts = ["-deprecation:false"],
     visibility = [
         "//visibility:public",
     ],

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapperUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapperUT.scala
@@ -66,7 +66,7 @@ class DomainTransactionMapperUT extends WordSpec with Matchers with AkkaTest {
       new TemplateCompanion.Empty[MockTemplate] {
         override val onlyInstance = MockTemplate()
         override val id: Primitive.TemplateId[MockTemplate] =
-          Primitive.TemplateId("packageId", "templateId")
+          ` templateId`("packageId", "moduleId", "templateId")
         override val consumingChoices: Set[Choice] = Set.empty
       }
   }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -91,11 +91,8 @@ sealed abstract class Primitive {
   }
 
   sealed abstract class TemplateIdApi {
-    // private as the sole source of valid Template-associated template IDs is
+    // the sole source of valid Template-associated template IDs is
     // their codegenned companions
-    @deprecated("Use 3-argument version instead", since = "15.0.0")
-    def apply[Tpl <: Template[Tpl]](packageId: String, name: String): TemplateId[Tpl]
-
     def apply[Tpl <: Template[Tpl]](
         packageId: String,
         moduleName: String,
@@ -177,9 +174,6 @@ private[client] object OnlyPrimitive extends Primitive {
   }
 
   object TemplateId extends TemplateIdApi {
-    override def apply[Tpl <: Template[Tpl]](packageId: String, name: String) =
-      ApiTypes.TemplateId(rpcvalue.Identifier(packageId = packageId, name = name))
-
     // the ledger api still uses names with only dots in them, while QualifiedName.toString
     // separates the module and the name in the module with colon.
     override def apply[Tpl <: Template[Tpl]](

--- a/ledger/ledger-api-integration-tests/BUILD.bazel
+++ b/ledger/ledger-api-integration-tests/BUILD.bazel
@@ -66,6 +66,7 @@ da_scala_test_suite(
     deps = [
         ":ledger-api-integration-tests-lib",
     ] + dependencies,
+    size = "large",
 )
 
 # DEPRECATED in favor of //ledger/ledger-api-test-tool:ledger-api-test-tool

--- a/ledger/ledger-api-integration-tests/BUILD.bazel
+++ b/ledger/ledger-api-integration-tests/BUILD.bazel
@@ -59,6 +59,7 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "ledger-api-integration-tests",
+    size = "large",
     srcs = glob(["src/test/itsuite/**/*.scala"]),
     data = [
         "//ledger/sandbox:Test.dar",
@@ -66,7 +67,6 @@ da_scala_test_suite(
     deps = [
         ":ledger-api-integration-tests-lib",
     ] + dependencies,
-    size = "large",
 )
 
 # DEPRECATED in favor of //ledger/ledger-api-test-tool:ledger-api-test-tool


### PR DESCRIPTION
These have been deprecated for a while; time to remove.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
