### PR TITLE
Add a test for function return type syntax

### DIFF
--- a/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
+++ b/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
@@ -1,0 +1,10 @@
+daml 1.2
+module FunRetTypeSig where
+
+-- Test parsing of function return type signature syntax
+-- (see Tim's proposal at
+-- https://github.com/ghc-proposals/ghc-proposals/pull/185).
+
+succ (x : Int) : Int = x + 1
+
+-- Related issue : https://github.com/digital-asset/daml/issues/747.


### PR DESCRIPTION
This PR adds a syntax test for inline function return types. Until now, this feature has only been tested incidentally in the language server tests. If this test had existed before now, it would have saved a bit of effort when merging the latest `ghc-lib` changes the other day. Writing this test has also exposed another related issue [explained here](https://github.com/digital-asset/daml/issues/747).