### PR TITLE
Add outdated version warnings in daml-assistant.

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -76,6 +76,7 @@ da_haskell_binary(
     hazel_deps = [
         "base",
         "directory",
+        "extra",
         "filepath",
         "process",
         "safe-exceptions",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -61,6 +61,7 @@ da_haskell_library(
         "temporary",
         "terminal-progress-bar",
         "text",
+        "time",
         "unix-compat",
         "utf8-string",
         "yaml",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -62,6 +62,7 @@ da_haskell_library(
         "terminal-progress-bar",
         "text",
         "time",
+        "tls",
         "unix-compat",
         "utf8-string",
         "yaml",

--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -66,6 +66,9 @@ versionToString = V.toString . unwrapSdkVersion
 versionToText :: SdkVersion -> Text
 versionToText = V.toText . unwrapSdkVersion
 
+isHeadVersion :: SdkVersion -> Bool
+isHeadVersion v = "0.0.0" == versionToString v
+
 data InvalidVersion = InvalidVersion
     { ivSource :: !Text -- ^ invalid version
     , ivMessage :: !String -- ^ error message

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -32,13 +32,13 @@ main = displayErrors $ do
 
     whenJust envLatestStableSdkVersion $ \latestVersion -> do
         let isHead = maybe False isHeadVersion envSdkVersion
-            test1 = not isHead && isJust envProjectPath && envSdkVersion < Just latestVersion
-            test2 = not isHead && not test1 && isJust envDamlAssistantSdkVersion &&
+            projectSdkVersionIsOld = isJust envProjectPath && envSdkVersion < Just latestVersion
+            assistantVersionIsOld = isJust envDamlAssistantSdkVersion &&
                 fmap unwrapDamlAssistantSdkVersion envDamlAssistantSdkVersion <
                 Just latestVersion
 
         -- Project SDK version is outdated.
-        when test1 $ do
+        when (not isHead && projectSdkVersionIsOld) $ do
             hPutStrLn stderr . unlines $
                 [ "WARNING: Using an outdated version of the DAML SDK in project."
                 , ""
@@ -51,7 +51,7 @@ main = displayErrors $ do
                 ]
 
         -- DAML assistant is outdated.
-        when test2 $ do
+        when (not isHead && not projectSdkVersionIsOld && assistantVersionIsOld) $ do
             hPutStrLn stderr . unlines $
                 [ "WARNING: Using an outdated version of the DAML assistant."
                 , ""

--- a/daml-assistant/src/DAML/Assistant/Cache.hs
+++ b/daml-assistant/src/DAML/Assistant/Cache.hs
@@ -1,0 +1,79 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module DAML.Assistant.Cache
+    ( cacheLatestSdkVersion
+    ) where
+
+import DAML.Assistant.Types
+import Control.Exception.Safe
+import Control.Monad.Extra
+import Data.String
+import Data.Either.Extra
+import Data.Time.Clock
+import qualified Data.Yaml as Y
+import System.Directory
+import System.FilePath
+import System.IO.Extra
+
+newtype CacheKey = CacheKey String
+    deriving (Show, Eq, Ord, IsString)
+
+newtype CacheTimeout = CacheTimeout NominalDiffTime
+    deriving (Show, Eq, Ord, Y.FromJSON)
+
+cacheLatestSdkVersion
+    :: DamlPath
+    -> IO (Maybe SdkVersion)
+    -> IO (Maybe SdkVersion)
+cacheLatestSdkVersion =
+    cacheWith "latest-sdk-version" (CacheTimeout 86400)
+        serializeMaybeSdkVersion deserializeMaybeSdkVersion
+
+serializeMaybeSdkVersion :: Maybe SdkVersion -> String
+serializeMaybeSdkVersion = \case
+    Nothing -> ""
+    Just v -> versionToString v
+
+deserializeMaybeSdkVersion :: String -> Maybe (Maybe SdkVersion)
+deserializeMaybeSdkVersion = \case
+    "" -> Nothing
+    v  -> fmap Just . eitherToMaybe $ parseVersion (pack v)
+
+cacheDirPath :: DamlPath -> FilePath
+cacheDirPath (DamlPath damlPath) = damlPath </> "cache"
+
+cacheFilePath :: DamlPath -> CacheKey -> FilePath
+cacheFilePath damlPath (CacheKey key) = cacheDirPath damlPath </> key
+
+cacheWith
+    :: CacheKey
+    -> CacheTimeout
+    -> (t -> String)
+    -> (String -> Maybe t)
+    -> DamlPath
+    -> IO t
+    -> IO t
+cacheWith key (CacheTimeout timeout) serialize deserialize damlPath getValue = do
+    let path = cacheFilePath damlPath key
+
+    modTimeE <- tryIO (getModificationTime path)
+    curTimeE <- tryIO getCurrentTime
+    let useCachedE = liftM2 (\mt ct -> diffUTCTime ct mt < timeout) modTimeE curTimeE
+        useCached = fromRight False useCachedE
+
+    valueMEM <- whenMaybe useCached $ tryIO $ do
+        valueStr <- readFileUTF8 path
+        pure (deserialize valueStr)
+
+    case valueMEM of
+        Just (Right (Just value)) -> pure value
+        _ -> do
+            value <- getValue
+            void . tryIO $ do
+                createDirectoryIfMissing True (cacheDirPath damlPath)
+                writeFileUTF8 path (serialize value)
+            pure value
+

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -46,7 +46,7 @@ dispatch info = subcommand
 commandParser :: [SdkCommandInfo] -> Parser Command
 commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
     [ subparser -- visible commands
-        $  builtin "version" "Display the current DAML SDK version in use" mempty (pure Version <**> helper)
+        $  builtin "version" "Display DAML version information" mempty (pure Version <**> helper)
         <> builtin "install" "Install the specified DAML SDK version" mempty (Install <$> installParser <**> helper)
         <> foldMap dispatch visible
     , subparser -- hidden commands

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -42,6 +42,7 @@ getDamlEnv = do
     envProjectPath <- getProjectPath
     (envSdkVersion, envSdkPath) <- getSdk envDamlPath
         envDamlAssistantSdkVersion envProjectPath
+    envLatestStableSdkVersion <- fmap eitherToMaybe (try getLatestVersion :: IO (Either AssistantError SdkVersion))
     pure Env {..}
 
 -- | Determine the viability of running sdk commands in the environment.

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -53,8 +53,9 @@ getLatestStableSdkVersion :: DamlPath -> IO (Maybe SdkVersion)
 getLatestStableSdkVersion damlPath =
     cacheLatestSdkVersion damlPath $ do
         versionE :: Either AssistantError SdkVersion
-            <- try (wrapErr "" getLatestVersion)
+            <- try getLatestVersion
         pure (eitherToMaybe versionE)
+
 
 
 -- | Determine the viability of running sdk commands in the environment.

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -42,8 +42,17 @@ getDamlEnv = do
     envProjectPath <- getProjectPath
     (envSdkVersion, envSdkPath) <- getSdk envDamlPath
         envDamlAssistantSdkVersion envProjectPath
-    envLatestStableSdkVersion <- fmap eitherToMaybe (try getLatestVersion :: IO (Either AssistantError SdkVersion))
+    envLatestStableSdkVersion <- getLatestStableSdkVersion
     pure Env {..}
+
+-- | Get the latest stable SDK version. Designed to return Nothing if
+-- anything fails (e.g. machine is offline). TODO: Cache the result.
+getLatestStableSdkVersion :: IO (Maybe SdkVersion)
+getLatestStableSdkVersion = do
+    versionE :: Either AssistantError SdkVersion
+      <- try (wrapErr "" getLatestVersion)
+    pure (eitherToMaybe versionE)
+
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -318,8 +318,8 @@ extractAndInstall env source =
 httpInstall :: InstallEnv -> InstallURL -> IO ()
 httpInstall env@InstallEnv{..} (InstallURL url) = do
     unlessQuiet env $ output "Downloading SDK release."
-    request <- parseRequest ("GET " <> unpack url)
-    withResponse request $ \response -> do
+    request <- requiredHttps "Failed to parse HTTPS request." $ parseRequest ("GET " <> unpack url)
+    requiredHttps "Failed to download SDK release." $ withResponse request $ \response -> do
         when (getResponseStatusCode response /= 200) $
             throwIO . assistantErrorBecause "Failed to download release."
                     . pack . show $ getResponseStatus response

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -25,6 +25,7 @@ import qualified Data.Text.Encoding as T
 -- where <VERSION> is an SDK version. For example, "v0.11.1".
 newtype Tag = Tag { unTag :: Text } deriving (Eq, Show, FromJSON)
 
+
 -- | Convert a version to a git tag.
 versionToTag :: SdkVersion -> Tag
 versionToTag v = Tag ("v" <> versionToText v)
@@ -55,12 +56,12 @@ tagToVersion (Tag t) =
 --
 -- So we take that URL to get the tag, and from there the version of
 -- the latest stable release.
-getLatestVersion ::  IO SdkVersion
+getLatestVersion :: IO SdkVersion
 getLatestVersion = do
 
     manager <- newTlsManager -- TODO: share a single manager throughout the daml install process.
     request <- parseRequest "HEAD https://github.com/digital-asset/daml/releases/latest"
-    finalRequest <- requiredIO "Failed to get latest SDK version from GitHub." $
+    finalRequest <- requiredHttps "Failed to get latest SDK version from GitHub." $
         withResponseHistory request manager $ pure . hrFinalRequest
 
     let pathText = T.decodeUtf8 (path finalRequest)

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -25,8 +25,8 @@ data AssistantError = AssistantError
 instance Exception AssistantError where
     displayException AssistantError {..} = unpack . T.unlines . catMaybes $
         [ Just ("daml: " <> fromMaybe "An unknown error has occured" errMessage)
-        , fmap ("   context: " <>) errContext
-        , fmap ("   reason:  " <>) errInternal
+        , fmap ("  context: " <>) errContext
+        , fmap ("  details: " <>) errInternal
         ]
 
 -- | Standard error message.
@@ -48,6 +48,7 @@ data Env = Env
     , envProjectPath   :: Maybe ProjectPath
     , envSdkPath       :: Maybe SdkPath
     , envSdkVersion    :: Maybe SdkVersion
+    , envLatestStableSdkVersion :: Maybe SdkVersion
     } deriving (Eq, Show)
 
 data BuiltinCommand


### PR DESCRIPTION
- Add a warning to update the project's sdk-version when it becomes outdated.
- Add a warning to install the latest sdk version if daml assistant is outdated (we may remove this if daml-assistant doesn't change much between sdk versions, in the future).
- Add more version information to the `daml version` command.
- Reinstate custom exception handling, because relying on the rts results in hard to read error messages. (For some reason, `displayException` isn't used to display exceptions by default...)