### PR TITLE
Release scala source jars to bintray

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -17,6 +17,7 @@ HEAD — ongoing
 - Remove DAML-LF Dev major version, ``--target dev`` option, and sandbox ``--allow-dev``
   option.  A "1.dev" target will handle the intended "Dev" use cases in a future release.
 - Include list of DAML packages used during interpretation in the produced transaction.
+- Release source jars for scala libraries.
 
 0.12.11 - 2019-04-26
 --------------------

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -47,25 +47,25 @@
 - target: //daml-lf/transaction/src/main/protobuf:blindinginfo_java_proto
   type: jar-proto
 - target: //daml-lf/transaction:transaction
-  type: jar
+  type: jar-scala
 - target: //daml-lf/transaction-scalacheck:transaction-scalacheck
   type: jar
 - target: //daml-lf/lfpackage:lfpackage
-  type: jar
+  type: jar-scala
 - target: //daml-lf/interface:interface
-  type: jar
+  type: jar-scala
 - target: //daml-lf/validation:validation
-  type: jar
+  type: jar-scala
 - target: //daml-lf/interpreter:interpreter
-  type: jar
+  type: jar-scala
 - target: //daml-lf/scenario-interpreter:scenario-interpreter
-  type: jar
+  type: jar-scala
 - target: //daml-lf/engine:engine
-  type: jar
+  type: jar-scala
 - target: //daml-lf/repl:repl
   type: jar
 - target: //daml-lf/testing-tools:testing-tools
-  type: jar
+  type: jar-scala
 - target: //ledger-api/grpc-definitions:ledger-api-protos-tarball
   type: targz
   location:
@@ -92,27 +92,27 @@
 - target: //ledger-api/grpc-definitions:ledger-api-scalapb
   type: jar
 - target: //ledger-api/testing-utils:testing-utils
-  type: jar
+  type: jar-scala
 - target: //language-support/scala/bindings:bindings
-  type: jar
+  type: jar-scala
 - target: //ledger-api/rs-grpc-akka:rs-grpc-akka
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-akka:ledger-api-akka
-  type: jar
+  type: jar-scala
 - target: //scala-protoc-plugins/scala-logging:scala-logging-lib
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-scala-logging:ledger-api-scala-logging
-  type: jar
+  type: jar-scala
 - target: //ledger/backend-api:backend-api
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-client:ledger-api-client
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-domain:ledger-api-domain
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-common:ledger-api-common
-  type: jar
+  type: jar-scala
 - target: //ledger/sandbox:sandbox
-  type: jar
+  type: jar-scala
 - target: //ledger/ledger-api-integration-tests:semantic-test-runner
   type: jar-deploy
 - target: //ledger/ledger-api-test-tool:ledger-api-test-tool
@@ -122,7 +122,7 @@
 - target: //language-support/scala/codegen:codegen-main
   type: jar
 - target: //language-support/scala/bindings-akka:bindings-akka
-  type: jar
+  type: jar-scala
 - target: //language-support/java/codegen:shaded_binary
   type: jar
 - target: //navigator/backend:navigator-binary
@@ -132,12 +132,12 @@
 - target: //language-support/codegen-main:shaded_binary
   type: jar
 - target: //ledger/participant-state:participant-state
-  type: jar
+  type: jar-scala
 - target: //ledger/participant-state/reference:reference
-  type: jar
+  type: jar-scala
 - target: //ledger/participant-state-index:participant-state-index
-  type: jar
+  type: jar-scala
 - target: //ledger/participant-state-index/reference:reference
-  type: jar
+  type: jar-scala
 - target: //ledger/api-server-damlonx:api-server-damlonx
-  type: jar
+  type: jar-scala


### PR DESCRIPTION
Tested with a dry run:
Copying .../com_github_digital_asset_daml/bazel-out/k8-fastbuild/bin/ledger/api-server-damlonx/api-server-damlonx_src.jar
to .../com/daml/ledger/api-server-damlonx_2.12/100.12.11/api-server-damlonx_2.12-100.12.11-sources.jar

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
