### PR TITLE
daml-lf: move EnvironmentInterface from Scala codegen to interface library

### DIFF
--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
@@ -11,16 +11,16 @@ import scala.collection.immutable.Map
 import scalaz.syntax.std.map._
 import scalaz.Semigroup
 
-final case class EnvironmentInterface(typeDecls: Map[Identifier, reader.InterfaceType])
+final case class EnvironmentInterface(typeDecls: Map[Identifier, InterfaceType])
 
 object EnvironmentInterface {
-  def fromReaderInterfaces(i: reader.Interface, o: reader.Interface*): EnvironmentInterface =
+  def fromReaderInterfaces(i: Interface, o: Interface*): EnvironmentInterface =
     EnvironmentInterface((i +: o).flatMap {
-      case reader.Interface(packageId, typeDecls) =>
+      case Interface(packageId, typeDecls) =>
         typeDecls mapKeys (Identifier(packageId, _))
     }(breakOut))
 
-  def fromReaderInterfaces(dar: Dar[reader.Interface]): EnvironmentInterface =
+  def fromReaderInterfaces(dar: Dar[Interface]): EnvironmentInterface =
     fromReaderInterfaces(dar.main, dar.dependencies: _*)
 
   implicit val environmentInterfaceSemigroup: Semigroup[EnvironmentInterface] = Semigroup instance {

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
@@ -1,12 +1,10 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.codegen
-package lf
+package com.digitalasset.daml.lf
+package iface
 
-import com.digitalasset.daml.lf.data.Ref.Identifier
-import com.digitalasset.daml.lf.{Dar, iface}
-import iface.reader
+import data.Ref.Identifier
 
 import scala.collection.breakOut
 import scala.collection.immutable.Map
@@ -25,11 +23,8 @@ object EnvironmentInterface {
   def fromReaderInterfaces(dar: Dar[reader.Interface]): EnvironmentInterface =
     fromReaderInterfaces(dar.main, dar.dependencies: _*)
 
-  val environmentInterfaceSemigroup = new Semigroup[EnvironmentInterface] {
-    override def append(
-        f1: EnvironmentInterface,
-        f2: => EnvironmentInterface): EnvironmentInterface = {
+  implicit val environmentInterfaceSemigroup: Semigroup[EnvironmentInterface] = Semigroup instance {
+    (f1, f2) =>
       EnvironmentInterface(f1.typeDecls ++ f2.typeDecls)
-    }
   }
 }

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/EnvironmentInterface.scala
@@ -11,6 +11,7 @@ import scala.collection.immutable.Map
 import scalaz.syntax.std.map._
 import scalaz.Semigroup
 
+/** The combination of multiple [[Interface]]s, such as from a dar. */
 final case class EnvironmentInterface(typeDecls: Map[Identifier, InterfaceType])
 
 object EnvironmentInterface {

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Interface.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Interface.scala
@@ -39,8 +39,10 @@ object InterfaceType {
   }
 }
 
-/** `templates` stores template info for record types which are templates. Note that all keys of `templates` must be
-  * present in `typeDecls`, too.'
+/** The interface of a single DALF archive.  Not expressive enough to
+  * represent a whole dar, as a dar can contain multiple DALF archives
+  * with separate package IDs and overlapping [[QualifiedName]]s; for a
+  * dar use [[EnvironmentInterface]] instead.
   */
 final case class Interface(packageId: PackageId, typeDecls: Map[QualifiedName, InterfaceType]) {
   def getTypeDecls: j.Map[QualifiedName, InterfaceType] = typeDecls.asJava
@@ -60,4 +62,3 @@ object Interface {
     : (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
     readInterface(f)
 }
-

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Interface.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Interface.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.iface
+
+import reader.Errors
+import com.digitalasset.daml_lf.{DamlLf, DamlLf1}
+import scalaz._
+import java.{util => j}
+
+import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
+import com.digitalasset.daml.lf.data.Ref.QualifiedName
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Map
+
+sealed abstract class InterfaceType extends Product with Serializable {
+  def `type`: DefDataType.FWT
+
+  def fold[Z](normal: DefDataType.FWT => Z, template: (Record.FWT, DefTemplate[Type]) => Z): Z =
+    this match {
+      case InterfaceType.Normal(typ) => normal(typ)
+      case InterfaceType.Template(typ, tpl) => template(typ, tpl)
+    }
+
+  /** Alias for `type`. */
+  def getType: DefDataType.FWT = `type`
+  def getTemplate: j.Optional[_ <: DefTemplate.FWT] =
+    fold({ _ =>
+      j.Optional.empty()
+    }, { (_, tpl) =>
+      j.Optional.of(tpl)
+    })
+}
+object InterfaceType {
+  final case class Normal(`type`: DefDataType.FWT) extends InterfaceType
+  final case class Template(rec: Record.FWT, template: DefTemplate[Type]) extends InterfaceType {
+    def `type`: DefDataType.FWT = DefDataType(ImmArraySeq.empty, rec)
+  }
+}
+
+/** `templates` stores template info for record types which are templates. Note that all keys of `templates` must be
+  * present in `typeDecls`, too.'
+  */
+final case class Interface(packageId: PackageId, typeDecls: Map[QualifiedName, InterfaceType]) {
+  def getTypeDecls: j.Map[QualifiedName, InterfaceType] = typeDecls.asJava
+}
+
+object Interface {
+  import Errors._, reader.InterfaceReader._
+
+  def read(lf: DamlLf.Archive): (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
+    readInterface(lf)
+
+  def read(lf: (PackageId, DamlLf.ArchivePayload))
+    : (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
+    readInterface(lf)
+
+  def read(f: () => String \/ (PackageId, DamlLf1.Package))
+    : (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
+    readInterface(f)
+}
+

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.iface
+package com.digitalasset.daml.lf
+package iface
 package reader
 
 import ErrorFormatter._
@@ -13,7 +14,6 @@ import scalaz.syntax.apply._
 import scalaz.syntax.bifunctor._
 import scalaz.syntax.monoid._
 import scalaz.syntax.traverse._
-import java.{util => j}
 
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
@@ -29,54 +29,8 @@ import scala.collection.JavaConverters._
 import scala.collection.breakOut
 import scala.collection.immutable.Map
 
-sealed abstract class InterfaceType extends Product with Serializable {
-  def `type`: DefDataType.FWT
-
-  def fold[Z](normal: DefDataType.FWT => Z, template: (Record.FWT, DefTemplate[Type]) => Z): Z =
-    this match {
-      case InterfaceType.Normal(typ) => normal(typ)
-      case InterfaceType.Template(typ, tpl) => template(typ, tpl)
-    }
-
-  def getType: DefDataType.FWT = `type`
-  def getTemplate: j.Optional[_ <: DefTemplate.FWT] =
-    fold({ _ =>
-      j.Optional.empty()
-    }, { (_, tpl) =>
-      j.Optional.of(tpl)
-    })
-}
-object InterfaceType {
-  final case class Normal(`type`: DefDataType.FWT) extends InterfaceType
-  final case class Template(rec: Record.FWT, template: DefTemplate[Type]) extends InterfaceType {
-    def `type`: DefDataType.FWT = DefDataType(ImmArraySeq.empty, rec)
-  }
-}
-
-/** `templates` stores template info for record types which are templates. Note that all keys of `templates` must be
-  * present in `typeDecls`, too.'
-  */
-final case class Interface(packageId: PackageId, typeDecls: Map[QualifiedName, InterfaceType]) {
-  def getTypeDecls: j.Map[QualifiedName, InterfaceType] = typeDecls.asJava
-}
-
-object Interface {
-  import Errors._, InterfaceReader._
-
-  def read(lf: DamlLf.Archive): (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
-    readInterface(lf)
-
-  def read(lf: (PackageId, DamlLf.ArchivePayload))
-    : (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
-    readInterface(lf)
-
-  def read(f: () => String \/ (PackageId, DamlLf1.Package))
-    : (Errors[ErrorLoc, InvalidDataTypeDefinition], Interface) =
-    readInterface(f)
-}
-
 object InterfaceReader {
-  import Errors._
+  import Errors._, iface.{Interface, InterfaceType}
 
   sealed abstract class InterfaceReaderError extends Product with Serializable
   final case class UnserializableDataType(error: String) extends InterfaceReaderError

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/package.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/package.scala
@@ -1,0 +1,14 @@
+package com.digitalasset.daml.lf.iface
+
+import com.digitalasset.daml.lf.{iface => parent}
+
+package object reader {
+  @deprecated("import from parent `iface` package instead", since = "0.12.12")
+  type InterfaceType = parent.InterfaceType
+  @deprecated("import from parent `iface` package instead", since = "0.12.12")
+  val InterfaceType = parent.InterfaceType
+  @deprecated("import from parent `iface` package instead", since = "0.12.12")
+  type Interface = parent.Interface
+  @deprecated("import from parent `iface` package instead", since = "0.12.12")
+  val Interface = parent.Interface
+}

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/package.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/package.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.daml.lf.iface
 
 import com.digitalasset.daml.lf.{iface => parent}

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/LedgerReader.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/LedgerReader.scala
@@ -7,9 +7,9 @@ import java.io.File
 import java.nio.file.Files
 
 import com.digitalasset.daml.lf.data.Ref.SimpleString
-import com.digitalasset.daml.lf.iface.reader.{InterfaceType, Interface, InterfaceReader}
+import com.digitalasset.daml.lf.iface.reader.InterfaceReader
 import com.digitalasset.daml.lf.iface
-import com.digitalasset.daml.lf.iface.DefDataType
+import com.digitalasset.daml.lf.iface.{DefDataType, InterfaceType, Interface}
 import com.digitalasset.daml.lf.archive.Reader
 import com.digitalasset.daml_lf.DamlLf
 import com.digitalasset.daml_lf.DamlLf.Archive

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/PostgreSQLWriter.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/PostgreSQLWriter.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.extractor.writers
 
-import com.digitalasset.daml.lf.iface.reader.{InterfaceType, Interface}
+import com.digitalasset.daml.lf.iface.{InterfaceType, Interface}
 import com.digitalasset.extractor.config.ExtractorConfig
 import com.digitalasset.extractor.ledger.LedgerReader
 import com.digitalasset.extractor.ledger.LedgerReader.PackageStore

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/PrettyPrintWriter.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/PrettyPrintWriter.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.extractor.writers
 
-import com.digitalasset.daml.lf.iface.reader.Interface
+import com.digitalasset.daml.lf.iface.Interface
 import com.digitalasset.extractor.ledger.types.Event
 import com.digitalasset.extractor.targets.PrettyPrintTarget
 import _root_.pprint.PPrinter

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/PrinterFunctionWriter.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/PrinterFunctionWriter.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.extractor.writers
 
-import com.digitalasset.daml.lf.iface.reader.Interface
+import com.digitalasset.daml.lf.iface.Interface
 import com.digitalasset.extractor.ledger.LedgerReader.PackageStore
 import com.digitalasset.extractor.ledger.types.{Event, TransactionTree}
 import com.digitalasset.extractor.writers.Writer.RefreshPackages

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/SimpleTextWriter.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/SimpleTextWriter.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.extractor.writers
 
-import com.digitalasset.daml.lf.iface.reader.Interface
+import com.digitalasset.daml.lf.iface.Interface
 import com.digitalasset.extractor.ledger.types.Event
 
 class SimpleTextWriter(val printer: Any => Unit) extends PrinterFunctionWriter with Writer {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -14,7 +14,7 @@ import com.digitalasset.daml.lf.codegen.backend.Backend
 import com.digitalasset.daml.lf.codegen.backend.java.JavaBackend
 import com.digitalasset.daml.lf.codegen.conf.Conf
 import com.digitalasset.daml.lf.data.ImmArray
-import com.digitalasset.daml.lf.iface.reader.{Interface, InterfaceReader}
+import com.digitalasset.daml.lf.iface.reader.InterfaceReader
 import com.digitalasset.daml.lf.iface.{Type => _, _}
 import com.digitalasset.daml_lf.DamlLf
 import com.typesafe.scalalogging.StrictLogging

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
@@ -5,8 +5,7 @@ package com.digitalasset.daml.lf.codegen
 
 import com.digitalasset.daml.lf.data.Ref.{Identifier, QualifiedName, SimpleString}
 import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Ref}
-import com.digitalasset.daml.lf.iface.reader.{Interface, InterfaceType}
-import com.digitalasset.daml.lf.iface.{DefDataType, Record, Variant}
+import com.digitalasset.daml.lf.iface.{DefDataType, Interface, InterfaceType, Record, Variant}
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.annotation.tailrec

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/Backend.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/Backend.scala
@@ -5,8 +5,7 @@ package com.digitalasset.daml.lf.codegen.backend
 
 import com.digitalasset.daml.lf.codegen.conf.Conf
 import com.digitalasset.daml.lf.codegen.{InterfaceTrees, NodeWithContext}
-import com.digitalasset.daml.lf.iface.PackageId
-import com.digitalasset.daml.lf.iface.reader.Interface
+import com.digitalasset.daml.lf.iface.{Interface, PackageId}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
@@ -7,8 +7,7 @@ import com.digitalasset.daml.lf.codegen.backend.Backend
 import com.digitalasset.daml.lf.codegen.backend.java.inner.{ClassForType, DecoderClass}
 import com.digitalasset.daml.lf.codegen.conf.Conf
 import com.digitalasset.daml.lf.codegen.{InterfaceTrees, ModuleWithContext, NodeWithContext}
-import com.digitalasset.daml.lf.iface.PackageId
-import com.digitalasset.daml.lf.iface.reader.Interface
+import com.digitalasset.daml.lf.iface.{Interface, PackageId}
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import org.slf4j.MDC

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -9,7 +9,6 @@ import com.digitalasset.daml.lf.codegen.TypeWithContext
 import com.digitalasset.daml.lf.codegen.backend.java.ObjectMethods
 import com.digitalasset.daml.lf.data.Ref.{ChoiceName, QualifiedName, SimpleString}
 import com.digitalasset.daml.lf.iface._
-import com.digitalasset.daml.lf.iface.reader.InterfaceType
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -8,8 +8,7 @@ import com.digitalasset.daml.lf.codegen.TypeWithContext
 import com.digitalasset.daml.lf.codegen.backend.java.JavaEscaper
 import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.iface._
-import com.digitalasset.daml.lf.iface.reader.InterfaceType
-import com.digitalasset.daml.lf.iface.reader.InterfaceType.Normal
+import InterfaceType.Normal
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/InterfaceTreeSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/InterfaceTreeSpec.scala
@@ -6,8 +6,7 @@ package com.digitalasset.daml.lf.codegen
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
 import com.digitalasset.daml.lf.data.Ref.{DottedName, QualifiedName, SimpleString}
-import com.digitalasset.daml.lf.iface.reader.{Interface, InterfaceType}
-import com.digitalasset.daml.lf.iface.{DefDataType, Record, Variant}
+import com.digitalasset.daml.lf.iface.{DefDataType, Interface, InterfaceType, Record, Variant}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
@@ -6,7 +6,7 @@ package com.digitalasset.codegen
 import com.digitalasset.codegen.types.Namespace
 import com.digitalasset.daml.lf.{Dar, UniversalArchiveReader, iface}
 import iface.{Type => _, _}
-import com.digitalasset.daml.lf.iface.reader.{Errors, Interface, InterfaceReader}
+import com.digitalasset.daml.lf.iface.reader.{Errors, InterfaceReader}
 import java.io._
 
 import scala.collection.breakOut

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
@@ -12,9 +12,8 @@ import java.io._
 import scala.collection.breakOut
 import com.digitalasset.codegen.dependencygraph._
 import com.digitalasset.codegen.exception.PackageInterfaceException
-import com.digitalasset.codegen.lf.EnvironmentInterface.environmentInterfaceSemigroup
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
-import lf.{DefTemplateWithRecord, EnvironmentInterface, LFUtil, ScopedDataType}
+import lf.{DefTemplateWithRecord, LFUtil, ScopedDataType}
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.iface.reader.Errors.ErrorLoc
 import com.digitalasset.daml_lf.DamlLf
@@ -132,10 +131,8 @@ object CodeGen {
   private def combineInterfaces(dar: Dar[Interface]): EnvironmentInterface =
     EnvironmentInterface.fromReaderInterfaces(dar)
 
-  private def combineEnvInterfaces(as: NonEmptyList[EnvironmentInterface]): EnvironmentInterface = {
-    val z = EnvironmentInterface(Map.empty)
-    as.foldLeft(z)((a1, a2) => environmentInterfaceSemigroup.append(a1, a2))
-  }
+  private def combineEnvInterfaces(as: NonEmptyList[EnvironmentInterface]): EnvironmentInterface =
+    as.suml1
 
   private def packageInterfaceToScalaCode(util: Util): Unit = {
     val interface = util.iface

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
@@ -7,7 +7,7 @@ import com.digitalasset.daml.lf.iface._
 import com.digitalasset.daml.lf.iface.reader.InterfaceType
 import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.codegen.{Util, lf}
-import lf.{DefTemplateWithRecord, EnvironmentInterface}
+import lf.DefTemplateWithRecord
 
 import scalaz.std.list._
 import scalaz.syntax.bifoldable._

--- a/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
+++ b/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
@@ -22,7 +22,7 @@ class UtilTest extends UtilTestHelpers with GeneratorDrivenPropertyChecks {
   val util =
     lf.LFUtil(
       scalaPackage,
-      lf.EnvironmentInterface fromReaderInterfaces packageInterface,
+      I.EnvironmentInterface fromReaderInterfaces packageInterface,
       outputDir.toFile)
 
   def damlScalaName(damlNameSpace: Array[String], name: String): util.DamlScalaName =

--- a/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
+++ b/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 class UtilTest extends UtilTestHelpers with GeneratorDrivenPropertyChecks {
 
   val packageInterface =
-    I.reader.Interface(packageId = SimpleString assertFromString "abcdef", typeDecls = Map.empty)
+    I.Interface(packageId = SimpleString assertFromString "abcdef", typeDecls = Map.empty)
   val scalaPackageParts = Array("com", "digitalasset")
   val scalaPackage: String = scalaPackageParts.mkString(".")
   val util =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -32,7 +32,7 @@ case class PackageRegistry(
     c.consuming
   )
 
-  def withPackages(interfaces: List[DamlLfIface.reader.Interface]): PackageRegistry = {
+  def withPackages(interfaces: List[DamlLfIface.Interface]): PackageRegistry = {
     val newPackages: Map[DamlLfPackageId, DamlLfPackage] = interfaces
       .filterNot(p => packages.contains(p.packageId))
       .map(p => {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -36,7 +36,7 @@ class PartyState(val name: ApiTypes.Party, val useDatabase: Boolean) {
     ()
   }
 
-  def addPackages(packs: List[DamlLfIface.reader.Interface]): Unit = {
+  def addPackages(packs: List[DamlLfIface.Interface]): Unit = {
     stateRef.updateAndGet(state =>
       state.copy(packageRegistry = packageRegistry.withPackages(packs)))
     ()

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -240,7 +240,7 @@ case object DamlConstants {
 
   // Note: these templates may not be valid DAML templates
   val simpleRecordTemplateId: DamlLfIdentifier = id("SimpleRecordTemplate")
-  val simpleRecordTemplate = DamlLfIface.reader.InterfaceType.Template(
+  val simpleRecordTemplate = DamlLfIface.InterfaceType.Template(
     simpleRecordT,
     DamlLfIface.DefTemplate(
       Map(
@@ -250,7 +250,7 @@ case object DamlConstants {
         "replace" -> DamlLfIface.TemplateChoice(simpleRecordTC, false, simpleUnitT)
       ))
   )
-  val complexRecordTemplate = DamlLfIface.reader.InterfaceType.Template(
+  val complexRecordTemplate = DamlLfIface.InterfaceType.Template(
     complexRecordT,
     DamlLfIface.DefTemplate(
       Map(
@@ -260,7 +260,7 @@ case object DamlConstants {
         "replace" -> DamlLfIface.TemplateChoice(complexRecordTC, false, simpleUnitT)
       ))
   )
-  val treeNodeTemplate = DamlLfIface.reader.InterfaceType.Template(
+  val treeNodeTemplate = DamlLfIface.InterfaceType.Template(
     treeNodeT,
     DamlLfIface.DefTemplate(
       Map(
@@ -271,14 +271,14 @@ case object DamlConstants {
       ))
   )
 
-  val iface = DamlLfIface.reader.Interface(
+  val iface = DamlLfIface.Interface(
     packageId0,
     Map(
-      emptyRecordId.qualifiedName -> DamlLfIface.reader.InterfaceType.Normal(emptyRecordGC),
-      simpleRecordId.qualifiedName -> DamlLfIface.reader.InterfaceType.Normal(simpleRecordGC),
-      simpleVariantId.qualifiedName -> DamlLfIface.reader.InterfaceType.Normal(simpleVariantGC),
-      treeId.qualifiedName -> DamlLfIface.reader.InterfaceType.Normal(treeGC),
-      treeNodeId.qualifiedName -> DamlLfIface.reader.InterfaceType.Normal(treeNodeGC),
+      emptyRecordId.qualifiedName -> DamlLfIface.InterfaceType.Normal(emptyRecordGC),
+      simpleRecordId.qualifiedName -> DamlLfIface.InterfaceType.Normal(simpleRecordGC),
+      simpleVariantId.qualifiedName -> DamlLfIface.InterfaceType.Normal(simpleVariantGC),
+      treeId.qualifiedName -> DamlLfIface.InterfaceType.Normal(treeGC),
+      treeNodeId.qualifiedName -> DamlLfIface.InterfaceType.Normal(treeNodeGC),
       simpleRecordTemplateId.qualifiedName -> simpleRecordTemplate,
       complexRecordId.qualifiedName -> complexRecordTemplate,
       treeNodeId.qualifiedName -> treeNodeTemplate


### PR DESCRIPTION
Also move `Interface` and `InterfaceType` out of the `reader` subpackage; they belong with the rest of the data model at the `iface` root.

The specific mechanics of reading a `Dar` all the way to producing an `EnvironmentInterface` are left to Scala codegen's `Codegen` and Java codegen's `CodeGenRunner`; there's no consensus or great stability on the best way to tie these pieces together, but all the pieces might as well be available in the `interface` library at least.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
