### PR TITLE
Return transaction in SubmitAndWaitResponse

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -15,6 +15,12 @@ HEAD — ongoing
 - Remove DAML-LF Dev major version, ``--target dev`` option, and sandbox ``--allow-dev``
   option.  A "1.dev" target will handle the intended "Dev" use cases in a future release.
 - Include list of DAML packages used during interpretation in the produced transaction.
+- Ledger API: Return transaction for commands submitted via :ref:`CommandService#SubmitAndWait <com.digitalasset.ledger.api.v1.commandservice>`
+  - *binary backwards-compatible, source-breaking*
+  - This avoids having to inspect the transaction stream to get hold of the result of a command
+    submitted via the command service.
+  - This breaking change is reflected in the Ledger API, the Java Bindings, and the Scala Bindings.
+    Previously released versions of the bindings will continue to work with newer ledgers and vice versa.
 
 0.12.11 - 2019-04-26
 --------------------

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/CommandClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/CommandClient.java
@@ -4,7 +4,9 @@
 package com.daml.ledger.rxjava;
 
 import com.daml.ledger.javaapi.data.Command;
+import com.daml.ledger.javaapi.data.TransactionTree;
 import com.google.protobuf.Empty;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -16,7 +18,12 @@ import java.util.List;
  */
 public interface CommandClient {
 
-    Single<Empty> submitAndWait(@NonNull String workflowId, @NonNull String applicationId,
-                                @NonNull String commandId, @NonNull String party, @NonNull Instant ledgerEffectiveTime,
-                                @NonNull Instant maximumRecordTime, @NonNull List<@NonNull Command> commands);
+    /**
+     * @return an empty or non-empty {@link Maybe} if the command was processed successfully,
+     * or an error otherwise. The {@link Maybe} contains a value if the response from the
+     * ledger contained a transaction tree.
+     */
+    Maybe<TransactionTree> submitAndWait(@NonNull String workflowId, @NonNull String applicationId,
+                                         @NonNull String commandId, @NonNull String party, @NonNull Instant ledgerEffectiveTime,
+                                         @NonNull Instant maximumRecordTime, @NonNull List<@NonNull Command> commands);
 }

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandClientImpl.java
@@ -3,15 +3,14 @@
 
 package com.daml.ledger.rxjava.grpc;
 
-import com.daml.ledger.rxjava.CommandClient;
 import com.daml.ledger.javaapi.data.Command;
 import com.daml.ledger.javaapi.data.SubmitAndWaitRequest;
+import com.daml.ledger.javaapi.data.TransactionTree;
+import com.daml.ledger.rxjava.CommandClient;
 import com.digitalasset.ledger.api.v1.CommandServiceGrpc;
 import com.digitalasset.ledger.api.v1.CommandServiceOuterClass;
-import com.google.protobuf.Empty;
 import io.grpc.Channel;
-import io.grpc.ManagedChannel;
-import io.reactivex.Single;
+import io.reactivex.Maybe;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.time.Instant;
@@ -28,11 +27,14 @@ public class CommandClientImpl implements CommandClient {
     }
 
     @Override
-    public Single<Empty> submitAndWait(@NonNull String workflowId, @NonNull String applicationId,
-                                       @NonNull String commandId, @NonNull String party, @NonNull Instant ledgerEffectiveTime,
-                                       @NonNull Instant maximumRecordTime, @NonNull List<@NonNull Command> commands) {
+    public Maybe<TransactionTree> submitAndWait(@NonNull String workflowId, @NonNull String applicationId,
+                                                @NonNull String commandId, @NonNull String party, @NonNull Instant ledgerEffectiveTime,
+                                                @NonNull Instant maximumRecordTime, @NonNull List<@NonNull Command> commands) {
         CommandServiceOuterClass.SubmitAndWaitRequest request = SubmitAndWaitRequest.toProto(this.ledgerId,
                 workflowId, applicationId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands);
-        return Single.fromFuture(serviceStub.submitAndWait(request));
+        return Maybe.fromFuture(serviceStub.submitAndWait(request)).flatMap(r -> {
+                if (r.hasTransaction()) return Maybe.just(TransactionTree.fromProto(r.getTransaction()));
+                    return Maybe.empty();
+                });
     }
 }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.javaapi.data.{Command, CreateCommand, Identifier, Record}
 import com.daml.ledger.rxjava.grpc.helpers._
 import com.daml.ledger.testkit.services._
 import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import com.digitalasset.ledger.api.v1.ledger_configuration_service.GetLedgerConfigurationResponse
 import com.digitalasset.ledger.api.v1.package_service._
 import com.google.protobuf.ByteString
@@ -213,7 +214,7 @@ class DamlLedgerClientTest extends FlatSpec with Matchers with OptionValues with
       Future.successful(Empty.defaultInstance),
       List(CompletionStreamResponse(None, Seq())),
       genCompletionEndResponse("completionEndResponse"),
-      Future.successful(Empty.defaultInstance),
+      Future.successful(SubmitAndWaitResponse.defaultInstance),
       List(genGetTimeResponse),
       Seq(GetLedgerConfigurationResponse.defaultInstance),
       Future.successful(ListPackagesResponse(Seq("id1"))),

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -16,6 +16,7 @@ import com.daml.ledger.javaapi.data.{Unit => DAMLUnit, _}
 import com.daml.ledger.rxjava.grpc.helpers.{DataLayerHelpers, LedgerServices}
 import com.daml.ledger.rxjava.{CommandSubmissionClient, DamlLedgerClient}
 import com.daml.ledger.testkit.services.TransactionServiceImpl
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import com.digitalasset.ledger.api.{v1 => scalaAPI}
 import com.google.protobuf.Empty
 import com.google.rpc.Status
@@ -371,7 +372,7 @@ class BotTest extends FlatSpec with Matchers with DataLayerHelpers {
       Future.successful(com.google.protobuf.empty.Empty.defaultInstance),
       List.empty,
       scalaAPI.command_completion_service.CompletionEndResponse.defaultInstance,
-      Future.successful(com.google.protobuf.empty.Empty.defaultInstance),
+      Future.successful(SubmitAndWaitResponse.defaultInstance),
       List.empty,
       Seq.empty,
       Future.successful(scalaAPI.package_service.ListPackagesResponse.defaultInstance),

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandClientImplTest.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.javaapi.data.{CreateCommand, Identifier, Record}
 import com.daml.ledger.rxjava.grpc.helpers.{DataLayerHelpers, LedgerServices, TestConfiguration}
-import com.google.protobuf.empty.Empty
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 import scala.collection.JavaConverters._
@@ -21,7 +21,7 @@ class CommandClientImplTest extends FlatSpec with Matchers with OptionValues wit
   behavior of "[2.1] CommandClientImpl.submitAndWait"
 
   it should "send the given command to the Ledger" in {
-    ledgerServices.withCommandClient(Future.successful(Empty.defaultInstance)) {
+    ledgerServices.withCommandClient(Future.successful(SubmitAndWaitResponse.defaultInstance)) {
       (client, service) =>
         val commands = genCommands(List.empty)
         client
@@ -43,7 +43,7 @@ class CommandClientImplTest extends FlatSpec with Matchers with OptionValues wit
   behavior of "[2.2] CommandClientImpl.submitAndWait"
 
   it should "send the given command with the correct parameters" in {
-    ledgerServices.withCommandClient(Future.successful(Empty.defaultInstance)) {
+    ledgerServices.withCommandClient(Future.successful(SubmitAndWaitResponse.defaultInstance)) {
       (client, service) =>
         val recordId = new Identifier("recordPackageId", "recordModuleName", "recordEntityName")
         val record = new Record(recordId, List.empty[Record.Field].asJava)

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandCompletionImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandCompletionImplTest.scala
@@ -56,8 +56,8 @@ class CommandCompletionImplTest
 
   it should "return a stream with all the completions" in {
     val applicationId = "applicationId"
-    val completion1 = Completion("cid1", Option(new Status(0)), None)
-    val completion2 = Completion("cid2", Option(new Status(1)), None)
+    val completion1 = Completion("cid1", Option(new Status(0)), "1", None)
+    val completion2 = Completion("cid2", Option(new Status(1)), traceContext = None)
     val completionResponse = CompletionStreamResponse(None, List(completion1, completion2))
     ledgerServices.withCommandCompletionClient(
       List(completionResponse),
@@ -75,6 +75,7 @@ class CommandCompletionImplTest
       val receivedCompletion2 = completions.getCompletions.get(1)
       receivedCompletion1.getCommandId shouldBe completion1.commandId
       receivedCompletion1.getStatus.getCode shouldBe completion1.getStatus.code
+      receivedCompletion1.getTransactionId shouldBe completion1.transactionId
       receivedCompletion2.getCommandId shouldBe completion2.commandId
       receivedCompletion2.getStatus.getCode shouldBe completion2.getStatus.code
     }
@@ -84,7 +85,7 @@ class CommandCompletionImplTest
 
   it should "send the request with the correct ledgerId" in {
     val applicationId = "applicationId"
-    val completion1 = Completion("cid1", Option(new Status(0)), None)
+    val completion1 = Completion("cid1", Option(new Status(0)), traceContext = None)
     val completionResponse = CompletionStreamResponse(None, List(completion1))
     val parties = Set("Alice")
     ledgerServices.withCommandCompletionClient(

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
@@ -8,14 +8,15 @@ import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.rxjava.grpc._
 import com.daml.ledger.rxjava.{CommandCompletionClient, LedgerConfigurationClient, PackageClient}
-import com.daml.ledger.testkit.services._
 import com.daml.ledger.testkit.services.TransactionServiceImpl.LedgerItem
+import com.daml.ledger.testkit.services._
 import com.digitalasset.grpc.adapter.{ExecutionSequencerFactory, SingleThreadExecutionSequencerPool}
 import com.digitalasset.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.digitalasset.ledger.api.v1.command_completion_service.{
   CompletionEndResponse,
   CompletionStreamResponse
 }
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import com.digitalasset.ledger.api.v1.ledger_configuration_service.GetLedgerConfigurationResponse
 import com.digitalasset.ledger.api.v1.package_service.{
   GetPackageResponse,
@@ -128,7 +129,7 @@ class LedgerServices(val ledgerId: String) {
     }
   }
 
-  def withCommandClient(response: Future[Empty])(
+  def withCommandClient(response: Future[SubmitAndWaitResponse])(
       f: (CommandClientImpl, CommandServiceImpl) => Any): Any = {
     val (service, serviceImpl) = CommandServiceImpl.createWithRef(response)(executionContext)
     withServerAndChannel(service) { channel =>
@@ -167,7 +168,7 @@ class LedgerServices(val ledgerId: String) {
       commandSubmissionResponse: Future[Empty],
       completions: List[CompletionStreamResponse],
       completionsEnd: CompletionEndResponse,
-      commandResponse: Future[Empty],
+      commandResponse: Future[SubmitAndWaitResponse],
       getTimeResponses: List[GetTimeResponse],
       getLedgerConfigurationResponses: Seq[GetLedgerConfigurationResponse],
       listPackagesResponse: Future[ListPackagesResponse],

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServicesImpls.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServicesImpls.scala
@@ -9,6 +9,7 @@ import com.digitalasset.ledger.api.v1.command_completion_service.{
   CompletionEndResponse,
   CompletionStreamResponse
 }
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import com.digitalasset.ledger.api.v1.ledger_configuration_service.GetLedgerConfigurationResponse
 import com.digitalasset.ledger.api.v1.package_service.{
   GetPackageResponse,
@@ -42,7 +43,7 @@ object LedgerServicesImpls {
       commandSubmissionResponse: Future[Empty],
       completions: List[CompletionStreamResponse],
       completionsEnd: CompletionEndResponse,
-      commandResponse: Future[Empty],
+      commandResponse: Future[SubmitAndWaitResponse],
       getTimeResponses: List[GetTimeResponse],
       getLedgerConfigurationResponses: Seq[GetLedgerConfigurationResponse],
       listPackagesResponse: Future[ListPackagesResponse],

--- a/language-support/java/testkit/src/main/scala/com/daml/ledger/testkit/services/CommandServiceImpl.scala
+++ b/language-support/java/testkit/src/main/scala/com/daml/ledger/testkit/services/CommandServiceImpl.scala
@@ -4,19 +4,32 @@
 package com.daml.ledger.testkit.services
 
 import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
-import com.digitalasset.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
-import com.google.protobuf.empty.Empty
+import com.digitalasset.ledger.api.v1.command_service._
 import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CommandServiceImpl(response: Future[Empty]) extends CommandService {
+class CommandServiceImpl(
+                          submitAndWaitResponse: Future[SubmitAndWaitResponse],
+                          submitAndWaitForTransactionResponse: Future[SubmitAndWaitForTransactionResponse],
+                          submitAndWaitForTransactionTreeResponse: Future[SubmitAndWaitForTransactionTreeResponse]) extends CommandService {
 
   private var lastRequest: Option[SubmitAndWaitRequest] = None
 
-  override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] = {
+  override def submitAndWait(request: SubmitAndWaitRequest): Future[SubmitAndWaitResponse] = {
     this.lastRequest = Some(request)
-    response
+    submitAndWaitResponse
+  }
+
+
+  override def submitAndWaitForTransaction(request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] = {
+    this.lastRequest = Some(request)
+    submitAndWaitForTransactionResponse
+  }
+
+  override def submitAndWaitForTransactionTree(request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] = {
+    this.lastRequest = Some(request)
+    submitAndWaitForTransactionTreeResponse
   }
 
   def getLastRequest: Option[SubmitAndWaitRequest] = this.lastRequest
@@ -24,9 +37,11 @@ class CommandServiceImpl(response: Future[Empty]) extends CommandService {
 
 object CommandServiceImpl {
 
-  def createWithRef(response: Future[Empty])(
+  def createWithRef(submitAndWaitResponse: Future[SubmitAndWaitResponse],
+                    submitAndWaitForTransactionResponse: Future[SubmitAndWaitForTransactionResponse],
+                    submitAndWaitForTransactionTreeResponse: Future[SubmitAndWaitForTransactionTreeResponse])(
       implicit ec: ExecutionContext): (ServerServiceDefinition, CommandServiceImpl) = {
-    val serviceImpl = new CommandServiceImpl(response)
+    val serviceImpl = new CommandServiceImpl(submitAndWaitResponse, submitAndWaitForTransactionResponse, submitAndWaitForTransactionTreeResponse)
     (CommandServiceGrpc.bindService(serviceImpl, ec), serviceImpl)
   }
 }

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
@@ -66,7 +66,7 @@ object CommandRetryFlow {
             outputPorts = 2, {
               case Ctx(
                   RetryInfo(request, nrOfRetries, firstSubmissionTime, _),
-                  Completion(_, Some(status: Status), _)) =>
+                  Completion(_, Some(status: Status), _, _)) =>
                 if (status.code == Code.OK_VALUE) {
                   PROPAGATE_PORT
                 } else if ((firstSubmissionTime plus maxRetryTime) isBefore timeProvider.getCurrentTime) {
@@ -79,7 +79,7 @@ object CommandRetryFlow {
                   RetryLogger.logNonFatal(request, status, nrOfRetries)
                   RETRY_PORT
                 }
-              case Ctx(_, Completion(commandId, _, _)) =>
+              case Ctx(_, Completion(commandId, _, _, _)) =>
                 statusNotFoundError(commandId)
             }
           ))

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -37,9 +37,11 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest {
             context @ RetryInfo(_, _, _, status),
             SubmitRequest(Some(Commands(_, _, _, commandId, _, let, _, _)), tc)) =>
           if (let.get.seconds == 0) {
-            Ctx(context, Completion(commandId, Some(status), tc))
+            Ctx(context, Completion(commandId, Some(status), traceContext = tc))
           } else {
-            Ctx(context, Completion(commandId, Some(status.copy(code = Code.OK_VALUE)), tc))
+            Ctx(
+              context,
+              Completion(commandId, Some(status.copy(code = Code.OK_VALUE)), traceContext = tc))
           }
         case x =>
           throw new RuntimeException(s"Unexpected input: '$x'")

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/command_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/command_service.proto
@@ -7,9 +7,7 @@ package com.digitalasset.ledger.api.v1;
 
 import "com/digitalasset/ledger/api/v1/commands.proto";
 import "com/digitalasset/ledger/api/v1/trace_context.proto";
-
-import "google/protobuf/empty.proto";
-
+import "com/digitalasset/ledger/api/v1/transaction.proto";
 
 option java_outer_classname = "CommandServiceOuterClass";
 option java_package = "com.digitalasset.ledger.api.v1";
@@ -21,7 +19,17 @@ service CommandService {
   // Submits a single composite command and waits for its result.
   // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
   // Propagates the gRPC error of failed submissions including DAML interpretation errors.
-  rpc SubmitAndWait (SubmitAndWaitRequest) returns (google.protobuf.Empty);
+  rpc SubmitAndWait (SubmitAndWaitRequest) returns (SubmitAndWaitResponse);
+
+  // Submits a single composite command, waits for its result, and returns the transaction.
+  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
+  // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  rpc SubmitAndWaitForTransaction (SubmitAndWaitRequest) returns (SubmitAndWaitForTransactionResponse);
+
+  // Submits a single composite command, waits for its result, and returns the transaction tree.
+  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
+  // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  rpc SubmitAndWaitForTransactionTree (SubmitAndWaitRequest) returns (SubmitAndWaitForTransactionTreeResponse);
 }
 
 // These commands are atomic, and will become transactions.
@@ -36,4 +44,22 @@ message SubmitAndWaitRequest {
   // Optional
   TraceContext trace_context = 1000;
 
+}
+
+message SubmitAndWaitResponse {
+  // The id of the transaction that resulted from the submitted command.
+  // Required
+  string transaction_id = 1;
+}
+
+message SubmitAndWaitForTransactionResponse {
+    // The flat transaction that resulted from the submitted command.
+    // Required
+    Transaction transaction = 1;
+}
+
+message SubmitAndWaitForTransactionTreeResponse {
+    // The transaction tree that resulted from the submitted command.
+    // Required
+    TransactionTree transaction = 1;
 }

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/completion.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/completion.proto
@@ -24,6 +24,11 @@ message Completion {
   // Optional
   google.rpc.Status status = 2;
 
+  // The transaction_id of the transaction that resulted from the command with command_id.
+  // Only set for successfully executed commands.
+  // Optional
+  string transaction_id = 3;
+
   // The trace context submitted with the command.
   // This field is a future extension point and is currently not supported.
   // Optional

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/transaction_service.proto
@@ -91,6 +91,11 @@ message GetTransactionByEventIdRequest {
   // Required
   repeated string requesting_parties = 3;
 
+  // This flag indicates whether the response should contain a TransactionTree (in case of false)
+  // or the flat Transaction (in case of true).
+  // Optional
+  bool return_flat_transaction = 4;
+
   // Server side tracing will be registered as a child of the submitted context.
   // This field is a future extension point and is currently not supported.
   // Optional
@@ -111,6 +116,11 @@ message GetTransactionByIdRequest {
   // Required
   repeated string requesting_parties = 3;
 
+  // This flag indicates whether the response should contain a TransactionTree (in case of false)
+  // or the flat Transaction (in case of true).
+  // Optional
+  bool return_flat_transaction = 4;
+
   // Server side tracing will be registered as a child of the submitted context.
   // This field is a future extension point and is currently not supported.
   // Optional
@@ -118,7 +128,13 @@ message GetTransactionByIdRequest {
 }
 
 message GetTransactionResponse {
-  TransactionTree transaction = 1;
+  // The transaction tree in case of return_flat_transaction == false
+  // Optional
+  TransactionTree transaction_tree = 1;
+
+  // The transaction tree in case of return_flat_transaction == true
+  // Optional
+  Transaction flat_transaction = 2;
 }
 
 message GetLedgerEndRequest {

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
@@ -129,7 +129,8 @@ object Server {
             .asInstanceOf[DamlOnXCommandCompletionService]
             .completionStreamSource(r),
         () =>
-          commandCompletionService.completionEnd(CompletionEndRequest(ledgerId.underlyingString))
+          commandCompletionService.completionEnd(CompletionEndRequest(ledgerId.underlyingString)),
+        transactionService.getTransactionById
       )
     )
 

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
@@ -77,12 +77,12 @@ class DamlOnXCommandCompletionService private (indexService: IndexService)(
       .fromFuture(compsFuture)
       .flatMapConcat(src => {
         src.map {
-          case CompletionEvent.CommandAccepted(offset, commandId) =>
+          case CompletionEvent.CommandAccepted(offset, commandId, transactionId) =>
             logger.debug(s"sending completion accepted $offset: $commandId")
 
             CompletionStreamResponse(
               None, // FIXME(JM): is the checkpoint present in each response?
-              List(Completion(commandId, Some(Status())))
+              List(Completion(commandId, Some(Status()), transactionId))
             )
           case CompletionEvent.CommandRejected(offset, commandId, reason) =>
             logger.debug(s"sending completion rejected $offset: $commandId: $reason")
@@ -124,7 +124,7 @@ class DamlOnXCommandCompletionService private (indexService: IndexService)(
         Code.INVALID_ARGUMENT
       case RejectionReason.PartyNotKnownOnLedger => Code.INVALID_ARGUMENT
     }
-    Completion(commandId, Some(Status(code.value(), error.description)), None)
+    Completion(commandId, Some(Status(code.value(), error.description)), traceContext = None)
   }
 
   override def close(): Unit = {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/SynchronousCommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/SynchronousCommandClient.scala
@@ -5,13 +5,12 @@ package com.digitalasset.ledger.client.services.commands
 
 import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
 import com.digitalasset.ledger.api.v1.command_service._
-import com.google.protobuf.empty.Empty
 
 import scala.concurrent.Future
 
 class SynchronousCommandClient(commandService: CommandService) {
 
-  def submitAndWait(submitAndWaitRequest: SubmitAndWaitRequest): Future[Empty] = {
+  def submitAndWait(submitAndWaitRequest: SubmitAndWaitRequest): Future[SubmitAndWaitResponse] = {
     commandService.submitAndWait(submitAndWaitRequest)
   }
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -235,7 +235,7 @@ private[commands] class CommandTracker[Context]
                     trackingData.commandId,
                     Some(
                       com.google.rpc.status.Status(RpcStatus.ABORTED.getCode.value(), "Timeout")),
-                    trackingData.traceContext)
+                    traceContext = trackingData.traceContext)
                 ))
             } else {
               Nil
@@ -276,7 +276,7 @@ private[commands] class CommandTracker[Context]
             Some(
               Ctx(
                 trackingData.context,
-                Completion(commandId, Some(status), trackingData.traceContext)))
+                Completion(commandId, Some(status), traceContext = trackingData.traceContext)))
           }
       }
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
@@ -41,16 +41,31 @@ final class TransactionClient(ledgerId: String, transactionService: TransactionS
       GetTransactionsRequest(ledgerId, Some(start), end, Some(transactionFilter), verbose))
   }
 
-  def getTransactionById(transactionId: String, parties: Seq[String])(
+  def getTransactionTreeById(transactionId: String, parties: Seq[String])(
       implicit ec: ExecutionContext): Future[GetTransactionResponse] = {
     transactionService
-      .getTransactionById(GetTransactionByIdRequest(ledgerId, transactionId, parties))
+      .getTransactionById(
+        GetTransactionByIdRequest(ledgerId, transactionId, parties, returnFlatTransaction = false))
   }
 
-  def getTransactionByEventId(eventId: String, parties: Seq[String])(
+  def getTransactionTreeByEventId(eventId: String, parties: Seq[String])(
       implicit ec: ExecutionContext): Future[GetTransactionResponse] =
     transactionService
-      .getTransactionByEventId(GetTransactionByEventIdRequest(ledgerId, eventId, parties))
+      .getTransactionByEventId(
+        GetTransactionByEventIdRequest(ledgerId, eventId, parties, returnFlatTransaction = false))
+
+  def getFlatTransactionById(transactionId: String, parties: Seq[String])(
+      implicit ec: ExecutionContext): Future[GetTransactionResponse] = {
+    transactionService
+      .getTransactionById(
+        GetTransactionByIdRequest(ledgerId, transactionId, parties, returnFlatTransaction = true))
+  }
+
+  def getFlatTransactionByEventId(eventId: String, parties: Seq[String])(
+      implicit ec: ExecutionContext): Future[GetTransactionResponse] =
+    transactionService
+      .getTransactionByEventId(
+        GetTransactionByEventIdRequest(ledgerId, eventId, parties, returnFlatTransaction = true))
 
   def getLedgerEnd: Future[GetLedgerEndResponse] =
     transactionService.getLedgerEnd(GetLedgerEndRequest(ledgerId))

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -196,7 +196,7 @@ class CommandTrackerFlowTest
           Completion(
             commandId,
             Some(Status(Code.RESOURCE_EXHAUSTED.value)),
-            submitRequest.value.traceContext)
+            traceContext = submitRequest.value.traceContext)
 
         results.expectNext(Ctx(context, failureCompletion))
         succeed
@@ -214,7 +214,10 @@ class CommandTrackerFlowTest
         results.expectNoMessage(3.seconds)
 
         val completion =
-          Completion(commandId, Some(Status(Code.ABORTED.value)), submitRequest.value.traceContext)
+          Completion(
+            commandId,
+            Some(Status(Code.ABORTED.value)),
+            traceContext = submitRequest.value.traceContext)
         completionStreamMock.send(CompletionStreamElement.CompletionElement(completion))
         results.requestNext().value shouldEqual completion
         succeed
@@ -230,7 +233,10 @@ class CommandTrackerFlowTest
         submissions.sendNext(submitRequest)
 
         val completion =
-          Completion(commandId, Some(Status(Code.ABORTED.value)), submitRequest.value.traceContext)
+          Completion(
+            commandId,
+            Some(Status(Code.ABORTED.value)),
+            traceContext = submitRequest.value.traceContext)
         completionStreamMock.send(CompletionStreamElement.CompletionElement(completion))
         results.requestNext().value shouldEqual completion
       }
@@ -317,7 +323,7 @@ class CommandTrackerFlowTest
           Completion(
             commandId,
             Some(Status(Code.INVALID_ARGUMENT.value)),
-            submitRequest.value.traceContext)
+            traceContext = submitRequest.value.traceContext)
         completionStreamMock.send(CompletionStreamElement.CompletionElement(failureCompletion))
 
         results.expectNext(Ctx(context, failureCompletion))
@@ -347,7 +353,7 @@ class CommandTrackerFlowTest
 
         results.expectNextUnorderedN(commandIds.map { commandId =>
           val successCompletion =
-            Completion(commandId, Some(Status()), submitRequest.value.traceContext)
+            Completion(commandId, Some(Status()), traceContext = submitRequest.value.traceContext)
           Ctx(context, successCompletion)
         })
         succeed
@@ -375,7 +381,12 @@ class CommandTrackerFlowTest
             _ <- completionStreamMock.send(successfulCompletion(commandId))
             _ = results.request(1)
             _ = results.expectNext(
-              Ctx(context, Completion(commandId, Some(Status()), submitRequest.value.traceContext)))
+              Ctx(
+                context,
+                Completion(
+                  commandId,
+                  Some(Status()),
+                  traceContext = submitRequest.value.traceContext)))
           } yield ()
         }
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -168,6 +168,7 @@ class TransactionServiceRequestValidator(
         ledgerId,
         domain.TransactionId(req.transactionId),
         parties,
+        req.returnFlatTransaction,
         req.traceContext.map(toBrave))
     }
   }
@@ -185,6 +186,7 @@ class TransactionServiceRequestValidator(
         ledgerId,
         domain.EventId(req.eventId),
         parties,
+        req.returnFlatTransaction,
         req.traceContext.map(toBrave))
     }
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
@@ -13,6 +13,7 @@ import com.digitalasset.ledger.api.messages.transaction.{
   GetTransactionsRequest
 }
 import com.digitalasset.ledger.api.v1.transaction_service.GetTransactionsResponse
+import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.platform.server.api.WithOffset
 import com.digitalasset.platform.server.services.transaction.VisibleTransaction
 
@@ -30,8 +31,9 @@ trait TransactionService {
 
   def offsetOrdering: Ordering[LedgerOffset.Absolute]
 
-  def getTransactionById(req: GetTransactionByIdRequest): Future[Option[VisibleTransaction]]
+  def getTransactionById(
+      req: GetTransactionByIdRequest): Future[Option[Either[VisibleTransaction, Transaction]]]
 
   def getTransactionByEventId(
-      req: GetTransactionByEventIdRequest): Future[Option[VisibleTransaction]]
+      req: GetTransactionByEventIdRequest): Future[Option[Either[VisibleTransaction, Transaction]]]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/CommandServiceValidation.scala
@@ -4,11 +4,10 @@
 package com.digitalasset.platform.server.api.validation
 
 import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
-import com.digitalasset.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
+import com.digitalasset.ledger.api.v1.command_service._
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.server.api.ProxyCloseable
-import com.google.protobuf.empty.Empty
 import io.grpc.ServerServiceDefinition
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -26,9 +25,21 @@ class CommandServiceValidation(
 
   protected val logger: Logger = LoggerFactory.getLogger(CommandService.getClass)
 
-  override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] = {
+  override def submitAndWait(request: SubmitAndWaitRequest): Future[SubmitAndWaitResponse] = {
     val validation = requirePresence(request.commands, "commands").flatMap(validateCommands)
     validation.fold(Future.failed, _ => service.submitAndWait(request))
+  }
+
+  override def submitAndWaitForTransaction(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] = {
+    val validation = requirePresence(request.commands, "commands").flatMap(validateCommands)
+    validation.fold(Future.failed, _ => service.submitAndWaitForTransaction(request))
+  }
+
+  override def submitAndWaitForTransactionTree(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] = {
+    val validation = requirePresence(request.commands, "commands").flatMap(validateCommands)
+    validation.fold(Future.failed, _ => service.submitAndWaitForTransactionTree(request))
   }
 
   override def bindService(): ServerServiceDefinition =

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ReferenceCommandService.scala
@@ -16,7 +16,13 @@ import com.digitalasset.ledger.api.v1.command_completion_service.{
 }
 import com.digitalasset.ledger.api.v1.command_service._
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
-import com.digitalasset.ledger.api.v1.command_submission_service.{SubmitRequest}
+import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
+import com.digitalasset.ledger.api.v1.completion.Completion
+import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionService
+import com.digitalasset.ledger.api.v1.transaction_service.{
+  GetTransactionByIdRequest,
+  GetTransactionResponse
+}
 import com.digitalasset.ledger.client.configuration.CommandClientConfiguration
 import com.digitalasset.ledger.client.services.commands.{
   CommandClient,
@@ -85,61 +91,103 @@ class ReferenceCommandService private (
     )
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] = {
+  override def submitAndWait(request: SubmitAndWaitRequest): Future[SubmitAndWaitResponse] = {
 
     val appId = request.getCommands.applicationId
     val submitter = TrackerMap.Key(application = appId, party = request.getCommands.party)
 
     if (running) {
-      submissionTracker.track(submitter, request) {
-        for {
-          trackingFlow <- {
-            lowLevelCommandServiceAccess match {
-              case LowLevelCommandServiceAccess.RemoteServices(submission, completion) =>
-                val client = commandClient(appId, submission, completion)
-                if (configuration.limitMaxCommandsInFlight)
-                  client.trackCommands[Promise[Empty]](List(submitter.party))
-                else
-                  client.trackCommandsUnbounded[Promise[Empty]](List(submitter.party))
-              case LowLevelCommandServiceAccess.LocalServices(
-                  submissionFlow,
-                  getCompletionSource,
-                  getCompletionEnd) =>
-                for {
-                  ledgerEnd <- getCompletionEnd().map(_.getOffset)
-                } yield {
-                  val tracker =
-                    CommandTrackerFlow[Promise[Empty], NotUsed](
-                      submissionFlow,
-                      offset =>
-                        getCompletionSource(
-                          CompletionStreamRequest(
-                            configuration.ledgerId,
-                            appId,
-                            List(submitter.party),
-                            Some(offset)))
-                          .mapConcat(CommandCompletionSource.toStreamElements),
-                      ledgerEnd
-                    )
-
+      submissionTracker
+        .track(submitter, request) {
+          for {
+            trackingFlow <- {
+              lowLevelCommandServiceAccess match {
+                case LowLevelCommandServiceAccess.RemoteServices(submission, completion, _) =>
+                  val client = commandClient(appId, submission, completion)
                   if (configuration.limitMaxCommandsInFlight)
-                    MaxInFlight(configuration.maxCommandsInFlight).joinMat(tracker)(Keep.right)
-                  else tracker
-                }
+                    client.trackCommands[Promise[Completion]](List(submitter.party))
+                  else
+                    client.trackCommandsUnbounded[Promise[Completion]](List(submitter.party))
+                case LowLevelCommandServiceAccess.LocalServices(
+                    submissionFlow,
+                    getCompletionSource,
+                    getCompletionEnd,
+                    _) =>
+                  for {
+                    ledgerEnd <- getCompletionEnd().map(_.getOffset)
+                  } yield {
+                    val tracker =
+                      CommandTrackerFlow[Promise[Completion], NotUsed](
+                        submissionFlow,
+                        offset =>
+                          getCompletionSource(
+                            CompletionStreamRequest(
+                              configuration.ledgerId,
+                              appId,
+                              List(submitter.party),
+                              Some(offset)))
+                            .mapConcat(CommandCompletionSource.toStreamElements),
+                        ledgerEnd
+                      )
+
+                    if (configuration.limitMaxCommandsInFlight)
+                      MaxInFlight(configuration.maxCommandsInFlight).joinMat(tracker)(Keep.right)
+                    else tracker
+                  }
+              }
             }
+          } yield {
+            TrackerImpl(trackingFlow, configuration.inputBufferSize, configuration.historySize)
           }
-        } yield {
-          TrackerImpl(trackingFlow, configuration.inputBufferSize, configuration.historySize)
         }
-      }
+        .map { compl =>
+          SubmitAndWaitResponse(compl.transactionId)
+        }
     } else {
       Future.failed(
         new ApiException(Status.UNAVAILABLE.withDescription("Service has been shut down.")))
     }
   }
 
+  override def submitAndWaitForTransaction(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] = {
+    submitAndWait(request).flatMap { resp =>
+      val txRequest = GetTransactionByIdRequest(
+        request.getCommands.ledgerId,
+        resp.transactionId,
+        List(request.getCommands.party),
+        returnFlatTransaction = true)
+      loadTransaction(txRequest).map(resp =>
+        SubmitAndWaitForTransactionResponse(resp.flatTransaction))
+
+    }
+  }
+
+  override def submitAndWaitForTransactionTree(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] = {
+    submitAndWait(request).flatMap { resp =>
+      val txRequest = GetTransactionByIdRequest(
+        request.getCommands.ledgerId,
+        resp.transactionId,
+        List(request.getCommands.party),
+        returnFlatTransaction = false)
+      loadTransaction(txRequest).map(resp =>
+        SubmitAndWaitForTransactionTreeResponse(resp.transactionTree))
+    }
+  }
+
   override def toString: String = ReferenceCommandService.getClass.getSimpleName
 
+  private def loadTransaction(
+      txRequest: GetTransactionByIdRequest): Future[GetTransactionResponse] = {
+    lowLevelCommandServiceAccess match {
+      case LowLevelCommandServiceAccess.RemoteServices(_, _, transaction) =>
+        transaction.getTransactionById(txRequest)
+
+      case LowLevelCommandServiceAccess.LocalServices(_, _, _, getTransactionById) =>
+        getTransactionById(txRequest)
+    }
+  }
 }
 
 object ReferenceCommandService {
@@ -170,16 +218,18 @@ object ReferenceCommandService {
 
     final case class RemoteServices(
         submissionStub: CommandSubmissionService,
-        completionStub: CommandCompletionService)
+        completionStub: CommandCompletionService,
+        transactionService: TransactionService)
         extends LowLevelCommandServiceAccess
 
     final case class LocalServices(
         submissionFlow: Flow[
-          Ctx[(Promise[Empty], String), SubmitRequest],
-          Ctx[(Promise[Empty], String), Try[Empty]],
+          Ctx[(Promise[Completion], String), SubmitRequest],
+          Ctx[(Promise[Completion], String), Try[Empty]],
           NotUsed],
         getCompletionSource: CompletionStreamRequest => Source[CompletionStreamResponse, NotUsed],
-        getCompletionEnd: () => Future[CompletionEndResponse])
+        getCompletionEnd: () => Future[CompletionEndResponse],
+        getTransactionById: GetTransactionByIdRequest => Future[GetTransactionResponse])
         extends LowLevelCommandServiceAccess
 
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/Tracker.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/Tracker.scala
@@ -4,13 +4,13 @@
 package com.digitalasset.platform.server.services.command
 
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.google.protobuf.empty.Empty
+import com.digitalasset.ledger.api.v1.completion.Completion
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait Tracker extends AutoCloseable {
 
-  def track(request: SubmitAndWaitRequest)(implicit ec: ExecutionContext): Future[Empty]
+  def track(request: SubmitAndWaitRequest)(implicit ec: ExecutionContext): Future[Completion]
 }
 
 object Tracker {
@@ -24,7 +24,7 @@ object Tracker {
     def getLastSubmission: Long = lastSubmission
 
     override def track(request: SubmitAndWaitRequest)(
-        implicit ec: ExecutionContext): Future[Empty] = {
+        implicit ec: ExecutionContext): Future[Completion] = {
       lastSubmission = System.nanoTime()
       delegate.track(request)
     }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/TrackerMap.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/TrackerMap.scala
@@ -6,16 +6,16 @@ package com.digitalasset.platform.server.services.command
 import java.util.concurrent.atomic.AtomicReference
 
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.server.services.command.TrackerMap.{AsyncResource, Key}
-import com.google.protobuf.empty.Empty
+import com.github.ghik.silencer.silent
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.immutable.HashMap
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import com.github.ghik.silencer.silent
 
 /**
   * A map for [[Tracker]]s with thread-safe tracking methods and automatic cleanup. A tracker tracker, if you will.
@@ -54,7 +54,7 @@ class TrackerMap(retentionPeriod: FiniteDuration) extends AutoCloseable with Laz
   }
 
   def track(submitter: Key, request: SubmitAndWaitRequest)(newTracker: => Future[Tracker])(
-      implicit ec: ExecutionContext): Future[Empty] =
+      implicit ec: ExecutionContext): Future[Completion] =
     // double-checked locking
     trackerBySubmitter
       .getOrElse(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -57,6 +57,7 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
       expectedLedgerId,
       eventId,
       Seq(party.underlyingString),
+      returnFlatTransaction = false,
       Some(traceContext))
 
   private val txByIdReq =
@@ -64,6 +65,7 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
       expectedLedgerId,
       transactionId,
       Seq(party.underlyingString),
+      returnFlatTransaction = false,
       Some(traceContext))
 
   val sut = new TransactionServiceRequestValidator(
@@ -379,6 +381,16 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
         }
       }
 
+      "translate returnFlatTransaction flag correctly" in {
+        inside(sut.validateTransactionById(txByIdReq.copy(returnFlatTransaction = false))) {
+          case Right(out) =>
+            out should have('returnFlatTransaction (false))
+        }
+        inside(sut.validateTransactionById(txByIdReq.copy(returnFlatTransaction = true))) {
+          case Right(out) =>
+            out should have('returnFlatTransaction (true))
+        }
+      }
     }
 
     "validating transaction by event id requests" should {
@@ -418,6 +430,17 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
           case Right(out) =>
             out should have('ledgerId (domain.LedgerId(expectedLedgerId)))
             isExpectedTraceContext(out.traceContext.value)
+        }
+      }
+
+      "translate returnFlatTransaction flag correctly" in {
+        inside(sut.validateTransactionByEventId(txByEvIdReq.copy(returnFlatTransaction = false))) {
+          case Right(out) =>
+            out should have('returnFlatTransaction (false))
+        }
+        inside(sut.validateTransactionByEventId(txByEvIdReq.copy(returnFlatTransaction = true))) {
+          case Right(out) =>
+            out should have('returnFlatTransaction (true))
         }
       }
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/services/command/TrackerImplTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/services/command/TrackerImplTest.scala
@@ -15,8 +15,9 @@ import com.digitalasset.ledger.api.testing.utils.{
 }
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.commands.Commands
+import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.platform.common.util.DirectExecutionContext
-import com.google.protobuf.empty.Empty
+import com.google.rpc.status.{Status => RpcStatus}
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, Matchers, Succeeded, WordSpec}
@@ -40,7 +41,7 @@ class TrackerImplTest
     val (q, sink) = Source
       .queue[TrackerImpl.QueueInput](1, OverflowStrategy.dropNew)
       .map { in =>
-        in.context.success(Empty())
+        in.context.success(Completion(in.value.getCommands.commandId, Some(RpcStatus())))
         NotUsed
       }
       .toMat(TestSink.probe[NotUsed])(Keep.both)

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByEventIdRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByEventIdRequest.scala
@@ -11,4 +11,5 @@ final case class GetTransactionByEventIdRequest(
     ledgerId: LedgerId,
     eventId: EventId,
     requestingParties: Set[Party],
+    returnFlatTransaction: Boolean,
     traceContext: Option[TraceContext])

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
@@ -13,4 +13,5 @@ final case class GetTransactionByIdRequest(
     ledgerId: LedgerId,
     transactionId: TransactionId,
     requestingParties: immutable.Set[Party],
+    returnFlatTransaction: Boolean,
     traceContext: Option[TraceContext])

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/SemanticLedgerConfigurationIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/SemanticLedgerConfigurationIT.scala
@@ -19,7 +19,6 @@ import com.digitalasset.ledger.client.services.configuration.LedgerConfiguration
 import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.tests.integration.ledger.api.commands.MultiLedgerCommandUtils
-import com.google.protobuf.empty.Empty
 import io.grpc.{Status, StatusRuntimeException}
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.time.Span
@@ -82,7 +81,7 @@ class SemanticLedgerConfigurationIT
           request = createRequest(
             _.commands.maximumRecordTime.seconds := (ledgerEffectiveTime.seconds + config.minTtl.value.seconds))
           resp <- syncClient.submitAndWait(request)
-        } yield (resp should equal(Empty()))
+        } yield resp.transactionId should not be empty
       }
 
       "not accept an MRT less than minTTL greater than LET" in allFixtures { context =>
@@ -93,7 +92,7 @@ class SemanticLedgerConfigurationIT
             _.commands.maximumRecordTime.seconds := ledgerEffectiveTime.seconds + config.minTtl.value.seconds - 1)
 
           resp <- syncClient.submitAndWait(request)
-        } yield (resp)
+        } yield resp
 
         resF.failed.map { failure =>
           val exception = failure.asInstanceOf[StatusRuntimeException]
@@ -110,7 +109,7 @@ class SemanticLedgerConfigurationIT
           request = createRequest(
             _.commands.maximumRecordTime.seconds := ledgerEffectiveTime.seconds + config.maxTtl.value.seconds)
           resp <- syncClient.submitAndWait(request)
-        } yield (resp should equal(Empty()))
+        } yield resp.transactionId should not be empty
       }
 
       "not accept an MRT more than maxTTL greater than LET" in allFixtures { context =>
@@ -120,7 +119,7 @@ class SemanticLedgerConfigurationIT
           request = createRequest(
             _.commands.maximumRecordTime.seconds := ledgerEffectiveTime.seconds + config.maxTtl.value.seconds + 1)
           resp <- syncClient.submitAndWait(request)
-        } yield (resp)
+        } yield resp
 
         resF.failed.map { failure =>
           val exception = failure.asInstanceOf[StatusRuntimeException]

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandServiceBackPressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandServiceBackPressureIT.scala
@@ -11,6 +11,7 @@ import com.digitalasset.ledger.api.testing.utils.{
   MockMessages,
   SuiteResourceManagementAroundAll
 }
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitResponse
 import com.digitalasset.platform.apitesting.LedgerBackend.SandboxSql
 import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture}
 import com.digitalasset.platform.sandbox.config.SandboxConfig
@@ -80,11 +81,11 @@ class CommandServiceBackPressureIT
   "Commands Service" when {
     "overloaded with commands" should {
       "reject requests with RESOURCE_EXHAUSTED" in allFixtures { ctx =>
-        val responses: immutable.Seq[Future[Empty]] = (1 to 256) map { _ =>
+        val responses = (1 to 256) map { _ =>
           ctx.commandService.submitAndWait(submitAndWaitRequest(ctx))
         }
 
-        val done: Future[immutable.Seq[Try[Empty]]] =
+        val done =
           Future.sequence(responses.map(_.map(Success(_)).recover({
             case ex => Failure(ex)
           })))

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandServiceIT.scala
@@ -12,10 +12,10 @@ import com.digitalasset.ledger.api.testing.utils.{
   SuiteResourceManagementAroundAll
 }
 import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture}
-import com.google.protobuf.empty.Empty
 import io.grpc.Status
 import org.scalatest.{AsyncWordSpec, Matchers}
 
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
 class CommandServiceIT
     extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
@@ -34,27 +34,83 @@ class CommandServiceIT
   "Commands Service" when {
     "submitting commands" should {
       "complete with an empty response if successful" in allFixtures { ctx =>
-        ctx.commandService.submitAndWait(request(ctx)) map {
-          _ shouldEqual Empty()
+        val req = request(ctx)
+        ctx.commandService.submitAndWait(req) map {
+          _.transactionId should not be empty
+        }
+      }
+
+      "return the flat transaction if successful" in allFixtures { ctx =>
+        val req = request(ctx)
+        ctx.commandService.submitAndWaitForTransaction(req) map {
+          _.transaction should not be empty
+        }
+      }
+
+      "return the transaction tree if successful" in allFixtures { ctx =>
+        val req = request(ctx)
+        ctx.commandService.submitAndWaitForTransactionTree(req) map {
+          _.transaction should not be empty
         }
       }
 
       "complete with an empty response if resending a successful command" in allFixtures { ctx =>
         val commandId = UUID.randomUUID().toString
-        ctx.commandService.submitAndWait(request(ctx, id = commandId)) map {
-          _ shouldEqual Empty()
+        val req = request(ctx, id = commandId)
+        ctx.commandService.submitAndWait(req) map {
+          _.transactionId should not be empty
         }
         ctx.commandService.submitAndWait(request(ctx, id = commandId)) map {
-          _ shouldEqual Empty()
+          _.transactionId should not be empty
         }
       }
 
-      "fail with not found if ledger id is invalid" in allFixtures { ctx =>
+      "return the flat transaction if resending a successful command" in allFixtures { ctx =>
+        val commandId = UUID.randomUUID().toString
+        val req = request(ctx, id = commandId)
+        ctx.commandService.submitAndWaitForTransaction(req) map {
+          _.transaction should not be empty
+        }
+        ctx.commandService.submitAndWaitForTransaction(request(ctx, id = commandId)) map {
+          _.transaction should not be empty
+        }
+      }
+
+      "return the transaction tree if resending a successful command" in allFixtures { ctx =>
+        val commandId = UUID.randomUUID().toString
+        val req = request(ctx, id = commandId)
+        ctx.commandService.submitAndWaitForTransactionTree(req) map {
+          _.transaction should not be empty
+        }
+        ctx.commandService.submitAndWaitForTransactionTree(request(ctx, id = commandId)) map {
+          _.transaction should not be empty
+        }
+      }
+
+      "fail SubmitAndWait with not found if ledger id is invalid" in allFixtures { ctx =>
         ctx.commandService
           .submitAndWait(request(ctx, ledgerId = UUID.randomUUID().toString))
           .failed map {
           IsStatusException(Status.NOT_FOUND)(_)
         }
+      }
+
+      "fail SubmitAndWaitForTransaction with not found if ledger id is invalid" in allFixtures {
+        ctx =>
+          ctx.commandService
+            .submitAndWaitForTransaction(request(ctx, ledgerId = UUID.randomUUID().toString))
+            .failed map {
+            IsStatusException(Status.NOT_FOUND)(_)
+          }
+      }
+
+      "fail SubmitAndWaitForTransactionTree with not found if ledger id is invalid" in allFixtures {
+        ctx =>
+          ctx.commandService
+            .submitAndWaitForTransactionTree(request(ctx, ledgerId = UUID.randomUUID().toString))
+            .failed map {
+            IsStatusException(Status.NOT_FOUND)(_)
+          }
       }
 
     }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionTtlIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionTtlIT.scala
@@ -11,10 +11,9 @@ import com.digitalasset.ledger.api.testing.utils.{
   IsStatusException,
   SuiteResourceManagementAroundAll
 }
-import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.digitalasset.ledger.api.v1.command_service.{SubmitAndWaitRequest, SubmitAndWaitResponse}
 import com.digitalasset.ledger.api.v1.commands.Commands
 import com.digitalasset.platform.apitesting.LedgerContext
-import com.google.protobuf.empty.Empty
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{AsyncWordSpec, Matchers, TryValues}
@@ -72,7 +71,9 @@ class CommandSubmissionTtlIT
         fromInstant(toInstant(submitRequest.getCommands.getLedgerEffectiveTime).plus(ttl)))
       .withCommandId(s"TTL of $ttl")
 
-  private def submitSingleCommand(ctx: LedgerContext, commands: Commands): Future[Empty] =
+  private def submitSingleCommand(
+      ctx: LedgerContext,
+      commands: Commands): Future[SubmitAndWaitResponse] =
     ctx.commandService.submitAndWait(SubmitAndWaitRequest(Some(commands)))
 
 }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandTransactionChecksHighLevelIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandTransactionChecksHighLevelIT.scala
@@ -3,22 +3,26 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api.commands
 
-import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.digitalasset.ledger.api.v1.command_service.{SubmitAndWaitRequest, SubmitAndWaitResponse}
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.platform.apitesting.{CommandTransactionChecks, LedgerContext}
-import com.google.protobuf.empty.Empty
 import com.google.rpc.status.Status
 import io.grpc.StatusRuntimeException
 
 import scala.concurrent.Future
 
 class CommandTransactionChecksHighLevelIT extends CommandTransactionChecks {
-  private[this] def emptyToCompletion(
+  private[this] def responseToCompletion(
       commandId: String,
-      emptyF: Future[Empty]): Future[Completion] =
-    emptyF
-      .map(_ => Completion(commandId, Some(Status(io.grpc.Status.OK.getCode.value(), ""))))
+      txF: Future[SubmitAndWaitResponse]): Future[Completion] =
+    txF
+      .map(
+        tx =>
+          Completion(
+            commandId,
+            Some(Status(io.grpc.Status.OK.getCode.value(), "")),
+            tx.transactionId))
       .recover {
         case sre: StatusRuntimeException =>
           Completion(
@@ -29,7 +33,7 @@ class CommandTransactionChecksHighLevelIT extends CommandTransactionChecks {
   override protected def submitCommand(
       ctx: LedgerContext,
       submitRequest: SubmitRequest): Future[Completion] = {
-    emptyToCompletion(
+    responseToCompletion(
       submitRequest.commands.value.commandId,
       ctx.commandService.submitAndWait(
         SubmitAndWaitRequest(submitRequest.commands, submitRequest.traceContext)))

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/FailingCommandsIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/FailingCommandsIT.scala
@@ -75,7 +75,7 @@ class FailingCommandsIT
             .runWith(Sink.head)
         } yield {
           result.value should matchPattern {
-            case Completion(`failingCommandId`, Some(status), _) if status.code == 3 =>
+            case Completion(`failingCommandId`, Some(status), _, _) if status.code == 3 =>
           }
         }
       }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceHelpers.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceHelpers.scala
@@ -69,8 +69,9 @@ trait TransactionServiceHelpers extends Matchers {
     } yield c)
       .via(trackingFlow)
       .runWith(Sink.foreach {
-        case Ctx(i, Completion(_, Some(status), _)) =>
+        case Ctx(i, Completion(_, Some(status), transactionId, _)) =>
           status should have('code (0))
+          transactionId should not be empty
           ()
       })
   }

--- a/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
+++ b/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/ReferenceIndexService.scala
@@ -291,7 +291,9 @@ final case class ReferenceIndexService(
           case (offset, (acceptedTx, _blindingInfo)) =>
             acceptedTx.optSubmitterInfo.flatMap { sinfo =>
               if (sinfo.applicationId == applicationId) {
-                Some(CompletionEvent.CommandAccepted(offset, sinfo.commandId))
+                Some(
+                  CompletionEvent
+                    .CommandAccepted(offset, sinfo.commandId, acceptedTx.transactionId))
               } else {
                 None
               }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v1/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v1/package.scala
@@ -55,7 +55,11 @@ package object v1 {
   }
   object CompletionEvent {
     final case class Checkpoint(offset: Offset, recordTime: Timestamp) extends CompletionEvent
-    final case class CommandAccepted(offset: Offset, commandId: CommandId) extends CompletionEvent
+    final case class CommandAccepted(
+        offset: Offset,
+        commandId: CommandId,
+        transactionId: TransactionId)
+        extends CompletionEvent
     final case class CommandRejected(offset: Offset, commandId: CommandId, reason: RejectionReason)
         extends CompletionEvent
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
@@ -150,7 +150,8 @@ object LedgerApiServer {
           completionService.service
             .asInstanceOf[SandboxCommandCompletionService]
             .completionStreamSource(r),
-        () => completionService.completionEnd(CompletionEndRequest(ledgerBackend.ledgerId))
+        () => completionService.completionEnd(CompletionEndRequest(ledgerBackend.ledgerId)),
+        transactionService.getTransactionById
       )
     )
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/SandboxCommandCompletionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/SandboxCommandCompletionService.scala
@@ -88,7 +88,8 @@ class SandboxCommandCompletionService private (
                 tx.submitter) =>
             CompletionStreamResponse(
               checkpoint,
-              tx.commandId.fold(List.empty[Completion])(c => List(Completion(c, Some(Status())))))
+              tx.commandId.fold(List.empty[Completion])(c =>
+                List(Completion(c, Some(Status()), tx.transactionId))))
           case err: LedgerSyncEvent.RejectedCommand
               if isRequested(
                 requestedApplicationId,
@@ -127,7 +128,7 @@ class SandboxCommandCompletionService private (
       case RejectionReason.DuplicateCommandId(description) => Code.INVALID_ARGUMENT
     }
 
-    Completion(commandId, Some(Status(code.value(), error.description)), None)
+    Completion(commandId, Some(Status(code.value(), error.description)), traceContext = None)
   }
 
   override def close(): Unit = {


### PR DESCRIPTION
When submitting a command via the CommandService (SubmitAndWait), it is
fairly cumbersome to get hold of the resulting transaction. Since the
response (Empty) doesn't contain any offset, transactionId, or other
metadata, the user has go wade through the transaction stream and check
for the transaction with the right commandId. This is not a good user
experience.

Instead we want to return the transaction tree directly. This means the
user directly has access to the outcome of the command (i.e. the
transaction, events, ...).

Fixes #406.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
