### PR TITLE
scenario-tester: Allow to mangle names used in scenarios before their executions.

### DIFF
--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
+    "lf_scalacopts",
 )
 
 da_scala_library(
@@ -21,5 +22,18 @@ da_scala_library(
         "//daml-lf/interpreter",
         "//daml-lf/lfpackage",
         "//daml-lf/transaction",
+    ],
+)
+
+da_scala_test_suite(
+    name = "scenario-interpreter_tests",
+    size = "small",
+    srcs = glob(["src/test/**/*.scala"]),
+    scalacopts = lf_scalacopts,
+    deps = [
+        ":scenario-interpreter",
+        "//daml-lf/data",
+        "//daml-lf/interpreter",
+        "//daml-lf/lfpackage",
     ],
 )

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -13,10 +13,6 @@ import com.digitalasset.daml.lf.speedy.SError._
 import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 
-//
-// Speedy scenario runner that uses the reference ledger.
-//
-
 private case class SRunnerException(err: SError) extends RuntimeException(err.toString)
 
 /** Speedy scenario runner that uses the reference ledger.

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.speedy
+
+import com.digitalasset.daml.lf.PureCompiledPackages
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.lfpackage.Ast
+import com.digitalasset.daml.lf.lfpackage.Ast.ScenarioGetParty
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
+
+  "ScenarioRunner" can {
+    "mangle party names correctly" in {
+      val e = Ast.EScenario(ScenarioGetParty(Ast.EPrimLit(Ast.PLText("foo-bar"))))
+      val m = Speedy.Machine.fromExpr(e, PureCompiledPackages(Map.empty).right.get, true)
+      val sr = ScenarioRunner(m, (s) => s + "-XXX")
+      sr.run()
+      m.ctrl shouldBe Speedy.CtrlValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
+    }
+  }
+
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.api.testtool
 
-import java.io.{File, StringWriter, PrintWriter}
-import java.nio.file.{Files, StandardCopyOption, Paths, Path}
+import java.io.{File, PrintWriter, StringWriter}
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -19,6 +19,7 @@ import com.digitalasset.platform.semantictest.SemanticTestAdapter
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.collection.breakOut
+import scala.util.Random
 
 object LedgerApiTestTool {
 
@@ -61,13 +62,17 @@ object LedgerApiTestTool {
     }
     var failed = false
 
+    val runSuffix = Random.alphanumeric.take(10).mkString
+    var partyNameMangler = (partyText: String) => s"$partyText-$runSuffix"
+
     try {
       scenarios.foreach {
         case (pkgId, names) =>
           val tester = new SemanticTester(
             parties => new SemanticTestAdapter(ledger, packages, parties.map(_.underlyingString)),
             pkgId,
-            packages)
+            packages,
+            partyNameMangler)
           names
             .foreach { name =>
               println(s"Testing scenario: $name")


### PR DESCRIPTION
This allows to run a scenario against a long-running server repeatedly and avoid
clashes between runs, since each party is unique (up to the randomness used).

Fixes part of #788

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
