### PR TITLE
#564, fix JUnit tests

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -20,11 +20,11 @@ module Development.IDE.State.Service(
     ) where
 
 import           Control.Concurrent.Extra
-import           Control.Concurrent.STM
 import           Control.Monad.Except
 import Development.IDE.Functions.Compile (CompileOpts(..))
 import           Development.IDE.State.FileStore
 import qualified Development.IDE.Logger as Logger
+import Data.Maybe
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
@@ -71,13 +71,13 @@ unsafeClearDiagnostics = unsafeClearAllDiagnostics
 
 -- | Initialise the Compiler Service.
 initialise :: Rules ()
-           -> Maybe (Event -> STM ())
+           -> Maybe (Event -> IO ())
            -> Logger.Handle IO
            -> CompileOpts
            -> IO IdeState
 initialise mainRule toDiags logger options =
     shakeOpen
-        (maybe (const $ pure ()) (atomically .) toDiags)
+        (fromMaybe (const $ pure ()) toDiags)
         logger
         (setProfiling options $
         shakeOptions { shakeThreads = optThreads options

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -152,7 +152,7 @@ newIdeState :: Options
             -> Logger.Handle IO
             -> Managed IdeState
 newIdeState compilerOpts mbEventHandler loggerH = do
-  mbScenarioService <- for mbEventHandler $ \eventHandler -> Scenario.startScenarioService eventHandler loggerH
+  mbScenarioService <- for mbEventHandler $ \eventHandler -> Scenario.startScenarioService (atomically . eventHandler) loggerH
 
   -- Load the packages from the package database for the scenario service. We swallow errors here
   -- but shake will report them when typechecking anything.

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -44,7 +44,6 @@ import           DA.Daml.LF.Proto3.Archive                  (encodeArchiveLazy)
 import qualified DA.Service.Logger                          as Logger
 import qualified DA.Service.Daml.Compiler.Impl.Dar          as Dar
 
-import           Control.Concurrent.STM
 import           Control.Monad.Except.Extended              as Ex
 import           Control.Monad.IO.Class                     (liftIO)
 import           Control.Monad.Managed.Extended
@@ -148,11 +147,11 @@ newtype GlobalPkgMap = GlobalPkgMap (Map.Map UnitId (LF.PackageId, LF.Package, B
 instance Shake.IsIdeGlobal GlobalPkgMap
 
 newIdeState :: Options
-            -> Maybe (Event -> STM ())
+            -> Maybe (Event -> IO ())
             -> Logger.Handle IO
             -> Managed IdeState
 newIdeState compilerOpts mbEventHandler loggerH = do
-  mbScenarioService <- for mbEventHandler $ \eventHandler -> Scenario.startScenarioService (atomically . eventHandler) loggerH
+  mbScenarioService <- for mbEventHandler $ \eventHandler -> Scenario.startScenarioService eventHandler loggerH
 
   -- Load the packages from the package database for the scenario service. We swallow errors here
   -- but shake will report them when typechecking anything.

--- a/daml-foundations/daml-ghc/src/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/src/Development/IDE/State/API/Testing.hs
@@ -104,7 +104,7 @@ runShakeTest mbScenarioService (ShakeTest m) = do
     virtualResources <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()
-    service <- API.initialise mainRule (Just eventLogger) Logger.makeNopHandle options mbScenarioService
+    service <- API.initialise mainRule (Just (atomically . eventLogger)) Logger.makeNopHandle options mbScenarioService
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv
                 { steService = service

--- a/daml-foundations/daml-ghc/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/src/Development/IDE/State/Rules/Daml.hs
@@ -62,12 +62,9 @@ runScenarios :: FilePath -> Action (Maybe [(VirtualResource, Either SS.Error SS.
 runScenarios file = use RunScenarios file
 
 -- | Get a list of the scenarios in a given file
-getScenarios :: FilePath -> Action [VirtualResource]
-getScenarios file = do
-    m <- use_ GenerateRawDalf file
-    pure [ VRScenario file (unTagged $ LF.qualObject ref)
-         | ref <- scenariosInModule m
-         ]
+getScenarioNames :: FilePath -> Action (Maybe [VirtualResource])
+getScenarioNames file = fmap f <$> use GenerateRawDalf file
+    where f = map (VRScenario file . unTagged . LF.qualObject) . scenariosInModule
 
 -- Generates the DALF for a module without adding serializability information
 -- or type checking it.

--- a/daml-foundations/daml-ghc/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/src/Development/IDE/State/Service/Daml.hs
@@ -14,7 +14,6 @@ module Development.IDE.State.Service.Daml(
     ) where
 
 import Control.Concurrent.Extra
-import Control.Concurrent.STM
 import Control.Monad
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -79,7 +78,7 @@ setOpenVirtualResources state resources = do
     void $ shakeRun state []
 
 initialise :: Rules ()
-           -> Maybe (Event -> STM ())
+           -> Maybe (Event -> IO ())
            -> Logger.Handle IO
            -> Options
            -> Maybe SS.Handle

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -98,7 +98,7 @@ cmdTest numProcessors =
   where
     cmd = execTest
       <$> many inputFileOpt
-      <*> fmap ColorTestResults colorOutput
+      <*> fmap UseColor colorOutput
       <*> junitOutput
       <*> optionsParser numProcessors optPackageName
     junitOutput = optional $ strOption $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -49,7 +49,7 @@ execTest inFiles colorTestResults mbJUnitOutput cliOptions = do
         liftIO $ Compiler.setFilesOfInterest hDamlGhc inFiles
         mbDeps <- liftIO $ CompilerService.runAction hDamlGhc $ fmap sequence $ mapM CompilerService.getDependencies inFiles
         depFiles <- maybe (reportDiagnostics hDamlGhc "Failed get dependencies") pure mbDeps
-        let files = Set.toList $ Set.fromList inFiles `Set.union`  Set.fromList (concat depFiles)
+        let files = Set.toList $ Set.fromList inFiles `Set.union` Set.fromList (concat depFiles)
         let lfVersion = Compiler.optDamlLfVersion cliOptions
         case mbJUnitOutput of
             Nothing -> testStdio lfVersion hDamlGhc files colorTestResults

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -46,7 +46,7 @@ execTest inFiles color mbJUnitOutput cliOptions = do
         eventLogger _ = return ()
     Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \h -> do
         let lfVersion = Compiler.optDamlLfVersion cliOptions
-        _ <- testRun h inFiles lfVersion color mbJUnitOutput
+        testRun h inFiles lfVersion color mbJUnitOutput
         diags <- CompilerService.getDiagnostics h
         when (any ((==) Error . dSeverity) diags) exitFailure
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -19,7 +19,6 @@ import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.PrettyScenario as SS
 import qualified DA.Daml.LF.ScenarioServiceClient as SSC
 import Data.Either
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
 import qualified Data.Vector as V
@@ -67,7 +66,7 @@ testRun hDamlGhc inFiles lfVersion colorTestResults mbJUnitOutput  = do
     case mbDeps of
         Nothing -> return Fail
         Just depFiles -> do
-            let files = Set.toList $ Set.fromList inFiles `Set.union` Set.fromList (concat depFiles)
+            let files = nubOrd $ concat $ inFiles : depFiles
             case mbJUnitOutput of
                 Nothing -> testStdio lfVersion hDamlGhc files colorTestResults
                 Just junitOutput -> testJUnit lfVersion hDamlGhc files junitOutput

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -59,7 +59,7 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
     -- take the transitive closure of all imports and run on all of them
     -- If some dependencies can't be resolved we'll get a Diagnostic out anyway, so don't worry
     deps <- CompilerService.runAction h $ mapM CompilerService.getDependencies inFiles
-    files <- return $ nubOrd $ concat $ inFiles : catMaybes deps
+    let files = return $ nubOrd $ concat $ inFiles : catMaybes deps
 
     results <- CompilerService.runAction h $
         Shake.forP files $ \file -> do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -6,7 +6,7 @@
 -- | Main entry-point of the DAML compiler
 module DA.Cli.Damlc.Test (
     execTest
-    , ColorTestResults(..)
+    , UseColor(..)
     ) where
 
 import Control.Monad.Except
@@ -35,10 +35,10 @@ import System.FilePath
 import qualified Text.XML.Light as XML
 
 
-newtype ColorTestResults = ColorTestResults{getColorTestResults :: Bool}
+newtype UseColor = UseColor {getUseColor :: Bool}
 
 -- | Test a DAML file.
-execTest :: [FilePath] -> ColorTestResults -> Maybe FilePath -> Compiler.Options -> IO ()
+execTest :: [FilePath] -> UseColor -> Maybe FilePath -> Compiler.Options -> IO ()
 execTest inFiles colorTestResults mbJUnitOutput cliOptions = do
     loggerH <- getLogger cliOptions "test"
     opts <- Compiler.mkOptions cliOptions
@@ -51,7 +51,7 @@ execTest inFiles colorTestResults mbJUnitOutput cliOptions = do
         when (any ((==) Error . dSeverity) diags) exitFailure
 
 
-testRun :: IdeState -> [FilePath] -> LF.Version -> ColorTestResults -> Maybe FilePath -> IO ()
+testRun :: IdeState -> [FilePath] -> LF.Version -> UseColor -> Maybe FilePath -> IO ()
 testRun h inFiles lfVersion colorTestResults mbJUnitOutput  = do
     liftIO $ Compiler.setFilesOfInterest h inFiles
     files <- filesToTest h inFiles
@@ -89,12 +89,12 @@ failedTestOutput h file = do
     pure $ map (, Just errMsg) $ fromMaybe [VRScenario file "Unknown"] mbScenarioNames
 
 
-printScenarioResults :: [(VirtualResource, SS.ScenarioResult)] -> ColorTestResults -> IO ()
+printScenarioResults :: [(VirtualResource, SS.ScenarioResult)] -> UseColor -> IO ()
 printScenarioResults results colorTestResults = do
     liftIO $ forM_ results $ \(VRScenario vrFile vrName, result) -> do
         let doc = prettyResult result
         let name = DA.Pretty.string vrFile <> ":" <> DA.Pretty.pretty vrName
-        let stringStyleToRender = if getColorTestResults colorTestResults then DA.Pretty.renderColored else DA.Pretty.renderPlain
+        let stringStyleToRender = if getUseColor colorTestResults then DA.Pretty.renderColored else DA.Pretty.renderPlain
         putStrLn $ stringStyleToRender (name <> ": " <> doc)
 
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -55,8 +55,9 @@ execTest inFiles colorTestResults mbJUnitOutput cliOptions = do
         eventLogger _ = return ()
     Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \hDamlGhc -> do
         let lfVersion = Compiler.optDamlLfVersion cliOptions
-        res <- testRun hDamlGhc inFiles lfVersion colorTestResults mbJUnitOutput
-        when (res == Fail) exitFailure
+        _ <- testRun hDamlGhc inFiles lfVersion colorTestResults mbJUnitOutput
+        diags <- CompilerService.getDiagnostics hDamlGhc
+        when (any ((==) Error . dSeverity) diags) exitFailure
 
 
 testRun :: IdeState -> [FilePath] -> LF.Version -> ColorTestResults -> Maybe FilePath -> IO Result

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -59,7 +59,7 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
     -- take the transitive closure of all imports and run on all of them
     -- If some dependencies can't be resolved we'll get a Diagnostic out anyway, so don't worry
     deps <- CompilerService.runAction h $ mapM CompilerService.getDependencies inFiles
-    let files = return $ nubOrd $ concat $ inFiles : catMaybes deps
+    let files = nubOrd $ concat $ inFiles : catMaybes deps
 
     results <- CompilerService.runAction h $
         Shake.forP files $ \file -> do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
@@ -6,11 +6,13 @@ module DA.Cli.Output
   ( writeOutput
   , writeOutputBSL
   , reportErr
+  , printDiagnostics
   ) where
 
 import qualified Data.ByteString.Lazy                           as BSL
 import           Data.String                                    (IsString)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import Development.IDE.Types.Diagnostics
 import Data.List.Extra
 import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
@@ -55,3 +57,7 @@ reportErr msg errs =
       Pretty.renderColored $
       Pretty.vcat $ map prettyDiagnostic $ nubOrd errs
     ]
+
+printDiagnostics :: [Diagnostic] -> IO ()
+printDiagnostics [] = return ()
+printDiagnostics xs = T.putStrLn $ Pretty.renderColored $ Pretty.vcat $ map prettyDiagnostic xs

--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -32,7 +32,7 @@ tests :: TestTree
 tests = testGroup
     "damlc test"
     [ testCase "Non-existent file" $ do
-        shouldThrow (Damlc.execTest ["foobar"] (Damlc.ColorTestResults False) Nothing opts)
+        shouldThrow (Damlc.execTest ["foobar"] (Damlc.UseColor False) Nothing opts)
     , testCase "File with compile error" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -40,7 +40,7 @@ tests = testGroup
               , "module Foo where"
               , "abc"
               ]
-            shouldThrow (Damlc.execTest [path] (Damlc.ColorTestResults False) Nothing opts)
+            shouldThrow (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
     , testCase "File with failing scenario" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -48,7 +48,7 @@ tests = testGroup
               , "module Foo where"
               , "x = scenario $ assert False"
               ]
-            shouldThrowExitFailure (Damlc.execTest [path] (Damlc.ColorTestResults False) Nothing opts)
+            shouldThrowExitFailure (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
     ]
 
 shouldThrowExitFailure :: IO () -> IO ()

--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -40,7 +40,7 @@ tests = testGroup
               , "module Foo where"
               , "abc"
               ]
-            shouldThrow (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
+            shouldThrowExitFailure (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
     , testCase "File with failing scenario" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines


### PR DESCRIPTION
Rewrites our test support so that now:

* The junit and normal code branches are identical up until it decides whether to write out a file. Hopefully this means no more junit specific bug reports.
* It uses the normal diagnostic printer to produce errors/warnings as they are reached, which means earlier feedback.
* Exit code is more robust, since it just uses the diagnostics store.
* If some scenarios fail to compile but some work it will produce partial information.
* Net shorter.

I also got rid of some arbitrary STM which could have been IO. Might conflict with @DavidM-D's ongoing LSP work.