### PR TITLE
Add explicit export list

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -11,7 +11,7 @@
 -- * Call runGhc, use runGhcFast instead. It's faster and doesn't require config we don't have.
 --
 -- * Call setSessionDynFlags, use modifyDynFlags instead. It's faster and avoids loading packages.
-module Development.IDE.UtilGHC where
+module Development.IDE.UtilGHC(module Development.IDE.UtilGHC) where
 
 import           "ghc-lib-parser" Config
 import qualified "ghc-lib-parser" CmdLineParser as Cmd (warnMsg)

--- a/da-assistant/DA/Sdk/Cli/Command/Types.hs
+++ b/da-assistant/DA/Sdk/Cli/Command/Types.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module DA.Sdk.Cli.Command.Types where
+module DA.Sdk.Cli.Command.Types(module DA.Sdk.Cli.Command.Types) where
 
 import           Control.Monad.Logger        (LogLevel)
 import           DA.Sdk.Prelude

--- a/da-assistant/DA/Sdk/Cli/Conf/Types.hs
+++ b/da-assistant/DA/Sdk/Cli/Conf/Types.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module DA.Sdk.Cli.Conf.Types where
+module DA.Sdk.Cli.Conf.Types(module DA.Sdk.Cli.Conf.Types) where
 
 import           Control.Lens                  (makePrisms)
 import qualified DA.Sdk.Cli.Message            as M

--- a/da-assistant/DA/Sdk/Cli/Monad/FileSystem/Types.hs
+++ b/da-assistant/DA/Sdk/Cli/Monad/FileSystem/Types.hs
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module DA.Sdk.Cli.Monad.FileSystem.Types where
+module DA.Sdk.Cli.Monad.FileSystem.Types(module DA.Sdk.Cli.Monad.FileSystem.Types) where
 
 import DA.Sdk.Prelude
 import qualified Data.Yaml as Y

--- a/da-assistant/DA/Sdk/Cli/Monad/Locations.hs
+++ b/da-assistant/DA/Sdk/Cli/Monad/Locations.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-module DA.Sdk.Cli.Monad.Locations where
+module DA.Sdk.Cli.Monad.Locations(module DA.Sdk.Cli.Monad.Locations) where
 
 import           DA.Sdk.Prelude
 import           DA.Sdk.Cli.System           (installationDir)
@@ -17,7 +17,7 @@ import           DA.Sdk.Cli.Conf.Types       (Project(..))
 import           DA.Sdk.Prelude.Path (stringToPath)
 import qualified DA.Sdk.Cli.Monad.FileSystem as FS
 import qualified Control.Monad.Logger as Log
-import Control.Monad.Trans.Except (ExceptT (..), runExceptT) 
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import qualified Control.Monad.Except as EE
 import Control.Monad.Trans (lift)
 import System.Directory (getAppUserDataDirectory)
@@ -32,7 +32,7 @@ class Monad m => MonadLocations m where
     default getInstallationDir :: MonadIO m => m L.FilePathOfInstallationDir
     getInstallationDir = installationDir
 
-    default getVscodeExtensionPath :: MonadIO m => m (Either GetVsCodeExtensionPathFailed FilePath) 
+    default getVscodeExtensionPath :: MonadIO m => m (Either GetVsCodeExtensionPathFailed FilePath)
     getVscodeExtensionPath = liftIO $ runExceptT $ do
       vscodePath <- lift $ stringToPath <$> getAppUserDataDirectory "vscode"
       whenM (notM $ FS.testdir' vscodePath) $

--- a/da-assistant/DA/Sdk/Cli/Monad/MockIO.hs
+++ b/da-assistant/DA/Sdk/Cli/Monad/MockIO.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE InstanceSigs   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
-module DA.Sdk.Cli.Monad.MockIO where
+module DA.Sdk.Cli.Monad.MockIO(module DA.Sdk.Cli.Monad.MockIO) where
 
 import DA.Sdk.Prelude
 import Control.Monad.Trans.Except

--- a/da-assistant/DA/Sdk/Cli/Test.hs
+++ b/da-assistant/DA/Sdk/Cli/Test.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Hidden test commands
-module DA.Sdk.Cli.Test where
+module DA.Sdk.Cli.Test(module DA.Sdk.Cli.Test) where
 
 import           DA.Sdk.Prelude             hiding (group)
 import DA.Sdk.Cli.Command (TestAction(..))

--- a/da-assistant/DA/Sdk/Cli/Version.hs
+++ b/da-assistant/DA/Sdk/Cli/Version.hs
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-module DA.Sdk.Cli.Version where
+module DA.Sdk.Cli.Version(module DA.Sdk.Cli.Version) where
 
 import Data.Text (Text)
 version :: Text

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -11,7 +11,9 @@
 -- * Call runGhc, use runGhcFast instead. It's faster and doesn't require config we don't have.
 --
 -- * Call setSessionDynFlags, use modifyDynFlags instead. It's faster and avoids loading packages.
-module DA.Daml.GHC.Compiler.UtilGHC where
+module DA.Daml.GHC.Compiler.UtilGHC(
+    module DA.Daml.GHC.Compiler.UtilGHC
+    ) where
 
 import           "ghc-lib-parser" Class
 import           "ghc-lib" GHC                         hiding (convertLit)

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilLF.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilLF.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | DAML-LF utility functions, may move to the LF utility if they are generally useful
-module DA.Daml.GHC.Compiler.UtilLF where
+module DA.Daml.GHC.Compiler.UtilLF(
+    module DA.Daml.GHC.Compiler.UtilLF
+    ) where
 
 import           DA.Daml.LF.Ast
 import qualified DA.Daml.LF.Proto3.Archive  as Archive

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Types.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Types.hs
@@ -3,8 +3,9 @@
 
 {-# LANGUAGE TemplateHaskell #-}
 
-module DA.Daml.GHC.Damldoc.Types
-  where
+module DA.Daml.GHC.Damldoc.Types(
+    module DA.Daml.GHC.Damldoc.Types
+    ) where
 
 import qualified Data.Aeson.TH.Extended as Aeson.TH
 import           Data.Text              (Text)

--- a/libs-haskell/da-hs-base/src/Orphans/Lib_pretty.hs
+++ b/libs-haskell/da-hs-base/src/Orphans/Lib_pretty.hs
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Orphans.Lib_pretty where
+module Orphans.Lib_pretty() where
 
 import qualified Data.Text as T
 import           Text.PrettyPrint.Annotated.HughesPJClass

--- a/libs-haskell/da-hs-base/tests/DataLimit.hs
+++ b/libs-haskell/da-hs-base/tests/DataLimit.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module DataLimit where
+module DataLimit(main) where
 
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/libs-haskell/da-hs-json-rpc/src/DA/Service/JsonRpc/Arbitrary.hs
+++ b/libs-haskell/da-hs-json-rpc/src/DA/Service/JsonRpc/Arbitrary.hs
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module DA.Service.JsonRpc.Arbitrary where
+module DA.Service.JsonRpc.Arbitrary() where
 
 import Data.Aeson.Types
 import qualified Data.HashMap.Strict as M

--- a/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Protocol.hs
+++ b/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Protocol.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module DA.LanguageServer.Protocol where
+module DA.LanguageServer.Protocol(module DA.LanguageServer.Protocol) where
 import qualified Data.Map.Strict  as MS
 import qualified Data.Aeson       as Aeson
 import qualified Data.Aeson.Types as Aeson

--- a/libs-haskell/da-hs-language-server/src/DA/LanguageServer/TH.hs
+++ b/libs-haskell/da-hs-language-server/src/DA/LanguageServer/TH.hs
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 
-module DA.LanguageServer.TH where
+module DA.LanguageServer.TH(deriveJSON) where
 
 import Data.Char
 import "template-haskell" Language.Haskell.TH (Name, Q, Dec)
@@ -20,4 +20,3 @@ deriveJSON name = Aeson.TH.deriveJSON options name
        case dropWhile isLower label of
          (x:xs) -> toLower x : xs
          _ -> []
-


### PR DESCRIPTION
They are a good idea. For things in the old assistant, I just did it to ignore HLint. For other places, I view these as reasonable data definitions which should be universally exported.