### PR TITLE
Don't promote warnings to errors in da-ghci

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -243,6 +243,7 @@ haskell_register_ghc_nixpkgs(
     repl_ghci_args = [
         "-O0",
         "-fexternal-interpreter",
+        "-Wwarn",
     ],
     repositories = dev_env_nix_repos,
     version = "8.6.5",

--- a/dev-env/bin/da-ghci
+++ b/dev-env/bin/da-ghci
@@ -72,7 +72,7 @@ def main():
             # Generate a -ghci-script that loads the module.
             script_fd, script_path = tempfile.mkstemp(text=True)
             os.write(script_fd, ":m {}".format(module_name).encode())
-            ghci_args = ["-ghci-script", script_path] + ghci_args
+            ghci_args = ["-ghci-script", script_path,"-Wwarn"] + ghci_args
 
         # Ignore SIGINT, so that Ctrl-C in GHCi doesn't kill the outer process.
         signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/dev-env/bin/da-ghci
+++ b/dev-env/bin/da-ghci
@@ -72,7 +72,7 @@ def main():
             # Generate a -ghci-script that loads the module.
             script_fd, script_path = tempfile.mkstemp(text=True)
             os.write(script_fd, ":m {}".format(module_name).encode())
-            ghci_args = ["-ghci-script", script_path,"-Wwarn"] + ghci_args
+            ghci_args = ["-ghci-script", script_path] + ghci_args
 
         # Ignore SIGINT, so that Ctrl-C in GHCi doesn't kill the outer process.
         signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
Particularly useful for da-ghcid which shows errors in preference to warnings, so improvements the dev experience a fair bit.