### PR TITLE
Hotfix damldoc render fixes

### DIFF
--- a/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.md
+++ b/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.md
@@ -42,10 +42,17 @@
 * `Transfer`
   changes the owner
 
-  | Field      | Type/Description |
-  | :--------- | :----------------
-  | `newOwner` | `Party` |
+  | Field    | Type/Description |
+  | :------- | :----------------
+  | `owner_` | `Party` |
 
 
 
+
+## Functions
+
+* `main`  
+  A single test scenario covering all functionality that `Iou` implements.
+  This description contains [a link](http://example.com), some bogus <inline html>,
+  and words_ with_ underscore, to test damldoc capabilities.
 

--- a/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.rst
+++ b/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.rst
@@ -74,8 +74,20 @@ template **Iou**
        * - Field
          - Type
          - Description
-       * - newOwner
+       * - owner\_
          - Party
          -
+
+
+
+Functions
+^^^^^^^^^
+
+.. _function-ioutemplate-main-42433:
+
+**main**
+  :   A single test scenario covering all functionality that ``Iou`` implements.
+  This description contains a link(http://example.com), some bogus <inline html>,
+  and words\_ with\_ underscore, to test damldoc capabilities.
 
 

--- a/daml-foundations/daml-ghc/tests/Iou_template.daml
+++ b/daml-foundations/daml-ghc/tests/Iou_template.daml
@@ -29,9 +29,9 @@ template Iou
           return (splitCid, restCid)
 
       Transfer : ContractId Iou -- ^ changes the owner
-        with newOwner : Party
+        with owner_ : Party
         do
-          create this with owner = newOwner
+          create this with owner = owner_
 
       Merge : ContractId Iou
         -- ^ merges two "compatible" `Iou`s
@@ -52,6 +52,11 @@ template Iou
           -- Return the merged IOU
           create this with amount = amount + otherIou.amount
 
+{- |
+A single test scenario covering all functionality that `Iou` implements.
+This description contains [a link](http://example.com), some bogus <inline html>,
+and words_ with_ underscore, to test damldoc capabilities.
+-}
 main = scenario do
   bank <- getParty "Acme Bank"
   alice <- getParty "Alice"

--- a/daml-foundations/daml-ghc/tests/Iou_template.daml
+++ b/daml-foundations/daml-ghc/tests/Iou_template.daml
@@ -47,7 +47,7 @@ template Iou
                   && issuer == otherIou.issuer )
           -- Retire the old IOU by transferring to the
           -- issuer and archiving
-          transferCid <- exercise otherCid Transfer with newOwner = issuer
+          transferCid <- exercise otherCid Transfer with owner_ = issuer
           exercise transferCid Archive
           -- Return the merged IOU
           create this with amount = amount + otherIou.amount
@@ -83,7 +83,7 @@ main = scenario do
   (split, rest) <- submit alice do
     exercise iouAliceCid Split with splitAmount = 40.0
   iouOtherCid <- submit alice do
-    exercise split Transfer with newOwner = bob
+    exercise split Transfer with owner_ = bob
 
   -- Bob merges them with the ones he had already.
   iouTotalCid <- submit bob do


### PR DESCRIPTION
* Escape trailing underscores on words because in rst they mean links.
* Render (bogus) inline html as simple text. Previously a trailing `\n` was added, breaking rst indentations.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
