### PR TITLE
Start cleaning up pretty-print

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
@@ -24,8 +24,7 @@ module Development.IDE.Types.Diagnostics (
   ideErrorPretty,
   errorDiag,
   ideTryIOException,
-  prettyFileDiagnostics,
-  prettyDiagnostic,
+  prettyDiagnostics,
   prettyDiagnosticStore,
   defDiagnostic,
   addDiagnostics,
@@ -175,6 +174,9 @@ prettyPosition Position{..} = label_ "Position" $ vcat
 
 stringParagraphs :: T.Text -> Doc a
 stringParagraphs = vcat . map (fillSep . map pretty . T.words) . T.lines
+
+prettyDiagnostics :: [LSP.Diagnostic] -> Doc SyntaxClass
+prettyDiagnostics = vcat . map prettyDiagnostic
 
 prettyDiagnostic :: LSP.Diagnostic -> Doc SyntaxClass
 prettyDiagnostic LSP.Diagnostic{..} =

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
@@ -24,7 +24,8 @@ module Development.IDE.Types.Diagnostics (
   ideErrorPretty,
   errorDiag,
   ideTryIOException,
-  prettyDiagnostics,
+  showDiagnostics,
+  showDiagnosticsColored,
   prettyDiagnosticStore,
   defDiagnostic,
   addDiagnostics,
@@ -174,6 +175,13 @@ prettyPosition Position{..} = slabel_ "Position" $ vcat
 
 stringParagraphs :: T.Text -> Doc a
 stringParagraphs = vcat . map (fillSep . map pretty . T.words) . T.lines
+
+showDiagnostics :: [LSP.Diagnostic] -> T.Text
+showDiagnostics = srenderPlain . prettyDiagnostics
+
+showDiagnosticsColored :: [LSP.Diagnostic] -> T.Text
+showDiagnosticsColored = srenderColored . prettyDiagnostics
+
 
 prettyDiagnostics :: [LSP.Diagnostic] -> Doc SyntaxClass
 prettyDiagnostics = vcat . map prettyDiagnostic

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
@@ -161,15 +161,15 @@ type FileDiagnostics = (Uri, [Diagnostic])
 
 prettyRange :: Range -> Doc SyntaxClass
 prettyRange Range{..} =
-  label_ "Range" $ vcat
-  [ label_ "Start:" $ prettyPosition _start
-  , label_ "End:  " $ prettyPosition _end
+  slabel_ "Range" $ vcat
+  [ slabel_ "Start:" $ prettyPosition _start
+  , slabel_ "End:  " $ prettyPosition _end
   ]
 
 prettyPosition :: Position -> Doc SyntaxClass
-prettyPosition Position{..} = label_ "Position" $ vcat
-   [ label_ "Line:" $ pretty _line
-   , label_ "Character:" $ pretty _character
+prettyPosition Position{..} = slabel_ "Position" $ vcat
+   [ slabel_ "Line:" $ pretty _line
+   , slabel_ "Character:" $ pretty _character
    ]
 
 stringParagraphs :: T.Text -> Doc a
@@ -181,18 +181,18 @@ prettyDiagnostics = vcat . map prettyDiagnostic
 prettyDiagnostic :: LSP.Diagnostic -> Doc SyntaxClass
 prettyDiagnostic LSP.Diagnostic{..} =
     vcat
-        [label_ "Range:   "
+        [slabel_ "Range:   "
             $ prettyRange _range
-        , label_ "Source:  " $ pretty _source
-        , label_ "Severity:" $ pretty $ show sev
-        , label_ "Message: "
+        , slabel_ "Source:  " $ pretty _source
+        , slabel_ "Severity:" $ pretty $ show sev
+        , slabel_ "Message: "
             $ case sev of
               LSP.DsError -> annotate ErrorSC
               LSP.DsWarning -> annotate WarningSC
               LSP.DsInfo -> annotate InfoSC
               LSP.DsHint -> annotate HintSC
             $ stringParagraphs _message
-        , label_ "Code:" $ pretty _code
+        , slabel_ "Code:" $ pretty _code
         ]
     where
         sev = fromMaybe LSP.DsError _severity
@@ -206,18 +206,18 @@ prettyDiagnosticStore ds =
 
 prettyFileDiagnostics :: FileDiagnostics -> Doc SyntaxClass
 prettyFileDiagnostics (uri, diags) =
-    label_ "Compiler error in" $ vcat
-        [ label_ "File:" $ pretty filePath
-        , label_ "Errors:" $ vcat $ map prettyDiagnostic diags
+    slabel_ "Compiler error in" $ vcat
+        [ slabel_ "File:" $ pretty filePath
+        , slabel_ "Errors:" $ vcat $ map prettyDiagnostic diags
         ] where
 
     -- prettyFileDiags :: (FilePath, [(T.Text, [LSP.Diagnostic])]) -> Doc SyntaxClass
     -- prettyFileDiags (fp,stages) =
-    --     label_ ("File: "<>fp) $ vcat $ map prettyStage stages
+    --     slabel_ ("File: "<>fp) $ vcat $ map prettyStage stages
 
     -- prettyStage :: (T.Text, [LSP.Diagnostic]) -> Doc SyntaxClass
     -- prettyStage (stage,diags) =
-    --     label_ ("Stage: "<>T.unpack stage) $ vcat $ map prettyDiagnostic diags
+    --     slabel_ ("Stage: "<>T.unpack stage) $ vcat $ map prettyDiagnostic diags
 
     filePath :: FilePath
     filePath = fromMaybe dontKnow $ uriToFilePath uri

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -479,9 +479,6 @@ prettyContractId :: TL.Text -> Doc SyntaxClass
 prettyContractId coid =
   linkToIdSC ("n" <> TL.toStrict coid) $ char '#' <> ltext coid
 
--- commentSC :: EmbedsSyntaxClass a => Doc SyntaxClass -> Doc SyntaxClass
--- commentSC = annotateSC CommentSC -- White
-
 linkSC :: T.Text -> T.Text -> Doc SyntaxClass -> Doc SyntaxClass
 linkSC url title = annotateSC (LinkSC url title)
 

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -49,7 +49,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
 
     let onErrorExit act =
             act >>= either (printAndExit . renderDiags) pure
-        renderDiags = T.unpack . Pretty.renderColored . Pretty.vcat . map prettyDiagnostic
+        renderDiags = T.unpack . Pretty.renderColored . prettyDiagnostics
 
     docData <- case cInputFormat of
             InputJson -> do

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -16,7 +16,6 @@ import           DA.Daml.GHC.Damldoc.Transform
 import qualified DA.Service.Daml.Compiler.Impl.Handle as DGHC
 import DA.Daml.GHC.Compiler.Options
 
-import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
 import Development.IDE.Types.Diagnostics
 
 import           Control.Monad.Extra
@@ -49,7 +48,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
 
     let onErrorExit act =
             act >>= either (printAndExit . renderDiags) pure
-        renderDiags = T.unpack . Pretty.srenderColored . prettyDiagnostics
+        renderDiags = T.unpack . showDiagnosticsColored
 
     docData <- case cInputFormat of
             InputJson -> do

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -49,7 +49,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
 
     let onErrorExit act =
             act >>= either (printAndExit . renderDiags) pure
-        renderDiags = T.unpack . Pretty.renderColored . prettyDiagnostics
+        renderDiags = T.unpack . Pretty.srenderColored . prettyDiagnostics
 
     docData <- case cInputFormat of
             InputJson -> do

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -15,8 +15,6 @@ module DA.Test.GHC
 import DA.Daml.GHC.Compiler.Options
 import           DA.Daml.GHC.Compiler.UtilLF
 
-import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
-
 import           DA.Daml.LF.Ast as LF hiding (IsTest)
 import           "ghc-lib-parser" UniqSupply
 import           "ghc-lib-parser" Unique

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -201,7 +201,7 @@ data DiagnosticField
 checkDiagnostics :: (String -> IO ()) -> [[DiagnosticField]] -> [D.Diagnostic] -> IO (Maybe String)
 checkDiagnostics log expected got = do
     when (got /= []) $
-        log $ T.unpack $ Pretty.renderPlain $ Pretty.vcat $ map prettyDiagnostic got
+        log $ T.unpack $ Pretty.renderPlain $ prettyDiagnostics got
 
     -- you require the same number of diagnostics as expected
     -- and each diagnostic is at least partially expected

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -201,7 +201,7 @@ data DiagnosticField
 checkDiagnostics :: (String -> IO ()) -> [[DiagnosticField]] -> [D.Diagnostic] -> IO (Maybe String)
 checkDiagnostics log expected got = do
     when (got /= []) $
-        log $ T.unpack $ Pretty.srenderPlain $ prettyDiagnostics got
+        log $ T.unpack $ showDiagnostics got
 
     -- you require the same number of diagnostics as expected
     -- and each diagnostic is at least partially expected

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -201,7 +201,7 @@ data DiagnosticField
 checkDiagnostics :: (String -> IO ()) -> [[DiagnosticField]] -> [D.Diagnostic] -> IO (Maybe String)
 checkDiagnostics log expected got = do
     when (got /= []) $
-        log $ T.unpack $ Pretty.renderPlain $ prettyDiagnostics got
+        log $ T.unpack $ Pretty.srenderPlain $ prettyDiagnostics got
 
     -- you require the same number of diagnostics as expected
     -- and each diagnostic is at least partially expected

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -42,7 +42,6 @@ import qualified Data.Set as Set
 import qualified Data.List.Split as Split
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
 import Development.IDE.Types.Diagnostics
 import GHC.Conc
 import qualified Network.Socket                    as NS
@@ -282,8 +281,7 @@ execPackageNew numProcessors mbOutFile =
                             unlines
                                 [ "Creation of DAR file failed:"
                                 , T.unpack $
-                                  Pretty.srenderColored $
-                                  prettyDiagnostics errs
+                                  showDiagnosticsColored errs
                                 ]
                         Right dar -> do
                             let fp = targetFilePath pName
@@ -414,8 +412,7 @@ execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relat
           Left errs
            -> ioError $ userError $ unlines
                 [ "Creation of DAR file failed:"
-                , T.unpack $ Pretty.srenderColored
-                    $ prettyDiagnostics
+                , T.unpack $ showDiagnosticsColored
                     $ Set.toList $ Set.fromList errs ]
           Right dar -> do
             createDirectoryIfMissing True $ takeDirectory targetFilePath

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -282,7 +282,7 @@ execPackageNew numProcessors mbOutFile =
                             unlines
                                 [ "Creation of DAR file failed:"
                                 , T.unpack $
-                                  Pretty.renderColored $
+                                  Pretty.srenderColored $
                                   prettyDiagnostics errs
                                 ]
                         Right dar -> do
@@ -414,7 +414,7 @@ execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relat
           Left errs
            -> ioError $ userError $ unlines
                 [ "Creation of DAR file failed:"
-                , T.unpack $ Pretty.renderColored
+                , T.unpack $ Pretty.srenderColored
                     $ prettyDiagnostics
                     $ Set.toList $ Set.fromList errs ]
           Right dar -> do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -283,7 +283,7 @@ execPackageNew numProcessors mbOutFile =
                                 [ "Creation of DAR file failed:"
                                 , T.unpack $
                                   Pretty.renderColored $
-                                  Pretty.vcat $ map prettyDiagnostic errs
+                                  prettyDiagnostics errs
                                 ]
                         Right dar -> do
                             let fp = targetFilePath pName
@@ -415,8 +415,7 @@ execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relat
            -> ioError $ userError $ unlines
                 [ "Creation of DAR file failed:"
                 , T.unpack $ Pretty.renderColored
-                    $ Pretty.vcat
-                    $ map prettyDiagnostic
+                    $ prettyDiagnostics
                     $ Set.toList $ Set.fromList errs ]
           Right dar -> do
             createDirectoryIfMissing True $ takeDirectory targetFilePath

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -83,7 +83,7 @@ failedTestOutput :: IdeState -> FilePath -> CompilerService.Action [(VirtualReso
 failedTestOutput h file = do
     mbScenarioNames <- CompilerService.getScenarioNames file
     diagnostics <- liftIO $ CompilerService.getDiagnostics h
-    let errMsg = Pretty.renderPlain $ prettyDiagnostics diagnostics
+    let errMsg = Pretty.srenderPlain $ prettyDiagnostics diagnostics
     pure $ map (, Just errMsg) $ fromMaybe [VRScenario file "Unknown"] mbScenarioNames
 
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -83,7 +83,7 @@ failedTestOutput :: IdeState -> FilePath -> CompilerService.Action [(VirtualReso
 failedTestOutput h file = do
     mbScenarioNames <- CompilerService.getScenarioNames file
     diagnostics <- liftIO $ CompilerService.getDiagnostics h
-    let errMsg = Pretty.srenderPlain $ prettyDiagnostics diagnostics
+    let errMsg = showDiagnostics diagnostics
     pure $ map (, Just errMsg) $ fromMaybe [VRScenario file "Unknown"] mbScenarioNames
 
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -83,7 +83,7 @@ failedTestOutput :: IdeState -> FilePath -> CompilerService.Action [(VirtualReso
 failedTestOutput h file = do
     mbScenarioNames <- CompilerService.getScenarioNames file
     diagnostics <- liftIO $ CompilerService.getDiagnostics h
-    let errMsg = T.unlines (map (Pretty.renderPlain . prettyDiagnostic) diagnostics)
+    let errMsg = Pretty.renderPlain $ prettyDiagnostics diagnostics
     pure $ map (, Just errMsg) $ fromMaybe [VRScenario file "Unknown"] mbScenarioNames
 
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
@@ -15,7 +15,6 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Development.IDE.Types.Diagnostics
 import Data.List.Extra
-import qualified Data.Text.Prettyprint.Doc.Syntax as Pretty
 import           System.IO                                      (Handle, hClose, hPutStr, stdout, openFile, IOMode (WriteMode))
 import           Control.Exception (bracket)
 
@@ -54,10 +53,9 @@ reportErr msg errs =
   unlines
     [ msg
     , T.unpack $
-      Pretty.srenderColored $
-      prettyDiagnostics $ nubOrd errs
+      showDiagnosticsColored $ nubOrd errs
     ]
 
 printDiagnostics :: [Diagnostic] -> IO ()
 printDiagnostics [] = return ()
-printDiagnostics xs = T.putStrLn $ Pretty.srenderColored $ prettyDiagnostics xs
+printDiagnostics xs = T.putStrLn $ showDiagnosticsColored xs

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
@@ -54,10 +54,10 @@ reportErr msg errs =
   unlines
     [ msg
     , T.unpack $
-      Pretty.renderColored $
+      Pretty.srenderColored $
       prettyDiagnostics $ nubOrd errs
     ]
 
 printDiagnostics :: [Diagnostic] -> IO ()
 printDiagnostics [] = return ()
-printDiagnostics xs = T.putStrLn $ Pretty.renderColored $ prettyDiagnostics xs
+printDiagnostics xs = T.putStrLn $ Pretty.srenderColored $ prettyDiagnostics xs

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Output.hs
@@ -55,9 +55,9 @@ reportErr msg errs =
     [ msg
     , T.unpack $
       Pretty.renderColored $
-      Pretty.vcat $ map prettyDiagnostic $ nubOrd errs
+      prettyDiagnostics $ nubOrd errs
     ]
 
 printDiagnostics :: [Diagnostic] -> IO ()
 printDiagnostics [] = return ()
-printDiagnostics xs = T.putStrLn $ Pretty.renderColored $ Pretty.vcat $ map prettyDiagnostic xs
+printDiagnostics xs = T.putStrLn $ Pretty.renderColored $ prettyDiagnostics xs

--- a/libs-haskell/prettyprinter-syntax/src/Data/Text/Prettyprint/Doc/Syntax.hs
+++ b/libs-haskell/prettyprinter-syntax/src/Data/Text/Prettyprint/Doc/Syntax.hs
@@ -4,17 +4,20 @@
 module Data.Text.Prettyprint.Doc.Syntax
     ( module Data.Text.Prettyprint.Doc
     , SyntaxClass(..)
-    , label_
     , reflow
-    , renderPlain
-    , renderColored
+    -- prefixing these names with an 's' is not pleasant
+    -- but we have duplicates of the functions with identical signatures
+    -- and different semantics at DA.Pretty, so important to try and disambiguate
+    , slabel_
+    , srenderPlain
+    , srenderColored
     ) where
 
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Text
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
 import Data.Text.Prettyprint.Doc.Render.Terminal (Color(..), color, colorDull)
-import Data.Text.Prettyprint.Doc.Util
+import Data.Text.Prettyprint.Doc.Util(reflow)
 import qualified Data.Text as T
 
 -- | Classes of syntax elements, which are used for highlighting.
@@ -37,8 +40,8 @@ data SyntaxClass
     deriving (Eq, Ord, Show)
 
 -- | Label a document.
-label_ :: String -> Doc a -> Doc a
-label_ t d = nest 2 $ sep [pretty t, d]
+slabel_ :: String -> Doc a -> Doc a
+slabel_ t d = nest 2 $ sep [pretty t, d]
 
 -- | The layout options used for the SDK assistant.
 cliLayout ::
@@ -50,12 +53,12 @@ cliLayout renderWidth = LayoutOptions
     }
 
 -- | Render without any syntax annotations
-renderPlain :: Doc ann -> T.Text
-renderPlain = renderStrict . layoutSmart (cliLayout defaultTermWidth)
+srenderPlain :: Doc ann -> T.Text
+srenderPlain = renderStrict . layoutSmart (cliLayout defaultTermWidth)
 
 -- | Render a 'Document' as an ANSII colored string.
-renderColored :: Doc SyntaxClass -> T.Text
-renderColored =
+srenderColored :: Doc SyntaxClass -> T.Text
+srenderColored =
     Terminal.renderStrict .
     layoutSmart defaultLayoutOptions { layoutPageWidth = AvailablePerLine 100 1.0 } .
     fmap toAnsiStyle

--- a/libs-haskell/prettyprinter-syntax/src/Data/Text/Prettyprint/Doc/Syntax.hs
+++ b/libs-haskell/prettyprinter-syntax/src/Data/Text/Prettyprint/Doc/Syntax.hs
@@ -5,7 +5,6 @@ module Data.Text.Prettyprint.Doc.Syntax
     ( module Data.Text.Prettyprint.Doc
     , SyntaxClass(..)
     , label_
-    , comment_
     , reflow
     , renderPlain
     , renderColored
@@ -20,15 +19,11 @@ import qualified Data.Text as T
 
 -- | Classes of syntax elements, which are used for highlighting.
 data SyntaxClass
-    = NoAnnotationSC
-      -- ^ Annotation to use as a no-op for highlighting.
-    | OperatorSC
+    = -- ^ Annotation to use as a no-op for highlighting.
+      OperatorSC
     | KeywordSC
-    | ParensSC
     | PredicateSC
     | ConstructorSC
-    | CommentSC
-    | ProofStepSC
     | TypeSC
     | ErrorSC
     | WarningSC
@@ -44,9 +39,6 @@ data SyntaxClass
 -- | Label a document.
 label_ :: String -> Doc a -> Doc a
 label_ t d = nest 2 $ sep [pretty t, d]
-
-comment_ :: Doc SyntaxClass -> Doc SyntaxClass
-comment_ = annotate CommentSC
 
 -- | The layout options used for the SDK assistant.
 cliLayout ::
@@ -71,18 +63,14 @@ renderColored =
     toAnsiStyle ann = case ann of
         OperatorSC -> colorDull Red
         KeywordSC -> colorDull Green
-        ParensSC -> colorDull Yellow
-        CommentSC -> colorDull White
         PredicateSC -> colorDull Magenta
         ConstructorSC -> color Blue
-        ProofStepSC -> colorDull Blue
         TypeSC -> color Green
         ErrorSC -> color Red
         WarningSC -> color Yellow
         InfoSC -> color Blue
         HintSC -> color Magenta
         LinkSC _ _ -> color Green
-        NoAnnotationSC -> mempty
         IdSC _ -> mempty
         OnClickSC _ -> mempty
 


### PR DESCRIPTION
We have three pretty printing modules, two of which define identical functions on identical types with different semantics. We seem to use either version pretty randomly throughout the stack. It's a mess. As a first step let's delete the code that isn't used at all, and rename functions that are different to have different names.

I also changed Diagnostic to not share pretty doc stuff but strings, since that's how its always used. One step along the way to making IDE not depend on our crazy pretty printing stuff. CC @DavidM-D - I didn't start deleting the unused stuff in this module, as I guess you are going to switch some of it on shortly?