### PR TITLE
Enable -Wprepositive-qualified-module

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -86,7 +86,7 @@ xFlagsSet = [
 wOptsSet :: [ WarningFlag ]
 wOptsSet =
   [ Opt_WarnUnusedImports
---, Opt_WarnPrepositiveQualifiedModule
+  , Opt_WarnPrepositiveQualifiedModule
   , Opt_WarnOverlappingPatterns
   , Opt_WarnIncompletePatterns
   ]

--- a/daml-foundations/daml-ghc/bond-trading/Dvp.daml
+++ b/daml-foundations/daml-ghc/bond-trading/Dvp.daml
@@ -5,12 +5,12 @@ daml 1.2
 module Dvp where
 
 import Bond hiding (Withdraw, Reject, Accept)
-import qualified Bond
+import Bond qualified
 import Cash hiding (Withdraw, Reject, Accept)
-import qualified Cash
+import Cash qualified
 import DvpTerms
 import DvpNotification hiding (Accept)
-import qualified DvpNotification
+import DvpNotification qualified
 
 import DA.Date
 

--- a/daml-foundations/daml-ghc/bond-trading/Test.daml
+++ b/daml-foundations/daml-ghc/bond-trading/Test.daml
@@ -4,11 +4,11 @@
 daml 1.2
 module Test where
 
-import qualified Bond
-import qualified Cash
-import qualified Dvp
-import qualified Helper
-import qualified Setup
+import Bond qualified
+import Cash qualified
+import Dvp qualified
+import Helper qualified
+import Setup qualified
 
 main = scenario do
   Bond.main

--- a/daml-foundations/daml-ghc/tests/Import.daml
+++ b/daml-foundations/daml-ghc/tests/Import.daml
@@ -5,8 +5,8 @@
 daml 1.2
 module Import where
 
-import qualified Good
-import qualified Bad
+import Good qualified
+import Bad qualified
 
 -- this checks that qualified names show up in error messages
 a : Good.T

--- a/daml-foundations/daml-ghc/tests/PreludeTest.daml
+++ b/daml-foundations/daml-ghc/tests/PreludeTest.daml
@@ -5,7 +5,7 @@ daml 1.2
 module PreludeTest where
 
 import DA.List as L
-import qualified DA.Text as T
+import DA.Text qualified as T
 import DA.Assert
 import DA.Date
 

--- a/daml-foundations/daml-ghc/tests/QualifiedPrelude.daml
+++ b/daml-foundations/daml-ghc/tests/QualifiedPrelude.daml
@@ -10,7 +10,7 @@
 daml 1.2
 module QualifiedPrelude where
 
-import qualified Prelude as P
+import Prelude qualified as P
 
 main = P.scenario do P.assert P.True
 


### PR DESCRIPTION
This PR turns on a warning about `import qualified M` suggesting a re-write as `import M qualified`. I *think* all the tests are passing (including language server -- we'll see).