### PR TITLE
Using free ports instead of hard coded ones while running daml start 

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -24,6 +24,7 @@ da_haskell_library(
         "optparse-applicative",
         "process",
         "safe-exceptions",
+        "port-utils",
         "text",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This PR addresses issue #764. The open port is determined using port-utils

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
