### PR TITLE
Add transaction provenance service methods for looking up flat transactions

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -10,6 +10,8 @@ HEAD — ongoing
 --------------
 
 - Fix an issue with Postgres of potentially not stopping the transaction stream at required ceiling offset. See more `here <https://github.com/digital-asset/daml/pull/802>`
+- Ledger API: You can now look up flat transactions with the new TransactionService methods
+  ``GetFlatTransactionByEventId`` and ``GetFlatTransactionById``.
 
 0.12.12 - 2019-04-30
 --------------------

--- a/language-support/hs/bindings/src/LedgerHL.hs
+++ b/language-support/hs/bindings/src/LedgerHL.hs
@@ -118,7 +118,7 @@ getTransactionStream h party = do
     forkIO_ tag $
         withGRPCClient (config port) $ \client -> do
             rpcs <- TS.transactionServiceClient client
-            let (TS.TransactionService rpc1 _ _ _ _) = rpcs
+            let (TS.TransactionService rpc1 _ _ _ _ _ _) = rpcs
             sendToChan request fromServiceResponse chan  rpc1
     return $ ResponseStream{chan}
 

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/TransactionsClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/TransactionsClient.java
@@ -29,6 +29,10 @@ public interface TransactionsClient {
 
     Single<TransactionTree> getTransactionById(String transactionId, Set<String> requestingParties);
 
+    Single<Transaction> getFlatTransactionByEventId(String eventId, Set<String> requestingParties);
+
+    Single<Transaction> getFlatTransactionById(String transactionId, Set<String> requestingParties);
+
     Single<LedgerOffset> getLedgerEnd();
 
 }

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/TransactionClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/TransactionClientImpl.java
@@ -97,6 +97,33 @@ public class TransactionClientImpl implements TransactionsClient {
     }
 
     @Override
+    public Single<Transaction> getFlatTransactionByEventId(String eventId, Set<String> requestingParties) {
+        TransactionServiceOuterClass.GetTransactionByEventIdRequest request = TransactionServiceOuterClass.GetTransactionByEventIdRequest.newBuilder()
+                .setLedgerId(ledgerId)
+                .setEventId(eventId)
+                .addAllRequestingParties(requestingParties)
+                .build();
+        return extractTransaction(serviceFutureStub.getFlatTransactionByEventId(request));
+    }
+
+    @Override
+    public Single<Transaction> getFlatTransactionById(String transactionId, Set<String> requestingParties) {
+        TransactionServiceOuterClass.GetTransactionByIdRequest request = TransactionServiceOuterClass.GetTransactionByIdRequest.newBuilder()
+                .setLedgerId(ledgerId)
+                .setTransactionId(transactionId)
+                .addAllRequestingParties(requestingParties)
+                .build();
+        return extractTransaction(serviceFutureStub.getFlatTransactionById(request));
+    }
+
+    private Single<Transaction> extractTransaction(Future<TransactionServiceOuterClass.GetFlatTransactionResponse> future) {
+        return Single
+                .fromFuture(future)
+                .map(GetFlatTransactionResponse::fromProto)
+                .map(GetFlatTransactionResponse::getTransaction);
+    }
+
+    @Override
     public Single<LedgerOffset> getLedgerEnd() {
         TransactionServiceOuterClass.GetLedgerEndRequest request = TransactionServiceOuterClass.GetLedgerEndRequest.newBuilder().setLedgerId(ledgerId).build();
         return Single

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -383,7 +383,7 @@ class BotTest extends FlatSpec with Matchers with DataLayerHelpers {
       client.connect()
 
       /* The bot is wired here and inside wire is where the race condition can happen. We catch the possible
-       * error to pretty-print it. This try-catch depends on the implementation of `TRansactionServiceImpl.getTransaction()`
+       * error to pretty-print it. This try-catch depends on the implementation of `TransactionServiceImpl.getTransactionTree()`
        */
       try {
         Bot.wireSimple(

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/LedgerViewFlowableSpec.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/LedgerViewFlowableSpec.scala
@@ -51,7 +51,7 @@ class LedgerViewFlowableSpec extends FlatSpec with Matchers {
     )
 
     ledgerViewFlowable
-      .timeout(10, TimeUnit.MILLISECONDS)
+      .timeout(1, TimeUnit.SECONDS)
       .blockingFirst() shouldBe initialLedgerView
   }
 

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/tests/helpers/DummyLedgerClient.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/tests/helpers/DummyLedgerClient.scala
@@ -79,6 +79,14 @@ class DummyLedgerClient(
         requestingParties: util.Set[String]): Single[TransactionTree] =
       ???
 
+    override def getFlatTransactionByEventId(
+        eventId: String,
+        requestingParties: util.Set[String]): Single[Transaction] = ???
+
+    override def getFlatTransactionById(
+        transactionId: String,
+        requestingParties: util.Set[String]): Single[Transaction] = ???
+
     override def getLedgerEnd: Single[LedgerOffset] = Single.just(ledgerEnd)
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/GetFlatTransactionResponse.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/GetFlatTransactionResponse.java
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.digitalasset.ledger.api.v1.TransactionServiceOuterClass;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Objects;
+
+public class GetFlatTransactionResponse {
+
+    private final Transaction transaction;
+
+    public GetFlatTransactionResponse(@NonNull Transaction transaction) {
+        this.transaction = transaction;
+    }
+
+    public static GetFlatTransactionResponse fromProto(TransactionServiceOuterClass.GetFlatTransactionResponse response) {
+        return new GetFlatTransactionResponse(Transaction.fromProto(response.getTransaction()));
+    }
+
+    public TransactionServiceOuterClass.GetFlatTransactionResponse toProto() {
+        return TransactionServiceOuterClass.GetFlatTransactionResponse.newBuilder()
+                .setTransaction(this.transaction.toProto())
+                .build();
+    }
+
+    public Transaction getTransaction() {
+        return transaction;
+    }
+
+    @Override
+    public String toString() {
+        return "GetFlatTransactionResponse{" +
+                "transaction=" + transaction +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetFlatTransactionResponse that = (GetFlatTransactionResponse) o;
+        return Objects.equals(transaction, that.transaction);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(transaction);
+    }
+}

--- a/language-support/java/testkit/src/main/scala/com/daml/ledger/testkit/services/TransactionServiceImpl.scala
+++ b/language-support/java/testkit/src/main/scala/com/daml/ledger/testkit/services/TransactionServiceImpl.scala
@@ -35,6 +35,8 @@ class TransactionServiceImpl(ledgerContent: Observable[LedgerItem]) extends Tran
   val lastTransactionsTreesRequest = new AtomicReference[GetTransactionsRequest]()
   val lastTransactionByEventIdRequest = new AtomicReference[GetTransactionByEventIdRequest]()
   val lastTransactionByIdRequest = new AtomicReference[GetTransactionByIdRequest]()
+  val lastFlatTransactionByEventIdRequest = new AtomicReference[GetTransactionByEventIdRequest]()
+  val lastFlatTransactionByIdRequest = new AtomicReference[GetTransactionByIdRequest]()
   val lastLedgerEndRequest = new AtomicReference[GetLedgerEndRequest]()
 
   override def getTransactions(
@@ -84,6 +86,22 @@ class TransactionServiceImpl(ledgerContent: Observable[LedgerItem]) extends Tran
       request: GetTransactionByIdRequest): Future[GetTransactionResponse] =
     Future.failed[GetTransactionResponse] {
       lastTransactionByIdRequest.set(request)
+      //  TODO DEL-6007
+      new StatusRuntimeException(Status.UNIMPLEMENTED.withDescription("Pending"))
+    }
+
+  override def getFlatTransactionByEventId(
+      request: GetTransactionByEventIdRequest): Future[GetFlatTransactionResponse] =
+    Future.failed[GetFlatTransactionResponse] {
+      lastFlatTransactionByEventIdRequest.set(request)
+      //  TODO DEL-6007
+      new StatusRuntimeException(Status.UNIMPLEMENTED.withDescription("Pending"))
+    }
+
+  override def getFlatTransactionById(
+      request: GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
+    Future.failed[GetFlatTransactionResponse] {
+      lastFlatTransactionByIdRequest.set(request)
       //  TODO DEL-6007
       new StatusRuntimeException(Status.UNIMPLEMENTED.withDescription("Pending"))
     }

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/transaction_service.proto
@@ -20,16 +20,26 @@ service TransactionService {
   // Read the ledger's filtered transaction stream for a set of parties.
   rpc GetTransactions (GetTransactionsRequest) returns (stream GetTransactionsResponse);
 
-  // Read the ledger's complete transaction stream for a set of parties.
+  // Read the ledger's complete transaction tree stream for a set of parties.
   rpc GetTransactionTrees (GetTransactionsRequest) returns (stream GetTransactionTreesResponse);
+
+  // Lookup a transaction tree by the ID of an event that appears within it.
+  // Returns ``NOT_FOUND`` if no such transaction exists.
+  // For looking up a transaction instead of a transaction tree, please see GetFlatTransactionByEventId
+  rpc GetTransactionByEventId (GetTransactionByEventIdRequest) returns (GetTransactionResponse);
+
+  // Lookup a transaction tree by its ID.
+  // Returns ``NOT_FOUND`` if no such transaction exists.
+  // For looking up a transaction instead of a transaction tree, please see GetFlatTransactionById
+  rpc GetTransactionById (GetTransactionByIdRequest) returns (GetTransactionResponse);
 
   // Lookup a transaction by the ID of an event that appears within it.
   // Returns ``NOT_FOUND`` if no such transaction exists.
-  rpc GetTransactionByEventId (GetTransactionByEventIdRequest) returns (GetTransactionResponse);
+  rpc GetFlatTransactionByEventId (GetTransactionByEventIdRequest) returns (GetFlatTransactionResponse);
 
   // Lookup a transaction by its ID.
   // Returns ``NOT_FOUND`` if no such transaction exists.
-  rpc GetTransactionById (GetTransactionByIdRequest) returns (GetTransactionResponse);
+  rpc GetFlatTransactionById (GetTransactionByIdRequest) returns (GetFlatTransactionResponse);
 
   // Get the current ledger end.
   // Subscriptions started with the returned offset will serve transactions created after this RPC was called.
@@ -119,6 +129,10 @@ message GetTransactionByIdRequest {
 
 message GetTransactionResponse {
   TransactionTree transaction = 1;
+}
+
+message GetFlatTransactionResponse {
+  Transaction transaction = 1;
 }
 
 message GetLedgerEndRequest {

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -27,6 +27,7 @@ import com.digitalasset.ledger.api.v1.transaction_service.{
 }
 import com.digitalasset.ledger.api.validation.PartyNameChecker
 import com.digitalasset.platform.participant.util.EventFilter
+import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.server.api._
 import com.digitalasset.platform.server.api.services.domain.TransactionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcTransactionService
@@ -85,50 +86,65 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
     runTransactionPipeline(ledgerId, request.begin, request.end, request.filter)
       .mapConcat {
         case (offset, (trans, blindingInfo)) =>
-          val transactionWithEventIds =
-            trans.transaction.mapNodeId(nodeIdToEventId(trans.transactionId, _))
-          val events =
-            TransactionConversion
-              .genToFlatTransaction(
-                transactionWithEventIds,
-                blindingInfo.explicitDisclosure.map {
-                  case (nodeId, parties) =>
-                    nodeIdToEventId(trans.transactionId, nodeId) -> parties.map(_.underlyingString)
-                },
-                request.verbose
-              )
+          acceptedToFlat(offset, trans, blindingInfo, request.verbose, eventFilter) match {
+            case Some(transaction) =>
+              val response = GetTransactionsResponse(Seq(transaction))
+              logger.debug(
+                "Serving item {} (offset: {}) in transaction subscription {} to client",
+                transaction.transactionId,
+                transaction.offset,
+                subscriptionId)
+              List(response)
 
-          val submitterIsSubscriber =
-            trans.optSubmitterInfo
-              .map(_.submitter)
-              .fold(false)(eventFilter.isSubmitterSubscriber)
-          if (events.nonEmpty || submitterIsSubscriber) {
-            val transaction = PTransaction(
-              transactionId = trans.transactionId,
-              commandId =
-                if (submitterIsSubscriber)
-                  trans.optSubmitterInfo.map(_.commandId).getOrElse("")
-                else "",
-              workflowId = trans.transactionMeta.workflowId,
-              effectiveAt = Some(fromInstant(trans.transactionMeta.ledgerEffectiveTime.toInstant)), // FIXME(JM): conversion
-              events = events,
-              offset = offset.toString,
-            )
-            val response = GetTransactionsResponse(Seq(transaction))
-            logger.debug(
-              "Serving item {} (offset: {}) in transaction subscription {} to client",
-              transaction.transactionId,
-              transaction.offset,
-              subscriptionId)
-            List(response)
-          } else {
-            logger.trace(
-              "Not serving item {} for transaction subscription {} as no events are visible",
-              trans.transactionId,
-              subscriptionId: Any)
-            Nil
+            case None =>
+              logger.trace(
+                "Not serving item {} for transaction subscription {} as no events are visible",
+                trans.transactionId,
+                subscriptionId: Any)
+              Nil
           }
       }
+  }
+
+  private def acceptedToFlat(
+      offset: Offset,
+      trans: TransactionAccepted,
+      blindingInfo: BlindingInfo,
+      verbose: Boolean,
+      eventFilter: TemplateAwareFilter) = {
+    val transactionWithEventIds =
+      trans.transaction.mapNodeId(nodeIdToEventId(trans.transactionId, _))
+    val events =
+      TransactionConversion
+        .genToFlatTransaction(
+          transactionWithEventIds,
+          blindingInfo.explicitDisclosure.map {
+            case (nodeId, parties) =>
+              nodeIdToEventId(trans.transactionId, nodeId) -> parties.map(_.underlyingString)
+          },
+          verbose
+        )
+
+    val submitterIsSubscriber =
+      trans.optSubmitterInfo
+        .map(_.submitter)
+        .fold(false)(eventFilter.isSubmitterSubscriber)
+    if (events.nonEmpty || submitterIsSubscriber) {
+      Some(
+        PTransaction(
+          transactionId = trans.transactionId,
+          commandId =
+            if (submitterIsSubscriber)
+              trans.optSubmitterInfo.map(_.commandId).getOrElse("")
+            else "",
+          workflowId = trans.transactionMeta.workflowId,
+          effectiveAt = Some(fromInstant(trans.transactionMeta.ledgerEffectiveTime.toInstant)), // FIXME(JM): conversion
+          events = events,
+          offset = offset.toString,
+        ))
+    } else {
+      None
+    }
   }
 
   override def getTransactionTrees(request: GetTransactionTreesRequest)
@@ -168,20 +184,34 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
     eventIdToTransactionId(request.eventId) match {
       case None => Future.successful(None)
       case Some(txId) =>
-        lookupTransactionById(request.ledgerId.unwrap, txId, request.requestingParties)
+        lookupTransactionTreeById(request.ledgerId.unwrap, txId, request.requestingParties)
     }
   }
 
   def getTransactionById(request: GetTransactionByIdRequest): Future[Option[VisibleTransaction]] = {
     logger.debug("Received {}", request)
 
-    lookupTransactionById(
+    lookupTransactionTreeById(
       request.ledgerId.unwrap,
       request.transactionId.unwrap,
       request.requestingParties)
   }
 
-  private def lookupTransactionById(
+  override def getFlatTransactionByEventId(
+      request: GetTransactionByEventIdRequest): Future[Option[PTransaction]] = {
+    eventIdToTransactionId(request.eventId) match {
+      case None => Future.successful(None)
+      case Some(txId) =>
+        lookupFlatTransactionById(request.ledgerId.unwrap, txId, request.requestingParties)
+    }
+  }
+
+  override def getFlatTransactionById(
+      req: GetTransactionByIdRequest): Future[Option[PTransaction]] = {
+    lookupFlatTransactionById(req.ledgerId.unwrap, req.transactionId.unwrap, req.requestingParties)
+  }
+
+  private def lookupTransactionTreeById[A](
       ledgerId: String,
       txId: String,
       requestingParties: Set[Party]): Future[Option[VisibleTransaction]] = {
@@ -189,37 +219,61 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
 
     // FIXME(JM): Move to IndexService
 
-    consumeAsyncResult(
-      indexService
-        .getAcceptedTransactions(
-          ledgerId = Ref.SimpleString.assertFromString(ledgerId),
-          beginAfter = None,
-          endAt = None,
-          filter = filter
-        )).flatMap { txs =>
-      txs
-        .collect {
-          case (offset: Offset, (t: TransactionAccepted, _)) if t.transactionId == txId =>
-            t
-        }
-        .runWith(Sink.headOption)
-        .flatMap {
-          case Some(trans) =>
-            val result = VisibleTransaction.toVisibleTransaction(
-              filter,
-              toTransactionWithMeta(trans)
-            )
-            Future.successful(result)
+    runTransactionPipeline(
+      Ref.SimpleString.assertFromString(ledgerId),
+      LedgerOffset.LedgerBegin,
+      Some(LedgerOffset.LedgerEnd),
+      filter)
+      .collect {
+        case (o, (t: TransactionAccepted, bi)) if t.transactionId == txId => (o, t, bi)
+      }
+      .runWith(Sink.headOption)
+      .flatMap {
+        case Some((_, trans, _)) =>
+          val result = VisibleTransaction.toVisibleTransaction(
+            filter,
+            toTransactionWithMeta(trans)
+          )
+          Future.successful(result)
 
-          case None =>
-            Future.failed(
-              Status.INVALID_ARGUMENT
-                .withDescription(s"$txId could not be found")
-                .asRuntimeException)
+        case None =>
+          Future.failed(
+            Status.INVALID_ARGUMENT
+              .withDescription(s"$txId could not be found")
+              .asRuntimeException)
+      }
+  }
 
-        }
+  private def lookupFlatTransactionById[A](
+      ledgerId: String,
+      txId: String,
+      requestingParties: Set[Party]): Future[Option[PTransaction]] = {
+    val filter = TransactionFilter.allForParties(requestingParties)
 
-    }
+    // FIXME(JM): Move to IndexService
+
+    runTransactionPipeline(
+      Ref.SimpleString.assertFromString(ledgerId),
+      LedgerOffset.LedgerBegin,
+      Some(LedgerOffset.LedgerEnd),
+      filter)
+      .collect {
+        case (o, (t: TransactionAccepted, bi)) if t.transactionId == txId => (o, t, bi)
+      }
+      .runWith(Sink.headOption)
+      .flatMap {
+        case Some((offset, trans, blindingInfo)) =>
+          val eventFilter = EventFilter.byTemplates(
+            TransactionFilter(requestingParties.map(_ -> Filters.noFilter)(breakOut)))
+          Future.successful(
+            acceptedToFlat(offset, trans, blindingInfo, verbose = true, eventFilter))
+
+        case None =>
+          Future.failed(
+            Status.INVALID_ARGUMENT
+              .withDescription(s"$txId could not be found")
+              .asRuntimeException)
+      }
   }
 
   override def getLedgerEnd(ledgerId: String): Future[LedgerOffset.Absolute] =

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
@@ -52,6 +52,17 @@ final class TransactionClient(ledgerId: String, transactionService: TransactionS
     transactionService
       .getTransactionByEventId(GetTransactionByEventIdRequest(ledgerId, eventId, parties))
 
+  def getFlatTransactionById(transactionId: String, parties: Seq[String])(
+      implicit ec: ExecutionContext): Future[GetFlatTransactionResponse] = {
+    transactionService
+      .getFlatTransactionById(GetTransactionByIdRequest(ledgerId, transactionId, parties))
+  }
+
+  def getFlatTransactionByEventId(eventId: String, parties: Seq[String])(
+      implicit ec: ExecutionContext): Future[GetFlatTransactionResponse] =
+    transactionService
+      .getFlatTransactionByEventId(GetTransactionByEventIdRequest(ledgerId, eventId, parties))
+
   def getLedgerEnd: Future[GetLedgerEndResponse] =
     transactionService.getLedgerEnd(GetLedgerEndRequest(ledgerId))
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/TransactionService.scala
@@ -13,6 +13,7 @@ import com.digitalasset.ledger.api.messages.transaction.{
   GetTransactionsRequest
 }
 import com.digitalasset.ledger.api.v1.transaction_service.GetTransactionsResponse
+import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.platform.server.api.WithOffset
 import com.digitalasset.platform.server.services.transaction.VisibleTransaction
 
@@ -34,4 +35,8 @@ trait TransactionService {
 
   def getTransactionByEventId(
       req: GetTransactionByEventIdRequest): Future[Option[VisibleTransaction]]
+
+  def getFlatTransactionById(req: GetTransactionByIdRequest): Future[Option[Transaction]]
+
+  def getFlatTransactionByEventId(req: GetTransactionByEventIdRequest): Future[Option[Transaction]]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
@@ -67,7 +67,11 @@ object TransactionFiltration {
         }
       )
 
-      if (filteredPartiesByNode.exists(_._2.nonEmpty)) {
+      // We currently allow composite commands without any actual commands and
+      // emit empty flat transactions. To be consistent with that behavior,
+      // we check for filteredPartiesByNode.isEmpty so that we also emit empty
+      // transaction trees.
+      if (filteredPartiesByNode.exists(_._2.nonEmpty) || filteredPartiesByNode.isEmpty) {
         val nodeIdToParty: Map[String, immutable.Set[Party]] = filteredPartiesByNode.map {
           case (k, v) => (nidToString(k), v)
         }(breakOut)

--- a/ledger/ledger-api-scala-logging/src/test/scala/com/digitalasset/ledger/api/logging/FailingServerFixture.scala
+++ b/ledger/ledger-api-scala-logging/src/test/scala/com/digitalasset/ledger/api/logging/FailingServerFixture.scala
@@ -9,14 +9,7 @@ import com.digitalasset.ledger.api.logging.FailingServerFixture.Exceptions.{
   InternalGrpc
 }
 import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionService
-import com.digitalasset.ledger.api.v1.command_completion_service.{
-  CommandCompletionServiceGrpc,
-  CommandCompletionServiceLogging,
-  CompletionEndRequest,
-  CompletionEndResponse,
-  CompletionStreamRequest,
-  CompletionStreamResponse
-}
+import com.digitalasset.ledger.api.v1.command_completion_service._
 import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
 import com.digitalasset.ledger.api.v1.ledger_identity_service.{
   GetLedgerIdentityRequest,
@@ -24,39 +17,11 @@ import com.digitalasset.ledger.api.v1.ledger_identity_service.{
   LedgerIdentityServiceGrpc,
   LedgerIdentityServiceLogging
 }
-import com.digitalasset.ledger.api.v1.package_service.{
-  GetPackageRequest,
-  GetPackageResponse,
-  GetPackageStatusRequest,
-  GetPackageStatusResponse,
-  ListPackagesRequest,
-  ListPackagesResponse,
-  PackageServiceGrpc,
-  PackageServiceLogging
-}
+import com.digitalasset.ledger.api.v1.package_service._
 import com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc.PackageService
-import com.digitalasset.ledger.api.v1.transaction_service.{
-  GetLedgerEndRequest,
-  GetLedgerEndResponse,
-  GetTransactionByEventIdRequest,
-  GetTransactionByIdRequest,
-  GetTransactionResponse,
-  GetTransactionTreesResponse,
-  GetTransactionsRequest,
-  GetTransactionsResponse,
-  TransactionServiceGrpc,
-  TransactionServiceLogging
-}
+import com.digitalasset.ledger.api.v1.transaction_service._
 import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionService
-import io.grpc.{
-  BindableService,
-  Channel,
-  ManagedChannel,
-  Server,
-  ServerServiceDefinition,
-  Status,
-  StatusRuntimeException
-}
+import io.grpc._
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import io.grpc.stub.StreamObserver
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -136,6 +101,12 @@ object FailingServerFixture {
       throw InternalGrpc
     override def getTransactionById(
         request: GetTransactionByIdRequest): Future[GetTransactionResponse] =
+      Future.failed(AbortedGrpc)
+    override def getFlatTransactionByEventId(
+        request: GetTransactionByEventIdRequest): Future[GetFlatTransactionResponse] =
+      Future.failed(AbortedGrpc)
+    override def getFlatTransactionById(
+        request: GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
       Future.failed(AbortedGrpc)
     override def getLedgerEnd(request: GetLedgerEndRequest): Future[GetLedgerEndResponse] =
       throw AbortedGrpc


### PR DESCRIPTION
This change is needed in preparation of #406, where we want to return a
transaction tree and flat transaction after a SubmitAndWaitForTransaction(Tree).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
