### PR TITLE
Reject running sandbox with --scenario and -w

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -112,6 +112,12 @@ object Cli {
       .text("Sandbox ledger ID. If missing, a random unique ledger ID will be used. Only useful with persistent stores.")
 
     help("help").text("Print the usage text")
+
+    checkConfig(c => {
+      if (c.scenario.isDefined && c.timeProviderType == TimeProviderType.WallClock)
+        failure("Wallclock mode (-w / --wall-clock-time) and scenario initialisation (--scenario) may not be used together.")
+      else success
+    })
   }
   // format: on
   private def assertTimeModeIsDefault(c: SandboxConfig): Unit = {


### PR DESCRIPTION
Scenarios are always run in static time mode.
This change prevents users from thinking the scenario was run in wallclock mode.

```
$ java -jar sandbox-binary_deploy.jar ./target/* --scenario=Main:example -w
Error: -w and --scenario options may not be used together (running scenarios in wallclock mode is not supported).
Try --help for more information.
```

Fixes #790

Implementing wallclock mode scenarios is described in #839