### PR TITLE
Fix path to daml in windows installer

### DIFF
--- a/release/windows-installer/BUILD.bazel
+++ b/release/windows-installer/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_binary(
     srcs = glob(["src/**/*.hs"]),
     hazel_deps = [
         "base",
+        "filepath",
         "nsis",
     ],
     src_strip_prefix = "src",


### PR DESCRIPTION
It turns out my suspicion that the tar plugin was the thing that
messed up paths was completely correct. However, I messed up the PATH
to daml which resulted in me still running the old binary.

I’ve fixed the path and also moved to a temporary
directory (PLUGINSDIR seems like the easiest option for that) so that
things are cleaned up automatically by nsis.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
