### PR TITLE
Deal with NUL bytes in strings

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -179,7 +179,7 @@ instance Pretty BuiltinExpr where
   pPrintPrec _lvl prec = \case
     BEInt64 n -> pretty (toInteger n)
     BEDecimal dec -> string (show dec)
-    BEText t -> doubleQuotes (pretty t)
+    BEText t -> string (show t) -- includes the double quotes, and escapes characters
     BEParty p -> pretty p
     BEEnumCon c -> pretty c
     BEError -> "ERROR"

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
@@ -17,6 +17,7 @@ module DA.Text
   , DA.Text.unwords
   , DA.Text.linesBy
   , DA.Text.wordsBy
+  , DA.Text.reverse
   , DA.Text.intercalate
   , DA.Text.dropPrefix
   , DA.Text.dropSuffix
@@ -302,3 +303,11 @@ parseDecimal t =
 -- This function will crash at runtime if you compile DAML to DAML-LF < 1.2.
 sha256 : Text -> Text
 sha256 = primitive @"BESha256Text"
+
+
+-- | Reverse some `Text`.
+-- ```
+--   reverse "DAML" == "LMAD"
+-- ```
+reverse : Text -> Text
+reverse = implode . P.reverse . explode

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -645,9 +645,9 @@ convertExpr env0 e = do
     go env (VarIs "fromString") (LExpr x : args)
         = fmap (, args) $ convertExpr env x
     go env (VarIs "unpackCString#") (LExpr (Lit (LitString x)) : args)
-        = fmap (, args) $ pure $ EBuiltin $ BEText $ decodeLitStringLatin1 x
+        = fmap (, args) $ pure $ EBuiltin $ BEText $ unpackCString x
     go env (VarIs "unpackCStringUtf8#") (LExpr (Lit (LitString x)) : args)
-        = fmap (, args) $ pure $ EBuiltin $ BEText $ decodeLitStringUtf8 x
+        = fmap (, args) $ pure $ EBuiltin $ BEText $ unpackCStringUtf8 x
     go env x@(Var f) (LType t1 : LType t2 : LExpr (untick -> Lit (LitString s)) : args)
         | Just m <- nameModule_maybe (getName f)
         , moduleNameString (GHC.moduleName m) == "Control.Exception.Base"
@@ -655,7 +655,7 @@ convertExpr env0 e = do
         x' <- convertExpr env x
         t1' <- convertType env t1
         t2' <- convertType env t2
-        pure (x' `ETyApp` t1' `ETyApp` t2' `ETmApp` EBuiltin (BEText (decodeLitStringUtf8 s)))
+        pure (x' `ETyApp` t1' `ETyApp` t2' `ETmApp` EBuiltin (BEText (unpackCStringUtf8 s)))
 
     -- conversion of bodies of $con2tag functions
     go env (VarIs "getTag") (LType (TypeCon t _) : LExpr x : args) = fmap (, args) $ do

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -104,7 +104,6 @@ import qualified Data.NameMap as NM
 import qualified Data.Set as Set
 import           Data.Tagged
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import           Data.Tuple.Extra
 import           Data.Ratio
 import           "ghc-lib" GHC
@@ -646,9 +645,9 @@ convertExpr env0 e = do
     go env (VarIs "fromString") (LExpr x : args)
         = fmap (, args) $ convertExpr env x
     go env (VarIs "unpackCString#") (LExpr (Lit (LitString x)) : args)
-        = fmap (, args) $ pure $ EBuiltin $ BEText $ T.decodeLatin1 x
+        = fmap (, args) $ pure $ EBuiltin $ BEText $ decodeLitStringLatin1 x
     go env (VarIs "unpackCStringUtf8#") (LExpr (Lit (LitString x)) : args)
-        = fmap (, args) $ pure $ EBuiltin $ BEText $ T.decodeUtf8 x
+        = fmap (, args) $ pure $ EBuiltin $ BEText $ decodeLitStringUtf8 x
     go env x@(Var f) (LType t1 : LType t2 : LExpr (untick -> Lit (LitString s)) : args)
         | Just m <- nameModule_maybe (getName f)
         , moduleNameString (GHC.moduleName m) == "Control.Exception.Base"
@@ -656,7 +655,7 @@ convertExpr env0 e = do
         x' <- convertExpr env x
         t1' <- convertType env t1
         t2' <- convertType env t2
-        pure (x' `ETyApp` t1' `ETyApp` t2' `ETmApp` EBuiltin (BEText (T.decodeUtf8 s)))
+        pure (x' `ETyApp` t1' `ETyApp` t2' `ETmApp` EBuiltin (BEText (decodeLitStringUtf8 s)))
 
     -- conversion of bodies of $con2tag functions
     go env (VarIs "getTag") (LType (TypeCon t _) : LExpr x : args) = fmap (, args) $ do

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -23,6 +23,9 @@ import           Data.Generics.Uniplate.Data
 import           Data.List
 import qualified Data.Set as Set
 import           Data.Tuple.Extra
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 ----------------------------------------------------------------------
 -- GHC utility functions
@@ -101,3 +104,10 @@ pattern LType x <- (_, Type x)
 
 pattern LExpr :: GHC.Expr b -> LArg b
 pattern LExpr x <- (_, x)
+
+
+decodeLitStringLatin1 :: BS.ByteString -> T.Text
+decodeLitStringLatin1 = T.decodeLatin1
+
+decodeLitStringUtf8 :: BS.ByteString -> T.Text
+decodeLitStringUtf8 = T.decodeUtf8

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -106,8 +106,8 @@ pattern LExpr :: GHC.Expr b -> LArg b
 pattern LExpr x <- (_, x)
 
 
-decodeLitStringLatin1 :: BS.ByteString -> T.Text
-decodeLitStringLatin1 = T.decodeLatin1
+unpackCString :: BS.ByteString -> T.Text
+unpackCString = T.decodeLatin1
 
-decodeLitStringUtf8 :: BS.ByteString -> T.Text
-decodeLitStringUtf8 = T.decodeUtf8
+unpackCStringUtf8 :: BS.ByteString -> T.Text
+unpackCStringUtf8 = T.decodeUtf8

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -25,7 +25,6 @@ import           Data.List
 import qualified Data.Set as Set
 import           Data.Tuple.Extra
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Unsafe as BS
 import qualified Data.Text as T
 import Control.Exception
 import GHC.Ptr(Ptr(..))
@@ -124,5 +123,5 @@ unpackCString = unpackCStringUtf8
 unpackCStringUtf8 :: BS.ByteString -> T.Text
 -- A "safe" unsafePerformIO since we copy into a strict result Text string
 unpackCStringUtf8 bs = unsafePerformIO $
-    BS.unsafeUseAsCString (bs <> BS.singleton 0) $ \(Ptr a) -> do
+    BS.useAsCString bs $ \(Ptr a) -> do
         evaluate $ T.unpackCString# a

--- a/daml-foundations/daml-ghc/tests/Text.daml
+++ b/daml-foundations/daml-ghc/tests/Text.daml
@@ -252,3 +252,6 @@ testParseDecimal = scenario do
   Some 10.0 === parseDecimal "0010"
   Some 1.0 === parseDecimal "01.00"
 
+testReverse = scenario do
+  T.reverse "DAML" === "LMAD"
+

--- a/daml-foundations/daml-ghc/tests/Text.daml
+++ b/daml-foundations/daml-ghc/tests/Text.daml
@@ -252,39 +252,3 @@ testParseDecimal = scenario do
   Some 10.0 === parseDecimal "0010"
   Some 1.0 === parseDecimal "01.00"
 
-main = scenario do
-    testExplode
-    testImplode
-    testLength
-    testTrim
-    testReplace
-    testLines
-    testUnlines
-    testWords
-    testUnwords
-    testLinesBy
-    testWordsBy
-    testIntercalate
-    testDropPrefix
-    testDropSuffix
-    testStripSuffix
-    testStripPrefix
-    testIsPrefixOf
-    testIsSuffixOf
-    testIsInfixOf
-    testTakeWhile
-    testTakeWhileEnd
-    testDropWhile
-    testDropWhileEnd
-    testSplitOn
-    testTake
-    testDrop
-    testSubstring
-    testIsSpace
-    testIsNewLine
-    testIsUpper
-    testIsLower
-    testIsDigit
-    testIsAlphaNum
-    testParseInt
-    testParseDecimal

--- a/daml-foundations/daml-ghc/tests/Text.daml
+++ b/daml-foundations/daml-ghc/tests/Text.daml
@@ -22,10 +22,10 @@ testLength = scenario do
   1 === T.length "a"
   3 === T.length "abc"
 
-testTrim =
+testTrim = scenario do
     assert $  trim "  digital asset  " == "digital asset"
 
-testReplace = do
+testReplace = scenario do
     assert $ replace "el" "_" "Hello Bella" == "H_lo B_la"
     assert $ replace "el" "e" "Hello"       == "Helo"
 
@@ -47,7 +47,7 @@ testUnwords = scenario do
   unwords [] === ""
   unwords ["one", "two"] === "one two"
 
-testLinesBy = do
+testLinesBy = scenario do
     assert $ linesBy (== "a") "aabbaca"  == ["","","bb","c"]
     assert $ linesBy (== "a") "aabbacaa" == ["","","bb","c",""]
     assert $ linesBy (== "a") ""         == []
@@ -55,7 +55,7 @@ testLinesBy = do
     assert $ linesBy (== ":") "::xyz:abc::123::" == ["","","xyz","abc","","123",""]
     assert $ linesBy (== ",") "my,list,here" == ["my","list","here"]
 
-testWordsBy = do
+testWordsBy = scenario do
     assert $ wordsBy (== "a") "aabbaca"  == ["bb","c"]
     assert $ wordsBy (== "a") "aabbacaa" == ["bb","c"]
     assert $ wordsBy (== "a") ""         == []
@@ -69,21 +69,21 @@ testIntercalate = scenario do
   ", 2, " === intercalate ", " ["", "2", ""]
   "" === intercalate ", " []
 
-testDropPrefix = do
+testDropPrefix = scenario do
     assert $ dropPrefix "Mr. " "Mr. Men" == "Men"
     assert $ dropPrefix "Mr. " "Dr. Men" == "Dr. Men"
 
-testDropSuffix = do
+testDropSuffix = scenario do
     assert $ dropSuffix "!" "Hello World!"  == "Hello World"
     assert $ dropSuffix "!" "Hello World!!" == "Hello World!"
     assert $ dropSuffix "!" "Hello World."  == "Hello World."
 
-testStripSuffix = do
+testStripSuffix = scenario do
     assert $ stripSuffix "bar" "foobar" == Some "foo"
     assert $ stripSuffix ""    "baz"    == Some "baz"
     assert $ stripSuffix "foo" "quux"   == None
 
-testStripPrefix = do
+testStripPrefix = scenario do
     assert $ stripPrefix "foo" "foobar" == Some "bar"
     assert $ stripPrefix ""    "baz"    == Some "baz"
     assert $ stripPrefix "foo" "quux"   == None

--- a/daml-foundations/daml-ghc/tests/Text.daml
+++ b/daml-foundations/daml-ghc/tests/Text.daml
@@ -255,3 +255,13 @@ testParseDecimal = scenario do
 testReverse = scenario do
   T.reverse "DAML" === "LMAD"
 
+testNuls = scenario do
+  "\0" === "\0"
+  "£" === "£"
+  "£\0" === "£\0"
+  "\0DAML" === "\0DAML"
+  "DA\0ML" === "DA\0ML"
+  T.reverse "DA\0⛄ML" === "LM⛄\0AD"
+  T.reverse "\0\1\2\3" === "\3\2\1\0"
+  parseInt (T.drop 1 "\0\&123") === Some 123
+  T.splitOn "\0" "Hello\0World" === ["Hello","World"]


### PR DESCRIPTION
Before, given: `ideError = "\0"`
That gave: `Cannot decode byte '\xc0': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream`

Now it works. I also added Text.reverse because its useful, and was useful to test it.