### PR TITLE
Move out classes from participant-state package object

### DIFF
--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -279,7 +279,7 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
       override def getLedgerEnd(): Offset = ledgerEnd
 
       override def compare(o1: Offset, o2: Offset): Int =
-        Offset.compare(o1, o2)
+        o1.compare(o2)
     }
   }
 

--- a/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/IndexState.scala
+++ b/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/IndexState.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.participant.state.index.v1.impl.reference
 
 import com.daml.ledger.participant.state.v1._
+import com.daml.ledger.participant.state.v1.Offset
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.data.Time.Timestamp

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.platform.services.time.TimeModel
+
+/** Ledger configuration describing the ledger's time model.
+  * Emitted in [[com.daml.ledger.participant.state.v1.Update.ConfigurationChanged]].
+  */
+final case class Configuration(
+    /** The time model of the ledger. Specifying the time-to-live bounds for Ledger API commands. */
+    timeModel: TimeModel
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/LedgerInitialConditions.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/LedgerInitialConditions.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** The initial conditions of the ledger before anything has been committed.
+  *
+  * @param ledgerId: The static ledger identifier.
+  * @param initialRecordTime: The initial record time prior to any [[Update]] event.
+  */
+final case class LedgerInitialConditions(
+    ledgerId: LedgerId,
+    initialRecordTime: Timestamp
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+/** Offsets into streams with hierarchical addressing.
+  *
+  * We use these [[Offset]]'s to address changes to the participant state.
+  * We allow for array of [[Int]] to allow for hierarchical addresses.
+  * These [[Int]] values are expected to be positive. Offsets are ordered by
+  * lexicographic ordering of the array elements.
+  *
+  * A typical use case for [[Offset]]s would be addressing a transaction in a
+  * blockchain by `[<blockheight>, <transactionId>]`. Depending on the
+  * structure of the underlying ledger these offsets are more or less
+  * nested, which is why we use an array of [[Int]]s. The expectation is
+  * though that there usually are few elements in the array.
+  *
+  */
+final case class Offset(private val xs: Array[Long]) extends Ordered[Offset] {
+  override def toString: String =
+    components.mkString("-")
+
+  def components: Iterable[Long] = xs
+
+  override def equals(that: Any): Boolean = that match {
+    case o: Offset => this.compare(o) == 0
+    case _ => false
+  }
+
+  override def compare(that: Offset): Int =
+    scala.math.Ordering.Iterable[Long].compare(this.xs.toIterable, that.xs.toIterable)
+}
+
+object Offset {
+
+  /** Create an offset from a string of form 1-2-3. Throws
+    * NumberFormatException on misformatted strings.
+    */
+  def assertFromString(s: String): Offset =
+    Offset(s.split('-').map(_.toLong))
+
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** Information provided by the submitter of changes submitted to the ledger.
+  *
+  * Note that this is used for party-originating changes only. They are
+  * usually issued via the Ledger API.
+  *
+  * @param submitter: the party that submitted the change.
+  *
+  * @param applicationId: an identifier for the DAML application that
+  *   submitted the command. This is used for monitoring and to allow DAML
+  *   applications subscribe to their own submissions only.
+  *
+  * @param commandId: a submitter provided identifier that he can use to
+  *   correlate the stream of changes to the participant state with the
+  *   changes he submitted.
+  *
+  * @param maxRecordTime: the maximum record time (inclusive) until which
+  *   the submitted change can be validly added to the ledger. This is used
+  *   by DAML applications to deduce from the record time reported by the
+  *   ledger whether a change that they submitted has been lost in transit.
+  *
+  */
+final case class SubmitterInfo(
+    submitter: Party,
+    applicationId: ApplicationId,
+    commandId: CommandId,
+    maxRecordTime: Timestamp,
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** Meta-data of a transaction visible to all parties that can see a part of
+  * the transaction.
+  *
+  * @param ledgerEffectiveTime: the submitter-provided time at which the
+  *   transaction should be interpreted. This is the time returned by the
+  *   DAML interpreter on a `getTime :: Update Time` call. See the docs on
+  *   [[WriteService.submitTransaction]] for how it relates to the notion of
+  *   `recordTime`.
+  *
+  * @param workflowId: a submitter-provided identifier used for monitoring
+  *   and to traffic-shape the work handled by DAML applications
+  *   communicating over the ledger.
+  *
+  */
+final case class TransactionMeta(ledgerEffectiveTime: Timestamp, workflowId: WorkflowId)


### PR DESCRIPTION
Having the classes specified in the package object makes the
unusable from Java.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
