### PR TITLE
Simplify daml new template release process and add a simpler default template.

### DIFF
--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -39,7 +39,7 @@ commandParser =
               [ ListTemplates <$ flag' () (long "list" <> help "List the available project templates.")
               , New
                   <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
-                  <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: quickstart-java)" <> value "quickstart-java")
+                  <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: skeleton)" <> value "skeleton")
               ]
           startCmd = pure Start
           readReplacement :: ReadM ReplaceExtension

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -58,7 +58,7 @@ tests tmpDir = testGroup "Integration tests"
 quickstartTests :: FilePath -> FilePath -> TestTree
 quickstartTests quickstartDir mvnDir = testGroup "quickstart"
     [ testCase "daml new" $
-          callProcessQuiet "daml" ["new", quickstartDir]
+          callProcessQuiet "daml" ["new", quickstartDir, "quickstart-java"]
     , testCase "daml build " $ withCurrentDirectory quickstartDir $
           callProcessQuiet "daml" ["build", "-o", "target/daml/iou.dar"]
     , testCase "daml damlc test" $ withCurrentDirectory quickstartDir $

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -86,7 +86,7 @@ genrule(
         "//ledger/sandbox:sandbox-binary_deploy.jar",
         "//navigator/backend:navigator-binary_deploy.jar",
         "//extractor:extractor-binary_deploy.jar",
-        "//docs:quickstart-java.tar.gz",
+        "//templates:templates-tarball.tar.gz",
     ],
     outs = ["sdk-release-tarball.tar.gz"],
     cmd = """
@@ -121,28 +121,8 @@ genrule(
       mkdir -p $$OUT/extractor
       cp $(location //extractor:extractor-binary_deploy.jar) $$OUT/extractor/extractor.jar
 
-      mkdir -p $$OUT/templates/quickstart-java
-      tar xf $(location //docs:quickstart-java.tar.gz) --strip-components=1 -C $$OUT/templates/quickstart-java
-      # While we use this template for both da-assistant and daml-assistant we do some manual patching here.
-      # Once da-assistant is dead, the quickstart-java rule should produce the final version.
-      rm $$OUT/templates/quickstart-java/da-skeleton.yaml
-      cat > $$OUT/templates/quickstart-java/daml.yaml.template << EOF
-sdk-version: __VERSION__
-name: __PROJECT_NAME__
-source: daml/Main.daml
-scenario: Main:setup
-parties:
-  - Alice
-  - Bob
-  - USD_Bank
-  - EUR_Bank
-version: 1.0.0
-exposed-modules:
-  - Main
-dependencies:
-  - daml-prim
-  - daml-stdlib
-EOF
+      mkdir -p $$OUT/templates
+      tar xf $(location //templates:templates-tarball.tar.gz) --strip-components=1 -C $$OUT/templates
 
       tar zcf $(location sdk-release-tarball.tar.gz) --format=ustar $$OUT
     """,

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -12,7 +12,7 @@ genrule(
 
         # skeleton template
         mkdir -p $$OUT/skeleton
-        cp -r $$SRC/skeleton/* $$OUT/skeleton/
+        cp -rL $$SRC/skeleton/* $$OUT/skeleton/
 
         # quickstart-java template
         # right now, uses the preexisting quickstart-java rule and replaces the da.yaml template with a daml.yaml template

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -4,15 +4,25 @@
 
 genrule(
     name = "templates-tarball",
-    srcs = glob(["skeleton/**"]),
+    srcs = glob(["skeleton/**", 'quickstart-java/**']) + ["//docs:quickstart-java.tar.gz"],
     outs = ["templates-tarball.tar.gz"],
     cmd = """
-        mkdir -p templates-tarball/skeleton
-        cp -r templates/skeleton/* templates-tarball/skeleton
+        SRC=templates
+        OUT=templates-tarball
+
+        # skeleton template
+        mkdir -p $$OUT/skeleton
+        cp -r $$SRC/skeleton/* $$OUT/skeleton/
+
+        # quickstart-java template
+        # right now, uses the preexisting quickstart-java rule and replaces the da.yaml template with a daml.yaml template
+        # in the future, move everything into //templates/quickstart-java and avoid untar, rm here
+        mkdir -p $$OUT/quickstart-java
+        tar xf $(location //docs:quickstart-java.tar.gz) --strip-components=1 -C $$OUT/quickstart-java
+        rm $$OUT/quickstart-java/da-skeleton.yaml
+        cp $$SRC/quickstart-java/* $$OUT/quickstart-java/
+
         tar zcf $(location :templates-tarball.tar.gz) templates-tarball
     """,
     visibility = ["//visibility:public"],
 )
-
-
-

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -20,7 +20,7 @@ genrule(
         mkdir -p $$OUT/quickstart-java
         tar xf $(location //docs:quickstart-java.tar.gz) --strip-components=1 -C $$OUT/quickstart-java
         rm $$OUT/quickstart-java/da-skeleton.yaml
-        cp $$SRC/quickstart-java/* $$OUT/quickstart-java/
+        cp -rL $$SRC/quickstart-java/* $$OUT/quickstart-java/
 
         tar zcf $(location :templates-tarball.tar.gz) templates-tarball
     """,

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -1,0 +1,18 @@
+
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+genrule(
+    name = "templates-tarball",
+    srcs = glob(["skeleton/**"]),
+    outs = ["templates-tarball.tar.gz"],
+    cmd = """
+        mkdir -p templates-tarball/skeleton
+        cp -r templates/skeleton/* templates-tarball/skeleton
+        tar zcf $(location :templates-tarball.tar.gz) templates-tarball
+    """,
+    visibility = ["//visibility:public"],
+)
+
+
+

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -1,10 +1,12 @@
-
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 genrule(
     name = "templates-tarball",
-    srcs = glob(["skeleton/**", 'quickstart-java/**']) + ["//docs:quickstart-java.tar.gz"],
+    srcs = glob([
+        "skeleton/**",
+        "quickstart-java/**",
+    ]) + ["//docs:quickstart-java.tar.gz"],
     outs = ["templates-tarball.tar.gz"],
     cmd = """
         SRC=templates

--- a/templates/quickstart-java/daml.yaml.template
+++ b/templates/quickstart-java/daml.yaml.template
@@ -1,0 +1,15 @@
+sdk-version: __VERSION__
+name: __PROJECT_NAME__
+source: daml/Main.daml
+scenario: Main:setup
+parties:
+  - Alice
+  - Bob
+  - USD_Bank
+  - EUR_Bank
+version: 1.0.0
+exposed-modules:
+  - Main
+dependencies:
+  - daml-prim
+  - daml-stdlib

--- a/templates/skeleton/daml.yaml.template
+++ b/templates/skeleton/daml.yaml.template
@@ -1,0 +1,13 @@
+sdk-version: __VERSION__
+name: __PROJECT_NAME__
+source: daml/Main.daml
+scenario: Main:setup
+parties:
+  - Alice
+  - Bob
+version: 1.0.0
+exposed-modules:
+  - Main
+dependencies:
+  - daml-prim
+  - daml-stdlib

--- a/templates/skeleton/daml/Main.daml
+++ b/templates/skeleton/daml/Main.daml
@@ -1,0 +1,39 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module Main where
+
+type AssetId = ContractId Asset
+
+template Asset
+  with
+    issuer : Party
+    owner  : Party
+    name   : Text
+  where
+    ensure name /= ""
+    signatory issuer
+    controller owner can
+      Give : AssetId
+        with
+          newOwner : Party
+        do
+          create this with
+            owner = newOwner
+
+setup = scenario do
+  alice <- getParty "Alice"
+  bob <- getParty "Bob"
+
+  aliceTV <- submit alice do
+    create Asset with
+      issuer = alice
+      owner = alice
+      name = "TV"
+
+  bobTV <- submit alice do
+    exercise aliceTV Give with newOwner = bob
+
+  submit bob do
+    exercise bobTV Give with newOwner = alice


### PR DESCRIPTION
Simplify the release process for `daml new` templates. The way it works now is you just have to add it to the `//templates:templates-tarball.tar.gz` rule. For adding a new template, just create a new folder in that tarball. (Preferably with a simple rule, like the one for quickstart-java). This templates tarball then gets incorporated into the SDK release tarball.

I wrote the daml example in the new template (`templates/skeleton/daml/Main.daml`), so ... no guarantees it's a particularly good example. I would appreciate a better example, but the key is to keep it very simple. This is only meant to act as a "reminder" -- new users will be directed to use the `quickstart-java` template instead, and go through the quickstart tutorial.