### PR TITLE
Pass project path as argument to vs code in daml studio.

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -90,7 +90,6 @@ runDamlStudio replaceExt remainingArguments = do
     projectPathM <- getProjectPath
     let codeCommand
             | isMac = "open -a \"Visual Studio Code\""
-            | isWindows = "cmd /C code"
             | otherwise = "code"
         path = fromMaybe "." projectPathM
         command = unwords $ codeCommand : path : remainingArguments

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -87,10 +87,14 @@ runDamlStudio replaceExt remainingArguments = do
     installExtension vscodeExtensionSrcDir vscodeExtensionTargetDir
     -- Note that it is important that we use `shell` rather than `proc` here as
     -- `proc` will look for `code.exe` in PATH which does not exist.
+    projectPathM <- getProjectPath
     let codeCommand
             | isMac = "open -a \"Visual Studio Code\""
+            | isWindows = "cmd /C code"
             | otherwise = "code"
-    exitCode <- withCreateProcess (shell $ unwords $ codeCommand : remainingArguments) $ \_ _ _ -> waitForProcess
+        path = fromMaybe "." projectPathM
+        command = unwords $ codeCommand : path : remainingArguments
+    exitCode <- withCreateProcess (shell command) $ \_ _ _ -> waitForProcess
     exitWith exitCode
 
 shouldReplaceExtension :: ReplaceExtension -> FilePath -> IO Bool


### PR DESCRIPTION
This causes vs code to open in the current project (or in the cwd if outside of a project). This is what the da assistant used to do.

@cocreature can you check if this works as expected on Windows, especially outside of a project?