### PR TITLE
Disable version nagging and avoid looking at unnecessary information in daml install.

### DIFF
--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -21,7 +21,6 @@ import System.Exit
 import System.IO
 import Control.Exception.Safe
 import Data.Maybe
-import Data.List.Extra
 import Control.Monad.Extra
 
 -- | Run the assistant and exit.

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -28,7 +28,7 @@ import Control.Monad.Extra
 main :: IO ()
 main = displayErrors $ do
     rawArgs <- getArgs
-    let isInstall = notNull rawArgs && head rawArgs == "install"
+    let isInstall = listToMaybe rawArgs == Just "install"
     env@Env{..} <- if isInstall then getMinimalDamlEnv else getDamlEnv
     sdkConfigM <- mapM readSdkConfig envSdkPath
     sdkCommandsM <- mapM (fromRightM throwIO . listSdkCommands) sdkConfigM

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = displayErrors $ do
     rawArgs <- getArgs
     let isInstall = notNull rawArgs && head rawArgs == "install"
-    env@Env{..} <- getDamlEnv
+    env@Env{..} <- if isInstall then getMinimalDamlEnv else getDamlEnv
     sdkConfigM <- mapM readSdkConfig envSdkPath
     sdkCommandsM <- mapM (fromRightM throwIO . listSdkCommands) sdkConfigM
     userCommand <- getCommand (fromMaybe [] sdkCommandsM)
@@ -42,7 +42,7 @@ main = displayErrors $ do
                 Just latestVersion
 
         -- Project SDK version is outdated.
-        when (not isHead && not isInstall && projectSdkVersionIsOld) $ do
+        when (not isHead && projectSdkVersionIsOld) $ do
             hPutStrLn stderr . unlines $
                 [ "WARNING: Using an outdated version of the DAML SDK in project."
                 , ""
@@ -55,7 +55,7 @@ main = displayErrors $ do
                 ]
 
         -- DAML assistant is outdated.
-        when (not isHead && not isInstall && not projectSdkVersionIsOld && assistantVersionIsOld) $ do
+        when (not isHead && not projectSdkVersionIsOld && assistantVersionIsOld) $ do
             hPutStrLn stderr . unlines $
                 [ "WARNING: Using an outdated version of the DAML assistant."
                 , ""

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -9,6 +9,7 @@ module DAML.Assistant.Env
     , ProjectPath (..)
     , SdkPath (..)
     , SdkVersion (..)
+    , getMinimalDamlEnv
     , getDamlEnv
     , testDamlEnv
     , getDamlPath
@@ -34,7 +35,19 @@ import Data.Maybe
 import Data.Either.Extra
 import Safe
 
--- | Calculate the environment variables in which to run daml-something.
+-- | Get a minimal environment in which to run daml install.
+getMinimalDamlEnv :: IO Env
+getMinimalDamlEnv = do
+    envDamlPath <- getDamlPath
+    envDamlAssistantPath <- getDamlAssistantPath envDamlPath
+    let envDamlAssistantSdkVersion = Nothing
+        envProjectPath = Nothing
+        envSdkVersion = Nothing
+        envSdkPath = Nothing
+        envLatestStableSdkVersion = Nothing
+    pure Env {..}
+
+-- | Calculate the environment variables in which to run daml commands.
 getDamlEnv :: IO Env
 getDamlEnv = do
     envDamlPath <- getDamlPath


### PR DESCRIPTION
- Don't display "please install" messages when already running daml install.
    - In particular this prevents daml-sdk-head, get-daml.sh, and install.sh from getting these messages.
- Don't fetch unnecessary project & sdk information when running daml install
    - In particular this would have prevented daml install from failing prematurely in some cases
    - This prevents daml install from auto-installing another SDK version!
    - Additionally, this prevents the creation of a cache for storing the latest sdk version before daml is installed -- which wasn't really a problem but would have been pretty unintuitive behavior.
