### PR TITLE
Make the time between new version checks configurable.

### DIFF
--- a/daml-assistant/daml-project-config/DAML/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Consts.hs
@@ -6,6 +6,7 @@ module DAML.Project.Consts
     , projectPathEnvVar
     , sdkPathEnvVar
     , sdkVersionEnvVar
+    , sdkVersionLatestEnvVar
     , damlAssistantEnvVar
     , damlAssistantVersionEnvVar
     , damlConfigName
@@ -55,6 +56,12 @@ sdkPathEnvVar = "DAML_SDK"
 -- 3. the latest stable SDK version available in $DAML_HOME/sdk.
 sdkVersionEnvVar :: String
 sdkVersionEnvVar = "DAML_SDK_VERSION"
+
+-- | Latest stable version available from GitHub. Note that this is
+-- updated based on the update-check property in the user's daml-config.yaml
+-- file, which means it will possibly never be available.
+sdkVersionLatestEnvVar :: String
+sdkVersionLatestEnvVar = "DAML_SDK_VERSION_LATEST"
 
 -- | The absolute path to the daml assistant executable.
 damlAssistantEnvVar :: String

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -221,6 +221,7 @@ getDispatchEnv Env{..} = do
            , (projectPathEnvVar, maybe "" unwrapProjectPath envProjectPath)
            , (sdkPathEnvVar, maybe "" unwrapSdkPath envSdkPath)
            , (sdkVersionEnvVar, maybe "" versionToString envSdkVersion)
+           , (sdkVersionLatestEnvVar, maybe "" versionToString envLatestStableSdkVersion)
            , (damlAssistantEnvVar, unwrapDamlAssistantPath envDamlAssistantPath)
            , (damlAssistantVersionEnvVar, maybe ""
                (versionToString . unwrapDamlAssistantSdkVersion)

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -37,7 +37,10 @@ tar xzf $TARBALL -C $TMPDIR/sdk-head --strip-components 1
 DAML_HOME=$DAML_HEAD $TMPDIR/sdk-head/install.sh
 mv $DAML_HEAD/bin/{daml,daml-head}
 
-echo "auto-install: false" > $DAML_HEAD/daml-config.yaml
+cat > $DAML_HEAD/daml-config.yaml << EOF
+auto-install: false
+update-check: never
+EOF
 
 trap - EXIT
 echo "$(tput setaf 3)Successfully installed daml-head command.$(tput sgr 0)"


### PR DESCRIPTION
As already documented in the new assistant docs, the time between version checks is now configurable by using the `update-check: SECONDS` option in daml-config.yaml, with the special case `update-check: never` to avoid such checks entirely. The default is to perform the check once per day (i.e. every 86400 seconds).