### PR TITLE
Add DA.Experimental.Set data type based on DA.TextMap

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
@@ -100,6 +100,9 @@ intersection s1 s2 = filter (`member` s2) s1
 difference : MapKey a => Set a -> Set a -> Set a
 difference s1 s2 = filter (\x -> not (x `member` s2)) s1
 
+instance (MapKey a, Show a) => Show (Set a) where
+  show s = "Set " <> show (toList s)
+
 instance IsParties (Set Party) where
   toParties = toList
 

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
@@ -1,0 +1,97 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+-- | Set - The `Set a` type represents a set of elements of type
+-- `a`. Most operations require that `a` be an instance of the `MapKey`
+-- type class.
+module DA.Experimental.Set
+  ( Set
+  , empty
+  , size
+  , toList
+  , fromList
+  , member
+  , null
+  , insert
+  , filter
+  , delete
+  , singleton
+  , union
+  , intersection
+  , difference
+  )
+where
+
+import Prelude hiding (filter, null, empty)
+import DA.Experimental.Map (MapKey (..))
+import DA.TextMap qualified as TextMap
+
+-- | The type of a set.
+newtype Set a = Set with textMap : TextMap ()
+  deriving (Eq, Ord)
+
+-- | The empty set.
+empty : MapKey a => Set a
+empty = Set TextMap.empty
+
+-- | The number of elements in the set.
+size : Set a -> Int
+size (Set t) = TextMap.size t
+
+-- | Convert the set to a list of elements.
+toList : MapKey a => Set a -> [a]
+toList (Set t) = map (keyFromText . fst) $ TextMap.toList t
+
+-- | Create a set from a list of elements.
+fromList : MapKey a => [a] -> Set a
+fromList xs = Set $ TextMap.fromList $ map (\x -> (keyToText x, ())) xs
+
+-- | Is the element in the set?
+member : MapKey a => a -> Set a -> Bool
+member x (Set t) = TextMap.member (keyToText x) t
+
+-- | Is this the empty set?
+null : Set a -> Bool
+null (Set t) = TextMap.null t
+
+-- | Insert an element in a set. If the set already contains an
+-- element equal to the given value, it is replaced with the new
+-- value.
+insert : MapKey a => a -> Set a -> Set a
+insert x (Set t) = Set $ TextMap.insert (keyToText x) () t
+
+-- | Filter all elements that satisfy the predicate.
+filter : MapKey a => (a -> Bool) -> Set a -> Set a
+filter p (Set t) = Set $ TextMap.filterWithKey (\x () -> p (keyFromText x)) t
+
+-- | Delete an element from a set.
+delete : MapKey a => a -> Set a -> Set a
+delete x (Set t) = Set $ TextMap.delete (keyToText x) t
+
+-- | Create a singleton set.
+singleton : MapKey a => a -> Set a
+singleton x = insert x empty
+
+-- | The union of two sets, preferring the first set when equal
+-- elements are encountered.
+union : MapKey a => Set a -> Set a -> Set a
+union (Set t1) (Set t2) = Set $ TextMap.union t1 t2
+
+-- | The intersection of two sets. Elements of the result come from
+-- the first set.
+intersection : MapKey a => Set a -> Set a -> Set a
+intersection s1 s2 = filter (`member` s2) s1
+
+-- | Difference of two sets.
+difference : MapKey a => Set a -> Set a -> Set a
+difference s1 s2 = filter (\x -> not (x `member` s2)) s1
+
+instance IsParties (Set Party) where
+  toParties = toList
+
+instance MapKey a => Semigroup (Set a) where
+  (<>) = union
+
+instance MapKey a => Monoid (Set a) where
+  mempty = empty

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
@@ -11,6 +11,8 @@ module DA.Experimental.Set
   , size
   , toList
   , fromList
+  , toTextMap
+  , fromTextMap
   , member
   , null
   , insert
@@ -46,6 +48,14 @@ toList (Set t) = map (keyFromText . fst) $ TextMap.toList t
 -- | Create a set from a list of elements.
 fromList : MapKey a => [a] -> Set a
 fromList xs = Set $ TextMap.fromList $ map (\x -> (keyToText x, ())) xs
+
+-- | Convert a `Set` into a `TextMap`.
+toTextMap : Set Text -> TextMap ()
+toTextMap (Set t) = t
+
+-- | Create a `Set` from a `TextMap`.
+fromTextMap : TextMap () -> Set Text
+fromTextMap = Set
 
 -- | Is the element in the set?
 member : MapKey a => a -> Set a -> Bool

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Experimental/Set.daml
@@ -32,6 +32,9 @@ import DA.TextMap qualified as TextMap
 -- | The type of a set.
 newtype Set a = Set with textMap : TextMap ()
   deriving (Eq, Ord)
+-- NOTE(MH): This is not a newtype wrapper around the `Map` type such that
+-- people using `Set` over the Ledger API don't have to wrap every set into
+-- two layers of newtypes.
 
 -- | The empty set.
 empty : MapKey a => Set a

--- a/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
@@ -14,6 +14,7 @@ import DA.Bifunctor
 import DA.Date
 import DA.Either
 import DA.Experimental.Map
+import DA.Experimental.Set
 import DA.Foldable
 import DA.Functor
 import DA.HKTemplate


### PR DESCRIPTION
`DA.Experimental` provides a set data type with the same API as `DA.Set`,
modulo `MapKey` vs `Ord` constraints. The type is intensionally not a
newtype wrapper around `DA.Experimental.Map` to avoid that consumers of the
Ledger API have to wrap all sets into two layers of newtypes.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/860)
<!-- Reviewable:end -->
