### PR TITLE
Drop DAML-LF 1.0 support from compiler

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -20,10 +20,6 @@ data Version
 data MinorVersion = PointStable Int | PointDev
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
--- | DAML-LF version 1.0.
-version1_0 :: Version
-version1_0 = V1 $ PointStable 0
-
 -- | DAML-LF version 1.1.
 version1_1 :: Version
 version1_1 = V1 $ PointStable 1
@@ -62,7 +58,7 @@ minorFromCliOption = \case
   _ -> Nothing
 
 supportedInputVersions :: [Version]
-supportedInputVersions = [version1_0, version1_1, version1_2, version1_3]
+supportedInputVersions = [version1_1, version1_2, version1_3]
 
 supportedOutputVersions :: [Version]
 supportedOutputVersions = supportedInputVersions
@@ -73,17 +69,8 @@ data Feature = Feature
     , featureMinVersion :: !Version
     }
 
-featureOptional :: Feature
-featureOptional = Feature "Optional type" version1_1
-
 featureTextMap :: Feature
 featureTextMap = Feature "Map type" version1_3
-
-featurePartyOrd :: Feature
-featurePartyOrd = Feature "Party comparison" version1_1
-
-featureArrowType :: Feature
-featureArrowType = Feature "Arrow type" version1_1
 
 featureSha256Text :: Feature
 featureSha256Text = Feature "sha256 function" version1_2

--- a/daml-foundations/daml-ghc/package-database/BUILD.bazel
+++ b/daml-foundations/daml-ghc/package-database/BUILD.bazel
@@ -14,7 +14,6 @@ load(
 )
 
 DAML_LF_VERSIONS = [
-    "1.0",
     "1.1",
     "1.2",
     "1.3",
@@ -81,7 +80,7 @@ genrule(
     outs = ["daml-prim.dar"],
     cmd = """
     $(location //daml-foundations/daml-tools/da-hs-damlc-app) \
-      package daml-foundations/daml-ghc/daml-prim-src/LibraryModules.daml daml-prim --target 1.0 -o $(location daml-prim.dar)
+      package daml-foundations/daml-ghc/daml-prim-src/LibraryModules.daml daml-prim --target 1.1 -o $(location daml-prim.dar)
   """,
     tools = ["//daml-foundations/daml-tools/da-hs-damlc-app"],
     visibility = ["//visibility:public"],

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,8 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- Drop support for DAML-LF 1.0 from compiler
+
 0.12.13 - 2019-05-02
 --------------------
 

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -104,7 +104,6 @@ pom_file(
 )
 
 daml_lf_target_versions = [
-    "1.0",
     "1.1",
     "1.3",
 ]


### PR DESCRIPTION
This will enable us to add `Functor`, `Applicative` and `Monad` instances
for `(->) r` in the `daml-stdlib`. We'll do this in a separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/863)
<!-- Reviewable:end -->
