### PR TITLE
Update urllib version to avoid security vulns warning

### DIFF
--- a/docs/scripts/Pipfile
+++ b/docs/scripts/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 sphinx-autobuild = "*"
 sphinx = "*"
 jinja2 = ">=2.10.1"
+urllib3 = ">=1.24.2"
 
 [requires]
 python_version = "3.6"

--- a/docs/scripts/Pipfile.lock
+++ b/docs/scripts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "737570a9d197080f1d9ea39817b35bb827d6afb55b3e95c06ac1ce6ce4b5cb10"
+            "sha256": "f97012d0338d4666db9f224d81019c92a697eabe40499176a754f17ac9c161cb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -270,10 +270,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
-            "version": "==1.24.1"
+            "index": "pypi",
+            "version": "==1.24.3"
         },
         "watchdog": {
             "hashes": [

--- a/navigator/docs/licenses/Pipfile
+++ b/navigator/docs/licenses/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 pystache = "==0.5.4"
 requests = "==2.20.0"
+urllib3 = ">=1.24.2"
 
 [dev-packages]
 

--- a/navigator/docs/licenses/Pipfile.lock
+++ b/navigator/docs/licenses/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e1ed4023f15530b99b19ea7bdd442d78d1dddfebe57997c14bf7cf9b868a077"
+            "sha256": "807d112cc615b1d43928d2645c4e2543f168f6cfb1a2b5252c777a03ca83a108"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -54,10 +54,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
-            "version": "==1.24.1"
+            "index": "pypi",
+            "version": "==1.24.3"
         }
     },
     "develop": {}

--- a/oss-compliance/Pipfile
+++ b/oss-compliance/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 pystache = "==0.5.4"
 requests = "==2.20.0"
+urllib3 = ">=1.24.2"
 
 [dev-packages]
 


### PR DESCRIPTION
Update urllib3 version to address security vulnerability alert from github

![image](https://user-images.githubusercontent.com/25179017/57097815-b0713d80-6ce6-11e9-857e-6961dc4616d5.png)

![image](https://user-images.githubusercontent.com/25179017/57097831-bb2bd280-6ce6-11e9-9a93-3383a76aa9b1.png)
