### PR TITLE
Don’t open a new terminal in the Windows installer

### DIFF
--- a/release/windows-installer/src/WindowsInstaller.hs
+++ b/release/windows-installer/src/WindowsInstaller.hs
@@ -28,4 +28,11 @@ installer sdkDir = do
         setOutPath (fromString dir)
         file [Recursive] (fromString (sdkDir <> "\\*.*"))
         -- install --activate will copy the SDK to the final location.
-        execWait $ fromString $ "\"" <> dir </> "daml" </> "daml.exe" <> "\" install " <> dir <> " --activate"
+        plugin "nsExec" "ExecToLog"
+            [ fromString $ unwords
+                  [ "\"" <> dir </> "daml" </> "daml.exe\""
+                  , "install"
+                  , "\"" <> dir <> "\""
+                  , "--activate"
+                  ] :: Exp String
+            ]


### PR DESCRIPTION
ExecWait will run the command in a new terminal which looks fairly
ugly and also makes it impossible to see what has been written to that
terminal (at the moment there is nothing particularly useful in there) since it closes automatically. nsexec::ExecToLog on the other
hand will write to the standard log window in the installer which
seems much nicer.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
