### PR TITLE
Remove a few duplicate/unused main scenarios from daml-ghc/tests

### DIFF
--- a/daml-foundations/daml-ghc/tests/Bad.daml
+++ b/daml-foundations/daml-ghc/tests/Bad.daml
@@ -5,6 +5,3 @@ daml 1.2
 module Bad where -- Used by test `Import.daml`
 
 data T = T {}
-
-main = scenario do
-  assert True

--- a/daml-foundations/daml-ghc/tests/Choice_no_params_template.daml
+++ b/daml-foundations/daml-ghc/tests/Choice_no_params_template.daml
@@ -56,6 +56,3 @@ template BondTransferRequest
       Withdraw : ContractId Bond
         do
           create Bond with ..
-
-main = scenario do
-  assert True

--- a/daml-foundations/daml-ghc/tests/Collision.daml
+++ b/daml-foundations/daml-ghc/tests/Collision.daml
@@ -4,6 +4,3 @@ module Collision where
 
 data Record = Record {}
 data RECORD = RECORD {}
-
-main = scenario do
-  pure ()

--- a/daml-foundations/daml-ghc/tests/DataRecursion.daml
+++ b/daml-foundations/daml-ghc/tests/DataRecursion.daml
@@ -5,6 +5,3 @@ daml 1.2
 module DataRecursion where
 
 data Foo a = Foo (Foo a)
-
-main = scenario do
-  return ()

--- a/daml-foundations/daml-ghc/tests/Deriving.daml
+++ b/daml-foundations/daml-ghc/tests/Deriving.daml
@@ -13,5 +13,3 @@ data Formula t
   | Conjunction [Formula t]
   | Disjunction [Formula t]
   deriving (Eq, Ord, Show, Functor)
-
-main = scenario (pure ())

--- a/daml-foundations/daml-ghc/tests/Either.daml
+++ b/daml-foundations/daml-ghc/tests/Either.daml
@@ -46,14 +46,3 @@ testOptionalToEither = scenario do
 testEitherToOptional = scenario do
   Some 1 === eitherToOptional (Right 1)
   None === eitherToOptional ((Left "a") : Either Text Int)
-
-main = scenario do
-    testLefts
-    testRights
-    testPartitionEithers
-    testIsLeft
-    testIsRight
-    testFromLeft
-    testFromRight
-    testOptionalToEither
-    testEitherToOptional

--- a/daml-foundations/daml-ghc/tests/Good.daml
+++ b/daml-foundations/daml-ghc/tests/Good.daml
@@ -5,6 +5,3 @@ daml 1.2
 module Good where -- Used by test `Import.daml`
 
 data T = T {}
-
-main = scenario do
-  assert True

--- a/daml-foundations/daml-ghc/tests/Hack.daml
+++ b/daml-foundations/daml-ghc/tests/Hack.daml
@@ -44,6 +44,3 @@ data FungibleRv a = SplitRv (ContractId a)
     archive otherCid
     create this with amount = amount + otherBond.amount
 -}
-
-main = scenario do
-  pure ()

--- a/daml-foundations/daml-ghc/tests/Import.daml
+++ b/daml-foundations/daml-ghc/tests/Import.daml
@@ -11,6 +11,3 @@ import Bad qualified
 -- this checks that qualified names show up in error messages
 a : Good.T
 a = Bad.T
-
-main = scenario do
-  assert True

--- a/daml-foundations/daml-ghc/tests/InternalImport.daml
+++ b/daml-foundations/daml-ghc/tests/InternalImport.daml
@@ -7,5 +7,3 @@ daml 1.2
 module InternalImport where
 
 import DA.Internal.Template
-
-main = scenario do return ()

--- a/daml-foundations/daml-ghc/tests/LogicTest.daml
+++ b/daml-foundations/daml-ghc/tests/LogicTest.daml
@@ -7,7 +7,7 @@ module LogicTest where
 import DA.Logic
 import DA.Assert
 
-proposition_test = do
+proposition_test = scenario do
   let
     p = Proposition 1
     q = Proposition 2
@@ -31,14 +31,10 @@ proposition_test = do
   Left r === interpret truth (q ||| r)
   interpret truth ( p &&& r) === Left r
 
-dnf_test = do
+dnf_test = scenario do
   Disjunction [Conjunction[Proposition 1]] === (toDNF $ Proposition 1)
   Disjunction [Conjunction[Proposition 1]] === (toDNF $ Conjunction[Proposition 1])
   Disjunction [Conjunction[Negation $ Proposition 1]] === (toDNF $ Negation . Proposition $ 1)
   Disjunction [Conjunction[Negation $ Proposition 1]] === (toDNF $ Conjunction [Negation . Proposition $ 1])
   (toDNF . neg . Conjunction $ Proposition <$> [1, 2, 3]) ===
     (Disjunction $ Conjunction . (:: []) . Negation . Proposition <$> [1,2,3])
-
-main = scenario do
-  proposition_test
-  dnf_test

--- a/daml-foundations/daml-ghc/tests/Map.daml
+++ b/daml-foundations/daml-ghc/tests/Map.daml
@@ -55,13 +55,3 @@ testDelete = scenario do
   [(2, False), (3, True), (4, False), (5, False)] === toList (delete 1 (fromList [(3, True), (1, False), (4, False), (2, True), (5, False), (2, False), (1, True)]))
   [(1, False), (2, True)] === toList (delete 3 (fromList [(2, False), (1, True), (2, True), (1, False)]))
 
-main = scenario do
-  testEmpty
-  testSize
-  testToList
-  testFromList
-  testMember
-  testNull
-  testInsert
-  testFilterWithKey
-  testDelete

--- a/daml-foundations/daml-ghc/tests/MultipleFields.daml
+++ b/daml-foundations/daml-ghc/tests/MultipleFields.daml
@@ -7,5 +7,3 @@ daml 1.2
 module MultipleFields where
 
 data Foo = Foo Int Int
-
-main = scenario do return ()

--- a/daml-foundations/daml-ghc/tests/NonEmpty.daml
+++ b/daml-foundations/daml-ghc/tests/NonEmpty.daml
@@ -11,6 +11,3 @@ testApplicative = scenario do
   let l = NonEmpty 1 [2, 3, 4]
   let fs = NonEmpty (*2) [(*3)]
   (fs <*> l) === NonEmpty 2 [4, 6, 8, 3, 6, 9, 12]
-
-main = scenario do
-    testApplicative

--- a/daml-foundations/daml-ghc/tests/Optional.daml
+++ b/daml-foundations/daml-ghc/tests/Optional.daml
@@ -76,15 +76,3 @@ testWhenSome = scenario do
   submit p (fetch cid)
   whenSome (Some 5) (\x -> submit p $ exercise cid $ ConsumeIfPositive x cid)
   submitMustFail p (fetch cid)
-
-main = scenario do
-  testFromSome
-  testFromSomeNote
-  testCatOptionals
-  testListToOptional
-  testOptionalToList
-  testFromSome
-  testIsSome
-  testIsNone
-  testMapOptional
-  testWhenSome

--- a/daml-foundations/daml-ghc/tests/Optional_Total.daml
+++ b/daml-foundations/daml-ghc/tests/Optional_Total.daml
@@ -18,8 +18,3 @@ testFromSomeNote = scenario do
   v === "abc"
   (Right 42 : Either Text Int) === fromSomeNote "problem" (Some 42)
   (Left "problem" : Either Text Int) === fromSomeNote "problem" None
-
-main = scenario do
-  testFromSome
-  testFromSomeNote
-

--- a/daml-foundations/daml-ghc/tests/PreludeTest.daml
+++ b/daml-foundations/daml-ghc/tests/PreludeTest.daml
@@ -279,30 +279,30 @@ testFilter = scenario do
 testFixedpoint = scenario do
   89 === fixedpoint (\f x -> if x < 2 then 1 else f (x-1) + f (x-2)) 10
 
-testIntToDecimal = do
+testIntToDecimal = scenario do
     assert $ intToDecimal 1 == 1.0
     assert $ intToDecimal (-7) == (-7.0)
     assert $ intToDecimal 0 == 0.0
 
-testTruncate = do
+testTruncate = scenario do
     assert $ truncate 14.9 == 14
     assert $ truncate 15.0 == 15
     assert $ truncate (-9.3) == (-9)
     assert $ truncate 0.0 == 0
 
-testCeiling = do
+testCeiling = scenario do
     assert $ ceiling 14.9 == 15
     assert $ ceiling 15.0 == 15
     assert $ ceiling (-9.3) == (-9)
     assert $ ceiling 0.0 == 0
 
-testFloor = do
+testFloor = scenario do
     assert $ floor 14.9 == 14
     assert $ floor 15.0 == 15
     assert $ floor (-9.3) == (-10)
     assert $ floor 0.0 == 0
 
-testRound = do
+testRound = scenario do
     assert $ roundCommercial 0 10.5 == 11.0
     assert $ roundCommercial 2 22.105 == 22.110
     assert $ roundBankers 0 10.5 == 10.0
@@ -312,12 +312,12 @@ testRound = do
     assert $ roundBankers 0 (-10.5) == -10.0
     assert $ roundBankers 2 (-22.105) == -22.100
 
-testNth = do
+testNth = scenario do
     let l = [1, 5, 10]
     let v = l !! 1
     assert $ v == 5
 
-testDiv = do
+testDiv = scenario do
     assert $ 10.0 / 2.0 == 5.0
     assert $ 13.2 / 5.0 == 2.64
 
@@ -336,65 +336,3 @@ testDiv = do
 testDayOfWeek = scenario do
     assert $ dayOfWeek (date 1900 Jan 01) == Monday
     assert $ dayOfWeek (date 2018 Jan 17) == Wednesday
-
-
-main = scenario do
-    testDollar
-    testCurry
-    testUncurry
-    testPow
-    testRemainder
-    testId
-    testFoldl
-    testFoldr
-    testFind
-    testLength
-    testAny
-    testAll
-    testOr
-    testAnd
-    testElem
-    testNotElem
-    testFmap
-    testOptional
-    testEither
-    testAppend
-    testPlusPlus
-    testConcat
-    testFlip
-    testReverse
-    testMapA
-    testForA
-    testSequence
-    testRbind
-    testConcatMap
-    testReplicate
-    testTake
-    testDrop
-    testSplitAt
-    testTakeWhile
-    testDropWhile
-    testSpan
-    testBreak
-    testLookup
-    testZip
-    testZip3
-    testZipWith
-    testZipWith3
-    testUnzip
-    testUnzip3
-    testFst
-    testSnd
-    testNull
-    testFilter
-    testFixedpoint
-
-    testRound
-    testNth
-    testDiv
-    testTruncate
-    testCeiling
-    testFloor
-    testIntToDecimal
-
-    testDayOfWeek

--- a/daml-foundations/daml-ghc/tests/RecordUpdate.daml
+++ b/daml-foundations/daml-ghc/tests/RecordUpdate.daml
@@ -7,11 +7,6 @@ module RecordUpdate where
 
 import DA.Assert
 
-main = scenario do
-  main1
-  main2
-  main3
-
 -- Check that record update and projection work in conjunction - see DEL-5426
 
 data Foo = Foo with
@@ -21,8 +16,7 @@ data Bar = Bar with
     bar : Int
   deriving (Eq,Show)
 
-main1 : Scenario ()
-main1 = do
+main1 = scenario do
   let x : Foo = Foo with foo = Bar with bar = 1
   let y1 = x.foo{bar=3}
   let y2 = x.foo with {bar=3}
@@ -40,14 +34,15 @@ data Record1 = Record1 with
 data Record2 = Record2 with
   field : Bool
 
-main2 = bug === 1
+main2 = scenario do
+    bug === 1
 
 bug = const rec1.field (\_ -> rec1.field)
   where rec1 = Record1 with field = 1
 
 -- Check that record selectors work on pairs and triples
 
-main3 = do
+main3 = scenario do
   let a = (1,2)
   a{_2=4}._2=== 4
 

--- a/daml-foundations/daml-ghc/tests/Set.daml
+++ b/daml-foundations/daml-ghc/tests/Set.daml
@@ -64,19 +64,3 @@ testDifference = scenario do
   [] === toList (difference S.empty (fromList [4, 2]))
   [1, 3, 5] === toList (difference (fromList [1, 5, 3]) S.empty)
   [] === toList (difference S.empty (fromList ([] : [Int])))
-
-main = scenario do
-  testEmpty
-  testSize
-  testToList
-  testFromList
-  testMember
-  testNull
-  testInsert
-  testFilter
-  testDelete
-  testSingleton
-  testUnion
-  testIntersection
-  testDifference
-

--- a/daml-foundations/daml-ghc/tests/Tuple.daml
+++ b/daml-foundations/daml-ghc/tests/Tuple.daml
@@ -29,10 +29,3 @@ testTuple = scenario do
 f : Int -> [Int]
 f 0 = []
 f i = i :: f (i-1)
-
-main = scenario do
-  testFirst
-  testSecond
-  testBoth
-  testSwap
-  testTuple

--- a/daml-foundations/daml-ghc/tests/ValueRecursion.daml
+++ b/daml-foundations/daml-ghc/tests/ValueRecursion.daml
@@ -7,5 +7,3 @@ module ValueRecursion where
 
 foo : [Int]
 foo = 1 :: foo
-
-main = scenario $ return ()

--- a/daml-foundations/daml-ghc/tests/Warnings.daml
+++ b/daml-foundations/daml-ghc/tests/Warnings.daml
@@ -8,5 +8,3 @@ daml 1.2
 module Warnings where
 	-- a tab
 import DA.List
-
-main = scenario $ return ()


### PR DESCRIPTION
Back in the day, every test case needed a `main` scenario and that was the
only scenario tested. Now, all scenarios are tested and hence a few of these
`main` scenarios are no longer necessary.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/891)
<!-- Reviewable:end -->
