### PR TITLE
Make daml-ghc test easier to debug by removing parallelism

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -300,20 +300,15 @@ mainProj TestArguments{..} service outdir log file = do
     let lfPrettyPrint = timed log "LF pretty-printing" . liftIO . writeFile (outdir </> proj <.> "pdalf") . renderPretty
 
     Compile.setFilesOfInterest service (Set.singleton file)
-    pkg <- Compile.runAction service $ lfTypeCheck log file
-    void $ Compile.runActions service
-        [do
+    Compile.runAction service $ do
             cores <- ghcCompile log file
             corePrettyPrint cores
-        ,do
             lf <- lfConvert log file
             lfPrettyPrint lf
-        ,do
             lf <- lfTypeCheck log file
             lfSave lf
             lfRunScenarios log file
-        ]
-    pure pkg
+            pure lf
 
 unjust :: Action (Maybe b) -> Action b
 unjust act = do


### PR DESCRIPTION
I often end up in situations where I need to to look at the GHC Core or
the DAML-LF before type checking. In the current parallel setting they
ususally don't get written to disk before the first error pops up. By
running the compiler stages one after another, we make sure that the
outputs of successful stages can be written to disk before starting the
next stage.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/899)
<!-- Reviewable:end -->
