### PR TITLE
Remove an unnecessary special case regarding strings from the compiler

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -490,11 +490,6 @@ convertBind2 env (NonRec name x)
     | Just internals <- MS.lookup (envGHCModuleName env) internalFunctions
     , is name `elem` internals
     = pure []
-    -- NOTE(MH): String literals should never appear at the top level since
-    -- they must be wrapped in either 'unpackCString#' or 'unpackCStringUtf8#'
-    -- to decide how to decode them.
-    | Lit LitString {} <- x
-    = unhandled "String literal at top level" x
     | otherwise
     = withRange (convNameLoc name) $ do
     x' <- convertExpr env x


### PR DESCRIPTION
There's no need for this special case since `convertExpr` will also fail on
string literals which are not surrounded by one of the special functions.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/900)
<!-- Reviewable:end -->
