### PR TITLE
Support the inline return type syntax for recursive functions

### DIFF
--- a/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
+++ b/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
@@ -1,11 +1,13 @@
 daml 1.2
 module FunRetTypeSig where
 
+import DA.Assert
+
 -- Test parsing of function return type signature syntax
 -- (see Tim's proposal at
 -- https://github.com/ghc-proposals/ghc-proposals/pull/185).
 
-succ (x : Int) : Int = x + 1
+mysucc (x : Int) : Int = x + 1
 
 -- Regression tests for https://github.com/digital-asset/daml/issues/747
 
@@ -21,5 +23,6 @@ mymap (f : a -> b) (xs : [a]) : [b] = case xs of
 
 -- Test that the rewriting in the compiler works.
 testFact = scenario do
-  assert $ fact 5 == 120
-  assert $ mymap show [1, 2] == ["1", "2"]
+  mysucc 12 === 13
+  fact 5 === 120
+  mymap show [1, 2] === ["1", "2"]

--- a/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
+++ b/daml-foundations/daml-ghc/tests/FunRetTypeSig.daml
@@ -7,4 +7,19 @@ module FunRetTypeSig where
 
 succ (x : Int) : Int = x + 1
 
--- Related issue : https://github.com/digital-asset/daml/issues/747.
+-- Regression tests for https://github.com/digital-asset/daml/issues/747
+
+-- Monomorphic test
+fact (n : Int) : Int
+  | n <= 1    = 1
+  | otherwise = n * fact (n - 1)
+
+-- Polymorphic test
+mymap (f : a -> b) (xs : [a]) : [b] = case xs of
+    [] -> []
+    x::xs -> f x::mymap f xs
+
+-- Test that the rewriting in the compiler works.
+testFact = scenario do
+  assert $ fact 5 == 120
+  assert $ mymap show [1, 2] == ["1", "2"]


### PR DESCRIPTION
Currently, the inline return type syntax does not work for recursive
functions as it produces a locat letrec which the compiler can't handle
yet. The PR works around this problem by doing a very limited form of
lambda lifting.

This fixes #747.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/904)
<!-- Reviewable:end -->
