### PR TITLE
Make record constructors in contract keys work

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -771,7 +771,6 @@ convertExpr env0 e = do
         -- work. Constructor workers are not handled (yet).
         | Just m <- nameModule_maybe $ varName x
         , Just con <- isDataConId_maybe x
-        -- , not ("$W" `isPrefixOf` is x)
         = do
             unitId <- convertUnitId (envModuleUnitId env) (envPkgMap env) $ GHC.moduleUnitId m
             let qualify = Qualified unitId (convertModuleName $ GHC.moduleName m)

--- a/daml-foundations/daml-ghc/tests/ContractKeysSyntax.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeysSyntax.daml
@@ -39,3 +39,22 @@ template T
     signatory i
     key k.s : M
     maintainer k.s.m
+
+-- This is a regression test for https://github.com/digital-asset/daml/issues/890
+data Rec = Rec with
+  a : Text
+  b : Text
+    deriving (Eq, Show)
+
+data MyKey = MyKey with
+  a : Text
+  p : Party
+
+template Foo
+  with
+    p : Party
+    r : Rec
+  where
+    signatory p
+    maintainer p
+    key (MyKey with a = r.a, p): MyKey


### PR DESCRIPTION
Currently, they don't always work because we don't inline record constructors
aggressively enough. The PR address this flaw by inlining more constructors.

Fixes #890.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/907)
<!-- Reviewable:end -->
