### PR TITLE
Shorten data-default-instances-dlist target name

### DIFF
--- a/3rdparty/haskell/BUILD.data-default
+++ b/3rdparty/haskell/BUILD.data-default
@@ -8,23 +8,19 @@ load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 haskell_library(
   name = "data-default",
   visibility = ["//visibility:public"],
-  generator_name = "data-default",
-  generator_function = "cabal_haskell_package",
-  generator_location = "/home/moritz/.cache/bazel/_bazel_moritz/bb4e4404f889dc1b816f246b08c0d9ea/external/haskell_data__default/BUILD:15",
   srcs = ["@haskell_data__default//:Data/Default.hs"],
   extra_srcs = [],
   deps = [
       hazel_library("base"),
       hazel_library("data-default-class"),
       "@haskell_data__default__instances__containers//:lib",
-      hazel_library("data-default-instances-dlist"),
+      "@haskell_data__default__instances__dlist//:lib",
       "@haskell_data__default__instances__old__locale//:lib"
   ],
   compiler_flags = ["-XHaskell98", "-w", "-Wwarn"],
   version = "0.7.1.1",
 )
 
-# /home/moritz/.cache/bazel/_bazel_moritz/bb4e4404f889dc1b816f246b08c0d9ea/external/haskell_data__default/BUILD:15:1
 cc_library(
   name = "data-default-cbits",
   visibility = ["//visibility:public"],

--- a/3rdparty/haskell/BUILD.data-default-instances-dlist
+++ b/3rdparty/haskell/BUILD.data-default-instances-dlist
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
+
+
+haskell_library(
+  name = "lib",
+  visibility = ["//visibility:public"],
+  srcs = [":Data/Default/Instances/DList.hs"],
+  deps = [hazel_library("base"), hazel_library("data-default-class"), hazel_library("dlist")],
+  version = "0.0.1",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -485,6 +485,9 @@ hazel_custom_package_hackage(
     version = "0.7.2",
 )
 
+# We patch various data-default packages to give them shorter filenames
+# to fix Windows builds.
+
 hazel_custom_package_hackage(
     package_name = "data-default",
     build_file = "//3rdparty/haskell:BUILD.data-default",
@@ -503,6 +506,13 @@ hazel_custom_package_hackage(
     package_name = "data-default-instances-old-locale",
     build_file = "//3rdparty/haskell:BUILD.data-default-instances-old-locale",
     sha256 = "60d3b02922958c4908d7bf2b24ddf61511665745f784227d206745784b0c0802",
+    version = "0.0.1",
+)
+
+hazel_custom_package_hackage(
+    package_name = "data-default-instances-dlist",
+    build_file = "//3rdparty/haskell:BUILD.data-default-instances-dlist",
+    sha256 = "7d683711cbf08abd7adcd5ac2be825381308d220397315a5570fe61b719b5959",
     version = "0.0.1",
 )
 


### PR DESCRIPTION
This PR copies the hack that I used for the other
data-default-instances-* packages to data-default-instances-dlist. The
exact conditions under which this seems to be required probably depend
on things like your username and the directory of your project which
is why this failed for Neil but not for me.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
