### PR TITLE
Rename the runTests function to main, since it serves as a main

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -119,7 +119,7 @@ da_haskell_test(
         "text",
         "unix-compat",
     ],
-    main_function = "DAML.Assistant.Tests.runTests",
+    main_function = "DAML.Assistant.Tests.main",
     src_strip_prefix = "test",
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-assistant/test/DAML/Assistant/Tests.hs
+++ b/daml-assistant/test/DAML/Assistant/Tests.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Tests
-    ( runTests
+    ( main
     ) where
 
 import DAML.Assistant.Env
@@ -36,8 +36,8 @@ import qualified Data.Conduit.Tar as Tar
 -- unix specific
 import System.PosixCompat.Files (createSymbolicLink)
 
-runTests :: IO ()
-runTests = do
+main :: IO ()
+main = do
     setEnv "TASTY_NUM_THREADS" "1" -- we need this because we use withEnv in our tests
     Tasty.defaultMain $ Tasty.testGroup "DAML.Assistant"
         [ testAscendants


### PR DESCRIPTION
Better for consistency and predictability.