### PR TITLE
Remove completely redundant imports of DA.Prelude

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
@@ -1,13 +1,11 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
 module DA.Daml.LF.Proto3.Decode
   ( Error(..)
   , decodePayload
   ) where
 
-import DA.Prelude
 import Da.DamlLf (ArchivePayload(..), ArchivePayloadSum(..))
 import DA.Daml.LF.Ast (Package)
 import DA.Daml.LF.Proto3.Error (Error(ParseError), Decode)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
-
 module DA.Daml.LF.Proto3.Error
     ( Decode
     , Error(..)
@@ -11,7 +9,6 @@ module DA.Daml.LF.Proto3.Error
 import qualified Data.Text as T
 
 import DA.Daml.LF.Ast
-import DA.Prelude
 
 data Error
   = MissingField String

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -20,8 +20,6 @@ module DA.Daml.LF.ScenarioServiceClient
   , encodeModule
   ) where
 
-import DA.Prelude
-
 import Control.Concurrent.Extra
 import Control.DeepSeq
 import Control.Exception

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/LanguageServer/Definition.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/LanguageServer/Definition.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Go to the definition of a variable.
@@ -11,7 +10,6 @@ module DA.Service.Daml.LanguageServer.Definition
 
 import           DA.LanguageServer.Protocol
 
-import           DA.Prelude
 import qualified DA.Service.Daml.Compiler.Impl.Handle as Compiler
 import           DA.Service.Daml.LanguageServer.Common
 import qualified DA.Service.Logger                     as Logger

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/LanguageServer/Hover.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/LanguageServer/Hover.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Display information on hover.
@@ -11,7 +10,6 @@ module DA.Service.Daml.LanguageServer.Hover
 
 import           DA.LanguageServer.Protocol
 
-import           DA.Prelude
 import qualified DA.Service.Daml.Compiler.Impl.Handle as Compiler
 import           DA.Service.Daml.LanguageServer.Common
 import qualified DA.Service.Logger                     as Logger

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -11,7 +11,6 @@ module DA.Cli.Damlc.Test (
 
 import Control.Monad.Except
 import qualified Control.Monad.Managed             as Managed
-import           DA.Prelude
 import qualified DA.Pretty
 import DA.Cli.Damlc.Base
 import Data.Tuple.Extra

--- a/libs-haskell/da-hs-base/src/DA/Pretty.hs
+++ b/libs-haskell/da-hs-base/src/DA/Pretty.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This library provides the basis for all our pretty-printing. It extends
@@ -53,8 +52,6 @@ module DA.Pretty
 
 import           Data.String
 import qualified Data.Text.Extended          as T
-
-import           DA.Prelude
 
 import           Orphans.Lib_pretty ()
 

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -24,7 +23,6 @@ import qualified Data.Map.Strict              as MS
 import qualified Data.Text.Extended           as T
 import qualified Data.Text.Encoding           as E
 
-import           DA.Prelude
 import qualified DA.Service.Logger            as Logger
 
 -- | Source locations, we can't use Parsec's built-in source location,

--- a/libs-haskell/da-hs-base/src/Data/Aeson/TH/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Data/Aeson/TH/Extended.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
-
 -- | An extended version of "Data.Aeson.TH", which provides our own
 -- 'daAesonEncodingOptions' and the corresponding 'deriveDAJSON'.
 module Data.Aeson.TH.Extended

--- a/libs-haskell/da-hs-base/src/Data/Text/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Data/Text/Extended.hs
@@ -1,14 +1,13 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoImplicitPrelude #-}
 -- | An extended version of "Data.Text", which provides a slightly more
 -- extensive export lists and missing orphan instances.
 module Data.Text.Extended
   (
     module Data.Text
 
-  , show
+  , Data.Text.Extended.show
   , Data.Text.Extended.splitOn
   , startsWithLower
   , startsWithUpper


### PR DESCRIPTION
Less imports where they were totally redundant. First step on the way to killing DA.Prelude.