### PR TITLE
Debug nix failures

### DIFF
--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -6,6 +6,7 @@
 
 # Installs nix on a fresh machine
 set -euo pipefail
+shopt -s nullglob
 
 ## Functions ##
 
@@ -27,7 +28,7 @@ if [[ ! -e /nix ]]; then
   if [[ $(uname -s) == "Darwin" ]]; then
       curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
   else
-      curl -sfL https://nixos.org/releases/nix/nix-2.2.2/install | bash
+      curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
   fi
 fi
 
@@ -36,5 +37,12 @@ source dev-env/lib/ensure-nix
 
 export NIX_CONF_DIR=$PWD/dev-env/etc
 
+step "Cleaning up nix store to make sure that we redownload"
+for res in result*; do
+    unlink $res
+done
+nix-store --gc --print-roots
+nix-store --gc
+
 step "Building dev-env dependencies"
-nix-build nix -A tools -A cached
+nix-build nix -A tools -A cached --no-out-link

--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -3,11 +3,13 @@ binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
 binary-cache-public-keys = hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
 
 # Keep build-time dependencies of non-garbage outputs around
-gc-keep-outputs = true
-gc-keep-derivations = true
+# gc-keep-outputs = true
+# gc-keep-derivations = true
 
 # NOTE(JM): This is broken on Mac: "cannot link ... : Operation not permitted"
 # auto-optimise-store = true
 
 # NOTE(D3): This is needed in order to run nix commands on monorepo from a Docker container.
 build-users-group =
+
+http2 = false


### PR DESCRIPTION
The nixpkgs upgrade has resulted in lots of "unexpected end-of-file" failures. I’ll use this PR to poke at CI to see if I can fix it.

The actual upgrade is being rolled back by #917 for now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
