### PR TITLE
tweak azure build file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ pr:
       - master
 
 jobs:
-  - job: linux
+  - job: Linux
     timeoutInMinutes: 360
     pool:
       name: 'linux-pool'
@@ -29,12 +29,14 @@ jobs:
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)
           curl -XPOST \
+               -i \
                -H 'Content-type: application/json' \
-               --data "{\"text\":\"<!channel> *FAILED*: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               --data "{\"text\":\"<!channel> *FAILED* Linux: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
-  - job: macos
+  - job: macOS
+    displayName: macos
     timeoutInMinutes: 360
     pool:
       vmImage: 'macOS-10.14'
@@ -46,12 +48,14 @@ jobs:
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)
           curl -XPOST \
+               -i \
                -H 'Content-type: application/json' \
-               --data "{\"text\":\"<!channel> *FAILED*: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               --data "{\"text\":\"<!channel> *FAILED* macOS: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
-  - job: windows
+  - job: Windows
+    displayName: windows
     timeoutInMinutes: 360
     pool:
       vmImage: 'vs2017-win2016'
@@ -61,8 +65,9 @@ jobs:
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)
           curl -XPOST \
+               -i \
                -H 'Content-type: application/json' \
-               --data "{\"text\":\"<!channel> *FAILED*: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               --data "{\"text\":\"<!channel> *FAILED* Windows: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
@@ -93,24 +98,25 @@ jobs:
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)
           curl -XPOST \
+               -i \
                -H 'Content-type: application/json' \
-               --data "{\"text\":\"<!channel> *FAILED*: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               --data "{\"text\":\"<!channel> *FAILED* perf: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
   - job: release
-    dependsOn: [ "linux", "macos", "windows", "perf"]
+    dependsOn: [ "Linux", "macOS", "Windows", "perf"]
     pool:
       vmImage: "Ubuntu-16.04"
     condition: and(succeeded(),
-                   eq( dependencies.linux.outputs['release.has_released'], 'true' ),
-                   eq( dependencies.macos.outputs['release.has_released'], 'true' ),
-                   eq( dependencies.windows.outputs['release.has_released'], 'true' ))
+                   eq( dependencies.Linux.outputs['release.has_released'], 'true' ),
+                   eq( dependencies.macOS.outputs['release.has_released'], 'true' ),
+                   eq( dependencies.Windows.outputs['release.has_released'], 'true' ))
     variables:
-      artifact-linux: $[ dependencies.linux.outputs['publish.artifact'] ]
-      artifact-macos: $[ dependencies.macos.outputs['publish.artifact'] ]
-      artifact-windows: $[ dependencies.windows.outputs['publish.artifact'] ]
-      artifact-windows-installer: $[ dependencies.windows.outputs['publish.artifact-windows-installer'] ]
+      artifact-linux: $[ dependencies.Linux.outputs['publish.artifact'] ]
+      artifact-macos: $[ dependencies.macOS.outputs['publish.artifact'] ]
+      artifact-windows: $[ dependencies.Windows.outputs['publish.artifact'] ]
+      artifact-windows-installer: $[ dependencies.Windows.outputs['publish.artifact-windows-installer'] ]
     steps:
       - checkout: self
         persistCredentials: true
@@ -150,7 +156,8 @@ jobs:
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)
           curl -XPOST \
+               -i \
                -H 'Content-type: application/json' \
-               --data "{\"text\":\"<!channel> *FAILED*: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               --data "{\"text\":\"<!channel> *FAILED* Release: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))


### PR DESCRIPTION
- change jobs names to match the names Azure uses, so GitHub doesn't get
  confused. These were the names when the pipeline was originally set
  up; since I changed them it looks like Azure and GitHub don't agree on
  test names, resulting in some occurrences of GitHub forever expecting
  more info about `linux` while `Linux` is completed.
- add `-i` to cURL invocations, so we can see the response headers. This
  is an attempt to debug a situation I have seen three times now where
  Azure says it executed the cURL step successfully, yet no message
  appears in Slack.
- add test name to failure message sent to Slack.