### PR TITLE
Avoid using package imports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -236,6 +236,7 @@ haskell_register_ghc_nixpkgs(
     compiler_flags = [
         "-O1",
         "-fexternal-dynamic-refs",
+        "-hide-package=ghc-boot-th",
     ],
     locale_archive = "@glibc_locales//:locale-archive",
     nix_file = "//nix:bazel.nix",

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
@@ -18,10 +18,10 @@ import           Development.IDE.Types.LSP
 import           Development.IDE.Types.SpanInfo as SpanInfo
 
 -- GHC API imports
-import "ghc-lib" GHC
-import "ghc-lib-parser" DynFlags
-import "ghc-lib-parser" Outputable hiding ((<>))
-import "ghc-lib-parser" Name
+import GHC
+import DynFlags
+import Outputable hiding ((<>))
+import Name
 
 import           Data.Maybe
 import           Data.List

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -29,22 +29,22 @@ import           Development.IDE.Functions.GHCError
 import           Development.IDE.Functions.SpanInfo
 import Development.IDE.UtilGHC
 
-import           "ghc-lib" GHC hiding (parseModule, typecheckModule)
-import qualified "ghc-lib-parser" Parser
-import           "ghc-lib-parser" Lexer
-import           "ghc-lib-parser" Bag
+import           GHC hiding (parseModule, typecheckModule)
+import qualified Parser
+import           Lexer
+import           Bag
 
-import qualified "ghc-lib" GHC
-import           "ghc-lib-parser" Panic
-import           "ghc-lib-parser" GhcMonad
-import           "ghc-lib" GhcPlugins                     as GHC hiding (PackageState, fst3, (<>))
-import qualified "ghc-lib" HeaderInfo                     as Hdr
-import           "ghc-lib" MkIface
-import           "ghc-lib-parser" NameCache
-import           "ghc-lib-parser" StringBuffer                   as SB
-import           "ghc-lib" TidyPgm
-import           "ghc-lib-parser" InstEnv
-import           "ghc-lib-parser" FamInstEnv
+import qualified GHC
+import           Panic
+import           GhcMonad
+import           GhcPlugins                     as GHC hiding (PackageState, fst3, (<>))
+import qualified HeaderInfo                     as Hdr
+import           MkIface
+import           NameCache
+import           StringBuffer                   as SB
+import           TidyPgm
+import           InstEnv
+import           FamInstEnv
 
 import Control.DeepSeq
 import           Control.Exception                        as E

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/DependencyInformation.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/DependencyInformation.hs
@@ -30,8 +30,8 @@ import GHC.Generics (Generic)
 import Development.IDE.Types.Diagnostics
 import Development.IDE.UtilGHC ()
 
-import "ghc-lib" GHC
-import "ghc-lib-parser" Module
+import GHC
+import Module
 
 -- | Unprocessed results that we get from following all imports recursively starting from a module.
 data RawDependencyInformation = RawDependencyInformation

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/FindImports.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/FindImports.hs
@@ -12,16 +12,16 @@ module Development.IDE.Functions.FindImports
 import           Development.IDE.Functions.GHCError as ErrUtils
 
 -- GHC imports
-import           "ghc-lib-parser" BasicTypes                  (StringLiteral(..))
-import           "ghc-lib-parser" DynFlags
-import           "ghc-lib-parser" FastString
-import           "ghc-lib" GHC
-import qualified "ghc-lib" HeaderInfo                  as Hdr
-import qualified "ghc-lib-parser" Module                      as M
-import qualified "ghc-lib-parser" GHC.LanguageExtensions.Type as GHC
-import           "ghc-lib-parser" Packages
-import           "ghc-lib-parser" Outputable                  (showSDoc, ppr, pprPanic)
-import           "ghc-lib" Finder
+import           BasicTypes                  (StringLiteral(..))
+import           DynFlags
+import           FastString
+import           GHC
+import qualified HeaderInfo                  as Hdr
+import qualified Module                      as M
+import qualified GHC.LanguageExtensions.Type as GHC
+import           Packages
+import           Outputable                  (showSDoc, ppr, pprPanic)
+import           Finder
 
 -- standard imports
 import           Control.Monad.Extra

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
@@ -31,13 +31,13 @@ module Development.IDE.Functions.GHCError
 import                     Development.IDE.Types.Diagnostics as D
 import qualified           Data.Text as T
 import Development.IDE.UtilGHC()
-import qualified "ghc-lib-parser" FastString as FS
-import "ghc-lib"           GHC
-import "ghc-lib-parser"           Bag
+import qualified FastString as FS
+import           GHC
+import           Bag
 import Data.Maybe
-import           "ghc-lib-parser" ErrUtils
-import           "ghc-lib-parser" SrcLoc
-import qualified "ghc-lib-parser" Outputable                 as Out
+import           ErrUtils
+import           SrcLoc
+import qualified Outputable                 as Out
 import qualified Language.Haskell.LSP.Types as LSP
 
 

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Warnings.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Warnings.hs
@@ -3,9 +3,9 @@
 
 module Development.IDE.Functions.Warnings(withWarnings) where
 
-import "ghc-lib-parser" ErrUtils
-import "ghc-lib-parser" GhcMonad
-import "ghc-lib" GhcPlugins as GHC hiding (Var)
+import ErrUtils
+import GhcMonad
+import GhcPlugins as GHC hiding (Var)
 
 import qualified Data.Text as T
 import           Data.Maybe

--- a/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
@@ -11,7 +11,7 @@ module Development.IDE.State.FileStore(
 
 
 
-import           "ghc-lib-parser" StringBuffer
+import           StringBuffer
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T

--- a/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
@@ -24,8 +24,8 @@ import           Data.Typeable
 import           Development.Shake                        hiding (Env, newCache)
 import           GHC.Generics                             (Generic)
 
-import           "ghc-lib" GHC
-import           "ghc-lib-parser" Module
+import           GHC
+import           Module
 
 import           Development.IDE.Types.SpanInfo
 

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -45,9 +45,9 @@ import           Development.Shake                        hiding (Diagnostic, En
 import           Development.IDE.Types.LSP as Compiler
 import Development.IDE.State.RuleTypes
 
-import           "ghc-lib" GHC
-import           "ghc-lib-parser" UniqSupply
-import           "ghc-lib-parser" Module                         as M
+import           GHC
+import           UniqSupply
+import           Module                         as M
 
 import qualified Development.IDE.Functions.AtPoint as AtPoint
 import Development.IDE.State.Service

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -32,7 +32,7 @@ import           Development.IDE.Functions.GHCError
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 import           Development.IDE.Types.LSP as Compiler
 
-import           "ghc-lib-parser" UniqSupply
+import           UniqSupply
 
 import           Development.IDE.State.Shake
 

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -13,20 +13,20 @@
 -- * Call setSessionDynFlags, use modifyDynFlags instead. It's faster and avoids loading packages.
 module Development.IDE.UtilGHC(module Development.IDE.UtilGHC) where
 
-import           "ghc-lib-parser" Config
-import qualified "ghc-lib-parser" CmdLineParser as Cmd (warnMsg)
-import           "ghc-lib-parser" DynFlags (parseDynamicFilePragma)
-import           "ghc-lib-parser" Fingerprint
-import           "ghc-lib" GHC                         hiding (convertLit)
-import           "ghc-lib-parser" GHC.LanguageExtensions.Type
-import           "ghc-lib-parser" GhcMonad
-import           "ghc-lib" GhcPlugins                  as GHC hiding (PackageState, fst3, (<>))
-import           "ghc-lib" HscMain
-import qualified "ghc-lib-parser" Packages
-import           "ghc-lib-parser" Panic (throwGhcExceptionIO)
-import           "ghc-lib-parser" Platform
-import qualified "ghc-lib-parser" StringBuffer                as SB
-import qualified "ghc-lib-parser" EnumSet
+import           Config
+import qualified CmdLineParser as Cmd (warnMsg)
+import           DynFlags (parseDynamicFilePragma)
+import           Fingerprint
+import           GHC                         hiding (convertLit)
+import           GHC.LanguageExtensions.Type
+import           GhcMonad
+import           GhcPlugins                  as GHC hiding (PackageState, fst3, (<>))
+import           HscMain
+import qualified Packages
+import           Panic (throwGhcExceptionIO)
+import           Platform
+import qualified StringBuffer                as SB
+import qualified EnumSet
 
 import           Control.DeepSeq
 import           Control.Monad


### PR DESCRIPTION
Package imports in haskell-ide-core make it harder to retarget "ghc" in just the .cabal file. This patch removes those package imports, and also hides the package ghc-boot-th, which is the only one other than GHC (which is hidden by default) which we conflict with. Still works in Bazel and ghci.

Not sure if there is a better way to hide ghc-boot-th when fetching from Hazel directly.