### PR TITLE
Fix "unbound variable" error in fmt.sh

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -81,7 +81,7 @@ done
 trap - EXIT
 
 # check for scala code style
-run ./scalafmt.sh "${scalafmt_args[@]}"
+run ./scalafmt.sh "${scalafmt_args[@]:-}"
 
 # check for Bazel build files code formatting
 run bazel run "$buildifier_target"


### PR DESCRIPTION
Seems like an array that is only declared but never assigned to cannot
be dereferenced with `arr[@]` under `set -u`. We can easily work around
this by using an empty string as default value like `:-`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
