### PR TITLE
Output a compilation message in damlc build

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -252,6 +252,7 @@ execPackageNew numProcessors mbOutFile =
         case parseProjectConfig project of
             Left err -> throwIO err
             Right PackageConfigFields {..} -> do
+                putStrLn $ "Compiling " <> pMain <> " to a DAR."
                 defaultOpts <- Compiler.defaultOptionsIO Nothing
                 let opts =
                         defaultOpts


### PR DESCRIPTION
For long builds, it’s nice to know what damlc is doing. We might want
to consider making this configurable via some --quiet flag but given
that we already output the “Created out.ar.” message unconditionally
it seems reasonable to add this without an option for now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
