### PR TITLE
Extend test durations on CI for Ledger API Test Tool driven test.

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/FutureTimeouts.scala
@@ -4,16 +4,19 @@
 package com.digitalasset.platform.tests.integration.ledger.api
 import akka.actor.ActorSystem
 import com.digitalasset.platform.common.util.DirectExecutionContext
+import org.scalatest.concurrent.Waiters
 
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise, TimeoutException}
 import scala.util.control.NoStackTrace
 
-trait FutureTimeouts {
+trait FutureTimeouts extends Waiters {
 
   // TODO get rid of the default timeout, see issue: #464 and #548
-  protected def timeout[T](f: Future[T], opName: String, duration: FiniteDuration = 500.seconds)(
-      implicit system: ActorSystem): Future[T] = {
+  protected def timeout[T](
+      f: Future[T],
+      opName: String,
+      duration: FiniteDuration = scaled(500.seconds))(implicit system: ActorSystem): Future[T] = {
     val promise: Promise[T] = Promise[T]()
 
     val cancellable = system.scheduler.scheduleOnce(duration, { () =>

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -81,6 +81,9 @@ client_server_test(
     timeout = "short",
     client = ":ledger-api-test-tool",
     client_args = [
+        # NOTE(GP): our CI has a tendency to be more unpredictable than local
+        # machine with timeouts, we value lack of flakes on CI.
+        "--timeout-scale-factor=10",
     ],
 
     # Data files available to both client and server.
@@ -103,9 +106,11 @@ client_server_test(
     timeout = "short",
     client = ":ledger-api-test-tool",
     client_args = [
-        "--crt $(rootpath testdata/client.crt) " +
-        "--cacrt $(rootpath testdata/ca.crt) " +
+        "--crt $(rootpath testdata/client.crt)",
+        "--cacrt $(rootpath testdata/ca.crt)",
         "--pem $(rootpath testdata/client.pem)",
+        # See note above.
+        "--timeout-scale-factor=10",
     ],
 
     # Data files available to both client and server.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -29,7 +29,7 @@ object Cli {
 
   private val argParser = new scopt.OptionParser[Config]("ledger-api-test-tool") {
     head("""The Ledger API Test Tool is a command line tool for testing the correctness of
-           |ledger implementations based on DAML and Ledger API.""".stripMargin)
+        |ledger implementations based on DAML and Ledger API.""".stripMargin)
 
     help("help").text("prints this usage text")
 
@@ -56,17 +56,25 @@ object Cli {
       .text("TLS: The crt file to be used as the the trusted root CA.")
       .action(cacrtConfig)
 
+    opt[Double](name = "timeout-scale-factor")
+      .optional()
+      .action((v, c) => c.copy(timeoutScaleFactor = v))
+      .text("""Scale factor for timeouts used in testing. Useful to tune timeouts
+          |depending on the environment and the Ledger implementation under test.
+          |Defaults to 1.0. Use numbers higher than 1.0 to make test timeouts more lax,
+          |use numbers lower than 1.0 to make test timeouts more strict.""".stripMargin)
+
     opt[Unit]("must-fail")
       .action((_, c) => c.copy(mustFail = true))
       .text("""Reverse success status logic of the tool. Use this flag if you expect one or
-              |more or the scenario tests to fail. If enabled, the tool will succeed when at
-              |least one test fails, and it will fail when all tests succeed. Defaults to
-              |false.""".stripMargin)
+          |more or the scenario tests to fail. If enabled, the tool will succeed when at
+          |least one test fails, and it will fail when all tests succeed. Defaults to
+          |false.""".stripMargin)
 
     opt[Unit]('r', "reset")
       .action((_, c) => c.copy(performReset = true))
       .text("""Perform a ledger reset before running the tests. If enabled, the tool will wipe
-              |all of the contents of the target ledger. Defaults to false.""".stripMargin)
+          |all of the contents of the target ledger. Defaults to false.""".stripMargin)
 
     opt[Unit]('x', "extract")
       .action((_, c) => c.copy(extract = true))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -12,6 +12,7 @@ final case class Config(
     packageContainer: DamlPackageContainer,
     performReset: Boolean,
     mustFail: Boolean,
+    timeoutScaleFactor: Double,
     extract: Boolean,
     tlsConfig: Option[TlsConfiguration]
 )
@@ -23,6 +24,7 @@ object Config {
     packageContainer = DamlPackageContainer(),
     performReset = false,
     mustFail = false,
+    timeoutScaleFactor = 1.0,
     extract = false,
     tlsConfig = None
   )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -72,7 +72,12 @@ object LedgerApiTestTool {
       scenarios.foreach {
         case (pkgId, names) =>
           val tester = new SemanticTester(
-            parties => new SemanticTestAdapter(ledger, packages, parties),
+            parties =>
+              new SemanticTestAdapter(
+                ledger,
+                packages,
+                parties,
+                timeoutScaleFactor = config.timeoutScaleFactor),
             pkgId,
             packages,
             partyNameMangler,
@@ -84,7 +89,7 @@ object LedgerApiTestTool {
               val _ = try {
                 Await.result(
                   tester.testScenario(name),
-                  10.seconds
+                  (60 * config.timeoutScaleFactor).seconds
                 )
               } catch {
                 case (t: Throwable) =>


### PR DESCRIPTION
This introduces a command-line argument to scale timeouts used in the test.

Fixes #815 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
