### PR TITLE
Java Codegen: variants with unserializable cases are now accepted

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -8,6 +8,7 @@ This page contains release notes for the SDK.
 
 HEAD — ongoing
 --------------
+- Java Codegen: variants with unserializable cases are now accepted (see `#946 <https://github.com/digital-asset/daml/pull/946>`_)
 
 0.12.15 - 2019-05-06
 --------------------

--- a/language-support/java/codegen/src/it/daml/Lib.daml
+++ b/language-support/java/codegen/src/it/daml/Lib.daml
@@ -13,3 +13,4 @@ import Tests.VariantTest
 import Tests.Import
 import Tests.Escape
 import Tests.MapTest
+import Tests.Serializable

--- a/language-support/java/codegen/src/it/daml/Tests/Serializable.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/Serializable.daml
@@ -1,0 +1,12 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module Tests.Serializable where
+
+
+data Serializability
+    = NonSerializable with
+      func: Int -> Int
+    | Serializable with
+      field: Int

--- a/language-support/java/codegen/src/it/java/com/digitalasset/SerializableTest.java
+++ b/language-support/java/codegen/src/it/java/com/digitalasset/SerializableTest.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset;
+
+import com.daml.ledger.javaapi.TestDecoder;
+import com.daml.ledger.javaapi.data.Int64;
+import com.daml.ledger.javaapi.data.Record;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import tests.serializable.serializability.Serializable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@RunWith(JUnitPlatform.class)
+public class SerializableTest {
+
+    @Test
+    void synthesizedRecordForVariantIsGenerated() {
+        // we only need to access the `Serializability.Serializable` record type
+        // if it's not being generated, it would be a compile error
+        Serializable fromConstructor = new Serializable(42L);
+        Record record = new Record(new Record.Field("field", new Int64(42L)));
+        Assertions.assertEquals(record, fromConstructor.toValue());
+    }
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
@@ -44,7 +44,7 @@ private[codegen] object JavaBackend extends Backend with StrictLogging {
       case (res, module: ModuleWithContext) =>
         val templateNames = module.typesLineages
           .collect {
-            case t if t.`type`.typ.getTemplate.isPresent =>
+            case t if t.`type`.typ.exists(_.getTemplate.isPresent) =>
               ClassName.bestGuess(inner.fullyQualifiedName(t.identifier, packagePrefixes))
           }
         res ++ templateNames

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -199,7 +199,7 @@ private[inner] object VariantClass extends StrictLogging {
       if (variantRecords.contains(child.name)) {
         logger.debug(s"${child.name} is a variant record")
         child.`type`.typ match {
-          case Normal(DefDataType(typeVars, record: Record.FWT)) =>
+          case Some(Normal(DefDataType(typeVars, record: Record.FWT))) =>
             innerClasses += VariantRecordClass
               .generate(
                 typeVars.map(JavaEscaper.escapeString),


### PR DESCRIPTION
If a variant itself is not serializable, but the synthesized record for
one of its constructors is, then said record is returned by the
interface reader in the set of type declarations, when the variant type
itself is not.
When constructing the InterfaceTree in preparation of the codegen, we
previously rejected such a situation.

We now generate Java code for such a synthesized record, as it is a more
generally correct way of interpreting DAML LF (i.e. the DAML compiler
could decide tomorrow to create such multi-component record names for
regular records).

In any case, we consider this to be an edge case, as the synthesized
record for the variant constructor cannot be used directly either from
DAML or the Ledger API.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
