### PR TITLE
remove -O option from curl command in order to pipe script contents t…

### DIFF
--- a/infra/vsts_agent_linux_startup.sh
+++ b/infra/vsts_agent_linux_startup.sh
@@ -28,7 +28,7 @@ apt-get install -qy \
   git \
   netcat
 
-curl -sS https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+curl -sSL https://dl.google.com/cloudagents/install-logging-agent.sh | bash
 
 ## Install the VSTS agent
 groupadd --gid 3000 vsts

--- a/infra/vsts_agent_linux_startup.sh
+++ b/infra/vsts_agent_linux_startup.sh
@@ -28,7 +28,7 @@ apt-get install -qy \
   git \
   netcat
 
-curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+curl -sS https://dl.google.com/cloudagents/install-logging-agent.sh | bash
 
 ## Install the VSTS agent
 groupadd --gid 3000 vsts


### PR DESCRIPTION
stackdriver install script was downloading to a file local on the VM and was never being piped to bash for execution. Removed -O option. please approve so that linux agents will start sendings logs to stackdriver.