### PR TITLE
GHC 8.6 compat for the IDE

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -74,7 +74,7 @@
   - {name: ViewPatterns, within: []}
 
   # Shady extensions
-  - {name: CPP, within: [DA.Sdk.Cli.System, DA.Sdk.Cli.Version, DAML.Assistant.Install.Path]}
+  - {name: CPP, within: [DA.Sdk.Cli.System, DA.Sdk.Cli.Version, DAML.Assistant.Install.Path, Development.IDE.Functions.Compile]}
   - {name: ImplicitParams, within: []}
 
 - flags:

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Documentation.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Documentation.hs
@@ -80,7 +80,7 @@ getDocumentation targetName tcs = fromMaybe [] $ do
 -- | Shows this part of the documentation
 docHeaders :: [RealLocated AnnotationComment]
            -> [T.Text]
-docHeaders = mapMaybe (wrk . unRealSrcSpan)
+docHeaders = mapMaybe (\(L _ x) -> wrk x)
   where
   wrk = \case
     AnnDocCommentNext s -> Just $ T.pack s

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/SpanInfo.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/SpanInfo.hs
@@ -36,7 +36,7 @@ getSpanInfo mods tcm =
   do let tcs = tm_typechecked_source tcm
          bs  = listifyAllSpans  tcs :: [LHsBind GhcTc]
          es  = listifyAllSpans  tcs :: [LHsExpr GhcTc]
-         ps  = listifyAllSpans' tcs :: [LPat GhcTc]
+         ps  = listifyAllSpans' tcs :: [Pat GhcTc]
      bts <- mapM (getTypeLHsBind tcm) bs -- binds
      ets <- mapM (getTypeLHsExpr tcm) es -- expressions
      pts <- mapM (getTypeLPat tcm)    ps -- patterns


### PR DESCRIPTION
Where we can, write code that works for both GHC API 8.6 and ghc-lib. Where we can't, do CPP.