### PR TITLE
Implement cross-package goto definition

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
@@ -14,27 +14,39 @@ import           Development.IDE.Functions.GHCError
 import Development.IDE.Orphans()
 
 -- DAML compiler and infrastructure
+import Development.Shake
+import Development.IDE.UtilGHC
+import Development.IDE.State.Shake
+import Development.IDE.State.RuleTypes
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.LSP
+import Development.IDE.Types.Options
 import           Development.IDE.Types.SpanInfo as SpanInfo
 
 -- GHC API imports
+import Avail
 import GHC
 import DynFlags
-import Outputable hiding ((<>))
+import HieTypes
+import FastString
 import Name
+import Outputable hiding ((<>))
 
+import Control.Monad.Extra
+import Control.Monad.Trans.Maybe
 import           Data.Maybe
 import           Data.List
 import qualified Data.Text as T
 
 -- | Locate the definition of the name at a given position.
 gotoDefinition
-  :: [SpanInfo]
+  :: IdeOptions
+  -> PackageDynFlags
+  -> [SpanInfo]
   -> Position
-  -> Maybe Location
-gotoDefinition srcSpans pos =
-  listToMaybe $ locationsAtPoint pos srcSpans
+  -> Action (Maybe Location)
+gotoDefinition ideOpts pkgState srcSpans pos =
+  listToMaybe <$> locationsAtPoint ideOpts pkgState pos srcSpans
 
 -- | Synopsis for the name at a given position.
 atPoint
@@ -74,10 +86,37 @@ atPoint tcs srcSpans pos = do
         Just name -> any (`isInfixOf` show name) ["==", "showsPrec"]
         Nothing -> False
 
-locationsAtPoint :: Position -> [SpanInfo] -> [Location]
-locationsAtPoint pos = map srcSpanToLocation
-                     . mapMaybe (SpanInfo.getSrcSpan . spaninfoSource)
-                     . spansAtPoint pos
+locationsAtPoint :: IdeOptions -> PackageDynFlags -> Position -> [SpanInfo] -> Action [Location]
+locationsAtPoint IdeOptions{..} pkgState pos =
+    fmap (map srcSpanToLocation) .
+    mapMaybeM (getSpan . spaninfoSource) .
+    spansAtPoint pos
+  where getSpan :: SpanSource -> Action (Maybe SrcSpan)
+        getSpan NoSource = pure Nothing
+        getSpan (Span sp) = pure $ Just sp
+        getSpan (Named name) = case nameSrcSpan name of
+            sp@(RealSrcSpan _) -> pure $ Just sp
+            UnhelpfulSpan _ -> runMaybeT $ do
+                -- This case usually arises when the definition is in an external package.
+                -- In this case the interface files contain garbage source spans
+                -- so we instead read the .hie files to get useful source spans.
+                let mod = nameModule name
+                let unitId = moduleUnitId mod
+                pkgConfig <- MaybeT $ pure $ lookupPackageConfig unitId pkgState
+                hiePath <- MaybeT $ liftIO $ optLocateHieFile pkgConfig mod
+                hieFile <- MaybeT $ use (GetHieFile hiePath) ""
+                avail <- MaybeT $ pure $ listToMaybe (filterAvails (eqName name) $ hie_exports hieFile)
+                srcPath <- MaybeT $ liftIO $ optLocateSrcFile pkgConfig mod
+                -- The location will point to the source file used during compilation.
+                -- This file might no longer exists and even if it does the path will be relative
+                -- to the compilation directory which we don’t know.
+                let span = setFileName srcPath $ nameSrcSpan $ availName avail
+                pure span
+        -- We ignore uniques and source spans and only compare the name and the module.
+        eqName :: Name -> Name -> Bool
+        eqName n n' = nameOccName n == nameOccName n' && nameModule n == nameModule n'
+        setFileName f (RealSrcSpan span) = RealSrcSpan (span { srcSpanFile = mkFastString f })
+        setFileName _ span@(UnhelpfulSpan _) = span
 
 spansAtPoint :: Position -> [SpanInfo] -> [SpanInfo]
 spansAtPoint pos = filter atp where

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
@@ -103,10 +103,10 @@ locationsAtPoint IdeOptions{..} pkgState pos =
                 let mod = nameModule name
                 let unitId = moduleUnitId mod
                 pkgConfig <- MaybeT $ pure $ lookupPackageConfig unitId pkgState
-                hiePath <- MaybeT $ liftIO $ optLocateHieFile pkgConfig mod
+                hiePath <- MaybeT $ liftIO $ optLocateHieFile optPkgLocationOpts pkgConfig mod
                 hieFile <- MaybeT $ use (GetHieFile hiePath) ""
                 avail <- MaybeT $ pure $ listToMaybe (filterAvails (eqName name) $ hie_exports hieFile)
-                srcPath <- MaybeT $ liftIO $ optLocateSrcFile pkgConfig mod
+                srcPath <- MaybeT $ liftIO $ optLocateSrcFile optPkgLocationOpts pkgConfig mod
                 -- The location will point to the source file used during compilation.
                 -- This file might no longer exists and even if it does the path will be relative
                 -- to the compilation directory which we don’t know.

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -6,6 +6,7 @@
 -- | Options
 module Development.IDE.Types.Options
   ( IdeOptions(..)
+  , IdePkgLocationOptions(..)
   ) where
 
 import Development.IDE.UtilGHC
@@ -18,13 +19,7 @@ data IdeOptions = IdeOptions
   , optRunGhcSession :: forall a. Maybe ParsedModule -> PackageDynFlags -> Ghc a -> IO a
   -- ^ Setup a GHC session using a given package state. If a `ParsedModule` is supplied,
   -- the import path should be setup for that module.
-  , optLocateHieFile :: PackageConfig -> Module -> IO (Maybe FilePath)
-  -- ^ Locate the HIE file for the given module. The PackageConfig can be
-  -- used to lookup settings like importDirs.
-  , optLocateSrcFile :: PackageConfig -> Module -> IO (Maybe FilePath)
-  -- ^ Locate the source file for the given module. The PackageConfig can be
-  -- used to lookup settings like importDirs. For DAML, we place them in the package DB.
-  -- For cabal this could point somewhere in ~/.cabal/packages.
+  , optPkgLocationOpts :: IdePkgLocationOptions
   , optWriteIface :: Bool
 
   , optMbPackageName :: Maybe String
@@ -35,4 +30,16 @@ data IdeOptions = IdeOptions
 
   , optThreads :: Int
   , optShakeProfiling :: Maybe FilePath
+  }
+
+
+-- | The set of options used to locate files belonging to external packages.
+data IdePkgLocationOptions = IdePkgLocationOptions
+  { optLocateHieFile :: PackageConfig -> Module -> IO (Maybe FilePath)
+  -- ^ Locate the HIE file for the given module. The PackageConfig can be
+  -- used to lookup settings like importDirs.
+  , optLocateSrcFile :: PackageConfig -> Module -> IO (Maybe FilePath)
+  -- ^ Locate the source file for the given module. The PackageConfig can be
+  -- used to lookup settings like importDirs. For DAML, we place them in the package DB.
+  -- For cabal this could point somewhere in ~/.cabal/packages.
   }

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -18,6 +18,13 @@ data IdeOptions = IdeOptions
   , optRunGhcSession :: forall a. Maybe ParsedModule -> PackageDynFlags -> Ghc a -> IO a
   -- ^ Setup a GHC session using a given package state. If a `ParsedModule` is supplied,
   -- the import path should be setup for that module.
+  , optLocateHieFile :: PackageConfig -> Module -> IO (Maybe FilePath)
+  -- ^ Locate the HIE file for the given module. The PackageConfig can be
+  -- used to lookup settings like importDirs.
+  , optLocateSrcFile :: PackageConfig -> Module -> IO (Maybe FilePath)
+  -- ^ Locate the source file for the given module. The PackageConfig can be
+  -- used to lookup settings like importDirs. For DAML, we place them in the package DB.
+  -- For cabal this could point somewhere in ~/.cabal/packages.
   , optWriteIface :: Bool
 
   , optMbPackageName :: Maybe String

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -10,6 +10,7 @@
 -- * Call setSessionDynFlags, use modifyDynFlags instead. It's faster and avoids loading packages.
 module Development.IDE.UtilGHC(
     PackageDynFlags(..), setPackageDynFlags, getPackageDynFlags,
+    lookupPackageConfig,
     modifyDynFlags,
     setPackageImports,
     setPackageDbs,
@@ -85,6 +86,16 @@ getPackageDynFlags DynFlags{..} = PackageDynFlags
     , pdfPkgState = pkgState
     , pdfThisUnitIdInsts = thisUnitIdInsts_
     }
+
+lookupPackageConfig :: UnitId -> PackageDynFlags -> Maybe PackageConfig
+lookupPackageConfig unitId PackageDynFlags {..} =
+    lookupPackage' False pkgConfigMap unitId
+    where
+        pkgConfigMap =
+            -- For some weird reason, the GHC API does not provide a way to get the PackageConfigMap
+            -- from PackageState so we have to wrap it in DynFlags first.
+            getPackageConfigMap fakeDynFlags { pkgState = pdfPkgState }
+
 
 
 prettyPrint :: Outputable a => a -> String

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Options.hs
@@ -71,8 +71,10 @@ toCompileOpts Options{..} =
             let importPaths = maybe [] moduleImportPaths mbMod <> optImportPath
             setupDamlGHC importPaths optMbPackageName packageState optGhcCustomOpts
             m
-      , optLocateHieFile = locateInPkgDb "hie"
-      , optLocateSrcFile = locateInPkgDb "daml"
+      , optPkgLocationOpts = Compile.IdePkgLocationOptions
+          { optLocateHieFile = locateInPkgDb "hie"
+          , optLocateSrcFile = locateInPkgDb "daml"
+          }
       , optWriteIface = optWriteInterface
       , optMbPackageName = optMbPackageName
       , optPackageDbs = optPackageDbs

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -57,7 +57,7 @@ buildDar dalf modRoot dalfDependencies fileDependencies dataFiles name = do
     -- produces interface files per default, hence we filter for existent files.
     fileDeps <-
         filterM doesFileExist $
-        concat [[dep, replaceExtension dep "hi"] | dep <- fileDependencies]
+        concat [[dep, dep -<.> "hi", dep -<.> "hie"] | dep <- fileDependencies]
     -- Reads all module source files, and pairs paths (with changed prefix)
     -- with contents as BS. The path must be within the module root path, and
     -- is modified to have prefix <name> instead of the original root path.

--- a/daml-foundations/daml-ghc/src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/ShakeIdeClient.hs
@@ -421,6 +421,15 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
             expectGoToDefinition (foo,2,[6..13]) (In "Prelude") -- "Optional"
             expectGoToDefinition (foo,2,[16..19]) (In "GHC.Types") -- "List"
             expectGoToDefinition (foo,2,[21..24]) (In "GHC.Types") -- "Bool"
+    ,    testCase' "Cross-package goto definition" $ do
+            foo <- makeModule "Foo"
+                [ "test = scenario do"
+                , "  p <- getParty \"Alice\""
+                , "  pure ()"
+                ]
+            setFilesOfInterest [foo]
+            expectNoErrors
+            expectGoToDefinition (foo, 3, [7..14]) (In "DA.Internal.LF")
     ]
     where
         testCase' = testCase mbScenarioService


### PR DESCRIPTION
This is more tricky than one might think at first:

- The interface files do not contain proper source spans so we cannot
  use the information in there.
- We could theoretically try to get the source location from the DALFs
  but that is the wrong layer and also not an option when we want to
  act as a Haskell IDE.

So what we do instead is whenever we write interface files we also
write .hie files and consult those instead when we get useless source
spans otherwise.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
