### PR TITLE
Show help on errors in daml-assistant and daml-helper

### DIFF
--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -8,7 +8,8 @@ import Options.Applicative
 import DamlHelper
 
 main :: IO ()
-main = runCommand =<< execParser (info (commandParser <**> helper) idm)
+main = runCommand =<< customExecParser parserPrefs (info (commandParser <**> helper) idm)
+  where parserPrefs = prefs showHelpOnError
 
 data Command
     = DamlStudio { replaceExtension :: ReplaceExtension, remainingArguments :: [String] }

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -22,7 +22,8 @@ import Options.Applicative
 
 getCommand :: [SdkCommandInfo] -> IO Command
 getCommand sdkCommands =
-    execParser $ info (commandParser sdkCommands <**> helper) forwardOptions
+    customExecParser parserPrefs $ info (commandParser sdkCommands <**> helper) forwardOptions
+    where parserPrefs = prefs showHelpOnError
 
 subcommand :: Text -> Text -> InfoMod Command -> Parser Command -> Mod CommandFields Command
 subcommand name desc infoMod parser =


### PR DESCRIPTION
As requested by @nickchapman-da  in #965 

> daml and daml new etc. could show the help text. Or at least report that --help is an option.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
