### PR TITLE
Update rules_nixpkgs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,6 +72,7 @@ nixpkgs_cc_configure(
     nix_file = "//nix:bazel-cc-toolchain.nix",
     nix_file_deps = common_nix_file_deps + [
         "//nix:bazel-cc-toolchain.nix",
+        "//nix:tools/bazel-cc-toolchain/default.nix",
     ],
     repositories = dev_env_nix_repos,
 )
@@ -296,6 +297,8 @@ nixpkgs_package(
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps + [
         "//nix:overrides/sass/default.nix",
+        "//nix:overrides/sass/Gemfile",
+        "//nix:overrides/sass/Gemfile.lock",
         "//nix:overrides/sass/gemset.nix",
     ],
     repositories = dev_env_nix_repos,

--- a/deps.bzl
+++ b/deps.bzl
@@ -29,7 +29,7 @@
 rules_scala_version = "6f8ee3d951d2ac6154356314600f6edb4eb5df8b"
 rules_haskell_version = "6c550c8eb7ce7950e702420be39d932b8b31ef22"
 rules_haskell_sha256 = "aef68cf5d732b2fa9ae0efea344cb83cb0c16f0f08a8d6901776a0085fbe7a8b"
-rules_nixpkgs_version = "40b5a9f23abca57f364c93245c7451206ef1a855"
+rules_nixpkgs_version = "5ffb8a4ee9a52bc6bc12f95cd64ecbd82a79bc82"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
@@ -56,7 +56,7 @@ def daml_deps():
             name = "io_tweag_rules_nixpkgs",
             strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
-            sha256 = "a1e113bbd69c97e49cbedce9af0f256756cc5ab1b77aafaab476f1d9d47e9d81",
+            sha256 = "085d480232c0bada20c0d0b8b1b4ba8c62fcc006d9dc826aa0e4205e4dca6cb3",
         )
 
     if "ai_formation_hazel" not in native.existing_rules():


### PR DESCRIPTION
Now enforces that the `nix_file_deps` attribute covers all files that are read by Nix.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
