### PR TITLE
Java Bindings: Properly convert CreateAndExerciseCommand

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,7 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 - Java Codegen: variants with unserializable cases are now accepted (see `#946 <https://github.com/digital-asset/daml/pull/946>`_)
+- Java Bindings: ``CreateAndExerciseCommand`` is now properly converted in the Java Bindings data layer (see `#979 <https://github.com/digital-asset/daml/pull/979>`_)
 
 0.12.15 - 2019-05-06
 --------------------

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Command.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Command.java
@@ -17,6 +17,8 @@ public abstract class Command {
                 return CreateCommand.fromProto(command.getCreate());
             case EXERCISE:
                 return ExerciseCommand.fromProto(command.getExercise());
+            case CREATEANDEXERCISE:
+                return CreateAndExerciseCommand.fromProto(command.getCreateAndExercise());
             case COMMAND_NOT_SET:
             default:
                 throw new ProtoCommandUnknown(command);
@@ -24,19 +26,17 @@ public abstract class Command {
     }
 
     public CommandsOuterClass.Command toProtoCommand() {
+        CommandsOuterClass.Command.Builder builder = CommandsOuterClass.Command.newBuilder();
         if (this instanceof CreateCommand) {
-            CreateCommand command = (CreateCommand) this;
-            return CommandsOuterClass.Command.newBuilder()
-                    .setCreate(command.toProto())
-                    .build();
+            builder.setCreate(((CreateCommand) this).toProto());
         } else if (this instanceof ExerciseCommand) {
-            ExerciseCommand command = (ExerciseCommand) this;
-            return CommandsOuterClass.Command.newBuilder()
-                    .setExercise(command.toProto())
-                    .build();
+            builder.setExercise(((ExerciseCommand) this).toProto());
+        } else if (this instanceof CreateAndExerciseCommand) {
+            builder.setCreateAndExercise(((CreateAndExerciseCommand) this).toProto());
         } else {
             throw new CommandUnknown(this);
         }
+        return builder.build();
     }
 
     public final Optional<CreateCommand> asCreateCommand() {

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/CommandSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/CommandSpec.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data
+
+import com.daml.ledger.javaapi.data.Generators._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class CommandSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSize = 1, sizeRange = 3)
+
+  "Command.fromProto" should "convert Protoc-generated instances to data instances" in forAll(
+    commandGen) { cmd =>
+    val converted = Command.fromProtoCommand(cmd)
+    Command.fromProtoCommand(converted.toProtoCommand) shouldEqual converted
+  }
+}

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -5,12 +5,7 @@ package com.daml.ledger.javaapi.data
 
 import java.time.{Instant, LocalDate}
 
-import com.digitalasset.ledger.api.v1.{
-  ActiveContractsServiceOuterClass,
-  EventOuterClass,
-  TransactionFilterOuterClass,
-  ValueOuterClass
-}
+import com.digitalasset.ledger.api.v1._
 import com.google.protobuf.Empty
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -297,4 +292,55 @@ object Generators {
         .setFilter(transactionFilter)
         .setVerbose(verbose)
         .build()
+
+  val createCommandGen: Gen[CommandsOuterClass.Command] =
+    for {
+      templateId <- identifierGen
+      record <- recordGen
+    } yield
+      CommandsOuterClass.Command
+        .newBuilder()
+        .setCreate(
+          CommandsOuterClass.CreateCommand
+            .newBuilder()
+            .setTemplateId(templateId)
+            .setCreateArguments(record))
+        .build()
+
+  val exerciseCommandGen: Gen[CommandsOuterClass.Command] =
+    for {
+      templateId <- identifierGen
+      choiceName <- Arbitrary.arbString.arbitrary
+      value <- valueGen
+    } yield
+      CommandsOuterClass.Command
+        .newBuilder()
+        .setExercise(
+          CommandsOuterClass.ExerciseCommand
+            .newBuilder()
+            .setTemplateId(templateId)
+            .setChoice(choiceName)
+            .setChoiceArgument(value))
+        .build()
+
+  val createAndExerciseCommandGen: Gen[CommandsOuterClass.Command] =
+    for {
+      templateId <- identifierGen
+      record <- recordGen
+      choiceName <- Arbitrary.arbString.arbitrary
+      value <- valueGen
+    } yield
+      CommandsOuterClass.Command
+        .newBuilder()
+        .setCreateAndExercise(
+          CommandsOuterClass.CreateAndExerciseCommand
+            .newBuilder()
+            .setTemplateId(templateId)
+            .setCreateArguments(record)
+            .setChoice(choiceName)
+            .setChoiceArgument(value))
+        .build()
+
+  val commandGen: Gen[CommandsOuterClass.Command] =
+    Gen.oneOf(createCommandGen, exerciseCommandGen, createAndExerciseCommandGen)
 }


### PR DESCRIPTION
The conversion of the CreateAndExerciseCommand in the Command base class
was missing. This also adds a missing test for that.

Fixes #979.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
