### PR TITLE
Fixes to kvutils when used as external workspace

### DIFF
--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -15,6 +15,7 @@ da_scala_library(
     visibility = [
         "//visibility:public",
     ],
+    exports = [":daml_kvutils_java_proto"],
     runtime_deps = [],
     deps = [
         ":daml_kvutils_java_proto",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -36,6 +36,9 @@ object KeyValueCommitting {
   def packDamlLogEntry(entry: DamlLogEntry): ByteString = entry.toByteString
   def unpackDamlLogEntry(bytes: ByteString): DamlLogEntry = DamlLogEntry.parseFrom(bytes)
 
+  def packDamlLogEntryId(entry: DamlLogEntryId): ByteString = entry.toByteString
+  def unpackDamlLogEntryId(bytes: ByteString): DamlLogEntryId = DamlLogEntryId.parseFrom(bytes)
+
   /** Pretty-printing of the entry identifier. Uses the same hexadecimal encoding as is used
     * for absolute contract identifiers.
     */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -58,7 +58,7 @@ import com.digitalasset.daml.lf.value.Value
 package object v1 {
 
   /** Identifier for the ledger, MUST match regexp [a-zA-Z0-9-]. */
-  type LedgerId = Ref.PackageId
+  type LedgerId = String
 
   /** Identifiers for transactions.
     * Currently unrestricted unicode (See issue #398). */


### PR DESCRIPTION
This fixes two issues encountered when trying to use kvutils from
an external bazel workspace:

- the daml_kvutils_java_proto wasn't listed as exported in the kvutils target and that caused missing symbols error.
- LedgerId's type was changed to Ref.PackageId which was clearly wrong. It is unclear to me how usable the MatchingStringModule (what a weird name) is from Java, so I'm playing it safe and setting it to a String.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
