### PR TITLE
avoiding linear searching for transactions from genesis

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -8,6 +8,7 @@ This page contains release notes for the SDK.
 
 HEAD — ongoing
 --------------
+- Making transaction lookups performant so we can handle such requests for large ledgers as well
 
 - Sandbox: Transactions with a record time that is after the maximum record time (as provided in the original command)
   are now properly rejected instead of committed to the ledger: `#987 <https://github.com/digital-asset/daml/issues/987>`_

--- a/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
+++ b/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
@@ -73,9 +73,9 @@ trait LedgerBackend extends AutoCloseable {
     * on reconnects to the Ledger API that they are connected to the same
     * ledger and can therefore expect to receive the same data on calls that
     * return append-only data. It is expected to be:
-    *   (1) immutable over the lifetime of a [[LedgerBackend]] instance,
-    *   (2) globally unique with high-probability,
-    *   (3) matching the regexp [a-zA-Z0-9]+.
+    * (1) immutable over the lifetime of a [[LedgerBackend]] instance,
+    * (2) globally unique with high-probability,
+    * (3) matching the regexp [a-zA-Z0-9]+.
     *
     * Implementations where Participant nodes share a global view on all
     * transactions in the ledger (e.g, via a blockchain) are expected to use
@@ -102,17 +102,17 @@ trait LedgerBackend extends AutoCloseable {
 
   /** Return the stream of ledger events starting from and including the given offset.
     *
-    * @param offset: the ledger offset starting from which events should be streamed.
+    * @param offset : the ledger offset starting from which events should be streamed.
     *
-    * The stream only terminates if there was an error.
+    *               The stream only terminates if there was an error.
     *
-    * Two calls to this method with the same arguments are related such
-    * that
-    *  (1) all events are delivered in the same order, but
-    *  (2) [[LedgerSyncEvent.RejectedCommand]] and [[LedgerSyncEvent.Heartbeat]] events can be elided if their
-    *      recordTime is equal to the preceding event.
-    * This rule provides implementors with the freedom to not persist
-    * [[LedgerSyncEvent.RejectedCommand]] and [[LedgerSyncEvent.Heartbeat]] events.
+    *               Two calls to this method with the same arguments are related such
+    *               that
+    *               (1) all events are delivered in the same order, but
+    *               (2) [[LedgerSyncEvent.RejectedCommand]] and [[LedgerSyncEvent.Heartbeat]] events can be elided if their
+    *               recordTime is equal to the preceding event.
+    *               This rule provides implementors with the freedom to not persist
+    *               [[LedgerSyncEvent.RejectedCommand]] and [[LedgerSyncEvent.Heartbeat]] events.
     *
     */
   def ledgerSyncEvents(offset: Option[LedgerSyncOffset] = None): Source[LedgerSyncEvent, NotUsed]
@@ -155,6 +155,6 @@ trait LedgerBackend extends AutoCloseable {
     */
   def getCurrentLedgerEnd: Future[LedgerSyncOffset]
 
-  //TODO: doc
+  /** Looks up a transaction by its id. */
   def getTransactionById(transactionId: TransactionId): Future[Option[AcceptedTransaction]]
 }

--- a/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
+++ b/ledger/backend-api/src/main/scala/com/digitalasset/ledger/backend/api/v1/LedgerBackend.scala
@@ -5,6 +5,7 @@ package com.digitalasset.ledger.backend.api.v1
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.digitalasset.ledger.backend.api.v1.LedgerSyncEvent.AcceptedTransaction
 
 import scala.concurrent.Future
 
@@ -153,4 +154,7 @@ trait LedgerBackend extends AutoCloseable {
     *
     */
   def getCurrentLedgerEnd: Future[LedgerSyncOffset]
+
+  //TODO: doc
+  def getTransactionById(transactionId: TransactionId): Future[Option[AcceptedTransaction]]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -157,7 +157,7 @@ class TransactionServiceRequestValidator(
       req: GetTransactionByIdRequest): Result[transaction.GetTransactionByIdRequest] = {
     for {
       ledgerId <- matchId(req.ledgerId)
-      _ <- requireNonEmptyString(req.transactionId, "transaction_id")
+      _ <- requireNumber(req.transactionId, "transaction_id")
       _ <- requireNonEmpty(req.requestingParties, "requesting_parties")
       parties <- requireParties(req.requestingParties)
       _ <- requireKnownParties(parties)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -157,14 +157,14 @@ class TransactionServiceRequestValidator(
       req: GetTransactionByIdRequest): Result[transaction.GetTransactionByIdRequest] = {
     for {
       ledgerId <- matchId(req.ledgerId)
-      _ <- requireNumber(req.transactionId, "transaction_id")
+      trId <- requireNumber(req.transactionId, "transaction_id")
       _ <- requireNonEmpty(req.requestingParties, "requesting_parties")
       parties <- requireParties(req.requestingParties)
       _ <- requireKnownParties(parties)
     } yield {
       transaction.GetTransactionByIdRequest(
         ledgerId,
-        domain.TransactionId(req.transactionId),
+        domain.TransactionId(trId.toString),
         parties,
         req.traceContext.map(toBrave))
     }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
@@ -8,6 +8,7 @@ import com.digitalasset.platform.server.api.validation.ErrorFactories._
 import io.grpc.StatusRuntimeException
 
 import scala.language.higherKinds
+import scala.util.Try
 
 trait FieldValidations {
 
@@ -18,6 +19,12 @@ trait FieldValidations {
   def requireNonEmptyString(s: String, fieldName: String): Either[StatusRuntimeException, String] =
     if (s.nonEmpty) Right(s)
     else Left(missingField(fieldName))
+
+  def requireNumber(s: String, fieldName: String): Either[StatusRuntimeException, Long] =
+    for {
+      s <- requireNonEmptyString(s, fieldName)
+      number <- Try(s.toLong).toEither.left.map(t => invalidField(fieldName, t.getMessage))
+    } yield number
 
   def requirePackageId(
       s: String,

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -30,7 +30,7 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
   protected val party = Ref.Party.assertFromString("party")
   protected val verbose = false
   protected val eventId = "eventId"
-  protected val transactionId = "transactionId"
+  protected val transactionId = "42"
   protected val offsetOrdering = Ordering.by[domain.LedgerOffset.Absolute, Int](_.value.toInt)
   protected val ledgerEnd = domain.LedgerOffset.Absolute("1000")
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxEventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxEventIdFormatter.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 
 object SandboxEventIdFormatter {
 
-  case class TransactionIdWithIndex(transactionId: String, nodeId: Transaction.NodeId)
+  case class TransactionIdWithIndex(transactionId: Long, nodeId: Transaction.NodeId)
 
   def makeAbsCoid(transactionId: String)(coid: Lf.ContractId): Lf.AbsoluteContractId = coid match {
     case a @ Lf.AbsoluteContractId(_) => a
@@ -34,8 +34,10 @@ object SandboxEventIdFormatter {
       case Array(transactionId, index) =>
         transactionId.splitAt(1) match {
           case ("#", transId) =>
-            Try(index.toInt).toOption
-              .map(ix => TransactionIdWithIndex(transId, Transaction.NodeId.unsafeFromIndex(ix)))
+            (for {
+              ix <- Try(index.toInt)
+              tId <- Try(transId.toLong)
+            } yield TransactionIdWithIndex(tId, Transaction.NodeId.unsafeFromIndex(ix))).toOption
           case _ => None
         }
       case _ => None

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
@@ -160,7 +160,9 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
             .withDescription(s"invalid eventId: ${request.eventId}")
             .asRuntimeException())) {
         case TransactionIdWithIndex(transactionId, index) =>
-          lookUpTreeByTransactionId(TransactionId(transactionId), request.requestingParties)
+          lookUpTreeByTransactionId(
+            TransactionId(transactionId.toString),
+            request.requestingParties)
       }
   }
 
@@ -180,7 +182,9 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
             .withDescription(s"invalid eventId: ${request.eventId}")
             .asRuntimeException())) {
         case TransactionIdWithIndex(transactionId, index) =>
-          lookUpFlatByTransactionId(TransactionId(transactionId), request.requestingParties)
+          lookUpFlatByTransactionId(
+            TransactionId(transactionId.toString),
+            request.requestingParties)
       }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxTransactionService.scala
@@ -202,7 +202,7 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
   private def lookUpTreeByTransactionId(
       transactionId: TransactionId,
       requestingParties: Set[Party]): Future[Option[VisibleTransaction]] =
-    ledgerBackend
+    transactionPipeline
       .getTransactionById(transactionId.unwrap)
       .flatMap {
         case Some(trans) =>
@@ -218,7 +218,7 @@ class SandboxTransactionService private (val ledgerBackend: LedgerBackend, paral
   private def lookUpFlatByTransactionId(
       transactionId: TransactionId,
       requestingParties: Set[Party]): Future[Option[PTransaction]] =
-    ledgerBackend
+    transactionPipeline
       .getTransactionById(transactionId.unwrap)
       .flatMap {
         case Some(trans) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -12,7 +12,11 @@ import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
-import com.digitalasset.ledger.backend.api.v1.{SubmissionResult, TransactionSubmission}
+import com.digitalasset.ledger.backend.api.v1.{
+  SubmissionResult,
+  TransactionId,
+  TransactionSubmission
+}
 import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ActiveContracts.ActiveContract
 import com.digitalasset.platform.sandbox.stores.ActiveContractsInMemory
@@ -40,6 +44,9 @@ trait Ledger extends AutoCloseable {
   def publishHeartbeat(time: Instant): Future[Unit]
 
   def publishTransaction(transactionSubmission: TransactionSubmission): Future[SubmissionResult]
+
+  def lookupTransaction(
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]]
 }
 
 object Ledger {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -10,7 +10,11 @@ import akka.stream.scaladsl.Source
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
-import com.digitalasset.ledger.backend.api.v1.{SubmissionResult, TransactionSubmission}
+import com.digitalasset.ledger.backend.api.v1.{
+  SubmissionResult,
+  TransactionId,
+  TransactionSubmission
+}
 import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ActiveContracts.ActiveContract
 
@@ -41,6 +45,10 @@ private class MeteredLedger(ledger: Ledger, mm: MetricsManager) extends Ledger {
   override def publishTransaction(
       transactionSubmission: TransactionSubmission): Future[SubmissionResult] =
     mm.timedFuture("Ledger:publishTransaction", ledger.publishTransaction(transactionSubmission))
+
+  override def lookupTransaction(
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
+    mm.timedFuture("Ledger:lookupTransaction", ledger.lookupTransaction(transactionId))
 
   override def close(): Unit = {
     ledger.close()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -14,6 +14,7 @@ import com.digitalasset.ledger.api.domain.{ApplicationId, CommandId}
 import com.digitalasset.ledger.backend.api.v1.{
   RejectionReason,
   SubmissionResult,
+  TransactionId,
   TransactionSubmission
 }
 import com.digitalasset.platform.sandbox.services.transaction.SandboxEventIdFormatter
@@ -159,4 +160,13 @@ class InMemoryLedger(
 
   override def close(): Unit = ()
 
+  override def lookupTransaction(
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
+    Future.successful(
+      entries
+        .getEntryAt(transactionId.toLong)
+        .collect[(Long, LedgerEntry.Transaction)] {
+          case t: LedgerEntry.Transaction =>
+            (transactionId.toLong, t) // the transaction id is also the offset
+        })
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
@@ -52,4 +52,7 @@ private[ledger] class LedgerEntries[T](identify: T => String) {
   def ledgerBeginning: Long = 0L
 
   def ledgerEnd: Long = state.get().ledgerEnd
+
+  def getEntryAt(offset: Long): Option[T] =
+    state.get.items.get(offset)
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventIdFormatterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventIdFormatterSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{Matchers, WordSpec}
 class EventIdFormatterSpec extends WordSpec with Matchers with ScalaFutures {
 
   "EventIdFormatter" should {
-    val transactionId = "SOME_TRANSACTION_ID"
+    val transactionId = "42"
     val index: Transaction.NodeId = Transaction.NodeId.unsafeFromIndex(42)
     val referenceEventID = s"#$transactionId:${index.index}"
 
@@ -21,7 +21,7 @@ class EventIdFormatterSpec extends WordSpec with Matchers with ScalaFutures {
 
     "split an eventId into a transactionId and an index" in {
       SandboxEventIdFormatter.split(referenceEventID) should equal(
-        Some(TransactionIdWithIndex(transactionId, index)))
+        Some(TransactionIdWithIndex(transactionId.toLong, index)))
     }
 
     "return None when parsing an invalid argument" in {


### PR DESCRIPTION
Transaction lookup has been implemented by running a linear search from genesis, which clearly has its downsides. This PR reduces the problem to an O(1) look-up.

fixes #831 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
