### PR TITLE
sandbox: correct KeyHasherSpec

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Decimal.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Decimal.scala
@@ -81,6 +81,9 @@ object Decimal {
     else
       Left(s"""Could not read Decimal string "$s"""")
 
+  def assertFromString(s: String): Decimal =
+    assert(fromString(s))
+
   def toString(d: Decimal): String = {
     // Strip the trailing zeros (which BigDecimal keeps if the string
     // it was created from had them), and use the plain notation rather
@@ -110,5 +113,8 @@ object Decimal {
     else
       Left(s"Decimal $x does not fit into an Int64")
   }
+
+  private def assert[X](either: Either[String, X]): X =
+    either.fold(e => throw new IllegalArgumentException(e), identity)
 
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
@@ -25,8 +25,8 @@ class KeyHasherSpec extends WordSpec with Matchers {
     builder += None -> ValueInt64(0)
     builder += None -> ValueInt64(123456)
     builder += None -> ValueInt64(-1)
-    builder += None -> ValueDecimal(BigDecimal(0))
-    builder += None -> ValueDecimal(BigDecimal(1) / BigDecimal(3))
+    builder += None -> ValueDecimal(Decimal.assertFromString("0"))
+    builder += None -> ValueDecimal(Decimal.assertFromString("0.3333333333"))
     builder += None -> ValueBool(true)
     builder += None -> ValueBool(false)
     builder += None -> ValueDate(Time.Date.assertFromDaysSinceEpoch(0))
@@ -63,7 +63,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     "be stable" in {
       // Hashing function must not change
       val value = VersionedValue(ValueVersion("4"), complexValue)
-      val hash = "4f44a1674ef37e1019fcfd1c74047aef97a4cf34991bb9ee3368166254b7c77c"
+      val hash = "ecbc3f9c121e23ef2851c06d77de82d0f58f27acdf9c5fecff9b904ad236621b"
 
       KeyHasher.hashKeyString(GlobalKey(templateId("module", "name"), value)) shouldBe hash
     }


### PR DESCRIPTION
The `KeyHasherSpec` test use Decimal value that should not  be  store on the ledger (namely `BigDecimal(0)` and `BigDecimal(1)/BigDecimal(3)`. 

This PR amends the test with a more reasonable values (namely a Decimal with scale = 10).
 
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
