### PR TITLE
More stringent detection of daml installation in daml-sdk-head.

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -66,12 +66,13 @@ mkdir -p $TMPDIR/sdk-head
 
 tar xzf $TARBALL -C $TMPDIR/sdk-head --strip-components 1
 
-if [ -d $DAML_HOME ] ; then
+readonly DAML_CMD="$(which daml)"
+if [ -x "$DAML_CMD" ] && [ "$DAML_CMD" == "$DAML_HOME/bin/daml" ] ; then
   # A daml installation already exists, so just install SDK version 0.0.0.
   $DAML_HOME/bin/daml install $TMPDIR/sdk-head --force
 else
-  # No daml installation exists, so install the tarball normally but disable auto-install.
-  $TMPDIR/sdk-head/install.sh
+  # No daml installation detected, so install the tarball normally but disable auto-install.
+  $TMPDIR/sdk-head/install.sh --force
   echo "auto-install: false" > $DAML_HOME/daml-config.yaml
 fi
 


### PR DESCRIPTION
Fixes a bug that @leo-da found with running daml-sdk-head multiple times without a working daml installation.