### PR TITLE
Remove broken timestamp test

### DIFF
--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/TimestampSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/TimestampSpec.scala
@@ -24,15 +24,6 @@ class TimestampSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyC
     }
   }
 
-  it should "be convertible to java.time.Instant" in {
-    val instant = java.time.Instant.now()
-    val timestamp = Timestamp.fromInstant(instant)
-    withClue(
-      s"input: ${instant} instant.getEpochSeconds: ${instant.getEpochSecond} instant.getNanos: ${instant.getNano} timestamp: ${timestamp} issue: ") {
-      timestamp.toInstant shouldBe instant
-    }
-  }
-
   it should "lose nanoseconds when doing TimeStamp.fromInstant(_).toInstant()" in {
     val instant = java.time.Instant.ofEpochSecond(1, 42)
     val timestamp = Timestamp.fromInstant(instant)


### PR DESCRIPTION
This test only worked by chance since in older JDK versions
java.time.Instant.now() didn’t have nanoseconds precision. As
evidenced by the test after this, nanoseconds are lost during a
roundtrip so this test breaks on newer JDK versions that increased the
precision. See https://bugs.openjdk.java.net/browse/JDK-8068730 for
more information.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
