### PR TITLE
making sql queue depth configurable -> making back-pressure tests more reliable

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
@@ -96,8 +96,9 @@ object SandboxApplication {
             ledgerId,
             timeProvider,
             records,
-            config.commandConfig.maxCommandsInFlight,
-            startMode)
+            config.commandConfig.maxCommandsInFlight * 2, // we can get commands directly as well on the submission service
+            startMode
+          )
 
           val ledger = Try(Await.result(ledgerF, asyncTolerance)).fold(t => {
             val msg = "Could not start PostgreSQL persistence layer"

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxApplication.scala
@@ -91,7 +91,13 @@ object SandboxApplication {
         case None =>
           ("in-memory", Ledger.metered(Ledger.inMemory(ledgerId, timeProvider, acs, records)))
         case Some(jdbcUrl) =>
-          val ledgerF = Ledger.postgres(jdbcUrl, ledgerId, timeProvider, records, startMode)
+          val ledgerF = Ledger.postgres(
+            jdbcUrl,
+            ledgerId,
+            timeProvider,
+            records,
+            config.commandConfig.maxCommandsInFlight,
+            startMode)
 
           val ledger = Try(Await.result(ledgerF, asyncTolerance)).fold(t => {
             val msg = "Could not start PostgreSQL persistence layer"

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -69,6 +69,7 @@ object Ledger {
     * @param ledgerId      the id to be used for the ledger
     * @param timeProvider  the provider of time
     * @param ledgerEntries the starting entries
+    * @param queueDepth    the depth of the buffer for persisting entries. When gets full, the system will signal back-pressure upstream
     * @param startMode     whether the ledger should be reset, or continued where it was
     * @return a Postgres backed Ledger
     */
@@ -77,10 +78,17 @@ object Ledger {
       ledgerId: String,
       timeProvider: TimeProvider,
       ledgerEntries: Seq[LedgerEntry],
+      queueDepth: Int,
       startMode: SqlStartMode
   )(implicit mat: Materializer, mm: MetricsManager): Future[Ledger] =
     //TODO (robert): casting from Seq to immutable.Seq, make ledgerEntries immutable throughout the Sandbox?
-    SqlLedger(jdbcUrl, Some(ledgerId), timeProvider, immutable.Seq(ledgerEntries: _*), startMode)
+    SqlLedger(
+      jdbcUrl,
+      Some(ledgerId),
+      timeProvider,
+      immutable.Seq(ledgerEntries: _*),
+      queueDepth,
+      startMode)
 
   /** Wraps the given Ledger adding metrics around important calls */
   def metered(ledger: Ledger)(implicit mm: MetricsManager): Ledger = MeteredLedger(ledger)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -23,13 +23,16 @@ class SqlLedgerSpec
 
   override val timeLimit: Span = 60.seconds
 
+  private val queueDepth = 128
+
   "SQL Ledger" should {
     "be able to be created from scratch with a random ledger id" in {
       val ledgerF = SqlLedger(
         jdbcUrl = postgresFixture.jdbcUrl,
         ledgerId = None,
         timeProvider = TimeProvider.UTC,
-        ledgerEntries = Nil)
+        ledgerEntries = Nil,
+        queueDepth)
 
       ledgerF.map { ledger =>
         ledger.ledgerId should not be equal("")
@@ -43,7 +46,8 @@ class SqlLedgerSpec
         jdbcUrl = postgresFixture.jdbcUrl,
         ledgerId = Some(ledgerId),
         timeProvider = TimeProvider.UTC,
-        ledgerEntries = Nil)
+        ledgerEntries = Nil,
+        queueDepth)
 
       ledgerF.map { ledger =>
         ledger.ledgerId should not be equal(ledgerId)
@@ -58,17 +62,20 @@ class SqlLedgerSpec
           jdbcUrl = postgresFixture.jdbcUrl,
           ledgerId = Some(ledgerId),
           timeProvider = TimeProvider.UTC,
-          ledgerEntries = Nil)
+          ledgerEntries = Nil,
+          queueDepth)
         ledger2 <- SqlLedger(
           jdbcUrl = postgresFixture.jdbcUrl,
           ledgerId = Some(ledgerId),
           timeProvider = TimeProvider.UTC,
-          ledgerEntries = Nil)
+          ledgerEntries = Nil,
+          queueDepth)
         ledger3 <- SqlLedger(
           jdbcUrl = postgresFixture.jdbcUrl,
           ledgerId = None,
           timeProvider = TimeProvider.UTC,
-          ledgerEntries = Nil)
+          ledgerEntries = Nil,
+          queueDepth)
       } yield {
         ledger1.ledgerId should not be equal(ledgerId)
         ledger1.ledgerId shouldEqual ledger2.ledgerId
@@ -83,13 +90,15 @@ class SqlLedgerSpec
           jdbcUrl = postgresFixture.jdbcUrl,
           ledgerId = Some("TheLedger"),
           timeProvider = TimeProvider.UTC,
-          ledgerEntries = Nil
+          ledgerEntries = Nil,
+          queueDepth
         )
         _ <- SqlLedger(
           jdbcUrl = postgresFixture.jdbcUrl,
           ledgerId = Some("AnotherLedger"),
           timeProvider = TimeProvider.UTC,
-          ledgerEntries = Nil
+          ledgerEntries = Nil,
+          queueDepth
         )
       } yield (())
 


### PR DESCRIPTION
Fixing a flaky back pressure test by making the sql buffer depth configurable. (Ironically in some cases it was performant enough, not to fail)

Fixes #1012 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
