### PR TITLE
Open docs.daml.com instead of running "da docs"

### DIFF
--- a/daml-foundations/daml-tools/daml-extension/package.json
+++ b/daml-foundations/daml-tools/daml-extension/package.json
@@ -13,7 +13,7 @@
     "activationEvents": [
         "onLanguage:daml",
         "onCommand:daml.showResource",
-        "onCommand:daml.showDamlUserGuide"
+        "onCommand:daml.openDamlDocs"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -57,8 +57,8 @@
                 "title": "Open DAML virtual resource"
             },
             {
-                "command": "daml.showDamlUserGuide",
-                "title": "[DAML User's Guide]"
+                "command": "daml.openDamlDocs",
+                "title": "[DAML Documentation]"
             },
             {
                 "command": "daml.resetTelemetryConsent",
@@ -67,7 +67,7 @@
         ],
         "keybindings": [
             {
-                "command": "daml.showDamlUserGuide",
+                "command": "daml.openDamlDocs",
                 "key": "ctrl+f1",
                 "mac": "cmd+f1"
             }
@@ -106,7 +106,7 @@
             "editor/title": [
                 {
                     "when": "resourceLangId == daml",
-                    "command": "daml.showDamlUserGuide",
+                    "command": "daml.openDamlDocs",
                     "group": "navigation"
                 }
             ]

--- a/daml-foundations/daml-tools/daml-extension/src/extension.ts
+++ b/daml-foundations/daml-tools/daml-extension/src/extension.ts
@@ -59,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
         (title,uri)=> damlContentProvider.showResource(title,uri)
         );
 
-    let d2 = vscode.commands.registerCommand('daml.showDamlUserGuide', showDamlUserGuide);
+    let d2 = vscode.commands.registerCommand('daml.openDamlDocs', openDamlDocs);
 
     let highlight = vscode.window.createTextEditorDecorationType({ backgroundColor: 'rgba(200,200,200,.35)' });
 
@@ -122,12 +122,8 @@ function getViewColumnForShowResource(): ViewColumn {
     }
 }
 
-function showDamlUserGuide() {
-    cp.exec(`${daCmdPath} docs`, (err) => {
-        if (err) {
-            vscode.window.showErrorMessage(`openURL error: ${err}`);
-        }
-    });
+function openDamlDocs() {
+    vscode.env.openExternal(vscode.Uri.parse("https://docs.daml.com"));
 }
 
 function modifyBuffer(filePath: {uri: string}) {

--- a/web-ide/ide-server/keybindings.json
+++ b/web-ide/ide-server/keybindings.json
@@ -1,7 +1,7 @@
 [
     {
         "key": "cmd+f1",
-        "command": "-daml.showDamlUserGuide"
+        "command": "-daml.openDamlDocs"
     },
     {
         "key": "ctrl+shift+`",


### PR DESCRIPTION
Previously we tried to run "da docs" which makes no sense for the new
assistant and for the old assistant it just outputs a message to go to
the website.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
