### PR TITLE
windows: back to official rules_scala repo

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -26,7 +26,7 @@
 # prefix: @com_github_digital_asset_daml//..., as these won't
 # be resolvable from external workspaces otherwise.
 
-rules_scala_version = "6f8ee3d951d2ac6154356314600f6edb4eb5df8b"
+rules_scala_version = "78104d8014d4e4fc8f905cd34b91dfabd9a268c8"
 rules_haskell_version = "6c550c8eb7ce7950e702420be39d932b8b31ef22"
 rules_haskell_sha256 = "aef68cf5d732b2fa9ae0efea344cb83cb0c16f0f08a8d6901776a0085fbe7a8b"
 rules_nixpkgs_version = "5ffb8a4ee9a52bc6bc12f95cd64ecbd82a79bc82"
@@ -91,14 +91,10 @@ def daml_deps():
     if "io_bazel_rules_scala" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_scala",
-            # TODO: switch back to bazelbuild/rules_scala repo after merge of these PRs:
-            # https://github.com/bazelbuild/rules_scala/pull/717
-            # https://github.com/bazelbuild/rules_scala/pull/718
-            #url = 'https://github.com/bazelbuild/rules_scala/archive/%s.zip' % rules_scala_version,
-            url = "https://github.com/majcherm-da/rules_scala/archive/%s.zip" % rules_scala_version,
+            url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
             type = "zip",
             strip_prefix = "rules_scala-%s" % rules_scala_version,
-            sha256 = "9774acd82267cdf486af38b325b410abf34965dc173e7188406852dd28ed6660",
+            sha256 = "2b39ea3eba5ce86126980fa2bf20db9e0896b75aec23f0c639d9bb47dd9914b9",
         )
 
     if "com_google_protobuf" not in native.existing_rules():

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -78,7 +78,7 @@ da_scala_test(
     name = "test",
     srcs = glob(["src/test/**/*.scala"]),
     data = [":test-daml.dar"],
-    resource_strip_prefix = "language-support/java/codegen/src/test/resources",
+    resource_strip_prefix = "language-support/java/codegen/src/test/resources/",
     resources = glob(["src/test/resources/**/*"]),
     deps = test_deps,
 )
@@ -183,7 +183,7 @@ da_scala_test(
     data = [
         ":ledger-tests-model.dar",
     ],
-    resource_strip_prefix = "language-support/java/codegen/src/ledger-tests/resources",
+    resource_strip_prefix = "language-support/java/codegen/src/ledger-tests/resources/",
     resources = ["src/ledger-tests/resources/logback-test.xml"],
     tags = ["exclusive"],
     deps = test_deps + [

--- a/ledger-api/rs-grpc-bridge/BUILD.bazel
+++ b/ledger-api/rs-grpc-bridge/BUILD.bazel
@@ -25,7 +25,7 @@ da_scala_library(
         "src/test/java/**/*.java",
         "src/test/scala/**/*.scala",
     ]),
-    resource_strip_prefix = "ledger-api/rs-grpc-bridge/src/test/resources",
+    resource_strip_prefix = "ledger-api/rs-grpc-bridge/src/test/resources/",
     resources = glob(["src/test/resources/**/*"]),
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
My PR to `rules_scala` (https://github.com/bazelbuild/rules_scala/pull/718) adding Windows support has been finally merged, so switching back to the official repo.

There's one more issue related to `resource_strip_prefix` attribute for which I created an upstream PR:
https://github.com/bazelbuild/rules_scala/pull/745
but it can be workarounded by adding a `/` at the end of `resource_strip_prefix`'s value


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
