### PR TITLE
Set cwd in DAML vscode extension

### DIFF
--- a/daml-foundations/daml-tools/daml-extension/src/extension.ts
+++ b/daml-foundations/daml-tools/daml-extension/src/extension.ts
@@ -194,7 +194,7 @@ export function createLanguageClient(config: vscode.WorkspaceConfiguration, tele
 
     return new LanguageClient(
         'daml-language-server', 'DAML Language Server',
-        { args: serverArgs, command: command},
+        { args: serverArgs, command: command, options: {cwd: vscode.workspace.rootPath }},
         clientOptions, true);
 }
 


### PR DESCRIPTION
We rely on this in the assistant to figure out which project we are
in. This fixes #1008 (but not only that).

For some reason I thought vscode does this automatically but that does not appear to be the case.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
