### PR TITLE
Stop highlighting rec and mdo as keywords in DAML

### DIFF
--- a/daml-foundations/daml-tools/daml-extension/syntaxes/daml12.tmLanguage.xml
+++ b/daml-foundations/daml-tools/daml-extension/syntaxes/daml12.tmLanguage.xml
@@ -406,7 +406,6 @@
 			| let
 			| in
 			| default
-			| rec
 			| with
 			| choice
 			| template
@@ -432,7 +431,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(m?do|if|then|else|case|of)(\b(?!'))</string>
+			<string>\b(do|if|then|else|case|of)(\b(?!'))</string>
 			<key>name</key>
 			<string>keyword.control.daml</string>
 		</dict>


### PR DESCRIPTION
They are keywords in Haskell only if the RecursiveDo extensions is enabled,
which we don't support.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1045)
<!-- Reviewable:end -->
