### PR TITLE
add non-strict mergify option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: automatic merge marked PRs on CI success and review
+  - name: "strict rebase"
     conditions:
       # All Azure builds should be green:
       - "status-success=digital-asset.daml"
@@ -16,5 +16,22 @@ pull_request_rules:
         method: squash
         strict: smart
         strict_method: rebase
+      # Takes no options, see <https://doc.mergify.io/examples.html#deleting-merged-branch>
+      delete_head_branch: {}
+  - name: "unsafe squash"
+    conditions:
+      # All Azure builds should be green:
+      - "status-success=digital-asset.daml"
+        # CLA check must pass:
+      - "status-success=license/cla"
+      # Special label to request automerge:
+      - "label=automerge-dangerous-but-faster"
+      # Note that this only matches people with write / admin access to the repo,
+      # see <https://doc.mergify.io/conditions.html#attribute-list>
+      - "#approved-reviews-by>=1"
+      # Note: mergify cannot break branch protection rules
+    actions:
+      merge:
+        method: squash
       # Takes no options, see <https://doc.mergify.io/examples.html#deleting-merged-branch>
       delete_head_branch: {}


### PR DESCRIPTION
Add the option of setting the `automerge-dangerous-but-fast` label on a PR to request mergify to merge it ASAP, i.e. as soon as tests pass, skipping the important "rebase" step, making it prone to "race condition" issues getting introduced and breaking master. This should only be used for either very safe or very urgent work.

Please keep in mind `master` is the stable, shared branch from which everyone works and its primary goal is to be stable. It is not the only way to share code and should not be the primary way to share code within small groups of people working on the same thing together.