### PR TITLE
Update to ghc-lib-0.20190509

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -445,7 +445,7 @@ hazel_repositories(
         extra =
             # Read [Working on ghc-lib] for ghc-lib update instructions at
             # https://github.com/DACH-NY/daml/blob/master/ghc-lib/working-on-ghc-lib.md
-            hazel_ghclibs("0.20190508", "2302edc1fadc1a9edd59a9ee468f1b4067f032292e12bcd5dbfff96bbd50c705", "97b4e7bc4b506a6ae450fffb31872360141ba5b9349a5ca66545f7a9a4a0a3d9") +
+            hazel_ghclibs("0.20190509.1", "0d7d89a3762ee95744dbbfd920b18850203d24ce174e72e9fa4210e5e6981069", "c7ff466aa699cad692800a391bfc034f225b163c0552c32d733534650846e87b") +
             hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("bytestring-nums", "0.3.6", "bdca97600d91f00bb3c0f654784e3fbd2d62fcf4671820578105487cdf39e7cd") +

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Config.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Config.hs
@@ -52,12 +52,13 @@ xExtensionsSet =
   , DamlVersionRequired
   , WithRecordSyntax
   , DamlTemplate
+  , ImportQualifiedPost
   ]
 
 
 -- | Language settings _disabled_ ($-XNo...$) in the DAML-1.2 compilation
 xExtensionsUnset :: [Extension]
-xExtensionsUnset = [  ]
+xExtensionsUnset = [ ]
 
 -- | Flags set for DAML-1.2 compilation
 xFlagsSet :: [ GeneralFlag ]

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -55,10 +55,10 @@ importDamlPreprocessor = fmap onModule
     where
         onModule y = y {
           GHC.hsmodImports =
-            newImport True "DA.Internal.Desugar" :
-            newImport False "DA.Internal.RebindableSyntax" : GHC.hsmodImports y
+            newImport GHC.QualifiedPost "DA.Internal.Desugar" :
+            newImport GHC.NotQualified "DA.Internal.RebindableSyntax" : GHC.hsmodImports y
           }
-        newImport :: Bool -> String -> GHC.Located (GHC.ImportDecl GHC.GhcPs)
+        newImport :: GHC.ImportDeclQualifiedStyle -> String -> GHC.Located (GHC.ImportDecl GHC.GhcPs)
         newImport qual = GHC.noLoc . importGenerated qual . mkImport . GHC.noLoc . GHC.mkModuleName
 
 -- | We ban people from importing modules such

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Records.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Records.hs
@@ -51,7 +51,7 @@ onModule x = x { hsmodImports = onImports $ hsmodImports x
 
 
 onImports :: [LImportDecl GhcPs] -> [LImportDecl GhcPs]
-onImports = (:) $ noL $ importGenerated True (mkImport $ noL mod_records)
+onImports = (:) $ noL $ importGenerated QualifiedPost (mkImport $ noL mod_records)
 
 
 {-

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -127,8 +127,8 @@ unpackCStringUtf8 bs = unsafePerformIO $
         evaluate $ T.unpackCString# a
 
 -- | This import was generated, not user written, so should not produce unused import warnings
-importGenerated :: Bool -> ImportDecl phase -> ImportDecl phase
+importGenerated :: ImportDeclQualifiedStyle -> ImportDecl phase -> ImportDecl phase
 importGenerated qual i = i{ideclImplicit=True, ideclQualified=qual}
 
 mkImport :: Located ModuleName -> ImportDecl GhcPs
-mkImport mname = GHC.ImportDecl GHC.NoExt GHC.NoSourceText mname Nothing False False False False Nothing Nothing
+mkImport mname = GHC.ImportDecl GHC.NoExt GHC.NoSourceText mname Nothing False False NotQualified False Nothing Nothing


### PR DESCRIPTION
This PR updates daml to ghc-lib version 0.20190509.1 (ghc `396e01b472bba36530e7eb065b82d311f0da7880`). Additionally, it contains a critical fix! Until now we have been ignoring "non-fatal" errors from the parser. We now check for these. The code contains an explanatory comment detailing exactly what the difference is between fatal and non-fatal parse errors and indicates why our previous implementation of `parseFileContents` (`//compiler/haskell-ide-core/src/Development/IDE/Functions/`) was wrong.
