### PR TITLE
ci: use windows-pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 360
     pool:
-      vmImage: 'vs2017-win2016'
+      name: 'windows-pool'
     steps:
       - template: ci/build-windows.yml
       - bash: |

--- a/dev-env/windows/libexec/core.ps1
+++ b/dev-env/windows/libexec/core.ps1
@@ -157,6 +157,27 @@ function da_install_all([String] $Directory) {
             da_error $msg
             throw $msg
         }
+
+        $resetted,$out = da_reset_app $app
+        If (-not($resetted)) {
+            $msg = "<< Resetting $app failed: `r`n$out"
+            da_error $msg
+            throw $msg
+        }
+    }
+}
+
+function da_reset_app([String] $app) {
+    $out = (scoop reset $app *>&1)
+    $out = $out -join "`r`n" | Out-String
+
+    $resettingFound = $out -like "*Resetting*"
+    $errorFound = $out -like "*ERROR*"
+
+    If (-not($resettingFound) -or $errorFound) {
+        return $False, $out
+    } Else {
+        return $True, $out
     }
 }
 


### PR DESCRIPTION
- Switches to GCP hosted Windows CI agents pool
- Adds `scoop reset $app` call to windows dev-env's sync command, so that environment variables set in tools' manifest files are (re)set - missing `BAZEL_SH` and `JAVA_HOME` env. variables were causing problems on GCP hosted Windows Agents of Azure Pipelines

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
