### PR TITLE
Handle module root `.` and non-normal source paths

### DIFF
--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -76,6 +76,7 @@ da_haskell_test(
     hazel_deps = [
         "async",
         "base",
+        "bytestring",
         "directory",
         "extra",
         "filepath",
@@ -88,6 +89,7 @@ da_haskell_test(
         "tasty",
         "tasty-hunit",
         "text",
+        "zip-archive",
     ],
     deps = [
         "//:sdk-version-hs-lib",

--- a/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -64,7 +64,7 @@ buildDar dalf modRoot dalfDependencies fileDependencies dataFiles name sdkVersio
     -- is modified to have prefix <name> instead of the original root path.
     mbSrcFiles <- forM fileDeps $ \mPath -> do
       contents <- BSL.readFile mPath
-      let mbNewPath = (name </>) <$> stripPrefix (addTrailingPathSeparator modRoot) mPath
+      let mbNewPath = (name </>) <$> stripModRoot mPath
       return $ fmap (, contents) mbNewPath
 
     let dalfName = name <> ".dalf"
@@ -84,6 +84,15 @@ buildDar dalf modRoot dalfDependencies fileDependencies dataFiles name sdkVersio
 
     pure $ BSL.toStrict $ Zip.fromArchive zipArchive
       where
+        -- Removes the module root from the given path. Returns Nothing if
+        -- mPath is not under the module root. Normalises paths to handle
+        -- source items like @Foo.daml@ or @././Foo.daml@.
+        stripModRoot mPath =
+          let (dir, file) = splitFileName mPath
+              normalModRoot = addTrailingPathSeparator (normalise modRoot)
+              strippedDir = stripPrefix normalModRoot (normalise dir)
+          in (</> file) <$> strippedDir
+
         manifestHeader :: FilePath -> [String] -> BSL.ByteString
         manifestHeader location dalfs = BSC.pack $ unlines
           [ "Manifest-Version: 1.0"


### PR DESCRIPTION
Closes #1048 

Normalises the module root and source file directory before stripping the module root. This handles source files without directory prefix (e.g. `Foo.daml`) or with redundant prefix (e.g. `././Foo.daml`).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
