### PR TITLE
Implement daml init command.

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -14,6 +14,7 @@ da_haskell_library(
         "aeson",
         "async",
         "base",
+        "bytestring",
         "directory",
         "extra",
         "filepath",

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -25,6 +25,7 @@ da_haskell_library(
         "process",
         "safe-exceptions",
         "text",
+        "yaml",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -169,8 +169,6 @@ runInit targetFolderM = do
 
     -- case 1 or 2
     unlessM (doesDirectoryExist targetFolder) $ do
-        let targetFolderRel = makeRelative currentDir targetFolder
-
         whenM (doesFileExist targetFolder) $ do
             hPutStrLn stderr $ unlines
                 [ "ERROR: daml init target should be a directory, but is a file."

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -15,6 +15,7 @@ data Command
     = DamlStudio { replaceExtension :: ReplaceExtension, remainingArguments :: [String] }
     | RunJar { jarPath :: FilePath, remainingArguments :: [String] }
     | New { targetFolder :: FilePath, templateName :: String }
+    | Init { targetFolderM :: Maybe FilePath }
     | ListTemplates
     | Start
 
@@ -23,6 +24,7 @@ commandParser =
     subparser $ fold
          [ command "studio" (info (damlStudioCmd <**> helper) forwardOptions)
          , command "new" (info (newCmd <**> helper) idm)
+         , command "init" (info (initCmd <**> helper) idm)
          , command "start" (info (startCmd <**> helper) idm)
          , command "run-jar" (info runJarCmd forwardOptions)
          ]
@@ -42,6 +44,7 @@ commandParser =
                   <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
                   <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: skeleton)" <> value "skeleton")
               ]
+          initCmd = Init <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
           startCmd = pure Start
           readReplacement :: ReadM ReplaceExtension
           readReplacement = maybeReader $ \case
@@ -55,6 +58,7 @@ runCommand :: Command -> IO ()
 runCommand DamlStudio {..} = runDamlStudio replaceExtension remainingArguments
 runCommand RunJar {..} = runJar jarPath remainingArguments
 runCommand New {..} = runNew targetFolder templateName
+runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
 runCommand Start = runStart
 

--- a/daml-assistant/daml-project-config/DAML/Project/Util.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Util.hs
@@ -6,6 +6,7 @@ module DAML.Project.Util
     , fromMaybeM
     , copyDirectory
     , moveDirectory
+    , ascendants
     ) where
 
 import Control.Exception.Safe
@@ -43,3 +44,22 @@ moveDirectory src target =
         (const $ do
              copyDirectory src target
              removePathForcibly src)
+
+-- | Calculate the ascendants of a path, i.e. the successive parents of a path,
+-- including the path itself, all the way to its root. For example:
+--
+--     ascendants "/foo/bar/baz" == ["/foo/bar/baz", "/foo/bar", "/foo", "/"]
+--     ascendants "~/foo/bar/baz" == ["~/foo/bar/baz", "~/foo/bar", "~/foo", "~"]
+--     ascendants "./foo/bar/baz" == ["./foo/bar/baz", "./foo/bar", "./foo", "."]
+--     ascendants "../foo/bar/baz" == ["../foo/bar/baz", "../foo/bar", "../foo", ".."]
+--     ascendants "foo/bar/baz"  == ["foo/bar/baz", "foo/bar", "foo", "."]
+--
+ascendants :: FilePath -> [FilePath]
+ascendants "" = ["."]
+ascendants "~" = ["~"]
+ascendants ".." = [".."]
+ascendants p =
+    let p' = takeDirectory (dropTrailingPathSeparator p)
+        ps = if p == p' then [] else ascendants p'
+    in p : ps
+

--- a/daml-assistant/src/DAML/Assistant/Util.hs
+++ b/daml-assistant/src/DAML/Assistant/Util.hs
@@ -3,6 +3,7 @@
 
 module DAML.Assistant.Util
     ( module DAML.Assistant.Util
+    , ascendants
     , fromRightM
     , fromMaybeM
     ) where
@@ -10,28 +11,9 @@ module DAML.Assistant.Util
 import DAML.Assistant.Types
 import DAML.Project.Util
 import System.Exit
-import System.FilePath
 import Control.Exception.Safe
 import Control.Applicative
 import Control.Monad.Extra hiding (fromMaybeM)
-
--- | Calculate the ascendants of a path, i.e. the successive parents of a path,
--- including the path itself, all the way to its root. For example:
---
---     ascendants "/foo/bar/baz" == ["/foo/bar/baz", "/foo/bar", "/foo", "/"]
---     ascendants "~/foo/bar/baz" == ["~/foo/bar/baz", "~/foo/bar", "~/foo", "~"]
---     ascendants "./foo/bar/baz" == ["./foo/bar/baz", "./foo/bar", "./foo", "."]
---     ascendants "../foo/bar/baz" == ["../foo/bar/baz", "../foo/bar", "../foo", ".."]
---     ascendants "foo/bar/baz"  == ["foo/bar/baz", "foo/bar", "foo", "."]
---
-ascendants :: FilePath -> [FilePath]
-ascendants "" = ["."]
-ascendants "~" = ["~"]
-ascendants ".." = [".."]
-ascendants p =
-    let p' = takeDirectory (dropTrailingPathSeparator p)
-        ps = if p == p' then [] else ascendants p'
-    in p : ps
 
 -- | Throw an assistant error.
 throwErr :: Text -> IO a

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -8,6 +8,10 @@ commands:
   path: daml-helper/daml-helper
   desc: "Create a new DAML project"
   args: ["new"]
+- name: init
+  path: daml-helper/daml-helper
+  desc: "Configure a folder as a DAML project"
+  args: ["init"]
 - name: build
   path: damlc/da-hs-damlc-app
   args: ["build"]


### PR DESCRIPTION
`daml init` is a new command to configure an existing project to work with `daml` assistant. In practice this just means creating a `daml.yaml`. It has two main modes of operation:

- convert an existing `da.yaml` to `daml.yaml`
- create `daml.yaml` from scratch, if no `da.yaml` exists

Furthermore, you can specify a path (`daml init PATH`) to specify the directory, or leave it blank (`daml init`) to initialize the current working directory.

Care has been taken not to allow the user to initialize a project inside another project, since that would lead to unexpected behavior most of the time, and the user is forced to pass the project root if they want to migrate an existing project. (If a user really wants to have one DAML project inside another, they can create the `daml.yaml` themselves.)

If the project already exists (i.e. daml.yaml exists), a message is shown saying just that.