### PR TITLE
webide: failing terminal

### DIFF
--- a/web-ide/ide-server/settings.json
+++ b/web-ide/ide-server/settings.json
@@ -1,3 +1,4 @@
 {
-    "daml.telemetry": "Enable"
+    "daml.telemetry": "Enable",
+    "terminal.integrated.shell.linux": "echo \"No terminal available\""
 }

--- a/web-ide/proxy/static/css/webide.main.css
+++ b/web-ide/proxy/static/css/webide.main.css
@@ -59,10 +59,10 @@ div.window-appicon {
 }*/
 
 /*hide the actual terminal and debug console*/
-.part.panel.bottom ul.actions-container li.action-item[title*="Debug Console"],
-.part.panel.bottom ul.actions-container li.action-item[title*="Terminal"],
-.part.panel.bottom div.integrated-terminal,
-.part.panel.bottom div.repl {
+.part.panel ul.actions-container li.action-item[title*="Debug Console"],
+.part.panel ul.actions-container li.action-item[title*="Terminal"],
+.part.panel div.integrated-terminal,
+.part.panel div.repl {
   display:none !important;
 }
 


### PR DESCRIPTION
* fail bash terminal by setting config to run bogus command
* one last fix for hiding terminal

Initially attempted to use external terminal with echo command but this
still opened an integrated terminal. Changing the terminal command from
/bin/bash to echo "No Terminal Available" crashes the integrated
terminal, which of course is better than having a working terminal!

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
