### PR TITLE
Fix a silly spelling mistake in developer docs

### DIFF
--- a/ghc-lib/working-on-ghc-lib.md
+++ b/ghc-lib/working-on-ghc-lib.md
@@ -104,6 +104,7 @@ tar xvf ghc-lib-parser-xxx.tar.gz
 tar xvf ghc-lib-xxx.tar.gz
 mv ghc-lib-parser-xxx ghc-lib-parser
 mv ghc-lib-xxx ghc-lib
+sed '$d' stack.yaml > stack.yaml.tmp&&cp stack.yaml.tmp stack.yaml
 cat << EOF >> stack.yaml
 - ghc-lib-parser
 - ghc-lib

--- a/ghc-lib/working-on-ghc-lib.md
+++ b/ghc-lib/working-on-ghc-lib.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 If you need to build, test, deploy or develop [`ghc-lib`](https://github.com/digital-asset/ghc-lib) as used by DAML and utilizing the Digital Asset [GHC fork](https://github.com/digital-asset/ghc) these notes are for you.
 
 ## Table of contents
-* [Prequsites](#prequisites)
+* [Prerequisites](#prerequisites)
 * [How to build `ghc` from the DA GHC fork](#how-to-build-ghc-lib-from-the-da-ghc-fork)
 * [How to build `ghc-lib` from the DA GHC fork](#how-to-build-ghc-lib-from-the-da-ghc-fork)
 * [How to test `ghc-lib`](#how-to-test-ghc-lib)
@@ -14,7 +14,7 @@ If you need to build, test, deploy or develop [`ghc-lib`](https://github.com/dig
 * [How to rebase `ghc-lib` on upstream master](#how-to-rebase-ghc-lib-on-upstream-master)
 * [How to develop `ghc-lib`](#how-to-develop-ghc-lib)
 
-## Prequisites
+## Prerequisites
 
 - Download `stack` and other tools:
 ```bash


### PR DESCRIPTION
Fix a spelling mistake in the ghc-lib developer docs.