### PR TITLE
Java Codegen: generate methods for CreateAndExerciseCommand

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -271,7 +271,7 @@ A file is generated that defines three Java classes:
 
 .. code-block:: java
   :caption: com/acme/Bar.java
-  :emphasize-lines: 3,10,20
+  :emphasize-lines: 3,14,24
 
   package com.acme;
 
@@ -281,6 +281,10 @@ A file is generated that defines three Java classes:
 
     public final String owner;
     public final String name;
+
+    public CreateAndExerciseCommand createAndExerciseBar_SomeChoice(Bar_SomeChoice arg) { /* ... */ }
+
+    public CreateAndExerciseCommand createAndExerciseBar_SomeChoice(String aName) { /* ... */ }
 
     public static class ContractId {
       public final String contractId;

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -25,7 +25,7 @@ Ledger API
   - new versions of ledger language bindings will work with previous versions of the Sandbox, because the field was never populated
   - previous versions of the ledger language bindings will work with new versions of the Sandbox, as the field was removed without any change in observable behavior
 
-How to migrate:
+  How to migrate:
 
   - If you check for the presence of :ref:`com.digitalasset.ledger.api.v1.ExercisedEvent` when handling a :ref:`com.digitalasset.ledger.api.v1.Transaction`, you have to remove this code now.
 
@@ -40,11 +40,21 @@ Java Bindings
   - ``data.CreatedEvent`` and ``data.ExercisedEvent`` now implement ``data.TreeEvent``.
   - ``data.TransactionTree#eventsById`` is now ``Map<String, TreeEvent>`` (was previously ``Map<String, Event>``).
 
-How to migrate:
+  How to migrate:
 
   - If you are processing ``data.TransactionTree`` objects, you need to change the type of the processed events from ``data.Event`` to ``data.TreeEvent``.
   - If you are checking for the presense of exercised events when processing ``data.Transaction`` objects, you can remove that code now.
     It would never have triggered in the first place, as transactions do not contain exercised events.
+
+- **Java Codegen**: You can now call a method to get a ``CreateAndExerciseCommand`` for each choice, for example:
+
+  .. code-block:: java
+
+     CreateAndExerciseCommand cmd = new MyTemplate(owner, someText).createAndExerciseAccept(42L);
+
+  In this case ``MyTemplate`` is a DAML template with a choice ``Accept`` and the resulting command will create a contract and exercise the ``Accept`` choice within the same transaction.
+
+  See `issue #1092 <https://github.com/digital-asset/daml/issues/1092>`__ for details.
 
 .. _release-0-12-17:
 

--- a/language-support/java/codegen/src/it/daml/Tests/Template1.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/Template1.daml
@@ -13,3 +13,18 @@ template TestTemplate
     where
         signatory owner
 
+
+template SimpleTemplate
+    with
+        owner : Party
+    where
+        signatory owner
+
+        controller owner can
+          TestTemplate_Unit : ()
+            do return ()
+
+          TestTemplate_Int : ()
+            with x : Int
+            do return ()
+

--- a/language-support/java/codegen/src/it/java/com/digitalasset/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/digitalasset/TemplateMethodTest.java
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset;
+
+import com.daml.ledger.javaapi.data.CreateAndExerciseCommand;
+import com.daml.ledger.javaapi.data.CreateCommand;
+import com.daml.ledger.javaapi.data.ExerciseCommand;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import tests.template1.SimpleTemplate;
+import tests.template1.TestTemplate_Int;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@RunWith(JUnitPlatform.class)
+public class TemplateMethodTest {
+
+    // Note that for the most part these tests should are designed to "fail"
+    // at compilation time in case any of the methods are generated differently
+    // or not at all
+
+    @Test
+    void templateHasCreateMethods() {
+        CreateCommand fromStatic = SimpleTemplate.create("Bob");
+        CreateCommand fromInstance = new SimpleTemplate("Bob").create();
+
+        assertNotNull(fromStatic, "CreateCommand from static method was null");
+        assertNotNull(fromInstance, "CreateCommand from method was null");
+    }
+
+    @Test
+    void contractIdHasInstanceExerciseMethods() {
+        SimpleTemplate.ContractId cid = new SimpleTemplate.ContractId("id");
+        ExerciseCommand fromSplattedInt = cid.exerciseTestTemplate_Int(42L);
+        ExerciseCommand fromRecordInt = cid.exerciseTestTemplate_Int(new TestTemplate_Int(42L));
+        ExerciseCommand fromSplattedUnit = cid.exerciseTestTemplate_Unit();
+
+        assertNotNull(fromSplattedInt, "ExerciseCommand from splatted choice was null");
+        assertNotNull(fromRecordInt, "ExerciseCommand from record choice was null");
+        assertNotNull(fromSplattedUnit, "ExerciseCommand from splatted unit choice was null");
+    }
+
+    @Test
+    void templateHasCreateAndExerciseMethods() {
+        SimpleTemplate simple = new SimpleTemplate("Bob");
+        CreateAndExerciseCommand fromSplatted = simple.createAndExerciseTestTemplate_Int(42L);
+        CreateAndExerciseCommand fromRecord = simple.createAndExerciseTestTemplate_Int(new TestTemplate_Int(42L));
+
+        assertNotNull(fromSplatted, "CreateAndExerciseCommand from splatted choice was null");
+        assertNotNull(fromRecord, "CreateAndExerciseCommand from record choice was null");
+    }
+}


### PR DESCRIPTION
The Java Codegen now generates methods for creating a
CreateAndExerciseCommand for a particular choice given a template.

Contributes to #1092.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
