### PR TITLE
In the language server tests, write out what fails

### DIFF
--- a/daml-foundations/daml-tools/language-server-tests/src/daml-test.ts
+++ b/daml-foundations/daml-tools/language-server-tests/src/daml-test.ts
@@ -100,6 +100,7 @@ export function truncatePaths(obj: any): any {
  */
 export function tryWriteActualJSON(rootPath : string, actual : any)
 {
+  console.log(actual);
   tryWriteActual(rootPath + '/ACTUAL.json', JSON.stringify(actual, null, 2));
 }
 


### PR DESCRIPTION
This is not a good way to go, but it's all we've got, since Bazel deletes the ACTUAL file. Should almost certainly be done better, but these tests are dying at some point and it's better than nothing (which is what we had before).