### PR TITLE
Add utility function for the IDE Logger

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Logger.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Logger.hs
@@ -7,6 +7,7 @@
 -- framework they want to.
 module Development.IDE.Logger
   ( Handle(..)
+  , makeOneHandle
   , makeNopHandle
   ) where
 
@@ -19,5 +20,7 @@ data Handle = Handle {
     }
 
 makeNopHandle :: Handle
-makeNopHandle = Handle e e where
-    e _ = pure ()
+makeNopHandle = makeOneHandle $ const $ pure ()
+
+makeOneHandle :: (HasCallStack => T.Text -> IO ()) -> Handle
+makeOneHandle x = Handle x x


### PR DESCRIPTION
Useful to create a dummy `putStrLn` logger in a single line.