### PR TITLE
Test DAML-LF version 1.dev in damlc integration tests

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -37,12 +37,9 @@ version1_3 = V1 $ PointStable 3
 versionDefault :: Version
 versionDefault = version1_3
 
--- | The newest non-development DAML-LF version.
-versionNewest :: Version
-versionNewest = version1_3
-
-maxV1minor :: Int
-maxV1minor = 3
+-- | The DAML-LF development version.
+versionDev :: Version
+versionDev = V1 PointDev
 
 minorInProtobuf :: MinorVersion -> TL.Text
 minorInProtobuf = TL.pack . \case
@@ -59,7 +56,7 @@ minorFromCliOption = \case
   _ -> Nothing
 
 supportedInputVersions :: [Version]
-supportedInputVersions = [version1_1, version1_2, version1_3, V1 PointDev]
+supportedInputVersions = [version1_1, version1_2, version1_3, versionDev]
 
 supportedOutputVersions :: [Version]
 supportedOutputVersions = supportedInputVersions

--- a/daml-foundations/daml-ghc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/BUILD.bazel
@@ -85,9 +85,9 @@ da_haskell_library(
     ],
 )
 
-daml_ghc_integration_test("daml-ghc-test-newest", "DA.Test.GHC.mainVersionNewest")
-
 daml_ghc_integration_test("daml-ghc-test-default", "DA.Test.GHC.mainVersionDefault")
+
+daml_ghc_integration_test("daml-ghc-test-dev", "DA.Test.GHC.mainVersionDev")
 
 da_haskell_test(
     name = "tasty-test",

--- a/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/GHC.hs
@@ -8,8 +8,8 @@
 -- typecheck with LF, test it.  Test annotations are documented as 'Ann'.
 module DA.Test.GHC
   ( main
-  , mainVersionNewest
   , mainVersionDefault
+  , mainVersionDev
   ) where
 
 import DA.Daml.GHC.Compiler.Options
@@ -72,13 +72,13 @@ import Test.Tasty.Runners
 newtype TODO = TODO String
 
 main :: IO ()
-main = mainVersionNewest
-
-mainVersionNewest :: IO ()
-mainVersionNewest = mainWithVersion versionNewest
+main = mainVersionDev
 
 mainVersionDefault :: IO ()
 mainVersionDefault = mainWithVersion versionDefault
+
+mainVersionDev :: IO ()
+mainVersionDev = mainWithVersion versionDev
 
 mainWithVersion :: Version -> IO ()
 mainWithVersion version =


### PR DESCRIPTION
Currently, we test the default and the newest DAML-LF version. After the
recent introduction of 1.dev, this doesn't make sense anymore. Instead, we
now test the default version (which should always be the newest version)
and the dev version.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1135)
<!-- Reviewable:end -->
