### PR TITLE
Scala examples bazel build + refactoring

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -296,6 +296,7 @@ daml_compile(
     srcs = glob(["source/getting-started/quickstart/template-root/**/*.daml"]),
     main_src = "source/getting-started/quickstart/template-root/daml/Main.daml",
     target = "1.1",
+    visibility = ["//language-support/scala/examples:__subpackages__"],
 )
 
 dar_to_java(

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -7,6 +7,21 @@ load(
     "da_scala_test_suite",
 )
 
+bindings_akka_deps = [
+    "//3rdparty/jvm/ch/qos/logback:logback_classic",
+    "//3rdparty/jvm/com/github/pureconfig",
+    "//3rdparty/jvm/com/typesafe/akka:akka_stream",
+    "//3rdparty/jvm/com/typesafe/scala_logging",
+    "//3rdparty/jvm/io/grpc:grpc_netty",
+    "//3rdparty/jvm/io/netty:netty_handler",
+    "//3rdparty/jvm/io/netty:netty_tcnative_boringssl_static",
+    "//3rdparty/jvm/org/scalaz:scalaz_core",
+    "//language-support/java/bindings:bindings-java",
+    "//language-support/scala/bindings",
+    "//ledger-api/rs-grpc-akka",
+    "//ledger/ledger-api-client",
+]
+
 da_scala_library(
     name = "bindings-akka",
     srcs = glob(["src/main/**/*.scala"]),
@@ -18,22 +33,8 @@ da_scala_library(
     visibility = [
         "//visibility:public",
     ],
-    exports = [],
-    runtime_deps = [],
-    deps = [
-        "//3rdparty/jvm/ch/qos/logback:logback_classic",
-        "//3rdparty/jvm/com/github/pureconfig",
-        "//3rdparty/jvm/com/typesafe/akka:akka_stream",
-        "//3rdparty/jvm/com/typesafe/scala_logging",
-        "//3rdparty/jvm/io/grpc:grpc_netty",
-        "//3rdparty/jvm/io/netty:netty_handler",
-        "//3rdparty/jvm/io/netty:netty_tcnative_boringssl_static",
-        "//3rdparty/jvm/org/scalaz:scalaz_core",
-        "//language-support/java/bindings:bindings-java",
-        "//language-support/scala/bindings",
-        "//ledger-api/rs-grpc-akka",
-        "//ledger/ledger-api-client",
-    ],
+    exports = bindings_akka_deps,
+    deps = bindings_akka_deps,
 )
 
 # Sources that do not define test-cases but utilities
@@ -45,6 +46,16 @@ testing_utils = [
     "src/test/scala/com/digitalasset/ledger/client/binding/SandboxBinding.scala",
 ]
 
+bindings_akka_test_deps = [
+    ":bindings-akka",
+    "//3rdparty/jvm/com/typesafe/akka:akka_stream_testkit",
+    "//3rdparty/jvm/org/scalacheck",
+    "//3rdparty/jvm/org/scalatest",
+    "//language-support/scala/sandbox-control",
+    "//ledger-api/rs-grpc-bridge",
+    "//language-support/scala/bindings-akka-testing",
+] + bindings_akka_deps
+
 da_scala_library(
     name = "bindings-akka-testing",
     srcs = testing_utils,
@@ -54,25 +65,7 @@ da_scala_library(
     visibility = [
         "//visibility:public",
     ],
-    exports = [],
-    runtime_deps = [],
-    deps = [
-        ":bindings-akka",
-        "//3rdparty/jvm/ch/qos/logback:logback_classic",
-        "//3rdparty/jvm/com/github/pureconfig",
-        "//3rdparty/jvm/com/typesafe/akka:akka_stream",
-        "//3rdparty/jvm/com/typesafe/akka:akka_stream_testkit",
-        "//3rdparty/jvm/com/typesafe/scala_logging",
-        "//3rdparty/jvm/io/grpc:grpc_netty",
-        "//3rdparty/jvm/io/netty:netty_handler",
-        "//3rdparty/jvm/org/scalacheck",
-        "//3rdparty/jvm/org/scalatest",
-        "//language-support/scala/bindings",
-        "//language-support/scala/bindings-akka-testing",
-        "//language-support/scala/sandbox-control",
-        "//ledger-api/rs-grpc-bridge",
-        "//ledger/ledger-api-client",
-    ],
+    deps = bindings_akka_test_deps,
 )
 
 da_scala_test_suite(
@@ -86,23 +79,5 @@ da_scala_test_suite(
     visibility = [
         "//visibility:public",
     ],
-    runtime_deps = [],
-    deps = [
-        ":bindings-akka",
-        ":bindings-akka-testing",
-        "//3rdparty/jvm/ch/qos/logback:logback_classic",
-        "//3rdparty/jvm/com/github/pureconfig",
-        "//3rdparty/jvm/com/typesafe/akka:akka_stream",
-        "//3rdparty/jvm/com/typesafe/akka:akka_stream_testkit",
-        "//3rdparty/jvm/com/typesafe/scala_logging",
-        "//3rdparty/jvm/org/scalacheck",
-        "//3rdparty/jvm/org/scalatest",
-        "//3rdparty/jvm/org/scalaz:scalaz_core",
-        "//language-support/java/bindings:bindings-java",
-        "//language-support/scala/bindings",
-        "//language-support/scala/bindings-akka-testing",
-        "//language-support/scala/sandbox-control",
-        "//ledger-api/rs-grpc-bridge",
-        "//ledger/ledger-api-client",
-    ],
+    deps = bindings_akka_test_deps,
 )

--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -7,6 +7,13 @@ load(
     "da_scala_test_suite",
 )
 
+bindings_scala_deps = [
+    "//3rdparty/jvm/com/github/ghik:silencer_lib",
+    "//3rdparty/jvm/io/grpc:grpc_core",
+    "//3rdparty/jvm/org/scalaz:scalaz_core",
+    "//ledger-api/grpc-definitions:ledger-api-scalapb",
+]
+
 da_scala_library(
     name = "bindings",
     srcs = glob(["src/main/**/*.scala"]),
@@ -21,15 +28,8 @@ da_scala_library(
     visibility = [
         "//visibility:public",
     ],
-    exports = [
-        "//ledger-api/grpc-definitions:ledger-api-scalapb",
-    ],
-    deps = [
-        "//3rdparty/jvm/com/github/ghik:silencer_lib",
-        "//3rdparty/jvm/io/grpc:grpc_core",
-        "//3rdparty/jvm/org/scalaz:scalaz_core",
-        "//ledger-api/grpc-definitions:ledger-api-scalapb",
-    ],
+    exports = bindings_scala_deps,
+    deps = bindings_scala_deps,
 )
 
 da_scala_test_suite(

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -1,6 +1,12 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+    "da_scala_library",
+)
+
 filegroup(
     name = "quickstart-scala-src",
     srcs = glob(
@@ -32,4 +38,45 @@ genrule(
         rm -rf $@/scala-codegen/target
     """,
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "examples-quickstart-scala-codegen",
+    srcs = ["//docs:quickstart-model.dar"],
+    outs = ["examples-quickstart-scala-codegen-out"],
+    cmd = "$(execpath //language-support/scala/codegen:codegen-main) $(location //docs:quickstart-model.dar)=com.digitalasset.quickstart.iou.model --output-directory=$@ --verbosity=2",
+    tools = [
+        "//language-support/scala/codegen:codegen-main",
+    ],
+)
+
+genrule(
+    name = "examples-quickstart-scala-codegen.srcjar",
+    srcs = [":examples-quickstart-scala-codegen"],
+    outs = ["examples-quickstart-scala-codegen-out.srcjar"],
+    cmd = "$(execpath @local_jdk//:bin/jar) -cf $@ -C $(location :examples-quickstart-scala-codegen) .",
+    tools = [
+        "@local_jdk//:bin/jar",
+    ],
+)
+
+da_scala_library(
+    name = "examples-quickstart-scala-codegen-lib",
+    srcs = ["examples-quickstart-scala-codegen-out.srcjar"],
+    deps = ["//language-support/scala/bindings"],
+)
+
+da_scala_binary(
+    name = "examples-quickstart-scala-bin",
+    srcs = glob(["quickstart-scala/application/src/main/scala/**/*.scala"]),
+    main_class = "com.digitalasset.quickstart.iou.IouMain",
+    resources = glob(["quickstart-scala/application/src/main/resources/**/*"]),
+    scalacopts = ["-Xsource:2.13"],
+    deps = [
+        ":examples-quickstart-scala-codegen-lib",
+        "//3rdparty/jvm/com/typesafe/akka:akka_slf4j",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+    ],
 )

--- a/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/DecodeUtil.scala
+++ b/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/DecodeUtil.scala
@@ -13,7 +13,7 @@ object DecodeUtil {
     for {
       event <- transaction.events
       created <- event.event.created.toList
-      a <- decodeCreated(created)
+      a <- decodeCreated(created).toList
     } yield a
 
   def decodeCreated[A <: Template[A]: ValueDecoder](transaction: Transaction): Option[Contract[A]] =


### PR DESCRIPTION
- Building `language-support/scala/examples/quickstart-scala` against the SDK head
- ~Extracting `language-support/scala/bindings` and `language-support/scala/bindings-akka` dependencies, introducing `depsets` that get loaded where needed, so don't have to copy/paste the set of corresponding `deps`~
- Introducing `exports` for `language-support/scala/bindings` and `language-support/scala/bindings-akka`, so transitive deps don't have to be copy/pasted.

Related to #675 `quickstart-scala` examples that becomes part of the SDK doc.
 
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
