### PR TITLE
Don't expose TextMap type via the Prelude anymore

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Next/Map.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Next/Map.daml
@@ -28,6 +28,7 @@ import Prelude hiding (lookup, null, empty)
 import DA.Foldable qualified as Foldable
 import DA.Optional
 import DA.Text
+import DA.TextMap (TextMap)
 import DA.TextMap qualified as TextMap
 import DA.Traversable qualified as Traversable
 import DA.Tuple

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Next/Set.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Next/Set.daml
@@ -27,6 +27,7 @@ where
 
 import Prelude hiding (filter, null, empty)
 import DA.Next.Map (MapKey (..))
+import DA.TextMap (TextMap)
 import DA.TextMap qualified as TextMap
 
 -- | The type of a set.

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
@@ -25,6 +25,7 @@ module DA.TextMap
 
 import Prelude hiding (lookup, null, filter, empty)
 import DA.Foldable qualified as Foldable
+import DA.Internal.Prelude (TextMap)
 import DA.List qualified as List
 import DA.Optional
 import DA.Traversable qualified as Traversable

--- a/daml-foundations/daml-ghc/daml-stdlib-src/Prelude.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/Prelude.daml
@@ -6,7 +6,7 @@ daml 1.2
 -- | The pieces that make up the DAML language.
 module Prelude (module X) where
 
-import DA.Internal.Prelude as X
+import DA.Internal.Prelude as X hiding (TextMap)
 import DA.Internal.LF as X
 import DA.Internal.Template as X
 import DA.Internal.Compatible as X

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -28,6 +28,10 @@ DAML
   - People using the Java/Scala codegen need to replace ``import ghc.tuple.*`` or ``import da.internal.prelude.*`` with ``import da.types.*``.
   - People using the Ledger API directly need to replace ``GHC.Tuple`` and ``DA.Internal.Prelude`` with ``DA.Types``.
 
+- **BREAKING CHANGE - DAML Standard Library**: Don't expose the ``TextMap`` type via the ``Prelude`` anymore.
+
+  How to migrate: Always import ``DA.TextMap`` when you want to use the ``TextMap`` type.
+
 - **DAML Standard Library**: Add ``String`` as a compatibility alias for ``Text``.
 
 Ledger API


### PR DESCRIPTION
This is not the perfect fix since the definition `data TextMap` is still
living in the wrong module, see issue #1142. However, this PR forces people
to import `DA.TextMap` when they want to use the `TextMap` type, which is
the desired behaviour for the future.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1144)
<!-- Reviewable:end -->
