### PR TITLE
windows: CI agent diagnostics

### DIFF
--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -8,6 +8,9 @@ steps:
       # to upload to the bazel cache
       GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
+  - powershell: '.\ci\windows-diagnostics.ps1'
+    displayName: 'Agent diagnostics'
+
   - powershell: '.\build.ps1'
     displayName: 'Build'
 

--- a/ci/windows-diagnostics.ps1
+++ b/ci/windows-diagnostics.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+$info = Get-CimInstance -ClassName win32_operatingsystem
+
+$info | format-table CSName
+
+$info | format-table LastBootUpTime
+
+$info | format-table FreePhysicalMemory, TotalVisibleMemorySize
+
+get-wmiobject win32_logicaldisk | format-table `
+    Name,`
+    @{n="Size [GB]";e={[math]::truncate($_.size / 1GB)}},`
+    @{n="Free [GB]";e={[math]::truncate($_.freespace / 1GB)}}


### PR DESCRIPTION
This adds few diagnostics information to Windows CI pipeline printing what's below:
```
CSName       
------       
VSTS-WIN-7RRW

LastBootUpTime      
--------------      
5/14/2019 3:24:13 PM

FreePhysicalMemory TotalVisibleMemorySize
------------------ ----------------------
          26911684               31456872

Name Size [GB] Free [GB]
---- --------- ---------
C:         199       149
D:         199       199
```

This will allow mapping Azure Pipeline agent IDs with GCP instance names and give few more details like last boot time, memory and disk usage.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
