### PR TITLE
Expose a contract's agreement text on the Ledger API

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
@@ -37,6 +37,7 @@ final case class CreateEvent[Cid, Val](
     contractId: Cid,
     templateId: Identifier,
     argument: Val,
+    agreementText: String,
     stakeholders: Set[Party],
     witnesses: Set[Party])
     extends Event[Nothing, Cid, Val] {
@@ -153,6 +154,7 @@ object Event {
                   nc.coid,
                   templateId,
                   nc.coinst.arg,
+                  nc.coinst.agreementText,
                   stakeholders intersect disclosure(nodeId),
                   disclosure(nodeId))
               evts += (nodeId -> evt)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -953,6 +953,7 @@ class EngineTest extends WordSpec with Matchers with BazelRunfiles {
                 (Some[Name]("giver"), ValueParty("Alice")),
                 (Some[Name]("receiver"), ValueParty("Clara")))
             )),
+          "",
           Set("Clara", "Alice"),
           Set("Bob", "Clara", "Alice"),
         )

--- a/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
+++ b/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticTester.scala
@@ -194,6 +194,7 @@ class SemanticTester(
                     nextScenarioCoidToLedgerCoid(scenarioCreateNode.coid),
                     scenarioCreateNode.coinst.template,
                     scenarioCreateNode.coinst.arg.mapContractId(nextScenarioCoidToLedgerCoid),
+                    scenarioCreateNode.coinst.agreementText,
                     scenarioCreateNode.stakeholders intersect scenarioWitnesses(scenarioNodeId),
                     scenarioWitnesses(scenarioNodeId),
                   )

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -60,7 +60,7 @@ To avoid possible name clashes in the generated Java sources, you should specify
 Generate the decoder utility class
 ----------------------------------
 
-When reading transactions from the ledger, you typically want to convert a `CreatedEvent <https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/CreatedEvent.html>`__ from the Ledger API to the corresponding generated ``Contract`` class. The Java codegen can optionally generate a decoder class based on the input DAR files that calls the ``fromIdAndRecord`` method of the respective generated ``Contract`` class (see :ref:`daml-codegen-java-templates`). The decoder class can do this for all templates in the input DAR files. 
+When reading transactions from the ledger, you typically want to convert a `CreatedEvent <https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/CreatedEvent.html>`__ from the Ledger API to the corresponding generated ``Contract`` class. The Java codegen can optionally generate a decoder class based on the input DAR files that calls the ``fromCreatedEvent`` method of the respective generated ``Contract`` class (see :ref:`daml-codegen-java-templates`). The decoder class can do this for all templates in the input DAR files.
 
 To generate such a decoder class, provide the command line parameter ``-d`` or ``--decoderClass`` with a fully qualified class name:
 
@@ -254,7 +254,7 @@ The Java codegen generates three classes for a DAML template:
       .. TODO: refer to another section explaining exactly that, when we have it.
 
   **TemplateName.Contract**
-      Represents an actual contract on the ledger. It contains a field for the contract ID (of type ``TemplateName.ContractId``) and a field for the template data (of type ``TemplateName``). With the static method ``TemplateName.Contract.fromIdAndRecord``, you can deserialize a `CreatedEvent <https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/CreatedEvent.html>`__ to an instance of ``TemplateName.Contract``.
+      Represents an actual contract on the ledger. It contains a field for the contract ID (of type ``TemplateName.ContractId``) and a field for the template data (of type ``TemplateName``). With the static method ``TemplateName.Contract.fromCreatedEvent``, you can deserialize a `CreatedEvent <https://docs.daml.com/app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/CreatedEvent.html>`__ to an instance of ``TemplateName.Contract``.
 
 
   .. literalinclude:: ./code-snippets/Templates.daml
@@ -300,7 +300,7 @@ A file is generated that defines three Java classes:
       public final ContractId id;
       public final Bar data;
 
-      public static Contract fromIdAndRecord(String contractId, Record record) { /* ... */ }
+      public static Contract fromCreatedEvent(CreatedEvent event) { /* ... */ }
     }
   }
 

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -56,6 +56,7 @@ To avoid possible name clashes in the generated Java sources, you should specify
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^        
       daml/project2.dar=com.example.daml.project2
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _daml-codegen-java-decoder-class:
 
 Generate the decoder utility class
 ----------------------------------

--- a/docs/source/getting-started/quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
+++ b/docs/source/getting-started/quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
@@ -70,7 +70,7 @@ public class IouMain {
                 .blockingForEach(response -> {
                     response.getOffset().ifPresent(offset -> acsOffset.set(new LedgerOffset.Absolute(offset)));
                     response.getCreatedEvents().stream()
-                            .map(e -> Iou.Contract.fromIdAndRecord(e.getContractId(), e.getArguments()))
+                            .map(Iou.Contract::fromCreatedEvent)
                             .forEach(contract -> {
                                 long id = idCounter.getAndIncrement();
                                 contracts.put(id, contract.data);
@@ -85,7 +85,7 @@ public class IouMain {
                         if (event instanceof CreatedEvent) {
                             CreatedEvent createdEvent = (CreatedEvent) event;
                             long id = idCounter.getAndIncrement();
-                            Iou.Contract contract = Iou.Contract.fromIdAndRecord(createdEvent.getContractId(), createdEvent.getArguments());
+                            Iou.Contract contract = Iou.Contract.fromCreatedEvent(createdEvent);
                             contracts.put(id, contract.data);
                             idMap.put(id, contract.id);
                         } else if (event instanceof ArchivedEvent) {

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -138,6 +138,16 @@ Java Bindings
             return decoder.get().apply(event);
         }
 
+Scala Bindings
+~~~~~~~~~~~~~~
+
+- **BREAKING** You can now access the :ref:`agreement text <daml-ref-agreements>` of a contract with the new field ``Contract#agreementText: Option[String]``.
+
+  How to migrate:
+
+  - If you are pattern matching on ``com.digitalasset.ledger.client.binding.Contract``, you need to add a match clause for the added field.
+  - If you are constructing ``com.digitalasset.ledger.client.binding.Contract`` values, for example for tests, you need to add a constructor parameter for the agreement text.
+
 Ledger
 ~~~~~~
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -148,11 +148,12 @@ Ledger
   `#1166 <https://github.com/digital-asset/daml/issues/1166>`_.
 - Contract visibility is now properly checked when looking up contracts in the SQL backend, see
   `#784 <https://github.com/digital-asset/daml/issues/784>`_.
+- The sandbox now exposes the :ref:`agreement text <daml-ref-agreements>` of contracts in :ref:`CreatedEvents <com.digitalasset.ledger.api.v1.CreatedEvent>`. See `#1110 <https://github.com/digital-asset/daml/issues/1110>`__
 
 Navigator
 ~~~~~~~~~
 
-- Non-empty agreement texts are now shown on the contract page above the section ``Contract details``. See `#1110 <https://github.com/digital-asset/daml/issues/1110>`__
+- Non-empty :ref:`agreement texts <daml-ref-agreements>` are now shown on the contract page above the section ``Contract details``, see `#1110 <https://github.com/digital-asset/daml/issues/1110>`__
 
 .. _release-0-12-17:
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -54,7 +54,7 @@ Ledger API
 
   - If you check for the presence of :ref:`com.digitalasset.ledger.api.v1.ExercisedEvent` when handling a :ref:`com.digitalasset.ledger.api.v1.Transaction`, you have to remove this code now.
 
-- Added the field ``agreement_text`` to the ``CreatedEvent`` message. This means you now have access to the agreement text of contracts via the Ledger API.
+- Added the :ref:`agreement text <daml-ref-agreements>` as a new field ``agreement_text`` to the ``CreatedEvent`` message. This means you now have access to the agreement text of contracts via the Ledger API.
   The type of this field is ``google.protobuf.StringValue`` to properly reflect the optionality on the wire for full backwards compatibility.
   See Google's `wrappers.proto <https://github.com/protocolbuffers/protobuf/blob/b4f193788c9f0f05d7e0879ea96cd738630e5d51/src/google/protobuf/wrappers.proto#L31-L34>`__ for more information about ``StringValue``.
 
@@ -88,7 +88,7 @@ Java Bindings
 
   See `issue #1092 <https://github.com/digital-asset/daml/issues/1092>`__ for details.
 
-- Added agreement text of contracts: `#1110 <https://github.com/digital-asset/daml/issues/1110>`__
+- Added :ref:`agreement text <daml-ref-agreements>` of contracts: `#1110 <https://github.com/digital-asset/daml/issues/1110>`__
 
   - **Java Bindings**
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -103,7 +103,7 @@ Java Bindings
       This method is useful for setting up tests, when you want to convert a ``Record`` into a contract without having to create a ``CreatedEvent`` first.
     - Deprecated generated static method ``TemplateName.Contract.fromIdAndRecord(String, Record)`` in favor of the new static methods in the generated ``Contract`` classes.
     - Changed the generated :ref:`decoder utility class <daml-codegen-java-decoder-class>` to use the new ``fromCreatedEvent`` method.
-    - Changed the return type of the ``getDecoder`` method in the generated decoder utility class from ``Optional<BiFunction<String, Record, Contract>>`` to ``Optional<Function<CreatedEvent, Contract>>``.
+    - **BREAKING** Changed the return type of the ``getDecoder`` method in the generated decoder utility class from ``Optional<BiFunction<String, Record, Contract>>`` to ``Optional<Function<CreatedEvent, Contract>>``.
 
   How to migrate:
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -107,8 +107,8 @@ Java Bindings
 
   How to migrate:
 
-  - If you are manually constructing instances of ``data.CreatedEvent`` (e.g.: for testing), you need to add an ``Optional<String>`` value as constructor parameter for the ``agreementText`` field.
-  - All calls to ``Contract.fromIdAndRecord`` should be changed to ``Contract.fromCreatedEvent``.
+  - If you are manually constructing instances of ``data.CreatedEvent`` (for example, for testing), you need to add an ``Optional<String>`` value as constructor parameter for the ``agreementText`` field.
+  - You should change all calls to ``Contract.fromIdAndRecord`` to ``Contract.fromCreatedEvent``.
 
     .. code-block:: java
 
@@ -121,7 +121,7 @@ Java Bindings
         Iou.Contract contract = Iou.Contract.fromCreatedEvent(event);
 
   - Pass the ``data.CreatedEvent`` directly to the function returned by the decoder's ``getDecoder`` method.
-    If you are using the decoder utility class' method ``fromCreatedEvent``, you don't need to change anything.
+    If you are using the decoder utility class method ``fromCreatedEvent``, you don't need to change anything.
 
     .. code-block:: java
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -98,9 +98,11 @@ Java Bindings
 
     - Added generated field ``Optional<String> TemplateName.Contract#agreementText``.
     - Added generated static method ``TemplateName.Contract.fromCreatedEvent(CreatedEvent)``.
+      This is the preferred method to use for converting a ``CreatedEvent`` into a ``Contract``.
     - Added generated static method ``TemplateName.Contract.fromIdAndRecord(String, Record, Optional<String>)``.
+      This method is useful for setting up tests, when you want to convert a ``Record`` into a contract without having to create a ``CreatedEvent`` first.
     - Deprecated generated static method ``TemplateName.Contract.fromIdAndRecord(String, Record)`` in favor of the new static methods in the generated ``Contract`` classes.
-    - Changed the generated `decoder utility class <https://docs.daml.com/app-dev/bindings-java/codegen.html#generate-the-decoder-utility-class>`__ to use the new ``fromCreatedEvent`` method.
+    - Changed the generated :ref:`decoder utility class <daml-codegen-java-decoder-class>` to use the new ``fromCreatedEvent`` method.
     - Changed the return type of the ``getDecoder`` method in the generated decoder utility class from ``Optional<BiFunction<String, Record, Contract>>`` to ``Optional<Function<CreatedEvent, Contract>>``.
 
   How to migrate:

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -426,7 +426,8 @@ class BotTest extends FlatSpec with Matchers with DataLayerHelpers {
       s"eid_$id",
       templateId,
       s"cid_$id",
-      new Record(List.empty[Record.Field].asJava))
+      new Record(List.empty[Record.Field].asJava),
+      Optional.empty())
 
   def archive(event: CreatedEvent): ArchivedEvent =
     new ArchivedEvent(

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.rxjava.grpc.helpers
 
 import java.time.Instant
 import java.util
-import java.util.Collections
+import java.util.{Collections, Optional}
 
 import com.daml.ledger.javaapi.data
 import com.daml.ledger.testkit.services.TransactionServiceImpl
@@ -183,13 +183,27 @@ object TransactionGenerator {
   val createdEventGen: Gen[(Created, data.CreatedEvent)] = for {
     eventId <- nonEmptyId
     contractId <- nonEmptyId
+    agreementText <- Gen.option(Gen.asciiStr)
     (scalaTemplateId, javaTemplateId) <- identifierGen
     (scalaRecord, javaRecord) <- Gen.sized(recordGen)
     parties <- Gen.listOf(nonEmptyId)
   } yield
     (
-      Created(CreatedEvent(eventId, contractId, Some(scalaTemplateId), Some(scalaRecord), parties)),
-      new data.CreatedEvent(parties.asJava, eventId, javaTemplateId, contractId, javaRecord)
+      Created(
+        CreatedEvent(
+          eventId,
+          contractId,
+          Some(scalaTemplateId),
+          Some(scalaRecord),
+          parties,
+          agreementText = agreementText)),
+      new data.CreatedEvent(
+        parties.asJava,
+        eventId,
+        javaTemplateId,
+        contractId,
+        javaRecord,
+        agreementText.map(Optional.of[String]).getOrElse(Optional.empty()))
     )
 
   val archivedEventGen: Gen[(Archived, data.ArchivedEvent)] = for {

--- a/language-support/java/codegen/src/it/java/com/digitalasset/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/digitalasset/TemplateMethodTest.java
@@ -3,16 +3,17 @@
 
 package com.digitalasset;
 
-import com.daml.ledger.javaapi.data.CreateAndExerciseCommand;
-import com.daml.ledger.javaapi.data.CreateCommand;
-import com.daml.ledger.javaapi.data.ExerciseCommand;
+import com.daml.ledger.javaapi.data.*;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import tests.template1.SimpleTemplate;
 import tests.template1.TestTemplate_Int;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
 public class TemplateMethodTest {
@@ -20,6 +21,8 @@ public class TemplateMethodTest {
     // Note that for the most part these tests should are designed to "fail"
     // at compilation time in case any of the methods are generated differently
     // or not at all
+
+    private static Record simpleTemplateRecord = new Record(new Record.Field(new Party("Bob")));
 
     @Test
     void templateHasCreateMethods() {
@@ -50,5 +53,34 @@ public class TemplateMethodTest {
 
         assertNotNull(fromSplatted, "CreateAndExerciseCommand from splatted choice was null");
         assertNotNull(fromRecord, "CreateAndExerciseCommand from record choice was null");
+        assertEquals(fromRecord, fromSplatted, "CreateAndExerciseCommands from both methods are not the same");
+    }
+
+    @Test
+    void contractHasDeprecatedFromIdAndRecord() {
+        SimpleTemplate.Contract contract = SimpleTemplate.Contract.fromIdAndRecord("SomeId", simpleTemplateRecord);
+        assertFalse(contract.agreementText.isPresent(), "Field agreementText should not be present");
+    }
+
+    @Test
+    void contractHasFromIdAndRecord() {
+        SimpleTemplate.Contract emptyAgreement = SimpleTemplate.Contract.fromIdAndRecord("SomeId", simpleTemplateRecord, Optional.empty());
+        assertFalse(emptyAgreement.agreementText.isPresent(), "Field agreementText should not be present");
+
+        SimpleTemplate.Contract nonEmptyAgreement = SimpleTemplate.Contract.fromIdAndRecord("SomeId", simpleTemplateRecord, Optional.of("I agree"));
+        assertTrue(nonEmptyAgreement.agreementText.isPresent(), "Field agreementText should be present");
+        assertEquals(nonEmptyAgreement.agreementText, Optional.of("I agree"), "Unexpected agreementText");
+    }
+
+    @Test
+    void contractHasFromCreatedEvent() {
+        CreatedEvent agreementEvent = new CreatedEvent(Collections.emptyList(), "eventId", SimpleTemplate.TEMPLATE_ID, "cid", simpleTemplateRecord, Optional.of("I agree"));
+        CreatedEvent noAgreementEvent = new CreatedEvent(Collections.emptyList(), "eventId", SimpleTemplate.TEMPLATE_ID, "cid", simpleTemplateRecord, Optional.empty());
+
+        SimpleTemplate.Contract withAgreement = SimpleTemplate.Contract.fromCreatedEvent(agreementEvent);
+        assertTrue(withAgreement.agreementText.isPresent(), "AgreementText was not present");
+
+        SimpleTemplate.Contract withoutAgreement = SimpleTemplate.Contract.fromCreatedEvent(noAgreementEvent);
+        assertFalse(withoutAgreement.agreementText.isPresent(), "AgreementText was present");
     }
 }

--- a/language-support/java/codegen/src/ledger-tests/daml/Wolpertinger.daml
+++ b/language-support/java/codegen/src/ledger-tests/daml/Wolpertinger.daml
@@ -28,7 +28,7 @@ template Wolpertinger
     where
         signatory owner
 
-        agreement show owner <> "has " <> show wings <> " wings and is " <> show age <> " years old."
+        agreement name <> " has " <> show wings <> " wings and is " <> show age <> " years old."
 
         controller owner can
             Reproduce : ContractId Wolpertinger

--- a/language-support/java/codegen/src/ledger-tests/daml/Wolpertinger.daml
+++ b/language-support/java/codegen/src/ledger-tests/daml/Wolpertinger.daml
@@ -28,6 +28,8 @@ template Wolpertinger
     where
         signatory owner
 
+        agreement show owner <> "has " <> show wings <> " wings and is " <> show age <> " years old."
+
         controller owner can
             Reproduce : ContractId Wolpertinger
                 with mateId : ContractId Wolpertinger

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
@@ -119,8 +119,7 @@ class CodegenLedgerTest extends FlatSpec with Matchers {
       .foldLeft(Map[String, Wolpertinger.Contract]())((acc, event) =>
         event match {
           case e: CreatedEvent =>
-            acc + (e.getContractId -> Wolpertinger.Contract
-              .fromIdAndRecord(e.getContractId, e.getArguments))
+            acc + (e.getContractId -> Wolpertinger.Contract.fromCreatedEvent(e))
           case a: ArchivedEvent => acc - a.getContractId
       })
       .toList

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
@@ -214,6 +214,6 @@ class CodegenLedgerTest extends FlatSpec with Matchers {
     val wolpertinger :: _ = readActiveContracts(client)
 
     wolpertinger.agreementText.isPresent shouldBe true
-    wolpertinger.agreementText.get should not be empty
+    wolpertinger.agreementText.get shouldBe s"${wolpertinger.data.name} has ${wolpertinger.data.wings} wings and is ${wolpertinger.data.age} years old."
   }
 }

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClassSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClassSpec.scala
@@ -3,8 +3,10 @@
 
 package com.digitalasset.daml.lf.codegen.backend.java.inner
 
+import java.util.Optional
+
 import com.daml.ledger.javaapi
-import com.squareup.javapoet.{ClassName, TypeName}
+import com.squareup.javapoet.{ClassName, ParameterizedTypeName, TypeName}
 import javax.lang.model.element.Modifier
 import org.scalatest.{FlatSpec, Matchers, OptionValues, TryValues}
 
@@ -25,7 +27,7 @@ final class TemplateClassSpec extends FlatSpec with Matchers with OptionValues w
 
   it should "generate a method taking exactly a template identifier and a record" in {
     val parameters = fromIdAndRecord.parameters.asScala.map(p => p.name -> p.`type`)
-    parameters should contain only ("contractId" -> string, "record$" -> record)
+    parameters should contain only ("contractId" -> string, "record$" -> record, "agreementText" -> optionalString)
   }
 
   private[this] val className = ClassName.bestGuess("Test")
@@ -35,5 +37,7 @@ final class TemplateClassSpec extends FlatSpec with Matchers with OptionValues w
     TemplateClass.generateFromIdAndRecord(className, templateClassName, idClassName)
   private[this] val string = TypeName.get(classOf[String])
   private[this] val record = TypeName.get(classOf[javaapi.data.Record])
+  private[this] val optionalString =
+    ParameterizedTypeName.get(classOf[Optional[_]], classOf[String])
 
 }

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapperUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapperUT.scala
@@ -20,7 +20,7 @@ import org.scalatest.{Matchers, WordSpec}
 import scala.collection.immutable
 
 class DomainTransactionMapperUT extends WordSpec with Matchers with AkkaTest {
-  private val mockContract = Contract(Primitive.ContractId("contractId"), MockTemplate())
+  private val mockContract = Contract(Primitive.ContractId("contractId"), MockTemplate(), None)
   private val transactionMapper = new DomainTransactionMapper(createdEvent => Right(mockContract))
 
   private def getResult(source: immutable.Iterable[Transaction]): Seq[DomainTransaction] =

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Contract.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Contract.scala
@@ -5,7 +5,10 @@ package com.digitalasset.ledger.client.binding
 
 import com.digitalasset.ledger.api.v1.{value => rpcvalue}
 
-final case class Contract[+T](contractId: Primitive.ContractId[T], value: T with Template[T]) {
+final case class Contract[+T](
+    contractId: Primitive.ContractId[T],
+    value: T with Template[T],
+    agreementText: Option[String]) {
   def arguments: rpcvalue.Record = value.arguments
 }
 

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EventDecoderApi.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EventDecoderApi.scala
@@ -39,6 +39,7 @@ abstract class EventDecoderApi(
     } yield
       Contract(
         Primitive.substContractId[Id, Nothing](ApiTypes.ContractId(createdEvent.contractId)),
-        tadt)
+        tadt,
+        createdEvent.agreementText)
   }
 }

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
@@ -488,7 +488,10 @@ class ScalaCodeGenIT
     event.event.isCreated shouldBe true
     decoder(event.getCreated) match {
       case Left(e) => fail(e.toString)
-      case Right(Contract(_, contract)) => contract shouldBe expectedContract
+      case Right(Contract(_, contract, agreementText)) =>
+        contract shouldBe expectedContract
+        agreementText shouldBe event.getCreated.agreementText
+
     }
   }
 

--- a/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/DecodeUtil.scala
+++ b/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/DecodeUtil.scala
@@ -28,7 +28,7 @@ object DecodeUtil {
     for {
       record <- event.createArguments: Option[V.Record]
       a <- decoder.read(V.Value.Sum.Record(record)): Option[A]
-    } yield Contract(P.ContractId(event.contractId), a)
+    } yield Contract(P.ContractId(event.contractId), a, event.agreementText)
   }
 
   def decodeArchived[A <: Template[A]](transaction: Transaction): Option[P.ContractId[A]] = {

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package com.digitalasset.ledger.api.v1;
 
 import "com/digitalasset/ledger/api/v1/value.proto";
+import "google/protobuf/wrappers.proto";
 
 
 option java_outer_classname = "EventOuterClass";
@@ -56,6 +57,10 @@ message CreatedEvent {
   // the contract.
   // Required
   repeated string witness_parties = 5;
+
+  // The agreement text of the contract.
+  // Optional
+  google.protobuf.StringValue agreement_text = 6;
 }
 
 // Records that a contract has been archived, and choices may no longer be exercised on it.

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -59,6 +59,8 @@ message CreatedEvent {
   repeated string witness_parties = 5;
 
   // The agreement text of the contract.
+  // We use StringValue to properly reflect optionality on the wire for backwards compatibility.
+  // This means a newer client works with an older sandbox seamlessly.
   // Optional
   google.protobuf.StringValue agreement_text = 6;
 }

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -60,6 +60,8 @@ message CreatedEvent {
 
   // The agreement text of the contract.
   // We use StringValue to properly reflect optionality on the wire for backwards compatibility.
+  // This is necessary since the empty string is an acceptable (and in fact the default) agreement
+  // text, but also the default string in protobuf.
   // This means a newer client works with an older sandbox seamlessly.
   // Optional
   google.protobuf.StringValue agreement_text = 6;

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/EventFilter.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/EventFilter.scala
@@ -43,7 +43,7 @@ object EventFilter {
 
     def filterEvent(event: Event): Option[Event] = {
       val servedEvent = event.event match {
-        case Created(CreatedEvent(_, _, Some(templateId), _, _)) =>
+        case Created(CreatedEvent(_, _, Some(templateId), _, _, _)) =>
           applyRequestingWitnesses(event, templateId)
 
         case Archived(ArchivedEvent(_, _, Some(templateId), _)) =>

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionConversion.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionConversion.scala
@@ -102,7 +102,8 @@ trait TransactionConversion {
               throw new RuntimeException(s"Unexpected error when converting stored contract: $err"),
             identity)),
       if (includeParentWitnesses) convert(create.witnesses)
-      else convert(create.stakeholders)
+      else convert(create.stakeholders),
+      Some(create.agreementText)
     )
   }
 

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -73,7 +73,8 @@ object domain {
         contractId: ContractId,
         templateId: Ref.Identifier,
         createArguments: ValueRecord[AbsoluteContractId],
-        witnessParties: immutable.Set[Ref.Party])
+        witnessParties: immutable.Set[Ref.Party],
+        agreementText: String)
         extends Event
         with CreateOrExerciseEvent
         with CreateOrArchiveEvent

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ActiveContractsServiceIT.scala
@@ -98,7 +98,7 @@ class ActiveContractsServiceIT
       template: Identifier,
       occurrence: Int = 1): Assertion =
     events.collect {
-      case ce @ CreatedEvent(_, _, Some(`template`), _, _) => ce
+      case ce @ CreatedEvent(_, _, Some(`template`), _, _, _) => ce
     }.size should equal(occurrence)
 
   def threeCommands(ledgerId: String, commandId: String): SubmitAndWaitRequest =
@@ -178,7 +178,7 @@ class ActiveContractsServiceIT
         def extractContractId(acsResponse: Seq[GetActiveContractsResponse]) = {
           val events = acsResponse.flatMap(_.activeContracts).toSet
           events.collect {
-            case CreatedEvent(contractId, _, Some(tid), _, _) if tid == templateIds.dummy =>
+            case CreatedEvent(contractId, _, Some(tid), _, _, _) if tid == templateIds.dummy =>
               contractId
           }.head
         }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -659,6 +659,28 @@ class TransactionServiceIT
           .map(_.getCreateArguments.fields shouldEqual expectedArgs)
       }
 
+      "expose the agreement text in CreatedEvents for templates with an explicit agreement text" in allFixtures {
+        c =>
+          for {
+            agreement <- createAgreement(c, "AgreementTextTest", party1, party2)
+          } yield {
+            agreement.agreementText should matchPattern {
+              case Some(text: String) if text.nonEmpty =>
+            }
+          }
+      }
+
+      "expose the defualt agreement text in CreatedEvents for templates with no explicit agreement text" in allFixtures {
+        c =>
+          val resultF = c.submitCreate(
+            "Creating dummy contract for default agreement text test",
+            templateIds.dummy,
+            List(RecordField("operator", party1.asParty)),
+            party1)
+
+          resultF.map(_.agreementText should matchPattern { case Some("") => })
+      }
+
       "accept exercising a well-authorized multi-actor choice" in allFixtures { c =>
         val List(operator, receiver, giver) = List(party1, party2, party3)
         val triProposalArg = mkTriProposalArg(operator, receiver, giver)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -670,7 +670,7 @@ class TransactionServiceIT
           }
       }
 
-      "expose the defualt agreement text in CreatedEvents for templates with no explicit agreement text" in allFixtures {
+      "expose the default agreement text in CreatedEvents for templates with no explicit agreement text" in allFixtures {
         c =>
           val resultF = c.submitCreate(
             "Creating dummy contract for default agreement text test",

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -661,13 +661,10 @@ class TransactionServiceIT
 
       "expose the agreement text in CreatedEvents for templates with an explicit agreement text" in allFixtures {
         c =>
-          for {
-            agreement <- createAgreement(c, "AgreementTextTest", party1, party2)
-          } yield {
-            agreement.agreementText should matchPattern {
-              case Some(text: String) if text.nonEmpty =>
-            }
-          }
+          createAgreement(c, "AgreementTextTest", party1, party2).map(
+            _.agreementText shouldBe Some(
+              s"'$party2' promise to pay the '$party1' on demand the sum of five pounds.")
+          )
       }
 
       "expose the default agreement text in CreatedEvents for templates with no explicit agreement text" in allFixtures {
@@ -678,7 +675,7 @@ class TransactionServiceIT
             List(RecordField("operator", party1.asParty)),
             party1)
 
-          resultF.map(_.agreementText should matchPattern { case Some("") => })
+          resultF.map(_.agreementText shouldBe Some(""))
       }
 
       "accept exercising a well-authorized multi-actor choice" in allFixtures { c =>

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandStaticTimeIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandStaticTimeIT.scala
@@ -102,7 +102,7 @@ class CommandStaticTimeIT
     } yield event.event
 
     events.collect {
-      case Created(CreatedEvent(contractId, _, _, _, _)) => contractId
+      case Created(CreatedEvent(contractId, _, _, _, _, _)) => contractId
     }.head
   }
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -573,7 +573,7 @@ abstract class CommandTransactionChecks
                 .map(_.event)
                 .collect {
                   case Archived(ArchivedEvent(eventId, _, _, _)) => eventId
-                  case Created(CreatedEvent(eventId, _, _, _, _)) => eventId
+                  case Created(CreatedEvent(eventId, _, _, _, _, _)) => eventId
                 })
             .takeWithin(5.seconds) //TODO: work around as ledger end is broken. see DEL-3151
             .runWith(Sink.seq)

--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
@@ -37,7 +37,7 @@ class AcsBench extends TestCommands with InfAwait {
       template: Identifier): Option[String] = {
     val events = response.activeContracts.toSet
     events.collectFirst {
-      case CreatedEvent(contractId, _, Some(id), _, _) if id == template => contractId
+      case CreatedEvent(contractId, _, Some(id), _, _, _) if id == template => contractId
     }
   }
 

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
@@ -132,7 +132,7 @@ trait TestHelper {
   def extractContractId(templateId: Identifier)(
       response: GetActiveContractsResponse): List[String] =
     response.activeContracts.toList.collect {
-      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _)
+      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _, _)
           if IdentifierEqual.equal(actualTemplateId, templateId) =>
         contractId
     }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
@@ -77,7 +77,7 @@ abstract class ScenarioLoadingITBase
       present: Boolean = true): Unit = {
     val occurrence = if (present) 1 else 0
     val _ = events.collect {
-      case ce @ CreatedEvent(_, _, Some(`template`), _, _) =>
+      case ce @ CreatedEvent(_, _, Some(`template`), _, _, _) =>
         // the absolute contract ids are opaque -- they have no specified format. however, for now
         // we like to keep it consistent between the DAML studio and the sandbox. Therefore verify
         // that they have the same format.

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/transaction/EventConverterSpec.scala
@@ -354,8 +354,9 @@ class EventConverterSpec
                   (Some("receiver"), Lf.ValueParty("receiver")),
                   (Some("giver"), Lf.ValueParty("giver")))
               )),
+              "I agree",
               Set("operator", "receiver", "giver"),
-              Set("operator", "receiver", "giver")
+              Set("operator", "receiver", "giver"),
             ),
             "#txId:0" -> rootEx
           )
@@ -387,7 +388,8 @@ class EventConverterSpec
               RecordField("giver", Some(Value(Value.Sum.Party("giver"))))
             )
           )),
-        Vector("operator", "receiver", "giver")
+        Vector("operator", "receiver", "giver"),
+        Some("I agree")
       )
       val nestedExercise = ExercisedEvent(
         "#txId:2",

--- a/navigator/backend/README.md
+++ b/navigator/backend/README.md
@@ -19,7 +19,7 @@ We can build and run a basic the backend using the following commands:
 
 ```bash
 # Build a distribution archive ("fat jar"):
-bazel build //navigator/backend/navigator-binary_deploy.jar
+bazel build //navigator/backend:navigator-binary_deploy.jar
 
 # Run without arguments to show usage:
 java -jar navigator-binary_deploy.jar --help

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/data/ContractRow.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/data/ContractRow.scala
@@ -16,7 +16,8 @@ final case class ContractRow(
     id: String,
     templateId: String,
     archiveTransactionId: Option[String],
-    argument: String
+    argument: String,
+    agreementText: Option[String]
 ) {
 
   def toContract(types: PackageRegistry): Try[Contract] = {
@@ -28,7 +29,7 @@ final case class ContractRow(
         ApiCodecCompressed.jsValueToApiType(argument.parseJson, tid, types.damlLfDefDataType _))
       recArg <- Try(recArgAny.asInstanceOf[ApiRecord])
     } yield {
-      Contract(id, template, recArg)
+      Contract(id, template, recArg, agreementText)
     }).recoverWith {
       case e: Throwable =>
         Failure(DeserializationFailed(s"Failed to deserialize Contract from row: $this. Error: $e"))
@@ -38,6 +39,11 @@ final case class ContractRow(
 
 object ContractRow {
   def fromContract(c: Contract): ContractRow = {
-    ContractRow(c.id.unwrap, c.template.id.asOpaqueString, None, c.argument.toJson.compactPrint)
+    ContractRow(
+      c.id.unwrap,
+      c.template.id.asOpaqueString,
+      None,
+      c.argument.toJson.compactPrint,
+      c.agreementText)
   }
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/data/DatabaseActions.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/data/DatabaseActions.scala
@@ -5,15 +5,13 @@ package com.digitalasset.navigator.data
 
 import java.sql.DriverManager
 
-import com.digitalasset.ledger.api.refinements.ApiTypes
-import com.digitalasset.navigator.model._
-import com.digitalasset.navigator.json.ApiCodecCompressed.JsonImplicits._
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
+import com.digitalasset.ledger.api.refinements.ApiTypes
+import com.digitalasset.navigator.model._
 import doobie._
 import doobie.implicits._
 import scalaz.syntax.tag._
-import spray.json._
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
@@ -347,10 +345,7 @@ class DatabaseActions {
   def insertContract(contract: Contract): Try[Int] = {
     Try {
       Queries
-        .insertContract(
-          contract.id.unwrap,
-          contract.template.id.asOpaqueString,
-          contract.argument.toJson.compactPrint)
+        .insertContract(ContractRow.fromContract(contract))
         .update
         .run
         .transact(xa)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/data/EventRow.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/data/EventRow.scala
@@ -28,7 +28,8 @@ final case class EventRow(
     choice: Option[String],
     argumentValue: Option[String],
     actingParties: Option[String],
-    isConsuming: Option[Boolean]) {
+    isConsuming: Option[Boolean],
+    agreementText: Option[String]) {
 
   def toEvent(types: PackageRegistry): Try[Event] = {
     subclassType match {
@@ -51,7 +52,8 @@ final case class EventRow(
             ApiTypes.WorkflowId(workflowId),
             ApiTypes.ContractId(contractId),
             tp,
-            recArg
+            recArg,
+            agreementText
           )
         }).recoverWith {
           case e: Throwable =>
@@ -121,7 +123,8 @@ object EventRow {
           None,
           None,
           None,
-          None
+          None,
+          c.agreementText
         )
       case e: ChoiceExercised =>
         EventRow(
@@ -138,7 +141,8 @@ object EventRow {
           Some(e.choice.unwrap),
           Some(e.argument.toJson.compactPrint),
           Some(e.actingParties.toJson.compactPrint),
-          Some(e.consuming)
+          Some(e.consuming),
+          None
         )
     }
   }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/data/Queries.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/data/Queries.scala
@@ -18,7 +18,8 @@ object Queries {
             id TEXT PRIMARY KEY NOT NULL,
             template_id TEXT NOT NULL,
             archive_transaction_id TEXT DEFAULT NULL,
-            argument JSON NOT NULL
+            argument JSON NOT NULL,
+            agreement_text TEXT DEFAULT NULL
           )
       """
 
@@ -216,13 +217,13 @@ object Queries {
       SELECT * FROM command
     """
 
-  def insertContract(id: String, templateId: String, argument: String): Fragment =
+  def insertContract(row: ContractRow): Fragment =
     sql"""
       INSERT INTO 
         contract 
-        (id, template_id, archive_transaction_id, argument)
-      VALUES 
-        ($id, $templateId, NULL, $argument)
+        (id, template_id, archive_transaction_id, argument, agreement_text)
+      VALUES
+        (${row.id}, ${row.templateId}, ${row.archiveTransactionId}, ${row.argument}, ${row.agreementText})
     """
 
   def archiveContract(contractId: String, archiveTransactionId: String): Fragment =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
@@ -317,7 +317,8 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
           ListType(ExercisedEventType),
           resolve =
             context => context.ctx.ledger.exercisedEventsOf(context.value, context.ctx.templates)),
-        Field("argument", JsonType.ApiRecordType, resolve = _.value.argument)
+        Field("argument", JsonType.ApiRecordType, resolve = _.value.argument),
+        Field("agreementText", OptionType(StringType), resolve = _.value.agreementText)
     )
   )
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
@@ -108,7 +108,7 @@ object ModelCodec {
         val argument = ApiCodecCompressed
           .jsValueToApiType(anyField(value, "record", "Contract"), template.id, types)
           .asInstanceOf[ApiRecord]
-        val agreementText = anyField(value, "agreementText", "Contract").convertTo[Option[String]]
+        val agreementText = optionStrField(value, "agreementText", "Contract")
         Contract(id, template, argument, agreementText)
       }
     }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
@@ -99,7 +99,8 @@ object ModelCodec {
       def write(value: Contract): JsValue = JsObject(
         "id" -> value.id.toJson,
         "template" -> value.template.toJson,
-        "argument" -> value.argument.toJson
+        "argument" -> value.argument.toJson,
+        "agreementText" -> value.agreementText.toJson
       )
       def read(value: JsValue, types: DamlLfTypeLookup): Contract = {
         val id = anyField(value, "id", "Contract").convertTo[ApiTypes.ContractId]
@@ -107,7 +108,8 @@ object ModelCodec {
         val argument = ApiCodecCompressed
           .jsValueToApiType(anyField(value, "record", "Contract"), template.id, types)
           .asInstanceOf[ApiRecord]
-        Contract(id, template, argument)
+        val agreementText = anyField(value, "agreementText", "Contract").convertTo[Option[String]]
+        Contract(id, template, argument, agreementText)
       }
     }
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
@@ -7,7 +7,6 @@ import com.digitalasset.ledger.api.refinements.ApiTypes
 import com.digitalasset.navigator.model._
 import com.digitalasset.navigator.json.Util._
 import com.digitalasset.navigator.json.DamlLfCodec.JsonImplicits._
-import com.digitalasset.navigator.json.ApiCodecCompressed.JsonImplicits._
 import spray.json._
 
 /**
@@ -93,24 +92,6 @@ object ModelCodec {
     implicit object PartyJsonFormat extends RootJsonFormat[ApiTypes.Party] {
       def write(value: ApiTypes.Party): JsValue = JsString(ApiTypes.Party.unwrap(value))
       def read(value: JsValue): ApiTypes.Party = ApiTypes.Party(asString(value, "Party"))
-    }
-
-    implicit object ContractFormat extends RootJsonWriter[Contract] {
-      def write(value: Contract): JsValue = JsObject(
-        "id" -> value.id.toJson,
-        "template" -> value.template.toJson,
-        "argument" -> value.argument.toJson,
-        "agreementText" -> value.agreementText.toJson
-      )
-      def read(value: JsValue, types: DamlLfTypeLookup): Contract = {
-        val id = anyField(value, "id", "Contract").convertTo[ApiTypes.ContractId]
-        val template = anyField(value, "template", "Contract").convertTo[Template]
-        val argument = ApiCodecCompressed
-          .jsValueToApiType(anyField(value, "record", "Contract"), template.id, types)
-          .asInstanceOf[ApiRecord]
-        val agreementText = optionStrField(value, "agreementText", "Contract")
-        Contract(id, template, argument, agreementText)
-      }
     }
 
     implicit val PartyListJsonFormat: RootJsonFormat[List[ApiTypes.Party]] =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/Util.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/Util.scala
@@ -20,6 +20,14 @@ object Util {
         deserializationError(s"Can't read ${obj.prettyPrint} as $as, missing field '$name'")
     }
 
+  def optionStrField(obj: JsValue, name: String, as: String): Option[String] =
+    asObject(obj, as).fields.get(name) match {
+      case Some(JsString(v)) => Some(v)
+      case None => None
+      case Some(_) =>
+        deserializationError(s"Can't read ${obj.prettyPrint} as $as, field '$name' is not a string")
+    }
+
   def nameField(obj: JsValue, name: String, as: String): Ref.Name =
     Ref.Name
       .fromString(strField(obj, name, as))

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/Util.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/Util.scala
@@ -20,14 +20,6 @@ object Util {
         deserializationError(s"Can't read ${obj.prettyPrint} as $as, missing field '$name'")
     }
 
-  def optionStrField(obj: JsValue, name: String, as: String): Option[String] =
-    asObject(obj, as).fields.get(name) match {
-      case Some(JsString(v)) => Some(v)
-      case None => None
-      case Some(_) =>
-        deserializationError(s"Can't read ${obj.prettyPrint} as $as, field '$name' is not a string")
-    }
-
   def nameField(obj: JsValue, name: String, as: String): Ref.Name =
     Ref.Name
       .fromString(strField(obj, name, as))

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Ledger.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Ledger.scala
@@ -110,7 +110,7 @@ case class Ledger(
     event match {
       case event: ContractCreated =>
         packageRegistry.template(event.templateId).fold(this) { template =>
-          val contract = Contract(event.contractId, template, event.argument)
+          val contract = Contract(event.contractId, template, event.argument, event.agreementText)
           withContractCreatedInEvent(contract, event)
         }
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -146,7 +146,8 @@ final case class ContractCreated(
     workflowId: ApiTypes.WorkflowId,
     contractId: ApiTypes.ContractId,
     templateId: DamlLfIdentifier,
-    argument: ApiRecord
+    argument: ApiRecord,
+    agreementText: Option[String]
 ) extends Event
 
 final case class ChoiceExercised(
@@ -172,7 +173,8 @@ final case class ChoiceExercised(
 final case class Contract(
     id: ApiTypes.ContractId,
     template: Template,
-    argument: ApiRecord
+    argument: ApiRecord,
+    agreementText: Option[String]
 ) extends TaggedNode[ApiTypes.ContractIdTag]
 
 // ------------------------------------------------------------------------------------------------

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -184,7 +184,8 @@ case object LedgerApiV1 {
         workflowId = workflowId,
         contractId = ApiTypes.ContractId(event.contractId),
         templateId = templateIdentifier,
-        argument = arg
+        argument = arg,
+        agreementText = event.agreementText
       )
   }
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
@@ -181,6 +181,13 @@ package object filter {
       .perform[String]((contract, id) => checkContained(contract.id.unwrap, id.toLowerCase))
       .onBranch("template", _.template, templateFilter)
       .onBranch("argument", _.argument, argumentFilter)
+      .onLeaf("agreementText")
+      .onValue("*")
+      .const(true)
+      .onAnyValue
+      .perform[String]((contract, agree) =>
+        checkContained(contract.agreementText.getOrElse(""), agree.toLowerCase))
+      .onTree
   //  .onStar(check all fields)
 
   lazy val choicesFilter =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
@@ -21,6 +21,15 @@ package object filter {
       "target.contains(value)"
   }
 
+  object checkOptionalContained extends ((Option[String], String) => Boolean) {
+
+    override def apply(v1: Option[String], v2: String): Boolean =
+      v1.exists(_.toLowerCase contains v2.toLowerCase)
+
+    override def toString(): String =
+      "target.exists(_.contains(value))"
+  }
+
   def checkParameter(
       rootParam: DamlLfType,
       cursor: PropertyCursor,
@@ -185,8 +194,7 @@ package object filter {
       .onValue("*")
       .const(true)
       .onAnyValue
-      .perform[String]((contract, agree) =>
-        checkContained(contract.agreementText.getOrElse(""), agree.toLowerCase))
+      .perform[String]((contract, agree) => checkOptionalContained(contract.agreementText, agree))
       .onTree
   //  .onStar(check all fields)
 

--- a/navigator/backend/src/test/resources/schema.graphql
+++ b/navigator/backend/src/test/resources/schema.graphql
@@ -79,6 +79,7 @@ type CreatedEvent implements Node & Event {
   workflowId: String!
   contract: Contract!
   argument: DamlLfValueRecord!
+  agreementText: String!
 }
 
 scalar DamlLfDataType

--- a/navigator/backend/src/test/resources/schema.graphql
+++ b/navigator/backend/src/test/resources/schema.graphql
@@ -51,6 +51,7 @@ type Contract implements Node {
   archiveEvent: ExercisedEvent
   exerciseEvents: [ExercisedEvent!]!
   argument: DamlLfValueRecord!
+  agreementText: String
 }
 
 type ContractEdge {
@@ -79,7 +80,6 @@ type CreatedEvent implements Node & Event {
   workflowId: String!
   contract: Contract!
   argument: DamlLfValueRecord!
-  agreementText: String!
 }
 
 scalar DamlLfDataType

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/data/RowSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/data/RowSpec.scala
@@ -124,7 +124,8 @@ class RowSpec extends WordSpec with Matchers {
         ApiTypes.WorkflowId("w01"),
         ApiTypes.ContractId("c01"),
         C.complexRecordId,
-        C.complexRecordV
+        C.complexRecordV,
+        Some("agreement")
       )
 
       "not change the value" in {

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/model/LedgerSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/model/LedgerSpec.scala
@@ -28,7 +28,8 @@ class LedgerSpec extends WordSpec with Matchers {
       Instant.now(),
       "0",
       List.empty)
-  def contract(id: String): Contract = Contract(ApiTypes.ContractId(id), template, contractArgument)
+  def contract(id: String): Contract =
+    Contract(ApiTypes.ContractId(id), template, contractArgument, Option(""))
   def error(commandId: String): CommandStatusError = CommandStatusError("code", "details")
 
   "A ledger with existing contracts" when {
@@ -43,7 +44,8 @@ class LedgerSpec extends WordSpec with Matchers {
             ApiTypes.WorkflowId("workflowId"),
             ApiTypes.ContractId("C0"),
             templateId,
-            contractArgument
+            contractArgument,
+            Some("")
           )
         )),
       templateRegistry
@@ -68,7 +70,8 @@ class LedgerSpec extends WordSpec with Matchers {
         workflowId = ApiTypes.WorkflowId("workflow"),
         contractId = ApiTypes.ContractId(contractId),
         templateId = templateId,
-        argument = contractArgument
+        argument = contractArgument,
+        Some("")
       )
       val created1 = contractCreated("E1", "C1")
       val created2 = contractCreated("E2", "C2")
@@ -180,7 +183,8 @@ class LedgerSpec extends WordSpec with Matchers {
         workflowId = ApiTypes.WorkflowId("workflow"),
         contractId = ApiTypes.ContractId("C3"),
         templateId = templateId,
-        argument = contractArgument
+        argument = contractArgument,
+        agreementText = Some("")
       )
       val exercisedEvent = ChoiceExercised(
         id = ApiTypes.EventId("E2"),

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
@@ -53,15 +53,18 @@ class ContractFilterSpec extends FlatSpec with Matchers {
   val contract1 = Contract(
     ApiTypes.ContractId("id1"),
     template1,
-    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))))
+    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))),
+    None)
   val contract2 = Contract(
     ApiTypes.ContractId("id2"),
     template2,
-    ApiRecord(None, List(ApiRecordField("int", ApiInt64(12)))))
+    ApiRecord(None, List(ApiRecordField("int", ApiInt64(12)))),
+    Some(""))
   val contract3 = Contract(
     ApiTypes.ContractId("id3"),
     template1,
-    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))))
+    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))),
+    Some("agreement"))
 
   val templates = List(template1, template2)
   val contracts = List(contract1, contract2, contract3)
@@ -98,6 +101,10 @@ class ContractFilterSpec extends FlatSpec with Matchers {
   testAnd(List("argument.foo" -> "bar", "argument.int" -> "1"), Nil)
 
   testOr(List("argument.foo" -> "bar", "argument.int" -> "1"), contracts)
+
+//  testAnd(List("agreementText" -> ""), List(contract2, contract3))
+  testAnd(List("agreementText" -> "gree"), List(contract3))
+  testAnd(List("agreementText" -> "not-matching"), List())
 
   val contractSearchFilterCriterion =
     new GraphQLSchema(Set()).contractSearchToFilter(template1.topLevelDecl)

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
@@ -102,7 +102,7 @@ class ContractFilterSpec extends FlatSpec with Matchers {
 
   testOr(List("argument.foo" -> "bar", "argument.int" -> "1"), contracts)
 
-//  testAnd(List("agreementText" -> ""), List(contract2, contract3))
+  testAnd(List("agreementText" -> ""), List(contract2, contract3))
   testAnd(List("agreementText" -> "gree"), List(contract3))
   testAnd(List("agreementText" -> "not-matching"), List())
 

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractSortSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractSortSpec.scala
@@ -51,19 +51,23 @@ class ContractSortSpec extends FlatSpec with Matchers {
   val contract1 = Contract(
     ApiTypes.ContractId("id1"),
     template1,
-    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))))
+    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))),
+    None)
   val contract2 = Contract(
     ApiTypes.ContractId("id2"),
     template2,
-    ApiRecord(None, List(ApiRecordField("int", ApiInt64(1)))))
+    ApiRecord(None, List(ApiRecordField("int", ApiInt64(1)))),
+    Some(""))
   val contract3 = Contract(
     ApiTypes.ContractId("id3"),
     template1,
-    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))))
+    ApiRecord(None, List(ApiRecordField("foo", ApiText("bar")))),
+    Some("agreement"))
   val contract4 = Contract(
     ApiTypes.ContractId("id4"),
     template2,
-    ApiRecord(None, List(ApiRecordField("int", ApiInt64(2)))))
+    ApiRecord(None, List(ApiRecordField("int", ApiInt64(2)))),
+    None)
 
   val contracts = List(contract1, contract2, contract3, contract4)
 
@@ -80,6 +84,10 @@ class ContractSortSpec extends FlatSpec with Matchers {
   test(List(), contracts)
   test(List("id" -> ASCENDING), contracts.sortBy(_.id.unwrap))
   test(List("id" -> DESCENDING), contracts.sortBy(_.id.unwrap)(Ordering[String].reverse))
+  test(
+    List("agreementText" -> ASCENDING),
+    contracts.sortBy(_.agreementText)
+  )
   test(List("argument.foo" -> ASCENDING), List(contract1, contract3, contract2, contract4))
   test(
     List("argument.foo" -> ASCENDING, "id" -> DESCENDING),

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
@@ -29,7 +29,7 @@ class FilterSpec extends FlatSpec with Matchers {
   val commandId = ApiTypes.CommandId("Cmd")
   val workflowId = ApiTypes.WorkflowId("Workflow")
 
-  val contract = Contract(contractId, template, C.complexRecordV)
+  val contract = Contract(contractId, template, C.complexRecordV, Some(""))
   val command =
     CreateCommand(commandId, 1, workflowId, Instant.EPOCH, template.id, C.complexRecordV)
 

--- a/navigator/frontend/src/api/Queries.ts
+++ b/navigator/frontend/src/api/Queries.ts
@@ -34,8 +34,8 @@ export interface ContractDetailsById_node_Contract {
   id: string;
   argument: OpaqueTypes.DamlLfValueRecord;
   archiveEvent: ContractDetailsById_node_Contract_archiveEvent | null;
+  agreementText: string | null;
   template: ContractDetailsById_node_Contract_template;
-  agreementText: string | undefined;
 }
 
 export type ContractDetailsById_node = ContractDetailsById_node_Transaction | ContractDetailsById_node_Contract;

--- a/navigator/frontend/src/api/Queries.ts
+++ b/navigator/frontend/src/api/Queries.ts
@@ -35,6 +35,7 @@ export interface ContractDetailsById_node_Contract {
   argument: OpaqueTypes.DamlLfValueRecord;
   archiveEvent: ContractDetailsById_node_Contract_archiveEvent | null;
   template: ContractDetailsById_node_Contract_template;
+  agreementText: string | undefined;
 }
 
 export type ContractDetailsById_node = ContractDetailsById_node_Transaction | ContractDetailsById_node_Contract;

--- a/navigator/frontend/src/applets/contract/ContractComponent.tsx
+++ b/navigator/frontend/src/applets/contract/ContractComponent.tsx
@@ -144,6 +144,11 @@ export default (props: Props) => {
         <p>{isArchived ? 'ARCHIVED' : null}</p>
         <ColumnContainer>
           <Column>
+              {contract.agreementText && contract.agreementText !== '' &&
+                (<span><SubHeader><Strong>Agreement Text</Strong></SubHeader>
+                   <span>{contract.agreementText}</span>
+                 </span>)
+              }
             <SubHeader><Strong>Contract details</Strong></SubHeader>
             <ArgumentDisplay
               argument={contract.argument}

--- a/navigator/frontend/src/applets/contract/ContractComponent.tsx
+++ b/navigator/frontend/src/applets/contract/ContractComponent.tsx
@@ -78,6 +78,12 @@ const ChoiceLink = styled(ActiveLink)`
   }
 `
 
+const AgreementText = ({text}: {text: string}) => (
+    <span><SubHeader><Strong>Agreement Text</Strong></SubHeader>
+        <span>{text}</span>
+    </span>
+);
+
 interface Props {
   contract: Contract;
   choice?: string;
@@ -144,11 +150,7 @@ export default (props: Props) => {
         <p>{isArchived ? 'ARCHIVED' : null}</p>
         <ColumnContainer>
           <Column>
-              {contract.agreementText && contract.agreementText !== '' &&
-                (<span><SubHeader><Strong>Agreement Text</Strong></SubHeader>
-                   <span>{contract.agreementText}</span>
-                 </span>)
-              }
+              {contract.agreementText && <AgreementText text={contract.agreementText} />}
             <SubHeader><Strong>Contract details</Strong></SubHeader>
             <ArgumentDisplay
               argument={contract.argument}

--- a/navigator/frontend/src/applets/contract/index.tsx
+++ b/navigator/frontend/src/applets/contract/index.tsx
@@ -155,6 +155,7 @@ const query = gql`
         archiveEvent {
           id
         }
+        agreementText
         template {
           id topLevelDecl
           choices { name parameter }

--- a/navigator/frontend/src/ui-core/src/index.ts
+++ b/navigator/frontend/src/ui-core/src/index.ts
@@ -10,7 +10,6 @@ export { default as Link } from './Link';
 export { makeSidebarLink } from './SidebarLink';
 export { default as ParameterForm } from './ParameterForm';
 export { default as Popover } from './Popover';
-export { default as AgreementText } from './AgreementText';
 export { default as ArgumentDisplay } from './ArgumentDisplay';
 export { default as Autosuggest } from './Autosuggest';
 export { default as AdvanceTime } from './AdvanceTime';

--- a/navigator/frontend/src/ui-core/src/index.ts
+++ b/navigator/frontend/src/ui-core/src/index.ts
@@ -10,6 +10,7 @@ export { default as Link } from './Link';
 export { makeSidebarLink } from './SidebarLink';
 export { default as ParameterForm } from './ParameterForm';
 export { default as Popover } from './Popover';
+export { default as AgreementText } from './AgreementText';
 export { default as ArgumentDisplay } from './ArgumentDisplay';
 export { default as Autosuggest } from './Autosuggest';
 export { default as AdvanceTime } from './AdvanceTime';


### PR DESCRIPTION
* Added `agreement_text` field to the `CreatedEvent` in Ledger API.
* Changed java bindings + java codegen
* Changed utilities for scala codegen
* Made necessary changes in Sandbox to propagate the agreement text from `ContractInst` to the `CreatedEvent`
* Made changes to the navigator to show the agreement text in the contract details page when it is set and not empty

Fixes #1110

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
