### PR TITLE
Add daml init to the docs.

### DIFF
--- a/docs/source/support/new-assistant.rst
+++ b/docs/source/support/new-assistant.rst
@@ -33,10 +33,18 @@ We've released a new command-line tool for working with the DAML SDK: DAML Assis
 Migrating a ``da`` project to ``daml``
 ======================================
 
-To migrate an existing project to use ``daml``:
+The easiest way to migrate an existing project is to use the ``daml init`` command. To use it, simple go to the project root on the command line and run ``daml init``. This will create a ``daml.yaml`` file based on ``da.yaml``.
+
+Some things to keep in mind when using ``daml init`` to migrate projects:
+
+- If your project used an SDK version prior to 0.12.15, the ``daml.yaml`` file will specify SDK version 0.12.15 instead, as this is the first SDK version for which we consider the new assistant to be ready to use. Support for previous SDK versions is limited.
+
+- ``daml.yaml`` adds ``exposed-modules`` and ``dependencies`` fields, which are needed for ``daml build``. Depending on your DAML project, may have to adjust these fields in the generated ``daml.yaml``.
+
+Alternatively, you can follow these steps to migrate your project manually:
 
 1. Upgrade your project to SDK version 0.12.15 or later.
-2. Convert your project's ``da.yaml`` file into a ``daml.yaml`` file. 
+2. Convert your project's ``da.yaml`` file into a ``daml.yaml`` file.
 
    .. To do this, run ``da migrate`` on your existing ``da.yaml``. This command isn't done yet so commenting this out.
 
@@ -106,7 +114,7 @@ Managing versions and config
      - ``daml install <version>``
    * - ``da list``
      - List installed SDK versions
-     - ``daml version`` prints the current SDK version in use
+     - ``daml version``
    * - ``da use``
      - Set the default SDK version
      - No direct equivalent; you now set the new SDK version (``sdk-version: X.Y.Z``) in your project config file (``daml.yaml``) manually

--- a/docs/source/support/new-assistant.rst
+++ b/docs/source/support/new-assistant.rst
@@ -33,20 +33,24 @@ We've released a new command-line tool for working with the DAML SDK: DAML Assis
 Migrating a ``da`` project to ``daml``
 ======================================
 
-The easiest way to migrate an existing project is to use the ``daml init`` command. To use it, simple go to the project root on the command line and run ``daml init``. This will create a ``daml.yaml`` file based on ``da.yaml``.
+Migrating with daml init
+************************
+
+You can migrate an existing project using the ``daml init`` command. To use it, go to the project root on the command line and run ``daml init``. This will create a ``daml.yaml`` file based on ``da.yaml``.
 
 Some things to keep in mind when using ``daml init`` to migrate projects:
 
-- If your project used an SDK version prior to 0.12.15, the ``daml.yaml`` file will specify SDK version 0.12.15 instead, as this is the first SDK version for which we consider the new assistant to be ready to use. Support for previous SDK versions is limited.
+- If your project uses an SDK version prior to 0.12.15, the generated ``daml.yaml`` will use SDK version 0.12.15 instead. Support for previous SDK versions in the new assistant is limited.
 
 - ``daml.yaml`` adds ``exposed-modules`` and ``dependencies`` fields, which are needed for ``daml build``. Depending on your DAML project, may have to adjust these fields in the generated ``daml.yaml``.
 
-Alternatively, you can follow these steps to migrate your project manually:
+Migrating manually
+******************
+
+To migrate the project manually:
 
 1. Upgrade your project to SDK version 0.12.15 or later.
 2. Convert your project's ``da.yaml`` file into a ``daml.yaml`` file.
-
-   .. To do this, run ``da migrate`` on your existing ``da.yaml``. This command isn't done yet so commenting this out.
 
    The two files are very similar: ``daml.yaml`` is the ``project`` section of ``da.yaml``, plus some additional packaging information. Here is an example of a ``daml.yaml`` file, from the quickstart-java template:
 

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -7,6 +7,7 @@ DAML Assistant (``daml``)
 ``daml`` is a command-line tool that does a lot of useful things related to the SDK. Using ``daml``, you can:
 
 - Create new DAML projects: ``daml new <path to create project in>``
+- Initialize a DAML project: ``daml init``
 - Compile a DAML project: ``daml build``
 
   This builds the DAML project according to the project config file ``daml.yaml`` (see `Configuration files`_ below).
@@ -56,7 +57,7 @@ By default it's blank, and you usually won't need to edit it. It recognizes the 
 - ``update-check``: how often ``daml`` will check for new versions of the SDK, in seconds (default to ``86400``, i.e. once a day)
 
    This setting is only used to inform you when an update is available.
-    
+
    Set ``update-check: <number>`` to check for new versions every N seconds. Set ``update-check: never`` to never check for new versions.
 
 Here is an example ``daml-config.yaml``:
@@ -72,6 +73,8 @@ Project config file (``daml.yaml``)
 The project config file ``daml.yaml`` must be in the root of your DAML project directory. It controls how the DAML project is built and how tools like Sandbox and Navigator interact with it.
 
 The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory contains a DAML project, and lets you use project-aware commands like ``daml build`` and ``daml start``.
+
+``daml init`` creates a ``daml.yaml`` in an existing folder, so ``daml`` knows it's a project folder. It incorporates info from ``da.yaml`` in the generated ``daml.yaml``, if ``da.yaml`` is available (see :doc:`/support/new-assistant`).
 
 ``daml new`` creates a skeleton application in a new project folder, which includes a config file. For example, ``daml new my_project`` creates a new folder ``my_project`` with a project config file ``daml.yaml`` like this:
 
@@ -90,6 +93,7 @@ The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory
     dependencies:
       - daml-prim
       - daml-stdlib
+
 
 Here is what each field means:
 


### PR DESCRIPTION
`daml init` is a more convenient way to migrate existing projects for most users.

(Also `daml version` now does pretty much exactly what `da list` used to do.)