### PR TITLE
Add complex contract keys to DAML-LF

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -109,12 +109,19 @@ decodeDefTemplate LF1.DefTemplate{..} =
 decodeDefTemplateKey :: ExprVarName -> LF1.DefTemplate_DefKey -> Decode TemplateKey
 decodeDefTemplateKey templateParam LF1.DefTemplate_DefKey{..} = do
   typ <- mayDecode "defTemplate_DefKeyType" defTemplate_DefKeyType decodeType
-  key <- mayDecode "defTemplate_DefKeyKey" defTemplate_DefKeyKey (decodeKeyExpr templateParam)
+  key <- mayDecode "defTemplate_DefKeyKeyExpr" defTemplate_DefKeyKeyExpr (decodeKeyExpr templateParam)
   maintainers <- mayDecode "defTemplate_DefKeyMaintainers" defTemplate_DefKeyMaintainers decodeExpr
   return (TemplateKey typ key maintainers)
 
-decodeKeyExpr :: ExprVarName -> LF1.KeyExpr -> Decode Expr
-decodeKeyExpr templateParam LF1.KeyExpr{..} = mayDecode "keyExprSum" keyExprSum $ \case
+decodeKeyExpr :: ExprVarName -> LF1.DefTemplate_DefKeyKeyExpr -> Decode Expr
+decodeKeyExpr templateParam = \case
+    LF1.DefTemplate_DefKeyKeyExprKey simpleKeyExpr ->
+        decodeSimpleKeyExpr templateParam simpleKeyExpr
+    LF1.DefTemplate_DefKeyKeyExprComplexKey keyExpr ->
+        decodeExpr keyExpr
+
+decodeSimpleKeyExpr :: ExprVarName -> LF1.KeyExpr -> Decode Expr
+decodeSimpleKeyExpr templateParam LF1.KeyExpr{..} = mayDecode "keyExprSum" keyExprSum $ \case
   LF1.KeyExprSumProjections LF1.KeyExpr_Projections{..} ->
     foldM
       (\rec_ LF1.KeyExpr_Projection{..} ->
@@ -126,12 +133,12 @@ decodeKeyExpr templateParam LF1.KeyExpr{..} = mayDecode "keyExprSum" keyExprSum 
   LF1.KeyExprSumRecord LF1.KeyExpr_Record{..} ->
     ERecCon
       <$> mayDecode "keyExpr_RecordTycon" keyExpr_RecordTycon decodeTypeConApp
-      <*> mapM (decodeFieldWithKeyExpr templateParam) (V.toList keyExpr_RecordFields)
+      <*> mapM (decodeFieldWithSimpleKeyExpr templateParam) (V.toList keyExpr_RecordFields)
 
-decodeFieldWithKeyExpr :: ExprVarName -> LF1.KeyExpr_RecordField -> Decode (Tagged a T.Text, Expr)
-decodeFieldWithKeyExpr templateParam LF1.KeyExpr_RecordField{..} =
+decodeFieldWithSimpleKeyExpr :: ExprVarName -> LF1.KeyExpr_RecordField -> Decode (Tagged a T.Text, Expr)
+decodeFieldWithSimpleKeyExpr templateParam LF1.KeyExpr_RecordField{..} =
   (taggedT keyExpr_RecordFieldField, ) <$>
-  mayDecode "keyExpr_RecordFieldExpr" keyExpr_RecordFieldExpr (decodeKeyExpr templateParam)
+  mayDecode "keyExpr_RecordFieldExpr" keyExpr_RecordFieldExpr (decodeSimpleKeyExpr templateParam)
 
 decodeChoice :: LF1.TemplateChoice -> Decode TemplateChoice
 decodeChoice LF1.TemplateChoice{..} =

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -466,9 +466,9 @@ instance Encode Template P.DefTemplate where
 encodeTemplateKey :: Version -> ExprVarName -> TemplateKey -> P.DefTemplate_DefKey
 encodeTemplateKey version templateVar TemplateKey{..} = checkFeature featureContractKeys version $ P.DefTemplate_DefKey
   { P.defTemplate_DefKeyType = encode' version tplKeyType
-  , P.defTemplate_DefKeyKey = case encodeKeyExpr version templateVar tplKeyBody of
+  , P.defTemplate_DefKeyKeyExpr = case encodeKeyExpr version templateVar tplKeyBody of
       Left err -> error err
-      Right x -> Just (P.KeyExpr (encode' version x))
+      Right x -> Just $ P.DefTemplate_DefKeyKeyExprKey $ P.KeyExpr $ encode' version x
   , P.defTemplate_DefKeyMaintainers = encode' version tplKeyMaintainers
   }
 

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -24,6 +24,7 @@
 //     -- 2019-03-18: Add flexible controllers (change scoping of controller expressions)
 // * 3 -- 2019-03-25: Add contract key
 //     -- 2019-03-27: Add Map type
+// dev -- 2019-05-15: Add complex contract keys
 
 
 syntax = "proto3";
@@ -957,7 +958,13 @@ message DefTemplate {
 
   message DefKey {
       Type type = 1;
-      KeyExpr key = 2;
+      // NOTE(MH): The first version of contract keys had syntactic
+      // restrictions that key expression had to be "simple". We lifted these
+      // restrictions later and allowed arbitrarily complext key expressions.
+      oneof key_expr {
+          KeyExpr key = 2;
+          Expr complex_key = 4;
+      }
       Expr maintainers = 3; // a function from the key type to [Party]
   }
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -143,9 +143,19 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
         key: PLF.DefTemplate.DefKey,
         tplVar: ExprVarName): TemplateKey = {
       assertSince("3", "DefTemplate.DefKey")
+      val keyExpr = key.getKeyExprCase match {
+        case PLF.DefTemplate.DefKey.KeyExprCase.KEY =>
+          decodeKeyExpr(key.getKey, tplVar)
+        case PLF.DefTemplate.DefKey.KeyExprCase.COMPLEX_KEY => {
+          assertSince("dev", "DefTemplate.DefKey.complex_key")
+          decodeExpr(key.getComplexKey)
+        }
+        case PLF.DefTemplate.DefKey.KeyExprCase.KEYEXPR_NOT_SET =>
+          throw ParseError("DefKey.KEYEXPR_NOT_SET")
+      }
       TemplateKey(
         decodeType(key.getType),
-        decodeKeyExpr(key.getKey, tplVar),
+        keyExpr,
         decodeExpr(key.getMaintainers)
       )
     }


### PR DESCRIPTION
Right now, contract key expressions are subject to various syntactic restrictions. We want to get rid of these restrictions and allow for arbitrarily complex contract keys.

This PR changes the DAML-LF specification and protobuf definition accordingly. It also adapts all consumers of DAML-LF accordingly. `damlc` will be adapted in a followup PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1162)
<!-- Reviewable:end -->
