### PR TITLE
webide: IE compatible proxy js + latest alpine

### DIFF
--- a/web-ide/proxy/Dockerfile
+++ b/web-ide/proxy/Dockerfile
@@ -7,7 +7,7 @@
 # docker build --rm -t digitalasset/daml-webide-proxy:latest
 
 
-FROM node:8.15-alpine
+FROM node:8.16-alpine
 
 RUN mkdir -p /webide-proxy/src
 COPY src /webide-proxy/src/

--- a/web-ide/proxy/static/js/main.js
+++ b/web-ide/proxy/static/js/main.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-window.addEventListener('load', (event) => {
+window.addEventListener('load', function(event) {
     var acceptButton = document.querySelector('#accept-btn');
     acceptButton.addEventListener('click', acceptClick);
 });
@@ -16,7 +16,7 @@ function acceptClick(event) {
 function setCookie(sKey, sValue, sPath, sDomain, protocol) {
     if (!sKey || /^(?:expires|max\-age|path|domain|secure)$/i.test(sKey)) { return false; }
     var sExpires = "; expires=Fri, 31 Dec 9999 23:59:59 GMT";
-    var bSecure = protocol.startsWith("https:") ? true : false
+    var bSecure = protocol === "https:";
     document.cookie = encodeURIComponent(sKey) + "=" + encodeURIComponent(sValue) + sExpires + (sDomain ? "; domain=" + sDomain : "") + (sPath ? "; path=" + sPath : "") + (bSecure ? "; secure" : "");
     return true;
-  }
+}


### PR DESCRIPTION
The web ide does not support all browsers, most notably, does not work
in IE. However, we have a tiny js script with terms and conditions which
might as well be IE compatible.

Also, due to security vulnerabilities with older alpine distributions, we are making sure to download the latest and patched version of alpine

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
