### PR TITLE
language: fix: Check for module ... where clause.

### DIFF
--- a/daml-foundations/daml-ghc/src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/src/DA/Test/ShakeIdeClient.hs
@@ -71,18 +71,20 @@ basicTests mbScenarioService = Tasty.testGroup "Basic tests"
     ,   testCase' "Set files of interest and expect parse error" $ do
             foo <- makeFile "Foo.daml" $ T.unlines
                 [ "daml 1.2"
+                , "module Foo where"
                 , "this is bad syntax"
                 ]
             setFilesOfInterest [foo]
-            expectOneError (foo,1,0) "Parse error"
+            expectOneError (foo,2,0) "Parse error"
 
     ,   testCase' "Set files of interest to clear parse error" $ do
             foo <- makeFile "Foo.daml" $ T.unlines
                 [ "daml 1.2"
+                , "module Foo where"
                 , "this is bad syntax"
                 ]
             setFilesOfInterest [foo]
-            expectOneError (foo,1,0) "Parse error"
+            expectOneError (foo,2,0) "Parse error"
             setFilesOfInterest []
             expectNoErrors
 

--- a/daml-foundations/daml-ghc/tests/ModuleName.daml
+++ b/daml-foundations/daml-ghc/tests/ModuleName.daml
@@ -1,0 +1,8 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ERROR Missing module name
+
+daml 1.2
+
+data Foo a = Foo a


### PR DESCRIPTION
We add a preprocessor check that makes sure the `module ... where`
clause is there. This fixes
https://github.com/digital-asset/daml/issues/1076.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
