### PR TITLE
extractor: use RFC-3339-format strings for JSON output of dates and timestamps

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,10 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- **SQL Extractor**: in JSON content, dates and timestamps are formatted like
+  ``"2020-02-22"`` and ``"2020-02-22T12:13:14Z"`` rather than UNIX epoch offsets like
+  ``18314`` or ``1582373594000000``.
+
 SDK tools
 ~~~~~~~~~
 

--- a/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
@@ -106,12 +106,10 @@ object JsonConverters {
   implicit val partyEncoder: Encoder[Ref.Party] =
     Encoder[String].contramap(identity)
 
-  // TODO SC this matches the prior behavior of JSON-ing the dates and timestamps
-  // as days-since and micros-since epoch, but maybe we'd like something else?
   implicit val lfDateEncoder: Encoder[Time.Date] =
-    Encoder[Int].contramap(_.days)
+    Encoder[String].contramap(_.toString)
   implicit val lfTimestampEncoder: Encoder[Time.Timestamp] =
-    Encoder[Long].contramap(_.micros)
+    Encoder[String].contramap(_.toString)
 
   implicit val multiTableStateEncoder: Encoder[MultiTableState] = deriveEncoder[MultiTableState]
   implicit val multiTableStateDecoder: Decoder[MultiTableState] = deriveDecoder[MultiTableState]

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/BasicPrimitiveTypesSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/BasicPrimitiveTypesSpec.scala
@@ -47,8 +47,8 @@ class BasicPrimitiveTypesSpec
           "text_field" : "Hey",
           "bool_field" : true,
           "party_field" : "Bob",
-          "date_field" : 18314,
-          "time_field" : 1582373594000000
+          "date_field" : "2020-02-22",
+          "time_field" : "2020-02-22T12:13:14Z"
         }
       """,
       """
@@ -59,8 +59,8 @@ class BasicPrimitiveTypesSpec
           "text_field" : "Hey",
           "bool_field" : true,
           "party_field" : "Bob",
-          "date_field" : 2932896,
-          "time_field" : 253402300799000000
+          "date_field" : "9999-12-31",
+          "time_field" : "9999-12-31T23:59:59Z"
         }
       """,
       """
@@ -71,8 +71,8 @@ class BasicPrimitiveTypesSpec
           "text_field" : "Hey",
           "bool_field" : true,
           "party_field" : "Bob",
-          "date_field" : -719162,
-          "time_field" : -62135596800000000
+          "date_field" : "0001-01-01",
+          "time_field" : "0001-01-01T00:00:00Z"
         }
       """
     ).traverseU(parse)


### PR DESCRIPTION
Where a date and timestamp might have occurred as `18314` and `1582373594000000` (epoch offsets) in extractor's JSON fallback output, instead we'll produce RFC-3339 format strings, `"2020-02-22"` and `"2020-02-22T12:13:14Z"`. Fixes #1174.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
