### PR TITLE
Add --open-browser flag to daml start

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -40,10 +40,12 @@ da_haskell_binary(
     srcs = ["src/Main.hs"],
     hazel_deps = [
         "base",
-        "optparse-applicative",
     ],
     visibility = ["//visibility:public"],
-    deps = [":daml-helper-lib"],
+    deps = [
+        ":daml-helper-lib",
+        "//libs-haskell/da-hs-base",
+    ],
 )
 
 package_app(

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import Data.Foldable
-import Options.Applicative
+import Options.Applicative.Extended
 
 import DamlHelper
 
@@ -17,7 +17,7 @@ data Command
     | New { targetFolder :: FilePath, templateName :: String }
     | Init { targetFolderM :: Maybe FilePath }
     | ListTemplates
-    | Start
+    | Start { openBrowser :: OpenBrowser }
 
 commandParser :: Parser Command
 commandParser =
@@ -45,7 +45,7 @@ commandParser =
                   <*> argument str (metavar "TEMPLATE" <> help "Name of the template used to create the project (default: skeleton)" <> value "skeleton")
               ]
           initCmd = Init <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
-          startCmd = pure Start
+          startCmd = Start . OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser automatically and point it to navigator."
           readReplacement :: ReadM ReplaceExtension
           readReplacement = maybeReader $ \case
               "never" -> Just ReplaceExtNever
@@ -60,5 +60,4 @@ runCommand RunJar {..} = runJar jarPath remainingArguments
 runCommand New {..} = runNew targetFolder templateName
 runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
-runCommand Start = runStart
-
+runCommand Start {..} = runStart openBrowser

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -18,7 +18,7 @@ import DAML.Assistant.Types
 import Data.List
 import Data.Maybe
 import Data.Foldable
-import Options.Applicative
+import Options.Applicative.Extended
 
 getCommand :: [SdkCommandInfo] -> IO Command
 getCommand sdkCommands =
@@ -64,18 +64,6 @@ installParser = InstallOptions
     <*> iflag ActivateInstall "activate" mempty "Activate installed version of daml"
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
     <*> iflag QuietInstall "quiet" (short 'q') "Don't display installation messages"
-    <*> fmap SetPath (flagWithAuto "set-path" True "Adjust PATH automatically. This option only has an effect on Windows.")
+    <*> fmap SetPath (flagYesNoAuto "set-path" True "Adjust PATH automatically. This option only has an effect on Windows.")
     where
         iflag p name opts desc = fmap p (switch (long name <> help desc <> opts))
-
--- | This constructs flags that can be set to yes, no, or auto to control a boolean value
--- with auto using the default.
-flagWithAuto :: String -> Bool -> String -> Parser Bool
-flagWithAuto flagName defaultValue helpText =
-    option reader (long flagName <> value defaultValue <> help (helpText <> commonHelp))
-  where reader = eitherReader $ \case
-            "yes" -> Right True
-            "no" -> Right False
-            "auto" -> Right defaultValue
-            s -> Left ("Expected \"yes\", \"no\" or \"auto\" but got " <> show s)
-        commonHelp = " Can be set to \"yes\", \"no\" or \"auto\" to select the default (" <> show defaultValue <> ")"

--- a/libs-haskell/da-hs-base/BUILD.bazel
+++ b/libs-haskell/da-hs-base/BUILD.bazel
@@ -30,6 +30,7 @@ da_haskell_library(
         "managed",
         "monad-control",
         "mtl",
+        "optparse-applicative",
         "pretty-show",
         "pretty",
         "random",

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -1,0 +1,23 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Options.Applicative.Extended
+    ( module Options.Applicative
+    , flagYesNoAuto
+    ) where
+
+import Options.Applicative
+
+
+-- | This constructs flags that can be set to yes, no, or auto to control a boolean value
+-- with auto using the default.
+flagYesNoAuto :: String -> Bool -> String -> Parser Bool
+flagYesNoAuto flagName defaultValue helpText =
+    option reader (long flagName <> value defaultValue <> help (helpText <> commonHelp))
+  where reader = eitherReader $ \case
+            "yes" -> Right True
+            "no" -> Right False
+            "auto" -> Right defaultValue
+            s -> Left ("Expected \"yes\", \"no\" or \"auto\" but got " <> show s)
+        commonHelp = " Can be set to \"yes\", \"no\" or \"auto\" to select the default (" <> show defaultValue <> ")"
+


### PR DESCRIPTION
I went with the yes/no/auto approach we already use in the assistant
and moved the logic for that to da-hs-base.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
