### PR TITLE
navigator: revert commented out tests in 2e3a8793

### DIFF
--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/json/ApiCodecVerboseSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/json/ApiCodecVerboseSpec.scala
@@ -29,47 +29,47 @@ class ApiCodecVerboseSpec extends WordSpec with Matchers {
 
     "serializing and parsing a value" should {
 
-//      "work for Text" in {
-//        serializeAndParse(C.simpleTextV, C.simpleTextT) shouldBe Success(C.simpleTextV)
-//      }
+      "work for Text" in {
+        serializeAndParse(C.simpleTextV, C.simpleTextT) shouldBe Success(C.simpleTextV)
+      }
       "work for Int64" in {
         serializeAndParse(C.simpleInt64V, C.simpleInt64T) shouldBe Success(C.simpleInt64V)
       }
-//      "work for Decimal" in {
-//        serializeAndParse(C.simpleDecimalV, C.simpleDecimalT) shouldBe Success(C.simpleDecimalV)
-//      }
-//      "work for Unit" in {
-//        serializeAndParse(C.simpleUnitV, C.simpleUnitT) shouldBe Success(C.simpleUnitV)
-//      }
-//      "work for Date" in {
-//        serializeAndParse(C.simpleDateV, C.simpleDateT) shouldBe Success(C.simpleDateV)
-//      }
-//      "work for Timestamp" in {
-//        serializeAndParse(C.simpleTimestampV, C.simpleTimestampT) shouldBe Success(
-//          C.simpleTimestampV)
-//      }
-//      "work for Optional" in {
-//        serializeAndParse(C.simpleOptionalV, C.simpleOptionalT(C.simpleTextT)) shouldBe Success(
-//          C.simpleOptionalV)
-//      }
-//      "work for EmptyRecord" in {
-//        serializeAndParse(C.emptyRecordV, C.emptyRecordTC) shouldBe Success(C.emptyRecordV)
-//      }
-//      "work for SimpleRecord" in {
-//        serializeAndParse(C.simpleRecordV, C.simpleRecordTC) shouldBe Success(C.simpleRecordV)
-//      }
-//      "work for SimpleVariant" in {
-//        serializeAndParse(C.simpleVariantV, C.simpleVariantTC) shouldBe Success(C.simpleVariantV)
-//      }
-//      "work for ComplexRecord" in {
-//        serializeAndParse(C.complexRecordV, C.complexRecordTC) shouldBe Success(C.complexRecordV)
-//      }
-//      "work for Tree" in {
-//        serializeAndParse(C.treeV, C.treeTC) shouldBe Success(C.treeV)
-//      }
-//      "work for Map" in {
-//        serializeAndParse(C.simpleMapV, C.simpleMapT(C.simpleTextT)) shouldBe Success(C.simpleMapV)
-//      }
+      "work for Decimal" in {
+        serializeAndParse(C.simpleDecimalV, C.simpleDecimalT) shouldBe Success(C.simpleDecimalV)
+      }
+      "work for Unit" in {
+        serializeAndParse(C.simpleUnitV, C.simpleUnitT) shouldBe Success(C.simpleUnitV)
+      }
+      "work for Date" in {
+        serializeAndParse(C.simpleDateV, C.simpleDateT) shouldBe Success(C.simpleDateV)
+      }
+      "work for Timestamp" in {
+        serializeAndParse(C.simpleTimestampV, C.simpleTimestampT) shouldBe Success(
+          C.simpleTimestampV)
+      }
+      "work for Optional" in {
+        serializeAndParse(C.simpleOptionalV, C.simpleOptionalT(C.simpleTextT)) shouldBe Success(
+          C.simpleOptionalV)
+      }
+      "work for EmptyRecord" in {
+        serializeAndParse(C.emptyRecordV, C.emptyRecordTC) shouldBe Success(C.emptyRecordV)
+      }
+      "work for SimpleRecord" in {
+        serializeAndParse(C.simpleRecordV, C.simpleRecordTC) shouldBe Success(C.simpleRecordV)
+      }
+      "work for SimpleVariant" in {
+        serializeAndParse(C.simpleVariantV, C.simpleVariantTC) shouldBe Success(C.simpleVariantV)
+      }
+      "work for ComplexRecord" in {
+        serializeAndParse(C.complexRecordV, C.complexRecordTC) shouldBe Success(C.complexRecordV)
+      }
+      "work for Tree" in {
+        serializeAndParse(C.treeV, C.treeTC) shouldBe Success(C.treeV)
+      }
+      "work for Map" in {
+        serializeAndParse(C.simpleMapV, C.simpleMapT(C.simpleTextT)) shouldBe Success(C.simpleMapV)
+      }
     }
   }
 }


### PR DESCRIPTION
This PR reactivate navigator tests that were commented out by mistaking in  #983 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
