### PR TITLE
Move to creating a single HscEnv that we reuse in all GHC sessions

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
@@ -41,7 +41,7 @@ import qualified Data.Text as T
 -- | Locate the definition of the name at a given position.
 gotoDefinition
   :: IdeOptions
-  -> PackageDynFlags
+  -> HscEnv
   -> [SpanInfo]
   -> Position
   -> Action (Maybe Location)
@@ -86,7 +86,7 @@ atPoint tcs srcSpans pos = do
         Just name -> any (`isInfixOf` show name) ["==", "showsPrec"]
         Nothing -> False
 
-locationsAtPoint :: IdeOptions -> PackageDynFlags -> Position -> [SpanInfo] -> Action [Location]
+locationsAtPoint :: IdeOptions -> HscEnv -> Position -> [SpanInfo] -> Action [Location]
 locationsAtPoint IdeOptions{..} pkgState pos =
     fmap (map srcSpanToLocation) .
     mapMaybeM (getSpan . spaninfoSource) .

--- a/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
@@ -15,7 +15,6 @@ module Development.IDE.State.RuleTypes(
 import           Control.DeepSeq
 import           Development.IDE.Functions.Compile             (TcModuleResult, GhcModule, LoadPackageResult(..))
 import qualified Development.IDE.Functions.Compile             as Compile
-import qualified Development.IDE.UtilGHC as Compile
 import           Development.IDE.Functions.FindImports         (Import(..))
 import           Development.IDE.Functions.DependencyInformation
 import           Data.Hashable
@@ -61,9 +60,8 @@ type instance RuleResult GetSpanInfo = [SpanInfo]
 -- | Convert to Core, requires TypeCheck*
 type instance RuleResult GenerateCore = GhcModule
 
--- | We capture the subset of `DynFlags` that is computed by package initialization in a rule to
--- make session initialization cheaper by reusing it.
-type instance RuleResult LoadPackageState = Compile.PackageDynFlags
+-- | A GHC session that we reuse.
+type instance RuleResult GhcSession = HscEnv
 
 -- | Resolve the imports in a module to the list of either external packages or absolute file paths
 -- for modules in the same package.
@@ -128,10 +126,10 @@ data GenerateCore = GenerateCore
 instance Hashable GenerateCore
 instance NFData   GenerateCore
 
-data LoadPackageState = LoadPackageState
+data GhcSession = GhcSession
     deriving (Eq, Show, Typeable, Generic)
-instance Hashable LoadPackageState
-instance NFData   LoadPackageState
+instance Hashable GhcSession
+instance NFData   GhcSession
 
 -- Note that we embed the filepath here instead of using the filepath associated with Shake keys.
 -- Otherwise we will garbage collect the result since files in package dependencies will not be declared reachable.
@@ -159,6 +157,12 @@ instance Show ParsedModule where
     show = show . pm_mod_summary
 
 instance NFData ModSummary where
+    rnf = rwhnf
+
+instance Show HscEnv where
+    show _ = "HscEnv"
+
+instance NFData HscEnv where
     rnf = rwhnf
 
 instance NFData ParsedModule where

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -9,14 +9,14 @@ module Development.IDE.Types.Options
   , IdePkgLocationOptions(..)
   ) where
 
-import Development.IDE.UtilGHC
+import Development.Shake
 import           GHC hiding (parseModule, typecheckModule)
 import           GhcPlugins                     as GHC hiding (fst3, (<>))
 
 
 data IdeOptions = IdeOptions
   { optPreprocessor :: GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
-  , optRunGhcSession :: forall a. Maybe ParsedModule -> PackageDynFlags -> Ghc a -> IO a
+  , optGhcSession :: Action HscEnv
   -- ^ Setup a GHC session using a given package state. If a `ParsedModule` is supplied,
   -- the import path should be setup for that module.
   , optPkgLocationOpts :: IdePkgLocationOptions

--- a/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Config.hs
+++ b/daml-foundations/daml-ghc/src/DA/Daml/GHC/Compiler/Config.hs
@@ -94,10 +94,9 @@ wOptsUnset =
   ]
 
 
-adjustDynFlags :: [FilePath] -> PackageDynFlags -> Maybe String -> DynFlags -> DynFlags
-adjustDynFlags paths packageState mbPackageName dflags
+adjustDynFlags :: [FilePath] -> Maybe String -> DynFlags -> DynFlags
+adjustDynFlags paths mbPackageName dflags
   = setImports paths
-  $ setPackageDynFlags packageState
   $ setThisInstalledUnitId (maybe mainUnitId stringToUnitId mbPackageName)
   -- once we have package imports working, we want to import the base package and set this to
   -- the default instead of always compiling in the context of ghc-prim.
@@ -132,12 +131,12 @@ setImports paths dflags = dflags { importPaths = paths }
 --     * Sets the import paths to the given list of 'FilePath'.
 --     * if present, parses and applies custom options for GHC
 --       (may fail if the custom options are inconsistent with std DAML ones)
-setupDamlGHC :: GhcMonad m => [FilePath] -> Maybe String -> PackageDynFlags -> [String] -> m ()
-setupDamlGHC importPaths mbPackageName packageState [] =
-  modifyDynFlags $ adjustDynFlags importPaths packageState mbPackageName
+setupDamlGHC :: GhcMonad m => [FilePath] -> Maybe String -> [String] -> m ()
+setupDamlGHC importPaths mbPackageName [] =
+  modifyDynFlags $ adjustDynFlags importPaths mbPackageName
 -- if custom options are given, add them after the standard DAML flag setup
-setupDamlGHC importPaths mbPackageName packageState customOpts = do
-  setupDamlGHC importPaths mbPackageName packageState []
+setupDamlGHC importPaths mbPackageName customOpts = do
+  setupDamlGHC importPaths mbPackageName []
   damlDFlags <- getSessionDynFlags
   (dflags', leftover, warns) <- parseDynamicFilePragma damlDFlags $ map noLoc customOpts
 


### PR DESCRIPTION
Before we created a fresh GHC Session from scratch each time. Now we create a single GHC Session, and reuse it. This change doesn't appear to have any functional change (which would be desirable), but opens the door to:

* Significant refactoring and simplification, which I haven't done in this patch (since this patch scares me)
* Simplify session creation - we go to a lot of effort to optimise from 100ms to 1ms. If we only do it once, we can reuse the standard GHC things which will be a lot less brittle.
* More powerful session creation, using tracked data in Shake, so things like modifying daml.yaml can be tracked in future.
* Reusing normal GHC sessions.
* Optimising away package loading - which currently costs us ~50% of time in my benchmarks, but can be cut in half by reusing the name cache.

Downside is this is prodding into the GHC API in different ways, which is inherently risky.