### PR TITLE
Rename render/parse functions for DAML-LF minor versions in Haskell

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -10,7 +10,6 @@ import GHC.Generics
 import           DA.Pretty
 import           Control.DeepSeq
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
 import qualified Text.Read as Read
 
 -- | DAML-LF version of an archive payload.
@@ -40,20 +39,6 @@ versionDefault = version1_3
 -- | The DAML-LF development version.
 versionDev :: Version
 versionDev = V1 PointDev
-
-minorInProtobuf :: MinorVersion -> TL.Text
-minorInProtobuf = TL.pack . \case
-  PointStable minor -> show minor
-  PointDev -> "dev"
-
-minorFromProtobuf :: TL.Text -> Maybe MinorVersion
-minorFromProtobuf = minorFromCliOption . TL.unpack
-
-minorFromCliOption :: String -> Maybe MinorVersion
-minorFromCliOption = \case
-  (Read.readMaybe -> Just i) -> Just $ PointStable i
-  "dev" -> Just PointDev
-  _ -> Nothing
 
 supportedInputVersions :: [Version]
 supportedInputVersions = [version1_1, version1_2, version1_3, versionDev]
@@ -85,11 +70,19 @@ featurePartyFromText = Feature "partyFromText function" version1_2
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 
+renderMinorVersion :: MinorVersion -> String
+renderMinorVersion = \case
+  PointStable minor -> show minor
+  PointDev -> "dev"
+
+parseMinorVersion :: String -> Maybe MinorVersion
+parseMinorVersion = \case
+  (Read.readMaybe -> Just i) -> Just $ PointStable i
+  "dev" -> Just PointDev
+  _ -> Nothing
+
 instance Pretty Version where
-  pPrint = \case
-    V1 minor -> "1." <> pretty minor
+  pPrint (V1 minor) = "1." <> pretty minor
 
 instance Pretty MinorVersion where
-  pPrint = \case
-    PointStable minor -> pretty minor
-    PointDev -> "dev"
+  pPrint = string . renderMinorVersion

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -33,7 +33,7 @@ decodeVersion minorText = do
   -- were a thing. DO NOT replicate this code bejond major version 1!
   minor <- if
     | TL.null minorText -> pure $ LF.PointStable 0
-    | Just minor <- LF.minorFromProtobuf minorText -> pure minor
+    | Just minor <- LF.parseMinorVersion (TL.unpack minorText) -> pure minor
     | otherwise -> unsupported
   let version = V1 minor
   if version `elem` LF.supportedInputVersions then pure version else unsupported

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Encode.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Encode.hs
@@ -5,6 +5,7 @@ module DA.Daml.LF.Proto3.Encode
   ( encodePayload
   ) where
 
+import qualified Data.Text.Lazy as TL
 import Da.DamlLf (ArchivePayload(..), ArchivePayloadSum(..))
 import DA.Daml.LF.Ast
 import qualified DA.Daml.LF.Proto3.EncodeV1 as EncodeV1
@@ -13,4 +14,4 @@ encodePayload :: Package -> ArchivePayload
 encodePayload package = case packageLfVersion package of
     V1 minor ->
         let payload = ArchivePayloadSumDamlLf1 (EncodeV1.encodePackage package)
-        in  ArchivePayload (minorInProtobuf minor) (Just payload)
+        in  ArchivePayload (TL.pack $ renderMinorVersion minor) (Just payload)

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -255,7 +255,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
     -- FixMe(#415): the proper minor version should be passed instead of "0"
     convModule (_, bytes) =
         case updDamlLfVersion of
-            LF.V1 minor -> SS.Module (Just (SS.ModuleModuleDamlLf1 bytes)) (LF.minorInProtobuf minor)
+            LF.V1 minor -> SS.Module (Just (SS.ModuleModuleDamlLf1 bytes)) (TL.pack $ LF.renderMinorVersion minor)
 
 runScenario :: Handle -> ContextId -> LF.ValueRef -> IO (Either Error SS.ScenarioResult)
 runScenario Handle{..} (ContextId ctxId) name = do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -124,7 +124,7 @@ lfVersionOpt = option (str >>= select) $
     versionsStr = intercalate ", " (map renderVersion LF.supportedOutputVersions)
     select = \case
       versionStr
-        | Just minor <- LF.minorFromCliOption =<< stripPrefix "1." versionStr
+        | Just minor <- LF.parseMinorVersion =<< stripPrefix "1." versionStr
         , let version = LF.V1 minor
         , version `elem` LF.supportedOutputVersions
         -> return version


### PR DESCRIPTION
The current naming suggests, the protobuf encoding and the CLI use different
textual representations of minor versions, which is not true. They only
differ in their types. We push this type conversion to the call sites
of both functions instead.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1182)
<!-- Reviewable:end -->
