### PR TITLE
language: init package db on ide start.

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -342,15 +342,18 @@ execPackageNew numProcessors mbOutFile =
 
     defaultOutDir = "dist"
 
--- | Read the daml.yaml field and create the project local package database.
+-- | If we're in a daml project, read the daml.yaml field and create the project local package
+-- database. Otherwise do nothing.
 execInit :: IO ()
 execInit =
     withProjectRoot $ \_relativize -> do
-        project <- readProjectConfig $ ProjectPath "."
-        case parseProjectConfig project of
-            Left err -> throwIO err
-            Right PackageConfigFields {..} -> do
-                createProjectPackageDb LF.versionDefault pDependencies
+        isProject <- doesFileExist projectConfigName
+        when isProject $ do
+          project <- readProjectConfig $ ProjectPath "."
+          case parseProjectConfig project of
+              Left err -> throwIO err
+              Right PackageConfigFields {..} -> do
+                  createProjectPackageDb LF.versionDefault pDependencies
 
 -- | Create the project package database containing the given dar packages.
 createProjectPackageDb :: LF.Version -> [FilePath] -> IO ()

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -212,9 +212,10 @@ execIde telemetry (Debug debug) = NS.withSocketsDo $ Managed.runManaged $ do
 
     opts <- liftIO $ defaultOptionsIO Nothing
 
-    Managed.liftIO $
+    Managed.liftIO $ do
+      execInit
       Daml.LanguageServer.runLanguageServer
-      (Compiler.newIdeState opts) loggerH
+        (Compiler.newIdeState opts) loggerH
 
 
 execCompile :: FilePath -> FilePath -> Compiler.Options -> Command


### PR DESCRIPTION
We initialize the package db when we start the ide service to make sure projects compiled against packages work without building them upfront.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
