### PR TITLE
Remove NameCache modification in the IDE

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -172,6 +172,7 @@ loadPackage opt packageState us lps p =
     let mods =
           [ Module (DefiniteUnitId (DefUnitId p)) mod
           | (mod, _mbParent) <- exposedMods
+          , False {- HLINT ignore "Short-circuited list comprehension" -}
           ]
     forM_ mods $ \mod -> GHC.getModuleInfo mod
     -- this populates the namecache and external package state
@@ -337,12 +338,13 @@ setupEnv uniqSupply tms lps = do
         foldl' (\fc (im, ifr) -> GHC.extendInstalledModuleEnv fc im ifr) fc
             $ zip ims ifrs
 
-    -- construct a new NameCache
-    nc' <- mkNameCache uniqSupply tms lps
-    -- update the name cache
-    liftIO $ modifyIORef (hsc_NC session) $ const nc'
-    -- update the external package state
-    liftIO $ modifyIORef (hsc_EPS session) (updateEps lps)
+    when False $ do
+        -- construct a new NameCache
+        nc' <- mkNameCache uniqSupply tms lps
+        -- update the name cache
+        liftIO $ modifyIORef (hsc_NC session) $ const nc'
+        -- update the external package state
+        liftIO $ modifyIORef (hsc_EPS session) (updateEps lps)
     -- load dependent modules, which must be in topological order.
     mapM_ loadModuleHome tms
 

--- a/daml-foundations/daml-tools/language-server-tests/tests/diagnostics/failed-name-resolution/EXPECTED.json
+++ b/daml-foundations/daml-tools/language-server-tests/tests/diagnostics/failed-name-resolution/EXPECTED.json
@@ -13,7 +13,7 @@
         }
       },
       "source": "Compiler",
-      "message": "/tests/diagnostics/failed-name-resolution/Main.daml:8:11: error:\n    • Variable not in scope: ab : Int\n    • Perhaps you meant one of these:\n        ‘a’ (line 8), ‘b’ (line 8), ‘abs’ (imported from Prelude)"
+      "message": "/tests/diagnostics/failed-name-resolution/Main.daml:8:11: error:\n    • Variable not in scope: ab : Int\n    • Perhaps you meant one of these:\n        ‘a’ (line 8), ‘b’ (line 8), ‘ap’ (imported from Prelude)"
     },
     {
       "severity": 1,
@@ -32,7 +32,7 @@
     }
   ],
   "file:/tests/diagnostics/failed-name-resolution/Prelude.daml": [],
-  "file:/tests/diagnostics/failed-name-resolution/DA/Internal/Desugar.daml": [],
   "file:/tests/diagnostics/failed-name-resolution/DA/Internal/Record.daml": [],
+  "file:/tests/diagnostics/failed-name-resolution/DA/Internal/Desugar.daml": [],
   "file:/tests/diagnostics/failed-name-resolution/DA/Internal/RebindableSyntax.daml": []
 }


### PR DESCRIPTION
Disables preloading of module info and doesn't modify the NameCache, relying on the single shared NameCache. Deliberately done with the minimal amount of code - there is a huge delete/cleanup pass afterwards if this works for us.