### PR TITLE
Move the DAML-LF version render/parse logic into LF.Version

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -81,8 +81,14 @@ parseMinorVersion = \case
   "dev" -> Just PointDev
   _ -> Nothing
 
-instance Pretty Version where
-  pPrint (V1 minor) = "1." <> pretty minor
+renderVersion :: Version -> String
+renderVersion = \case
+    V1 minor -> "1." ++ renderMinorVersion minor
 
-instance Pretty MinorVersion where
-  pPrint = string . renderMinorVersion
+parseVersion :: String -> Maybe Version
+parseVersion = \case
+    '1':'.':minor -> V1 <$> parseMinorVersion minor
+    _ -> Nothing
+
+instance Pretty Version where
+  pPrint = string . renderVersion

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -124,8 +124,7 @@ lfVersionOpt = option (str >>= select) $
     versionsStr = intercalate ", " (map renderVersion LF.supportedOutputVersions)
     select = \case
       versionStr
-        | Just minor <- LF.parseMinorVersion =<< stripPrefix "1." versionStr
-        , let version = LF.V1 minor
+        | Just version <- LF.parseVersion versionStr
         , version `elem` LF.supportedOutputVersions
         -> return version
         | otherwise


### PR DESCRIPTION
I've missed that in my last PR. Sorry.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1190)
<!-- Reviewable:end -->
