### PR TITLE
Improve how daml-ghc tests depend on DAML-LF version

### DIFF
--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -149,7 +149,7 @@ testCase :: TestArguments -> LF.Version -> IO Compile.IdeState -> FilePath -> (T
 testCase args version getService outdir registerTODO file = singleTest file . TestCase $ \log -> do
   service <- getService
   anns <- readFileAnns file
-  if any (`elem` [Ignore, IgnoreLfVersion (renderPretty version)]) anns
+  if any (ignoreVersion version) anns
     then pure $ Result
       { resultOutcome = Success
       , resultDescription = ""
@@ -168,6 +168,11 @@ testCase args version getService outdir registerTODO file = singleTest file . Te
       case failures of
         err : _others -> pure $ testFailed err
         [] -> pure $ testPassed ""
+  where
+    ignoreVersion version = \case
+      Ignore -> True
+      SinceLF minVersion -> version < minVersion
+      _ -> False
 
 runJqQuery :: (String -> IO ()) -> [(LF.Package, String)] -> IO [Maybe String]
 runJqQuery log qs = do
@@ -240,7 +245,7 @@ withTestArguments f =
 -- functionality
 data Ann
     = Ignore                             -- Don't run this test at all
-    | IgnoreLfVersion String             -- Don't run this test when testing the given DAML-LF version
+    | SinceLF LF.Version                 -- Only run this test since the given DAML-LF version
     | DiagnosticFields [DiagnosticField] -- I expect a diagnostic that has the given fields
     | QueryLF String                       -- The jq query against the produced DAML-LF returns "true"
     | Todo String                        -- Just a note that is printed out
@@ -255,7 +260,7 @@ readFileAnns file = do
         f :: String -> Maybe Ann
         f (stripPrefix "-- @" . trim -> Just x) = case word1 $ trim x of
             ("IGNORE",_) -> Just Ignore
-            ("IGNORE-LF", x) -> Just (IgnoreLfVersion (trim x))
+            ("SINCE-LF", x) -> Just $ SinceLF $ fromJust $ LF.parseVersion $ trim x
             ("ERROR",x) -> Just (DiagnosticFields (DSeverity DsError : parseFields x))
             ("WARN",x) -> Just (DiagnosticFields (DSeverity DsWarning : parseFields x))
             ("QUERY-LF", x) -> Just $ QueryLF x

--- a/daml-foundations/daml-ghc/tests/ContractKeys.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeys.daml
@@ -1,7 +1,5 @@
 -- Check that the compiler bits of contract keys work.
--- @IGNORE-LF 1.0
--- @IGNORE-LF 1.1
--- @IGNORE-LF 1.2
+-- @SINCE-LF 1.3
 daml 1.2
 module ContractKeys where
 

--- a/daml-foundations/daml-ghc/tests/ContractKeysSyntax.daml
+++ b/daml-foundations/daml-ghc/tests/ContractKeysSyntax.daml
@@ -1,4 +1,4 @@
--- @IGNORE-LF 1.2
+-- @SINCE-LF 1.3
 daml 1.2
 module ContractKeysSyntax where
 

--- a/daml-foundations/daml-ghc/tests/HKTemplate.daml
+++ b/daml-foundations/daml-ghc/tests/HKTemplate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
--- @IGNORE-LF 1.0
--- @IGNORE-LF 1.1
+-- @SINCE-LF 1.2
 
 {-# LANGUAGE FlexibleContexts #-}
 

--- a/daml-foundations/daml-ghc/tests/PartyFromText.daml
+++ b/daml-foundations/daml-ghc/tests/PartyFromText.daml
@@ -1,5 +1,4 @@
--- @IGNORE-LF 1.0
--- @IGNORE-LF 1.1
+-- @SINCE-LF 1.2
 daml 1.2
 module PartyFromText where
 

--- a/daml-foundations/daml-ghc/tests/Profunctor.daml
+++ b/daml-foundations/daml-ghc/tests/Profunctor.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @IGNORE-LF 1.0
+-- @SINCE-LF 1.1
 -- Test that `(->)` can be used without any arguments.
 daml 1.2
 module Profunctor where

--- a/daml-foundations/daml-ghc/tests/Sha256.daml
+++ b/daml-foundations/daml-ghc/tests/Sha256.daml
@@ -1,5 +1,4 @@
--- @IGNORE-LF 1.0
--- @IGNORE-LF 1.1
+-- @SINCE-LF 1.2
 daml 1.2
 module Sha256 where
 

--- a/daml-foundations/daml-ghc/tests/TextMap.daml
+++ b/daml-foundations/daml-ghc/tests/TextMap.daml
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
--- @IGNORE-LF 1.0
--- @IGNORE-LF 1.1
--- @IGNORE-LF 1.2
+-- @SINCE-LF 1.3
 
 daml 1.2
 module TextMap where


### PR DESCRIPTION
Right now, we're excluding specific DAML-LF versions. This is not great.

This PR changes it such that we can give a lower bound on the DAML-LF
version against which tests whould be run.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1195)
<!-- Reviewable:end -->
