### PR TITLE
Warn if there are any missing methods in type classes in DAML

### DIFF
--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Config.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Config.hs
@@ -76,6 +76,7 @@ wOptsSet =
   , Opt_WarnPrepositiveQualifiedModule
   , Opt_WarnOverlappingPatterns
   , Opt_WarnIncompletePatterns
+  , Opt_WarnMissingMethods
   ]
 
 -- | Warning options set for DAML compilation, which become errors.

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Config.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Config.hs
@@ -76,13 +76,13 @@ wOptsSet =
   , Opt_WarnPrepositiveQualifiedModule
   , Opt_WarnOverlappingPatterns
   , Opt_WarnIncompletePatterns
-  , Opt_WarnMissingMethods
   ]
 
 -- | Warning options set for DAML compilation, which become errors.
 wOptsSetFatal :: [ WarningFlag ]
 wOptsSetFatal =
   [ Opt_WarnMissingFields
+  , Opt_WarnMissingMethods
   ]
 
 -- | Warning options unset for DAML compilation. Note that these can be modified

--- a/daml-lf/tests/scenario/daml-1.3/mustfails/Test.daml
+++ b/daml-lf/tests/scenario/daml-1.3/mustfails/Test.daml
@@ -55,7 +55,7 @@ template NoSignatory
   with
     text : Text
   where
-    agreement text
+    signatory ([] : [Party]); agreement text
 
 template X
   with p: Party

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -23,7 +23,7 @@ SDK tools
 DAML
 ~~~~
 
-- **BREAKING CHANGE - DAML Compiler**: It is now an error to omit method bodies in class ``instance``s if the method
+- **BREAKING CHANGE - DAML Compiler**: It is now an error to omit method bodies in class ``instance`` s if the method
   has no default. Almost all instances of such behaviour were an error - add in a suitable definition.
 
 - **Contract keys**: We've added documentation for contract keys, a way of specifying a primary key for contract instances. For information about how to use them, see :doc:`/daml/reference/contract-keys`.

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -23,6 +23,9 @@ SDK tools
 DAML
 ~~~~
 
+- **BREAKING CHANGE - DAML Compiler**: It is now an error to omit method bodies in class ``instance``s if the method
+  has no default. Almost all instances of such behaviour were an error - add in a suitable definition.
+
 - **BREAKING CHANGE - DAML Standard Library**: Moved the ``Tuple`` and ``Either`` types to ``daml-prim:DA.Types``
   rather than exposing internal locations.
 


### PR DESCRIPTION
Helps with #1194, but generally useful too.