### PR TITLE
add createAnd syntax to prepare CreateAndExercise commands from Scala codegen contracts

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -14,6 +14,8 @@ HEAD — ongoing
 - **SQL Extractor**: in JSON content, dates and timestamps are formatted like
   ``"2020-02-22"`` and ``"2020-02-22T12:13:14Z"`` rather than UNIX epoch offsets like
   ``18314`` or ``1582373594000000``.
+- **Scala codegen**: ``CreateAndExercise`` support via ``createAnd`` method,
+  e.g. ``MyTemplate(owner, someText).createAnd.exerciseAccept(controller, 42)``.
 
 SDK tools
 ~~~~~~~~~

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -128,11 +128,11 @@ sealed abstract class Primitive {
       companion: TemplateCompanion[_ <: Tpl],
       na: rpcvalue.Record): Update[ContractId[Tpl]]
 
-  private[binding] def exercise[Tpl, Out](
+  private[binding] def exercise[ExOn, Tpl, Out](
       templateCompanion: TemplateCompanion[Tpl],
-      contractId: ContractId[Tpl],
+      receiver: ExOn,
       choiceId: String,
-      argument: rpcvalue.Value): Update[Out]
+      argument: rpcvalue.Value)(implicit ev: ExerciseOn[ExOn, Tpl]): Update[Out]
 
   private[binding] def arguments(
       recordId: rpcvalue.Identifier,
@@ -216,25 +216,7 @@ private[client] object OnlyPrimitive extends Primitive {
           .Create(rpccmd.CreateCommand(templateId = Some(companion.id.unwrap), Some(na)))),
       companion)
 
-  private[binding] override def exercise[Tpl, Out](
-      templateCompanion: TemplateCompanion[Tpl],
-      contractId: ContractId[Tpl],
-      choiceId: String,
-      argument: rpcvalue.Value): Update[Out] =
-    DomainCommand(
-      rpccmd.Command(
-        rpccmd.Command.Command.Exercise(
-          rpccmd.ExerciseCommand(
-            templateId = Some(templateCompanion.id.unwrap),
-            contractId = contractId.unwrap,
-            choice = choiceId,
-            choiceArgument = Some(argument)
-          ))),
-      templateCompanion
-    )
-
-  // TODO SC replace exercise&sig above with this
-  private[binding] /*override*/ def newExercise[ExOn, Tpl, Out](
+  private[binding] override def exercise[ExOn, Tpl, Out](
       templateCompanion: TemplateCompanion[Tpl],
       receiver: ExOn,
       choiceId: String,

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -10,6 +10,15 @@ abstract class Template[+T] extends ValueRef { self: T =>
   final def create(implicit d: DummyImplicit): Primitive.Update[Primitive.ContractId[T]] =
     Primitive.createFromArgs(templateCompanion, templateCompanion.toNamedArguments(self))
 
+  /** Part of a `CreateAndExercise` command.
+    *
+    * {{{
+    *   Iou(foo, bar).createAnd.exerciseTransfer(controller, ...)
+    * }}}
+    */
+  final def createAnd(implicit d: DummyImplicit): Template.CreateForExercise[T] =
+    Template.CreateForExercise(this)
+
   final def arguments(implicit d: DummyImplicit): rpcvalue.Record =
     templateCompanion.toNamedArguments(self)
 
@@ -23,4 +32,15 @@ abstract class Template[+T] extends ValueRef { self: T =>
   // public, though the latter might be more "powerful"
   protected[this] def templateCompanion(
       implicit d: DummyImplicit): TemplateCompanion[_ >: self.type <: T]
+}
+
+object Template {
+
+  /** Part of a `CreateAndExercise` command.
+    *
+    * {{{
+    *   Iou(foo, bar).createAnd.exerciseTransfer(controller, ...)
+    * }}}
+    */
+  final case class CreateForExercise[+T](value: T with Template[T])
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -17,7 +17,7 @@ abstract class Template[+T] extends ValueRef { self: T =>
     * }}}
     */
   final def createAnd(implicit d: DummyImplicit): Template.CreateForExercise[T] =
-    Template.CreateForExercise(this)
+    Template.CreateForExercise(self)
 
   final def arguments(implicit d: DummyImplicit): rpcvalue.Record =
     templateCompanion.toNamedArguments(self)

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -8,7 +8,7 @@ import scala.language.higherKinds
 import com.digitalasset.ledger.api.refinements.ApiTypes.{Choice, TemplateId}
 import com.digitalasset.ledger.api.v1.{event => rpcevent, value => rpcvalue}
 import rpcvalue.Value.{Sum => VSum}
-import encoding.{LfEncodable, LfTypeEncoding, RecordView}
+import encoding.{ExerciseOn, LfEncodable, LfTypeEncoding, RecordView}
 
 import scalaz.Liskov
 import Liskov.<~<
@@ -73,11 +73,12 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
       (id, _.createArguments flatMap fromNamedArguments))
   }
 
-  protected final def ` exercise`[Out](
-      contractId: Primitive.ContractId[T],
+  protected final def ` exercise`[ExOn, Out](
+      receiver: ExOn,
       choiceId: String,
-      arguments: Option[rpcvalue.Value]): Primitive.Update[Out] =
-    Primitive.exercise(this, contractId, choiceId, arguments getOrElse Value.encode(()))
+      arguments: Option[rpcvalue.Value])(
+      implicit exon: ExerciseOn[ExOn, T]): Primitive.Update[Out] =
+    Primitive.exercise(this, receiver, choiceId, arguments getOrElse Value.encode(()))
 
   protected final def ` arguments`(elems: (String, rpcvalue.Value)*): rpcvalue.Record =
     Primitive.arguments(` recordOrVariantId`, elems)

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
@@ -1,42 +1,23 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.ledger.client.binding
 package encoding
 
-import com.digitalasset.ledger.api.v1.{value => rpcvalue}
-import Primitive.{Update, ContractId}
+import Primitive.ContractId
 import Template.CreateForExercise
 
 import scala.annotation.implicitNotFound
 
 @implicitNotFound(
-  """Cannot decide how to exercise a choice on ${Self}; only well-typed contract IDs and Templates are candidates for choice exercise""")
-sealed abstract class ExerciseOn[-Self, Tpl] {
-  private[binding] def exercise[Out](
-      self: Self,
-      companion: TemplateCompanion[Tpl],
-      choiceId: String,
-      arguments: rpcvalue.Value): Update[Out]
-}
+  """Cannot decide how to exercise a choice on ${Self}; only well-typed contract IDs and Templates (.createAnd) are candidates for choice exercise""")
+sealed abstract class ExerciseOn[-Self, Tpl]
 
 object ExerciseOn {
   implicit def OnId[T]: ExerciseOn[ContractId[T], T] = new OnId
   implicit def CreateAndOnTemplate[T]: ExerciseOn[CreateForExercise[T], T] =
     new CreateAndOnTemplate
 
-  private[this] final class OnId[T] extends ExerciseOn[ContractId[T], T] {
-    private[binding] override def exercise[Out](
-        self: ContractId[T],
-        companion: TemplateCompanion[T],
-        choiceId: String,
-        arguments: rpcvalue.Value): Update[Out] =
-      Primitive.exercise(companion, self, choiceId, arguments)
-  }
-
-  private[this] final class CreateAndOnTemplate[T] extends ExerciseOn[CreateForExercise[T], T] {
-    private[binding] override def exercise[Out](
-        self: CreateForExercise[T],
-        companion: TemplateCompanion[T],
-        choiceId: String,
-        arguments: rpcvalue.Value): Update[Out] = sys.error("TODO SC CreateAndExercise")
-
-  }
+  private[binding] final class OnId[T] extends ExerciseOn[ContractId[T], T]
+  private[binding] final class CreateAndOnTemplate[T] extends ExerciseOn[CreateForExercise[T], T]
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
@@ -1,0 +1,42 @@
+package com.digitalasset.ledger.client.binding
+package encoding
+
+import com.digitalasset.ledger.api.v1.{value => rpcvalue}
+import Primitive.{Update, ContractId}
+import Template.CreateForExercise
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  """Cannot decide how to exercise a choice on ${Self}; only well-typed contract IDs and Templates are candidates for choice exercise""")
+sealed abstract class ExerciseOn[-Self, Tpl] {
+  private[binding] def exercise[Out](
+      self: Self,
+      companion: TemplateCompanion[Tpl],
+      choiceId: String,
+      arguments: rpcvalue.Value): Update[Out]
+}
+
+object ExerciseOn {
+  implicit def OnId[T]: ExerciseOn[ContractId[T], T] = new OnId
+  implicit def CreateAndOnTemplate[T]: ExerciseOn[CreateForExercise[T], T] =
+    new CreateAndOnTemplate
+
+  private[this] final class OnId[T] extends ExerciseOn[ContractId[T], T] {
+    private[binding] override def exercise[Out](
+        self: ContractId[T],
+        companion: TemplateCompanion[T],
+        choiceId: String,
+        arguments: rpcvalue.Value): Update[Out] =
+      Primitive.exercise(companion, self, choiceId, arguments)
+  }
+
+  private[this] final class CreateAndOnTemplate[T] extends ExerciseOn[CreateForExercise[T], T] {
+    private[binding] override def exercise[Out](
+        self: CreateForExercise[T],
+        companion: TemplateCompanion[T],
+        choiceId: String,
+        arguments: rpcvalue.Value): Update[Out] = sys.error("TODO SC CreateAndExercise")
+
+  }
+}

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.codegen
+
+import com.digitalasset.sample.MyMain.SimpleListExample
+import com.digitalasset.ledger.api.v1.{commands => rpccmd}
+import com.digitalasset.ledger.client.binding.{Primitive => P}
+
+import org.scalatest.{Inside, Matchers, WordSpec}
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+class GeneratedCommandsUT extends WordSpec with Matchers with Inside {
+  private val alice = P.Party("Alice")
+  private val contract = SimpleListExample(alice, List(42))
+
+  "create" should {
+    "make a create command" in {
+      inside(contract.create.command.command) {
+        case rpccmd.Command.Command.Create(rpccmd.CreateCommand(_, _)) => ()
+      }
+    }
+  }
+
+  "createAnd" should {
+    "make a create-and-exercise command" in {
+      inside(contract.createAnd.exerciseGo(alice).command.command) {
+        case rpccmd.Command.Command
+              .CreateAndExercise(rpccmd.CreateAndExerciseCommand(_, _, _, _)) =>
+          ()
+      }
+    }
+  }
+}

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
@@ -51,6 +51,7 @@ import com.digitalasset.sample.MyMain.{
   NameClashVariant,
   PayOut,
   RecordWithNestedMyVariant,
+  SimpleListExample,
   TemplateWith23Arguments,
   TemplateWithCustomTypes,
   TemplateWithNestedRecordsAndVariants,
@@ -363,6 +364,15 @@ class ScalaCodeGenIT
     val contract = arbitrary[MySecondMain.DummyTemplateFromAnotherDar].sample getOrElse sys.error(
       "random DummyTemplateFromAnotherDar failed")
     testCreateContractAndReceiveEvent(contract copy (owner = alice), alice)
+  }
+
+  "alice creates-and-exercises SimpleListExample with Go and receives corresponding event" in {
+    val contract = SimpleListExample(alice, P.List(42))
+    val exerciseConsequence = MkListExample(alice, P.List(42))
+    testCommandAndReceiveEvent(
+      contract.createAnd.exerciseGo(alice),
+      alice,
+      assertCreateEvent(_)(exerciseConsequence))
   }
 
   private def testCreateContractAndReceiveEvent(

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -65,13 +65,13 @@ da_scala_library(
 da_scala_test_suite(
     name = "tests",
     size = "small",
-    scalacopts = ["-Xsource:2.13"],
     srcs = glob(
         [
             "src/test/**/*.scala",
         ],
         exclude = testing_utils,
     ),
+    scalacopts = ["-Xsource:2.13"],
     deps = [
         ":codegen-testing",
         ":codegen-testing-testing",

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -65,6 +65,7 @@ da_scala_library(
 da_scala_test_suite(
     name = "tests",
     size = "small",
+    scalacopts = ["-Xsource:2.13"],
     srcs = glob(
         [
             "src/test/**/*.scala",

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncodingSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncodingSpec.scala
@@ -46,23 +46,22 @@ class EqualityEncodingSpec extends WordSpec with Matchers {
       contract1 assert_=== contract1
       contract1 assert_=== contract1.copy()
 
-      equality.apply(contract1, contract1.copy()) should equal(true)
-      equality.apply(contract1, contract1.copy(subr = t.TrialSubRec(11, 101))) should equal(false)
-      equality.apply(contract1, contract1.copy(lst = List())) should equal(false)
-      equality.apply(contract1, contract1.copy(lst = List(3, 2, 1))) should equal(false)
-      equality.apply(contract1, contract1.copy(lst = List(1, 2, 3, 4))) should equal(false)
+      equality.apply(contract1, contract1.copy()) should ===(true)
+      equality.apply(contract1, contract1.copy(subr = t.TrialSubRec(11, 101))) should ===(false)
+      equality.apply(contract1, contract1.copy(lst = List())) should ===(false)
+      equality.apply(contract1, contract1.copy(lst = List(3, 2, 1))) should ===(false)
+      equality.apply(contract1, contract1.copy(lst = List(1, 2, 3, 4))) should ===(false)
 
-      equality.apply(contract2, contract2) should equal(true)
-      equality.apply(contract2, contract2.copy()) should equal(true)
-      equality.apply(contract2, contract2.copy(variant = t.TrialVariant.TLeft("schön"))) should equal(
+      equality.apply(contract2, contract2) should ===(true)
+      equality.apply(contract2, contract2.copy()) should ===(true)
+      equality.apply(contract2, contract2.copy(variant = t.TrialVariant.TLeft("schön"))) should ===(
         false)
       equality.apply(
         contract2,
         contract2.copy(variant =
-          t.TrialVariant.TRight(P.ContractId("ABC123"), P.ContractId("DEF456")))) should equal(
-        false)
+          t.TrialVariant.TRight(P.ContractId("ABC123"), P.ContractId("DEF456")))) should ===(false)
 
-      equality.apply(contract1, contract2) should equal(false)
+      equality.apply(contract1, contract2) should ===(false)
     }
   }
 }

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ExerciseOnSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ExerciseOnSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.ledger.client.binding
+package encoding
+
+import com.digitalasset.ledger.client.binding.{Primitive => P}
+
+import org.scalatest.{Matchers, WordSpec}
+
+class ExerciseOnSpec extends WordSpec with Matchers {
+  import ExerciseOnSpec._
+
+  val owner: P.Party = P.Party("owner")
+
+  "ids" should {
+    "select an instance" in {
+      (id: Sth.ContractId) => id.exerciseFoo(owner)
+    }
+
+    "select an instance, even if subtype" in {
+      def exer[T <: Sth.ContractId] = (id: T) => id.exerciseFoo(owner)
+    }
+  }
+}
+
+object ExerciseOnSpec {
+  final case class Sth() extends Template[Sth] {
+    protected[this] override def templateCompanion(implicit d: DummyImplicit) = Sth
+  }
+
+  object Sth extends TemplateCompanion.Empty[Sth] with (() => Sth) {
+    override val id = ` templateId`("Foo", "Bar", "Sth")
+    override val onlyInstance = Sth()
+    override val consumingChoices = Set()
+
+    /** An example of generated code so we can see how implicit resolution will
+      * behave. Do *not* import `Sth syntax`; the whole point is to make sure
+      * this all works without doing that.
+      */
+    implicit final class `Sth syntax`[+` ExOn`](private val id: ` ExOn`) extends AnyVal {
+      def exerciseFoo(controller: P.Party)(implicit ` exOn`: ExerciseOn[` ExOn`, Sth]): Unit = ()
+    }
+  }
+}

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncodingSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncodingSpec.scala
@@ -45,13 +45,13 @@ class ShowEncodingSpec extends WordSpec with Matchers {
       val escapedName = "\"sch\\u00F6n\""
       val expected: String =
         s"""MyMain.CallablePayout(receiver = P@"Alice", subr = TrialSubRec(num = 10, a = 100), lst = [1,2,3], emptyRec = TrialSubRec(), variant = TLeft($escapedName))"""
-      contract1.show.toString should equal(expected)
+      contract1.show.toString should ===(expected)
     }
 
     "show t.CallablePayout 2" in {
       val expected: String =
         """MyMain.CallablePayout(receiver = P@"Alice", subr = TrialSubRec(num = 11, a = 111), lst = [10,20,30], emptyRec = TrialSubRec(), variant = TRight(TrialVariant.TRight(one = CID@abc123, two = CID@def456)))"""
-      contract2.show.toString should equal(expected)
+      contract2.show.toString should ===(expected)
     }
   }
 }

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ShowUnicodeEscapedStringSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/ShowUnicodeEscapedStringSpec.scala
@@ -17,27 +17,27 @@ class ShowUnicodeEscapedStringSpec
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 10000)
 
   "should unicode-escape all non-ascii chars in the format that can compile back to original string" in {
-    "scho\u0308n" shouldNot equal("schön")
-    normalize("scho\u0308n") should equal(normalize("schön"))
+    "scho\u0308n" should !==("schön")
+    normalize("scho\u0308n") should ===(normalize("schön"))
 
     println(ShowUnicodeEscapedString.show("scho\u0308n"))
-    ShowUnicodeEscapedString.show("scho\u0308n").toString should equal("\"scho\\u0308n\"")
+    ShowUnicodeEscapedString.show("scho\u0308n").toString should ===("\"scho\\u0308n\"")
 
     println(ShowUnicodeEscapedString.show("schön"))
-    ShowUnicodeEscapedString.show("schön").toString should equal("\"sch\\u00F6n\"")
-    "sch\u00F6n" should equal("schön")
-    "\u00F6" should equal("ö")
+    ShowUnicodeEscapedString.show("schön").toString should ===("\"sch\\u00F6n\"")
+    "sch\u00F6n" should ===("schön")
+    "\u00F6" should ===("ö")
   }
 
   "normalizing unicode string multiple times does not change it" in {
-    "scho\u0308n" shouldNot equal("schön")
-    normalize("scho\u0308n") should equal(normalize("schön"))
-    normalize(normalize("scho\u0308n")) should equal(normalize("schön"))
-    normalize("scho\u0308n") should equal(normalize(normalize("schön")))
+    "scho\u0308n" should !==("schön")
+    normalize("scho\u0308n") should ===(normalize("schön"))
+    normalize(normalize("scho\u0308n")) should ===(normalize("schön"))
+    normalize("scho\u0308n") should ===(normalize(normalize("schön")))
   }
 
   "ASCII slash should be unicode escaped" in {
-    ShowUnicodeEscapedString.show("\\").toString.getBytes should equal("\"\\u005C\"".getBytes)
+    ShowUnicodeEscapedString.show("\\").toString.getBytes should ===("\"\\u005C\"".getBytes)
   }
 
   "unicode escaped string can be interpreted back to original string one example" in {
@@ -59,7 +59,7 @@ class ShowUnicodeEscapedStringSpec
   private def testUnicodeEscapedStringCanBeUnescapedBackToOriginalString(s0: String): Assertion = {
     val s1: Cord = ShowUnicodeEscapedString.show(s0)
     val s2: String = StringEscapeUtils.unescapeJava(removeWrappingQuotes(s1.toString))
-    s2.getBytes should equal(s0.getBytes)
+    s2.getBytes should ===(s0.getBytes)
   }
 
   private def removeWrappingQuotes(s: String): String = {


### PR DESCRIPTION
Typeclassification to let you use the existing `exercise*` methods made by Scala codegen like so:

```scala
Iou(foo, bar).createAnd.exerciseTransfer(controller, ...)
```

Fixes #1092.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
