### PR TITLE
Delete redundant IDE Cleanup

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/RuleTypes.hs
@@ -51,9 +51,6 @@ type instance RuleResult GetDependencies = TransitiveDependencies
 -- | The type checked version of this file, requires TypeCheck+
 type instance RuleResult TypeCheck = TcModuleResult
 
--- | The result of loading a module from a package.
-type instance RuleResult LoadPackage = LoadPackageResult
-
 -- | Information about what spans occur where, requires TypeCheck
 type instance RuleResult GetSpanInfo = [SpanInfo]
 
@@ -110,11 +107,6 @@ data TypeCheck = TypeCheck
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable TypeCheck
 instance NFData   TypeCheck
-
-data LoadPackage = LoadPackage InstalledUnitId
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable LoadPackage
-instance NFData   LoadPackage
 
 data GetSpanInfo = GetSpanInfo
     deriving (Eq, Show, Typeable, Generic)

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -23,8 +23,6 @@ module Development.IDE.State.Rules(
     fileFromParsedModule
     ) where
 
-import           Control.Concurrent.Extra
-import Control.Exception (evaluate)
 import           Control.Monad.Except
 import Control.Monad.Extra (whenJust)
 import qualified Development.IDE.Functions.Compile             as Compile
@@ -71,16 +69,6 @@ defineNoFile :: IdeRule k v => (k -> Action v) -> Rules ()
 defineNoFile f = define $ \k file -> do
     if file == "" then do res <- f k; return ([], Just res) else
         fail $ "Rule " ++ show k ++ " should always be called with the empty string for a file"
-
-
--- | Return a distinct supply of uniques.
-getUniqSupply :: Action UniqSupply
-getUniqSupply =
-    getServiceEnv >>= liftIO . getUniqSupplyFrom
-
-getUniqSupplyFrom :: Env -> IO UniqSupply
-getUniqSupplyFrom Env{..} =
-    modifyVar envUniqSupplyVar $ evaluate . splitUniqSupply
 
 
 ------------------------------------------------------------
@@ -290,45 +278,23 @@ typeCheckRule =
     define $ \TypeCheck file -> do
         pm <- use_ GetParsedModule file
         deps <- use_ GetDependencies file
-        lps <- mapM (flip use_ "" . LoadPackage) (transitivePkgDeps deps)
         tms <- uses_ TypeCheck (transitiveModuleDeps deps)
         setPriority PriorityTypeCheck
-        us <- getUniqSupply
         packageState <- use_ GhcSession ""
         opt <- getOpts
-        liftIO $ Compile.typecheckModule opt pm packageState us tms lps pm
-
-
-loadPackageRule :: Rules ()
-loadPackageRule =
-  defineNoFile $ \(LoadPackage pkg) -> do
-      packageState <- use_ GhcSession ""
-      opt <- getOpts
-      pkgs <- liftIO $ Compile.computePackageDeps opt packageState pkg
-      case pkgs of
-        Left e -> do
-            reportSeriousErrorDie $ "LoadPackage " ++ show pkg ++ " computePackageDeps failed, " ++ show e
-        Right v -> do
-            lps <- mapM (flip use_ "" . LoadPackage) v
-            us <- getUniqSupply
-            res <- liftIO $ Compile.loadPackage opt packageState us lps pkg
-            case res of
-                Left e -> reportSeriousErrorDie $ "LoadPackage " ++ show pkg ++ " loadPackage failed, " ++ show e
-                Right v -> return v
+        liftIO $ Compile.typecheckModule opt pm packageState tms pm
 
 
 generateCoreRule :: Rules ()
 generateCoreRule =
     define $ \GenerateCore file -> do
         deps <- use_ GetDependencies file
-        lps <- mapM (flip use_ "" . LoadPackage) (transitivePkgDeps deps)
         (tm:tms) <- uses_ TypeCheck (file:transitiveModuleDeps deps)
         let pm = tm_parsed_module . Compile.tmrModule $ tm
         setPriority PriorityGenerateDalf
-        us <- getUniqSupply
         packageState <- use_ GhcSession ""
         opt <- getOpts
-        liftIO $ Compile.compileModule opt pm packageState us tms lps tm
+        liftIO $ Compile.compileModule opt pm packageState tms tm
 
 loadGhcSession :: Rules ()
 loadGhcSession =
@@ -359,7 +325,6 @@ mainRule = do
     getSpanInfoRule
     generateCoreRule
     loadGhcSession
-    loadPackageRule
     getHieFileRule
 
 ------------------------------------------------------------


### PR DESCRIPTION
A promised in a previous PR. Just deletes dead code, dead parameters and dead stuff. All just chasing HLint and warnings.