### PR TITLE
sandbox-sql: minor cleanup of KeyHasher

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Note: package name must correspond exactly to the flyway 'locations' setting, which defaults to 'db.migration'
+package db.migration
+
+import java.sql.{Connection, ResultSet}
+
+import anorm.{BatchSql, NamedParameter}
+import com.digitalasset.daml.lf.data._
+import com.digitalasset.daml.lf.transaction.Node.GlobalKey
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
+  KeyHasher,
+  ValueSerializer
+}
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+
+class V3__Recompute_Key_Hash extends BaseJavaMigration {
+
+  def migrate(context: Context): Unit = {
+    implicit val conn: Connection = context.getConnection
+    updateKeyHashed(loadContractKeys)
+  }
+
+  private val SQL_SELECT_CONTRACT_KEYS =
+    """
+      |SELECT
+      |  contracts.id as contract_id,
+      |  contracts.package_id as package_id,
+      |  contracts.name as template_name,
+      |  contracts.key as contract_key
+      |FROM
+      |  contracts
+      |WHERE
+      |  contracts.key is not null
+     """.stripMargin
+
+  private val SQL_UPDATE_CONTRACT_KEYS_HASH =
+    """
+      |UPDATE
+      |  contract_keys
+      |SET
+      |  value_hash = {valueHash}
+      |WHERE
+      |  contract_id = {contractId}
+      |""".stripMargin
+
+  def loadContractKeys(
+      implicit connection: Connection
+  ): ImmArray[(AbsoluteContractId, GlobalKey)] = {
+
+    var stack = FrontStack.empty[(AbsoluteContractId, GlobalKey)]
+
+    val rows: ResultSet = connection.createStatement().executeQuery(SQL_SELECT_CONTRACT_KEYS)
+
+    while (rows.next()) {
+      val contractId = AbsoluteContractId(rows.getString("contract_id"))
+      val packageId = Ref.PackageId.assertFromString(rows.getString("package_id"))
+      val templateName = rows.getString("template_name")
+      val templateId = Ref.Identifier(packageId, Ref.QualifiedName.assertFromString(templateName))
+      val keyStream = rows.getBytes("contract_key")
+      val key: VersionedValue[AbsoluteContractId] = ValueSerializer
+        .deserialiseValue(keyStream)
+        .fold(err => throw new IllegalArgumentException(err.errorMessage), identity)
+
+      stack = (contractId -> GlobalKey(templateId, key)) +: stack
+
+    }
+    stack.toImmArray
+  }
+
+  def updateKeyHashed(contractKeys: ImmArray[(AbsoluteContractId, GlobalKey)])(
+      implicit conn: Connection): Unit = {
+    val statements = contractKeys.map {
+      case (cid, key) =>
+        Seq[NamedParameter](
+          "contractId" -> cid.coid,
+          "valueHash" -> KeyHasher.hashKeyString(key)
+        )
+    }
+
+    statements match {
+      case ImmArrayCons(firstStatement, otherStatements) =>
+        BatchSql(
+          SQL_UPDATE_CONTRACT_KEYS_HASH,
+          firstStatement,
+          otherStatements.toSeq: _*
+        ).execute
+        ()
+      case _ =>
+        ()
+    }
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
@@ -9,7 +9,7 @@ import java.sql.{Connection, ResultSet}
 import anorm.{BatchSql, NamedParameter}
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
-import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   KeyHasher,
   ValueSerializer
@@ -18,13 +18,20 @@ import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
 class V3__Recompute_Key_Hash extends BaseJavaMigration {
 
+  // the number of contracts proceeded in a batch.
+  private val batchSize = 100 * 1000
+
   def migrate(context: Context): Unit = {
     implicit val conn: Connection = context.getConnection
     updateKeyHashed(loadContractKeys)
   }
 
-  private val SQL_SELECT_CONTRACT_KEYS =
-    """
+  private def loadContractKeys(
+      implicit connection: Connection
+  ): Iterator[(AbsoluteContractId, GlobalKey)] = {
+
+    val SQL_SELECT_CONTRACT_KEYS =
+      """
       |SELECT
       |  contracts.id as contract_id,
       |  contracts.package_id as package_id,
@@ -34,62 +41,55 @@ class V3__Recompute_Key_Hash extends BaseJavaMigration {
       |  contracts
       |WHERE
       |  contracts.key is not null
-     """.stripMargin
-
-  private val SQL_UPDATE_CONTRACT_KEYS_HASH =
-    """
-      |UPDATE
-      |  contract_keys
-      |SET
-      |  value_hash = {valueHash}
-      |WHERE
-      |  contract_id = {contractId}
-      |""".stripMargin
-
-  def loadContractKeys(
-      implicit connection: Connection
-  ): ImmArray[(AbsoluteContractId, GlobalKey)] = {
-
-    var stack = FrontStack.empty[(AbsoluteContractId, GlobalKey)]
+    """.stripMargin
 
     val rows: ResultSet = connection.createStatement().executeQuery(SQL_SELECT_CONTRACT_KEYS)
 
-    while (rows.next()) {
-      val contractId = AbsoluteContractId(rows.getString("contract_id"))
-      val packageId = Ref.PackageId.assertFromString(rows.getString("package_id"))
-      val templateName = rows.getString("template_name")
-      val templateId = Ref.Identifier(packageId, Ref.QualifiedName.assertFromString(templateName))
-      val keyStream = rows.getBytes("contract_key")
-      val key: VersionedValue[AbsoluteContractId] = ValueSerializer
-        .deserialiseValue(keyStream)
-        .fold(err => throw new IllegalArgumentException(err.errorMessage), identity)
+    new Iterator[(AbsoluteContractId, GlobalKey)] {
 
-      stack = (contractId -> GlobalKey(templateId, key)) +: stack
+      var hasNext: Boolean = rows.next()
 
+      def next(): (AbsoluteContractId, GlobalKey) = {
+        val contractId = AbsoluteContractId(rows.getString("contract_id"))
+        val packageId = Ref.PackageId.assertFromString(rows.getString("package_id"))
+        val templateName = rows.getString("template_name")
+        val templateId = Ref.Identifier(packageId, Ref.QualifiedName.assertFromString(templateName))
+        val key = ValueSerializer
+          .deserialiseValue(rows.getBytes("contract_key"))
+          .fold(err => throw new IllegalArgumentException(err.errorMessage), identity)
+
+        hasNext = rows.next()
+
+        contractId -> GlobalKey(templateId, key)
+      }
     }
-    stack.toImmArray
+
   }
 
-  def updateKeyHashed(contractKeys: ImmArray[(AbsoluteContractId, GlobalKey)])(
+  private def updateKeyHashed(contractKeys: Iterator[(AbsoluteContractId, GlobalKey)])(
       implicit conn: Connection): Unit = {
+
+    val SQL_UPDATE_CONTRACT_KEYS_HASH =
+      """
+        |UPDATE
+        |  contract_keys
+        |SET
+        |  value_hash = {valueHash}
+        |WHERE
+        |  contract_id = {contractId}
+      """.stripMargin
+
     val statements = contractKeys.map {
       case (cid, key) =>
-        Seq[NamedParameter](
-          "contractId" -> cid.coid,
-          "valueHash" -> KeyHasher.hashKeyString(key)
-        )
+        Seq[NamedParameter]("contractId" -> cid.coid, "valueHash" -> KeyHasher.hashKeyString(key))
     }
 
-    statements match {
-      case ImmArrayCons(firstStatement, otherStatements) =>
-        BatchSql(
-          SQL_UPDATE_CONTRACT_KEYS_HASH,
-          firstStatement,
-          otherStatements.toSeq: _*
-        ).execute
-        ()
-      case _ =>
-        ()
+    statements.toStream.grouped(batchSize).foreach { batch =>
+      BatchSql(
+        SQL_UPDATE_CONTRACT_KEYS_HASH,
+        batch.head,
+        batch.tail: _*
+      ).execute()
     }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/scripts/V3__Recompute_Key_Hash.scala
@@ -19,7 +19,7 @@ import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 class V3__Recompute_Key_Hash extends BaseJavaMigration {
 
   // the number of contracts proceeded in a batch.
-  private val batchSize = 100 * 1000
+  private val batchSize = 10 * 1000
 
   def migrate(context: Context): Unit = {
     implicit val conn: Connection = context.getConnection

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
@@ -65,7 +65,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     "be stable" in {
       // Hashing function must not change
       val value = VersionedValue(ValueVersion("4"), complexValue)
-      val hash = "ecbc3f9c121e23ef2851c06d77de82d0f58f27acdf9c5fecff9b904ad236621b"
+      val hash = "2b1019f99147ca726baa3a12509399327746f1f9c4636a6ec5f5d7af1e7c2942"
 
       KeyHasher.hashKeyString(GlobalKey(templateId("module", "name"), value)) shouldBe hash
     }


### PR DESCRIPTION
In this PR, we cleanup the KeyHasher used by the SQL backend of the sandbox.

In particular we :

1.  Use daml-lf Decimal to String conversion instead of BigDecimal to string conversion.
   
2.  We do use UTF8 length instead of UTF16 length.
   

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
