### PR TITLE
Add Scala codegen bazel rule: dar_to_scala

### DIFF
--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -34,7 +34,7 @@ dar_to_scala(
     ],
     package_prefix = "com.digitalasset.sample",
     srcjar_out = "MyMain.srcjar",
-    verbosity = "2",
+    verbosity = 2,
 )
 
 da_scala_library(

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -12,6 +12,7 @@ load(
     "daml_compile",
 )
 load("@os_info//:os_info.bzl", "is_linux")
+load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
 
 daml_compile(
     name = "MyMain",
@@ -25,34 +26,20 @@ daml_compile(
     target = "1.3",
 )
 
-genrule(
+dar_to_scala(
     name = "MyMain-codegen",
     srcs = [
-        ":MyMain",
-        ":MySecondMain",
-    ],
-    outs = ["MyMain-codegen-out"],
-    cmd = "$(execpath //language-support/scala/codegen:codegen-main) $(location :MyMain.dar)=com.digitalasset.sample $(location :MySecondMain.dar)=com.digitalasset.sample --output-directory=$@ --verbosity=2",
-    tools = [
         ":MyMain.dar",
         ":MySecondMain.dar",
-        "//language-support/scala/codegen:codegen-main",
     ],
-)
-
-genrule(
-    name = "MyMain-codegen.srcjar",
-    srcs = [":MyMain-codegen"],
-    outs = ["MyMain-codegen-out.srcjar"],
-    cmd = "$(execpath @local_jdk//:bin/jar) -cf $@ -C $(location :MyMain-codegen) .",
-    tools = [
-        "@local_jdk//:bin/jar",
-    ],
+    package_prefix = "com.digitalasset.sample",
+    srcjar_out = "MyMain.srcjar",
+    verbosity = "2",
 )
 
 da_scala_library(
     name = "daml-lf-codegen-sample-app",
-    srcs = ["MyMain-codegen-out.srcjar"] + glob(["src/main/**/*.scala"]),
+    srcs = [":MyMain.srcjar"] + glob(["src/main/**/*.scala"]),
     plugins = [
         # Plugins have to be specified as JARs.
         "//external:jar/org/spire_math/kind_projector_2_12",

--- a/language-support/scala/codegen/codegen.bzl
+++ b/language-support/scala/codegen/codegen.bzl
@@ -17,7 +17,7 @@ def dar_to_scala(**kwargs):
 
     cmd = """
         $(execpath //language-support/scala/codegen:codegen-main) --output-directory={gen_out} --verbosity={verbosity} {gen_in}
-        $(execpath @local_jdk//:bin/jar) -cf $@ -C {gen_out} .
+        $(execpath @bazel_tools//tools/jdk:jar) -cf $@ -C {gen_out} .
     """.format(
         verbosity = verbosity,
         gen_in = dars_with_package_prefix(dars, package_prefix),
@@ -31,7 +31,7 @@ def dar_to_scala(**kwargs):
         cmd = cmd,
         tools = [
             "//language-support/scala/codegen:codegen-main",
-            "@local_jdk//:bin/jar",
+            "@bazel_tools//tools/jdk:jar",
         ],
     )
 

--- a/language-support/scala/codegen/codegen.bzl
+++ b/language-support/scala/codegen/codegen.bzl
@@ -1,0 +1,45 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+def dar_to_scala(**kwargs):
+    """
+    Generate scala code from provided DAR files.
+
+    This macro does not try to compile the generated classes it just outputs the `srcjar` with generated files.
+    """
+    name = kwargs["name"]
+    dars = kwargs["srcs"]
+    package_prefix = kwargs["package_prefix"]
+    verbosity = kwargs.get("verbosity", "2")
+    srcjar_out = kwargs["srcjar_out"]
+
+    src_out = name + "-srcs"
+
+    cmd = """
+        $(execpath //language-support/scala/codegen:codegen-main) --output-directory={gen_out} --verbosity={verbosity} {gen_in}
+        $(execpath @local_jdk//:bin/jar) -cf $@ -C {gen_out} .
+    """.format(
+        verbosity = verbosity,
+        gen_in = dars_with_package_prefix(dars, package_prefix),
+        gen_out = src_out,
+    )
+
+    native.genrule(
+        name = name,
+        srcs = dars,
+        outs = [srcjar_out],
+        cmd = cmd,
+        tools = [
+            "//language-support/scala/codegen:codegen-main",
+            "@local_jdk//:bin/jar",
+        ],
+    )
+
+def dar_with_package_prefix(dar, package_prefix):
+    return "$(location %s)=%s" % (dar, package_prefix)
+
+def dars_with_package_prefix(dars, package_prefix):
+    arr = []
+    for d in dars:
+        arr.append(dar_with_package_prefix(d, package_prefix))
+    return " ".join(arr)

--- a/language-support/scala/codegen/codegen.bzl
+++ b/language-support/scala/codegen/codegen.bzl
@@ -3,7 +3,7 @@
 
 def _dar_to_scala_impl(ctx):
     codegen_out_dir = ctx.outputs.codegen_out
-    srcjar_out_dir = ctx.outputs.srcjar_out
+    srcjar_out_file = ctx.outputs.srcjar_out
 
     # Call Scala codegen
     gen_args = ctx.actions.args()
@@ -38,15 +38,15 @@ def _dar_to_scala_impl(ctx):
     # Call zipper to create srcjar
     zipper_args = ctx.actions.args()
     zipper_args.add("c")
-    zipper_args.add(srcjar_out_dir.path)
+    zipper_args.add(srcjar_out_file.path)
     zipper_args.add("@%s" % zipper_args_file.path)
     ctx.actions.run(
         mnemonic = "CreateSrcJar",
         executable = ctx.executable._zipper,
         inputs = [codegen_out_dir, zipper_args_file],
-        outputs = [srcjar_out_dir],
+        outputs = [srcjar_out_file],
         arguments = [zipper_args],
-        progress_message = "srcjar: %s" % srcjar_out_dir.path,
+        progress_message = "srcjar: %s" % srcjar_out_file.path,
     )
 
 dar_to_scala = rule(

--- a/language-support/scala/codegen/codegen.bzl
+++ b/language-support/scala/codegen/codegen.bzl
@@ -1,45 +1,89 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-def dar_to_scala(**kwargs):
-    """
-    Generate scala code from provided DAR files.
+def _dar_to_scala_impl(ctx):
+    codegen_out_dir = ctx.outputs.codegen_out
+    srcjar_out_dir = ctx.outputs.srcjar_out
 
-    This macro does not try to compile the generated classes it just outputs the `srcjar` with generated files.
-    """
-    name = kwargs["name"]
-    dars = kwargs["srcs"]
-    package_prefix = kwargs["package_prefix"]
-    verbosity = kwargs.get("verbosity", "2")
-    srcjar_out = kwargs["srcjar_out"]
-
-    src_out = name + "-srcs"
-
-    cmd = """
-        $(execpath //language-support/scala/codegen:codegen-main) --output-directory={gen_out} --verbosity={verbosity} {gen_in}
-        $(execpath @bazel_tools//tools/jdk:jar) -cf $@ -C {gen_out} .
-    """.format(
-        verbosity = verbosity,
-        gen_in = dars_with_package_prefix(dars, package_prefix),
-        gen_out = src_out,
+    # Call Scala codegen
+    gen_args = ctx.actions.args()
+    gen_args.add("--output-directory=%s" % codegen_out_dir.path)
+    gen_args.add("--verbosity=%s" % ctx.attr.verbosity)
+    for dar in ctx.files.srcs:
+        gen_args.add("./%s=%s" % (dar.path, ctx.attr.package_prefix))
+    ctx.actions.run(
+        mnemonic = "ScalaCodegen",
+        inputs = ctx.files.srcs,
+        outputs = [codegen_out_dir],
+        arguments = [gen_args],
+        progress_message = "scala codegen files: %s" % ctx.attr.name,
+        executable = ctx.executable._codegen,
+        use_default_shell_env = True,
     )
 
-    native.genrule(
-        name = name,
-        srcs = dars,
-        outs = [srcjar_out],
-        cmd = cmd,
-        tools = [
-            "//language-support/scala/codegen:codegen-main",
-            "@bazel_tools//tools/jdk:jar",
-        ],
+    # Create zipper_args file
+    zipper_args_file = ctx.actions.declare_file(ctx.label.name + ".zipper_args")
+    ctx.actions.run_shell(
+        mnemonic = "CreateZipperArgsFile",
+        outputs = [zipper_args_file],
+        inputs = [codegen_out_dir],
+        command = "find -L {src_path} -type f | sed -E 's#^{src_path}/(.*)$#\\1={src_path}/\\1#' | sort > {args_file}".format(
+            src_path = codegen_out_dir.path,
+            args_file = zipper_args_file.path,
+        ),
+        progress_message = "zipper_args_file: %s" % zipper_args_file.path,
+        use_default_shell_env = True,
     )
 
-def dar_with_package_prefix(dar, package_prefix):
-    return "$(location %s)=%s" % (dar, package_prefix)
+    # Call zipper to create srcjar
+    zipper_args = ctx.actions.args()
+    zipper_args.add("c")
+    zipper_args.add(srcjar_out_dir.path)
+    zipper_args.add("@%s" % zipper_args_file.path)
+    ctx.actions.run(
+        mnemonic = "CreateSrcJar",
+        executable = ctx.executable._zipper,
+        inputs = [codegen_out_dir, zipper_args_file],
+        outputs = [srcjar_out_dir],
+        arguments = [zipper_args],
+        progress_message = "srcjar: %s" % srcjar_out_dir.path,
+    )
 
-def dars_with_package_prefix(dars, package_prefix):
-    arr = []
-    for d in dars:
-        arr.append(dar_with_package_prefix(d, package_prefix))
-    return " ".join(arr)
+dar_to_scala = rule(
+    implementation = _dar_to_scala_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+            doc = "DAR files.",
+        ),
+        "srcjar_out": attr.string(
+            mandatory = True,
+            doc = "The name of the output srcjar",
+        ),
+        "package_prefix": attr.string(
+            mandatory = True,
+            doc = "Package name e.g. 'com.digitalasset.mypackage'.",
+        ),
+        "verbosity": attr.int(
+            default = 2,
+        ),
+        "_codegen": attr.label(
+            default = Label("//language-support/scala/codegen:codegen-main"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+        "_zipper": attr.label(
+            default = Label("@bazel_tools//tools/zip:zipper"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    outputs = {
+        "codegen_out": "%{name}-src",
+        "srcjar_out": "%{srcjar_out}",  # I want it to be explicit, other rules will depend on it
+    },
+    output_to_genfiles = True,
+)

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_binary",
     "da_scala_library",
 )
-
 load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
 
 filegroup(

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -38,6 +38,7 @@ genrule(
         rm -rf $@/application/target
         rm -rf $@/scala-codegen/target
     """,
+    tools = [":examples-quickstart-scala-bin"],  # this is to make sure that quickstart-scala compiles
     visibility = ["//visibility:public"],
 )
 

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -47,7 +47,7 @@ dar_to_scala(
     srcs = ["//docs:quickstart-model.dar"],
     package_prefix = "com.digitalasset.quickstart.iou.model",
     srcjar_out = "examples-quickstart-scala-codegen.srcjar",
-    verbosity = "2",
+    verbosity = 2,
 )
 
 da_scala_library(

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -7,6 +7,8 @@ load(
     "da_scala_library",
 )
 
+load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
+
 filegroup(
     name = "quickstart-scala-src",
     srcs = glob(
@@ -40,29 +42,17 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+dar_to_scala(
     name = "examples-quickstart-scala-codegen",
     srcs = ["//docs:quickstart-model.dar"],
-    outs = ["examples-quickstart-scala-codegen-out"],
-    cmd = "$(execpath //language-support/scala/codegen:codegen-main) $(location //docs:quickstart-model.dar)=com.digitalasset.quickstart.iou.model --output-directory=$@ --verbosity=2",
-    tools = [
-        "//language-support/scala/codegen:codegen-main",
-    ],
-)
-
-genrule(
-    name = "examples-quickstart-scala-codegen.srcjar",
-    srcs = [":examples-quickstart-scala-codegen"],
-    outs = ["examples-quickstart-scala-codegen-out.srcjar"],
-    cmd = "$(execpath @local_jdk//:bin/jar) -cf $@ -C $(location :examples-quickstart-scala-codegen) .",
-    tools = [
-        "@local_jdk//:bin/jar",
-    ],
+    package_prefix = "com.digitalasset.quickstart.iou.model",
+    srcjar_out = "examples-quickstart-scala-codegen.srcjar",
+    verbosity = "2",
 )
 
 da_scala_library(
     name = "examples-quickstart-scala-codegen-lib",
-    srcs = ["examples-quickstart-scala-codegen-out.srcjar"],
+    srcs = [":examples-quickstart-scala-codegen.srcjar"],
     deps = ["//language-support/scala/bindings"],
 )
 

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -43,57 +43,6 @@ def _daml_impl_package_dar(ctx):
         executable = ctx.executable.damlc,
     )
 
-def _daml_impl_generate_scala(ctx):
-    # Declare Scala source directory
-    scala_dir = ctx.actions.declare_directory("%s_scala" % ctx.attr.name)
-
-    # Call codegen
-    gen_args = ctx.actions.args()
-    gen_args.add("--input-file")
-    gen_args.add(ctx.outputs.dalf.path)
-    gen_args.add("--package-name")
-    gen_args.add(ctx.attr.package)
-    gen_args.add("--output-dir")
-    gen_args.add(scala_dir.path)
-    ctx.actions.run(
-        inputs = depset([ctx.outputs.dalf]),
-        outputs = [
-            scala_dir,
-        ],
-        arguments = [gen_args],
-        progress_message = "scala files %s" % ctx.attr.name,
-        executable = ctx.executable._codegen,
-        use_default_shell_env = True,
-    )
-
-    # Call jar to create srcjar
-    jar_args = ctx.actions.args()
-    jar_args.add("cf")
-    jar_args.add(ctx.outputs.srcjar.path)
-    jar_args.add("-C")
-    jar_args.add(scala_dir.path)
-    jar_args.add(".")
-    ctx.actions.run(
-        inputs = depset([scala_dir]),
-        outputs = [ctx.outputs.srcjar],
-        arguments = [jar_args],
-        progress_message = "srcjar %s" % ctx.outputs.srcjar.short_path,
-        executable = ctx.executable._jar,
-    )
-
-def _daml_impl(ctx):
-    _daml_impl_compile_dalf(ctx)
-    _daml_impl_package_dar(ctx)
-    _daml_impl_generate_scala(ctx)
-
-    # DAML provider
-    daml = daml_provider(
-        dalf = ctx.outputs.dalf,
-        dar = ctx.outputs.dar,
-        srcjar = ctx.outputs.srcjar,
-    )
-    return [daml]
-
 def _daml_outputs_impl(name):
     patterns = {
         "dalf": "{name}.dalf",
@@ -182,68 +131,6 @@ daml_test = rule(
     },
     test = True,
 )
-
-# Going forward this rule should be refactored by the DAML team and the
-# codegen parts should be separated into its own rule.
-daml = rule(
-    implementation = _daml_impl,
-    attrs = {
-        "main_src": attr.label(
-            allow_single_file = [".daml"],
-            mandatory = True,
-            doc = "The main DAML file that will be passed to the compiler.",
-        ),
-        "srcs": attr.label_list(
-            allow_files = [".daml"],
-            default = [],
-            doc = "Other DAML files that compilation depends on.",
-        ),
-        "target": attr.string(doc = "DAML-LF version to output"),
-        "package": attr.string(mandatory = True, doc = "Package name e.g. com.digitalasset.mypackage."),
-        "damlc": attr.label(
-            executable = True,
-            cfg = "host",
-            allow_files = True,
-            default = Label("//daml-foundations/daml-tools/damlc-jar:damlc_jar"),
-        ),
-        "_codegen": attr.label(
-            executable = True,
-            cfg = "host",
-            allow_files = True,
-            default = Label("//rules_daml:codegen"),
-        ),
-        "_jar": attr.label(
-            executable = True,
-            cfg = "host",
-            allow_single_file = True,
-            default = Label("@bazel_tools//tools/jdk:jar"),
-        ),
-    },
-    executable = False,
-    outputs = _daml_outputs_impl,
-)
-"""
-Define a DAML package.
-
-This rule covers compilation to DAML-LF using `damlc`, DAR package generation
-using `damlc`, and Scala code-generation using `codegen`.
-
-Example:
-  ```
-  daml(
-      name = "example",
-      main_src = "src/Main.daml",
-      srcs = glob(["src/**/*.daml"]),
-      package = "com.digitalasset.sample",
-  )
-  ```
-
-  This defines a DAML package with the main DAML source file `src/Main.daml`
-  and all other DAML source files underneath `src/`.
-  The generated Scala sources are available under the label `:example.srcjar`.
-  The generated DAML-LF file is available under `:example.lf`.
-  The generated DAR file is available under the label `:example.dar`.
-"""
 
 _daml_binary_script_template = """
 #!/usr/bin/env sh


### PR DESCRIPTION
Removing unused/broken daml.bzl rules, adding Scala codegen rule. Scala codegen rule: `dar_to_scala` follows the same approach as `dar_to_java` with a few differences:
- `dar_to_scala` supports multiple dars as an input
- `dar_to_scala` does not try to compile the generated scala (separation  of responsibilities)
- `dar_to_scala` creates srcjar using zipper instead of jar

This PR is the follow-up refactoring for #1138

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
