### PR TITLE
Fix Maven setup instructions

### DIFF
--- a/docs/source/app-dev/bindings-java/code-snippets/pom.xml
+++ b/docs/source/app-dev/bindings-java/code-snippets/pom.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.acme</groupId>
+    <artifactId>example-project</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0</version>
+
+    <!-- start snippet: dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>com.daml.ledger</groupId>
+            <artifactId>bindings-rxjava</artifactId>
+            <version>x.y.z</version>
+        </dependency>
+    </dependencies>
+    <!-- end snippet: dependencies -->
+
+    <!-- start snippet: repositories -->
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-digitalassetsdk-DigitalAssetSDK</id>
+            <name>bintray</name>
+            <url>https://digitalassetsdk.bintray.com/DigitalAssetSDK</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-digitalassetsdk-DigitalAssetSDK</id>
+            <name>bintray</name>
+            <url>https://digitalassetsdk.bintray.com/DigitalAssetSDK</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <!-- end snippet: repositories -->
+</project>

--- a/docs/source/app-dev/bindings-java/index.rst
+++ b/docs/source/app-dev/bindings-java/index.rst
@@ -139,7 +139,7 @@ Reference documentation
 Getting started
 ***************
 
-The Java bindings library can be added to a `Maven <https://maven.apache.org/>`_ project. Read :ref:`setup-maven-project` to configure your machine.
+The Java bindings library can be added to a `Maven <https://maven.apache.org/>`_ project.
 
 .. _bindings-java-setup-maven:
 
@@ -148,22 +148,26 @@ Set up a Maven project
 
 To use the Java bindings library, add the following dependencies to your project's ``pom.xml``:
 
-.. code-block:: xml
-
-    <dependency>
-        <groupId>com.daml.ledger</groupId>
-        <artifactId>bindings-java</artifactId>
-        <version>x.y.z</version>
-    </dependency>
-
-    <dependency>
-        <groupId>com.daml.ledger</groupId>
-        <artifactId>bindings-rxjava</artifactId>
-        <version>x.y.z</version>
-    </dependency>
+.. literalinclude:: ./code-snippets/pom.xml
+    :language: XML
+    :start-after: <!-- start snippet: dependencies -->
+    :end-before: <!-- end snippet: dependencies -->
+    :dedent: 4
 
 Replace ``x.y.z`` for both dependencies with the version that you want to use. You can find the available versions at
 `https://digitalassetsdk.bintray.com/DigitalAssetSDK/com/daml/ledger/`.
+
+You also have to add the DAML Bintray Repository to your ``pom.xml``:
+
+.. literalinclude:: ./code-snippets/pom.xml
+    :language: xml
+    :start-after: <!-- start snippet: repositories -->
+    :end-before: <!-- end snippet: repositories -->
+    :dedent: 4
+
+
+You can also take a look at the ``pom.xml`` file from the :ref:`quickstart project <quickstart>`.
+
 
 .. _ledger-api-java-binding-connecting:
 

--- a/docs/source/app-dev/grpc/index.rst
+++ b/docs/source/app-dev/grpc/index.rst
@@ -29,7 +29,7 @@ Example project
 
 We have an example project demonstrating the use of the Ledger API with gRPC. To get the example project, ``PingPongGrpc``:
 
-#. Configure your machine to use the example by following the instructions at :ref:`setup-maven-project`.
+#. Configure your machine to use the example by following the instructions at :ref:`bindings-java-setup-maven`.
 #. Clone the `repository from GitHub <https://github.com/digital-asset/ex-java-bindings>`__. 
 #. Follow the `setup instructions in the README <https://github.com/digital-asset/ex-java-bindings/blob/master/README.rst#setting-up-the-example-projects>`__. Use ``examples.pingpong.grpc.PingPongGrpcMain`` as the main class.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -32,17 +32,6 @@ Windows
 
 To install the SDK on Windows, download and run the installer from `github.com/digital-asset/daml/releases/latest <https://github.com/digital-asset/daml/releases/latest>`__.
 
-.. _setup-maven-project:
-
-3. Configure Maven
-******************
-
-To use the Java bindings (and to follow the quickstart guide), you need to install Maven and configure it to use the Digital Asset repository:
-
-#. Install `Maven <https://maven.apache.org/>`_.
-#. Download `settings.xml <https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fdigitalassetsdk%2FDigitalAssetSDK>`_.
-#. Copy the downloaded file to ``~/.m2/settings.xml``. If you already have ``~/.m2/settings.xml``, integrate the downloaded file with it instead.
-
 Next steps
 **********
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -10,6 +10,7 @@ HEAD — ongoing
 --------------
 
 - **Documentation**: Removed unnecessary dependency in the quickstart-java example project.
+- **Documentation**: Remove the *Configure Maven* section from the installation instructions. This step is not needed anymore.
 - **SQL Extractor**: in JSON content, dates and timestamps are formatted like
   ``"2020-02-22"`` and ``"2020-02-22T12:13:14Z"`` rather than UNIX epoch offsets like
   ``18314`` or ``1582373594000000``.


### PR DESCRIPTION
The DAML Bintray repository is now accessible without
credentials. Therefore our users don't need to change their local
maven settings.xml file. Considering that this particular step has shown
to be somewhat a barrier or hurdle to overcome, I am removing the
instructions for the settings.xml setup, and adding a note to the java
bindings documentation about adding the repository to the project's
pom.xml file.

Fixes #1207.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
