### PR TITLE
windows: daml-ghc-deterministic test working

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -69,4 +69,5 @@ bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/test_execution_w
     //ledger-api/... `
     //navigator/backend/... `
     //daml-assistant/integration-tests/... `
+    //daml-foundations/daml-ghc:daml-ghc-deterministic `
     //daml-foundations/daml-tools/da-hs-damlc-app/...

--- a/daml-foundations/daml-ghc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/BUILD.bazel
@@ -154,6 +154,9 @@ sh_test(
         "//daml-foundations/daml-tools/da-hs-damlc-app",
         "@com_google_protobuf//:protoc",
     ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 # Generating DAML stdlib docs.

--- a/daml-foundations/daml-ghc/tests/daml-ghc-deterministic.sh
+++ b/daml-foundations/daml-ghc/tests/daml-ghc-deterministic.sh
@@ -2,6 +2,32 @@
 # All rights reserved.
 set -euo pipefail
 
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+TESTS_DIR=$(dirname $(rlocation "$TEST_WORKSPACE/daml-foundations/daml-ghc/tests/Examples.daml"))
+damlc=$(rlocation "$TEST_WORKSPACE/$1")
+protoc=$(rlocation "$TEST_WORKSPACE/$2")
+
 # Check that DAML compilation is deterministic.
 TMP_SRC1=$(mktemp -d)
 TMP_SRC2=$(mktemp -d)
@@ -12,11 +38,8 @@ cleanup () {
 }
 trap cleanup EXIT
 
-cp -r daml-foundations/daml-ghc/tests/* "$TMP_SRC1"
-cp -r daml-foundations/daml-ghc/tests/* "$TMP_SRC2"
-
-damlc="$PWD/$1"
-protoc="$PWD/$2"
+cp -r $TESTS_DIR/* "$TMP_SRC1"
+cp -r $TESTS_DIR/* "$TMP_SRC2"
 
 (cd "$TMP_SRC1" && $damlc compile "Examples.daml" -o "$TMP_OUT/out_1")
 (cd "$TMP_SRC2" && $damlc compile "Examples.daml" -o "$TMP_OUT/out_2")

--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -25,6 +25,6 @@
       "bash.exe -lc 'pacman -S --noconfirm unzip zip mingw-w64-x86_64-gcc'",
       "try { bash.exe -lc 'pacman -S --noconfirm tar diffutils' } catch { }",
       "mkdir $dir\\bin",
-      "cp $dir\\mingw64\\bin\\*.dll $dir\\bin"
+      "cp $dir\\mingw64\\bin\\*.dll $dir\\usr\\bin"
     ]
 }


### PR DESCRIPTION
`daml-ghc-deterministic` test using `rlocation` to make it work also on Windows

(msys2 dlls moved from `<msys2>/bin` to `<msys2>/usr/bin` as in contrast to other Bazel's bash calls `sh_test` use only the latter one, not both to populate the PATH. dlls are needed to run protoc.exe on windows.)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
