### PR TITLE
Ledger API authentication interceptor with plugin mechanism

### DIFF
--- a/ledger/ledger-api-authentication-api/BUILD.bazel
+++ b/ledger/ledger-api-authentication-api/BUILD.bazel
@@ -1,0 +1,16 @@
+load(
+    "//bazel_tools:java.bzl",
+    "da_java_library",
+)
+
+da_java_library(
+    name = "ledger-api-authentication-api",
+    srcs = glob(["src/main/java/**/*.java"]),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//3rdparty/jvm/io/grpc:grpc_core",
+    ],
+    tags = ["maven_coordinates=com.digitalasset.platform:ledger-api-authentication-api:__VERSION__"],
+)

--- a/ledger/ledger-api-authentication-api/src/main/java/com/digitalasset/ledger/server/authentication/api/LedgerApiAuthenticator.java
+++ b/ledger/ledger-api-authentication-api/src/main/java/com/digitalasset/ledger/server/authentication/api/LedgerApiAuthenticator.java
@@ -1,0 +1,5 @@
+package com.digitalasset.ledger.server.authentication.api;
+
+public interface LedgerApiAuthenticator {
+    boolean authenticate(String authenticationData);
+}

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -32,6 +32,7 @@ compileDependencies = [
     "//ledger/ledger-api-akka",
     "//ledger/ledger-api-scala-logging",
     "//language-support/scala/bindings",
+    "//ledger/ledger-api-authentication-api:ledger-api-authentication-api",
     "//ledger/ledger-api-domain:ledger-api-domain",
     "//ledger/ledger-api-common:ledger-api-common",
     "//ledger/ledger-api-client:ledger-api-client",

--- a/ledger/sandbox/src/main/resources/META-INF/services/com.digitalasset.ledger.server.authentication.api.LedgerApiAuthenticator
+++ b/ledger/sandbox/src/main/resources/META-INF/services/com.digitalasset.ledger.server.authentication.api.LedgerApiAuthenticator
@@ -1,0 +1,1 @@
+com.digitalasset.ledger.server.LedgerApiServer.authentication.OnlyBobAuthenticator

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/LedgerApiServer.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.stream.ActorMaterializer
 import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.digitalasset.ledger.server.LedgerApiServer.authentication.AuthenticationInterceptor
 import io.grpc.netty.NettyServerBuilder
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.handler.ssl.SslContext
@@ -85,6 +86,9 @@ class LedgerApiServer(
     builder.workerEventLoopGroup(serverEventLoopGroup)
     builder.permitKeepAliveTime(10, TimeUnit.SECONDS)
     builder.permitKeepAliveWithoutCalls(true)
+
+    builder.intercept(AuthenticationInterceptor.initialize())
+
     val grpcServer = apiServices.services.foldLeft(builder)(_ addService _).build
     try {
       grpcServer.start()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/authentication/AuthenticationInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/LedgerApiServer/authentication/AuthenticationInterceptor.scala
@@ -1,0 +1,40 @@
+package com.digitalasset.ledger.server.LedgerApiServer.authentication
+
+import java.util.{ServiceConfigurationError, ServiceLoader}
+
+import com.digitalasset.ledger.server.authentication.api.LedgerApiAuthenticator
+import com.typesafe.scalalogging.StrictLogging
+import io.grpc.Metadata.Key
+import io.grpc._
+
+import scala.collection.JavaConverters._
+
+class AuthenticationInterceptor private(authenticators: List[LedgerApiAuthenticator]) extends ServerInterceptor {
+
+  private val authenticationToken = Key.of("authentication_token", Metadata.ASCII_STRING_MARSHALLER)
+
+  override def interceptCall[ReqT, RespT](serverCall: ServerCall[ReqT, RespT], metadata: Metadata, serverCallHandler: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    val token = metadata.get(authenticationToken)
+    authenticators.foreach(auth => if (auth.authenticate(token)) throw new StatusRuntimeException(Status.PERMISSION_DENIED))
+    serverCallHandler.startCall(serverCall, metadata)
+  }
+}
+
+object AuthenticationInterceptor extends StrictLogging{
+  def initialize(): AuthenticationInterceptor = {
+    try {
+      val classpathAuthenticators = ServiceLoader.load(classOf[LedgerApiAuthenticator]).iterator().asScala.toList
+      new AuthenticationInterceptor(classpathAuthenticators)
+    } catch {
+      case ex: ServiceConfigurationError =>
+        logger.error("Error initializing AuthenticationInterceptor!", ex)
+        throw ex
+    }
+  }
+}
+
+class OnlyBobAuthenticator extends LedgerApiAuthenticator {
+  override def authenticate(authenticationData: String): Boolean = {
+    authenticationData == "Bob"
+  }
+}


### PR DESCRIPTION
# DRAFT DRAFT DRAFT

Quickly whipped together a gRPC interceptor with a pluggable authentication mechanism.
The class `OnlyBobAuthenticator` is detected at runtime (by being referenced in the [service file](https://github.com/digital-asset/daml/compare/ledger-api-authentication?expand=1#diff-438efb24c71f38e48262136c6b755be7).

All implementations of `LedgerApiAuthenticator` that are referenced in such a file are detected automatically and must permit access to auth token provided in the headers.

This is SUPER-WIP and only serves as a starting point for discussion which features 
* the authentication mechanism itself
* the plugin mechanism 
must provide.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
