### PR TITLE
Relax syntactic restriction on contract keys in DAML-LF 1.dev

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -11,12 +11,14 @@ import Data.Maybe
 import qualified Data.Text as T
 import           Control.Lens
 import           Control.Lens.Ast
+import           Data.Functor.Foldable
 import qualified Data.Graph as G
 import           Data.List.Extra (nubSort)
 import qualified Data.NameMap as NM
 
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.Optics
+import DA.Daml.LF.Ast.Recursive
 
 dvalName :: DefValue -> ExprValName
 dvalName = fst . dvalBinder
@@ -251,3 +253,9 @@ partitionDefinitions = foldr f ([], [], [])
 -- `ModuleName` type.
 moduleNameString :: ModuleName -> T.Text
 moduleNameString = T.intercalate "." . unTagged
+
+-- | Remove all location information from an expression.
+removeLocations :: Expr -> Expr
+removeLocations = cata $ \case
+    ELocationF _loc e -> e
+    b -> embed b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -67,6 +67,9 @@ featureContractKeys = Feature "Contract keys" version1_3
 featurePartyFromText :: Feature
 featurePartyFromText = Feature "partyFromText function" version1_2
 
+featureComplexContractKeys :: Feature
+featureComplexContractKeys = Feature "Complex contract keys" versionDev
+
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -32,6 +32,11 @@ version1_2 = V1 $ PointStable 2
 version1_3 :: Version
 version1_3 = V1 $ PointStable 3
 
+-- TODO(MH): Change this when freezing 1.dev into 1.4.
+version1_4 :: Version
+version1_4 = versionDev
+-- version1_4 = V1 $ PointStable 4
+
 -- | The DAML-LF version used by default.
 versionDefault :: Version
 versionDefault = version1_3
@@ -68,7 +73,7 @@ featurePartyFromText :: Feature
 featurePartyFromText = Feature "partyFromText function" version1_2
 
 featureComplexContractKeys :: Feature
-featureComplexContractKeys = Feature "Complex contract keys" versionDev
+featureComplexContractKeys = Feature "Complex contract keys" version1_4
 
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -430,9 +430,14 @@ encodeTemplate version Template{..} =
 encodeTemplateKey :: Version -> ExprVarName -> TemplateKey -> P.DefTemplate_DefKey
 encodeTemplateKey version templateVar TemplateKey{..} = checkFeature featureContractKeys version $ P.DefTemplate_DefKey
   { P.defTemplate_DefKeyType = encodeType version tplKeyType
-  , P.defTemplate_DefKeyKeyExpr = case exprToKeyExpr templateVar tplKeyBody of
-      Left err -> error err
-      Right x -> Just $ P.DefTemplate_DefKeyKeyExprKey $ encodeKeyExpr version x
+  , P.defTemplate_DefKeyKeyExpr =
+      if version `supports` featureComplexContractKeys
+      then
+          Just $ P.DefTemplate_DefKeyKeyExprComplexKey $ encodeExpr' version tplKeyBody
+      else
+          case exprToKeyExpr templateVar tplKeyBody of
+              Left err -> error err
+              Right x -> Just $ P.DefTemplate_DefKeyKeyExprKey $ encodeKeyExpr version x
   , P.defTemplate_DefKeyMaintainers = encodeExpr version tplKeyMaintainers
   }
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -557,7 +557,9 @@ checkTemplateKey param tcon TemplateKey{..} = do
     checkFeature featureContractKeys
     introExprVar param (TCon tcon) $ do
       checkType tplKeyType KStar
-      checkValidKeyExpr tplKeyBody
+      version <- getLfVersion
+      unless (version `supports` featureComplexContractKeys) $
+          checkValidKeyExpr tplKeyBody
       checkExpr tplKeyBody tplKeyType
     checkExpr tplKeyMaintainers (tplKeyType :-> TList TParty)
 

--- a/daml-foundations/daml-ghc/tests/RelaxedContractKeys.daml
+++ b/daml-foundations/daml-ghc/tests/RelaxedContractKeys.daml
@@ -1,0 +1,57 @@
+-- Check that the compiler bits of contract keys work.
+-- @SINCE-LF 1.4
+daml 1.2
+module RelaxedContractKeys where
+
+import DA.Assert
+
+template AccountInvitation with
+    account : Account
+  where
+    signatory account.bank
+
+    controller account.accountHolder can
+      Accept : ContractId Account
+        do create account
+
+template Account with
+    bank : Party
+    accountHolder : Party
+    accountNumber : (Text, Int)
+  where
+    signatory [bank, accountHolder]
+
+    key (bank, accountNumber._1 <> show (this.accountNumber._2)) : (Party, Text)
+    -- NOTE(MH): This duplication is intended to test both `this.bank` and `bank`.
+    maintainer [this.bank, bank]
+
+test = scenario do
+    bank <- getParty "Bank"
+    alice <- getParty "Alice"
+    let account = Account with
+            bank
+            accountHolder = alice
+            accountNumber = ("CH", 123)
+    let accountKey = key account
+    invitationCid <- submit bank do
+        create AccountInvitation with account
+    accountCid <- submit alice do
+        exercise invitationCid Accept
+
+    accountCid' <- submit bank do
+        lookupByKey accountKey
+    accountCid' === Some accountCid
+
+    (accountCid', account') <- submit bank do
+        fetchByKey accountKey
+    accountCid' === accountCid
+    account' === account
+
+template Singleton with
+    signatories : [Party]
+  where
+    signatory signatories
+    -- NOTE(MH): Check that the compiler rediscovers the sub-expression
+    -- of `key` in `maintainer`.
+    key (signatory this) : [Party]
+    maintainer (signatory this)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -202,6 +202,9 @@ private[validation] object Typing {
     private val supportsFlexibleControllers =
       LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "2"))
 
+    private val supportsComplexContractKeys =
+      LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "dev"))
+
     private def introTypeVar(v: TypeVarName, k: Kind): Env = {
       if (tVars.isDefinedAt(v))
         throw EShadowingTypeVar(ctx, v)
@@ -285,7 +288,9 @@ private[validation] object Typing {
       mbKey.foreach { key =>
         checkType(key.typ, KStar)
         env.checkExpr(key.body, key.typ)
-        checkValidKeyExpression(key.body)
+        if (!supportsComplexContractKeys) {
+          checkValidKeyExpression(key.body)
+        }
         checkExpr(key.maintainers, TFun(key.typ, TParties))
         ()
       }


### PR DESCRIPTION
We lift the syntactic restriction that contact keys must be built using
only record constructions and projections entirely when compiling to
DAML-LF 1.dev. To make this more useful, we also search all sub-expressions
of `maintainer` in `key` during our rewriting of `maintainer` for using
`this` to using `key`.

As one of our next steps we should bring `key` into scope in `maintainer`
and perhaps deprecate the use of `this` at some point in the future.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1219)
<!-- Reviewable:end -->
