### PR TITLE
Expose a testable ledger view

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,11 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+Java Bindings
+~~~~~~~~~~~~~
+
+- **Bots**: A class called LedgerTestView was added to make bot unit testing possible
+
 .. _release-0-12-18:
 
 0.12.18 - 2019-05-20

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/components/LedgerViewFlowable.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/components/LedgerViewFlowable.java
@@ -298,12 +298,12 @@ public class LedgerViewFlowable {
      */
     public static class LedgerView<R> {
 
-        private final PMap<String, PMap<Identifier, PSet<String>>> commandIdToContractIds;
-        private final PMap<Identifier, PMap<String, PSet<String>>> contractIdsToCommandIds;
-        private final PMap<Identifier, PMap<String, R>> pendingContractSet;
-        private final PMap<Identifier, PMap<String, R>> activeContractSet;
+        protected final PMap<String, PMap<Identifier, PSet<String>>> commandIdToContractIds;
+        protected final PMap<Identifier, PMap<String, PSet<String>>> contractIdsToCommandIds;
+        protected final PMap<Identifier, PMap<String, R>> pendingContractSet;
+        protected final PMap<Identifier, PMap<String, R>> activeContractSet;
 
-        private LedgerView(PMap<String, PMap<Identifier, PSet<String>>> commandIdToContractIds,
+        LedgerView(PMap<String, PMap<Identifier, PSet<String>>> commandIdToContractIds,
                            PMap<Identifier, PMap<String, PSet<String>>> contractIdsToCommandIds,
                            PMap<Identifier, PMap<String, R>> pendingContractSet,
                            PMap<Identifier, PMap<String, R>> activeContractSet) {
@@ -507,6 +507,30 @@ public class LedgerViewFlowable {
         public int hashCode() {
 
             return Objects.hash(commandIdToContractIds, contractIdsToCommandIds, pendingContractSet, activeContractSet);
+        }
+    }
+
+    /**
+     * A ledger view for unit testing of bots.
+     *
+     * @param <R> The type of the contracts in this application.
+     */
+    public static class LedgerTestView<R> extends LedgerView<R> {
+        public LedgerTestView(PMap<String, PMap<Identifier, PSet<String>>> commandIdToContractIds,
+                              PMap<Identifier, PMap<String, PSet<String>>> contractIdsToCommandIds,
+                              PMap<Identifier, PMap<String, R>> pendingContractSet,
+                              PMap<Identifier, PMap<String, R>> activeContractSet) {
+            super(commandIdToContractIds, contractIdsToCommandIds, pendingContractSet, activeContractSet);
+        }
+
+        @Override
+        public LedgerTestView<R> addActiveContract(Identifier templateId, String contractId, R r) {
+            LedgerView lv = super.addActiveContract(templateId, contractId, r);
+            return new LedgerTestView<R>(
+                    lv.commandIdToContractIds,
+                    lv.contractIdsToCommandIds,
+                    lv.pendingContractSet,
+                    lv.activeContractSet);
         }
     }
 }


### PR DESCRIPTION
### Description

This PR contains a Ledger View subclass that can be used for unit testing of Bots. It exposes the `add...` method to enable extension of the active contract set.

Note: I think no unit test is needed in this case as this is just a new class.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
