### PR TITLE
Add daml clean command

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -419,16 +419,15 @@ execBuild options mbOutFile = do
 -- | Remove any build artifacts if they exist.
 execClean :: IO ()
 execClean = do
-    withProjectRoot $ \relativize -> do
+    withProjectRoot $ \_relativize -> do
         isProject <- doesFileExist projectConfigName
         if isProject then do
             let removeAndWarn path = do
-                    rpath <- relativize path
                     whenM (doesDirectoryExist path) $ do
-                        putStrLn ("Removing directory " <> rpath)
+                        putStrLn ("Removing directory " <> path)
                         removePathForcibly path
                     whenM (doesFileExist path) $ do
-                        putStrLn ("Removing file " <> rpath)
+                        putStrLn ("Removing file " <> path)
                         removePathForcibly path
             removeAndWarn projectPackageDatabase
             removeAndWarn ".interfaces"

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -16,10 +16,18 @@ commands:
   path: damlc/da-hs-damlc-app
   args: ["build"]
   desc: "Build the current DAML project into a DAR file"
+- name: test
+  path: damlc/da-hs-damlc-app
+  args: ["test"]
+  desc: "Run the scenarios in the given DAML file and all dependencies"
 - name: start
   path: daml-helper/daml-helper
   args: ["start"]
   desc: "Launch Sandbox and Navigator for current DAML project"
+- name: clean
+  path: damlc/da-hs-damlc-app
+  args: ["clean"]
+  desc: "Delete build artifacts from project folder"
 - name: damlc
   path: damlc/da-hs-damlc-app
   desc: "Run the DAML compiler"
@@ -38,7 +46,3 @@ commands:
 - name: ide
   path: damlc/da-hs-damlc-app
   args: ["lax", "ide"]
-- name: test
-  path: damlc/da-hs-damlc-app
-  args: ["test"]
-  desc: "Run the scenarios in the given DAML file and all dependencies"


### PR DESCRIPTION
Adds a `daml clean` to delete build artifacts, and an integration test to ensure it doesn't drift out of sync with `daml build`. Fixes #1223 