### PR TITLE
Move packaging logic out of haskell-ide-core

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -18,7 +18,6 @@ module Development.IDE.Functions.Compile
   , typecheckModule
   , loadPackage
   , computePackageDeps
-  , generatePackageState
   ) where
 
 import           Development.IDE.Functions.Warnings
@@ -441,12 +440,6 @@ parsePragmasIntoDynFlags fp contents = catchSrcErrors $ do
     let opts = Hdr.getOptions dflags0 contents fp
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
     return dflags
-
-generatePackageState :: [FilePath] -> Bool -> [(String, ModRenaming)] -> IO PackageDynFlags
-generatePackageState paths hideAllPkgs pkgImports = do
-  let dflags = setPackageImports hideAllPkgs pkgImports $ setPackageDbs paths fakeDynFlags
-  (newDynFlags, _) <- initPackages dflags
-  pure $ getPackageDynFlags newDynFlags
 
 -- | Run something in a Ghc monad and catch the errors (SourceErrors and
 -- compiler-internal exceptions like Panic or InstallationError).

--- a/compiler/haskell-ide-core/src/Development/IDE/Orphans.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Orphans.hs
@@ -38,11 +38,3 @@ instance Show (GenLocated SrcSpan ModuleName) where show = prettyPrint
 instance Show PackageName where show = prettyPrint
 instance Show PackageState where show _ = "PackageState"
 instance Show Name where show = prettyPrint
-
-
--- Things which are defined in this module, but still orphan since I need
--- the definitions in this module
-
-deriving instance Show PackageDynFlags
-instance NFData PackageDynFlags where
-    rnf (PackageDynFlags db state insts) = db `seq` state `seq` rnf insts

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -33,7 +33,6 @@ import           Development.IDE.State.FileStore
 import           Development.IDE.Types.Diagnostics as Base
 import Data.Bifunctor
 import Data.Either.Extra
-import Development.IDE.UtilGHC
 import Data.Maybe
 import           Data.Foldable
 import qualified Data.Map.Strict                          as Map
@@ -45,7 +44,6 @@ import           Development.IDE.Types.LSP as Compiler
 import Development.IDE.State.RuleTypes
 
 import           GHC
-import HscTypes
 import Development.IDE.Compat
 import           UniqSupply
 import           Module                         as M
@@ -300,10 +298,7 @@ loadGhcSession :: Rules ()
 loadGhcSession =
     defineNoFile $ \GhcSession -> do
         opts <- envOptions <$> getServiceEnv
-        env <- Compile.optGhcSession opts
-        pkg <- liftIO $ Compile.generatePackageState
-            (Compile.optPackageDbs opts) (Compile.optHideAllPkgs opts) (Compile.optPackageImports opts)
-        return env{hsc_dflags = setPackageDynFlags pkg $ hsc_dflags env}
+        Compile.optGhcSession opts
 
 
 getHieFileRule :: Rules ()

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -23,8 +23,6 @@ data IdeOptions = IdeOptions
   , optWriteIface :: Bool
   , optExtensions :: [String]
 
-  , optMbPackageName :: Maybe String
-
   , optThreads :: Int
   , optShakeProfiling :: Maybe FilePath
   }

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -25,10 +25,6 @@ data IdeOptions = IdeOptions
 
   , optMbPackageName :: Maybe String
 
-  , optPackageDbs :: [FilePath]
-  , optHideAllPkgs :: Bool
-  , optPackageImports :: [(String, ModRenaming)]
-
   , optThreads :: Int
   , optShakeProfiling :: Maybe FilePath
   }

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -18,14 +18,14 @@ module Development.IDE.UtilGHC(
     runGhcEnv
     ) where
 
-import           Config
-import           Fingerprint
-import           GHC                         hiding (convertLit)
-import           GhcMonad
-import           GhcPlugins                  as GHC hiding (fst3, (<>))
-import           HscMain
-import           Platform
-import           Data.IORef
+import Config
+import Fingerprint
+import GHC
+import GhcMonad
+import GhcPlugins
+import HscMain
+import Platform
+import Data.IORef
 import Control.Exception
 import FileCleanup
 

--- a/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/UtilGHC.hs
@@ -14,7 +14,6 @@ module Development.IDE.UtilGHC(
     modifyDynFlags,
     fakeDynFlags,
     prettyPrint,
-    runGhcFast,
     runGhcEnv
     ) where
 
@@ -23,7 +22,6 @@ import Fingerprint
 import GHC
 import GhcMonad
 import GhcPlugins
-import HscMain
 import Platform
 import Data.IORef
 import Control.Exception
@@ -64,19 +62,6 @@ runGhcEnv env act = do
         cleanTempFiles dflags
         cleanTempDirs dflags
 
-
--- | Like 'runGhc' but much faster (400x), with less IO and no file dependency
-runGhcFast :: Ghc a -> IO a
--- copied from GHC with the nasty bits dropped
-runGhcFast act = do
-  ref <- newIORef (error "empty session")
-  let session = Session ref
-  flip unGhc session $ do
-    dflags <- liftIO $ initDynFlags fakeDynFlags
-    liftIO $ setUnsafeGlobalDynFlags dflags
-    env <- liftIO $ newHscEnv dflags
-    setSession env
-    withCleanupSession act
 
 -- Fake DynFlags which are mostly undefined, but define enough to do a little bit
 fakeDynFlags :: DynFlags

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -160,7 +160,7 @@ newIdeState compilerOpts mbEventHandler loggerH = do
   -- but shake will report them when typechecking anything.
   (_diags, pkgMap) <- liftIO $ CompilerService.generatePackageMap (optPackageDbs compilerOpts)
   let rule = do
-        CompilerService.mainRule
+        CompilerService.mainRule compilerOpts
         Shake.addIdeGlobal $ GlobalPkgMap pkgMap
   liftIO $ CompilerService.initialise rule mbEventHandler (toIdeLogger loggerH) compilerOpts mbScenarioService
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
@@ -82,7 +82,6 @@ toCompileOpts Options{..} =
           }
       , optWriteIface = optWriteInterface
       , optExtensions = ["daml"]
-      , optMbPackageName = optMbPackageName
       , optThreads = optThreads
       , optShakeProfiling = optShakeProfiling
       }

--- a/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
@@ -106,7 +106,7 @@ runShakeTest mbScenarioService (ShakeTest m) = do
     virtualResources <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()
-    service <- API.initialise mainRule (Just (atomically . eventLogger)) Logger.makeNopHandle options mbScenarioService
+    service <- API.initialise (mainRule options) (Just (atomically . eventLogger)) Logger.makeNopHandle options mbScenarioService
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv
                 { steService = service

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     -- initialise the compiler service
     pure $
       withResource
-      (Compile.initialise Compile.mainRule (Just (\_ -> pure ())) IdeLogger.makeNopHandle opts (Just scenarioService))
+      (Compile.initialise (Compile.mainRule opts) (Just (\_ -> pure ())) IdeLogger.makeNopHandle opts (Just scenarioService))
       Compile.shutdown $ \service ->
       withTestArguments $ \args -> testGroup ("Tests for DAML-LF " ++ renderPretty version) $
         map (testCase args version service outdir registerTODO) files


### PR DESCRIPTION
This pushes all the gunk we didn't want in haskell-ide-core out towards the daml-ghc piece. I suspect it can be further simplified now we are using the GHC name cache, but leave that for future work. Removes 4 fields from the IdeOptions field.

There's almost no code changes, just code moves.