### PR TITLE
making Netty's EventLoopGroup shutdown's eager

### DIFF
--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
@@ -198,7 +198,9 @@ final class Server private (
     logger.info("Shutting down server...")
     server.shutdownNow()
     assume(server.awaitTermination(10, TimeUnit.SECONDS))
-    serverEventLoopGroup.shutdownGracefully().await(10L, TimeUnit.SECONDS)
+    serverEventLoopGroup
+      .shutdownGracefully(0, 0, TimeUnit.SECONDS)
+      .await(10, TimeUnit.SECONDS)
     serverEsf.close()
   }
 }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/RemoteServerResource.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/RemoteServerResource.scala
@@ -58,7 +58,9 @@ class RemoteServerResource(host: String, port: Int, tlsConfig: Option[TlsConfigu
   override def close(): Unit = {
     channel.shutdownNow()
     channel.awaitTermination(1L, TimeUnit.SECONDS)
-    eventLoopGroup.shutdownGracefully().await(1L, TimeUnit.SECONDS)
+    eventLoopGroup
+      .shutdownGracefully(0, 0, TimeUnit.SECONDS)
+      .await(10L, TimeUnit.SECONDS)
     channel = null
     eventLoopGroup = null
   }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/SandboxServerResource.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/SandboxServerResource.scala
@@ -52,7 +52,9 @@ class SandboxServerResource(sandboxConfig: SandboxConfig) extends Resource[Platf
   override def close(): Unit = {
     channel.shutdownNow()
     channel.awaitTermination(5L, TimeUnit.SECONDS)
-    eventLoopGroup.shutdownGracefully().await(10L, TimeUnit.SECONDS)
+    eventLoopGroup
+      .shutdownGracefully(0, 0, TimeUnit.SECONDS)
+      .await(10L, TimeUnit.SECONDS)
     sandboxServer.close()
     channel = null
     eventLoopGroup = null

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
@@ -46,7 +46,9 @@ class SandboxServerResource(config: => SandboxConfig) extends Resource[Channel] 
 
   override def close(): Unit = {
     channel.shutdownNow()
-    eventLoopGroup.shutdownGracefully().await(10L, TimeUnit.SECONDS)
+    eventLoopGroup
+      .shutdownGracefully(0, 0, TimeUnit.SECONDS)
+      .await(10L, TimeUnit.SECONDS)
     sandboxServer.close()
     channel = null
     eventLoopGroup = null


### PR DESCRIPTION
This change is mostly motivated by flaky hanging perf-tests, where the lingering is traced back to 
closing a `NioEventLoopGroup`. We had related problems earlier with the 2s default quitePeriod and decided to use eager shutdowns. See notes here: https://github.com/digital-asset/daml/blob/4328d27c80a59faafbc82fc1fb7413a281cf6a2c/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/LedgerApiServer.scala#L131

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
