### PR TITLE
Set program name of daml-helper to daml

### DIFF
--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -4,11 +4,12 @@ module Main (main) where
 
 import Data.Foldable
 import Options.Applicative.Extended
+import System.Environment
 
 import DamlHelper
 
 main :: IO ()
-main = runCommand =<< customExecParser parserPrefs (info (commandParser <**> helper) idm)
+main = withProgName "daml" $ runCommand =<< customExecParser parserPrefs (info (commandParser <**> helper) idm)
   where parserPrefs = prefs showHelpOnError
 
 data Command


### PR DESCRIPTION
This prevents "daml new --help" and similar commands from showing
"daml-helper" instead of "daml".

This addresses part 1 of #1221 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
