### PR TITLE
Reject transaction filters without any party

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,13 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+Ledger
+~~~~~~
+
+- Transaction filters in `GetTransactionsRequest` without any party are now rejected with `INVALID_ARGUMENT` instead of yielding an empty stream
+
+  See `#1250 <https://github.com/digital-asset/daml/issues/1250>`__ for details.
+
 .. _release-0-12-18:
 
 0.12.18 - 2019-05-20

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -9,7 +9,7 @@ import com.digitalasset.ledger.api.domain.InclusiveFilters
 import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
 import com.digitalasset.ledger.api.v1.value.Identifier
 import com.digitalasset.platform.server.api.validation.FieldValidations._
-import com.digitalasset.platform.server.api.validation.IdentifierResolver
+import com.digitalasset.platform.server.api.validation.{ErrorFactories, IdentifierResolver}
 import com.digitalasset.platform.server.api.validation.FieldValidations._
 import io.grpc.StatusRuntimeException
 import scalaz.Traverse
@@ -22,15 +22,19 @@ class TransactionFilterValidator(identifierResolver: IdentifierResolver) {
   def validate(
       txFilter: TransactionFilter,
       fieldName: String): Either[StatusRuntimeException, domain.TransactionFilter] = {
-    val convertedFilters =
-      txFilter.filtersByParty.toList.traverseU {
-        case (k, v) =>
-          for {
-            key <- requireParty(k)
-            value <- validateFilters(v)
-          } yield key -> value
-      }
-    convertedFilters.map(m => domain.TransactionFilter(m.toMap))
+    if (txFilter.filtersByParty.isEmpty) {
+      Left(ErrorFactories.invalidArgument("filtersByParty cannot be empty"))
+    } else {
+      val convertedFilters =
+        txFilter.filtersByParty.toList.traverseU {
+          case (k, v) =>
+            for {
+              key <- requireParty(k)
+              value <- validateFilters(v)
+            } yield key -> value
+        }
+      convertedFilters.map(m => domain.TransactionFilter(m.toMap))
+    }
   }
 
   def validateFilters(filters: Filters): Either[StatusRuntimeException, domain.Filters] = {

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -81,21 +81,15 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
           "Missing field: filter")
       }
 
-      "tolerate empty filter" in {
-        inside(
+      "return the correct error on empty filter" in {
+        requestMustFailWith(
           sut.validate(
             txReq.update(_.filter.filtersByParty := Map.empty),
             ledgerEnd,
-            offsetOrdering)) {
-          case Right(req) =>
-            req.ledgerId shouldEqual expectedLedgerId
-            req.begin shouldEqual domain.LedgerOffset.LedgerBegin
-            req.end shouldEqual Some(domain.LedgerOffset.Absolute(absoluteOffset))
-            val filtersByParty = req.filter.filtersByParty
-            filtersByParty should have size 0
-            req.verbose shouldEqual verbose
-            hasExpectedTraceContext(req)
-        }
+            offsetOrdering),
+          INVALID_ARGUMENT,
+          "Invalid argument: filtersByParty cannot be empty"
+        )
       }
 
       "return the correct error on missing begin" in {

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -145,11 +145,15 @@ class TransactionServiceIT
           }
       }
 
-      "respond with empty stream if TransactionFilter is empty" in allFixtures { context =>
-        context.transactionClient
-          .getTransactions(ledgerBegin, None, TransactionFilter())
-          .runWith(Sink.seq)
-          .map(_ shouldBe empty)
+      "return INVALID_ARGUMENT if TransactionFilter is empty" in allFixtures { context =>
+        for {
+          error <- context.transactionClient
+            .getTransactions(ledgerBegin, None, TransactionFilter())
+            .runWith(Sink.seq)
+            .failed
+        } yield {
+          IsStatusException(Status.INVALID_ARGUMENT)(error)
+        }
       }
 
       "complete the stream by itself as soon as LedgerEnd is hit" in allFixtures { context =>


### PR DESCRIPTION
Fixes #1250

The previous behavior when receiving a transaction filter without any
party was to reply with an empty stream. Since, given the current
situation, no data could ever be served for such request, it represents
a better feedback for the user to reject such requests as carrying an
`INVALID_ARGUMENT`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
