### PR TITLE
webide: bugfix for content policy

### DIFF
--- a/web-ide/proxy/src/config.json
+++ b/web-ide/proxy/src/config.json
@@ -4,6 +4,7 @@
         "port" : 3000,
         "managementPort" : 3001,
         "httpToHttpsPort" : 3002,
+        "hostname" : "localhost",
         "secureHeaders" :true
     },
     "session" : {

--- a/web-ide/proxy/src/docker.ts
+++ b/web-ide/proxy/src/docker.ts
@@ -77,6 +77,7 @@ export default class Docker {
             const createOptions = { HostConfig: config.docker.hostConfig }
             if (!this.onInternalNetwork && config.devMode) createOptions.HostConfig.PublishAllPorts=true
 
+            debug("sending run api command")
             const runner = this.api.run(imageId, ["code-server", "--no-auth", "--allow-http", "--disable-telemetry"], [], createOptions, (err :any, result :any) => {
                 if (err) reject(err) 
             })
@@ -86,7 +87,7 @@ export default class Docker {
                     cResolve(container)
                 })
             })
-            runner.on('container', (container :Container) => debug(`created container ${container.id}`))
+            runner.on('container', (container :Container) => { debug(`created container ${container.id}`) })
             runner.on('stream', (stream :Stream) => {
                 let started = false
                 stream.pipe(process.stdout) //TODO should we create context aware log messages per container (including the user session info)??

--- a/web-ide/proxy/src/proxy.ts
+++ b/web-ide/proxy/src/proxy.ts
@@ -48,7 +48,8 @@ http.createServer(httpToHttpsApp).listen(conf.http.httpToHttpsPort, () => {
 
 if (!conf.http.port) throw new Error("MUST configure port for webide: 'conf.http.port'")
 const webideServer = createWebIdeServer()
-if (conf.secureHeaders || conf.secureHeaders === undefined) {
+if (conf.http.secureHeaders || conf.http.secureHeaders === undefined) {
+    console.log("INFO adding security headers")
     webIdeApp.use((req, res, next) => {
         addSecureHeaders(res, conf)
         next()
@@ -143,5 +144,5 @@ function addSecureHeaders(res :Response, config :any) {
     res.setHeader("X-Frame-Options", "sameorigin")
     res.setHeader("X-XSS-Protection", "1; mode=block")
     res.setHeader("Referrer-Policy", "no-referrer-when-downgrade")
-    res.setHeader("Content-Security-Policy", `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;`)
+    res.setHeader("Content-Security-Policy", `default-src 'self'; connect-src 'self' ws://${config.http.hostname}:${config.http.port}/; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:;`)
 }

--- a/web-ide/proxy/src/session.ts
+++ b/web-ide/proxy/src/session.ts
@@ -28,8 +28,12 @@ export function onTimeout(callback: Callback<any>) {
   });
 }
 
-function remove(sessionId :string) {
-  store.del(sessionId)
+/**
+ * explicit synchronous getter in case we need state current state
+ * @param sessionId 
+ */
+export function getStateSync(sessionId :string) :any {
+  return store.get(sessionId)
 }
 
 /**
@@ -122,7 +126,7 @@ function save(sessionId :string, state :any) :boolean {
         store.del(sessionId)
       }, delay)
     }
-    return store.set(sessionId, state)
+    return store.set(sessionId, state, 0)
 }
 
 function generateSessionId() {


### PR DESCRIPTION
* safari has stricter intepretations of the policy. This adds explicit
web socket connect-src field

* bugfix for multiple requests for webpage in a very small amount of
time. This would previously start up multiple containers

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
