### PR TITLE
Install the Windows SDK on CI nodes

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -85,10 +85,11 @@ iex (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/ins
 
 # Install git, bash
 & choco install git --no-progress --yes 2>&1 | %{ "$_" }
+& choco install windows-sdk-10.1 --no-progress --yes 2>&1 | %{ "$_" }
 
 # Add tools to the PATH
 $OldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
-$NewPath = "$OldPath;C:\Program Files\Git\bin"
+$NewPath = "$OldPath;C:\Program Files\Git\bin;C:\Program Files (x86)\Windows Kits\10\App Certification Kit"
 Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $NewPath
 
 echo "== Prepare the D:\ drive"


### PR DESCRIPTION
This provides signtool.exe which we need to sign our Windows installer.

I don’t have any permissions to test or apply the terraform changes but I tried this out on my local Windows machine and it seems to work. It is somewhat annoying that we have to get this via chocolatey instead of via scoop (and thereby via dev-env) but the Windows SDK is not available via scoop.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
