### PR TITLE
Make daml test, build, clean check if running in project.

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -20,7 +20,6 @@ type Document = Pretty.Doc Pretty.SyntaxClass
 newtype DontDivulgeContractIdsInCreateArguments = DontDivulgeContractIdsInCreateArguments Bool
 newtype DontDiscloseNonConsumingChoicesToObservers = DontDiscloseNonConsumingChoicesToObservers Bool
 
-
 -- | Document rendering styles for console output.
 data Style
   = Plain
@@ -109,7 +108,6 @@ versionOpt :: Parser String
 versionOpt = argument str $
         metavar "VERSION"
     <> help "Artifact's version"
-
 
 lfVersionOpt :: Parser LF.Version
 lfVersionOpt = option (str >>= select) $
@@ -233,7 +231,6 @@ ekgPortOpt = option (str >>= parse) $
       Nothing -> readerError $ "Invalid port '" <> cs <> "'."
       p       -> pure p
 
-
 verboseOpt :: Parser Bool
 verboseOpt = switch $
        long "verbose"
@@ -254,6 +251,12 @@ experimentalOpt =
     fmap Experimental $
     switch $
     help "Enable experimental IDE features" <> long "experimental"
+
+newtype ProjectCheck = ProjectCheck Bool
+projectCheckOpt :: Parser ProjectCheck
+projectCheckOpt = fmap ProjectCheck . switch $
+       help "Check if running in DAML project."
+    <> long "project-check"
 
 data Telemetry = OptedIn | OptedOut | Undecided
 telemetryOpt :: Parser Telemetry

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -14,11 +14,11 @@ commands:
   args: ["init"]
 - name: build
   path: damlc/da-hs-damlc-app
-  args: ["build"]
+  args: ["build", "--project-check"]
   desc: "Build the current DAML project into a DAR file"
 - name: test
   path: damlc/da-hs-damlc-app
-  args: ["test"]
+  args: ["test", "--project-check"]
   desc: "Run the scenarios in the given DAML file and all dependencies"
 - name: start
   path: daml-helper/daml-helper
@@ -26,7 +26,7 @@ commands:
   desc: "Launch Sandbox and Navigator for current DAML project"
 - name: clean
   path: damlc/da-hs-damlc-app
-  args: ["clean"]
+  args: ["clean", "--project-check"]
   desc: "Delete build artifacts from project folder"
 - name: damlc
   path: damlc/da-hs-damlc-app


### PR DESCRIPTION
* added a `--project-check` option in damlc test, build, and clean commands, that will cause these commands to fail when run outside a DAML project.
* passing `--project-check` automatically when running these commands directly threough the assistant, as `daml test`, `daml build`, and `daml clean`. 

Fixes #1215. Fixes #1222.