### PR TITLE
Fixes #1280 docs: Fix the inclusion of the Javadocs into the docs.

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -186,8 +186,8 @@ genrule(
             exit 1
         fi
 
-        # Copy Javadoc using unzip to avoid having to know the path to the 'jar' binary.
-        unzip -f ../$(locations //language-support/java:javadoc) -d html/app-dev/bindings-java
+        # Copy Javadoc using unzip to avoid having to know the path to the 'jar' binary. Note flag to overwrite
+        unzip -o ../$(locations //language-support/java:javadoc) -d html/app-dev/bindings-java/javadocs
 
         # Copy in hoogle DB
         mkdir -p html/hoogle_db


### PR DESCRIPTION
Fix problems with unpacking the Javadocs into the documentation build.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
