### PR TITLE
[ci/linux] restart fluentd after installing

### DIFF
--- a/infra/vsts_agent_linux_startup.sh
+++ b/infra/vsts_agent_linux_startup.sh
@@ -29,6 +29,7 @@ apt-get install -qy \
   netcat
 
 curl -sSL https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+systemctl restart google-fluentd.service
 
 ## Install the VSTS agent
 groupadd --gid 3000 vsts


### PR DESCRIPTION
It looks like the curl command is currently installing but not starting the service that is supposed to send logs to StackDriver. When connecting to the machines manually, a call to `restart` seems to fix it.