### PR TITLE
Fold "damlc package-new" into "damlc build" and hide "damlc compile"

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -7,7 +7,7 @@ module DA.Cli.Options
 
 import qualified Data.Text           as T
 import           Data.List.Extra     (trim, splitOn)
-import           Options.Applicative
+import Options.Applicative.Extended
 import Data.List
 import Text.Read
 import qualified DA.Pretty           as Pretty
@@ -257,6 +257,10 @@ projectCheckOpt :: Parser ProjectCheck
 projectCheckOpt = fmap ProjectCheck . switch $
        help "Check if running in DAML project."
     <> long "project-check"
+
+newtype InitPkgDb = InitPkgDb Bool
+initPkgDbOpt :: Parser InitPkgDb
+initPkgDbOpt = InitPkgDb <$> flagYesNoAuto "init-package-db" True "Initialize package database"
 
 data Telemetry = OptedIn | OptedOut | Undecided
 telemetryOpt :: Parser Telemetry


### PR DESCRIPTION
The only difference between `damlc package-new` and `damlc build` was
that `package-new` did not initialize the package database. This
commit adds a `--init-package-db=yes/no/auto` flag to control
initialization of the package database.

I’ve also hidden compile since it should only be used for testing and
debugging purposes.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
