### PR TITLE
Add more tests for (un)serializable contract ids

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -6,7 +6,7 @@ package com.digitalasset.daml.lf.validation
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.digitalasset.daml.lf.lfpackage.Ast._
-import com.digitalasset.daml.lf.lfpackage.Util.{TContractId, TList, TOptional, TMap}
+import com.digitalasset.daml.lf.lfpackage.Util.{TContractId, TList, TMap, TOptional}
 
 private[validation] object Serializability {
 
@@ -33,8 +33,12 @@ private[validation] object Serializability {
 
     def checkType(typ0: Type): Unit = typ0 match {
       case TContractId(TTyCon(tCon)) =>
-        lookupTemplate(ctx, tCon)
-        ()
+        lookupDataType(ctx, tCon) match {
+          case DDataType(_, _, DataRecord(_, Some(_))) =>
+            ()
+          case _ =>
+            unserializable(URContractId)
+        }
       case TVar(name) =>
         if (!vars(name)) unserializable(URFreeVar(name))
       case TTyCon(tycon) =>


### PR DESCRIPTION
I want to lift this restriction in a subsequent PR for the next version
of DAML-LF. Let's first make sure we have a correct implementation for the
current version though.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1296)
<!-- Reviewable:end -->
