### PR TITLE
Disallow empty record updates

### DIFF
--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -292,7 +292,7 @@ parseRange s =
         Range
             (Position (rowStart - 1) (colStart - 1))
             (Position (rowEnd - 1) (colEnd - 1))
-    _ -> noRange
+    _ -> error $ "Failed to parse range, got " ++ s
 
 mainProj :: TestArguments -> Compile.IdeState -> FilePath -> (String -> IO ()) -> FilePath -> IO LF.Package
 mainProj TestArguments{..} service outdir log file = do

--- a/daml-foundations/daml-ghc/tests/EmptyWith.daml
+++ b/daml-foundations/daml-ghc/tests/EmptyWith.daml
@@ -1,0 +1,18 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ERROR range=18:12-19:1; Empty record update
+daml 1.2
+module EmptyWith where
+
+data Foo = Foo with -- this should be fine
+
+data Bar = Bar with
+  bar : Int
+
+create = Foo with -- this should be fine
+
+match (Bar with) = 1 -- this should be fine
+
+update : Bar -> Bar
+update x = x with -- this should be an error (according to Haskell)

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -34,6 +34,8 @@ Java Bindings
 DAML
 ~~~~
 
+- **BREAKING CHANGE - Syntax**: Records with empty update blocks, e.g. ``foo with``, is now an error (the fact it was ever accepted was a bug).
+
 - **BREAKING CHANGE - Contract Keys**: Before, maintainers were incorrectly not checked to be a subset of the signatories, now they are. See `issue #1123 <https://github.com/digital-asset/daml/issues/1123>`__
 
 Sandbox


### PR DESCRIPTION
The record preprocessor was inadvertently transforming `e{}` into `e`. The former is an error in Haskell, but detected during renaming, so we were missing that error. I now avoid transforming such updates.