### PR TITLE
Fix an issue in module chasing caused by unnormalized file paths

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -233,7 +233,12 @@ runGhcSession IdeOptions{..} modu env act = runGhcEnv env $ do
 moduleImportPaths :: GHC.ParsedModule -> Maybe FilePath
 moduleImportPaths pm
   | rootModDir == "." = Just rootPathDir
-  | otherwise = dropTrailingPathSeparator <$> stripSuffix rootModDir rootPathDir
+  | otherwise =
+    -- TODO (MK) stripSuffix (normalise rootModDir) (normalise rootPathDir)
+    -- would be a better choice but at the moment we do not consistently
+    -- normalize file paths in the Shake graph so we can end up with the
+    -- same module being represented twice in the Shake graph.
+    Just $ dropTrailingPathSeparator $ dropEnd (length rootModDir) rootPathDir
   where
     ms   = GHC.pm_mod_summary pm
     file = GHC.ms_hspp_file ms


### PR DESCRIPTION
On Windows we can end up with rootModDir having / in the filepath
while rootPathDir uses \ so stripSuffix didn’t work.

This fixes #1284

As mentioned in the comment, this is a somewhat ugly workaround but I’d like to wait until @DavidM-D’s filepath changes land before attempting to fix this properly.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
