### PR TITLE
force replacement of old test-interface

### DIFF
--- a/3rdparty/dependencies.digest
+++ b/3rdparty/dependencies.digest
@@ -1,1 +1,1 @@
-57cefaabfeddb8747b1fc5f7554c412c247ea337  dependencies.yaml
+7d42b6a87018f028d0dad3a48c5810d38fdf7e8a  dependencies.yaml

--- a/3rdparty/dependencies.digest
+++ b/3rdparty/dependencies.digest
@@ -1,1 +1,1 @@
-7d42b6a87018f028d0dad3a48c5810d38fdf7e8a  dependencies.yaml
+643a5531d82d832abd2af7322385afa1e8b56449  dependencies.yaml

--- a/3rdparty/jvm/com/storm_enroute/BUILD
+++ b/3rdparty/jvm/com/storm_enroute/BUILD
@@ -13,7 +13,7 @@ scala_import(
         "//3rdparty/jvm/org/scala_lang/modules:scala_parser_combinators",
         "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
         "//3rdparty/jvm/org/scala_lang:scala_library",
-        "//3rdparty/jvm/org/scala_sbt:test_interface",
+        "//3rdparty/jvm/org/scala_tools/testing:test_interface",
         ":scalameter_core"
     ],
     jars = [

--- a/3rdparty/jvm/org/scala_tools/testing/BUILD
+++ b/3rdparty/jvm/org/scala_tools/testing/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
 java_library(
     name = "test_interface",
     exports = [
-        "//external:jar/org/scala_sbt/test_interface"
+        "//3rdparty/jvm/org/scala_sbt:test_interface"
     ],
     visibility = [
         "//3rdparty/jvm:__subpackages__"

--- a/3rdparty/jvm/org/scala_tools/testing/BUILD
+++ b/3rdparty/jvm/org/scala_tools/testing/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
 java_library(
     name = "test_interface",
     exports = [
-        "//external:jar/org/scala_tools/testing/test_interface"
+        "//external:jar/org/scala_sbt/test_interface"
     ],
     visibility = [
         "//3rdparty/jvm:__subpackages__"

--- a/3rdparty/jvm/org/scala_tools/testing/BUILD
+++ b/3rdparty/jvm/org/scala_tools/testing/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
 java_library(
     name = "test_interface",
     exports = [
-        "//external:jar/org/scala_sbt/test_interface"
+        "//external:jar/org/scala_tools/testing/test_interface"
     ],
     visibility = [
         "//3rdparty/jvm:__subpackages__"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -581,5 +581,5 @@ replacements:
       target: "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators"
   org.scala-tools.testing:
     test-interface:
-      lang: scala/unmangled
-      target: "//3rdparty/jvm/org/scala_sbt:test_interface"
+      lang: java
+      target: "//external:jar/org/scala_sbt/test_interface"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -579,3 +579,7 @@ replacements:
     scala-parser-combinators:
       lang: scala
       target: "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators"
+  org.scala-tools.testing:
+    test-interface:
+      lang: scala/unmangled
+      target: "//3rdparty/jvm/org/scala_sbt:test_interface"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -582,4 +582,4 @@ replacements:
   org.scala-tools.testing:
     test-interface:
       lang: java
-      target: "//external:jar/org/scala_sbt/test_interface"
+      target: "//3rdparty/jvm/org/scala_sbt:test_interface"


### PR DESCRIPTION
force replacement of `org/scala-tools/testing/test-interface/0.5/test-interface`  with `org/scala-sbt/test-interface/1.0/test-interface`