### PR TITLE
IndexService independent from participant-state

### DIFF
--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -230,6 +230,11 @@ object domain {
   type ApplicationId = String @@ ApplicationIdTag
   val ApplicationId: Tag.TagOf[ApplicationIdTag] = Tag.of[ApplicationIdTag]
 
+  sealed trait AbsoluteNodeIdTag
+
+  type AbsoluteNodeId = String @@ AbsoluteNodeIdTag
+  val AbsoluteNodeId: Tag.TagOf[AbsoluteNodeIdTag] = Tag.of[AbsoluteNodeIdTag]
+
   case class Commands(
       ledgerId: LedgerId,
       workflowId: Option[WorkflowId],

--- a/ledger/participant-state-index/BUILD.bazel
+++ b/ledger/participant-state-index/BUILD.bazel
@@ -13,17 +13,28 @@ compileDependencies = [
     "//daml-lf/data",
     "//daml-lf/transaction",
     "//ledger/ledger-api-domain",
-    "//ledger/participant-state",
 ]
 
 da_scala_library(
     name = "participant-state-index",
-    srcs = glob(["src/main/scala/**/*.scala"]),
+    srcs = glob(["src/main/scala/com/daml/ledger/participant/state/index/v1/*.scala"]),
     resources = glob(["src/main/resources/**/*"]),
     tags = ["maven_coordinates=com.daml.ledger:participant-state-index:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],
     runtime_deps = [],
-    deps = compileDependencies,
+    deps = compileDependencies + ["//ledger/participant-state"],
+)
+
+da_scala_library(
+    name = "participant-state-index-v2",
+    srcs = glob(["src/main/scala/com/daml/ledger/participant/state/index/v2/*.scala"]),
+    resources = glob(["src/main/resources/**/*"]),
+    #    tags = ["maven_coordinates=com.daml.ledger:participant-state-index:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    runtime_deps = [],
+    deps = compileDependencies + ["//3rdparty/jvm/org/scalaz:scalaz_core"],
 )

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ActiveContractsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ActiveContractsService.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.digitalasset.ledger.api.domain.TransactionFilter
+
+import scala.concurrent.Future
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService]]
+  **/
+trait ActiveContractsService {
+
+  def getActiveContractSetSnapshot(
+      filter: TransactionFilter
+  ): Future[ActiveContractSetSnapshot]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/CompletionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/CompletionsService.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerOffset}
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionService]]
+  **/
+trait CompletionsService {
+  def getCompletions(
+      begin: Option[LedgerOffset],
+      applicationId: ApplicationId,
+      parties: List[Ref.Party]
+  ): Source[CompletionEvent, NotUsed]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ConfigurationService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ConfigurationService.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.ledger_configuration_service.LedgerConfigurationServiceGrpc.LedgerConfigurationService]]
+  **/
+trait ConfigurationService {
+  def getLedgerConfiguration(): Source[LedgerConfiguration, NotUsed]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
+
+import scala.concurrent.Future
+
+/**
+  * Meant be used for optimistic contract lookups before command submission.
+  */
+trait ContractStore {
+  def lookupActiveContract(
+      submitter: Ref.Party,
+      contractId: AbsoluteContractId
+  ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]]
+
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IdentityService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IdentityService.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.digitalasset.ledger.api.domain.LedgerId
+
+import scala.concurrent.Future
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService]]
+  **/
+trait IdentityService {
+  def getLedgerId(): Future[LedgerId]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexService.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+trait IndexService
+    extends PackagesService
+    with ConfigurationService
+    with CompletionsService
+    with TransactionsService
+    with ActiveContractsService
+    with ContractStore
+    with IdentityService
+    with TimeService

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PackagesService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PackagesService.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.digitalasset.daml.lf.data.Ref.PackageId
+import com.digitalasset.daml_lf.DamlLf.Archive
+
+import scala.concurrent.Future
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc.PackageService]]
+  */
+trait PackagesService {
+  def listPackages(): Future[Set[PackageId]]
+
+  def getPackage(packageId: PackageId): Future[Option[Archive]]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/RejectionReason.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/RejectionReason.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+sealed trait RejectionReason {
+  val description: String
+}
+
+object RejectionReason {
+
+  /** The transaction relied on contracts being active that were no longer
+    * active at the point where it was sequenced.
+    */
+  final case class Inconsistent(description: String) extends RejectionReason
+
+  /** The Participant node did not have sufficient resource quota with the
+    * to submit the transaction.
+    */
+  final case class OutOfQuota(description: String) extends RejectionReason
+
+  /** The transaction submission timed out.
+    *
+    * This means the 'maximumRecordTime' was smaller than the recordTime seen
+    * in an event in the Participant node.
+    */
+  final case class TimedOut(description: String) extends RejectionReason
+
+  /** The transaction submission was disputed.
+    *
+    * This means that the underlying ledger and its validation logic
+    * considered the transaction potentially invalid. This can be due to a bug
+    * in the submission or validiation logic, or due to malicious behaviour.
+    */
+  final case class Disputed(description: String) extends RejectionReason
+
+  /** The participant node has already seen a command with the same commandId
+    * during its implementation specific deduplication window.
+    *
+    * TODO (SM): explain in more detail how command de-duplication should
+    * work.
+    */
+  final case class DuplicateCommandId(description: String) extends RejectionReason
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/TimeService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/TimeService.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.digitalasset.daml.lf.data.Time
+
+/** Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService]]
+  */
+trait TimeService {
+  def getLedgerRecordTimeStream(): Source[Time.Timestamp, NotUsed]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/TransactionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/TransactionsService.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.ledger.api.domain.{LedgerOffset, TransactionFilter, TransactionId}
+
+import scala.concurrent.Future
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionService]]
+  **/
+trait TransactionsService {
+  def transactions(
+      begin: LedgerOffset,
+      endAt: Option[LedgerOffset],
+      filter: TransactionFilter
+  ): Source[Transaction, NotUsed]
+
+  def currentLedgerEnd(): Future[LedgerOffset.Absolute]
+
+  def getTransactionById(
+      transactionId: TransactionId,
+      requestingParties: Set[Ref.Party]
+  ): Future[Option[Transaction]]
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index
+
+import java.time.{Duration, Instant}
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.transaction.GenTransaction
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.ledger.api.domain._
+
+package object v2 {
+
+  final case class AcsUpdate(
+      optSubmitterInfo: Option[SubmitterInfo],
+      offset: LedgerOffset.Absolute,
+      transactionMeta: TransactionMeta,
+      events: List[AcsUpdateEvent]
+  )
+
+  sealed trait AcsUpdateEvent extends Product with Serializable
+
+  object AcsUpdateEvent {
+
+    final case class Create(
+        transactionId: TransactionId,
+        nodeId: AbsoluteNodeId,
+        contractId: Value.AbsoluteContractId,
+        templateId: Ref.Identifier,
+        argument: Value.VersionedValue[Value.AbsoluteContractId],
+        // TODO(JM,SM): understand witnessing parties
+        stakeholders: List[Ref.Party],
+    ) extends AcsUpdateEvent
+
+    final case class Archive(
+        transactionId: TransactionId,
+        nodeId: AbsoluteNodeId,
+        contractId: Value.AbsoluteContractId,
+        templateId: Ref.Identifier,
+        // TODO(JM,SM): understand witnessing parties
+        stakeholders: List[Ref.Party],
+    ) extends AcsUpdateEvent
+
+  }
+
+  sealed trait CompletionEvent extends Product with Serializable {
+    def offset: LedgerOffset.Absolute
+  }
+
+  object CompletionEvent {
+
+    final case class Checkpoint(offset: LedgerOffset.Absolute, recordTime: Instant)
+        extends CompletionEvent
+
+    final case class CommandAccepted(
+        offset: LedgerOffset.Absolute,
+        commandId: CommandId,
+        transactionId: TransactionId)
+        extends CompletionEvent
+
+    final case class CommandRejected(
+        offset: LedgerOffset.Absolute,
+        commandId: CommandId,
+        reason: RejectionReason)
+        extends CompletionEvent
+
+  }
+
+  final case class ActiveContractSetSnapshot(
+      takenAt: LedgerOffset.Absolute,
+      activeContracts: Source[(WorkflowId, AcsUpdateEvent.Create), NotUsed])
+
+  /** A transaction that has been accepted as committed by the Participant
+    * node.
+    *
+    * @param transactionData: the transaction that was accepted as committed.
+    *
+    * @param transactionMeta: Meta-data of a transaction visible to all parties
+    *                       that can see a part of the transaction.
+    *
+    * @param submitterInfo: information about the original submission of the transaction. Is [[None]]
+    *   if the participant node does not host the submitter.
+    *
+    */
+  final case class Transaction(
+      transactionData: GenTransaction.WithTxValue[AbsoluteNodeId, AbsoluteContractId],
+      transactionMeta: TransactionMeta,
+      submitterInfo: Option[SubmitterInfo]
+  )
+
+  /** Information provided by the submitter of changes submitted to the ledger.
+    *
+    * Note that this is used for party-originating changes only. They are
+    * usually issued via the Ledger API.
+    *
+    * @param submitter: the party that submitted the change.
+    *
+    * @param applicationId: an identifier for the DAML application that
+    *   submitted the command. This is used for monitoring and to allow DAML
+    *   applications subscribe to their own submissions only.
+    *
+    * @param commandId: a submitter provided identifier that he can use to
+    *   correlate the stream of changes to the participant state with the
+    *   changes he submitted.
+    *
+    */
+  final case class SubmitterInfo(
+      submitter: Ref.Party,
+      applicationId: ApplicationId,
+      commandId: CommandId
+  )
+
+  /** Meta-data of a transaction visible to all parties that can see a part of
+    * the transaction.
+    *
+    * @param transactionId: identifier of the transaction for looking it up
+    *   over the DAML Ledger API.
+    *
+    *   Implementors are free to make it equal to the 'offset' of this event.
+    *
+    * @param offset: The offset of this event, which uniquely identifies it.
+
+    * @param ledgerEffectiveTime: the submitter-provided time at which the
+    *   transaction should be interpreted. This is the time returned by the
+    *   DAML interpreter on a `getTime :: Update Time` call.
+    *
+    * @param recordTime:
+    *   The time at which this event was recorded. Depending on the
+    *   implementation this time can be local to a Participant node or global
+    *   to the whole ledger.
+    *
+    *
+    * @param workflowId: a submitter-provided identifier used for monitoring
+    *   and to traffic-shape the work handled by DAML applications
+    *   communicating over the ledger. Meant to used in a coordinated
+    *   fashion by all parties participating in the workflow.
+    */
+  final case class TransactionMeta(
+      transactionId: TransactionId,
+      offset: LedgerOffset.Absolute,
+      ledgerEffectiveTime: Instant,
+      recordTime: Instant,
+      workflowId: WorkflowId)
+
+  final case class LedgerConfiguration(minTTL: Duration, maxTTL: Duration)
+}


### PR DESCRIPTION
The index service serves as a "bridge" between the data on the ledger and the ledger api users. That is also the reason why the index service API is defined in terms of the types in `ledger-api-domain`. It is the responsibility of the index service implementations to return compatible types and adhere to the expected semantics, so we can actually reuse index service implementations in the ledger api servers.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
