### PR TITLE
Lift restriction on serializable contract ids in DAML-LF 1.dev

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -36,6 +36,11 @@ version1_3 = V1 $ PointStable 3
 version1_4 :: Version
 version1_4 = V1 $ PointStable 4
 
+-- TODO(MH): Roll this over when releasing DAML-LF 1.5.
+version1_5 :: Version
+version1_5 = versionDev
+-- version1_5 = V1 $ PointStable 5
+
 -- | The DAML-LF version used by default.
 versionDefault :: Version
 versionDefault = version1_4
@@ -73,6 +78,9 @@ featurePartyFromText = Feature "partyFromText function" version1_2
 
 featureComplexContractKeys :: Feature
 featureComplexContractKeys = Feature "Complex contract keys" version1_4
+
+featureSerializablePolymorphicContractIds :: Feature
+featureSerializablePolymorphicContractIds = Feature "Serializable polymorphic contract ids" version1_5
 
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/InferSerializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/InferSerializability.hs
@@ -16,8 +16,8 @@ import           Data.Semigroup.FixedPoint (leastFixedPointBy)
 import DA.Daml.LF.Ast
 import DA.Daml.LF.TypeChecker.Serializability (serializabilityConditionsDataType)
 
-inferModule :: World -> Module -> Either String Module
-inferModule world0 mod0 = do
+inferModule :: World -> Version -> Module -> Either String Module
+inferModule world0 version mod0 = do
   let modName = moduleName mod0
   let dataTypes = moduleDataTypes mod0
   let templates1 = NM.namesSet (moduleTemplates mod0)
@@ -25,7 +25,7 @@ inferModule world0 mod0 = do
         [ (dataTypeCon dataType, serializable, deps)
         | dataType <- NM.toList dataTypes
         , let (serializable, deps) =
-                case serializabilityConditionsDataType world0 (Just (modName, templates1)) dataType of
+                case serializabilityConditionsDataType world0 version (Just (modName, templates1)) dataType of
                   Left _ -> (False, [])
                   Right deps0 -> (True, HS.toList deps0)
         ]
@@ -42,6 +42,6 @@ inferModule world0 mod0 = do
 inferPackage :: [(PackageId, Package)] -> Package -> Either String Package
 inferPackage pkgDeps (Package version mods0) = do
       let infer1 (mods1, world0) mod0 = do
-            mod1 <- inferModule world0 mod0
+            mod1 <- inferModule world0 version mod0
             pure (NM.insert mod1 mods1, extendWorldSelf mod1 world0)
       Package version . fst <$> foldlM infer1 (NM.empty, initWorld pkgDeps version) mods0

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -96,7 +96,7 @@ generateDalfRule =
 
         dalf <- withExceptT (pure . ideErrorPretty file)
           $ liftEither
-          $ Serializability.inferModule world rawDalf
+          $ Serializability.inferModule world lfVersion rawDalf
 
         withExceptT (pure . ideErrorPretty file)
           $ liftEither

--- a/daml-foundations/daml-ghc/tests/SerializablePolymorphicContractId.daml
+++ b/daml-foundations/daml-ghc/tests/SerializablePolymorphicContractId.daml
@@ -1,0 +1,17 @@
+-- Check that `ContractId a` is serializable whenever `a` is serializable.
+-- @SINCE-LF 1.5
+daml 1.2
+module SerializablePolymorphicContractId where
+
+data ContractIdNT a = ContractIdNT with unContractIdNT : ContractId a
+  deriving (Eq, Show)
+
+data Bar = Bar{}
+
+template Foo with
+    party  : Party
+    foo : ContractIdNT Foo
+    bar : ContractId Bar
+    int : ContractId Int
+  where
+    signatory party

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -25,6 +25,7 @@
 // * 3 -- 2019-03-25: Add contract key
 //     -- 2019-03-27: Add Map type
 // * 4 -- 2019-05-15: Add complex contract keys
+// dev -- 2019-05-22: Relax serializability constraints for contract ids
 
 
 syntax = "proto3";

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -23,7 +23,8 @@ private[validation] object Serializability {
     import world._
 
     private val supportsSerializablePolymorphicContractIds =
-      LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LanguageMajorVersion.V1, "dev"))
+      LanguageVersion.ordering
+        .gteq(languageVersion, LanguageVersion(LanguageMajorVersion.V1, "dev"))
 
     def unserializable(reason: UnserializabilityReason): Nothing =
       throw EExpectedSerializableType(ctx, requirement, typeToSerialize, reason)
@@ -40,8 +41,7 @@ private[validation] object Serializability {
       case TContractId(tArg) => {
         if (supportsSerializablePolymorphicContractIds) {
           checkType(tArg)
-        }
-        else {
+        } else {
           tArg match {
             case TTyCon(tCon) => {
               lookupDataType(ctx, tCon) match {
@@ -120,7 +120,11 @@ private[validation] object Serializability {
 
   // Assumes template are well typed,
   // in particular choice argument types and choice return types are of kind KStar
-  def checkTemplate(version: LanguageVersion, world: World, tyCon: TTyCon, template: Template): Unit = {
+  def checkTemplate(
+      version: LanguageVersion,
+      world: World,
+      tyCon: TTyCon,
+      template: Template): Unit = {
     val context = ContextTemplate(tyCon.tycon)
     Env(version, world, context, SRTemplateArg, tyCon).checkType()
     template.choices.values.foreach { choice =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.daml.lf.validation
 
+import com.digitalasset.daml.lf.archive.{LanguageVersion, LanguageMajorVersion}
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.digitalasset.daml.lf.lfpackage.Ast._
@@ -11,6 +12,7 @@ import com.digitalasset.daml.lf.lfpackage.Util.{TContractId, TList, TMap, TOptio
 private[validation] object Serializability {
 
   case class Env(
+      languageVersion: LanguageVersion,
       world: World,
       ctx: Context,
       requirement: SerializabilityRequirement,
@@ -19,6 +21,9 @@ private[validation] object Serializability {
   ) {
 
     import world._
+
+    private val supportsSerializablePolymorphicContractIds =
+      LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LanguageMajorVersion.V1, "dev"))
 
     def unserializable(reason: UnserializabilityReason): Nothing =
       throw EExpectedSerializableType(ctx, requirement, typeToSerialize, reason)
@@ -32,13 +37,24 @@ private[validation] object Serializability {
     def checkType(): Unit = checkType(typeToSerialize)
 
     def checkType(typ0: Type): Unit = typ0 match {
-      case TContractId(TTyCon(tCon)) =>
-        lookupDataType(ctx, tCon) match {
-          case DDataType(_, _, DataRecord(_, Some(_))) =>
-            ()
-          case _ =>
-            unserializable(URContractId)
+      case TContractId(tArg) => {
+        if (supportsSerializablePolymorphicContractIds) {
+          checkType(tArg)
         }
+        else {
+          tArg match {
+            case TTyCon(tCon) => {
+              lookupDataType(ctx, tCon) match {
+                case DDataType(_, _, DataRecord(_, Some(_))) =>
+                  ()
+                case _ =>
+                  unserializable(URContractId)
+              }
+            }
+            case _ => unserializable(URContractId)
+          }
+        }
+      }
       case TVar(name) =>
         if (!vars(name)) unserializable(URFreeVar(name))
       case TTyCon(tycon) =>
@@ -83,12 +99,13 @@ private[validation] object Serializability {
   }
 
   def checkDataType(
+      version: LanguageVersion,
       world: World,
       tyCon: TTyCon,
       params: ImmArray[(TypeVarName, Kind)],
       dataCons: DataCons): Unit = {
     val context = ContextDefDataType(tyCon.tycon)
-    val env = (Env(world, context, SRDataType, tyCon) /: params.iterator)(_.introVar(_))
+    val env = (Env(version, world, context, SRDataType, tyCon) /: params.iterator)(_.introVar(_))
     val typs = dataCons match {
       case DataVariant(variants) if variants.isEmpty =>
         env.unserializable(URUninhabitatedType)
@@ -103,27 +120,28 @@ private[validation] object Serializability {
 
   // Assumes template are well typed,
   // in particular choice argument types and choice return types are of kind KStar
-  def checkTemplate(world: World, tyCon: TTyCon, template: Template): Unit = {
+  def checkTemplate(version: LanguageVersion, world: World, tyCon: TTyCon, template: Template): Unit = {
     val context = ContextTemplate(tyCon.tycon)
-    Env(world, context, SRTemplateArg, tyCon).checkType()
+    Env(version, world, context, SRTemplateArg, tyCon).checkType()
     template.choices.values.foreach { choice =>
-      Env(world, context, SRChoiceArg, choice.argBinder._2).checkType()
-      Env(world, context, SRChoiceRes, choice.returnType).checkType()
+      Env(version, world, context, SRChoiceArg, choice.argBinder._2).checkType()
+      Env(version, world, context, SRChoiceRes, choice.returnType).checkType()
     }
-    template.key.foreach(k => Env(world, context, SRKey, k.typ).checkType())
+    template.key.foreach(k => Env(version, world, context, SRKey, k.typ).checkType())
   }
 
-  def checkModule(world: World, pkgId: PackageId, module: Module): Unit =
+  def checkModule(world: World, pkgId: PackageId, module: Module): Unit = {
+    val version = module.languageVersion
     module.definitions.foreach {
       case (defName, DDataType(serializable, params, dataCons)) =>
         val tyCon = TTyCon(Identifier(pkgId, QualifiedName(module.name, defName)))
-        if (serializable) checkDataType(world, tyCon, params, dataCons)
+        if (serializable) checkDataType(version, world, tyCon, params, dataCons)
         dataCons match {
           case DataRecord(_, Some(template)) =>
-            checkTemplate(world, tyCon, template)
+            checkTemplate(version, world, tyCon, template)
           case _ =>
         }
       case _ =>
     }
-
+  }
 }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
@@ -3,10 +3,12 @@
 
 package com.digitalasset.daml.lf.validation
 
+import com.digitalasset.daml.lf.archive.{LanguageMajorVersion, LanguageVersion}
 import com.digitalasset.daml.lf.data.Ref.DottedName
 import com.digitalasset.daml.lf.lfpackage.Ast.Package
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import com.digitalasset.daml.lf.testing.parser._
+import com.digitalasset.daml.lf.validation.SpecUtil._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
 
@@ -36,7 +38,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
 
       forEvery(testCases) { typ =>
         Serializability
-          .Env(defaultWorld, NoContext, SRDataType, typ)
+          .Env(LanguageVersion.default, defaultWorld, NoContext, SRDataType, typ)
           .introVar(n"serializableType" -> k"*")
           .checkType()
       }
@@ -63,7 +65,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
       forEvery(testCases) { typ =>
         an[EExpectedSerializableType] should be thrownBy
           Serializability
-            .Env(defaultWorld, NoContext, SRDataType, typ)
+            .Env(LanguageVersion.default, defaultWorld, NoContext, SRDataType, typ)
             .introVar(n"serializableType" -> k"*")
             .checkType()
       }
@@ -225,7 +227,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
 
     "reject unserializable contract id" in {
 
-      val pkg =
+      val pkg0 =
         p"""
           // well-formed module
           module NegativeTestCase1 {
@@ -247,32 +249,61 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
             record @serializable SerializableContractId = { cid : ContractId NegativeTestCase1:SerializableRecord };
           }
 
-          module PositiveTestCase1 {
+          module OncePositiveTestCase1 {
             record @serializable SerializableRecord = {};
+
+            record @serializable OnceUnserializableContractId = { cid : ContractId OncePositiveTestCase1:SerializableRecord };
+          }
+
+          module OncePositiveTestCase2 {
+            record @serializable OnceUnserializableContractId = { cid : ContractId Int64 };
+          }
+
+          module OncePositiveTestCase3 {
+            record @serializable OnceUnserializableContractId (a : *) = { cid : ContractId a };
+          }
+
+          module PositiveTestCase1 {
+            record SerializableRecord = {};
 
             record @serializable UnserializableContractId = { cid : ContractId PositiveTestCase1:SerializableRecord };
           }
 
           module PositiveTestCase2 {
-            record @serializable UnserializableContractId = { cid : ContractId Int64 };
-          }
-
-          module PositiveTestCase3 {
-            record @serializable UnserializableContractId (a : *) = { cid : ContractId a };
+            record @serializable UnserializableContractId = { cid : ContractId (Int64 -> Int64) };
           }
          """
 
-      val positiveTestCases = Table(
-        "module",
-        "PositiveTestCase1",
-        "PositiveTestCase2",
-        "PositiveTestCase3",
+      val version1_4 = LanguageVersion(LanguageMajorVersion.V1, "4")
+      // TODO(MH): We need to roll this over when we freeze DAML-LF 1.5.
+      val version1_5 = LanguageVersion(LanguageMajorVersion.V1, "dev")
+      val versions = Table("version", version1_4, version1_5)
+
+      val neverFail = (_: LanguageVersion) => false
+      val failBefore1_5 = (version: LanguageVersion) => LanguageVersion.ordering.lteq(version, version1_4)
+      val alwaysFail = (_: LanguageVersion) => true
+      val testCases = Table[String, LanguageVersion => Boolean](
+        "module" -> "should fail",
+        "NegativeTestCase1" -> neverFail,
+        "NegativeTestCase2" -> neverFail,
+        "OncePositiveTestCase1" -> failBefore1_5,
+        "OncePositiveTestCase2" -> failBefore1_5,
+        "OncePositiveTestCase3" -> failBefore1_5,
+        "PositiveTestCase1" -> alwaysFail,
+        "PositiveTestCase2" -> alwaysFail,
       )
 
-      check(pkg, "NegativeTestCase1")
-      check(pkg, "NegativeTestCase2")
-      forEvery(positiveTestCases) { modName =>
-        an[EExpectedSerializableType] shouldBe thrownBy(check(pkg, modName))
+      forEvery(versions) { version =>
+        val pkg = pkg0.updateVersion(version)
+        forEvery(testCases) { (modName: String, shouldFail: LanguageVersion => Boolean) =>
+          if (shouldFail(version)) {
+            an[EExpectedSerializableType] shouldBe thrownBy(check(pkg, modName))
+            ()
+          }
+          else {
+            check(pkg, modName)
+          }
+        }
       }
     }
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
@@ -280,7 +280,8 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
       val versions = Table("version", version1_4, version1_5)
 
       val neverFail = (_: LanguageVersion) => false
-      val failBefore1_5 = (version: LanguageVersion) => LanguageVersion.ordering.lteq(version, version1_4)
+      val failBefore1_5 =
+        (version: LanguageVersion) => LanguageVersion.ordering.lteq(version, version1_4)
       val alwaysFail = (_: LanguageVersion) => true
       val testCases = Table[String, LanguageVersion => Boolean](
         "module" -> "should fail",
@@ -299,8 +300,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
           if (shouldFail(version)) {
             an[EExpectedSerializableType] shouldBe thrownBy(check(pkg, modName))
             ()
-          }
-          else {
+          } else {
             check(pkg, modName)
           }
         }


### PR DESCRIPTION
In DAML-LF 1.dev, make `ContractId a` serializable whenever `a` is
serializable. This is part 2 of #1277.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1315)
<!-- Reviewable:end -->
