### PR TITLE
Fix package validation for DAML-LF 1.4

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -203,7 +203,7 @@ private[validation] object Typing {
       LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "2"))
 
     private val supportsComplexContractKeys =
-      LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "dev"))
+      LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "4"))
 
     private def introTypeVar(v: TypeVarName, k: Kind): Env = {
       if (tVars.isDefinedAt(v))

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -394,6 +394,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
     }
 
     "reject ill formed template definition" in {
+      import com.digitalasset.daml.lf.archive.{LanguageMajorVersion => LVM, LanguageVersion => LV}
 
       /*
       (Mod:T8Bis { person = (Mod:T {name} this), party = (Mod:T {person} this) })
@@ -594,17 +595,19 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         "PositiveTestCase5",
       )
 
-      def checkModule(modName: String) = Typing.checkModule(
+      def checkModule(pkg: Package, modName: String) = Typing.checkModule(
         world,
         defaultPkgId,
         pkg.modules(DottedName.assertFromString(modName))
       )
 
-      checkModule("NegativeTestCase")
-      forAll(typeMismatchCases)(module => an[ETypeMismatch] shouldBe thrownBy(checkModule(module))) // and
-      forAll(kindMismatchCases)(module => an[EKindMismatch] shouldBe thrownBy(checkModule(module)))
-      an[EIllegalKeyExpression] shouldBe thrownBy(checkModule("PositiveTestCase6"))
-      an[EUnknownExprVar] shouldBe thrownBy(checkModule("PositiveTestCase9"))
+      val version1_3 = LV(LVM.V1, "3")
+      checkModule(pkg, "NegativeTestCase")
+      forAll(typeMismatchCases)(module => an[ETypeMismatch] shouldBe thrownBy(checkModule(pkg, module))) // and
+      forAll(kindMismatchCases)(module => an[EKindMismatch] shouldBe thrownBy(checkModule(pkg, module)))
+      an[EIllegalKeyExpression] shouldBe thrownBy(checkModule(pkg.updateVersion(version1_3), "PositiveTestCase6"))
+      checkModule(pkg, "PositiveTestCase6")
+      an[EUnknownExprVar] shouldBe thrownBy(checkModule(pkg, "PositiveTestCase9"))
     }
 
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -603,9 +603,12 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
 
       val version1_3 = LV(LVM.V1, "3")
       checkModule(pkg, "NegativeTestCase")
-      forAll(typeMismatchCases)(module => an[ETypeMismatch] shouldBe thrownBy(checkModule(pkg, module))) // and
-      forAll(kindMismatchCases)(module => an[EKindMismatch] shouldBe thrownBy(checkModule(pkg, module)))
-      an[EIllegalKeyExpression] shouldBe thrownBy(checkModule(pkg.updateVersion(version1_3), "PositiveTestCase6"))
+      forAll(typeMismatchCases)(module =>
+        an[ETypeMismatch] shouldBe thrownBy(checkModule(pkg, module))) // and
+      forAll(kindMismatchCases)(module =>
+        an[EKindMismatch] shouldBe thrownBy(checkModule(pkg, module)))
+      an[EIllegalKeyExpression] shouldBe thrownBy(
+        checkModule(pkg.updateVersion(version1_3), "PositiveTestCase6"))
       checkModule(pkg, "PositiveTestCase6")
       an[EUnknownExprVar] shouldBe thrownBy(checkModule(pkg, "PositiveTestCase9"))
     }


### PR DESCRIPTION
Currently, complex contract keys are are not accepted for DAML-LF 1.4
although they should because we forgot to roll the version when freezing
DAML-LF 1.4.

@bitonic we need a way forward to avoid this in the future.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1316)
<!-- Reviewable:end -->
