### PR TITLE
Fix race condition in the initialization of scenario ctx roots

### DIFF
--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/RuleTypes/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/RuleTypes/Daml.hs
@@ -46,6 +46,17 @@ type instance RuleResult EncodeModule = (SS.Hash, BS.ByteString)
 -- itself but also for all of its transitive dependencies.
 type instance RuleResult CreateScenarioContext = SS.ContextId
 
+-- ^ A map from a file A to a file B whose scenario context should be
+-- used for executing scenarios in A. We use this when running the scenarios
+-- in transitive dependencies of the files of interest so that we only need
+-- one scenario context per file of interest.
+type instance RuleResult GetScenarioRoots = Map FilePath FilePath
+
+-- ^ The root for the given file based on GetScenarioRoots.
+-- This is a separate rule so we can avoid rerunning scenarios if
+-- only the roots of other files have changed.
+type instance RuleResult GetScenarioRoot = FilePath
+
 data GenerateDalf = GenerateDalf
     deriving (Eq, Show, Typeable, Generic)
 instance Binary   GenerateDalf
@@ -99,3 +110,13 @@ data CreateScenarioContext = CreateScenarioContext
 instance Binary   CreateScenarioContext
 instance Hashable CreateScenarioContext
 instance NFData   CreateScenarioContext
+
+data GetScenarioRoots = GetScenarioRoots
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetScenarioRoots
+instance NFData   GetScenarioRoots
+
+data GetScenarioRoot = GetScenarioRoot
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetScenarioRoot
+instance NFData   GetScenarioRoot

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -40,11 +40,6 @@ data DamlEnv = DamlEnv
   -- are active so that we can GC inactive scenarios.
   -- This should eventually go away and we should track scenario contexts
   -- in the same way that we track diagnostics.
-  , envScenarioContextRoots :: Var (Map FilePath FilePath)
-  -- ^ This is a map from a file A to a file B whose scenario context should be
-  -- used for executing scenarios in A. We use this when running the scenarios
-  -- in transitive dependencies of the files of interest so that we only need
-  -- one scenario context per file of interest.
   , envPreviousScenarioContexts :: Var [SS.ContextId]
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
@@ -57,13 +52,11 @@ mkDamlEnv :: Options -> Maybe SS.Handle -> IO DamlEnv
 mkDamlEnv opts scenarioService = do
     openVRsVar <- newVar Set.empty
     scenarioContextsVar <- newVar Map.empty
-    scenarioContextRootsVar <- newVar Map.empty
     previousScenarioContextsVar <- newVar []
     pure DamlEnv
         { envScenarioService = scenarioService
         , envOpenVirtualResources = openVRsVar
         , envScenarioContexts = scenarioContextsVar
-        , envScenarioContextRoots = scenarioContextRootsVar
         , envPreviousScenarioContexts = previousScenarioContextsVar
         , envDamlLfVersion = optDamlLfVersion opts
         }

--- a/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
@@ -211,7 +211,7 @@ expectLastRebuilt predicate = ShakeTest $ do
         API.writeProfile service file
         rebuilt <- either error (return . parseShakeProfileJSON testDir) =<< Aeson.eitherDecodeFileStrict' file
         -- ignore those which are set to alwaysRerun - not interesting
-        let alwaysRerun typ = typ `elem` ["OfInterest","GetModificationTime","GetFileExists"]
+        let alwaysRerun typ = typ `elem` ["OfInterest","GetModificationTime","GetFileExists", "GetScenarioRoots", "GetScenarioRoot"]
         when (null rebuilt) $
             error "Detected that zero files have rebuilt. Most likely that's a bug and we failed to parse the Shake output file."
         let bad = filter (\(typ, file) -> not $ alwaysRerun typ || predicate typ file) rebuilt

--- a/daml-foundations/daml-ghc/util.bzl
+++ b/daml-foundations/daml-ghc/util.bzl
@@ -98,6 +98,4 @@ def daml_ghc_integration_test(name, main_function):
             "time",
         ],
         visibility = ["//visibility:public"],
-        # TODO fix flakiness, see #1306
-        flaky = True,
     )


### PR DESCRIPTION
Fixes #1306

The problem was caused by the following steps:

1. We first call setFilesOfInterest. However that does not block until
 ofInterestRule finishes and subsequent calls to shakeRun will kill
 the current run so we never reach the point where the scenario
 context roots are updated.

2. We then call runScenarios before ever setting up the context roots
and throw an exception.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
