### PR TITLE
Fix //navigator/frontend genrule

### DIFF
--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -72,8 +72,8 @@ genrule(
     export OUT="$$(pwd)/$(@D)/out"
     export WP_IN={WP_IN}
     export WP_OUT={WP_OUT}
-    [ -d "$$IN" ] || mkdir "$$IN"
-    [ -d "$$OUT" ] || mkdir "$$OUT"
+    rm -rf $$IN $$OUT
+    mkdir "$$IN" "$$OUT"
 
     # Our tools (node.js, webpack, webpack plugins, typescript) do not work nicely
     # with symbolic links and a node_modules directory that is not in the project root.


### PR DESCRIPTION
`//navigator/frontend` genrule on Windows (no sandbox) was not idempotent, i.a. due to `cp` behavior when destination folder is/is not present. This ensures both input and output folders will be cleaned on every (re-)run.

Fixes the:
```
ERROR in Entry module not found: Error: Can't resolve 'ts-loader' in ...
```
problem

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
