### PR TITLE
Test damlc against all supported DAML-LF version

### DIFF
--- a/daml-foundations/daml-ghc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/BUILD.bazel
@@ -13,9 +13,9 @@ load(
     "daml_ghc_integration_test",
 )
 
-daml_ghc_integration_test("daml-ghc-test-default", "DA.Test.GHC.mainVersionDefault")
+daml_ghc_integration_test("daml-ghc-test-all", "DA.Test.GHC.mainAll")
 
-daml_ghc_integration_test("daml-ghc-test-dev", "DA.Test.GHC.mainVersionDev")
+daml_ghc_integration_test("daml-ghc-test-dev", "DA.Test.GHC.main")
 
 da_haskell_test(
     name = "tasty-test",

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -8,8 +8,7 @@
 -- typecheck with LF, test it.  Test annotations are documented as 'Ann'.
 module DA.Test.GHC
   ( main
-  , mainVersionDefault
-  , mainVersionDev
+  , mainAll
   ) where
 
 import DA.Daml.GHC.Compiler.Options
@@ -72,22 +71,19 @@ import Test.Tasty.Runners
 newtype TODO = TODO String
 
 main :: IO ()
-main = mainVersionDev
+main = mainWithVersions [versionDev]
 
-mainVersionDefault :: IO ()
-mainVersionDefault = mainWithVersion versionDefault
+mainAll :: IO ()
+mainAll = mainWithVersions (delete versionDev supportedInputVersions)
 
-mainVersionDev :: IO ()
-mainVersionDev = mainWithVersion versionDev
-
-mainWithVersion :: Version -> IO ()
-mainWithVersion version =
+mainWithVersions :: [Version] -> IO ()
+mainWithVersions versions =
   with (SS.startScenarioService (\_ -> pure ()) Logger.makeNopHandle) $ \scenarioService -> do
   setEnv "TASTY_NUM_THREADS" "1" True
   todoRef <- newIORef DList.empty
   let registerTODO (TODO s) = modifyIORef todoRef (`DList.snoc` ("TODO: " ++ s))
-  integrationTest <- getIntegrationTests registerTODO scenarioService version
-  let tests = testGroup "All" [uniqueUniques, integrationTest]
+  integrationTests <- mapM (getIntegrationTests registerTODO scenarioService) versions
+  let tests = testGroup "All" $ uniqueUniques : integrationTests
   defaultMainWithIngredients ingredients tests
     `finally` (do
     todos <- readIORef todoRef

--- a/daml-foundations/daml-ghc/tests/DisjunctionChoices.daml
+++ b/daml-foundations/daml-ghc/tests/DisjunctionChoices.daml
@@ -1,3 +1,7 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.2
 daml 1.2
 module DisjunctionChoices where
 

--- a/daml-foundations/daml-ghc/tests/Map.daml
+++ b/daml-foundations/daml-ghc/tests/Map.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+-- @SINCE-LF 1.3
 daml 1.2
 module Map where
 

--- a/daml-foundations/daml-ghc/tests/Set.daml
+++ b/daml-foundations/daml-ghc/tests/Set.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+-- @SINCE-LF 1.3
 daml 1.2
 module Set where
 


### PR DESCRIPTION
I disabled this in the past because the tests were to slow. They have gotten
quite a bit faster since then and I'm slowly getting scared by the fact we
don't do this right now. Also, it incentivices us to drop support for old
DAML-LF versions more frequently, which will most of the time also remove
complexity from the compiler.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1337)
<!-- Reviewable:end -->
