### PR TITLE
List all available versions, and persist version data.

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -41,6 +41,7 @@ da_haskell_library(
         "bytestring",
         "conduit",
         "conduit-extra",
+        "containers",
         "directory",
         "extra",
         "filepath",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -41,7 +41,7 @@ da_haskell_library(
         "bytestring",
         "conduit",
         "conduit-extra",
-        "containers",
+        "unordered-containers",
         "directory",
         "extra",
         "filepath",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -84,6 +84,7 @@ da_haskell_binary(
         "extra",
         "filepath",
         "process",
+        "safe",
         "safe-exceptions",
         "text",
     ],

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -140,6 +140,7 @@ handleCommand env@Env{..} = \case
 
     Builtin Version -> do
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
+        availableVersionsE <- tryAssistant $ getAvailableSdkVersions
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
 
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion
@@ -167,7 +168,7 @@ handleCommand env@Env{..} = \case
                     <$ guard (not (isInstalled v))
                 ]
 
-            versions = nubSort (envVersions ++ fromRight [] installedVersionsE)
+            versions = nubSort (envVersions ++ fromRight [] installedVersionsE ++ fromRight [] availableVersionsE)
             versionTable = [ (versionToText v, versionAttrs v) | v <- versions ]
             versionWidth = maximum (1 : map (T.length . fst) versionTable)
             versionLines =

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -142,7 +142,7 @@ handleCommand env@Env{..} = \case
 
     Builtin (Version VersionOptions{..}) -> do
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
-        availableVersionsE <- tryAssistant $ getAvailableSdkVersions envDamlPath
+        availableVersionsE <- tryAssistant $ refreshAvailableSdkVersions envDamlPath
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
 
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -142,7 +142,7 @@ handleCommand env@Env{..} = \case
 
     Builtin (Version VersionOptions{..}) -> do
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
-        availableVersionsE <- tryAssistant $ getAvailableSdkVersions
+        availableVersionsE <- tryAssistant $ getAvailableSdkVersions envDamlPath
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
 
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion

--- a/daml-assistant/src/DAML/Assistant/Cache.hs
+++ b/daml-assistant/src/DAML/Assistant/Cache.hs
@@ -5,6 +5,7 @@
 
 module DAML.Assistant.Cache
     ( cacheLatestSdkVersion
+    , saveToCache
     ) where
 
 import DAML.Assistant.Types
@@ -95,4 +96,13 @@ cacheWith key (CacheTimeout timeout) serialize deserialize damlPath getValue = d
                 createDirectoryIfMissing True (cacheDirPath damlPath)
                 writeFileUTF8 path (serialize value)
             pure value
+
+
+saveToCache :: DamlPath -> CacheKey -> String -> IO ()
+saveToCache damlPath key value =
+    void . tryIO $ do
+        let dirPath = cacheDirPath damlPath
+            filePath = cacheFilePath damlPath key
+        createDirectoryIfMissing True dirPath
+        writeFileUTF8 filePath value
 

--- a/daml-assistant/src/DAML/Assistant/Cache.hs
+++ b/daml-assistant/src/DAML/Assistant/Cache.hs
@@ -96,7 +96,7 @@ cacheWith damlPath key timeout ser deser getFresh = do
     case valueAgeM of
         Just (value, Fresh) -> pure value
         Just (value, Stale) -> do
-            valueE <- tryAny $ getFresh
+            valueE <- tryAny getFresh
             case valueE of
                 Left _ -> pure value
                 Right value' -> do

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -64,7 +64,7 @@ dispatch info = subcommand
 commandParser :: [SdkCommandInfo] -> Parser Command
 commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
     [ subparser -- visible commands
-        $  builtin "version" "Display DAML version information" mempty (pure Version <**> helper)
+        $  builtin "version" "Display DAML version information" mempty (Version <$> versionParser <**> helper)
         <> builtin "install" "Install the specified DAML SDK version" mempty (Install <$> installParser <**> helper)
         <> foldMap dispatch visible
     , subparser -- hidden commands
@@ -73,6 +73,10 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
             (Exec <$> strArgument (metavar "CMD") <*> many (strArgument (metavar "ARGS")))
         <> foldMap dispatch hidden
     ]
+
+versionParser :: Parser VersionOptions
+versionParser = VersionOptions
+    <$> flagYesNoAuto "all" False "Display all available versions."
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -52,7 +52,7 @@ data Env = Env
     } deriving (Eq, Show)
 
 data BuiltinCommand
-    = Version
+    = Version VersionOptions
     | Exec String [String]
     | Install InstallOptions
     deriving (Eq, Show)
@@ -66,12 +66,18 @@ newtype UserCommandArgs = UserCommandArgs
     { unwrapUserCommandArgs :: [String]
     } deriving (Eq, Show)
 
+-- | Command-line options for daml version command.
+data VersionOptions = VersionOptions
+    { vAll :: Bool -- ^ list all available versions
+    } deriving (Eq, Show)
+
+-- | Command-line options for daml install command.
 data InstallOptions = InstallOptions
-    { iTargetM :: Maybe RawInstallTarget
-    , iActivate :: ActivateInstall
-    , iForce :: ForceInstall
-    , iQuiet :: QuietInstall
-    , iSetPath :: SetPath
+    { iTargetM :: Maybe RawInstallTarget -- ^ version to install
+    , iActivate :: ActivateInstall -- ^ activate the assistant
+    , iForce :: ForceInstall -- ^ force reinstall if already installed
+    , iQuiet :: QuietInstall -- ^ don't print messages
+    , iSetPath :: SetPath -- ^ set the user's PATH (on Windows)
     } deriving (Eq, Show)
 
 -- | An install URL is a fully qualified HTTP[S] URL to an SDK release tarball. For example:

--- a/daml-assistant/src/DAML/Assistant/Version.hs
+++ b/daml-assistant/src/DAML/Assistant/Version.hs
@@ -31,7 +31,7 @@ import Data.Either.Extra
 import Data.Aeson (eitherDecodeStrict')
 import Safe
 import Network.HTTP.Simple
-import qualified Data.Map as M
+import qualified Data.HashMap.Strict as M
 
 -- | Determine SDK version of running daml assistant. Fails with an
 -- AssistantError exception if the version cannot be determined.
@@ -103,7 +103,7 @@ getAvailableSdkVersions = wrapErr "Fetching list of avalaible SDK versions" $ do
             "Fetching list of available SDK versions from docs.daml.com failed"
             (pack . show $ getResponseStatus response)
 
-    versionsMap :: M.Map Text Text <-
+    versionsMap :: M.HashMap Text Text <-
         fromRightM
             (throwIO . assistantErrorBecause "Versions list from docs.daml.com does not contain vaild JSON" . pack)
             (eitherDecodeStrict' (getResponseBody response))

--- a/daml-assistant/src/DAML/Assistant/Version.hs
+++ b/daml-assistant/src/DAML/Assistant/Version.hs
@@ -105,7 +105,7 @@ getAvailableSdkVersions = wrapErr "Fetching list of avalaible SDK versions" $ do
 
     versionsMap :: M.HashMap Text Text <-
         fromRightM
-            (throwIO . assistantErrorBecause "Versions list from docs.daml.com does not contain vaild JSON" . pack)
+            (throwIO . assistantErrorBecause "Versions list from docs.daml.com does not contain valid JSON" . pack)
             (eitherDecodeStrict' (getResponseBody response))
 
     pure . sort $ mapMaybe (eitherToMaybe . parseVersion) (M.keys versionsMap)

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -16,7 +16,7 @@ DAML Assistant
   not specified, all modules in the project are exposed.
   See `#1328 <https://github.com/digital-asset/daml/issues/1328>`_.
 
-- Added `--all` flag in `daml version` to show all available versions.
+- You can now see all available versions with ``daml version`` using the ``--all`` flag.
 
 0.12.20 - 2019-05-23
 --------------------

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -16,6 +16,8 @@ DAML Assistant
   not specified, all modules in the project are exposed.
   See `#1328 <https://github.com/digital-asset/daml/issues/1328>`_.
 
+- Added `--all` flag in `daml version` to show all available versions.
+
 0.12.20 - 2019-05-23
 --------------------
 


### PR DESCRIPTION
- Adds a flag to `daml version` to list all available versions.
- Use the fetched version list (instead of the github redirection trick) to determine latest available version.
- Persists version list even if stale (e.g. user is offline, or user disabled update check).
- Refresh version list every time user calls `daml version`.

Fixes #1094. Fixes #1225 (except for fetching versions asynchronously, which I'm happy to leave for later / never).

Definitely also room for refactoring / improvement. 