### PR TITLE
Fixes #1340 - Add Scaladocs generation to the Bazel rules.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -418,6 +418,15 @@ dev_env_tool(
     win_tool = "nsis-3.04",
 ) if is_windows else None
 
+# Scaladoc
+nixpkgs_package(
+    name = "scala_nix",
+    attribute_path = "scala",
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
 # Dummy target //external:python_headers.
 # To avoid query errors due to com_google_protobuf.
 # See https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/util/python/BUILD

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -230,15 +230,14 @@ def _scaladoc_jar_impl(ctx):
 
     ctx.actions.run(
         executable = ctx.executable._scaladoc,
-        inputs = ctx.files.srcs + classpath,
+        inputs = ctx.files.srcs + classpath + pluginPaths,
         outputs = [ outdir ],
         arguments = [
             "-d",
             outdir.path,
             "-classpath",
             ":".join([jar.path for jar in classpath]),
-            "-Xplugin:%s" % ",".join([jar.path for jar in  depset(pluginPaths).to_list()]),
-            # ^^ Not sure at all if Scaladoc runs any plugins. Note comma separator
+            "-Xplugin:%s" % ",".join([jar.path for jar in pluginPaths]),
             "-doc-title",
             ctx.attr.doctitle,
             "-no-link-warnings",

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -201,6 +201,122 @@ def _create_scala_source_jar(**kwargs):
             srcs = kwargs["srcs"],
         )
 
+def _scaladoc_jar_impl(ctx):
+
+    srcFiles = [
+        src.path
+        for src in ctx.files.srcs
+    ]
+
+    # Not sure at all if Scaladoc runs any plugins but it is harmless.
+    pluginPaths = []
+    for p in ctx.attr.plugins:
+        if hasattr(p, "path"):
+            pluginPaths.append(p)
+        elif hasattr(p, "scala"):
+            pluginPaths.extend([j.class_jar for j in p.scala.outputs.jars])
+        elif hasattr(p, "java"):
+            pluginPaths.extend([j.class_jar for j in p.java.outputs.jars])
+            # support http_file pointed at a jar. http_jar uses ijar,
+            # which breaks scala macros
+
+        elif hasattr(p, "files"):
+            pluginPaths.extend([f for f in p.files if "-sources.jar" not in f.basename])
+
+    transitive_deps = [dep[JavaInfo].transitive_deps for dep in ctx.attr.deps]
+    classpath = depset([], transitive = transitive_deps).to_list()
+
+    outdir = ctx.actions.declare_directory(ctx.label.name + "_scaladoc_tmpdir")
+
+    ctx.actions.run(
+        executable = ctx.executable._scaladoc,
+        inputs = ctx.files.srcs + classpath,
+        outputs = [ outdir ],
+        arguments = [
+            "-d",
+            outdir.path,
+            "-classpath",
+            ":".join([jar.path for jar in classpath]),
+            "-Xplugin:%s" % ",".join([jar.path for jar in  depset(pluginPaths).to_list()]),
+            # ^^ Not sure at all if Scaladoc runs any plugins. Note comma separator
+            "-doc-title",
+            ctx.attr.doctitle,
+            "-no-link-warnings",
+        ] + common_scalacopts + srcFiles,
+        mnemonic = "ScaladocGen",
+    )
+
+    # since we only have the output directory of the scaladoc generation we need to find
+    # all the files below sources_out and add them to the zipper args file
+    zipper_args_file = ctx.actions.declare_file(ctx.label.name + ".zipper_args")
+    ctx.actions.run_shell(
+        mnemonic = "ScaladocFindOutputFiles",
+        outputs = [zipper_args_file],
+        inputs = [outdir],
+        command = "find -L {src_path} -type f | sed -E 's#^{src_path}/(.*)$#\\1={src_path}/\\1#' | sort > {args_file}".format(
+            src_path = outdir.path,
+            args_file = zipper_args_file.path,
+        ),
+        progress_message = "find_scaladoc_output_files %s" % zipper_args_file.path,
+        use_default_shell_env = True,
+    )
+
+    ctx.actions.run(
+        executable = ctx.executable._zipper,
+        inputs = ctx.files.srcs + classpath + [ outdir, zipper_args_file ],
+        outputs = [ctx.outputs.out],
+        arguments = ["c", ctx.outputs.out.path, "@" + zipper_args_file.path ],
+        mnemonic = "ScaladocJar",
+    )
+
+scaladoc_jar = rule(
+    implementation = _scaladoc_jar_impl,
+    attrs = {
+        "deps": attr.label_list(),
+        "doctitle": attr.string(default = ""),
+        "plugins": attr.label_list(default = []),
+        "srcs": attr.label_list(allow_files = True),
+
+        "_zipper": attr.label(
+            default = Label("@bazel_tools//tools/zip:zipper"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+        "_scaladoc": attr.label(
+            default = Label("@scala_nix//:bin/scaladoc"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    outputs = {
+        "out": "%{name}.jar",
+    },
+)
+"""
+Generates a Scaladoc jar path/to/target/<name>.jar.
+
+Arguments:
+  srcs: source files to process
+  deps: targets that contain references to other types referenced in Scaladoc.
+  doctitle: title for Scalaadoc's index.html. Typically the name of the library
+"""
+
+def _create_scaladoc_jar(**kwargs):
+    # Try to not create empty scaladoc jars and limit execution to Linux and MacOS
+    if len(kwargs["srcs"]) > 0 and is_windows == False:
+        plugins = []
+        if "plugins" in kwargs:
+            plugins = kwargs["plugins"]
+
+        scaladoc_jar(
+            name = kwargs["name"] + "_scaladoc",
+            deps = kwargs["deps"],
+            plugins = plugins,
+            srcs = kwargs["srcs"],
+        )
+
 def da_scala_library(name, **kwargs):
     """
     Define a Scala library.
@@ -213,6 +329,7 @@ def da_scala_library(name, **kwargs):
     """
     _wrap_rule(scala_library, name, **kwargs)
     _create_scala_source_jar(name = name, **kwargs)
+    _create_scaladoc_jar(name = name, **kwargs)
 
     if "tags" in kwargs:
         for tag in kwargs["tags"]:

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -207,8 +207,6 @@ def _scaladoc_jar_impl(ctx):
         src.path
         for src in ctx.files.srcs
     ]
-
-    # Not sure at all if Scaladoc runs any plugins but it is harmless.
     pluginPaths = []
     for p in ctx.attr.plugins:
         if hasattr(p, "path"):
@@ -304,17 +302,21 @@ Arguments:
 
 def _create_scaladoc_jar(**kwargs):
     # Try to not create empty scaladoc jars and limit execution to Linux and MacOS
+    # Detect an actual scala source file rather than a srcjar or other label
     if len(kwargs["srcs"]) > 0 and is_windows == False:
-        plugins = []
-        if "plugins" in kwargs:
-            plugins = kwargs["plugins"]
+        for src in kwargs["srcs"]:
+            if src.endswith(".scala"):
+                plugins = []
+                if "plugins" in kwargs:
+                    plugins = kwargs["plugins"]
 
-        scaladoc_jar(
-            name = kwargs["name"] + "_scaladoc",
-            deps = kwargs["deps"],
-            plugins = plugins,
-            srcs = kwargs["srcs"],
-        )
+                scaladoc_jar(
+                    name = kwargs["name"] + "_scaladoc",
+                    deps = kwargs["deps"],
+                    plugins = plugins,
+                    srcs = kwargs["srcs"],
+                )
+                break
 
 def da_scala_library(name, **kwargs):
     """

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -206,6 +206,7 @@ def _scaladoc_jar_impl(ctx):
         src.path
         for src in ctx.files.srcs
     ]
+
     # The following plugin handling is lifted from a private library of 'rules_scala'.
     # https://github.com/bazelbuild/rules_scala/blob/1cffc5fcae1f553a7619b98bf7d6456d65081665/scala/private/rule_impls.bzl#L130
     pluginPaths = []
@@ -230,8 +231,8 @@ def _scaladoc_jar_impl(ctx):
     args = ctx.actions.args()
     args.add_all(["-d", outdir.path])
     args.add("-classpath")
-    args.add_joined(classpath, join_with=":")
-    args.add_joined(pluginPaths, join_with=",", format_joined="-Xplugin:%s")
+    args.add_joined(classpath, join_with = ":")
+    args.add_joined(pluginPaths, join_with = ",", format_joined = "-Xplugin:%s")
     args.add_all(common_scalacopts)
     args.add_all(srcFiles)
 
@@ -239,7 +240,7 @@ def _scaladoc_jar_impl(ctx):
         executable = ctx.executable._scaladoc,
         inputs = ctx.files.srcs + classpath + pluginPaths,
         outputs = [outdir],
-        arguments = [ args ],
+        arguments = [args],
         mnemonic = "ScaladocGen",
     )
 

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -202,7 +202,6 @@ def _create_scala_source_jar(**kwargs):
         )
 
 def _scaladoc_jar_impl(ctx):
-
     srcFiles = [
         src.path
         for src in ctx.files.srcs
@@ -229,7 +228,7 @@ def _scaladoc_jar_impl(ctx):
     ctx.actions.run(
         executable = ctx.executable._scaladoc,
         inputs = ctx.files.srcs + classpath + pluginPaths,
-        outputs = [ outdir ],
+        outputs = [outdir],
         arguments = [
             "-d",
             outdir.path,
@@ -260,9 +259,9 @@ def _scaladoc_jar_impl(ctx):
 
     ctx.actions.run(
         executable = ctx.executable._zipper,
-        inputs = ctx.files.srcs + classpath + [ outdir, zipper_args_file ],
+        inputs = ctx.files.srcs + classpath + [outdir, zipper_args_file],
         outputs = [ctx.outputs.out],
-        arguments = ["c", ctx.outputs.out.path, "@" + zipper_args_file.path ],
+        arguments = ["c", ctx.outputs.out.path, "@" + zipper_args_file.path],
         mnemonic = "ScaladocJar",
     )
 
@@ -273,7 +272,6 @@ scaladoc_jar = rule(
         "doctitle": attr.string(default = ""),
         "plugins": attr.label_list(default = []),
         "srcs": attr.label_list(allow_files = True),
-
         "_zipper": attr.label(
             default = Label("@bazel_tools//tools/zip:zipper"),
             cfg = "host",

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -58,7 +58,6 @@ da_scala_library(
         "//3rdparty/jvm/com/typesafe/scala_logging",
         "//3rdparty/jvm/org/scalaz:scalaz_core",
         "//3rdparty/jvm/org/slf4j:slf4j_api",
-        "//daml-foundations/daml-tools/da-hs-damlc-app",
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//language-support/scala/codegen-testing",

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -19,6 +19,7 @@ rec {
     nodejs
     patchelf
     protobuf3_5
+    scala
     zip
     ;
 


### PR DESCRIPTION
Still doesn't work for Scala targets that use the 'kind_projector'
scalac plugin.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
