### PR TITLE
Make exposed-modules field in daml.yaml optional

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -253,6 +253,9 @@ partitionDefinitions = foldr f ([], [], [])
 moduleNameString :: ModuleName -> T.Text
 moduleNameString = T.intercalate "." . unModuleName
 
+packageModuleNames :: Package -> [T.Text]
+packageModuleNames = map (moduleNameString . moduleName) . NM.elems . packageModules
+
 -- | Remove all location information from an expression.
 removeLocations :: Expr -> Expr
 removeLocations = cata $ \case

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -149,6 +149,21 @@ packagingTests tmpDir = testGroup "packaging"
         -- Note that we really want a forward slash here instead of </> since filepaths in
         -- zip files use forward slashes.
         assertBool "A.daml is missing" ("proj/A.daml" `elem` darFiles)
+    , testCase "Project without exposed modules" $ withTempDir $ \projDir -> do
+        writeFileUTF8 (projDir </> "A.daml") $ unlines
+            [ "daml 1.2"
+            , "module A (a) where"
+            , "a : ()"
+            , "a = ()"
+            ]
+        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: proj"
+            , "version: \"1.0\""
+            , "source: A.daml"
+            , "dependencies: [daml-prim, daml-stdlib]"
+            ]
+        withCurrentDirectory projDir $ callProcessQuiet damlName ["build"]
     ]
 
 quickstartTests :: FilePath -> FilePath -> TestTree

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,13 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+DAML Assistant
+~~~~~~~~~~~~~~
+
+- The `exposed-modules` field in `daml.yaml` is now optional. If it is
+  not specified, all modules in the project are exposed.
+  See `#1328 <https://github.com/digital-asset/daml/issues/1328>`_.
+
 0.12.20 - 2019-05-23
 --------------------
 

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -108,6 +108,7 @@ Here is what each field means:
 - ``parties``: the parties to display in the Navigator when using ``daml start``.
 - ``version``: the project version.
 - ``exposed-modules``: the DAML modules that are exposed by this project, which can be imported in other projects.
+  If this field is not specified all modules in the project are exposed.
 - ``dependencies``: the dependencies of this project.
 
 ..  TODO (@robin-da) document the dependency syntax


### PR DESCRIPTION
If unspecified, we expose all modules in the project.

Fixes #1328

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
