### PR TITLE
[ci/linux] keep daml copy until it's actually not needed anymore

### DIFF
--- a/infra/vsts_agent_linux_startup.sh
+++ b/infra/vsts_agent_linux_startup.sh
@@ -118,9 +118,6 @@ echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
   ./ci/dev-env-install.sh
   ./build.sh "_$(uname)"
 ) || true
-
-# free some disk space
-rm -rf ~/daml
 CACHE_WARMUP
 
 # Purge old agents


### PR DESCRIPTION
The existing script is deleting the daml directory too early, leading to
the "shutdown agents" step failing.