### PR TITLE
Remove exerciseExplicit from daml-stdlib

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -13,7 +13,6 @@ module DA.Internal.Template(
     create, exercise, fetch,
     archive, Archive(..),
     lookupByKey, fetchByKey, exerciseByKey,
-    exerciseExplicit,
     IsParties(toParties),
     TemplateKey(key, maintainer)
     ) where
@@ -28,15 +27,11 @@ import DA.Internal.Prelude
 create : Template c => c -> Update (ContractId c)
 create = internalCreate
 
--- | HIDE
-exerciseExplicit : Choice c e r => [Party] -> ContractId c -> e -> Update r
-exerciseExplicit = internalExercise
-
 -- | Exercise a contract choice.
 exercise : forall c e r . Choice c e r => ContractId c -> e -> Update r
 exercise c e = do
     cc <- fetch c
-    exerciseExplicit (choiceController cc e) c e
+    internalExercise (choiceController cc e) c e
 
 -- | Fetch the contract data associated with the given contract id.
 -- This fails and aborts the entire transaction if the `ContractId c`
@@ -90,7 +85,7 @@ fetchByKey k = fmap unpackPair (internalFetchByKey k)
 exerciseByKey : forall c k e r. (TemplateKey c k, Choice c e r) => k -> e -> Update r
 exerciseByKey k e = do
     (c, cc) <- fetchByKey @c k
-    exerciseExplicit (choiceController cc e) c e
+    internalExercise (choiceController cc e) c e
 
 class Template c where
 

--- a/daml-lf/tests/AuthorizedDivulgence.daml
+++ b/daml-lf/tests/AuthorizedDivulgence.daml
@@ -110,8 +110,8 @@ data GoSwap2 = GoSwap2
 instance Choice Swap2 GoSwap2  () where
   choiceController Swap2{..} _ = [p2]
   choice Swap2{..} _self GoSwap2{..} = do
-    exerciseExplicit [p1] cid1 Sell {newOwner = p2}
-    exerciseExplicit [p2] cid2 Sell {newOwner = p1}
+    exercise cid1 Sell {newOwner = p2}
+    exercise cid2 Sell {newOwner = p1}
     pure ()
 
 -- We're testing the classic swap example.
@@ -164,7 +164,7 @@ template D
         -- We create a contract right before exercising. p2 can't know about it and will only learn of
         -- it when he exercises the choice in the validation.
         cid <- create $ E p1 p2
-        exerciseExplicit [p2] cid DoSomething
+        exercise cid DoSomething
         pure cid
 
 template E

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/daml/SemanticTests.daml
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/daml/SemanticTests.daml
@@ -398,7 +398,6 @@ template PaintCounterOffer
       PaintCounterOffer_Accept: (ContractId Iou, ContractId PaintAgree)
         do offerCid <- create PaintOffer with painter; houseOwner; obligor; amount
            -- This is delegation, the painter exercises the offer on behalf of the houseOwner.
-           -- exerciseExplicit [houseOwner] offerCid PaintOffer_Accept with iouCid
            exercise offerCid PaintOffer_Accept with iouCid
 
 template PaintAgree


### PR DESCRIPTION
This is a preparation for making the actors in DAML-LF's `exercise`
instruction optional (see #1347).

This is a breaking change but since `exerciseExplicit` has never
been exposed via the documentation, this should be acceptable.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1351)
<!-- Reviewable:end -->
