### PR TITLE
Extractor to support template filtering

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -36,6 +36,10 @@ SQL Extractor
   for all three parties in the database.
   See `#1360 <https://github.com/digital-asset/daml/pull/1360>`__.
 
+- The extractor ``--templates`` option to specify template IDs in the format:
+  ``<module1>:<entity1>,<module2>:<entity2>``. If not provided, extractor subscribes to all available templates.
+  See `#1352 <https://github.com/digital-asset/daml/issues/1352>`__.
+
 Sandbox
 ~~~~~~~
 

--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.extractor
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, KillSwitches}
+import akka.stream.{KillSwitches, ActorMaterializer}
 import akka.stream.scaladsl.{RestartSource, Sink}
 import com.digitalasset.extractor.Types._
 import com.digitalasset.extractor.Main.log
@@ -12,10 +12,13 @@ import com.digitalasset.extractor.config.{ExtractorConfig, SnapshotEndSetting}
 import com.digitalasset.extractor.ledger.LedgerReader
 import com.digitalasset.extractor.ledger.types.TransactionTree
 import com.digitalasset.extractor.ledger.types.TransactionTree._
+import com.digitalasset.extractor.ledger.LedgerReader.PackageStore
 import com.digitalasset.extractor.targets.Target
 import com.digitalasset.extractor.writers.Writer
 import com.digitalasset.extractor.writers.Writer.RefreshPackages
-import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.digitalasset.extractor.helpers.TemplateIds
+import com.digitalasset.extractor.helpers.FutureUtil.toFuture
+import com.digitalasset.grpc.adapter.{ExecutionSequencerFactory, AkkaExecutionSequencerPool}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction_filter.{
   Filters,
@@ -33,9 +36,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scalaz._
 import Scalaz._
-import com.digitalasset.extractor.helpers.TemplateIds
-import com.digitalasset.extractor.ledger.LedgerReader.PackageStore
-import com.digitalasset.extractor.helpers.FutureUtil.toFuture
+
 import scalaz.syntax.tag._
 
 class Extractor[T <: Target](config: ExtractorConfig, target: T) {

--- a/extractor/src/main/scala/com/digitalasset/extractor/config/CustomScoptReaders.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/config/CustomScoptReaders.scala
@@ -14,8 +14,18 @@ import scala.collection.breakOut
 import scala.collection.generic.CanBuildFrom
 
 private[extractor] object CustomScoptReaders {
-  implicit def partyRead: Read[Party] = reads { s =>
+  implicit val partyRead: Read[Party] = reads { s =>
     Party fromString s fold (e => throw new IllegalArgumentException(e), identity)
+  }
+
+  implicit val templateConfigRead: Read[TemplateConfig] = reads { s =>
+    s.split(':') match {
+      case Array(moduleName, entityName) =>
+        TemplateConfig(moduleName, entityName)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected TemplateConfig string: '<moduleName>:<entityName>', got: '$s'")
+    }
   }
 
   implicit def nonEmptySeqRead[F[_], A](

--- a/extractor/src/main/scala/com/digitalasset/extractor/config/ExtractorConfig.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/config/ExtractorConfig.scala
@@ -40,3 +40,8 @@ object ExtractorConfig {
 }
 
 final case class TemplateConfig(moduleName: String, entityName: String)
+
+object TemplateConfig {
+  implicit val templateConfigOrdering: Ordering[TemplateConfig] =
+    Ordering.by(TemplateConfig.unapply)
+}

--- a/extractor/src/main/scala/com/digitalasset/extractor/config/ExtractorConfig.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/config/ExtractorConfig.scala
@@ -27,6 +27,7 @@ final case class ExtractorConfig(
     from: LedgerOffset,
     to: SnapshotEndSetting,
     parties: ExtractorConfig.Parties,
+    templateConfigs: Set[TemplateConfig],
     tlsConfig: TlsConfiguration,
     appId: String = s"Extractor-${UUID.randomUUID().toString}"
 ) {
@@ -37,3 +38,5 @@ final case class ExtractorConfig(
 object ExtractorConfig {
   type Parties = OneAnd[List, Party]
 }
+
+final case class TemplateConfig(moduleName: String, entityName: String)

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/FutureUtil.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/FutureUtil.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor.helpers
+
+import scalaz.{NonEmptyList, Show, ValidationNel, \/}
+import scala.concurrent.Future
+
+object FutureUtil {
+  def toFuture[E: Show, A](a: E \/ A): Future[A] = {
+    val E = implicitly[Show[E]]
+    a.fold(
+      e => Future.failed(new RuntimeException(E.shows(e))),
+      a => Future.successful(a)
+    )
+  }
+
+  def toFuture[E: Show, A](a: ValidationNel[E, A]): Future[A] =
+    a.fold(
+      es => Future.failed(new RuntimeException(formatErrors(es))),
+      a => Future.successful(a)
+    )
+
+  private def formatErrors[E: Show](es: NonEmptyList[E]): String = {
+    val E = implicitly[Show[E]]
+    es.map(e => E.shows(e)).list.toList.mkString(", ")
+  }
+}

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/TemplateIds.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/TemplateIds.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor.helpers
+
+import com.digitalasset.daml.lf.data.Ref.QualifiedName
+import com.digitalasset.daml.lf.iface.Interface
+import com.digitalasset.daml.lf.iface.InterfaceType.Template
+import com.digitalasset.extractor.config.TemplateConfig
+import com.digitalasset.ledger.api.v1.value.Identifier
+
+import scala.collection.breakOut
+
+object TemplateIds {
+
+  def getTemplateIds(interfaces: Set[Interface]): Set[Identifier] =
+    interfaces.flatMap(getTemplateIds)
+
+  private def getTemplateIds(interface: Interface): Set[Identifier] =
+    interface.typeDecls.collect {
+      case (qn: QualifiedName, _: Template) =>
+        Identifier(
+          packageId = interface.packageId,
+          name = qn.qualifiedName,
+          moduleName = qn.module.dottedName,
+          entityName = qn.name.dottedName)
+    }(breakOut)
+
+  def intersection(known: Set[Identifier], requested: Set[TemplateConfig]): Set[Identifier] =
+    known.filter(a => requested.contains(asConf(a)))
+
+  private def asConf(a: Identifier): TemplateConfig =
+    TemplateConfig(moduleName = a.moduleName, entityName = a.entityName)
+}

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
@@ -10,11 +10,11 @@ import com.digitalasset.ledger.api.v1.value.Identifier
 object TransactionTreeTrimmer {
   def trim(templateIds: Set[Identifier]): TransactionTree => TransactionTree = {
     val shouldKeep: TreeEvent.Kind => Boolean = containsTemplateId(templateIds.map(asTuple))
-    transactionTree =>
+    transactionTree: TransactionTree =>
       {
         val eventsById = transactionTree.eventsById.filter(kv => shouldKeep(kv._2.kind))
         val eventIds = eventsById.keySet
-        val rootEventIds = transactionTree.rootEventIds.filter(id => eventIds(id))
+        val rootEventIds = transactionTree.rootEventIds.filter(eventIds)
         transactionTree.copy(eventsById = eventsById, rootEventIds = rootEventIds)
       }
   }

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor.helpers
+
+import com.digitalasset.ledger.api.v1.transaction.TreeEvent.Kind
+import com.digitalasset.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
+import com.digitalasset.ledger.api.v1.value.Identifier
+
+object TransactionTreeTrimmer {
+  def trim(templateIds: Set[Identifier]): TransactionTree => TransactionTree = {
+    val shouldKeep: TreeEvent.Kind => Boolean = containsTemplateId(templateIds.map(asTuple))
+    transactionTree =>
+      {
+        val eventsById = transactionTree.eventsById.filter(kv => shouldKeep(kv._2.kind))
+        val eventIds = eventsById.keySet
+        val rootEventIds = transactionTree.rootEventIds.filter(id => eventIds(id))
+        transactionTree.copy(eventsById = eventsById, rootEventIds = rootEventIds)
+      }
+  }
+
+  private def containsTemplateId(
+      templateIds: Set[(String, String, String)]): TreeEvent.Kind => Boolean = {
+    case Kind.Created(event) => contains(templateIds)(event.templateId.map(asTuple))
+    case Kind.Exercised(event) => contains(templateIds)(event.templateId.map(asTuple))
+    case Kind.Empty => false
+  }
+
+  private def contains[A](as: Set[A])(o: Option[A]): Boolean =
+    o.exists(as)
+
+  private def asTuple(a: Identifier): (String, String, String) =
+    (a.packageId, a.moduleName, a.entityName)
+}

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
@@ -58,7 +58,7 @@ object Event {
     def convert: String \/ CreatedEvent = {
       for {
         apiTemplateId <- createdTemplateIdLens(apiEvent)
-        templateId <- apiTemplateId.convert
+        templateId <- \/.right(apiTemplateId.convert)
         apiRecord <- createdArgumentsLens(apiEvent)
         createArguments <- apiRecord.convert
       } yield
@@ -76,7 +76,7 @@ object Event {
     def convert: String \/ ExercisedEvent = {
       for {
         apiTemplateId <- exercisedTemplateIdLens(apiEvent)
-        templateId <- apiTemplateId.convert
+        templateId <- \/.right(apiTemplateId.convert)
         apiChoiceArg <- exercisedChoiceArgLens(apiEvent)
         choiceArg <- apiChoiceArg.convert
       } yield

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Identifier.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Identifier.scala
@@ -4,19 +4,24 @@
 package com.digitalasset.extractor.ledger.types
 
 import com.digitalasset.ledger.api.{v1 => api}
-
-import scalaz._
-import Scalaz._
+import scalaz.\/
 
 final case class Identifier(packageId: String, name: String)
 
 object Identifier {
+  private val separator: Char = ':'
+
   final implicit class ApiIdentifierOps(val apiIdentifier: api.value.Identifier) extends AnyVal {
-    // Even if it couldn't return a `Left`, making it return an `Either` for the sake of consistency
-    def convert: String \/ Identifier =
+    def convert: Identifier =
       Identifier(
         apiIdentifier.packageId,
-        apiIdentifier.moduleName + ":" + apiIdentifier.entityName
-      ).right
+        apiIdentifier.moduleName + separator.toString + apiIdentifier.entityName
+      )
   }
+
+  def product(identifier: Identifier): String \/ (String, String, String) =
+    identifier.name.split(separator) match {
+      case Array(module, entity) => \/.right((identifier.packageId, module, entity))
+      case _ => \/.left(s"Cannot unpack Identifier: $identifier")
+    }
 }

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Identifier.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Identifier.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.extractor.ledger.types
 
 import com.digitalasset.ledger.api.{v1 => api}
-import scalaz.\/
 
 final case class Identifier(packageId: String, name: String)
 
@@ -18,10 +17,4 @@ object Identifier {
         apiIdentifier.moduleName + separator.toString + apiIdentifier.entityName
       )
   }
-
-  def product(identifier: Identifier): String \/ (String, String, String) =
-    identifier.name.split(separator) match {
-      case Array(module, entity) => \/.right((identifier.packageId, module, entity))
-      case _ => \/.left(s"Cannot unpack Identifier: $identifier")
-    }
 }

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -11,12 +11,10 @@ import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.sandbox.persistence.PostgresAround
 import com.digitalasset.platform.sandbox.services.SandboxFixture
-
 import scalaz.OneAnd
 import cats.effect.{ContextShift, IO}
 import doobie._
 import doobie.implicits._
-
 import org.scalatest._
 
 import scala.concurrent.{Await, ExecutionContext}
@@ -33,12 +31,13 @@ trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
     LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
     SnapshotEndSetting.Head,
     OneAnd(Party assertFromString "Bob", List.empty),
+    Set.empty,
     TlsConfiguration(
       enabled = false,
       None,
       None,
-      None
-    )
+      None,
+    ),
   )
 
   protected def configureExtractor(ec: ExtractorConfig): ExtractorConfig = ec

--- a/extractor/src/test/resources/damls/TransactionExample.daml
+++ b/extractor/src/test/resources/damls/TransactionExample.daml
@@ -36,9 +36,37 @@ template RightOfUseOffer
           create RightOfUseAgreement
             with landlord; tenant; address; expirationDate
 
+template DummyTemplateWeDontSubscribeFor
+  with
+    party1: Party
+    party2: Party
+  where
+    signatory party1
+
 example = scenario do
   bob <- getParty "Bob"
   alice <- getParty "Alice"
+
+  -- Alice offers Bob room at Blaha Lujza Square, Budapest
+  offer <- submit alice do
+    create RightOfUseOffer with
+      landlord = alice
+      tenant = bob
+      address = "Blaha Lujza Square, Budapest"
+      expirationDate = date 2020 Jan 1
+
+  -- Bob accepts the offer, which creates a RightOfUseAgreement
+  submit bob do
+    exercise offer Accept
+
+templateFilterTest = scenario do
+  bob <- getParty "Bob"
+  alice <- getParty "Alice"
+
+  submit alice do
+    create DummyTemplateWeDontSubscribeFor with
+        party1 = alice
+        party2 = bob
 
   -- Alice offers Bob room at Blaha Lujza Square, Budapest
   offer <- submit alice do

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/MultiPartyTemplateSubscriptionSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/MultiPartyTemplateSubscriptionSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.{FlatSpec, Inside, Matchers, Suite}
 import scalaz.OneAnd
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class TemplateSubscriptionSpec
+class MultiPartyTemplateSubscriptionSpec
     extends FlatSpec
     with Suite
     with PostgresAroundAll
@@ -27,25 +27,36 @@ class TemplateSubscriptionSpec
 
   override def scenario: Option[String] = Some("TransactionExample:templateFilterTest")
 
+  private final val alice = Party assertFromString "Alice"
+  private final val bob = Party assertFromString "Bob"
+
   override def configureExtractor(ec: ExtractorConfig): ExtractorConfig = {
     val ec2 = super.configureExtractor(ec)
     ec2.copy(
-      parties = OneAnd(Party assertFromString "Bob", Nil),
-      templateConfigs = Set(TemplateConfig("TransactionExample", "RightOfUseAgreement")))
+      parties = OneAnd(alice, List(bob)),
+      templateConfigs = Set(
+        TemplateConfig("TransactionExample", "RightOfUseOffer"),
+        TemplateConfig("TransactionExample", "RightOfUseAgreement"))
+    )
   }
 
   "Transactions" should "be extracted" in {
-    getTransactions should have length 1
+    getTransactions should have length 2
   }
 
   "Exercises" should "be extracted" in {
-    getExercises should have length 0
+    inside(getExercises) {
+      case List(e) =>
+        e.template should ===("TransactionExample:RightOfUseOffer")
+        e.choice should ===("Accept")
+    }
   }
 
   "Contracts" should "be extracted" in {
     inside(getContracts) {
-      case List(contract) =>
-        contract.template should ===("TransactionExample:RightOfUseAgreement")
+      case List(a1, a2) =>
+        a1.template should ===("TransactionExample:RightOfUseOffer")
+        a2.template should ===("TransactionExample:RightOfUseAgreement")
     }
   }
 }

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TemplateSubscriptionSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TemplateSubscriptionSpec.scala
@@ -1,0 +1,40 @@
+package com.digitalasset.extractor
+
+import java.io.File
+
+import com.digitalasset.extractor.config.{ExtractorConfig, TemplateConfig}
+import com.digitalasset.extractor.services.ExtractorFixtureAroundAll
+import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
+import org.scalatest.{FlatSpec, Matchers, Suite}
+
+class TemplateSubscriptionSpec
+    extends FlatSpec
+    with Suite
+    with PostgresAroundAll
+    with SuiteResourceManagementAroundAll
+    with ExtractorFixtureAroundAll
+    with Matchers {
+
+  override protected def darFile = new File("extractor/TransactionExample.dar")
+
+  override def scenario: Option[String] = Some("TransactionExample:example")
+
+  override def configureExtractor(ec: ExtractorConfig): ExtractorConfig = {
+    val ec2 = super.configureExtractor(ec)
+    ec2.copy(templateConfigs = Set(TemplateConfig("TransactionExample", "RightOfUseAgreement")))
+  }
+
+  "Transactions" should "be extracted" in {
+    getTransactions should have length 2
+  }
+
+  "Exercises" should "be extracted" in {
+    getExercises should have length 1
+  }
+
+  "Contracts" should "be extracted" in {
+    getContracts should have length 2
+  }
+
+}

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/config/CustomScoptReadersSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/config/CustomScoptReadersSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor.config
+
+import org.scalacheck.{Gen, Shrink}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import scopt.Read
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+class CustomScoptReadersSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+  behavior of "CustomScoptReaders"
+
+  implicit def noShrink[A]: Shrink[A] = Shrink.shrinkAny
+
+  it should "parse a TemplateConfig" in forAll(genTemplateConfig) {
+    templateConfig: TemplateConfig =>
+      val sut = CustomScoptReaders.templateConfigRead
+      val input: String = inputString(templateConfig)
+      val actual: TemplateConfig = sut.reads(input)
+      actual should ===(templateConfig)
+  }
+
+  it should "parse a list of TemplateConfigs" in forAll(Gen.nonEmptyListOf(genTemplateConfig)) {
+    templateConfigs: List[TemplateConfig] =>
+      import CustomScoptReaders.templateConfigRead
+      val sut: Read[Seq[TemplateConfig]] = implicitly
+      val input: String = inputString(templateConfigs)
+      val actual: Seq[TemplateConfig] = sut.reads(input)
+      actual.toList should ===(templateConfigs)
+  }
+
+  private def inputString(templateConfig: TemplateConfig): String =
+    templateConfig.moduleName + ':'.toString + templateConfig.entityName
+
+  private def inputString(templateConfigs: List[TemplateConfig]): String =
+    templateConfigs.map(inputString).mkString(",")
+
+  private def genTemplateConfig: Gen[TemplateConfig] =
+    for {
+      moduleName <- Gen.identifier
+      entityName <- Gen.identifier
+    } yield TemplateConfig(moduleName, entityName)
+}


### PR DESCRIPTION
Template configs can be passed in the format: `--templates <module1>:<entity1>,<module2>:<entity2>`
If no templates passed, extractor subscribes to all available templates.

- TODOs:
  + [x] add template config validation to `validateArgumentsAgainstStatus`

See: #1352

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
