### PR TITLE
Disable daml-ghc-shake-test-ci on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -70,6 +70,8 @@ bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/test_execution_w
     //navigator/backend/... `
     //daml-assistant/integration-tests/... `
     //daml-foundations/daml-ghc:daml-ghc-deterministic `
-    //daml-foundations/daml-ghc:daml-ghc-shake-test-ci `
     //daml-foundations/daml-tools/da-hs-daml-cli `
     //daml-foundations/daml-tools/da-hs-damlc-app/...
+    # Disabled since there seems to be an issue with starting up the scenario service.
+    # See https://github.com/digital-asset/daml/issues/1354
+    # //daml-foundations/daml-ghc:daml-ghc-shake-test-ci


### PR DESCRIPTION
See See https://github.com/digital-asset/daml/issues/1354 for the
issue. I’m already looking into it but until we can make it reliable disabling it seems like a better solution than making CI flaky.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
