### PR TITLE
Display warnings in daml build.

### DIFF
--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -53,7 +53,7 @@ commandParser =
                   <*> optional (argument str (metavar "TEMPLATE" <> help ("Name of the template used to create the project (default: " <> defaultProjectTemplate <> ")")))
               ]
           initCmd = Init <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
-          startCmd = Start . OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser automatically and point it to navigator."
+          startCmd = Start . OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser automatically and point it to navigator." idm
           readReplacement :: ReadM ReplaceExtension
           readReplacement = maybeReader $ \case
               "never" -> Just ReplaceExtNever

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -76,7 +76,7 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 
 versionParser :: Parser VersionOptions
 versionParser = VersionOptions
-    <$> flagYesNoAuto "all" False "Display all available versions."
+    <$> flagYesNoAuto "all" False "Display all available versions." idm
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions
@@ -84,7 +84,7 @@ installParser = InstallOptions
     <*> iflag ActivateInstall "activate" mempty "Activate installed version of daml"
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
     <*> iflag QuietInstall "quiet" (short 'q') "Don't display installation messages"
-    <*> fmap SetPath (flagYesNoAuto "set-path" True "Adjust PATH automatically. This option only has an effect on Windows.")
+    <*> fmap SetPath (flagYesNoAuto "set-path" True "Adjust PATH automatically. This option only has an effect on Windows." idm)
     where
         iflag p name opts desc = fmap p (switch (long name <> help desc <> opts))
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
@@ -64,6 +64,8 @@ data Options = Options
     -- ^ Whether to enable debugging output
   , optGhcCustomOpts :: [String]
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
+  , optScenarioService :: Bool
+    -- ^ disable scenario service when False
   } deriving Show
 
 -- | Convert to the DAML-independent CompileOpts type.
@@ -215,6 +217,7 @@ defaultOptions mbVersion =
         , optDamlLfVersion = fromMaybe LF.versionDefault mbVersion
         , optDebug = False
         , optGhcCustomOpts = []
+        , optScenarioService = True
         }
 
 getBaseDir :: IO FilePath

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
@@ -65,7 +65,7 @@ data Options = Options
   , optGhcCustomOpts :: [String]
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: Bool
-    -- ^ disable scenario service when False
+    -- ^ disable scenario service when False, but not necessarily enabled when True
   } deriving Show
 
 -- | Convert to the DAML-independent CompileOpts type.

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -47,7 +47,7 @@ import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.LSP
 import GHC.Conc
 import qualified Network.Socket                    as NS
-import           Options.Applicative
+import Options.Applicative.Extended
 import qualified Proto3.Suite as PS
 import qualified Proto3.Suite.JSONPB as Proto.JSONPB
 import System.Directory
@@ -666,12 +666,12 @@ optionsParser numProcessors parsePkgName = Compiler.Options
         help "Options to pass to the underlying GHC"
 
     optScenarioService :: Parser Bool
-    optScenarioService = fmap not .
-        switch $
-            help "Disable scenario service." <>
-            long "disable-scenario-service" <>
+    optScenarioService =
+        flagYesNoAuto
+            "scenario-service"
+            True
+            "Run with scenario service."
             internal
-
 
 options :: Int -> Parser Command
 options numProcessors =

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -364,14 +364,8 @@ execBuild options mbOutFile initPkgDb projectCheck = do
                     (\pkg -> [confFile pkg])
                     (UseDalf False)
             case darOrErr of
-                Left errs ->
-                    ioError $
-                    userError $
-                    unlines
-                        [ "Creation of DAR file failed:"
-                        , T.unpack $
-                          showDiagnosticsColored errs
-                        ]
+                Left _ -> -- Errors already displayed via eventHandler.
+                    ioError $ userError "Creation of DAR file failed"
                 Right dar -> do
                     let fp = targetFilePath pName
                     createDirectoryIfMissing True $ takeDirectory fp

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -44,6 +44,7 @@ import qualified Data.List.Split as Split
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Development.IDE.Types.Diagnostics
+import Development.IDE.Types.LSP
 import GHC.Conc
 import qualified Network.Socket                    as NS
 import           Options.Applicative
@@ -340,6 +341,7 @@ execBuild options mbOutFile initPkgDb projectCheck = do
         let opts = options'
                     { optMbPackageName = Just pName
                     , optWriteInterface = True
+                    , optScenarioService = False
                     }
         loggerH <- getLogger opts "package"
         let confFile =
@@ -348,7 +350,9 @@ execBuild options mbOutFile initPkgDb projectCheck = do
                     pVersion
                     pExposedModules
                     pDependencies
-        Managed.with (Compiler.newIdeState opts Nothing loggerH) $ \compilerH -> do
+        let eventLogger (EventFileDiagnostics (fp, diags)) = printDiagnostics $ map (fp,) diags
+            eventLogger _ = return ()
+        Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \compilerH -> do
             darOrErr <-
                 runExceptT $
                 Compiler.buildDar
@@ -596,6 +600,7 @@ optionsParser numProcessors parsePkgName = Compiler.Options
     <*> lfVersionOpt
     <*> optDebugLog
     <*> (concat <$> many optGhcCustomOptions)
+    <*> optScenarioService
   where
     optImportPath :: Parser [FilePath]
     optImportPath =
@@ -665,6 +670,14 @@ optionsParser numProcessors parsePkgName = Compiler.Options
         long "ghc-option" <>
         metavar "OPTION" <>
         help "Options to pass to the underlying GHC"
+
+    optScenarioService :: Parser Bool
+    optScenarioService = fmap not .
+        switch $
+            help "Disable scenario service." <>
+            long "disable-scenario-service" <>
+            internal
+
 
 options :: Int -> Parser Command
 options numProcessors =

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -260,7 +260,7 @@ projectCheckOpt = fmap ProjectCheck . switch $
 
 newtype InitPkgDb = InitPkgDb Bool
 initPkgDbOpt :: Parser InitPkgDb
-initPkgDbOpt = InitPkgDb <$> flagYesNoAuto "init-package-db" True "Initialize package database"
+initPkgDbOpt = InitPkgDb <$> flagYesNoAuto "init-package-db" True "Initialize package database" idm
 
 data Telemetry = OptedIn | OptedOut | Undecided
 telemetryOpt :: Parser Telemetry

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -11,9 +11,9 @@ import Options.Applicative
 
 -- | This constructs flags that can be set to yes, no, or auto to control a boolean value
 -- with auto using the default.
-flagYesNoAuto :: String -> Bool -> String -> Parser Bool
-flagYesNoAuto flagName defaultValue helpText =
-    option reader (long flagName <> value defaultValue <> help (helpText <> commonHelp))
+flagYesNoAuto :: String -> Bool -> String -> Mod OptionFields Bool -> Parser Bool
+flagYesNoAuto flagName defaultValue helpText mods =
+    option reader (long flagName <> value defaultValue <> help (helpText <> commonHelp) <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right True
             "no" -> Right False


### PR DESCRIPTION
Fixes #1198 by displaying diagnostics in `daml build`. Adds a `--disable-scenario-service` compiler option to avoid starting the scenario service (which creates unrelated warnings because of "reflective access").