### PR TITLE
Make the actors optional in DAML-LF's exercise instruction

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -497,7 +497,7 @@ data Update
       -- ^ Choice to exercise.
     , exeContractId :: !Expr
       -- ^ Contract id of the contract template instance to exercise choice on.
-    , exeActors     :: !Expr
+    , exeActors     :: !(Maybe Expr)
       -- ^ Parties exercising the choice.
     , exeArg        :: !Expr
       -- ^ Argument for the choice.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -302,9 +302,13 @@ instance Pretty Update where
           $$ keyword_ "in" <-> pretty body
     UCreate tpl arg ->
       prettyAppKeyword prec "create" [tplArg tpl, TmArg arg]
-    UExercise tpl choice cid actor arg ->
+    UExercise tpl choice cid Nothing arg ->
       -- NOTE(MH): Converting the choice name into a variable is a bit of a hack.
       prettyAppKeyword prec "exercise"
+      [tplArg tpl, TmArg (EVar (ExprVarName (unChoiceName choice))), TmArg cid, TmArg arg]
+    UExercise tpl choice cid (Just actor) arg ->
+      -- NOTE(MH): Converting the choice name into a variable is a bit of a hack.
+      prettyAppKeyword prec "exercise_with_actors"
       [tplArg tpl, TmArg (EVar (ExprVarName (unChoiceName choice))), TmArg cid, TmArg actor, TmArg arg]
     UFetch tpl cid ->
       prettyAppKeyword prec "fetch" [tplArg tpl, TmArg cid]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -61,7 +61,7 @@ data UpdateF expr
   = UPureF     !Type !expr
   | UBindF     !(BindingF expr) !expr
   | UCreateF   !(Qualified TypeConName) !expr
-  | UExerciseF !(Qualified TypeConName) !ChoiceName !expr !expr !expr
+  | UExerciseF !(Qualified TypeConName) !ChoiceName !expr !(Maybe expr) !expr
   | UFetchF    !(Qualified TypeConName) !expr
   | UGetTimeF
   | UEmbedExprF !Type !expr

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -85,6 +85,9 @@ featureSerializablePolymorphicContractIds = Feature "Serializable polymorphic co
 featureCoerceContractId :: Feature
 featureCoerceContractId = Feature "Coerce function for contract ids" version1_5
 
+featureExerciseActorsOptional :: Feature
+featureExerciseActorsOptional = Feature "Optional exercise actors" version1_5
+
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -354,7 +354,7 @@ decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case
       <$> mayDecode "update_ExerciseTemplate" update_ExerciseTemplate decodeTypeConName
       <*> decodeName ChoiceName update_ExerciseChoice
       <*> mayDecode "update_ExerciseCid" update_ExerciseCid decodeExpr
-      <*> mayDecode "update_ExerciseActor" update_ExerciseActor decodeExpr
+      <*> traverse decodeExpr update_ExerciseActor
       <*> mayDecode "update_ExerciseArg" update_ExerciseArg decodeExpr
   LF1.UpdateSumFetch LF1.Update_Fetch{..} ->
     fmap EUpdate $ UFetch

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -340,7 +340,7 @@ encodeUpdate version = P.Update . Just . \case
       let (bindings, body) = EUpdate e ^. rightSpine (_EUpdate . _UBind)
       in P.UpdateSumBlock $ encodeBlock version bindings body
     UCreate{..} -> P.UpdateSumCreate $ P.Update_Create (encodeQualTypeConName creTemplate) (encodeExpr version creArg)
-    UExercise{..} -> P.UpdateSumExercise $ P.Update_Exercise (encodeQualTypeConName exeTemplate) (encodeName unChoiceName exeChoice) (encodeExpr version exeContractId) (encodeExpr version exeActors) (encodeExpr version exeArg)
+    UExercise{..} -> P.UpdateSumExercise $ P.Update_Exercise (encodeQualTypeConName exeTemplate) (encodeName unChoiceName exeChoice) (encodeExpr version exeContractId) (fmap (encodeExpr' version) exeActors) (encodeExpr version exeArg)
     UFetch{..} -> P.UpdateSumFetch $ P.Update_Fetch (encodeQualTypeConName fetTemplate) (encodeExpr version fetContractId)
     UGetTime -> P.UpdateSumGetTime P.Unit
     UEmbedExpr typ e -> P.UpdateSumEmbedExpr $ P.Update_EmbedExpr (encodeType version typ) (encodeExpr version e)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -8,6 +8,7 @@ module DA.Daml.LF.Simplifier(
 
 import Control.Lens hiding (para)
 import Data.Functor.Foldable
+import Data.Maybe
 import qualified Data.Set as Set
 import qualified Safe
 import qualified Safe.Exact as Safe
@@ -60,7 +61,7 @@ freeVarsStep = \case
       UPureF _ s -> s
       UBindF b s -> fvBinding b s
       UCreateF _ s -> s
-      UExerciseF _ _ s1 s2 s3 -> s1 <> s2 <> s3
+      UExerciseF _ _ s1 s2 s3 -> s1 <> fromMaybe Set.empty s2 <> s3
       UFetchF _ s1 -> s1
       UGetTimeF -> mempty
       UEmbedExprF _ s -> s

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -374,11 +374,13 @@ checkCreate tpl arg = do
   checkExpr arg (TCon tpl)
 
 typeOfExercise :: MonadGamma m =>
-  Qualified TypeConName -> ChoiceName -> Expr -> Expr -> Expr -> m Type
-typeOfExercise tpl chName cid actors arg = do
+  Qualified TypeConName -> ChoiceName -> Expr -> Maybe Expr -> Expr -> m Type
+typeOfExercise tpl chName cid mbActors arg = do
   choice <- inWorld (lookupChoice (tpl, chName))
   checkExpr cid (TContractId (TCon tpl))
-  checkExpr actors (TList TParty)
+  case mbActors of
+    Nothing -> checkFeature featureExerciseActorsOptional
+    Just actors -> checkExpr actors (TList TParty)
   checkExpr arg (chcArgType choice)
   pure (TUpdate (chcReturnType choice))
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -375,7 +375,7 @@ convertChoice env signatories
             --     expr this self arg >>= \res ->
             --     archive signatories self >>= \_ ->
             --     return res
-            let archive = EUpdate $ UExercise tmplTyCon' (mkChoiceName "Archive") selfVar signatories EUnit
+            let archive = EUpdate $ UExercise tmplTyCon' (mkChoiceName "Archive") selfVar (Just signatories) EUnit
             in EUpdate $ UBind (Binding (mkVar "res", chcReturnType) expr) $
                EUpdate $ UBind (Binding (mkVar "_", TUnit) archive) $
                EUpdate $ UPure chcReturnType (EVar $ mkVar "res")
@@ -594,13 +594,13 @@ convertExpr env0 e = do
         withTmArg env (varV1, TList TParty) args $ \x1 args ->
             withTmArg env (varV2, TContractId t') args $ \x2 args ->
             withTmArg env (varV3, c') args $ \x3 args ->
-                pure (EUpdate $ UExercise tmpl' (mkChoiceName $ is chc) x2 x1 x3, args)
+                pure (EUpdate $ UExercise tmpl' (mkChoiceName $ is chc) x2 (Just x1) x3, args)
     go env (VarIs "$dminternalArchive") (LType t@(TypeCon tmpl []) : _dict : args) = do
         t' <- convertType env t
         tmpl' <- convertQualified env tmpl
         withTmArg env (varV1, TList TParty) args $ \x1 args ->
             withTmArg env (varV2, TContractId t') args $ \x2 args ->
-                pure (EUpdate $ UExercise tmpl' (mkChoiceName "Archive") x2 x1 EUnit, args)
+                pure (EUpdate $ UExercise tmpl' (mkChoiceName "Archive") x2 (Just x1) EUnit, args)
     go env (VarIs f) (LType t@(TypeCon tmpl []) : LType key : _dict : args)
         | f == "$dminternalFetchByKey" = conv UFetchByKey
         | f == "$dminternalLookupByKey" = conv ULookupByKey

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -27,6 +27,7 @@
 // * 4 -- 2019-05-15: Add complex contract keys
 // dev -- 2019-05-22: Relax serializability constraints for contract ids
 //        2019-05-23: Add BuiltinFunction.COERCE_CONTRACT_ID
+//        2019-05-24: Make actors in exercise optional
 
 
 syntax = "proto3";
@@ -815,7 +816,7 @@ message Update {
     string choice = 2;
     // contract id
     Expr cid = 3;
-    // actort
+    // actors, optional since DAML-LF 1.5
     Expr actor = 4;
     // argument
     Expr arg = 5;

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -421,7 +421,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
             compileCreate(tmplId, translate(arg))
 
           case UpdateExercise(tmplId, chId, cidE, actorsE, argE) =>
-            compileExercise(tmplId, translate(cidE), chId, translate(actorsE), translate(argE))
+            compileExercise(tmplId, translate(cidE), chId, actorsE.map(translate), translate(argE))
 
           case UpdateGetTime =>
             SEAbs(1) { SBGetTime(SEVar(1)) }
@@ -1157,14 +1157,18 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
       contractId: SExpr,
       choiceId: ChoiceName,
       // actors are either the singleton set of submitter of an exercise command,
-      // or the acting parties of an exercise node
+      // or the acting parties of an exercise node (if present)
       // of a transaction under reconstruction for validation
-      actors: SExpr,
+      optActors: Option[SExpr],
       argument: SExpr): SExpr =
     // Translates 'A does exercise cid Choice with <params>'
     // into:
     // SomeTemplate$SomeChoice <actorsE> <cidE> <argE>
     withEnv { _ =>
+      val actors: SExpr = optActors match {
+        case None => SEValue(SOptional(None))
+        case Some(actors) => SEApp(SEBuiltin(SBSome), Array(actors))
+      }
       SEApp(SEVal(ChoiceDefRef(tmplId, choiceId), None), Array(actors, contractId, argument))
     }
 
@@ -1183,7 +1187,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         SELet(
           SEApp(compileCreate(tmplId, SEValue(createArg)), Array(SEVar(1))),
           SEApp(
-            compileExercise(tmplId, SEVar(1), choiceId, actors, SEValue(choiceArg)),
+            compileExercise(tmplId, SEVar(1), choiceId, Some(actors), SEValue(choiceArg)),
             Array(SEVar(2)))
         ) in SEVar(1)
       }
@@ -1198,7 +1202,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         templateId,
         SEValue(contractId),
         choiceId,
-        SEValue(SList(FrontStack(submitters))),
+        Some(SEValue(SList(FrontStack(submitters)))),
         SEValue(argument))
     case Command.Fetch(templateId, coid) =>
       compileFetch(templateId, SEValue(coid))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -695,7 +695,10 @@ object SBuiltin {
         case SContractId(coid) => coid
         case v => crash(s"expected contract id, got: $v")
       }
-      val actors = extractParties(args.get(2))
+      val optActors = args.get(2) match {
+        case SOptional(optValue) => optValue.map(extractParties)
+        case v => crash(s"expect optional parties, got: $v")
+      }
       val sigs = extractParties(args.get(3))
       val obs = extractParties(args.get(4))
       val ctrls = extractParties(args.get(5))
@@ -711,7 +714,7 @@ object SBuiltin {
           choiceId = choiceId,
           optLocation = machine.lastLocation,
           consuming = consuming,
-          actingParties = actors,
+          actingParties = optActors.getOrElse(ctrls),
           signatories = sigs,
           stakeholders = sigs union obs,
           controllers = ctrls,

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
@@ -402,7 +402,7 @@ object Ast {
       templateId: TypeConName,
       choice: ChoiceName,
       cidE: Expr,
-      actorsE: Expr,
+      actorsE: Option[Expr],
       argE: Expr)
       extends Update
   case object UpdateGetTime extends Update

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -509,7 +509,13 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
             templateId = decodeTypeConName(exercise.getTemplate),
             choice = name(exercise.getChoice),
             cidE = decodeExpr(exercise.getCid),
-            actorsE = if (exercise.hasActor) Some(decodeExpr(exercise.getActor)) else None,
+            actorsE =
+              if (exercise.hasActor)
+                Some(decodeExpr(exercise.getActor))
+              else {
+                assertSince("dev", "Update.Exercise.actors optional")
+                None
+              },
             argE = decodeExpr(exercise.getArg)
           )
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -509,7 +509,7 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
             templateId = decodeTypeConName(exercise.getTemplate),
             choice = name(exercise.getChoice),
             cidE = decodeExpr(exercise.getCid),
-            actorsE = decodeExpr(exercise.getActor),
+            actorsE = if (exercise.hasActor) Some(decodeExpr(exercise.getActor)) else None,
             argE = decodeExpr(exercise.getArg)
           )
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -331,8 +331,13 @@ private[parser] object ExprParser {
     }
 
   private lazy val updateExercise =
-    `exercise` ~! `@` ~> fullIdentifier ~ id ~ expr0 ~ expr0 ~ expr0 ^^ {
-      case t ~ choice ~ cid ~ actor ~ arg => UpdateExercise(t, choice, cid, actor, arg)
+    `exercise` ~! `@` ~> fullIdentifier ~ id ~ expr0 ~ expr0 ^^ {
+      case t ~ choice ~ cid ~ arg => UpdateExercise(t, choice, cid, None, arg)
+    }
+
+  private lazy val updateExerciseWithActors =
+    `exercise_with_actors` ~! `@` ~> fullIdentifier ~ id ~ expr0 ~ expr0 ~ expr0 ^^ {
+      case t ~ choice ~ cid ~ actor ~ arg => UpdateExercise(t, choice, cid, Some(actor), arg)
     }
 
   private lazy val updateFetchByKey =
@@ -359,6 +364,7 @@ private[parser] object ExprParser {
       updateCreate |
       updateFetch |
       updateExercise |
+      updateExerciseWithActors |
       updateFetchByKey |
       updateLookupByKey |
       updateGetTime |

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -35,6 +35,7 @@ private[parser] object Lexer extends RegexParsers {
     "create" -> `create`,
     "fetch" -> `fetch`,
     "exercise" -> `exercise`,
+    "exercise_with_actors" -> `exercise_with_actors`,
     "fetch_by_key" -> `fetch_by_key`,
     "lookup_by_key" -> `lookup_by_key`,
     "by" -> `by`,

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -46,6 +46,7 @@ private[parser] object Token {
   case object `create` extends Token
   case object `fetch` extends Token
   case object `exercise` extends Token
+  case object `exercise_with_actors` extends Token
   case object `fetch_by_key` extends Token
   case object `lookup_by_key` extends Token
   case object `by` extends Token

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -347,8 +347,10 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
           UpdateCreate(T.tycon, e"e"),
         "fetch @Mod:T e" ->
           UpdateFetch(T.tycon, e"e"),
-        "exercise @Mod:T Choice cid actor arg" ->
-          UpdateExercise(T.tycon, n"Choice", e"cid", e"actor", e"arg"),
+        "exercise @Mod:T Choice cid arg" ->
+          UpdateExercise(T.tycon, n"Choice", e"cid", None, e"arg"),
+        "exercise_with_actors @Mod:T Choice cid actor arg" ->
+          UpdateExercise(T.tycon, n"Choice", e"cid", Some(e"actor"), e"arg"),
         "fetch_by_key @Mod:T e" ->
           UpdateFetchByKey(RetrieveByKey(T.tycon, e"e")),
         "lookup_by_key @Mod:T e" ->

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -77,7 +77,7 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
     case UpdateFetch(templateId, contractId) =>
       UpdateFetch(templateId, apply(contractId))
     case UpdateExercise(templateId, choice, cidE, actorsE, argE) =>
-      UpdateExercise(templateId, choice, apply(cidE), apply(actorsE), apply(argE))
+      UpdateExercise(templateId, choice, apply(cidE), actorsE.map(apply), apply(argE))
     case UpdateEmbedExpr(typ, body) =>
       UpdateEmbedExpr(apply(typ), apply(body))
     case UpdateLookupByKey(retrieveByKey) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -575,12 +575,12 @@ private[validation] object Typing {
         tpl: TypeConName,
         chName: ChoiceName,
         cid: Expr,
-        actors: Expr,
+        actors: Option[Expr],
         arg: Expr
     ): Type = {
       val choice = lookupChoice(ctx, tpl, chName)
       checkExpr(cid, TContractId(TTyCon(tpl)))
-      checkExpr(actors, TParties)
+      actors.foreach(checkExpr(_, TParties))
       checkExpr(arg, choice.argBinder._2)
       TUpdate(choice.returnType)
     }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -74,7 +74,7 @@ private[validation] object ExprTraversable {
         f(contractId)
       case UpdateExercise(templateId @ _, choice @ _, cid, actors, arg) =>
         f(cid)
-        f(actors)
+        actors.foreach(f)
         f(arg)
       case UpdateGetTime =>
       case UpdateFetchByKey(rbk) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -91,7 +91,7 @@ private[validation] object TypeTraversable {
       case UpdateExercise(templateId, choice @ _, cid, actors, arg) =>
         f(TTyCon(templateId))
         foreach(cid, f)
-        foreach(actors, f)
+        actors.foreach(foreach(_, f))
         foreach(arg, f)
       case UpdateEmbedExpr(typ, body) =>
         f(typ)

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -206,7 +206,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           T"∀ (τ : ⋆) (τ₂ : ⋆) (τ₁ : ⋆). Update τ₁ → Update τ₂ → (τ₁ → τ₂ → Update τ) → (( Update τ ))",
         E"λ (e: Mod:T) → (( create @Mod:T e))" ->
           T"Mod:T → (( Update (ContractId Mod:T) ))",
-        E"λ (e₁: ContractId Mod:T) (e₂: List Party) (e₃: Int64) → (( exercise @Mod:T Ch e₁ e₂ e₃ ))" ->
+        E"λ (e₁: ContractId Mod:T) (e₂: Int64) → (( exercise @Mod:T Ch e₁ e₂ ))" ->
+          T"ContractId Mod:T → Int64 → (( Update Decimal ))",
+        E"λ (e₁: ContractId Mod:T) (e₂: List Party) (e₃: Int64) → (( exercise_with_actors @Mod:T Ch e₁ e₂ e₃ ))" ->
           T"ContractId Mod:T → List Party → Int64 → (( Update Decimal ))",
         E"λ (e: ContractId Mod:T) → (( fetch @Mod:T e ))" ->
           T"ContractId Mod:T → (( Update Mod:T ))",


### PR DESCRIPTION
If they are not present, the controllers will be filled in. Surface DAML
does this currenty anyway by fetching the contract and computing the
choice controllers before each `exercise`. This change will allow for
getting rid of the additional `fetch` preceding each `exercise`.

The compiler does not use the new form yet. I will do this in a separate
PR together with tests for the new behaviour.

This fixes https://github.com/digital-asset/daml/issues/1347.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1377)
<!-- Reviewable:end -->
