### PR TITLE
Change damlc and daml-stdlib to use exercise without actors

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -29,9 +29,7 @@ create = internalCreate
 
 -- | Exercise a contract choice.
 exercise : forall c e r . Choice c e r => ContractId c -> e -> Update r
-exercise c e = do
-    cc <- fetch c
-    internalExercise (choiceController cc e) c e
+exercise = internalExercise
 
 -- | Fetch the contract data associated with the given contract id.
 -- This fails and aborts the entire transaction if the `ContractId c`
@@ -85,7 +83,7 @@ fetchByKey k = fmap unpackPair (internalFetchByKey k)
 exerciseByKey : forall c k e r. (TemplateKey c k, Choice c e r) => k -> e -> Update r
 exerciseByKey k e = do
     (c, cc) <- fetchByKey @c k
-    internalExercise (choiceController cc e) c e
+    internalExerciseWithActors (choiceController cc e) c e
 
 class Template c where
 
@@ -113,8 +111,14 @@ class Template c where
     internalFetch = magic @"fetch"
 
     -- | HIDE
-    internalArchive : [Party] -> ContractId c -> Update ()
-    internalArchive = magic @"archive"
+    internalArchive : ContractId c -> Update ()
+    internalArchive c = do
+        cc <- fetch c
+        internalArchiveWithActors (signatory cc) c
+
+    -- | HIDE
+    internalArchiveWithActors : [Party] -> ContractId c -> Update ()
+    internalArchiveWithActors = magic @"archive"
 
 
 -- Deliberately not exported.
@@ -143,8 +147,14 @@ class Template c => Choice c e r | c e -> r where
     choice : c -> ContractId c -> e -> Update r
 
     -- | HIDE
-    internalExercise : [Party] -> ContractId c -> e -> Update r
-    internalExercise = magic @"exercise"
+    internalExercise : ContractId c -> e -> Update r
+    internalExercise c e = do
+        cc <- fetch c
+        internalExerciseWithActors (choiceController cc e) c e
+
+    -- | HIDE
+    internalExerciseWithActors : [Party] -> ContractId c -> e -> Update r
+    internalExerciseWithActors = magic @"exercise"
 
 data Archive = Archive
 
@@ -152,7 +162,8 @@ instance Template c => Choice c Archive () where
     choiceController c _ = signatory c
     choice _ _ _ = return ()
 
-    internalExercise p c _ = internalArchive p c
+    internalExercise c Archive = internalArchive c
+    internalExerciseWithActors p c Archive = internalArchiveWithActors p c
 
 -- | HIDE
 data NoEvent c e = NoEvent

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -299,7 +299,7 @@ isTypeableInfo _ = False
 
 convertTemplate :: Env -> GHC.Expr Var -> ConvertM [Definition]
 convertTemplate env (VarIs "C:Template" `App` Type (TypeCon ty [])
-        `App` ensure `App` signatories `App` observer `App` agreement `App` _create `App` _fetch `App` _archive)
+        `App` ensure `App` signatories `App` observer `App` agreement `App` _create `App` _fetch `App` _archive `App` _archiveWithActors)
     = do
     tplSignatories <- applyTplParam <$> convertExpr env signatories
     tplChoices <- fmap (\cs -> NM.fromList (archiveChoice tplSignatories : cs)) (choices tplSignatories)
@@ -346,7 +346,7 @@ convertChoice env signatories
            _templateDict `App`
              consuming `App`
                Var controller `App`
-                 choice `App` _exercise) = do
+                 choice `App` _exercise `App` _exerciseWithActors) = do
     consumption <- f (10 :: Int) consuming
     let chcConsuming = consumption == PreConsuming -- Runtime should auto-archive?
     argType <- convertType env $ TypeCon chc []
@@ -493,7 +493,7 @@ convertBind env x = convertBind2 env x
 
 convertBind2 :: Env -> CoreBind -> ConvertM [Definition]
 convertBind2 env (NonRec name x)
-    | Just internals <- MS.lookup (envGHCModuleName env) internalFunctions
+    | Just internals <- MS.lookup (envGHCModuleName env) (internalFunctions $ envLfVersion env)
     , is name `elem` internals
     = pure []
     -- NOTE(MH): Our inline return type syntax produces a local letrec for
@@ -532,20 +532,27 @@ convertBind2 env (Rec xs) = concatMapM (\(a, b) -> convertBind env (NonRec a b))
 internalTypes :: [String]
 internalTypes = ["Scenario","Update","ContractId","Time","Date","Party","Pair"]
 
-internalFunctions :: MS.Map GHC.ModuleName [String]
-internalFunctions = MS.fromList $ map (first mkModuleName)
+internalFunctions :: LF.Version -> MS.Map GHC.ModuleName [String]
+internalFunctions version = MS.fromList $ map (first mkModuleName)
     [ ("DA.Internal.Record",
         [ "getFieldPrim"
         , "setFieldPrim"
         ])
     , ("DA.Internal.Template", -- template funcs defined with magic
-        [ "$dminternalExercise"
+        [ "$dminternalExerciseWithActors"
         , "$dminternalFetch"
         , "$dminternalCreate"
-        , "$dminternalArchive"
+        , "$dminternalArchiveWithActors"
         , "$dminternalFetchByKey"
         , "$dminternalLookupByKey"
-        ])
+        ] ++
+        if version `supports` featureExerciseActorsOptional
+          then
+            [ "$dminternalExercise"
+            , "$dminternalArchive"
+            ]
+          else []
+      )
     , ("DA.Internal.LF", "unpackPair" : map ("$W" ++) internalTypes)
     , ("GHC.Base",
         [ "getTag"
@@ -587,7 +594,15 @@ convertExpr env0 e = do
         tmpl' <- convertQualified env tmpl
         withTmArg env (varV1, TContractId t') args $ \x args ->
             pure (EUpdate $ UFetch tmpl' x, args)
-    go env (VarIs "$dminternalExercise") (LType t@(TypeCon tmpl []) : LType c@(TypeCon chc []) : LType _result : _dict : args) = do
+    go env (VarIs "$dminternalExercise") (LType t@(TypeCon tmpl []) : LType c@(TypeCon chc []) : LType _result : _dict : args)
+      | envLfVersion env `supports` featureExerciseActorsOptional = do
+        t' <- convertType env t
+        c' <- convertType env c
+        tmpl' <- convertQualified env tmpl
+        withTmArg env (varV2, TContractId t') args $ \x2 args ->
+            withTmArg env (varV3, c') args $ \x3 args ->
+                pure (EUpdate $ UExercise tmpl' (mkChoiceName $ is chc) x2 Nothing x3, args)
+    go env (VarIs "$dminternalExerciseWithActors") (LType t@(TypeCon tmpl []) : LType c@(TypeCon chc []) : LType _result : _dict : args) = do
         t' <- convertType env t
         c' <- convertType env c
         tmpl' <- convertQualified env tmpl
@@ -595,7 +610,13 @@ convertExpr env0 e = do
             withTmArg env (varV2, TContractId t') args $ \x2 args ->
             withTmArg env (varV3, c') args $ \x3 args ->
                 pure (EUpdate $ UExercise tmpl' (mkChoiceName $ is chc) x2 (Just x1) x3, args)
-    go env (VarIs "$dminternalArchive") (LType t@(TypeCon tmpl []) : _dict : args) = do
+    go env (VarIs "$dminternalArchive") (LType t@(TypeCon tmpl []) : _dict : args)
+      | envLfVersion env `supports` featureExerciseActorsOptional = do
+        t' <- convertType env t
+        tmpl' <- convertQualified env tmpl
+        withTmArg env (varV2, TContractId t') args $ \x2 args ->
+            pure (EUpdate $ UExercise tmpl' (mkChoiceName "Archive") x2 Nothing EUnit, args)
+    go env (VarIs "$dminternalArchiveWithActors") (LType t@(TypeCon tmpl []) : _dict : args) = do
         t' <- convertType env t
         tmpl' <- convertQualified env tmpl
         withTmArg env (varV1, TList TParty) args $ \x1 args ->
@@ -767,7 +788,7 @@ convertExpr env0 e = do
           withTmArg env (varV1, t) args $ \x args ->
             pure (ESome t x, args)
     go env (Var x) args
-        | Just internals <- MS.lookup modName internalFunctions
+        | Just internals <- MS.lookup modName (internalFunctions $ envLfVersion env)
         , is x `elem` internals
         = unsupported "Direct call to internal function" x
         | is x == "()" = fmap (, args) $ pure EUnit

--- a/daml-foundations/daml-ghc/tests/ExerciseWithoutActors.daml
+++ b/daml-foundations/daml-ghc/tests/ExerciseWithoutActors.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that `exercise` is compiled to the DAML-LF `exercise` instruction
+-- without actors. Also check that `internalExerciseWithActors` actually
+-- uses actors as a sanity check.
+
+-- @SINCE-LF 1.5
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$cinternalExercise"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor") | not
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$cinternalExerciseWithActors"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor")
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$cinternalArchive"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor") | not
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$cinternalArchiveWithActors"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor")
+daml 1.2
+module ExerciseWithoutActors where
+
+template Foo with
+    sign : Party
+  where
+    signatory sign
+
+    choice Bar : ()
+      controller sign
+      do pure ()


### PR DESCRIPTION
The main purpose of this is to get rid of the `fetch` preceding each
`exercise`. This will work for DAML-LF 1.5 when it is frozen.

This finishes #1347.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1380)
<!-- Reviewable:end -->
