### PR TITLE
Rewrite coercion conversion in higher-order abstract syntax style

### DIFF
--- a/daml-foundations/daml-ghc/tests/DefaultMethods.daml
+++ b/daml-foundations/daml-ghc/tests/DefaultMethods.daml
@@ -23,3 +23,11 @@ class (Functor t, FoldableX t) => TraversableX t where
 
   sequenceX : Applicative m => t (m a) -> m (t a)
   sequenceX = traverseX identity
+
+-- Default implementation for the only method on a class. This used to trigger
+-- a value cycle.
+class Id a where
+  id : a -> a
+  id = \x -> x
+
+instance Id Int where


### PR DESCRIPTION
The current version in first-order abstract syntax style does not play well
with dictionary sanitization in the corner case of a type class which has
exactly on method and this method has a default implementation. As a side
effect we also eliminate a few lambdas in the generated code.

I've deliberatly removed the handling of forall coercions and coercion
applications since we don't have any code triggering them. I'll add them
back as soon as we find such code. In the meantime, I prefer not handling
these cases and blowing up loudly rather than silently doing something
which might be wrong.

This fixes #1379.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1383)
<!-- Reviewable:end -->
