### PR TITLE
Detect type class instances during template resugaring qualified

### DIFF
--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/UtilGHC.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/UtilGHC.hs
@@ -37,8 +37,14 @@ import System.IO.Unsafe
 is :: NamedThing a => a -> String
 is = getOccString
 
+qis :: NamedThing a => a -> (Maybe String, String)
+qis x = (moduleNameString . moduleName <$> nameModule_maybe (getName x), getOccString x)
+
 pattern Is :: NamedThing a => String -> a
 pattern Is x <- (is -> x)
+
+pattern QIs :: NamedThing a => String -> String -> a
+pattern QIs modName name <- (qis -> (Just modName, name))
 
 pattern VarIs :: String -> GHC.Expr Var
 pattern VarIs x <- Var (Is x)


### PR DESCRIPTION
Currently, we match on any class named `Template`. This PR changes it such
that we only matchon `Template` from `DA.Internal.Template`. Similarly for
`Choice` and `TemplateKey`.

Unfortunately, default method implementation names do not carry a module
name with them, this we need to continue matching on them unqualified.

This change is a preparation for #1387. We'll have two sets of type classes
for templates during the implementation phase of generic templates, although
the new set will be hidden from the documentation.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1388)
<!-- Reviewable:end -->
