### PR TITLE
Improve parseInt/parseDecimal at the edge cases

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
@@ -251,9 +251,9 @@ isAlpha = isPred (\t -> t >= "a" && t <= "z" || t >= "A" && t <= "Z")
 isAlphaNum : Text -> Bool
 isAlphaNum = isPred (\t -> t >= "0" && t <= "9" || t >= "a" && t <= "z" || t >= "A" && t <= "Z")
 
-parseInt_ : [Text] -> Int -> Optional Int
-parseInt_ [] s = Some s
-parseInt_ (c :: cs) s =
+parseInt_ : Number a => (Int -> a) -> [Text] -> a -> Optional a
+parseInt_ lift [] s = Some s
+parseInt_ lift (c :: cs) s =
   let v = case c of
             "0" -> Some 0
             "1" -> Some 1
@@ -266,14 +266,16 @@ parseInt_ (c :: cs) s =
             "8" -> Some 8
             "9" -> Some 9
             _ -> None
-  in optional None (\x -> parseInt_ cs (10*s + x)) v
+  in optional None (\x -> parseInt_ lift cs ((lift 10 * s) + lift x)) v
 
 -- | Attempt to parse an `Int` value from a given `Text`.
 parseInt : Text -> Optional Int
 parseInt t = case explode t of
   [] -> None
-  "-" :: c :: cs -> fmap negate (parseInt_ (c :: cs) 0)
-  cs -> parseInt_ cs 0
+  -- remember that negative numbers have greater range than positive numbers
+  -- so can't just negate at the end
+  "-" :: c :: cs -> parseInt_ (\x -> if x == 10 then 10 else negate x) (c :: cs) 0
+  cs -> parseInt_ identity cs 0
 
 parsePositiveDecimal : [Text] -> Optional Decimal
 parsePositiveDecimal cs =
@@ -288,7 +290,7 @@ parsePositiveDecimal cs =
       return $ integralParsed + fractionalScaled
     _ -> None
  where
-  parseIntToDecimal cs = intToDecimal <$> parseInt_ cs 0
+  parseIntToDecimal cs = parseInt_ intToDecimal cs 0.0
 
 -- | Attempt to parse a `Decimal` value from a given `Text`.
 -- To get `Some` value, the text must follow the regex '-'?[0-9]+('.'[0-9]+)?

--- a/daml-foundations/daml-ghc/tests/Text.daml
+++ b/daml-foundations/daml-ghc/tests/Text.daml
@@ -226,6 +226,9 @@ testParseInt = scenario do
   None === parseInt ""
   None === parseInt "-"
   None === parseInt " 0"
+  parseInt (show @Int maxBound) === Some maxBound
+  parseInt (show @Int minBound) === Some minBound
+  None === parseInt "1.1234567890123456789"
 
 testParseDecimal = scenario do
   None === parseDecimal ""
@@ -257,6 +260,9 @@ testParseDecimal = scenario do
   Some 0.0 === parseDecimal "00"
   Some 10.0 === parseDecimal "0010"
   Some 1.0 === parseDecimal "01.00"
+  Some 111111111111111111111111.0 === parseDecimal "111111111111111111111111"
+  Some 1.123456789 === parseDecimal "1.123456789"
+
 
 testReverse = scenario do
   T.reverse "DAML" === "LMAD"

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -18,6 +18,11 @@ DAML Assistant
 
 - You can now see all available versions with ``daml version`` using the ``--all`` flag.
 
+DAML Standard Library
+~~~~~~~~~~~~~~~~~~~~~
+
+- `parseInt` and `parseDecimal` now work at more extremes of values.
+
 0.12.20 - 2019-05-23
 --------------------
 


### PR DESCRIPTION
Before we parsed numbers as positive integers then converted after. Now we convert as we go. That means we can now cope with:

* `parseInt minBound` - because minBound has more precision than maxBound.
* `parseDecimal` of numbers that are bigger than `Int`.