### PR TITLE
Generic templates: restructure type classes

### DIFF
--- a/daml-foundations/daml-ghc/tests/GenericTemplates.daml
+++ b/daml-foundations/daml-ghc/tests/GenericTemplates.daml
@@ -10,17 +10,18 @@ module GenericTemplates where
 import Prelude hiding (Template (..), Choice (..), create, fetch, exercise)
 
 class Template t where
+  -- TODO(MH): Decide if we actually want to provide `signatory` and
+  -- `observer` to DAML devs. If not, we can remove them here since they are
+  -- not required for template desugaring/resugaring anymore.
   signatory : t -> [Party]
   observer : t -> [Party]
-  observer _ = []
-
-class Template t => Creatable t where
   create : t -> Update (ContractId t)
   fetch : ContractId t -> Update t
 
 class Template t => Choice t c r | t c -> r where
+  -- TODO(MH): Decide if we actually want to provide `choiceController` and
+  -- `action` to DAML devs. If not, we can remove them here since they are
+  -- not required for template desugaring/resugaring anymore.
   choiceController : t -> c -> [Party]
   action : ContractId t -> t -> c -> Update r
-
-class (Creatable t, Choice t c r) => Exercisable t c r | t c -> r where
   exercise : ContractId t -> c -> Update r

--- a/daml-foundations/daml-ghc/tests/IouDSL.daml
+++ b/daml-foundations/daml-ghc/tests/IouDSL.daml
@@ -17,40 +17,36 @@ data Iou = Iou with
     amount : Decimal
   deriving (Eq, Show)
 
-instance Template Iou where
-  signatory this@Iou{..} = [issuer, owner]
+instance IouInstance => Template Iou where
+  signatory = signatoryIou
+  observer = observerIou
+  create = createIou
+  fetch = fetchIou
 
 data Burn = Burn{}
   deriving (Eq, Show)
 
-instance Choice Iou Burn () where
-  choiceController this@Iou{..} arg@Burn = [owner]
-  action self this@Iou{..} arg@Burn = do
-    pure ()
+instance IouInstance => Choice Iou Burn () where
+  choiceController = controllerIouBurn
+  action = actionIouBurn
+  exercise = exerciseIouBurn
 
 class IouInstance where
-  -- TODO(MH): Look for other ways to transfer the template definition.
   signatoryIou : Iou -> [Party]
-  signatoryIou = signatory
+  signatoryIou this@Iou{..} = [issuer, owner]
   observerIou : Iou -> [Party]
-  observerIou = observer
+  observerIou this@Iou{..} = []
   createIou : Iou -> Update (ContractId Iou)
   createIou = error "code will be injected by the compiler"
   fetchIou : ContractId Iou -> Update Iou
   fetchIou = error "code will be injected by the compiler"
   controllerIouBurn : Iou -> Burn -> [Party]
-  controllerIouBurn = choiceController
+  controllerIouBurn this@Iou{..} arg@Burn = [owner]
   actionIouBurn : ContractId Iou -> Iou -> Burn -> Update ()
-  actionIouBurn = action
+  actionIouBurn self this@Iou{..} arg@Burn = do
+    pure ()
   exerciseIouBurn : ContractId Iou -> Burn -> Update ()
   exerciseIouBurn = error "code will be injected by the compiler"
-
-instance IouInstance => Creatable Iou where
-  create = createIou
-  fetch = fetchIou
-
-instance IouInstance => Exercisable Iou Burn () where
-  exercise = exerciseIouBurn
 
 instance IouInstance where
 

--- a/daml-foundations/daml-ghc/tests/ProposalDSL.daml
+++ b/daml-foundations/daml-ghc/tests/ProposalDSL.daml
@@ -21,39 +21,36 @@ data Proposal t = Proposal with
     receivers : [Party]
   deriving (Eq, Show)
 
-instance Creatable t => Template (Proposal t) where
-  signatory this@Proposal{..} = signatory asset \\ receivers
-  observer this@Proposal{..} = receivers
+instance ProposalInstance t => Template (Proposal t) where
+    signatory = signatoryProposal
+    observer = observerProposal
+    create = createProposal
+    fetch = fetchProposal
+
 
 
 data Accept = Accept{}
   deriving (Eq, Show)
 
-instance Creatable t => Choice (Proposal t) Accept (ContractId t) where
-  choiceController this@Proposal{..} arg@Accept = receivers
-  action self this@Proposal{..} arg@Accept = do
-    create asset
+instance ProposalInstance t => Choice (Proposal t) Accept (ContractId t) where
+    choiceController = controllerProposalAccept
+    action = actionProposalAccept
+    exercise = exerciseProposalAccept
 
 
-class Creatable t => ProposalInstance t where
+class Template t => ProposalInstance t where
     signatoryProposal : Proposal t -> [Party]
-    signatoryProposal = signatory
+    signatoryProposal this@Proposal{..} = signatory asset \\ receivers
     observerProposal : Proposal t -> [Party]
-    observerProposal = observer
+    observerProposal this@Proposal{..} = receivers
     createProposal : Proposal t -> Update (ContractId (Proposal t))
     createProposal = error "code will be injected by the compiler"
     fetchProposal : ContractId (Proposal t) -> Update (Proposal t)
     fetchProposal = error "code will be injected by the compiler"
     controllerProposalAccept : Proposal t -> Accept -> [Party]
-    controllerProposalAccept = choiceController
+    controllerProposalAccept this@Proposal{..} arg@Accept = receivers
     actionProposalAccept : ContractId (Proposal t) -> Proposal t -> Accept -> Update (ContractId t)
-    actionProposalAccept = action
+    actionProposalAccept self this@Proposal{..} arg@Accept = do
+        create asset
     exerciseProposalAccept : ContractId (Proposal t) -> Accept -> Update (ContractId t)
     exerciseProposalAccept = error "code will be injected by the compiler"
-
-instance ProposalInstance t => Creatable (Proposal t) where
-    create = createProposal
-    fetch = fetchProposal
-
-instance ProposalInstance t => Exercisable (Proposal t) Accept (ContractId t) where
-    exercise = exerciseProposalAccept


### PR DESCRIPTION
Instead of scattering the information regarding a single template across
multiple type class instances, we put it all into a single type class,
more precisley into its default method implementations.

This has the additional benefit that we can merge the `Creatable` class
into `Template` and `Exercisable` into `Choice` again.

The only potential downside of this approach is that we can call, say,
`signatory` on `Proposal t` only if there's an instance
`ProposalInstance t`. However, this might actually also be an upside.

This is part of #1387.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1393)
<!-- Reviewable:end -->
