### PR TITLE
Add a --project-root option damlc to specify the project root

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -501,7 +501,7 @@ withNavigator (SandboxPort sandboxPort) navigatorPort config args a = do
 newtype OpenBrowser = OpenBrowser Bool
 
 runStart :: OpenBrowser -> IO ()
-runStart (OpenBrowser shouldOpenBrowser) = withProjectRoot $ \_ -> do
+runStart (OpenBrowser shouldOpenBrowser) = withProjectRoot Nothing (ProjectCheck "daml start" True) $ \_ -> do
     projectConfig <- getProjectConfig
     projectName :: String <-
         requiredE "Project must have a name" $

--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -61,6 +61,7 @@ da_haskell_library(
         "//daml-foundations/daml-ghc/ide",
         "//daml-foundations/daml-ghc/language-server",
         "//daml-lf/archive:daml_lf_haskell_proto",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
         "//libs-haskell/prettyprinter-syntax",
     ],

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -58,6 +58,7 @@ import System.Process(callCommand)
 import           System.IO
 import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 import DA.Cli.Damlc.Test
+import DA.Bazel.Runfiles
 
 --------------------------------------------------------------------------------
 -- Commands
@@ -97,27 +98,28 @@ cmdTest numProcessors =
     <> fullDesc
   where
     cmd = runTestsInProjectOrFiles
-      <$> many inputFileOpt
+      <$> projectOpts "daml test"
+      <*> many inputFileOpt
       <*> fmap UseColor colorOutput
       <*> junitOutput
       <*> optionsParser numProcessors optPackageName
-      <*> projectCheckOpt
     junitOutput = optional $ strOption $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"
     colorOutput = switch $ long "color" <> help "Colored test results"
 
-runTestsInProjectOrFiles :: [FilePath] -> UseColor -> Maybe FilePath -> Compiler.Options -> ProjectCheck -> IO ()
-runTestsInProjectOrFiles [] color mbJUnitOutput cliOptions projectCheck = do
-    runProjectCheck "daml test" projectCheck
-    projectPath <- getProjectPath
-    case projectPath of
-      Nothing -> execTest [] color mbJUnitOutput cliOptions
-      Just pPath -> do
-        project <- readProjectConfig $ ProjectPath pPath
-        case parseProjectConfig project of
-          Left err -> throwIO err
-          Right PackageConfigFields {..} -> execTest [pMain] color mbJUnitOutput cliOptions
-runTestsInProjectOrFiles inFiles color mbJUnitOutput cliOptions projectCheck = do
-    runProjectCheck "daml test" projectCheck
+-- TODO (MK) The logic here is sufficiently convoluted that this should be split up into two commands, e.g.,
+-- damlc test and damlc test-files or damlc test --files.
+runTestsInProjectOrFiles :: ProjectOpts -> [FilePath] -> UseColor -> Maybe FilePath -> Compiler.Options -> IO ()
+runTestsInProjectOrFiles projectOpts [] color mbJUnitOutput cliOptions =
+    withProjectRoot' projectOpts $ \_ -> do
+        projectPath <- maybe getProjectPath (pure . Just . unwrapProjectPath) (projectRoot projectOpts)
+        case projectPath of
+          Nothing -> execTest [] color mbJUnitOutput cliOptions
+          Just pPath -> do
+            project <- readProjectConfig $ ProjectPath pPath
+            case parseProjectConfig project of
+              Left err -> throwIO err
+              Right PackageConfigFields {..} -> execTest [pMain] color mbJUnitOutput cliOptions
+runTestsInProjectOrFiles _ inFiles color mbJUnitOutput cliOptions =
     execTest inFiles color mbJUnitOutput cliOptions
 
 cmdInspect :: Mod CommandFields Command
@@ -137,10 +139,10 @@ cmdBuild numProcessors =
   where
     cmd =
         execBuild
-            <$> optionsParser numProcessors (pure Nothing)
+            <$> projectOpts "daml build"
+            <*> optionsParser numProcessors (pure Nothing)
             <*> optionalOutputFileOpt
             <*> initPkgDbOpt
-            <*> projectCheckOpt
 
 cmdClean :: Mod CommandFields Command
 cmdClean =
@@ -148,14 +150,14 @@ cmdClean =
     info (helper <*> cmd) $
     progDesc "Remove DAML project build artifacts" <> fullDesc
   where
-    cmd = execClean <$> projectCheckOpt
+    cmd = execClean <$> projectOpts "daml clean"
 
 cmdInit :: Mod CommandFields Command
 cmdInit =
     command "init" $
     info (helper <*> cmd) $ progDesc "Initialize a DAML project" <> fullDesc
   where
-    cmd = pure $ execInit (InitPkgDb True)
+    cmd = execInit <$> projectOpts "daml damlc init" <*> pure (InitPkgDb True)
 
 cmdPackage :: Int -> Mod CommandFields Command
 cmdPackage numProcessors =
@@ -165,7 +167,8 @@ cmdPackage numProcessors =
   where
     dumpPom = fmap DumpPom $ switch $ help "Write out pom and sha256 files" <> long "dump-pom"
     cmd = execPackage
-        <$> inputFileOpt
+        <$> projectOpts "daml damlc package"
+        <*> inputFileOpt
         <*> optionsParser numProcessors (Just <$> packageNameOpt)
         <*> optionalOutputFileOpt
         <*> dumpPom
@@ -221,12 +224,12 @@ execIde telemetry (Debug debug) = NS.withSocketsDo $ Managed.runManaged $ do
     opts <- liftIO $ defaultOptionsIO Nothing
 
     Managed.liftIO $ do
-      execInit (InitPkgDb True)
+      execInit (ProjectOpts Nothing (ProjectCheck "" False)) (InitPkgDb True)
       Daml.LanguageServer.runLanguageServer
         (Compiler.newIdeState opts) loggerH
 
 execCompile :: FilePath -> FilePath -> Compiler.Options -> Command
-execCompile inputFile outputFile opts = withProjectRoot $ \relativize -> do
+execCompile inputFile outputFile opts = withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize -> do
     loggerH <- getLogger opts "compile"
     inputFile <- relativize inputFile
     opts' <- Compiler.mkOptions opts
@@ -264,20 +267,20 @@ parseProjectConfig project = do
     sdkVersion <- queryProjectConfigRequired ["sdk-version"] project
     Right $ PackageConfigFields name main exposedModules version dependencies sdkVersion
 
+-- | We assume that this is only called within `withProjectRoot`.
 withPackageConfig :: (PackageConfigFields -> IO a) -> IO a
 withPackageConfig f = do
-    withProjectRoot $ \_ -> do
-        project <- readProjectConfig $ ProjectPath "."
-        case parseProjectConfig project of
-            Left err -> throwIO err
-            Right pkgConfig -> f pkgConfig
+    project <- readProjectConfig $ ProjectPath "."
+    case parseProjectConfig project of
+        Left err -> throwIO err
+        Right pkgConfig -> f pkgConfig
 
 -- | If we're in a daml project, read the daml.yaml field and create the project local package
 -- database. Otherwise do nothing.
-execInit :: InitPkgDb -> IO ()
-execInit (InitPkgDb shouldInit) =
+execInit :: ProjectOpts -> InitPkgDb -> IO ()
+execInit projectOpts (InitPkgDb shouldInit) =
     when shouldInit $
-    withProjectRoot $ \_relativize -> do
+    withProjectRoot' projectOpts $ \_relativize -> do
         isProject <- doesFileExist projectConfigName
         when isProject $ do
           project <- readProjectConfig $ ProjectPath "."
@@ -320,10 +323,10 @@ createProjectPackageDb lfVersion fps = do
             let path = dbPath </> eRelativePath src
             createDirectoryIfMissing True $ takeDirectory path
             BSL.writeFile path (fromEntry src)
-    sdkRoot <- getSdkPath
+    ghcPkgPath <- locateRunfiles (mainWorkspace </> "daml-foundations" </> "daml-tools" </> "da-hs-damlc-app" </> "ghc-pkg")
     callCommand $
         unwords
-            [ sdkRoot </> "damlc/resources/ghc-pkg"
+            [ ghcPkgPath </> "ghc-pkg"
             , "recache"
             -- ghc-pkg insists on using a global package db and will trie
             -- to find one automatically if we don’t specify it here.
@@ -331,10 +334,9 @@ createProjectPackageDb lfVersion fps = do
             , "--expand-pkgroot"
             ]
 
-execBuild :: Compiler.Options -> Maybe FilePath -> InitPkgDb -> ProjectCheck -> IO ()
-execBuild options mbOutFile initPkgDb projectCheck = do
-    runProjectCheck "daml build" projectCheck
-    execInit initPkgDb
+execBuild :: ProjectOpts -> Compiler.Options -> Maybe FilePath -> InitPkgDb -> IO ()
+execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts $ \_relativize -> do
+    execInit projectOpts initPkgDb
     withPackageConfig $ \PackageConfigFields {..} -> do
         putStrLn $ "Compiling " <> pMain <> " to a DAR."
         options' <- mkOptions options
@@ -408,10 +410,9 @@ execBuild options mbOutFile initPkgDb projectCheck = do
                     ]
 
 -- | Remove any build artifacts if they exist.
-execClean :: ProjectCheck -> IO ()
-execClean projectCheck = do
-    runProjectCheck "daml clean" projectCheck
-    withProjectRoot $ \_relativize -> do
+execClean :: ProjectOpts -> IO ()
+execClean projectOpts = do
+    withProjectRoot' projectOpts $ \_relativize -> do
         isProject <- doesFileExist projectConfigName
         when isProject $ do
             let removeAndWarn path = do
@@ -426,26 +427,17 @@ execClean projectCheck = do
             removeAndWarn "dist"
             putStrLn "Removed build artifacts."
 
--- | If ProjectCheck is true and we are outside a project,
--- print an error message and exit.
-runProjectCheck :: String -> ProjectCheck -> IO ()
-runProjectCheck command (ProjectCheck projectCheck) = do
-    when projectCheck $ do
-        projectPathM <- getProjectPath
-        when (isNothing projectPathM) $ do
-            hPutStrLn stderr (command <> ": Not in project.")
-            exitFailure
-
 lfVersionString :: LF.Version -> String
 lfVersionString = DA.Pretty.renderPretty
 
-execPackage:: FilePath -- ^ input file
+execPackage:: ProjectOpts
+            -> FilePath -- ^ input file
             -> Compiler.Options
             -> Maybe FilePath
             -> DumpPom
             -> Compiler.UseDalf
             -> IO ()
-execPackage filePath opts mbOutFile dumpPom dalfInput = withProjectRoot $ \relativize -> do
+execPackage projectOpts filePath opts mbOutFile dumpPom dalfInput = withProjectRoot' projectOpts $ \relativize -> do
     loggerH <- getLogger opts "package"
     filePath <- relativize filePath
     opts' <- Compiler.mkOptions opts
@@ -708,3 +700,6 @@ main :: IO ()
 main = do
     numProcessors <- getNumProcessors
     withProgName "damlc" $ join $ execParserLax (parserInfo numProcessors)
+
+withProjectRoot' :: ProjectOpts -> ((FilePath -> IO FilePath) -> IO a) -> IO a
+withProjectRoot' ProjectOpts{..} = withProjectRoot projectRoot projectCheck

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -12,6 +12,8 @@ import Data.List
 import Text.Read
 import qualified DA.Pretty           as Pretty
 import qualified DA.Daml.LF.Ast.Version as LF
+import DAML.Project.Consts
+import DAML.Project.Types
 
 -- | Pretty-printing documents with syntax-highlighting annotations.
 type Document = Pretty.Doc Pretty.SyntaxClass
@@ -252,12 +254,6 @@ experimentalOpt =
     switch $
     help "Enable experimental IDE features" <> long "experimental"
 
-newtype ProjectCheck = ProjectCheck Bool
-projectCheckOpt :: Parser ProjectCheck
-projectCheckOpt = fmap ProjectCheck . switch $
-       help "Check if running in DAML project."
-    <> long "project-check"
-
 newtype InitPkgDb = InitPkgDb Bool
 initPkgDbOpt :: Parser InitPkgDb
 initPkgDbOpt = InitPkgDb <$> flagYesNoAuto "init-package-db" True "Initialize package database" idm
@@ -291,3 +287,27 @@ stringsSepBy sep = eitherReader sepBy'
           | otherwise = Right items
           where
             items = map trim $ splitOn [sep] input
+
+data ProjectOpts = ProjectOpts
+    { projectRoot :: Maybe ProjectPath
+    -- ^ An explicit project path specified by the user.
+    , projectCheck :: ProjectCheck
+    -- ^ Throw an error if this is not run in a project.
+    }
+
+projectOpts :: String -> Parser ProjectOpts
+projectOpts name = ProjectOpts <$> projectRootOpt <*> projectCheckOpt name
+    where
+        projectRootOpt =
+            optional $
+            fmap ProjectPath $
+            strOption $
+            long "project-root" <>
+            help
+                (mconcat
+                     [ "Path to the root of a project containing daml.yaml. "
+                     , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
+                     ])
+        projectCheckOpt cmdName = fmap (ProjectCheck cmdName) . switch $
+               help "Check if running in DAML project."
+            <> long "project-check"


### PR DESCRIPTION
This was already possible before via the DAML_PROJECT environment
variable but for users that want to call damlc directly, e.g., via
damlc.jar a CLI flag can be more convenient.

cc @jberthold-da 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
