### PR TITLE
Make logback config explicit in binaries and tests.

### DIFF
--- a/ledger/ledger-api-integration-tests/BUILD.bazel
+++ b/ledger/ledger-api-integration-tests/BUILD.bazel
@@ -51,12 +51,19 @@ dependencies = [
 da_scala_library(
     name = "ledger-api-integration-tests-lib",
     srcs = glob(["src/test/lib/**/*.scala"]),
-    resources = ["src/test/resources/logback-test.xml"],
     visibility = [
         "//visibility:public",
     ],
     deps = dependencies + [
         "//daml-lf/testing-tools",
+    ],
+)
+
+java_library(
+    name = "default-it-logback-config",
+    resources = ["src/test/resources/logback-test.xml"],
+    visibility = [
+        "//visibility:public",
     ],
 )
 
@@ -76,6 +83,7 @@ da_scala_test_suite(
         "exclusive",
     ],
     deps = [
+        ":default-it-logback-config",
         ":ledger-api-integration-tests-lib",
     ] + dependencies,
 )
@@ -95,6 +103,7 @@ da_scala_binary(
     ],
     visibility = ["//visibility:public"],
     deps = dependencies + [
+        ":default-it-logback-config",
         ":ledger-api-integration-tests-lib",
         "//daml-lf/testing-tools",
     ],
@@ -109,6 +118,7 @@ da_scala_test_suite(
     tags = ["exclusive"],
     deps = [
         ":ledger-api-integration-tests-lib",
+        ":default-it-logback-config",
         "//daml-lf/testing-tools",
     ] + dependencies,
 )

--- a/ledger/sandbox-perf/BUILD.bazel
+++ b/ledger/sandbox-perf/BUILD.bazel
@@ -63,5 +63,6 @@ da_scala_benchmark_jmh(
     visibility = ["//visibility:public"],
     deps = [
         ":sandbox-perf-lib",
+        "//ledger/ledger-api-integration-tests:default-it-logback-config",
     ] + dependencies,
 )


### PR DESCRIPTION
This prevents binaries from including random logback configuration via library
dependencies.

Relevant binaries were found with:

    bazel query  --order_output=no  --universe_scope='//...:*' \
       'kind(".*(test|binary).*", allrdeps(//ledger/ledger-api-integration-tests:ledger-api-integration-tests-lib))'

Fixes #1402

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
