### PR TITLE
damlc test --files

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -501,7 +501,7 @@ withNavigator (SandboxPort sandboxPort) navigatorPort config args a = do
 newtype OpenBrowser = OpenBrowser Bool
 
 runStart :: OpenBrowser -> IO ()
-runStart (OpenBrowser shouldOpenBrowser) = withProjectRoot Nothing (ProjectCheck "daml start" True) $ \_ -> do
+runStart (OpenBrowser shouldOpenBrowser) = withProjectRoot Nothing (ProjectCheck "daml start" True) $ \_ _ -> do
     projectConfig <- getProjectConfig
     projectName :: String <-
         requiredE "Project must have a name" $

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -195,8 +195,10 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart" $
           callProcessQuiet damlName ["new", quickstartDir, "quickstart-java"]
     , testCase "daml build " $ withCurrentDirectory quickstartDir $
           callProcessQuiet damlName ["build", "-o", "target/daml/iou.dar"]
-    , testCase "daml damlc test" $ withCurrentDirectory quickstartDir $
-          callProcessQuiet damlName ["damlc", "test", "daml/Main.daml"]
+    , testCase "daml test" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet damlName ["test"]
+    , testCase "daml damlc test-files" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet damlName ["damlc", "test-files", "daml/Main.daml"]
     , testCase "sandbox startup" $
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -197,8 +197,8 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart" $
           callProcessQuiet damlName ["build", "-o", "target/daml/iou.dar"]
     , testCase "daml test" $ withCurrentDirectory quickstartDir $
           callProcessQuiet damlName ["test"]
-    , testCase "daml damlc test-files" $ withCurrentDirectory quickstartDir $
-          callProcessQuiet damlName ["damlc", "test-files", "daml/Main.daml"]
+    , testCase "daml damlc test --files" $ withCurrentDirectory quickstartDir $
+          callProcessQuiet damlName ["damlc", "test", "--files", "daml/Main.daml"]
     , testCase "sandbox startup" $
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -298,18 +298,17 @@ data ProjectOpts = ProjectOpts
 projectOpts :: String -> Parser ProjectOpts
 projectOpts name = ProjectOpts <$> projectRootOpt <*> projectCheckOpt name
     where
+        projectRootOpt :: Parser (Maybe ProjectPath)
+        projectRootOpt =
+            optional $
+            fmap ProjectPath $
+            strOption $
+            long "project-root" <>
+            help
+                (mconcat
+                     [ "Path to the root of a project containing daml.yaml. "
+                     , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
+                     ])
         projectCheckOpt cmdName = fmap (ProjectCheck cmdName) . switch $
                help "Check if running in DAML project."
             <> long "project-check"
-
-projectRootOpt :: Parser (Maybe ProjectPath)
-projectRootOpt =
-    optional $
-    fmap ProjectPath $
-    strOption $
-    long "project-root" <>
-    help
-        (mconcat
-             [ "Path to the root of a project containing daml.yaml. "
-             , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
-             ])

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -298,16 +298,18 @@ data ProjectOpts = ProjectOpts
 projectOpts :: String -> Parser ProjectOpts
 projectOpts name = ProjectOpts <$> projectRootOpt <*> projectCheckOpt name
     where
-        projectRootOpt =
-            optional $
-            fmap ProjectPath $
-            strOption $
-            long "project-root" <>
-            help
-                (mconcat
-                     [ "Path to the root of a project containing daml.yaml. "
-                     , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
-                     ])
         projectCheckOpt cmdName = fmap (ProjectCheck cmdName) . switch $
                help "Check if running in DAML project."
             <> long "project-check"
+
+projectRootOpt :: Parser (Maybe ProjectPath)
+projectRootOpt =
+    optional $
+    fmap ProjectPath $
+    strOption $
+    long "project-root" <>
+    help
+        (mconcat
+             [ "Path to the root of a project containing daml.yaml. "
+             , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
+             ])

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -18,7 +18,7 @@ commands:
   desc: "Build the current DAML project into a DAR file"
 - name: test
   path: damlc/da-hs-damlc-app
-  args: ["test", "--project-check"]
+  args: ["test"]
   desc: "Run the scenarios in the given DAML file and all dependencies"
 - name: start
   path: daml-helper/daml-helper

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -104,7 +104,7 @@ daml_compile = rule(
 
 def _daml_test_impl(ctx):
     script = """
-      {damlc} test {files}
+      {damlc} test-files {files}
     """.format(damlc = ctx.executable.damlc.short_path, files = " ".join([f.short_path for f in ctx.files.srcs]))
 
     ctx.actions.write(

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -104,7 +104,7 @@ daml_compile = rule(
 
 def _daml_test_impl(ctx):
     script = """
-      {damlc} test-files {files}
+      {damlc} test --files {files}
     """.format(damlc = ctx.executable.damlc.short_path, files = " ".join([f.short_path for f in ctx.files.srcs]))
 
     ctx.actions.write(


### PR DESCRIPTION
Before `damlc test` could be called in the following ways:
- `damlc test`: If in project then test project, otherwise just succeed.
- `damlc test FILE...`: Test the given files.
- `damlc test ... --project-check`: Fail if not in project.

This has been simplified to instead
- `damlc test`: Test the current project, fail if not in project.
- `damlc --files FILE...`: Test the given files, succeed if no files are given.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
