### PR TITLE
Back parseInt/parseDecimal by DAML-LF primitives when available

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -74,6 +74,8 @@ featureCoerceContractId = Feature "Coerce function for contract ids" version1_5
 featureExerciseActorsOptional :: Feature
 featureExerciseActorsOptional = Feature "Optional exercise actors" version1_5
 
+-- TODO(MH): When we remove this because we drop support for DAML-LF 1.4,
+-- we should remove `legacyParse{Int, Decimal}` from `DA.Text` as well.
 featureNumberFromText :: Feature
 featureNumberFromText = Feature "Number parsing functions" version1_5
 

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Text.daml
@@ -251,9 +251,9 @@ isAlpha = isPred (\t -> t >= "a" && t <= "z" || t >= "A" && t <= "Z")
 isAlphaNum : Text -> Bool
 isAlphaNum = isPred (\t -> t >= "0" && t <= "9" || t >= "a" && t <= "z" || t >= "A" && t <= "Z")
 
-parseInt_ : Number a => (Int -> a) -> [Text] -> a -> Optional a
-parseInt_ lift [] s = Some s
-parseInt_ lift (c :: cs) s =
+legacyParseInt_ : Number a => (Int -> a) -> [Text] -> a -> Optional a
+legacyParseInt_ lift [] s = Some s
+legacyParseInt_ lift (c :: cs) s =
   let v = case c of
             "0" -> Some 0
             "1" -> Some 1
@@ -266,32 +266,36 @@ parseInt_ lift (c :: cs) s =
             "8" -> Some 8
             "9" -> Some 9
             _ -> None
-  in optional None (\x -> parseInt_ lift cs ((lift 10 * s) + lift x)) v
+  in optional None (\x -> legacyParseInt_ lift cs ((lift 10 * s) + lift x)) v
 
 -- | Attempt to parse an `Int` value from a given `Text`.
 parseInt : Text -> Optional Int
-parseInt t = case explode t of
+parseInt = primitive @"BEInt64FromText"
+
+-- | HIDE Implementation to use for `parseInt` for DAML-LF < 1.5.
+legacyParseInt : Text -> Optional Int
+legacyParseInt t = case explode t of
   [] -> None
   -- remember that negative numbers have greater range than positive numbers
   -- so can't just negate at the end
-  "-" :: c :: cs -> parseInt_ (\x -> if x == 10 then 10 else negate x) (c :: cs) 0
-  "+" :: c :: cs -> parseInt_ identity (c :: cs) 0
-  cs -> parseInt_ identity cs 0
+  "-" :: c :: cs -> legacyParseInt_ (\x -> if x == 10 then 10 else negate x) (c :: cs) 0
+  "+" :: c :: cs -> legacyParseInt_ identity (c :: cs) 0
+  cs -> legacyParseInt_ identity cs 0
 
-parsePositiveDecimal : [Text] -> Optional Decimal
-parsePositiveDecimal cs =
+legacyParsePositiveDecimal : [Text] -> Optional Decimal
+legacyParsePositiveDecimal cs =
   case L.breakOn ["."] cs of
     ([], _) -> None
     (_, ["."]) -> None
-    (integral, []) -> parseIntToDecimal integral
+    (integral, []) -> legacyParseIntToDecimal integral
     (integral, "." :: fractional) -> do
-      integralParsed <- parseIntToDecimal integral
-      fractionalParsed <- parseIntToDecimal fractional
+      integralParsed <- legacyParseIntToDecimal integral
+      fractionalParsed <- legacyParseIntToDecimal fractional
       let fractionalScaled = fractionalParsed / (intToDecimal $ 10 ^ L.length fractional)
       return $ integralParsed + fractionalScaled
     _ -> None
  where
-  parseIntToDecimal cs = parseInt_ intToDecimal cs 0.0
+  legacyParseIntToDecimal cs = legacyParseInt_ intToDecimal cs 0.0
 
 -- | Attempt to parse a `Decimal` value from a given `Text`.
 -- To get `Some` value, the text must follow the regex '-'?[0-9]+('.'[0-9]+)?
@@ -303,11 +307,15 @@ parsePositiveDecimal cs =
 --   parseDecimal "+12.0" == None
 -- ```
 parseDecimal : Text -> Optional Decimal
-parseDecimal t =
+parseDecimal = primitive @"BEDecimalFromText"
+
+-- | HIDE Implementation to use for `parseDecimal` for DAML-LF < 1.5.
+legacyParseDecimal : Text -> Optional Decimal
+legacyParseDecimal t =
   case explode t of
-    "-" :: cs -> negate <$> parsePositiveDecimal cs
-    "+" :: cs -> parsePositiveDecimal cs
-    cs -> parsePositiveDecimal cs
+    "-" :: cs -> negate <$> legacyParsePositiveDecimal cs
+    "+" :: cs -> legacyParsePositiveDecimal cs
+    cs -> legacyParsePositiveDecimal cs
 
 -- | Computes the SHA256 of the UTF8 bytes of the `Text`, and returns it in its hex-encoded
 -- form. The hex encoding uses lowercase letters.

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Primitives.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Primitives.hs
@@ -129,10 +129,12 @@ convertPrim _ "BEPartyToQuotedText" (TParty :-> TText) =
     EBuiltin BEPartyToQuotedText
 convertPrim _ "BEPartyFromText" (TText :-> TOptional TParty) =
     EBuiltin BEPartyFromText
-convertPrim version "BEInt64FromText" t@(TText :-> TOptional TInt64) =
-    whenRuntimeSupports version featureNumberFromText t $ EBuiltin BEInt64FromText
-convertPrim version "BEDecimalFromText" t@(TText :-> TOptional TDecimal) =
-    whenRuntimeSupports version featureNumberFromText t $ EBuiltin BEDecimalFromText
+convertPrim version "BEInt64FromText" (TText :-> TOptional TInt64)
+    | version `supports` featureNumberFromText = EBuiltin BEInt64FromText
+    | otherwise = EVal $ Qualified PRSelf (mkModName ["DA", "Text"]) (mkVal "legacyParseInt")
+convertPrim version "BEDecimalFromText" (TText :-> TOptional TDecimal)
+    | version `supports` featureNumberFromText = EBuiltin BEDecimalFromText
+    | otherwise = EVal $ Qualified PRSelf (mkModName ["DA", "Text"]) (mkVal "legacyParseDecimal")
 
 -- Map operations
 

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -730,7 +730,7 @@ object DecodeV1 {
       TO_QUOTED_TEXT_PARTY -> (BToQuotedTextParty -> "0"),
       FROM_TEXT_PARTY -> (BFromTextParty -> "2"),
       FROM_TEXT_INT64 -> (BFromTextInt64 -> "5"),
-      FROM_TEXT_DECIMAL -> (BFromTextInt64 -> "5"),
+      FROM_TEXT_DECIMAL -> (BFromTextDecimal -> "5"),
       SHA256_TEXT -> (BSHA256Text -> "2"),
       DATE_TO_UNIX_DAYS -> (BDateToUnixDays -> "0"),
       EXPLODE_TEXT -> (BExplodeText -> "0"),


### PR DESCRIPTION
DAML-LF 1.5 introduces two new primitives `FROM_TEXT_INT64` and
`FROM_TEXT_DECIMAL`. We translate `parseInt` and `parseDecimal` to
these primitives when compiling to DAML-LF 1.5 or later.

This fixes #1398.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1415)
<!-- Reviewable:end -->
