### PR TITLE
Better error message for install --force failure on Windows.

### DIFF
--- a/daml-assistant/ghci.sh
+++ b/daml-assistant/ghci.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-# To run tests run :main
-
-exec da-ghci --data no //daml-assistant:daml

--- a/daml-assistant/ghcid.sh
+++ b/daml-assistant/ghcid.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-[ -n "$1" ] && ARGS="--test=$1"
-exec ghcid --command="$(dirname $0)/ghci.sh" "$ARGS"


### PR DESCRIPTION
Adds a nicer error message when user attempts to `install --force` the currently running version on Windows. The error also suggests the user to go get the latest github release and reinstall the DAML SDK from scratch, if they really want to reinstall.

Also, removes `ghci.sh` and `ghcid.sh` since these can just be invoked in dev-env now as `da-ghcid :daml` instead, even when there are errors.

Fixes #1164 (parsimoniously).