### PR TITLE
Make generic template de/re-sugaring work for old DAML-LF versions

### DIFF
--- a/daml-foundations/daml-ghc/tests/GenTemplCompat.daml
+++ b/daml-foundations/daml-ghc/tests/GenTemplCompat.daml
@@ -1,0 +1,66 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that non-generic templates work with the new de/re-sugaring of
+-- templates for DAML-LF < 1.5 as well. This test can be deleted when
+-- generic templates (#1387) land in master.
+daml 1.2
+module GenTemplCompat where
+
+import Prelude hiding (Template (..), Choice (..), create, fetch, exercise)
+import DA.Assert
+import GenericTemplates
+
+data Fact = Fact with
+    owner : Party
+    name : Text
+    value : Int
+  deriving (Eq, Show)
+
+instance FactInstance => Template Fact where
+    signatory = signatoryFact
+    observer = observerFact
+    ensure = ensureFact
+    agreement = agreementFact
+    create = createFact
+    fetch = fetchFact
+
+data Revoke = Revoke{}
+  deriving (Eq, Show)
+
+instance FactInstance => Choice Fact Revoke () where
+    exercise = exerciseFactRevoke
+
+class FactInstance where
+    signatoryFact : Fact -> [Party]
+    signatoryFact this@Fact{..} = [owner]
+    observerFact : Fact -> [Party]
+    observerFact this@Fact{..} = []
+    ensureFact : Fact -> Bool
+    ensureFact this@Fact{..} = name /= ""
+    agreementFact : Fact -> Text
+    agreementFact this@Fact{..} =
+        show owner <> " provides " <> show name <> ": " <> show value
+    createFact : Fact -> Update (ContractId Fact)
+    createFact = error "code will be injected by the compiler"
+    fetchFact : ContractId Fact -> Update Fact
+    fetchFact = error "code will be injected by the compiler"
+    controllerFactRevoke : Fact -> Revoke -> [Party]
+    controllerFactRevoke this@Fact{..} arg@Revoke = [owner]
+    actionFactRevoke : ContractId Fact -> Fact -> Revoke -> Update ()
+    actionFactRevoke self this@Fact{..} arg@Revoke = do
+        pure ()
+    exerciseFactRevoke : ContractId Fact -> Revoke -> Update ()
+    exerciseFactRevoke = error "code will be injected by the compiler"
+
+instance FactInstance where
+
+
+test = scenario do
+    alice <- getParty "Alice"
+    let fact = Fact with owner = alice; name = "Answer"; value = 42
+    factId <- submit alice do create fact
+    fact' <- submit alice do fetch factId
+    fact' === fact
+    submit alice do exercise factId Revoke
+    submitMustFail alice do fetch factId


### PR DESCRIPTION
We probably don't want to drop support for DAML-LF < 1.5 from the compiler
when we switch to the new template de/re-sugaring backing generic templates.
Thus, we need to make sure non-generic template work with this new
de/re-sugaring for DAML-LF < 1.5.

This is part of #1387.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1424)
<!-- Reviewable:end -->
