### PR TITLE
DAML Engine. Improve error message for arithmetic overflow

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Utf8.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Utf8.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 
 // The DAML-LF strings are supposed to be UTF-8 while standard java strings are UTF16
 // Note number of UTF16 operations are not Utf8 equivalent (for instance length, charAt, ordering ...)
-// This module provide UTF8 emulation functions.
+// This module provides UTF8 emulation functions.
 object Utf8 {
 
   // The DAML-LF strings are supposed to be UTF-8.
@@ -20,12 +20,10 @@ object Utf8 {
     val len = s.length
     val arr = ImmArray.newBuilder[String]
     var i = 0
-    var j = 0
     while (i < len) {
       // if s(i) is a high surrogate the current codepoint uses 2 chars
       val next = if (s(i).isHighSurrogate) i + 2 else i + 1
       arr += s.substring(i, next)
-      j += 1
       i = next
     }
     arr.result()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -252,7 +252,7 @@ object SBuiltin {
   }
 
   final case object SBFromTextDecimal extends SBuiltin(1) {
-    private val pattern = """[+-]?[0-9]+(\.[0-9]+)?""".r.pattern
+    private val pattern = """[+-]?\d+(\.\d+)?""".r.pattern
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val s = args.get(0).asInstanceOf[SText].value
@@ -333,10 +333,7 @@ object SBuiltin {
 
   final case object SBMapToList extends SBuiltin(1) {
 
-    //  implicit val classTag: ClassTag[Ref.Name.T] = Ref.Name.classTag
-
-    private val entryFields =
-      Name.Array(Ast.keyFieldName, Ast.valueFieldName)
+    private val entryFields = Name.Array(Ast.keyFieldName, Ast.valueFieldName)
 
     private def entry(key: String, value: SValue) = {
       val args = new util.ArrayList[SValue](2)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -32,7 +32,9 @@ object SError {
   sealed trait SErrorDamlException extends SError
 
   /** Arithmetic error such as division by zero */
-  final case class DamlEArithmeticError(message: String) extends SErrorDamlException
+  final case class DamlEArithmeticError(message: String) extends SErrorDamlException {
+    override def toString: String = message
+  }
 
   /** User initiated error, via e.g. 'abort' or 'assert' */
   final case class DamlEUserError(message: String) extends SErrorDamlException

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -67,6 +67,11 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"DIV_INT64 $MaxInt64 -1") shouldBe Right(SInt64(-MaxInt64))
         eval(e"DIV_INT64 $MinInt64 -1") shouldBe 'left
       }
+
+      "throws an exception when dividing by 0" in {
+        eval(e"DIV_INT64 1 $MaxInt64") shouldBe Right(SInt64(0))
+        eval(e"DIV_INT64 1 0") shouldBe 'left
+      }
     }
 
     "EXP_INT64" - {
@@ -214,6 +219,20 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"MUL_DECIMAL $bigBigDecimal $bigBigDecimal") shouldBe 'left
         eval(e"MUL_DECIMAL ${1E13} ${1E14}") shouldBe Right(SDecimal(decimal(1E27)))
         eval(e"MUL_DECIMAL ${1E14} ${1E14}") shouldBe 'left
+      }
+    }
+
+    "DEV_DECIMAL" - {
+      "throws exception in case of overflow" in {
+        eval(e"DIV_DECIMAL 1.1 2.2") shouldBe Right(SDecimal(decimal(0.5)))
+        eval(e"DIV_DECIMAL $bigBigDecimal ${1E-10}") shouldBe 'left
+        eval(e"DIV_DECIMAL ${1E17} ${1E-10}") shouldBe Right(SDecimal(decimal(1E27)))
+        eval(e"DIV_DECIMAL ${1E18} ${1E-10}") shouldBe 'left
+      }
+
+      "throws exception when divided by 0" in {
+        eval(e"DIV_DECIMAL 1.0 ${1E-10}") shouldBe Right(SDecimal(decimal(1E10)))
+        eval(e"DIV_DECIMAL 1.0 0.0") shouldBe 'left
       }
     }
 
@@ -613,7 +632,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
   "Conversion operations" - {
 
-    val almostZero = BigDecimal("0.0000000001")
+    val almostZero = BigDecimal("1E-10")
 
     "DECIMAL_TO_INT64" - {
       "throws exception in case of overflow" in {
@@ -625,7 +644,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"DECIMAL_TO_INT64 ${BigDecimal(2).pow(63) - almostZero}") shouldBe Right(
           SInt64(Long.MaxValue))
         eval(e"DECIMAL_TO_INT64 ${BigDecimal(2).pow(63)}") shouldBe 'left
-        eval(e"DECIMAL_TO_INT64 1000000000000000000000.0") shouldBe 'left
+        eval(e"DECIMAL_TO_INT64 ${1E22}") shouldBe 'left
       }
 
       "works as expected" in {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -8,7 +8,7 @@ import java.util
 import com.digitalasset.daml.lf.PureCompiledPackages
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.lfpackage.Ast._
-import com.digitalasset.daml.lf.speedy.SError.SError
+import com.digitalasset.daml.lf.speedy.SError.{DamlEArithmeticError, SError}
 import com.digitalasset.daml.lf.speedy.SResult.{SResultContinue, SResultError}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
@@ -22,6 +22,7 @@ import scala.language.implicitConversions
 class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks {
 
   import SBuiltinTest._
+  import Decimal.{toString => str}
 
   "Integer operations" - {
 
@@ -37,7 +38,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"ADD_INT64 $MaxInt64 1") shouldBe 'left
         eval(e"ADD_INT64 $MinInt64 1") shouldBe Right(SInt64(MinInt64 + 1))
         eval(e"ADD_INT64 $MinInt64 -1") shouldBe 'left
-        eval(e"ADD_INT64 $aBigOddInt64 $aBigOddInt64") shouldBe 'left
+        eval(e"ADD_INT64 $aBigOddInt64 $aBigOddInt64") shouldBe
+          Left(DamlEArithmeticError(s"Int64 overflow when adding $aBigOddInt64 to $aBigOddInt64."))
       }
     }
 
@@ -47,7 +49,9 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"SUB_INT64 $MaxInt64 -1") shouldBe 'left
         eval(e"SUB_INT64 $MinInt64 -1") shouldBe Right(SInt64(MinInt64 + 1))
         eval(e"SUB_INT64 $MinInt64 1") shouldBe 'left
-        eval(e"SUB_INT64 -$aBigOddInt64 $aBigOddInt64") shouldBe 'left
+        eval(e"SUB_INT64 -$aBigOddInt64 $aBigOddInt64") shouldBe Left(
+          DamlEArithmeticError(
+            s"Int64 overflow when subtracting $aBigOddInt64 from -$aBigOddInt64."))
       }
     }
 
@@ -58,19 +62,23 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"MUL_INT64 ${1L << 32} -${1L << 31}") shouldBe Right(SInt64(1L << 63))
         eval(e"MUL_INT64 ${1L << 32} -${1L << 32}") shouldBe 'left
         eval(e"MUL_INT64 ${1L << 32} -${1L << 32}") shouldBe 'left
-        eval(e"MUL_INT64 $aBigOddInt64 10") shouldBe 'left
+        eval(e"MUL_INT64 $aBigOddInt64 42") shouldBe
+          Left(DamlEArithmeticError(s"Int64 overflow when multiplying $aBigOddInt64 by 42."))
       }
     }
 
     "DIV_INT64" - {
       "throws an exception if it overflows" in {
         eval(e"DIV_INT64 $MaxInt64 -1") shouldBe Right(SInt64(-MaxInt64))
-        eval(e"DIV_INT64 $MinInt64 -1") shouldBe 'left
+        eval(e"DIV_INT64 $MinInt64 -1") shouldBe
+          Left(DamlEArithmeticError(s"Int64 overflow when dividing $MinInt64 by -1."))
       }
 
       "throws an exception when dividing by 0" in {
         eval(e"DIV_INT64 1 $MaxInt64") shouldBe Right(SInt64(0))
         eval(e"DIV_INT64 1 0") shouldBe 'left
+        eval(e"DIV_INT64 $aBigOddInt64 0") shouldBe
+          Left(DamlEArithmeticError(s"Attempt to divide $aBigOddInt64 by 0."))
       }
     }
 
@@ -82,7 +90,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"EXP_INT64 0 -1") shouldBe 'left
         eval(e"EXP_INT64 10 -1") shouldBe 'left
         eval(e"EXP_INT64 10 -20") shouldBe 'left
-        eval(e"EXP_INT64 $aBigOddInt64 -10") shouldBe 'left
+        eval(e"EXP_INT64 $aBigOddInt64 -42") shouldBe Left(
+          DamlEArithmeticError(s"Attempt to raise $aBigOddInt64 to the negative exponent -42."))
       }
 
       "throws an exception if it overflows" in {
@@ -90,7 +99,9 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"EXP_INT64 ${1L << 7} 9") shouldBe 'left
         eval(e"EXP_INT64 ${-(1L << 7)} 9") shouldBe Right(SInt64(1L << 63))
         eval(e"EXP_INT64 ${-(1L << 7)} 10") shouldBe 'left
-        eval(e"EXP_INT64 3 $aBigOddInt64") shouldBe 'left
+        eval(e"EXP_INT64 3 $aBigOddInt64") shouldBe Left(
+          DamlEArithmeticError(s"Int64 overflow when raising 3 to the exponent $aBigOddInt64.")
+        )
       }
 
       "accepts huge exponents for bases -1, 0 and, 1" in {
@@ -200,7 +211,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"ADD_DECIMAL $bigBigDecimal 2.0") shouldBe Right(SDecimal(bigBigDecimal + 2))
         eval(e"ADD_DECIMAL $maxDecimal $minPosDecimal") shouldBe 'left
         eval(e"ADD_DECIMAL ${-maxDecimal} ${-minPosDecimal}") shouldBe 'left
-        eval(e"ADD_DECIMAL $bigBigDecimal $bigBigDecimal") shouldBe 'left
+        eval(e"ADD_DECIMAL $bigBigDecimal ${bigBigDecimal - 1}") shouldBe
+          Left(
+            DamlEArithmeticError(
+              s"Decimal overflow when adding ${bigBigDecimal - 1} to $bigBigDecimal."))
       }
     }
 
@@ -209,30 +223,42 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"SUB_DECIMAL $bigBigDecimal 2.0") shouldBe Right(SDecimal(bigBigDecimal - 2))
         eval(e"SUB_DECIMAL $maxDecimal -$minPosDecimal") shouldBe 'left
         eval(e"SUB_DECIMAL ${-maxDecimal} $minPosDecimal") shouldBe 'left
-        eval(e"SUB_DECIMAL ${-bigBigDecimal} $bigBigDecimal") shouldBe 'left
+        eval(e"SUB_DECIMAL ${-bigBigDecimal} $bigBigDecimal") shouldBe
+          Left(DamlEArithmeticError(
+            s"Decimal overflow when subtracting ${str(bigBigDecimal)} from ${str(-bigBigDecimal)}."))
       }
     }
 
     "MUL_DECIMAL" - {
       "throws exception in case of overflow" in {
         eval(e"MUL_DECIMAL 1.1 2.2") shouldBe Right(SDecimal(decimal(2.42)))
-        eval(e"MUL_DECIMAL $bigBigDecimal $bigBigDecimal") shouldBe 'left
         eval(e"MUL_DECIMAL ${1E13} ${1E14}") shouldBe Right(SDecimal(decimal(1E27)))
         eval(e"MUL_DECIMAL ${1E14} ${1E14}") shouldBe 'left
+        eval(e"MUL_DECIMAL $bigBigDecimal ${bigBigDecimal - 1}") shouldBe Left(
+          DamlEArithmeticError(
+            s"Decimal overflow when multiplying ${str(bigBigDecimal)} by ${str(bigBigDecimal - 1)}.")
+        )
       }
     }
 
-    "DEV_DECIMAL" - {
+    "DIV_DECIMAL" - {
       "throws exception in case of overflow" in {
         eval(e"DIV_DECIMAL 1.1 2.2") shouldBe Right(SDecimal(decimal(0.5)))
         eval(e"DIV_DECIMAL $bigBigDecimal ${1E-10}") shouldBe 'left
         eval(e"DIV_DECIMAL ${1E17} ${1E-10}") shouldBe Right(SDecimal(decimal(1E27)))
-        eval(e"DIV_DECIMAL ${1E18} ${1E-10}") shouldBe 'left
+        eval(e"DIV_DECIMAL ${1E18} ${1E-10}") shouldBe Left(
+          DamlEArithmeticError(
+            s"Decimal overflow when dividing ${str(BigDecimal(1E18))} by ${str(BigDecimal(1E-10))}.")
+        )
       }
 
       "throws exception when divided by 0" in {
         eval(e"DIV_DECIMAL 1.0 ${1E-10}") shouldBe Right(SDecimal(decimal(1E10)))
         eval(e"DIV_DECIMAL 1.0 0.0") shouldBe 'left
+        eval(e"DIV_DECIMAL $bigBigDecimal 0.0") shouldBe Left(
+          DamlEArithmeticError(s"Attempt to divide $bigBigDecimal by 0.0.")
+        )
+
       }
     }
 

--- a/daml-lf/tests/scenario/daml-1.3/eval-agreement/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.3/eval-agreement/EXPECTED.ledger
@@ -1,1 +1,1 @@
-Error: / by zero
+Error: Attempt to divide 0 by 0.


### PR DESCRIPTION
This PR addresses the Issue #1365.

In case of Integer and Decimal overflow, the engine returns now an error message describing the operation (together with its arguments) that yields the overflow. 

For instance when trying to multiply `1000000000000` with `1000000000000` the engine will crash with the error messsage:
``
Int64 overflow when multiplying 1000000000000 by 1000000000000
``

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
