### PR TITLE
Add deprecation warning to da assistant.

### DIFF
--- a/da-assistant/BUILD.bazel
+++ b/da-assistant/BUILD.bazel
@@ -5,7 +5,7 @@ load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_test")
 load("//bazel_tools:packaging/packaging.bzl", "package_app")
 load("@ai_formation_hazel//:hazel.bzl", "hazel_binary")
 
-da_cli_version = "114-7582c1a0bd"
+da_cli_version = "115-c2bae7375a"
 
 da_cli_version_flag = '-DDA_CLI_VERSION="%s"' % da_cli_version
 

--- a/da-assistant/DA/Sdk/Cli.hs
+++ b/da-assistant/DA/Sdk/Cli.hs
@@ -104,6 +104,20 @@ runAssistant = do
     displayStr $ "Warning: The SDK Assistant should be run as a normal user. " <>
                  "Now it is run as root."
     displayNewLine
+
+
+  IO.hPutStr IO.stderr . unlines $
+    [ "WARNING: The da assistant is deprecated in favor of the new daml assistant."
+    , "Please follow the installation instructions for the new daml assistant:"
+    , ""
+    , "    https://docs.daml.com/getting-started/installation.html"
+    , ""
+    , "And consult the migration guide at:"
+    , ""
+    , "    https://docs.daml.com/support/new-assistant.html"
+    , ""
+    ]
+
   -- First parse CLI argument into a structured command (or exit).
   command <- getCommand
 


### PR DESCRIPTION
Prints a deprecation warning to stderr, pointing user to installation instructions and migration guide for the new assistant. Part of #1327.