### PR TITLE
Use effective_at to populate contracts loaded in SqlBackend

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -27,6 +27,12 @@ SQL Extractor
   for all three parties in the database.
   See `#1360 <https://github.com/digital-asset/daml/pull/1360>`__.
 
+Sandbox
+~~~~~~~
+
+- Fixed a bug in the SQL backend that caused transactions with a fetch node referencing a contract created in the same transaction to be rejected.
+  See [issue #1435](https://github.com/digital-asset/daml/issues/1435).
+
 0.12.21 - 2019-05-28
 --------------------
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestTemplateIdentifiers.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestTemplateIdentifiers.scala
@@ -119,6 +119,8 @@ final case class TestTemplateIdentifiers(testPackageId: String) {
       "Test.MaintainerNotSignatory",
       moduleName = "Test",
       entityName = "MaintainerNotSignatory")
+  val createAndFetch =
+    Identifier(testPackageId, "Test.CreateAndFetch", "Test", "CreateAndFetch")
   val allTemplates =
     List(
       dummy,
@@ -134,6 +136,7 @@ final case class TestTemplateIdentifiers(testPackageId: String) {
       divulgence1,
       divulgence2,
       witnesses,
-      maintainerNotSignatory
+      maintainerNotSignatory,
+      createAndFetch
     )
 }

--- a/ledger/sandbox/src/test/resources/damls/Test.daml
+++ b/ledger/sandbox/src/test/resources/damls/Test.daml
@@ -518,3 +518,16 @@ template MaintainerNotSignatory
 
     key q: Party
     maintainer q
+
+template CreateAndFetch
+  with
+    p: Party
+  where
+    signatory p
+
+    controller p can
+      CreateAndFetch_Run: ()
+        do
+            cid <- create CreateAndFetch with p
+            _ <- fetch cid
+            return ()


### PR DESCRIPTION
Because the record time was mapped to the ledger effective time field
when deserializing contracts from the SQL database, a subsequent
comparison between the LETs of two nodes in the same transaction caused
the transaction to be rejected.

Fixes #1435.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
