### PR TITLE
Test java codegen against the latest DAML-LF version

### DIFF
--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -108,7 +108,7 @@ pom_file(
 daml_lf_target_versions = [
     "1.0",
     "1.1",
-    "1.3",
+    "latest",
 ]
 
 ########################################################
@@ -130,10 +130,9 @@ alias(
 )
 
 daml_compile(
-    name = "integration-tests-model-1.3",
+    name = "integration-tests-model-latest",
     srcs = glob(["src/it/daml/**/*.daml"]),
     main_src = "src/it/daml/Lib.daml",
-    target = "1.3",
 )
 
 [
@@ -152,7 +151,7 @@ daml_compile(
         dar_to_java(
             name = "integration-tests-model-%s" % target,
             src = ":integration-tests-model-%s.dar" % target,
-            package_prefix = "lf%s" % mangle_for_java(target),
+            package_prefix = "lf_%s" % mangle_for_java(target),
         ),
     ]
     for target in daml_lf_target_versions
@@ -165,7 +164,7 @@ daml_compile(
             "src/it/java-%s/**/*.java" % target,
             "src/it/java/**/*.java",
         ]),
-        test_class = "com.digitalasset.lf%s.AllTests" % mangle_for_java(target),
+        test_class = "com.digitalasset.lf_%s.AllTests" % mangle_for_java(target),
         deps = [
             ":integration-tests-model-%s.jar" % target,
             ":integration-tests-model-noprefix-%s.jar" % target,

--- a/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/AllTests.java
+++ b/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/AllTests.java
@@ -1,15 +1,15 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_3;
+package com.digitalasset.lf_1_0;
 
+import com.digitalasset.AllGenericTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import com.digitalasset.AllGenericTests;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        MapTest.class,
+        OptionalTest.class,
         AllGenericTests.class
 })
 public class AllTests {

--- a/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/OptionalTest.java
+++ b/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/OptionalTest.java
@@ -1,21 +1,21 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_0;
+package com.digitalasset.lf_1_0;
 
 import com.daml.ledger.javaapi.data.*;
-import lf1_0.da.internal.prelude.optional.Some;
-import lf1_0.da.internal.prelude.Optional;
+import lf_1_0.da.internal.prelude.optional.Some;
+import lf_1_0.da.internal.prelude.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import lf1_0.tests.optionaltest.MyListOfOptionalsRecord;
-import lf1_0.tests.optionaltest.MyOptionalListRecord;
-import lf1_0.tests.optionaltest.MyOptionalRecord;
-import lf1_0.tests.optionaltest.NestedOptionalRecord;
-import lf1_0.tests.optionaltest.optionalvariant.OptionalParametricVariant;
-import lf1_0.tests.optionaltest.optionalvariant.OptionalPrimVariant;
+import lf_1_0.tests.optionaltest.MyListOfOptionalsRecord;
+import lf_1_0.tests.optionaltest.MyOptionalListRecord;
+import lf_1_0.tests.optionaltest.MyOptionalRecord;
+import lf_1_0.tests.optionaltest.NestedOptionalRecord;
+import lf_1_0.tests.optionaltest.optionalvariant.OptionalParametricVariant;
+import lf_1_0.tests.optionaltest.optionalvariant.OptionalPrimVariant;
 
 import java.util.Arrays;
 import java.util.List;

--- a/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/AllTests.java
+++ b/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/AllTests.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_1;
+package com.digitalasset.lf_1_1;
 
 import com.digitalasset.AllGenericTests;
 import org.junit.runner.RunWith;

--- a/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/OptionalTest.java
+++ b/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/OptionalTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_1;
+package com.digitalasset.lf_1_1;
 
 import com.daml.ledger.javaapi.data.*;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
@@ -9,9 +9,9 @@ import com.google.protobuf.Empty;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import lf1_1.tests.optionaltest.*;
-import lf1_1.tests.optionaltest.optionalvariant.OptionalParametricVariant;
-import lf1_1.tests.optionaltest.optionalvariant.OptionalPrimVariant;
+import lf_1_1.tests.optionaltest.*;
+import lf_1_1.tests.optionaltest.optionalvariant.OptionalParametricVariant;
+import lf_1_1.tests.optionaltest.optionalvariant.OptionalPrimVariant;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/AllTests.java
+++ b/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/AllTests.java
@@ -1,15 +1,15 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_0;
+package com.digitalasset.lf_latest;
 
-import com.digitalasset.AllGenericTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import com.digitalasset.AllGenericTests;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        OptionalTest.class,
+        MapTest.class,
         AllGenericTests.class
 })
 public class AllTests {

--- a/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/MapTest.java
+++ b/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/MapTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf1_3;
+package com.digitalasset.lf_latest;
 
 import com.daml.ledger.javaapi.data.Int64;
 import com.daml.ledger.javaapi.data.Record;


### PR DESCRIPTION
I'm refurbishing the DAML-LF 1.3 specific tests to run against the
latest DAML-LF version (by removing the explicit target version in the
daml_compile target).
Going forward we only "reify" specific DAML LF versions when breaking
changes or new features are introduced, and we need to test the old
behavior specifically (just like we did for DAML LF 1.0 and 1.1).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
