### PR TITLE
windows: fixing damldoc tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -76,6 +76,7 @@ bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/test_execution_w
     //daml-foundations/daml-ghc:daml-ghc-deterministic `
     //daml-foundations/daml-ghc:examples-memory `
     //daml-foundations/daml-ghc:module-tree-memory `
+    //daml-foundations/daml-ghc:tasty-test `
     //daml-foundations/daml-tools/da-hs-daml-cli `
     //daml-foundations/daml-tools/da-hs-damlc-app/...
     # Disabled since there seems to be an issue with starting up the scenario service.

--- a/daml-foundations/daml-ghc/damldoc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/damldoc/BUILD.bazel
@@ -58,6 +58,7 @@ da_haskell_library(
     deps = [
         "//daml-foundations/daml-ghc/damldoc",
         "//daml-foundations/daml-ghc/ghc-compiler",
+        "//daml-foundations/daml-ghc/test-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Anchor.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Anchor.hs
@@ -27,7 +27,8 @@ import qualified Data.Char as C
 type Anchor = T.Text
 
 moduleAnchor :: Modulename -> Anchor
-moduleAnchor m = T.intercalate "-" ["module", convertModulename m, hashText m]
+-- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
+moduleAnchor m = T.intercalate "-" ["module", convertModulename m, hashText $ T.unpack m]
 
 convertModulename :: Modulename -> T.Text
 convertModulename = T.toLower . T.replace "." "-" . T.replace "_" ""
@@ -48,7 +49,8 @@ functionAnchor     = anchor "function"
 
 
 anchor :: Hashable v => T.Text -> Modulename -> T.Text -> v -> Anchor
-anchor k m n v = T.intercalate "-" [k, convertModulename m, expandOps n, hashText (k,m,n,v)]
+-- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
+anchor k m n v = T.intercalate "-" [k, convertModulename m, expandOps n, hashText (T.unpack k, T.unpack m, T.unpack n, v)]
   where
     expandOps :: T.Text -> T.Text
     expandOps = T.pack . replaceEmpty . concatMap expandOp . T.unpack

--- a/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -77,31 +77,31 @@ cases = [ ("Empty module",
 expectRst :: [T.Text]
 expectRst =
         [ T.empty
-        , mkExpectRst "module-typedef-84401" "Typedef" "" [] []
-            ["\n.. _type-typedef-t-46263:\n\ntype **T a**\n    = TT TTT\n\n  T descr"] []
-        , mkExpectRst "module-twotypes-29865" "TwoTypes" "" []
+        , mkExpectRst "module-typedef-50108" "Typedef" "" [] []
+            ["\n.. _type-typedef-t-88479:\n\ntype **T a**\n    = TT TTT\n\n  T descr"] []
+        , mkExpectRst "module-twotypes-33303" "TwoTypes" "" []
             []
-            ["\n.. _type-twotypes-t-78671:\n\ntype **T a**\n    = TT\n\n  T descr"
-            , "\n.. _data-twotypes-d-26535:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d-44264:\n  \n  **D** a\n  \n  D descr"]
+            ["\n.. _type-twotypes-t-17090:\n\ntype **T a**\n    = TT\n\n  T descr"
+            , "\n.. _data-twotypes-d-66754:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d-45919:\n  \n  **D** a\n  \n  D descr"]
             []
-        , mkExpectRst "module-function1-41637" "Function1" "" [] [] [] [ "\n.. _function-function1-f-58156:\n\n**f**\n  : TheType\n\n  the doc\n"]
-        , mkExpectRst "module-function2-8780" "Function2" "" [] [] [] [ "\n.. _function-function2-f-82168:\n\n**f**\n  :   the doc\n"]
-        , mkExpectRst "module-function3-86399" "Function3" "" [] [] [] [ "\n.. _function-function3-f-29506:\n\n**f**\n  : TheType\n\n"]
-        , mkExpectRst "module-onlyclass-16562" "OnlyClass" ""
+        , mkExpectRst "module-function1-29590" "Function1" "" [] [] [] [ "\n.. _function-function1-f-2320:\n\n**f**\n  : TheType\n\n  the doc\n"]
+        , mkExpectRst "module-function2-7227" "Function2" "" [] [] [] [ "\n.. _function-function2-f-87524:\n\n**f**\n  :   the doc\n"]
+        , mkExpectRst "module-function3-84844" "Function3" "" [] [] [] [ "\n.. _function-function3-f-53414:\n\n**f**\n  : TheType\n\n"]
+        , mkExpectRst "module-onlyclass-88463" "OnlyClass" ""
             []
-            [ "\n.. _class-onlyclass-c-67131:"
-            , "**class C a where**\n  \n  .. _function-onlyclass-member-21063:\n  \n  **member**\n    : a"
+            [ "\n.. _class-onlyclass-c-63566:"
+            , "**class C a where**\n  \n  .. _function-onlyclass-member-29050:\n  \n  **member**\n    : a"
             ]
             []
             []
-        , mkExpectRst "module-multilinefield-44931" "MultiLineField" ""
+        , mkExpectRst "module-multilinefield-24755" "MultiLineField" ""
             []
             []
-            [ "\n.. _data-multilinefield-d-29541:"
+            [ "\n.. _data-multilinefield-d-47142:"
             , "data **D**"
             , T.concat
                   [ "  \n  \n"
-                  , "  .. _constr-multilinefield-d-88570:\n  \n"
+                  , "  .. _constr-multilinefield-d-61939:\n  \n"
                   , "  **D**\n  \n  \n"
                   , "  .. list-table::\n"
                   , "     :widths: 15 10 30\n"

--- a/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -11,6 +11,7 @@ import           DA.Daml.GHC.Compiler.Options
 import           DA.Daml.GHC.Damldoc.HaddockParse
 import           DA.Daml.GHC.Damldoc.Render
 import           DA.Daml.GHC.Damldoc.Types
+import           DA.Test.Util
 
 import           Control.Monad.Except
 import qualified Data.Aeson.Encode.Pretty as AP
@@ -269,7 +270,7 @@ fileTest damlFile = do
 
               expectEqual :: String -> T.Text -> T.Text -> Assertion
               expectEqual extension ref actual
-                | ref == actual = pure ()
+                | standardizeEoL ref == standardizeEoL actual = pure ()
                 | otherwise = do
                     let actualFile = replaceExtensions expectation ("ACTUAL" <> extension)
                         asLines = lines . T.unpack

--- a/daml-foundations/daml-ghc/test-lib/DA/Test/Util.hs
+++ b/daml-foundations/daml-ghc/test-lib/DA/Test/Util.hs
@@ -2,7 +2,10 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- | Test utils
-module DA.Test.Util (standardizeQuotes) where
+module DA.Test.Util (
+    standardizeQuotes,
+    standardizeEoL
+) where
 
 import qualified Data.Text as T
 
@@ -13,3 +16,6 @@ standardizeQuotes msg = let
         repl '`' = '\''
         repl  c   = c
     in  T.map repl msg
+
+standardizeEoL :: T.Text -> T.Text
+standardizeEoL = T.replace (T.singleton '\r') T.empty

--- a/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.rst
+++ b/daml-foundations/daml-ghc/tests/Iou_template.EXPECTED.rst
@@ -1,6 +1,6 @@
 
 
-.. _module-ioutemplate-80440:
+.. _module-ioutemplate-98694:
 
 Module Iou_template
 -------------------
@@ -9,7 +9,7 @@ Module Iou_template
 Templates
 ^^^^^^^^^
 
-.. _template-ioutemplate-iou-86035:
+.. _template-ioutemplate-iou-32396:
 
 template **Iou**
 
@@ -83,7 +83,7 @@ template **Iou**
 Functions
 ^^^^^^^^^
 
-.. _function-ioutemplate-main-42433:
+.. _function-ioutemplate-main-13221:
 
 **main**
   :   A single test scenario covering all functionality that ``Iou`` implements.


### PR DESCRIPTION
Fixes `//daml-foundations/daml-ghc:tasty-test`
- `Data.Hashable.hash` gives different results for `Data.Text` instances on Windows compared to other OSes - I guess it's because of hash calculation on a byte array (https://github.com/tibbe/hashable/blob/cc4ede9bf7821f952eb700a131cf1852d3fd3bcd/Data/Hashable/Class.hs#L643), where endianess and/or encoding affects the array content - as a workaround I switched to `String`s for hash calculation in the `Anchor`, which behave correctly
- standardize end of lines in actual-expected files comparison

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
