### PR TITLE
webide: remove usage of sdk docker image

### DIFF
--- a/web-ide/ide-server/Dockerfile
+++ b/web-ide/ide-server/Dockerfile
@@ -1,32 +1,43 @@
-ARG DAML_VERSION=0.12.16
+FROM openjdk:8-slim
 
-FROM "digitalasset/daml-sdk:${DAML_VERSION}-master"
-
-#strange but true...if we simply redeclare the arg defined before FROM it is visible after FROM
-ARG DAML_VERSION
-
-RUN da list
+ARG DAML_VERSION=0.12.21
 USER root
-# Install VS Code's deps, libxkbfile-dev and libsecret-1-dev
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - &&\
-    apt-get update && apt-get install -y \
+
+RUN addgroup --gid 1000 sdk && \
+    adduser --gecos "" --uid 1000 --gid 1000 \
+            --home /home/sdk --shell /bin/bash \
+            --disabled-password \
+            sdk
+
+RUN apt-get update -y && \
+        apt-get -y install \
+        curl \
         procps \
         nodejs \
-        libxkbfile-dev \
+        # Install VS Code's deps, libxkbfile-dev and libsecret-1-dev
+        libxkbfile-dev \ 
         libsecret-1-dev &&\
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - &&\
+    apt-get clean &&\
     apt-get remove -y --allow-remove-essential apt
-
+ 
 USER sdk
 ENV CODESERVER_SHA256=4fe5b4d10d3048a5e5aa3e0772c09ece56241b91e76eeaa7404b4da292442881\
-    CODESERVER_VERSION=1.939-vsc1.33.1
-RUN mkdir -p /home/sdk/.local/share/code-server/extensions/ &&\
+    CODESERVER_VERSION=1.939-vsc1.33.1\
+    PATH="${PATH}:/home/sdk/.daml/bin"
+    
+RUN cd /home/sdk/ &&\
+    curl -Lo - "https://github.com/digital-asset/daml/releases/download/v${DAML_VERSION}/daml-sdk-${DAML_VERSION}-linux.tar.gz" | tar xzvf - --strip-components 1 &&\
+    ls -l &&\
+    bash install.sh &&\
+    mkdir -p /home/sdk/.local/share/code-server/extensions/ &&\
     mkdir -p /home/sdk/.local/share/code-server/User/ &&\
     mkdir /home/sdk/workspace &&\
     curl -Lo - "https://github.com/codercom/code-server/releases/download/${CODESERVER_VERSION}/code-server${CODESERVER_VERSION}-linux-x64.tar.gz" | tar xzvf - --strip-components 1 "code-server${CODESERVER_VERSION}-linux-x64/code-server" &&\
     echo "${CODESERVER_SHA256} code-server" | sha256sum -c &&\
-    mv ./code-server /home/sdk/.da/bin/ &&\
-    ln -s /home/sdk/.da/packages/daml-extension/10${DAML_VERSION} /home/sdk/.local/share/code-server/extensions/da-vscode-daml-extension &&\
-    cp -R /home/sdk/.da/packages/quickstart-java/10${DAML_VERSION}/daml/* /home/sdk/workspace/ 
+    mv ./code-server /home/sdk/.daml/bin/ &&\
+    ln -s /home/sdk/.daml/sdk/${DAML_VERSION}/studio /home/sdk/.local/share/code-server/extensions/da-vscode-daml-extension &&\
+    cp -R /home/sdk/.daml/sdk/${DAML_VERSION}/templates/quickstart-java/daml/* /home/sdk/workspace/ 
 
 COPY ./settings.json /home/sdk/.local/share/code-server/User/settings.json
 # Don't let the user change the keybindings file

--- a/web-ide/ide-server/Dockerfile
+++ b/web-ide/ide-server/Dockerfile
@@ -1,6 +1,9 @@
 FROM openjdk:8-slim
 
 ARG DAML_VERSION=0.12.21
+ARG CODESERVER_SHA256=4fe5b4d10d3048a5e5aa3e0772c09ece56241b91e76eeaa7404b4da292442881
+ARG CODESERVER_VERSION=1.939-vsc1.33.1
+
 USER root
 
 RUN addgroup --gid 1000 sdk && \
@@ -22,13 +25,10 @@ RUN apt-get update -y && \
     apt-get remove -y --allow-remove-essential apt
  
 USER sdk
-ENV CODESERVER_SHA256=4fe5b4d10d3048a5e5aa3e0772c09ece56241b91e76eeaa7404b4da292442881\
-    CODESERVER_VERSION=1.939-vsc1.33.1\
-    PATH="${PATH}:/home/sdk/.daml/bin"
+ENV PATH="${PATH}:/home/sdk/.daml/bin"
     
 RUN cd /home/sdk/ &&\
     curl -Lo - "https://github.com/digital-asset/daml/releases/download/v${DAML_VERSION}/daml-sdk-${DAML_VERSION}-linux.tar.gz" | tar xzvf - --strip-components 1 &&\
-    ls -l &&\
     bash install.sh &&\
     mkdir -p /home/sdk/.local/share/code-server/extensions/ &&\
     mkdir -p /home/sdk/.local/share/code-server/User/ &&\

--- a/web-ide/ide-server/README.md
+++ b/web-ide/ide-server/README.md
@@ -2,11 +2,13 @@
 This is the dockerfile for creating and image with DAML SDK and the [code-server](https://github.com/codercom/code-server) IDE
 
 ### Building
-Under the main daml directory `docker build --rm -t digitalasset/daml-webide:0.11.19-master web-ide/ide-server/`
-the tagged version should match what is configured in `web-ide/proxy/config.json` if you want to run locally.
+Under the main daml directory 
+```
+docker build --rm -t digitalasset/daml-webide:latest web-ide/ide-server/
+```
 
 ### Running
-We haven't uploaded to github yet, so you must first create an image (mentioned above).
+Currently, images are in a private DA repo `digitalasset/daml-webide`. However, you can build the image as mentioned above
 
 * To run the IDE server (with ports enabled)
 `docker run --rm -i -t -p 8443:8443 {IMAGE_ID}`

--- a/web-ide/ide-server/README.md
+++ b/web-ide/ide-server/README.md
@@ -9,7 +9,7 @@ the tagged version should match what is configured in `web-ide/proxy/config.json
 We haven't uploaded to github yet, so you must first create an image (mentioned above).
 
 * To run the IDE server (with ports enabled)
-`docker run --rm -i -t -P {IMAGE_ID}`
+`docker run --rm -i -t -p 8443:8443 {IMAGE_ID}`
 
 * To bash into the image without automatically running IDE server
 `docker run --rm --user root -i -t -P {IMAGE_ID} /bin/bash`

--- a/web-ide/proxy/README.md
+++ b/web-ide/proxy/README.md
@@ -2,8 +2,23 @@
 This proxies the docker hosted web ide. It spins up a docker instance for each user and forwards http and websocket connections.
 Session state is managed by cookie (webide.connect.sid by default)
 
+### Building images
+```
+docker build --rm -t digitalasset/daml-webide-proxy:latest web-ide/proxy/
+docker build --rm -t digitalasset/daml-webide:latest web-ide/ide-server/
+```
+
+### Downloading images
+Images are stored in a private DA repo `digitalasset/daml-webide-proxy` and `digitalasset/daml-webide`. If you don't have access you can build the image, as mentioned above.
+download the proxy and webide images from dockerhub
+```
+docker pull digitalasset/daml-webide-proxy:latest
+docker pull digitalasset/daml-webide:latest
+```
+
 ### Running
-For quick developement cycles we can disable some cumbersome security features; create a copy of `src/config.json` as `src/config.local.json` and remove `docker.hostConfig.NetworkMode` entry.
+For quick developement cycles we can disable some cumbersome security features; create a copy of `src/config.json` as `src/config.local.json` and remove `docker.hostConfig.NetworkMode` entry. If you have node and npm installed, the below command will run the proxy directly on your host instead of running from within a 
+`daml-webide-proxy` container.
 
 ```
 cd web-ide/proxy
@@ -13,19 +28,13 @@ npm run compile && npm run local-start
 
 When running on server, the proxy creates containers on an internal network "web-int". In order for the proxy to communicate with them it must run under docker attached to two networks, "web-int" and "web-ext". The network creation and attachment happen automatically but it simply means that in order to run the proxy locally the same way it runs on server you have to run it via docker image and mount docker.sock.
 
-download the proxy and webide images from dockerhub
-```
-docker pull digitalasset/daml-webide-proxy:0.11.19-master
-docker pull digitalasset/daml-webide:0.11.19-master
-```
-then run it
 ```
 docker run --rm -it -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock ${IMAGE_ID_OF_PROXY}
 ```
 
-### Building image
+with custom config `~/daml/web-ide/proxy/src/config.local.json`
 ```
-docker build --rm -t digitalasset/daml-webide-proxy:0.11.19-master web-ide/proxy/
+docker run --rm -it -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock -e WEBIDE_PROXY_CONFIG=/webide-proxy/webide.config.json -v ~/daml/web-ide/proxy/src/config.local.json:/webide-proxy/webide.config.json:ro ${IMAGE_ID_OF_PROXY}
 ```
 
 ### Container settings


### PR DESCRIPTION
This PR builds the webide server image without relying on the sdk docker
image: https://github.com/DACH-NY/damlc-docker/blob/master/Dockerfile

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
