### PR TITLE
release-notes: damlc test --files

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,11 +9,6 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
-DAML Compiler
-~~~~~~~~~~~~~
-
-- **BREAKING CHANGE**: By default ``damlc test`` must be executed in a project and will test the whole project. Testing individual files, potentially outside a project, requires passing the new ``--files`` flag.
-
 Navigator
 ~~~~~~~~~~~
 
@@ -32,6 +27,7 @@ DAML Compiler
 ~~~~~~~~~~~~~
 
 - **BREAKING CHANGE**: Drop support for DAML-LF 1.2. Compiling to DAML-LF 1.3 should work without any code changes, although we highly recommend not specifying a target DAML-LF version at all.
+- **BREAKING CHANGE**: By default ``damlc test`` must be executed in a project and will test the whole project. Testing individual files, potentially outside a project, requires passing the new ``--files`` flag.
 
 SQL Extractor
 ~~~~~~~~~~~~~

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,11 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+DAML Compiler
+~~~~~~~~~~~~~
+
+- **BREAKING CHANGE**: By default ``damlc test`` must be executed in a project and will test the whole project. Testing individual files, potentially outside a project, requires passing the new ``--files`` flag.
+
 Navigator
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Update release-notes to reflect changes in #1409. I've classified it as a breaking change since `damlc test SomeFile.daml` no longer works and requires `damlc test --files SomeFile.daml` instead.

@jberthold-da sorry for not updating them right away.

cc @neil-da @cocreature 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
