### PR TITLE
Switch Hover from MarkedString to MarkupContent

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -88,7 +88,6 @@
 - flags:
   - default: false
   - {name: [-Wno-missing-signatures, -Wno-orphans, -Wno-overlapping-patterns, -Wno-incomplete-patterns, -Wno-missing-fields, -Wno-unused-matches]}
-  - {name: -Wno-deprecations, within: DA.Service.Daml.LanguageServer.Hover}
 
 # - modules:
 #   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/AtPoint.hs
@@ -58,7 +58,7 @@ atPoint tcs srcSpans pos = do
     SpanInfo{..} <- listToMaybe $ orderSpans $ spansAtPoint pos srcSpans
     ty <- spaninfoType
     let mbName  = getNameM spaninfoSource
-        mbDefinedAt = HoverHeading . ("Defined " <>) . T.pack . showSDocUnsafe . pprNameDefnLoc <$> mbName
+        mbDefinedAt = fmap (\name -> HoverMarkdown $ "**Defined " <> T.pack (showSDocUnsafe $ pprNameDefnLoc name) <> "**\n") mbName
         mbDocs  = fmap (\name -> getDocumentation name tcs) mbName
         docInfo = maybe [] (map HoverMarkdown . docHeaders) mbDocs
         range = Range

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/LSP.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/LSP.hs
@@ -16,9 +16,7 @@ import Development.IDE.Types.Diagnostics
 
 -- | Different types of content we can show on hover.
 data HoverText
-    = HoverHeading !T.Text
-      -- ^ A header that explains the content below it.
-    | HoverDamlCode !T.Text
+    = HoverDamlCode !T.Text
       -- ^ Highlighted DAML-Code
     | HoverMarkdown !T.Text
       -- ^ Markdown text.
@@ -26,7 +24,6 @@ data HoverText
 
 getHoverTextContent :: HoverText -> T.Text
 getHoverTextContent = \case
-    HoverHeading t -> t
     HoverDamlCode t -> t
     HoverMarkdown t -> t
 

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Hover.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Hover.hs
@@ -1,9 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- TODO MarkedString is deprecated in LSP protocol so we should move to MarkupContent at some point.
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Display information on hover.
@@ -42,16 +39,16 @@ handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri
     case mbResult of
         Just (mbRange, contents) ->
             pure $ Just $ Hover
-                        (HoverContentsMS $ List $ map showHoverInformation contents)
+                        (HoverContents $ MarkupContent MkMarkdown $ T.intercalate sectionSeparator $ map showHoverInformation contents)
                         mbRange
 
         Nothing -> pure Nothing
   where
-    showHoverInformation :: Compiler.HoverText -> MarkedString
+    showHoverInformation :: Compiler.HoverText -> T.Text
     showHoverInformation = \case
-        Compiler.HoverHeading h -> PlainString ("***" <> h <> "***:")
-        Compiler.HoverDamlCode damlCode -> CodeString $ LanguageString
-            { _language = damlLanguageIdentifier
-            , _value = damlCode
-            }
-        Compiler.HoverMarkdown md -> PlainString md
+        Compiler.HoverDamlCode damlCode -> T.unlines
+            [ "```" <> damlLanguageIdentifier
+            , damlCode
+            , "```"
+            ]
+        Compiler.HoverMarkdown md -> md

--- a/daml-foundations/daml-tools/language-server-tests/tests/requests/type-on-hover-2/EXPECTED.json
+++ b/daml-foundations/daml-tools/language-server-tests/tests/requests/type-on-hover-2/EXPECTED.json
@@ -1,10 +1,8 @@
 {
-  "contents": [
-    {
-      "value": ": Decimal",
-      "language": "daml"
-    }
-  ],
+  "contents": {
+    "kind": "markdown",
+    "value": "```daml\n: Decimal\n```\n"
+  },
   "range": {
     "start": {
       "line": 8,

--- a/daml-foundations/daml-tools/language-server-tests/tests/requests/type-on-hover/EXPECTED.json
+++ b/daml-foundations/daml-tools/language-server-tests/tests/requests/type-on-hover/EXPECTED.json
@@ -1,11 +1,8 @@
 {
-  "contents": [
-    {
-      "value": "Main.add\n  : Int -> Int -> Int",
-      "language": "daml"
-    },
-    "***Defined at /tests/requests/type-on-hover/Main.daml:8:1***:"
-  ],
+  "contents": {
+    "kind": "markdown",
+    "value": "```daml\nMain.add\n  : Int -> Int -> Int\n```\n*\t*\t*\n**Defined at /tests/requests/type-on-hover/Main.daml:8:1**\n"
+  },
   "range": {
     "start": {
       "line": 20,


### PR DESCRIPTION
MarkedString is deprecated in LSP (both the protocol itself and the
Haskell library) so we should move away from it. I’ve also killed `HoverHeading` since a) the name is really confusing since it is shown below and b) using Heading for the `defined in` line also seems really weird.

I’ve eyeballed the change in the IDE and couldn’t spot a difference.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
