### PR TITLE
Don't steal the name Pair for something the user doesn't want

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/TextMap.daml
@@ -26,6 +26,7 @@ module DA.TextMap
 import Prelude hiding (lookup, null, filter, empty)
 import DA.Foldable qualified as Foldable
 import DA.Internal.Prelude (TextMap)
+import DA.Internal.LF (unpackPair)
 import DA.List qualified as List
 import DA.Optional
 import DA.Traversable qualified as Traversable

--- a/daml-foundations/daml-ghc/daml-stdlib-src/Prelude.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/Prelude.daml
@@ -7,7 +7,7 @@ daml 1.2
 module Prelude (module X) where
 
 import DA.Internal.Prelude as X hiding (TextMap)
-import DA.Internal.LF as X
+import DA.Internal.LF as X hiding (Pair(..), unpackPair)
 import DA.Internal.Template as X
 import DA.Internal.Compatible as X
 import DA.Internal.Assert as X


### PR DESCRIPTION
Before we exported `Pair` from the Prelude, but it was a function no one should have used unless interfacing with LF directly. Now we don't, giving the user back a name to use.