### PR TITLE
Stop sending daml/keepAlive notifications

### DIFF
--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -10,7 +10,6 @@ module DA.Service.Daml.LanguageServer
     ( runLanguageServer
     ) where
 
-import           Control.Concurrent                        (threadDelay)
 import qualified Control.Concurrent.Async                  as Async
 import           Control.Concurrent.STM                    (TChan, atomically, newTChanIO,
                                                             readTChan, writeTChan)
@@ -259,17 +258,7 @@ runLanguageServer handleBuild loggerH = Managed.runManaged $ do
       }
     liftIO $ Async.race_
       (eventSlinger loggerH eventChan notifChan)
-      (Async.race_
-        (forever $ do
-            -- Send keep-alive notifications once a second in order to detect
-            -- when the parent has exited.
-            threadDelay (1000*1000)
-            atomically $ writeTChan notifChan
-              $ CustomNotification "daml/keepAlive"
-              $ Aeson.object []
-        )
-        (runServer loggerH (handleRequest ihandle) (handleNotification ihandle) notifChan)
-      )
+      (runServer loggerH (handleRequest ihandle) (handleNotification ihandle) notifChan)
 
 -- | Event slinger slings compiler events to the client as notifications.
 eventSlinger


### PR DESCRIPTION
These notifications appear to be completely useless. We do have a
keepAlive mechanism in the extension but it is based on the extension
sending a daml/keepAlive request to which we then respond using a
daml/keepAlive response. This is unchanged by this PR. The
daml/keepAlive notifications however, are completely unused in the
extension.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
