### PR TITLE
Use haskell-lsp’s builtin VFS in "damlc ide"

### DIFF
--- a/compiler/haskell-ide-core/BUILD.bazel
+++ b/compiler/haskell-ide-core/BUILD.bazel
@@ -20,6 +20,7 @@ depends = [
     "haskell-lsp-types",
     "mtl",
     "pretty",
+    "rope-utf16-splay",
     "safe-exceptions",
     "sorted-list",
     "shake",

--- a/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
@@ -6,7 +6,10 @@
 module Development.IDE.State.FileStore(
     getFileExists, getFileContents,
     setBufferModified,
-    fileStoreRules
+    fileStoreRules,
+    VFSHandle(..),
+    makeVFSHandle,
+    makeLSPVFSHandle,
     ) where
 
 
@@ -14,7 +17,9 @@ module Development.IDE.State.FileStore(
 import           StringBuffer
 import Development.IDE.Orphans()
 
+import Control.Concurrent.STM
 import qualified Data.Map.Strict as Map
+import Data.Maybe
 import qualified Data.Text as T
 import           Data.Time.Clock
 import           Control.Monad.Extra
@@ -22,28 +27,53 @@ import qualified System.Directory as Dir
 import           Development.Shake
 import           Development.Shake.Classes
 import           Development.IDE.State.Shake
-import           Control.Concurrent.Extra
 import           Control.Exception
 import           GHC.Generics
 import System.IO.Error
 import qualified Data.ByteString.Char8 as BS
 import qualified StringBuffer as SB
 import Development.IDE.Types.Diagnostics
+import qualified Data.Rope.UTF16 as Rope
 import           Data.Time
 
+import Language.Haskell.LSP.Core
+import Language.Haskell.LSP.VFS
 
--- This module stores the changed files in memory, and answers file system questions
--- from either the memory changes OR the file system itself
+-- | haskell-lsp manages the VFS internally and automatically so we cannot use
+-- the builtin VFS without spawning up an LSP server. To be able to test things
+-- like `setBufferModified` we abstract over the VFS implementation.
+data VFSHandle = VFSHandle
+    { getVirtualFile :: Uri -> IO (Maybe VirtualFile)
+    , setVirtualFileContents :: Uri -> T.Text -> Int -> IO ()
+    , removeVirtualFile :: Uri -> IO ()
+    }
 
-type DirtyFiles = Map.Map FilePath (UTCTime, StringBuffer) -- when it was modified, it's current value
+instance IsIdeGlobal VFSHandle
 
--- Store the DirtyFiles globally, so we can get at it through setBufferModified
-newtype GlobalDirtyFiles = GlobalDirtyFiles (Var DirtyFiles)
-instance IsIdeGlobal GlobalDirtyFiles
+makeVFSHandle :: IO VFSHandle
+makeVFSHandle = do
+    vfsVar <- newTVarIO Map.empty
+    pure VFSHandle
+        { getVirtualFile = \uri -> do
+              vfs <- readTVarIO vfsVar
+              pure $ Map.lookup uri vfs
+        , setVirtualFileContents = \uri content version ->
+              atomically $ modifyTVar vfsVar $ Map.insert uri (VirtualFile version (Rope.fromText content) Nothing)
+        , removeVirtualFile = \uri -> atomically $ modifyTVar vfsVar $ Map.delete uri
+        }
+
+makeLSPVFSHandle :: LspFuncs c -> VFSHandle
+makeLSPVFSHandle lspFuncs = VFSHandle
+    { getVirtualFile = getVirtualFileFunc lspFuncs
+    , setVirtualFileContents = \_ _ _ -> pure ()
+    -- ^ Handled internally by haskell-lsp.
+    , removeVirtualFile = \_ -> pure ()
+    -- ^ Handled internally by haskell-lsp.
+    }
 
 
 -- | Get the contents of a file, either dirty (if the buffer is modified) or from disk.
-type instance RuleResult GetFileContents = (UTCTime, StringBuffer)
+type instance RuleResult GetFileContents = (FileVersion, StringBuffer)
 
 -- | Does the file exist.
 type instance RuleResult GetFileExists = Bool
@@ -60,12 +90,12 @@ instance Hashable GetFileContents
 instance NFData   GetFileContents
 
 
-getFileExistsRule :: Var DirtyFiles -> Rules ()
-getFileExistsRule dirty =
+getFileExistsRule :: VFSHandle -> Rules ()
+getFileExistsRule vfs =
     defineEarlyCutoff $ \GetFileExists file -> do
         alwaysRerun
         res <- liftIO $ handle (\(_ :: IOException) -> return False) $
-            (Map.member file <$> readVar dirty) ||^
+            (isJust <$> getVirtualFile vfs (filePathToUri file)) ||^
             Dir.doesFileExist file
         return (Just $ if res then BS.singleton '1' else BS.empty, ([], Just res))
 
@@ -73,36 +103,36 @@ getFileExistsRule dirty =
 showTimePrecise :: UTCTime -> String
 showTimePrecise UTCTime{..} = show (toModifiedJulianDay utctDay, diffTimeToPicoseconds utctDayTime)
 
-getModificationTimeRule :: Var DirtyFiles -> Rules ()
-getModificationTimeRule dirty =
+getModificationTimeRule :: VFSHandle -> Rules ()
+getModificationTimeRule vfs =
     defineEarlyCutoff $ \GetModificationTime file -> do
-        let wrap time = (Just $ BS.pack $ showTimePrecise time, ([], Just time))
+        let wrap time = (Just $ BS.pack $ showTimePrecise time, ([], Just $ ModificationTime time))
         alwaysRerun
-        mp <- liftIO $ readVar dirty
-        case Map.lookup file mp of
-            Just (time, _) -> return $ wrap time
+        mbVirtual <- liftIO $ getVirtualFile vfs $ filePathToUri file
+        case mbVirtual of
+            Just (VirtualFile ver _ _) -> pure (Just $ BS.pack $ show ver, ([], Just $ VFSVersion ver))
             Nothing -> liftIO $ fmap wrap (Dir.getModificationTime file) `catch` \(e :: IOException) -> do
                 let err | isDoesNotExistError e = "File does not exist: " ++ file
                         | otherwise = "IO error while reading " ++ file ++ ", " ++ displayException e
                 return (Nothing, ([ideErrorText file $ T.pack err], Nothing))
 
 
-getFileContentsRule :: Var DirtyFiles -> Rules ()
-getFileContentsRule dirty =
+getFileContentsRule :: VFSHandle -> Rules ()
+getFileContentsRule vfs =
     define $ \GetFileContents file -> do
         -- need to depend on modification time to introduce a dependency with Cutoff
         time <- use_ GetModificationTime file
         res <- liftIO $ ideTryIOException file $ do
-            mp <- readVar dirty
-            case Map.lookup file mp of
-                Just (_, contents) -> return contents
+            mbVirtual <- getVirtualFile vfs $ filePathToUri file
+            case mbVirtual of
+                Just (VirtualFile _ rope _) -> return $ textToStringBuffer $ Rope.toText rope
                 Nothing -> hGetStringBuffer file
         case res of
             Left err -> return ([err], Nothing)
             Right contents -> return ([], Just (time, contents))
 
 
-getFileContents :: FilePath -> Action (UTCTime, StringBuffer)
+getFileContents :: FilePath -> Action (FileVersion, StringBuffer)
 getFileContents = use_ GetFileContents
 
 getFileExists :: FilePath -> Action Bool
@@ -113,29 +143,21 @@ getFileExists =
     use_ GetFileExists
 
 
-fileStoreRules :: Rules ()
-fileStoreRules = do
-    dirty <- liftIO $ newVar Map.empty
-    addIdeGlobal $ GlobalDirtyFiles dirty
-    getModificationTimeRule dirty
-    getFileContentsRule dirty
-    getFileExistsRule dirty
-
-
-strictPair :: a -> b -> (a, b)
-strictPair !a !b = (a,b)
+fileStoreRules :: VFSHandle -> Rules ()
+fileStoreRules vfs = do
+    addIdeGlobal vfs
+    getModificationTimeRule vfs
+    getFileContentsRule vfs
+    getFileExistsRule vfs
 
 
 -- | Notify the compiler service of a modified buffer
-setBufferModified :: IdeState -> FilePath -> (Maybe T.Text, UTCTime) -> IO ()
-setBufferModified state absFile (mcontents, !time) = do
-    GlobalDirtyFiles envDirtyFiles <- getIdeGlobalState state
-    -- update vars synchronously
-    modifyVar_ envDirtyFiles $ evaluate . case mcontents of
-        Nothing -> Map.delete absFile
-        Just contents -> Map.insert absFile $ strictPair time $ textToStringBuffer contents
-
-    -- run shake to update results regarding the files of interest
+setBufferModified :: IdeState -> FilePath -> Maybe (T.Text, Int) -> IO ()
+setBufferModified state absFile mbContents = do
+    VFSHandle{..} <- getIdeGlobalState state
+    case mbContents of
+        Nothing -> removeVirtualFile (filePathToUri absFile)
+        Just (contents, version) -> setVirtualFileContents (filePathToUri absFile) contents version
     void $ shakeRun state []
 
 

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -164,7 +164,7 @@ data Priority
 getParsedModuleRule :: Rules ()
 getParsedModuleRule =
     define $ \GetParsedModule file -> do
-        contents <- getFileContents file
+        (_, contents) <- getFileContents file
         packageState <- use_ GhcSession ""
         opt <- getOpts
         liftIO $ Compile.parseModule opt packageState file contents

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -73,8 +73,9 @@ initialise :: Rules ()
            -> Maybe (Event -> IO ())
            -> Logger.Handle
            -> IdeOptions
+           -> VFSHandle
            -> IO IdeState
-initialise mainRule toDiags logger options =
+initialise mainRule toDiags logger options vfs =
     shakeOpen
         (fromMaybe (const $ pure ()) toDiags)
         logger
@@ -83,7 +84,7 @@ initialise mainRule toDiags logger options =
                      , shakeFiles   = "/dev/null"
                      }) $ do
             addIdeGlobal =<< liftIO (mkEnv options)
-            fileStoreRules
+            fileStoreRules vfs
             mainRule
 
 writeProfile :: IdeState -> FilePath -> IO ()

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
@@ -44,8 +44,6 @@ import Data.Either.Combinators
 import Data.Maybe as Maybe
 import Data.Foldable
 import qualified Data.Map as Map
-import Data.Time.Clock
-import Data.Time.Clock.POSIX
 import qualified Data.Text as T
 import Data.Text.Prettyprint.Doc.Syntax
 import qualified Data.SortedList as SL
@@ -179,18 +177,16 @@ emptyDiagnostics = ProjectDiagnostics mempty
 setStageDiagnostics ::
   Show stage =>
   FilePath ->
-  Maybe UTCTime ->
+  Maybe Int ->
   -- ^ the time that the file these diagnostics originate from was last edited
   stage ->
   [LSP.Diagnostic] ->
   ProjectDiagnostics stage ->
   ProjectDiagnostics stage
 setStageDiagnostics fp timeM stage diags (ProjectDiagnostics ds) =
-    ProjectDiagnostics $ updateDiagnostics ds uri posixTime diagsBySource
+    ProjectDiagnostics $ updateDiagnostics ds uri timeM diagsBySource
     where
         diagsBySource = Map.singleton (Just $ T.pack $ show stage) (SL.toSortedList diags)
-        posixTime :: Maybe Int
-        posixTime = fmap (fromEnum . utcTimeToPOSIXSeconds) timeM
         uri = filePathToUri fp
 
 fromUri :: LSP.Uri -> FilePath

--- a/compiler/haskell-ide-core/test/Demo.hs
+++ b/compiler/haskell-ide-core/test/Demo.hs
@@ -6,6 +6,7 @@ module Demo(main) where
 import Control.Concurrent.Extra
 import Control.Monad
 import System.Time.Extra
+import Development.IDE.State.FileStore
 import Development.IDE.State.Service
 import Development.IDE.State.Rules
 import Development.IDE.State.Shake
@@ -38,6 +39,7 @@ main = do
     -- lock to avoid overlapping output on stdout
     lock <- newLock
 
+    vfs <- makeVFSHandle
     ide <- initialise
         mainRule
         (Just $ showEvent lock)
@@ -51,6 +53,7 @@ main = do
             ,optThreads = 0
             ,optShakeProfiling = Nothing -- Just "output.html"
             }
+        vfs
     setFilesOfInterest ide $ Set.fromList files
     _ <- runAction ide $ uses_ TypeCheck files
     -- shake now writes an async message that it is completed with timing info,

--- a/daml-foundations/daml-ghc/daml-compiler/BUILD.bazel
+++ b/daml-foundations/daml-ghc/daml-compiler/BUILD.bazel
@@ -17,6 +17,7 @@ da_haskell_library(
         "extra",
         "filepath",
         "ghc-lib-parser",
+        "haskell-lsp",
         "http-types",
         "mtl",
         "network-uri",

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -279,7 +279,7 @@ compileFile service fp = do
 onFileModified
     :: IdeState
     -> FilePath
-    -> Maybe (T.Text, Int)
+    -> Maybe T.Text
     -> IO ()
 onFileModified service fp mbContents = do
     CompilerService.logDebug service $ "File modified " <> T.pack (show fp)

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -7,6 +7,7 @@ module DA.Daml.GHC.Damldoc.HaddockParse(mkDocs) where
 
 import           DA.Daml.GHC.Damldoc.Types                 as DDoc
 import Development.IDE.Types.Options (IdeOptions(..))
+import Development.IDE.State.FileStore
 import qualified Development.IDE.State.Service     as Service
 import qualified Development.IDE.State.Rules     as Service
 import           Development.IDE.Types.Diagnostics
@@ -120,7 +121,8 @@ haddockParse :: IdeOptions ->
                 [FilePath] ->
                 Ex.ExceptT [FileDiagnostic] IO [ParsedModule]
 haddockParse opts f = ExceptT $ do
-  service <- Service.initialise Service.mainRule Nothing Logger.makeNopHandle opts
+  vfs <- makeVFSHandle
+  service <- Service.initialise Service.mainRule Nothing Logger.makeNopHandle opts vfs
   Service.setFilesOfInterest service (Set.fromList f)
   parsed  <- Service.runAction service $
              Ex.runExceptT $

--- a/daml-foundations/daml-ghc/ide/BUILD.bazel
+++ b/daml-foundations/daml-ghc/ide/BUILD.bazel
@@ -22,6 +22,7 @@ da_haskell_library(
         "ghc-lib-parser",
         "ghc-lib",
         "hashable",
+        "haskell-lsp",
         "haskell-lsp-types",
         "mtl",
         "shake",

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -23,6 +23,9 @@ module Development.IDE.State.API
     , getDependencies
     , logDebug
     , logSeriousError
+    , VFSHandle(..)
+    , makeVFSHandle
+    , makeLSPVFSHandle
     ) where
 
 import           Development.IDE.Types.LSP

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -23,6 +23,7 @@ import Development.Shake
 
 import qualified Development.IDE.Logger as Logger
 import Development.IDE.State.Service hiding (initialise)
+import Development.IDE.State.FileStore
 import qualified Development.IDE.State.Service as IDE
 import Development.IDE.State.Shake
 import Development.IDE.Types.LSP
@@ -70,16 +71,19 @@ setOpenVirtualResources state resources = do
     modifyVar_ envOpenVirtualResources $ const $ return resources
     void $ shakeRun state []
 
-initialise :: Rules ()
-           -> Maybe (Event -> IO ())
-           -> Logger.Handle
-           -> Options
-           -> Maybe SS.Handle
-           -> IO IdeState
-initialise mainRule toDiags logger options scenarioService =
+initialise
+    :: Rules ()
+    -> Maybe (Event -> IO ())
+    -> Logger.Handle
+    -> Options
+    -> VFSHandle
+    -> Maybe SS.Handle
+    -> IO IdeState
+initialise mainRule toDiags logger options vfs scenarioService =
     IDE.initialise
         (do addIdeGlobal =<< liftIO (mkDamlEnv options scenarioService)
             mainRule)
         toDiags
         logger
         (toCompileOpts options)
+        vfs

--- a/daml-foundations/daml-ghc/language-server/BUILD.bazel
+++ b/daml-foundations/daml-ghc/language-server/BUILD.bazel
@@ -19,6 +19,7 @@ da_haskell_library(
         "haskell-lsp-types",
         "managed",
         "network-uri",
+        "rope-utf16-splay",
         "safe",
         "safe-exceptions",
         "stm",

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -20,9 +20,9 @@ import           DA.LanguageServer.Protocol
 import           DA.LanguageServer.Server
 
 import Control.Monad
+import Data.Maybe
 import Data.List.Extra
 import Control.Monad.IO.Class
-import Safe
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Service.Daml.Compiler.Impl.Handle as Compiler
 import qualified DA.Service.Daml.LanguageServer.CodeLens   as LS.CodeLens
@@ -34,9 +34,11 @@ import DAML.Project.Consts
 import qualified Data.Aeson                                as Aeson
 import           Data.Aeson.TH.Extended                    (deriveDAToJSON)
 import           Data.IORef                                (IORef, atomicModifyIORef', newIORef)
+import qualified Data.Rope.UTF16 as Rope
 import qualified Data.Set                                  as S
 import qualified Data.Text.Extended                        as T
 
+import Development.IDE.State.FileStore
 import qualified Development.IDE.Types.Diagnostics as Compiler
 import           Development.IDE.Types.LSP as Compiler
 
@@ -44,7 +46,9 @@ import qualified Network.URI                               as URI
 
 import qualified System.Exit
 
+import Language.Haskell.LSP.Core (LspFuncs(..))
 import Language.Haskell.LSP.Messages
+import Language.Haskell.LSP.VFS
 
 ------------------------------------------------------------------------
 -- Types
@@ -125,14 +129,14 @@ handleRequest (IHandle _stateRef loggerH compilerH _notifChan) makeResponse make
         pure $ RspError $ makeErrorResponse MethodNotFound
 
 
-handleNotification :: IHandle () LF.Package -> ServerNotification -> IO ()
-handleNotification (IHandle stateRef loggerH compilerH _notifChan) = \case
+handleNotification :: LspFuncs () -> IHandle () LF.Package -> ServerNotification -> IO ()
+handleNotification lspFuncs (IHandle stateRef loggerH compilerH _notifChan) = \case
 
     DidOpenTextDocument (DidOpenTextDocumentParams item) ->
         case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
           Just uri
               | URI.uriScheme uri == "file:"
-              -> handleDidOpenFile (URI.unEscapeString (URI.uriPath uri)) (_text (item :: TextDocumentItem))
+              -> handleDidOpenFile item
 
               | URI.uriScheme uri == "daml:"
               -> handleDidOpenVirtualResource uri
@@ -144,14 +148,14 @@ handleNotification (IHandle stateRef loggerH compilerH _notifChan) = \case
           _ -> Logger.logError loggerH $ "Invalid URI in DidOpenTextDocument: "
                     <> T.show (_uri (item :: TextDocumentItem))
 
-    DidChangeTextDocument (DidChangeTextDocumentParams docId (List changes)) ->
-        case Compiler.uriToFilePath' $ _uri (docId :: VersionedTextDocumentIdentifier) of
+    DidChangeTextDocument (DidChangeTextDocumentParams docId _) -> do
+        let uri = _uri (docId :: VersionedTextDocumentIdentifier)
+        case Compiler.uriToFilePath' uri of
           Just filePath -> do
-            -- ISSUE DEL-3281: Add support for incremental synchronisation
-            -- to language server.
-            let newContents = fmap (\ev -> _text (ev :: TextDocumentContentChangeEvent)) $ lastMay changes
-            Compiler.onFileModified compilerH filePath newContents
-
+            mbVirtual <- getVirtualFileFunc lspFuncs uri
+            let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
+            Compiler.onFileModified compilerH filePath
+                (Just (contents, fromMaybe 0 $ _version (docId :: VersionedTextDocumentIdentifier)))
             Logger.logInfo loggerH
               $ "Updated text document: " <> T.show filePath
 
@@ -179,15 +183,18 @@ handleNotification (IHandle stateRef loggerH compilerH _notifChan) = \case
     -- When we have parallel compilation we could manage the state
     -- changes in STM so that we can atomically change the state.
     -- Internally it should be done via the IO oracle. See PROD-2808.
-    handleDidOpenFile filePath contents = do
+    handleDidOpenFile (TextDocumentItem uri _ version contents) = do
+        Just filePath <- pure $ Compiler.uriToFilePath' uri
         documents <- atomicModifyIORef' stateRef $
           \state -> let documents = S.insert filePath $ sOpenDocuments state
                     in ( state { sOpenDocuments = documents }
                        , documents
                        )
 
+
+
         -- Update the file contents
-        Compiler.onFileModified compilerH filePath (Just contents)
+        Compiler.onFileModified compilerH filePath (Just (contents, version))
 
         -- Update the list of open files
         Compiler.setFilesOfInterest compilerH (S.toList documents)
@@ -238,7 +245,7 @@ handleNotification (IHandle stateRef loggerH compilerH _notifChan) = \case
 
 runLanguageServer  :: (  Maybe (Compiler.Event -> IO ())
                       -> Logger.Handle IO
-                      -> Managed.Managed Compiler.IdeState
+                      -> Managed.Managed (VFSHandle -> IO Compiler.IdeState)
                       )
                    -> Logger.Handle IO
                    -> IO ()
@@ -248,17 +255,19 @@ runLanguageServer handleBuild loggerH = Managed.runManaged $ do
     notifChan <- liftIO newTChanIO
     eventChan <- liftIO newTChanIO
     state     <- liftIO $ newIORef $ State S.empty S.empty
-    compilerH <- handleBuild (Just (atomically . writeTChan eventChan)) loggerH
-
-    let ihandle = IHandle {
-        ihState = state
-      , ihLoggerH = loggerH
-      , ihCompilerH = compilerH
-      , ihNotifChan = notifChan
-      }
+    getIdeState <- handleBuild (Just (atomically . writeTChan eventChan)) loggerH
+    let getHandlers lspFuncs = do
+            compilerH <- getIdeState (makeLSPVFSHandle lspFuncs)
+            let ihandle = IHandle
+                    { ihState = state
+                    , ihLoggerH = loggerH
+                    , ihCompilerH = compilerH
+                    , ihNotifChan = notifChan
+                    }
+            pure (Handlers (handleRequest ihandle) (handleNotification lspFuncs ihandle))
     liftIO $ Async.race_
       (eventSlinger loggerH eventChan notifChan)
-      (runServer loggerH (handleRequest ihandle) (handleNotification ihandle) notifChan)
+      (runServer loggerH getHandlers notifChan)
 
 -- | Event slinger slings compiler events to the client as notifications.
 eventSlinger

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -126,9 +126,10 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- fmap (\opts ->  opts { optThreads = 0 }) $ defaultOptionsIO (Just version)
 
     -- initialise the compiler service
+    vfs <- Compile.makeVFSHandle
     pure $
       withResource
-      (Compile.initialise (Compile.mainRule opts) (Just (\_ -> pure ())) IdeLogger.makeNopHandle opts (Just scenarioService))
+      (Compile.initialise (Compile.mainRule opts) (Just (\_ -> pure ())) IdeLogger.makeNopHandle opts vfs (Just scenarioService))
       Compile.shutdown $ \service ->
       withTestArguments $ \args -> testGroup ("Tests for DAML-LF " ++ renderPretty version) $
         map (testCase args version service outdir registerTODO) allTestFiles

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -45,7 +45,7 @@ execTest inFiles color mbJUnitOutput cliOptions = do
     opts <- Compiler.mkOptions cliOptions
     let eventLogger (EventFileDiagnostics (fp, diags)) = printDiagnostics $ map (fp,) diags
         eventLogger _ = return ()
-    Managed.with (Compiler.newIdeState opts (Just eventLogger) loggerH) $ \h -> do
+    Managed.with (Compiler.newIdeState' opts (Just eventLogger) loggerH) $ \h -> do
         let lfVersion = Compiler.optDamlLfVersion cliOptions
         testRun h inFiles lfVersion color mbJUnitOutput
         diags <- CompilerService.getDiagnostics h

--- a/daml-foundations/daml-tools/language-server-tests/tests/requests/initialize/EXPECTED.json
+++ b/daml-foundations/daml-tools/language-server-tests/tests/requests/initialize/EXPECTED.json
@@ -2,7 +2,7 @@
   "capabilities": {
     "textDocumentSync": {
       "openClose": true,
-      "change": 1,
+      "change": 2,
       "willSave": true,
       "save": {
         "includeText": false


### PR DESCRIPTION
haskell-lsp has a builtin VFS that it updates automatically on the
corresponding requests. This PR removes our own VFS implementation and
uses that builtin VFS in "damlc ide". To allow the use of functions
like setBufferModified (we use that heavily in daml-ghc-shake-test-ci)
without having to spawn an LSP server, we also add a fallback where we
spin up our own LSP implementation.

Sorry for the somewhat large diff. I could probably split some of this out into a refactoring PR but I think the refactoring parts on their own are hard to make sense off. Most of the changes are fairly mechanical so hopefully it should be reasonably easy to review.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
