### PR TITLE
windows: fix daml-ghc warnings test issue

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -28,12 +28,11 @@ import Data.Maybe
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import           Development.IDE.Functions.GHCError
-import           Development.Shake                        hiding (Diagnostic, Env, newCache)
-import           Development.IDE.Types.LSP as Compiler
-
-import           UniqSupply
-
 import           Development.IDE.State.Shake
+import           Development.IDE.Types.LSP as Compiler
+import           Development.Shake                        hiding (Diagnostic, Env, newCache)
+import           System.FilePath
+import           UniqSupply
 
 
 -- | Environment threaded through the Shake actions.
@@ -111,7 +110,7 @@ setFilesOfInterest :: IdeState -> Set FilePath -> IO ()
 setFilesOfInterest state files = do
     Env{..} <- getIdeGlobalState state
     -- update vars synchronously
-    modifyVar_ envOfInterestVar $ const $ return files
+    modifyVar_ envOfInterestVar $ const $ return (Set.map normalise files)
 
     -- run shake to update results regarding the files of interest
     void $ shakeRun state []

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
@@ -344,7 +344,11 @@ type instance RuleResult (Q k) = A (RuleResult k)
 -- | Compute the value
 uses :: IdeRule k v
     => k -> [FilePath] -> Action [Maybe v]
-uses key files = map (\(A value _) -> value) <$> apply (map (Q . (key,)) files)
+uses key files = map (\(A value _) -> value) <$> apply (map (Q . (key,)) (normaliseNonEmpty <$> files))
+
+normaliseNonEmpty :: FilePath -> FilePath
+normaliseNonEmpty "" = ""
+normaliseNonEmpty fp = normalise fp
 
 defineEarlyCutoff
     :: IdeRule k v


### PR DESCRIPTION
Fixes tab warning test issue in `Warnings.daml` daml-ghc on Windows (`Wrong number of diagnostics, expected 2, but got 1`). Absolute paths in Bazel's MANIFEST contain fwd. slashes instead of backward ones, which was later on causing a drop of a FileDiagnostic somewhere after shake parser stage.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
