### PR TITLE
Handle exceptions when sending logOptOut messages

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -220,7 +220,7 @@ execIde telemetry (Debug debug) = NS.withSocketsDo $ Managed.runManaged $ do
     loggerH <-
       case telemetry of
           OptedIn -> Logger.GCP.gcpLogger (>= Logger.Warning) loggerH
-          OptedOut -> liftIO $ Logger.GCP.logOptOut $> loggerH
+          OptedOut -> liftIO $ Logger.GCP.logOptOut loggerH $> loggerH
           Undecided -> pure loggerH
 
     opts <- liftIO $ defaultOptionsIO Nothing

--- a/libs-haskell/da-hs-base/BUILD.bazel
+++ b/libs-haskell/da-hs-base/BUILD.bazel
@@ -35,6 +35,7 @@ da_haskell_library(
         "pretty",
         "random",
         "safe",
+        "safe-exceptions",
         "stm",
         "tar-conduit",
         "tasty-hunit",


### PR DESCRIPTION
We already do this for all other log messages and it makes sense to do
it for the opt out message as well.

This should fix #1487.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
