### PR TITLE
Escape colons in URIs to be consistent with VSCode

### DIFF
--- a/compiler/haskell-ide-core/BUILD.bazel
+++ b/compiler/haskell-ide-core/BUILD.bazel
@@ -19,6 +19,7 @@ depends = [
     "haskell-lsp",
     "haskell-lsp-types",
     "mtl",
+    "network-uri",
     "pretty",
     "rope-utf16-splay",
     "safe-exceptions",

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
@@ -38,7 +38,6 @@ import Data.Maybe
 import           ErrUtils
 import           SrcLoc
 import qualified Outputable                 as Out
-import qualified Language.Haskell.LSP.Types as LSP
 
 
 
@@ -79,7 +78,7 @@ srcSpanToFilename (RealSrcSpan real) = FS.unpackFS $ srcSpanFile real
 
 srcSpanToLocation :: SrcSpan -> Location
 srcSpanToLocation src =
-  Location (LSP.filePathToUri $ srcSpanToFilename src) (srcSpanToRange src)
+  Location (D.filePathToUri' $ srcSpanToFilename src) (srcSpanToRange src)
 
 -- | Convert a GHC severity to a DAML compiler Severity. Severities below
 -- "Warning" level are dropped (returning Nothing).

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Diagnostics.hs
@@ -28,7 +28,7 @@ module Development.IDE.Types.Diagnostics (
   showDiagnostics,
   showDiagnosticsColored,
   defDiagnostic,
-  filePathToUri,
+  filePathToUri',
   uriToFilePath',
   ProjectDiagnostics,
   emptyDiagnostics,
@@ -47,6 +47,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as T
 import Data.Text.Prettyprint.Doc.Syntax
 import qualified Data.SortedList as SL
+import Network.URI (escapeURIString)
 import qualified Text.PrettyPrint.Annotated.HughesPJClass as Pretty
 import qualified Language.Haskell.LSP.Types as LSP
 import Language.Haskell.LSP.Types as LSP (
@@ -67,8 +68,20 @@ import Development.IDE.Types.Location
 -- So we have our own wrapper here that supports empty filepaths.
 uriToFilePath' :: Uri -> Maybe FilePath
 uriToFilePath' uri
-    | uri == filePathToUri "" = Just ""
+    | uri == filePathToUri' "" = Just ""
     | otherwise = LSP.uriToFilePath uri
+
+-- TODO This is a temporary hack: VSCode escapes ':' in URIs while haskell-lsp’s filePathToUri doesn't.
+-- This causes issues since haskell-lsp stores the original URI in the VFS while we roundtrip once via
+-- uriToFilePath' and filePathToUri before we look it up again. At that point : will be unescaped in the URI
+-- so the lookup fails. The long-term solution here is to avoid roundtripping URIs but that is a larger task
+-- so for now we have our own version of filePathToUri that does escape colons.
+filePathToUri' :: FilePath -> Uri
+filePathToUri' fp =
+    case T.stripPrefix "file:" (getUri uri) of
+        Just suffix -> Uri $ T.pack $ "file:" <> escapeURIString (/= ':') (T.unpack suffix)
+        Nothing -> uri
+    where uri = filePathToUri fp
 
 ideErrorText :: FilePath -> T.Text -> FileDiagnostic
 ideErrorText fp = errorDiag fp "Ide Error"


### PR DESCRIPTION
The details are described in a comment but the short story is
that a roundtrip Uri -> FilePath -> Uri necessarily loses information
on which characters were escaped. The long-term solution here is to
avoid this roundtrip altogether but this at least fixes the issue for
now.

I am currently writing up an issue for a plan to avoid this issue and similar issues but this does at least fix the immediate issue so we can think carefully about how we fix this properly and avoid having these issues over and over again.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
