### PR TITLE
added recovery logic around ledger entry persistence failures

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -25,6 +25,13 @@ Navigator
 - Fixed a regression where Navigator console was not able to inspect contracts and events.
   See `#1454 <https://github.com/digital-asset/daml/issues/1454>`__.
 
+
+Sandbox
+~~~~~~~
+
+- Added recovery around failing ledger entry persistence queries using Postgres. See `#1505 <https://github.com/digital-asset/daml/pull/1505>`__.
+
+
 0.12.22 - 2019-05-29
 --------------------
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -138,7 +138,7 @@ private class SqlLedger(
     queue
       .watchCompletion()
       .onComplete {
-        case Failure(t) => logger.warn(s"$name queue has been closed with a failure!", t)
+        case Failure(t) => logger.error(s"$name queue has been closed with a failure!", t)
         case _ => ()
       }(DEC)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -131,6 +131,13 @@ private class SqlLedger(
       SourceQueueWithComplete[Long => PersistenceEntry],
       SourceQueueWithComplete[Long => PersistenceEntry]) = createQueues()
 
+  checkpointQueue
+    .watchCompletion()
+    .foreach(_ => logger.warn("checkpoint queue has been closed!"))(DEC)
+  persistenceQueue
+    .watchCompletion()
+    .foreach(_ => logger.warn("persistence queue has been closed!"))(DEC)
+
   private def createQueues(): (
       SourceQueueWithComplete[Long => PersistenceEntry],
       SourceQueueWithComplete[Long => PersistenceEntry]) = {
@@ -170,6 +177,12 @@ private class SqlLedger(
               ledgerDao
                 .storeLedgerEntry(offset, offset + 1, ledgerEntryGen(offset))
                 .map(_ => ())(DEC)
+                .recover {
+                  case t =>
+                    //recovering from the failure so the persistence stream doesn't die
+                    logger.error(s"Failed to persist entry with offset: $offset", t)
+                    ()
+                }
           })
           .map { _ =>
             //note that we can have holes in offsets in case of the storing of an entry failed for some reason
@@ -177,12 +190,11 @@ private class SqlLedger(
             dispatcher.signalNewHead(headRef) //signalling downstream subscriptions
           }(DEC)
       }
-      .toMat(Sink.ignore)(
-        Keep.left[
-          (
-              SourceQueueWithComplete[Long => PersistenceEntry],
-              SourceQueueWithComplete[Long => PersistenceEntry]),
-          Future[Done]])
+      .toMat(Sink.ignore)(Keep.left[
+        (
+            SourceQueueWithComplete[Long => PersistenceEntry],
+            SourceQueueWithComplete[Long => PersistenceEntry]),
+        Future[Done]])
       .run()
   }
 
@@ -191,9 +203,8 @@ private class SqlLedger(
     ledgerDao.close()
   }
 
-  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] = {
+  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
     dispatcher.startingAt(offset.getOrElse(0))
-  }
 
   override def ledgerEnd: Long = headRef
 
@@ -270,7 +281,7 @@ private class SqlLedger(
       }
     }
 
-  private def enqueue(f: Long => PersistenceEntry): Future[SubmissionResult] = {
+  private def enqueue(f: Long => PersistenceEntry): Future[SubmissionResult] =
     persistenceQueue
       .offer(f)
       .transform {
@@ -283,7 +294,6 @@ private class SqlLedger(
         case Success(QueueOfferResult.Failure(e)) => Failure(e)
         case Failure(f) => Failure(f)
       }(DEC)
-  }
 
   override def lookupTransaction(
       transactionId: Ref.TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =


### PR DESCRIPTION
This PR introduces recovery over failing Postgres persistence operations. Without having this recovery the Sandbox will stop working as soon as a Postgres persistence operation fails.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
