### PR TITLE
daml-lf: add enum pattern matching

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -425,6 +425,9 @@ decodeCaseAlt LF1.CaseAlt{..} = do
         <$> mayDecode "caseAlt_VariantCon" caseAlt_VariantCon decodeTypeConName
         <*> decodeName VariantConName caseAlt_VariantVariant
         <*> decodeName ExprVarName caseAlt_VariantBinder
+    LF1.CaseAltSumEnum _ ->
+      -- FixMe (RH) https://github.com/digital-asset/daml/issues/105
+      Left (ParseError "Enum type not supported")
     LF1.CaseAltSumPrimCon (Proto.Enumerated (Right pcon)) ->
       CPEnumCon <$> decodePrimCon pcon
     LF1.CaseAltSumPrimCon (Proto.Enumerated (Left idx)) ->

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -776,7 +776,7 @@ message CaseAlt {
 
     // name of the variant constructor
     // *Must be a valid identifier*
-    string constructors = 2;
+    string constructor = 2;
   }
 
   // Non empty list pattern
@@ -804,6 +804,7 @@ message CaseAlt {
     Cons cons = 5;
     Unit none = 7; // * Available since version 1*
     Some some = 8; // * Available since version 1*
+    Enum enum = 9; // * Available since version dev*
   }
 
   Expr body = 6;
@@ -1051,7 +1052,7 @@ message DefDataType {
     repeated FieldWithType fields = 1;
   }
 
-  message EnumConstructor {
+  message EnumConstructors {
     repeated string constructors = 1;
   }
 
@@ -1065,7 +1066,7 @@ message DefDataType {
   oneof DataCons {
     Fields record = 3; // Records without fields are explicitly allowed.
     Fields variant = 4; // Variants without constructors are explicitly allowed.
-    EnumConstructor enum = 7; //  *available since version dev*
+    EnumConstructors enum = 7; //  *available since version dev*
   }
 
   // If true, this data type preserves serializability in the sense that when

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/DefDataType.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/DefDataType.scala
@@ -113,7 +113,7 @@ object Variant extends FWTLike[Variant] {
     }
 }
 
-final case class Enum(values: ImmArraySeq[Ref.Name]) extends DataType[Nothing, Nothing] {
+final case class Enum(constructors: ImmArraySeq[Ref.Name]) extends DataType[Nothing, Nothing] {
 
   /** Widen to DataType, in Java. */
   def asDataType[RT, PVT]: DataType[RT, PVT] = this

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -46,6 +46,7 @@ da_scala_test_suite(
         "//daml-lf/lfpackage",
         "//daml-lf/parser",
         "//daml-lf/transaction",
+        "//daml-lf/validation",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -328,6 +328,10 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
                   withBinder(binder) { _ =>
                     SCaseAlt(SCPVariant(tycon, variant), translate(expr))
                   }
+
+                case CPEnum(tycon, constructor) =>
+                  SCaseAlt(SCPEnum(tycon, constructor), translate(expr))
+
                 case CPNil =>
                   SCaseAlt(SCPNil, translate(expr))
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.speedy
+
+import java.util
+
+import com.digitalasset.daml.lf.PureCompiledPackages
+import com.digitalasset.daml.lf.data.{FrontStack, Ref}
+import com.digitalasset.daml.lf.lfpackage.Ast
+import com.digitalasset.daml.lf.lfpackage.Ast.Expr
+import com.digitalasset.daml.lf.speedy.SError.SError
+import com.digitalasset.daml.lf.speedy.SResult.{SResultContinue, SResultError}
+import com.digitalasset.daml.lf.speedy.SValue.{STuple, _}
+import com.digitalasset.daml.lf.testing.parser.Implicits._
+import com.digitalasset.daml.lf.testing.parser.defaultPkgId
+import com.digitalasset.daml.lf.validation.Validation
+import org.scalatest.{Matchers, WordSpec}
+
+class SpeedyTest extends WordSpec with Matchers {
+
+  import SpeedyTest._
+
+  "pattern matching" should {
+
+    val pkg =
+      p"""
+        module Matcher {
+          val unit : Unit -> Int64 = \ (x: Unit) -> case x of () -> 2;
+          val bool : Bool -> Int64 = \ (x: Bool) -> case x of True -> 3 | False -> 5;
+          val list : forall (a: *). List a -> Option <x1: a, x2: List a> = /\ (a: *).
+            \(x: List a) -> case x of
+              Nil      -> None @(<x1: a, x2: List a>)
+           |  Cons h t -> Some @(<x1: a, x2: List a>) <x1 = h, x2 = t>;
+          val option: forall (a: *). a -> Option a-> a = /\ (a: *). \(x: a) -> \(y: Option a) -> case y of
+              None -> x
+           |  Some z -> z;
+          val variant: forall (a: *). Mod:Tree a -> a = /\ (a: *). \(x: Mod:Tree a) -> case x of
+              Mod:Tree:Leaf y -> y
+           |  Mod:Tree:Node node -> Matcher:variant @a (Mod:Tree.Node @a {left} node);
+          val enum: Mod:Color -> Int64 = \(x: Mod:Color) -> case x of
+              Mod:Color:Red -> 37
+           |  Mod:Color:Green -> 41
+           |  Mod:Color:Blue -> 43;
+        }
+
+        module Mod {
+          variant Tree (a: *) =  Node : Mod:Tree.Node a | Leaf : a ;
+          record Tree.Node (a: *) = {left: Mod:Tree a, right: Mod:Tree a } ;
+          enum Color = Red | Green | Blue ;
+       }
+
+
+      """
+
+    val pkgs = typeAndCompile(pkg)
+
+    "works as expected on primitive constructors" in {
+
+      eval(e"Matcher:unit ()", pkgs) shouldBe Right(SInt64(2))
+      eval(e"Matcher:bool True", pkgs) shouldBe Right(SInt64(3))
+      eval(e"Matcher:bool False", pkgs) shouldBe Right(SInt64(5))
+
+    }
+
+    "works as expected on lists" in {
+      eval(e"Matcher:list @Int64 ${intList()}", pkgs) shouldBe Right(SOptional(None))
+      eval(e"Matcher:list @Int64 ${intList(7, 11, 13)}", pkgs) shouldBe Right(
+        SOptional(
+          Some(STuple(
+            Ref.Name.Array(n"x1", n"x2"),
+            ArrayList(SInt64(7), SList(FrontStack(SInt64(11), SInt64(13))))))))
+    }
+
+    "works as expected on Optionals" in {
+      eval(e"Matcher:option @Int64 17 (None @Int64)", pkgs) shouldBe Right(SInt64(17))
+      eval(e"Matcher:option @Int64 17 (Some @Int64 19)", pkgs) shouldBe Right(SInt64(19))
+    }
+
+    "works as expected on Variants" in {
+      eval(e"""Matcher:variant @Int64 (Mod:Tree:Leaf @Int64 23)""", pkgs) shouldBe Right(SInt64(23))
+      eval(
+        e"""Matcher:variant @Int64 (Mod:Tree:Node @Int64 (Mod:Tree.Node @Int64 {left = Mod:Tree:Leaf @Int64 27, right = Mod:Tree:Leaf @Int64 29 }))""",
+        pkgs) shouldBe Right(SInt64(27))
+    }
+
+    "works as expected on Enums" in {
+      eval(e"""Matcher:enum Mod:Color:Red""", pkgs) shouldBe Right(SInt64(37))
+      eval(e"""Matcher:enum Mod:Color:Green""", pkgs) shouldBe Right(SInt64(41))
+      eval(e"""Matcher:enum Mod:Color:Blue""", pkgs) shouldBe Right(SInt64(43))
+    }
+
+  }
+
+}
+
+object SpeedyTest {
+
+  private def eval(e: Expr, packages: PureCompiledPackages): Either[SError, SValue] = {
+    val machine = Speedy.Machine.fromExpr(e, packages, false)
+    final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
+    try {
+      while (!machine.isFinal) machine.step() match {
+        case SResultContinue => ()
+        case SResultError(err) => throw Goodbye(err)
+        case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
+      }
+
+      Right(machine.toSValue)
+    } catch {
+      case Goodbye(err) => Left(err)
+    }
+  }
+
+  private def typeAndCompile(pkg: Ast.Package): PureCompiledPackages = {
+    val rawPkgs = Map(defaultPkgId -> pkg)
+    Validation.checkPackage(rawPkgs, defaultPkgId)
+    PureCompiledPackages(rawPkgs).right.get
+  }
+
+  private def intList(xs: Long*): String =
+    if (xs.isEmpty) "(Nil @Int64)"
+    else xs.mkString(s"(Cons @Int64 [", ", ", s"] (Nil @Int64))")
+
+  private def ArrayList[X](as: X*): util.ArrayList[X] = {
+    val a = new util.ArrayList[X](as.length)
+    as.foreach(a.add)
+    a
+  }
+}

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/Ast.scala
@@ -444,6 +444,8 @@ object Ast {
   // Match on variant
   final case class CPVariant(tycon: TypeConName, variant: VariantConName, binder: ExprVarName)
       extends CasePat
+  // Match on enum
+  final case class CPEnum(tycon: TypeConName, constructor: EnumConName) extends CasePat
   // Match on primitive constructor.
   final case class CPPrimCon(pc: PrimCon) extends CasePat
   // Match on an empty list.

--- a/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
+++ b/daml-lf/lfpackage/src/main/scala/com/digitalasset/daml/lf/lfpackage/DecodeV1.scala
@@ -470,6 +470,9 @@ private[lf] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPackage
             decodeTypeConName(variant.getCon),
             name(variant.getVariant),
             name(variant.getBinder))
+        case PLF.CaseAlt.SumCase.ENUM =>
+          val enum = lfCaseAlt.getEnum
+          CPEnum(decodeTypeConName(enum.getCon), name(enum.getConstructor))
         case PLF.CaseAlt.SumCase.PRIM_CON =>
           CPPrimCon(decodePrimCon(lfCaseAlt.getPrimCon))
         case PLF.CaseAlt.SumCase.NIL =>

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -21,7 +21,7 @@ private[parser] object ExprParser {
       eRecCon |
       eRecProj |
       eRecUpd |
-      eVariantCon |
+      eVariantOrEnumCon |
       eTupleCon |
       eTupleUpd |
       eTupleProj |
@@ -123,10 +123,14 @@ private[parser] object ExprParser {
         ERecUpd(tConApp, fName, record, fValue)
     }
 
-  private lazy val eVariantCon: Parser[Expr] =
-    fullIdentifier ~ (`:` ~> id) ~ rep(argTyp) ~! expr0 ^^ {
-      case tName ~ vName ~ argsTyp ~ arg =>
+  private lazy val eVariantOrEnumCon: Parser[Expr] =
+    fullIdentifier ~ (`:` ~> id) ~ rep(argTyp) ~ opt(expr0) ^^ {
+      case tName ~ vName ~ argsTyp ~ Some(arg) =>
         EVariantCon(TypeConApp(tName, ImmArray(argsTyp)), vName, arg)
+      case _ ~ _ ~ argsTyp ~ None if argsTyp.nonEmpty =>
+        throw new java.lang.Error("enum type do not take type parameters")
+      case tName ~ vName ~ _ ~ None =>
+        EEnumCon(tName, vName)
     }
 
   private lazy val eTupleCon: Parser[Expr] =
@@ -174,9 +178,11 @@ private[parser] object ExprParser {
       `cons` ~>! id ~ id ^^ { case x1 ~ x2 => CPCons(x1, x2) } |
       `none` ^^^ CPNone |
       `some` ~>! id ^^ CPSome |
-      (fullIdentifier <~ `:`) ~ id ~ id ^^ {
-        case tyCon ~ vName ~ x =>
+      (fullIdentifier <~ `:`) ~ id ~ opt(id) ^^ {
+        case tyCon ~ vName ~ Some(x) =>
           CPVariant(tyCon, vName, x)
+        case tyCon ~ vName ~ None =>
+          CPEnum(tyCon, vName)
       } |
       Token.`_` ^^^ CPDefault
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -42,7 +42,7 @@ private[parser] object ModParser {
     }
 
   private lazy val definition: Parser[Def] =
-    recDefinition | variantDefinition | valDefinition | templateDefinition
+    recDefinition | variantDefinition | enumDefinition | valDefinition | templateDefinition
 
   private def tags(allowed: Set[String]): Parser[Set[String]] =
     rep(`@` ~> id) ^^ { tags =>
@@ -73,6 +73,15 @@ private[parser] object ModParser {
         DataDef(
           id,
           DDataType(defTags(serializableTag), ImmArray(params), DataVariant(ImmArray(variants)))
+        )
+    }
+
+  private lazy val enumDefinition: Parser[DataDef] =
+    Id("enum") ~>! tags(dataDefTags) ~ dottedName ~ (`=` ~> repsep(id, `|`)) ^^ {
+      case defTags ~ id ~ constructors =>
+        DataDef(
+          id,
+          DDataType(defTags(serializableTag), ImmArray.empty, DataEnum(ImmArray(constructors)))
         )
     }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -484,6 +484,22 @@ private[validation] object Typing {
             throw EExpectedVariantType(ctx, patnTCon)
         }
 
+      case CPEnum(patnTCon, con) =>
+        val DDataType(_, _, dataCons) = lookupDataType(ctx, patnTCon)
+        dataCons match {
+          case DataEnum(enumCons) =>
+            if (!enumCons.toSeq.contains(con)) throw EUnknownEnumCon(ctx, con)
+            scrutType match {
+              case TTyCon(scrutTCon) =>
+                if (scrutTCon != patnTCon) throw ETypeConMismatch(ctx, patnTCon, scrutTCon)
+                this
+              case _ =>
+                throw EExpectedDataType(ctx, scrutType)
+            }
+          case _ =>
+            throw EExpectedVariantType(ctx, patnTCon)
+        }
+
       case CPPrimCon(con) =>
         val conType = typeOfPRimCon(con)
         if (!alphaEquiv(scrutType, conType))

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -137,6 +137,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpVarCon
         E"Λ (σ : ⋆). λ (e : σ) → (( Mod:Tree:Leaf @σ e ))" ->
           T"∀ (σ : ⋆). σ  → (( Mod:Tree σ ))",
+        // ExpEnumCon
+        E"(( Mod:Color:Blue ))" ->
+          T"Mod:Color",
         // ExpTupleCon
         E"Λ (τ₁ : ⋆) (τ₂ : ⋆). λ (e₁ : τ₁) (e₂ : τ₂)  →  (( ⟨ f₁ = e₁, f₂ = e₂ ⟩ ))" ->
           T"∀ (τ₁ : ⋆) (τ₂ : ⋆). τ₁ → τ₂ → (( ⟨ f₁: τ₁, f₂: τ₂ ⟩ ))",
@@ -149,6 +152,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpCaseVariant
         E"Λ (τ : ⋆). λ (e : Mod:Tree τ) → (( case e of Mod:Tree:Node x → (x).left | Mod:Tree:Leaf x -> e ))" ->
           T"∀ (τ : ⋆). Mod:Tree τ →  ((  Mod:Tree τ  ))",
+        // ExpCaseEnum
+        E"λ (e : Mod:Color) → (( case e of Mod:Color:Red → True | Mod:Color:Green → False | Mod:Color:Blue → False  ))" ->
+          T"Mod:Color → (( Bool ))",
         // ExpCaseNil & ExpCaseCons
         E"Λ (τ : ⋆) (σ : ⋆). λ (e : List τ) (c: σ) (f: τ → List τ → σ) → (( case e of Nil → c | Cons x y → f x y ))" ->
           T"∀ (τ : ⋆) (σ : ⋆). List τ → σ → (τ → List τ → σ) → (( σ ))",
@@ -397,11 +403,6 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
 
     "reject ill formed template definition" in {
       import com.digitalasset.daml.lf.archive.{LanguageMajorVersion => LVM, LanguageVersion => LV}
-
-      /*
-      (Mod:T8Bis { person = (Mod:T {name} this), party = (Mod:T {person} this) })
-      \ (p: Party) -> Cons @Party [(Mod:T {person} this), 'Alice'] (Nil @Party)
-       */
 
       val pkg =
         p"""
@@ -714,6 +715,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
          record R (a: *) = {f1: Int64, f2: List a } ;
 
          variant Tree (a: *) =  Node : < left: Mod:Tree a, right: Mod:Tree a > | Leaf : a ;
+
+         enum Color = Red | Green | Blue ;
 
          record T = {person: Party, name: Text };
          template (this : T) =  {


### PR DESCRIPTION
This PR continue the effort started with #1397 to have enum type in DAML-LF (see issue #105)

Here we add support pattern matching that was forgotten in #1397 and add some extra tests. 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
