### PR TITLE
Add party management to participant state

### DIFF
--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -252,6 +252,11 @@ object domain {
   type LedgerId = String @@ LedgerIdTag
   val LedgerId: Tag.TagOf[LedgerIdTag] = Tag.of[LedgerIdTag]
 
+  sealed trait ParticipantIdTag
+
+  type ParticipantId = String @@ ParticipantIdTag
+  val ParticipantId: Tag.TagOf[ParticipantIdTag] = Tag.of[ParticipantIdTag]
+
   sealed trait ApplicationIdTag
 
   type ApplicationId = Ref.LedgerString @@ ApplicationIdTag
@@ -269,4 +274,10 @@ object domain {
       maximumRecordTime: Instant,
       commands: LfCommands)
 
+  /**
+    * @param party The stable unique identifier of a DAML party.
+    * @param displayName Human readable name associated with the party. Might not be unique.
+    * @param isLocal True if party is hosted by the backing participant.
+    */
+  case class PartyDetails(party: Ref.Party, displayName: Option[String], isLocal: Boolean)
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexService.scala
@@ -12,3 +12,4 @@ trait IndexService
     with ContractStore
     with IdentityProvider
 //with IndexTimeService //TODO: this needs some further discussion as the TimeService is actually optional
+    with PartyManagementService

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/PartyManagementService.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.digitalasset.ledger.api.domain.{ParticipantId, PartyDetails}
+
+import scala.concurrent.Future
+
+/**
+  * Serves as a backend to implement
+  * [[com.digitalasset.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc]]
+  */
+trait PartyManagementService {
+  def getParticipantId(): Future[ParticipantId]
+
+  def listParties(): Future[List[PartyDetails]]
+}

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -24,5 +24,6 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/transaction/src/main/protobuf:transaction_java_proto",
         "//daml-lf/transaction/src/main/protobuf:value_java_proto",
+        "//ledger/ledger-api-domain",
     ],
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
@@ -312,6 +312,13 @@ class InMemoryKVParticipantState(implicit system: ActorSystem, mat: Materializer
       SubmissionResult.Acknowledged
     })
 
+  /** Allocate a party on the ledger */
+  override def allocateParty(
+      hint: Option[String],
+      displayName: Option[String]): CompletionStage[PartyAllocationResult] =
+    // TODO: Implement party management
+    CompletableFuture.completedFuture(PartyAllocationResult.NotSupported)
+
   /** Back-channel for uploading DAML-LF archives.
     * Currently participant-state interfaces do not specify an admin
     * interface to upload packages.

--- a/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Ledger.scala
+++ b/ledger/participant-state/reference/src/main/scala/com/daml/ledger/participant/state/v1/impl/reference/Ledger.scala
@@ -329,6 +329,13 @@ class Ledger(timeModel: TimeModel, timeProvider: TimeProvider)(implicit mat: Act
     }
   }
 
+  /** Allocate a new party on the ledger */
+  override def allocateParty(
+      hint: Option[String],
+      displayName: Option[String]): CompletionStage[PartyAllocationResult] =
+    // TODO: Implement party management
+    CompletableFuture.completedFuture(PartyAllocationResult.NotSupported)
+
   /**
     * Shutdown this ledger implementation, stopping the heartbeat tasks and closing
     * all subscription streams.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.ledger.api.domain.PartyDetails
+
+sealed abstract class PartyAllocationResult extends Product with Serializable
+
+object PartyAllocationResult {
+
+  /** The party was successfully allocated */
+  final case class Ok(result: PartyDetails) extends PartyAllocationResult
+
+  /** Synchronous party allocation is not supported */
+  final case object NotSupported extends PartyAllocationResult
+
+  /** The requested party name already exists */
+  final case object AlreadyExists extends PartyAllocationResult
+
+  /** The requested party name is not valid */
+  final case object InvalidName extends PartyAllocationResult
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
@@ -19,8 +19,9 @@ import java.util.concurrent.CompletionStage
   * plans to make this functionality uniformly available: see the roadmap for
   * progress information https://github.com/digital-asset/daml/issues/121.
   *
-  * As of now there is only one method for changing the state of a DAML
-  * ledger: submitting a transaction using [[WriteService!.submitTransaction]].
+  * As of now there are two methods for changing the state of a DAML ledger:
+  * - submitting a transaction using [[WriteService!.submitTransaction]].
+  * - allocating a new party using [[WriteService!.allocateParty]]
   *
   */
 trait WriteService {
@@ -95,4 +96,24 @@ trait WriteService {
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction): CompletionStage[SubmissionResult]
 
+  /**
+    * Adds a new party to the set managed by the ledger.
+    *
+    * Caller specifies a party identifier suggestion, the actual identifier
+    * allocated might be different and is implementation specific.
+    *
+    * In particular, a ledger may:
+    * - Disregard the given hint and choose a completely new party identifier
+    * - Construct a new unique identifier from the given hint, e.g., by appending a UUID
+    * - Use the given hint as is, and reject the call if such a party already exists
+    *
+    * @param hint A party identifier suggestion
+    * @param displayName A human readable name of the new party
+    *
+    * @return an async result of a PartyAllocationResult
+    */
+  def allocateParty(
+      hint: Option[String],
+      displayName: Option[String]
+  ): CompletionStage[PartyAllocationResult]
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxIndexService.scala
@@ -3,12 +3,13 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger
 
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, _}
+import com.daml.ledger.participant.state.v1.PartyAllocationResult
 import com.daml.ledger.participant.state.{v1 => ParticipantState}
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party, TransactionIdString}
@@ -351,4 +352,21 @@ class SandboxIndexService(
       key: GlobalKey): Future[Option[AbsoluteContractId]] =
     contractStore.lookupContractKey(submitter, key)
 
+  // WriteService (write part of party management)
+  override def allocateParty(
+      hint: Option[String],
+      displayName: Option[String]): CompletionStage[PartyAllocationResult] = {
+    // TODO: Implement party management
+    CompletableFuture.completedFuture(PartyAllocationResult.NotSupported)
+  }
+
+  // PartyManagementService
+  override def getParticipantId(): Future[ParticipantId] =
+    // In the case of the sandbox, there is only one participant node
+    // TODO: Make the participant ID configurable
+    Future.successful(ParticipantId(ledger.ledgerId.unwrap))
+
+  override def listParties(): Future[List[PartyDetails]] =
+    // TODO: Implement party management
+    Future.failed(new RuntimeException("Not implemented"))
 }


### PR DESCRIPTION
This PR extends the participant state interfaces with the new party management calls.

It is split from https://github.com/digital-asset/daml/pull/1452 to unblock @mziolekda 