### PR TITLE
Remove empty team placeholder in CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,46 +3,15 @@
 
 # Only files explicitly mentioned are guarded by code owners (no * rule).
 
-*           @digital-asset/empty
 CODEOWNERS  @bitonic @neil-da @hurryabit @cbaatz-da
-VERSION     @digital-asset/empty
 
 # Build / CI / environment
-/3rdparty/          @digital-asset/empty
-/bazel_tools/       @digital-asset/empty
-/build-scripts/     @digital-asset/empty
 /ci/                @garyverhaegen-da
 /dev-env/           @garyverhaegen-da
-/dotfiles/          @digital-asset/empty
-/hazel/             @digital-asset/empty
 /nix/               @garyverhaegen-da
 /infra/             @garyverhaegen-da
-/rattle/            @digital-asset/empty
-/replacements/      @digital-asset/empty
-/rules_daml/        @digital-asset/empty
-BAZEL-JVM.md        @digital-asset/empty
-BAZEL-haskell.md    @digital-asset/empty
-BAZEL.md            @digital-asset/empty
-BUILD               @digital-asset/empty
-WORKSPACE           @digital-asset/empty
 azure-pipelines.yml @garyverhaegen-da
 azure-cron.yml      @garyverhaegen-da
-build.ps1           @digital-asset/empty
-build.sh            @digital-asset/empty
-deps.bzl            @digital-asset/empty
-
-# Language
-/compiler/          @digital-asset/empty
-/daml-foundations/  @digital-asset/empty
-/libs-haskell/      @digital-asset/empty
-/ghc-lib/           @digital-asset/empty
-
-# SDK
-/release/           @digital-asset/empty
-/sdk/               @digital-asset/empty
-/da-assistant/      @digital-asset/empty
-/daml-assistant/    @digital-asset/empty
-/templates/         @digital-asset/empty
 
 # Runtime
 /daml-lf/           @leo-da @S11001001
@@ -50,31 +19,13 @@ deps.bzl            @digital-asset/empty
 /daml-lf/archive/da/ @bitonic @remyhaemmerle-da
 /daml-lf/spec/      @bitonic @remyhaemmerle-da @S11001001
 /daml-lf/validation/ @remyhaemmerle-da
-/ledger/            @digital-asset/empty
-/ledger-api/        @digital-asset/empty
 
 # Ecosystems
-/language-support/          @digital-asset/empty
-/language-support/java/     @digital-asset/empty @gerolf-da @nicholassmith-da
-/language-support/js/       @digital-asset/empty
+/language-support/java/     @gerolf-da @nicholassmith-da
 /language-support/scala/    @leo-da @S11001001
-/scala-protoc-plugins/      @digital-asset/empty
 
 # Tools
 /extractor/         @leo-da @S11001001
-/navigator/         @digital-asset/empty
-/web-ide/           @digital-asset/empty
 
 # Misc
 /docs/              @bethaitman
-/notices-gen/       @digital-asset/empty
-/oss-compliance/    @digital-asset/empty
-
-CHANGELOG           @digital-asset/empty
-CODE_OF_CONDUCT.md  @digital-asset/empty
-CONTRIBUTING.md     @digital-asset/empty
-COPY                @digital-asset/empty
-LICENSE             @digital-asset/empty
-NOTICES             @digital-asset/empty
-README.md           @digital-asset/empty
-daml-logo.png       @digital-asset/empty


### PR DESCRIPTION
The @digital-asset/empty team was added to have a placeholder in the
CODEOWNERS file to make it easy for developers to scan it and see what
to claim ownership of. It is being removed to tidy up the file with the
expectation that those who still want to claim ownership will just add
the corresponding globs themselves.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
