### PR TITLE
Generics impl

### DIFF
--- a/daml-foundations/daml-ghc/daml-prim-src/LibraryModules.daml
+++ b/daml-foundations/daml-ghc/daml-prim-src/LibraryModules.daml
@@ -23,4 +23,3 @@ import GHC.Real
 import GHC.Show
 import GHC.Tuple
 import GHC.Types
-import GHC.Generics

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
@@ -40,7 +40,7 @@ daml 1.2
 -- <http://hackage.haskell.org/package/generic-deriving> package, which
 -- contains many useful generic functions.
 
-module GHC.Generics (
+module DA.Generics (
 -- * Introduction
 --
 -- |
@@ -725,7 +725,6 @@ module GHC.Generics (
   , Fixity(..), FixityI(..), Associativity(..), prec
   , SourceUnpackedness(..), SourceStrictness(..), DecidedStrictness(..)
   , Meta(..), MetaData0(..), MetaCons0(..), MetaSel0(..)
-  , Maybe(..)
 
   -- * Generic type classes
   , Generic(..), Generic1(..)
@@ -758,6 +757,7 @@ import GHC.Show    ( Show(..), showString )
 import GHC.CString (fromString)
 import GHC.Integer.Type (fromInteger)
 import Control.Exception.Base
+import DA.Internal.Prelude (Optional(..))
 
 -- | The kind of types with values. For example @Int :: Type@.
 -- [DA] copied from ghc-prim/GHC/Types.hs. Usually set to
@@ -1420,13 +1420,11 @@ data Meta = MetaData MetaData0
 
 data MetaData0 = MetaData0 {name :: Symbol, module_ :: Symbol, package :: Symbol, isNewType :: Bool}
 data MetaCons0 = MetaCons0 {name :: Symbol, fixity :: FixityI, hasRecordSelectors :: Bool}
-data MetaSel0 = MetaSel0 {  mbRecordName :: Maybe Symbol
+data MetaSel0 = MetaSel0 {  mbRecordName :: Optional Symbol
                           , sourceUnpackedness :: SourceUnpackedness
                           , sourceStrictness :: SourceStrictness
                           , decidedStrictness ::DecidedStrictness
                           }
-
-data Maybe a = Just a | Nothing
 
 --------------------------------------------------------------------------------
 -- Derived instances

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
@@ -1423,7 +1423,6 @@ data MetaCons0 = MetaCons0 {name :: Symbol, fixity :: FixityI, hasRecordSelector
 data MetaSel0 = MetaSel0 {  mbRecordName :: Optional Symbol
                           , sourceUnpackedness :: SourceUnpackedness
                           , sourceStrictness :: SourceStrictness
-                          , decidedStrictness ::DecidedStrictness
                           }
 
 --------------------------------------------------------------------------------

--- a/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/LibraryModules.daml
@@ -17,6 +17,7 @@ import DA.Experimental.Map
 import DA.Experimental.Set
 import DA.Foldable
 import DA.Functor
+import DA.Generics
 import DA.HKTemplate
 import DA.Internal.Assert
 import DA.Internal.Compatible

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
@@ -234,6 +234,7 @@ generateGenericInstanceFor genClass name@(L loc _n) pkgName modName tyVars dataD
     prod (PrefixCon as)
         | null as = u1
         | otherwise = foldBal mkProd [mkS Nothing $ mkRec0 a | a <- as]
+    prod (RecCon (L _ fs)) | null fs = u1
     prod (RecCon (L _ fs)) =
         foldBal mkProd
         [ mkS (Just cd_fld_names) $ mkRec0 cd_fld_type

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
@@ -221,8 +221,7 @@ generateGenericInstanceFor genClass name@(L loc _n) pkgName modName tyVars dataD
     mkC :: LConDecl GhcPs -> LHsType GhcPs
     mkC c@(L _ ConDeclH98 {..}) = mkHsAppTys c1 [metaConsTy c, prod con_args]
     mkC (L _ ConDeclGADT {}) = gADTError
-    mkC (L _ XConDecl {}) =
-        error "Can't generate generic instance for extended AST"
+    mkC (L _ XConDecl {}) = extError
     prod :: HsConDeclDetails GhcPs -> LHsType GhcPs
     prod (PrefixCon as)
         | null as = u1
@@ -312,7 +311,7 @@ generateGenericInstanceFor genClass name@(L loc _n) pkgName modName tyVars dataD
     metaSelTy0 mbLbs a =
         mkHsAppTys
             ms0
-            [mbRecordName, srcUnpackedness, srcStrictness, decidedStrictness]
+            [mbRecordName, srcUnpackedness, srcStrictness]
       where
         mbRecordName
             | Just [l] <- mbLbs =
@@ -333,7 +332,6 @@ generateGenericInstanceFor genClass name@(L loc _n) pkgName modName tyVars dataD
                 SrcLazy -> mkGenCon sourceLazyDataConName
                 SrcStrict -> mkGenCon sourceStrictDataConName
                 NoSrcStrict -> mkGenCon noSourceStrictnessDataConName
-        decidedStrictness = mkGenCon decidedLazyDataConName -- TODO (drsk) we don't know decided strictness at parsing, we need to remove the field.
 generateGenericInstanceFor _genClass _n _pkgName _mod _tyVars XHsDataDefn {} = extError
 
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Generics.hs
@@ -1,0 +1,280 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+{-# LANGUAGE RecordWildCards #-}
+
+module DA.Daml.GHC.Compiler.Generics
+    ( genericsPreprocessor
+    ) where
+
+import "ghc-lib-parser" Bag
+import "ghc-lib-parser" BasicTypes
+import Data.Maybe
+import "ghc-lib-parser" FastString
+import "ghc-lib" GHC
+import "ghc-lib-parser" Name
+import "ghc-lib-parser" Outputable
+import "ghc-lib-parser" PrelNames
+import "ghc-lib-parser" RdrName
+
+
+
+data GenericKind = Gen0 | Gen1
+
+-- | Generate a generic instance for data definitions with a `deriving Generic` or `deriving
+-- Generic1` derivation.
+genericsPreprocessor :: Maybe String -> ParsedSource -> ParsedSource
+genericsPreprocessor mbPkgName (L l src) =
+    L l
+        src
+            { hsmodDecls =
+                  map dropGenericDeriv (hsmodDecls src) ++
+                  [ generateGenericInstanceFor
+                      t
+                      n
+                      (fromMaybe "Main" mbPkgName)
+                      (fromMaybe (error "Missing module name") $ hsmodName src)
+                      tys
+                      d
+                  | (t, n, tys, d) <- dataDecls
+                  ]
+            }
+    -- the data declarations deriving generic instances
+  where
+    dataDecls =
+        [ (name, tcdLName, tcdTyVars, tcdDataDefn)
+        | L _ (TyClD _x (DataDecl {..})) <- hsmodDecls src
+        , d <- unLoc $ dd_derivs tcdDataDefn
+        , (HsIB _ (L _ (HsTyVar _ _ (L _ (Unqual name))))) <-
+              unLoc $ deriv_clause_tys $ unLoc d
+        , name `elem` [nameOccName n | n <- genericClassNames]
+        ]
+    dropGenericDeriv :: LHsDecl GhcPs -> LHsDecl GhcPs
+    dropGenericDeriv decl =
+        case decl of
+            L loc (TyClD x (DataDecl tcdDExt tcdLName tcdTyVars tcdFixity (HsDataDefn dd_ext dd_ND dd_ctxt dd_cType dd_kindSig dd_cons (L loc2 derivs)))) ->
+                L
+                    loc
+                    (TyClD
+                         x
+                         (DataDecl
+                              tcdDExt
+                              tcdLName
+                              tcdTyVars
+                              tcdFixity
+                              (HsDataDefn
+                                   dd_ext
+                                   dd_ND
+                                   dd_ctxt
+                                   dd_cType
+                                   dd_kindSig
+                                   dd_cons
+                                   (L loc2 $ map dropGeneric derivs))))
+            _other -> decl
+      where
+        dropGeneric :: LHsDerivingClause GhcPs -> LHsDerivingClause GhcPs
+        dropGeneric clause =
+            case clause of
+                L l (HsDerivingClause deriv_clause_ext deriv_clause_strategy (L l2 derive_clause_tys)) ->
+                    L
+                        l
+                        (HsDerivingClause
+                             deriv_clause_ext
+                             deriv_clause_strategy
+                             (L l2 $ filter (not . isGeneric) derive_clause_tys))
+                _other -> clause
+        isGeneric :: LHsSigType GhcPs -> Bool
+        isGeneric (HsIB _ (L _ (HsTyVar _ _ (L _ (Unqual name)))))
+            | name `elem` [nameOccName n | n <- genericClassNames] = True
+        isGeneric _other = False
+
+
+-- | Generate a generic instance for a data type.
+generateGenericInstanceFor ::
+       OccName
+    -> Located (IdP GhcPs)
+    -> String
+    -> Located ModuleName
+    -> LHsQTyVars GhcPs
+    -> HsDataDefn GhcPs
+    -> LHsDecl GhcPs
+generateGenericInstanceFor genClass name@(L loc _n) pkgName modName tyVars dataDef@HsDataDefn {} =
+    pprTrace "reptype" (ppr instDecl) $
+    L loc $ InstD NoExt (ClsInstD {cid_d_ext = NoExt, cid_inst = instDecl})
+  where
+    instDecl =
+        ClsInstDecl
+            { cid_ext = NoExt
+            , cid_poly_ty = HsIB NoExt typ
+            , cid_binds = emptyBag -- unitBag from `unionBags` unitBag to
+            , cid_sigs = []
+            , cid_tyfam_insts = []
+            , cid_datafam_insts = []
+            , cid_overlap_mode = Just $ mkLoc $ NoOverlap NoSourceText
+            }
+    _genKind
+        | genClass == nameOccName genClassName = Gen0
+        | genClass == nameOccName gen1ClassName = Gen1
+        | otherwise = error $ "Deriving generic instance for non-generic class"
+    -- Tag something with the location of the data type we're creating a generic instance for.
+    mkLoc = L loc
+    typ =
+        mkHsAppTys
+            (mkLoc $ HsTyVar NoExt NotPromoted $ mkLoc (Unqual genClass))
+            [tycon, repType]
+    tycon =
+        mkHsAppTys (mkLoc $ HsTyVar NoExt NotPromoted name) $
+        hsLTyVarBndrsToTypes tyVars
+
+    -- The generic type representation
+    ----------------------------------
+    repType :: LHsType GhcPs
+    repType = mkD dataDef
+    mkD :: HsDataDefn GhcPs -> LHsType GhcPs
+    mkD a =
+        mkHsAppTys
+            d1
+            [ metaDataTy
+                  (occNameString $ rdrNameOcc $ unLoc name)
+                  (moduleNameString $ unLoc modName)
+                  pkgName
+                  (dd_ND dataDef == NewType)
+            , sumP $ dd_cons a
+            ]
+    mkS :: Maybe [LFieldOcc GhcPs] -> LHsType GhcPs -> LHsType GhcPs
+    mkS mLbl a = mkHsAppTys s1 [metaSelTy mLbl a, a]
+    sumP :: [LConDecl GhcPs] -> LHsType GhcPs
+    sumP [] = v1
+    sumP cs = foldr1 mkSum' $ map mkC cs
+    mkSum' :: LHsType GhcPs -> LHsType GhcPs -> LHsType GhcPs
+    mkSum' a b = mkHsAppTys plus [a, b]
+    mkProd :: LHsType GhcPs -> LHsType GhcPs -> LHsType GhcPs
+    mkProd a b = mkHsAppTys times [a, b]
+    mkC :: LConDecl GhcPs -> LHsType GhcPs
+    mkC c@(L _ ConDeclH98 {..}) = mkHsAppTys c1 [metaConsTy c, prod con_args]
+    mkC (L _ ConDeclGADT {}) =
+        error "Can't generate generic instances for data types with GADT's"
+    mkC (L _ XConDecl {}) =
+        error "Can't generate generic instance for extended AST"
+    prod :: HsConDeclDetails GhcPs -> LHsType GhcPs
+    prod (PrefixCon as)
+        | null as = u1
+        | otherwise = foldr1 mkProd $ [mkS Nothing $ mkRec0 a | a <- as]
+    prod (RecCon (L _ fs)) =
+        foldr1 mkProd $
+        [ mkS (Just cd_fld_names) $ mkRec0 $ cd_fld_type
+        | (L _ (ConDeclField {..})) <- fs
+        ]
+    prod (InfixCon a b) = mkProd (mkRec0 a) (mkRec0 b)
+    -- | We don't have no unboxed types, so nothing to do here.
+    mkRec0 :: LBangType GhcPs -> LHsType GhcPs
+    mkRec0 t = mkHsAppTy rec0 t
+    -- | Type variables defined in GHC.Generics
+    mkGenTy :: Name -> LHsType GhcPs
+    mkGenTy name =
+        mkLoc $
+        HsTyVar NoExt NotPromoted $
+        mkLoc $ Qual (moduleName gHC_GENERICS) $ occName name
+
+    mkGenCon = mkGenCon0 . occNameString . occName
+    mkGenCon0 :: String -> LHsType GhcPs
+    mkGenCon0 name =
+        mkLoc $
+        HsTyVar NoExt IsPromoted $
+        mkLoc $ Qual (moduleName gHC_GENERICS) $ mkDataOcc name
+
+    mkStrLit :: String -> LHsType GhcPs
+    mkStrLit n = mkLoc $ HsTyLit NoExt $ HsStrTy (SourceText n) (mkFastString n)
+    mkGenPromotedTy :: String -> LHsType GhcPs
+    mkGenPromotedTy n =
+        mkLoc $
+        HsTyVar NoExt IsPromoted $
+        mkLoc $ Qual (moduleName gHC_GENERICS) $ mkDataOcc n
+    mkPromotedTy :: Module -> String -> LHsType GhcPs
+    mkPromotedTy m n =
+        mkLoc $
+        HsTyVar NoExt IsPromoted $ mkLoc $ Qual (moduleName m) $ mkDataOcc n
+    d1 = mkGenTy d1TyConName
+    v1 = mkGenTy v1TyConName
+    c1 = mkGenTy c1TyConName
+    u1 = mkGenTy u1TyConName
+    s1 = mkGenTy s1TyConName
+    rec0 = mkGenTy rec0TyConName
+    md = mkGenCon metaDataDataConName
+    md0 = mkGenCon0 "MetaData0"
+    mc = mkGenCon metaConsDataConName
+    mc0 = mkGenCon0 "MetaCons0"
+    ms = mkGenCon metaSelDataConName
+    ms0 = mkGenCon0 "MetaSel0"
+    plus = mkGenTy sumTyConName
+    times = mkGenTy prodTyConName
+    metaDataTy :: String -> String -> String -> Bool -> LHsType GhcPs
+    metaDataTy name mod pkg isNewType =
+        mkHsAppTy md (metaDataTy0 name mod pkg isNewType)
+    metaConsTy :: LConDecl GhcPs -> LHsType GhcPs
+    metaConsTy c = mkHsAppTy mc $ metaConsTy0 c
+    metaSelTy mbLbs a = mkHsAppTy ms $ metaSelTy0 mbLbs a
+    metaDataTy0 name mod pkg isNewType =
+        mkHsAppTys
+            md0
+            [ mkStrLit name
+            , mkStrLit mod
+            , mkStrLit pkg
+            , if isNewType
+                  then mkPromotedTy gHC_TYPES "True"
+                  else mkPromotedTy gHC_TYPES "False"
+            ]
+    metaConsTy0 :: LConDecl GhcPs -> LHsType GhcPs
+    metaConsTy0 (L _ ConDeclH98 {..}) =
+        mkHsAppTys mc0 [n, fixity, hasRecordSelectors]
+      where
+        n = mkStrLit $ occNameString $ rdrNameOcc $ unLoc con_name
+        fixity
+            | PrefixCon {} <- con_args = mkGenPromotedTy "PrefixI"
+            | InfixCon {} <- con_args = mkGenPromotedTy "PrefixI" -- TODO (drsk) where is the fixity noted?
+            | RecCon {} <- con_args = mkGenPromotedTy "PrefixI"
+        hasRecordSelectors
+            | PrefixCon {} <- con_args = mkPromotedTy gHC_TYPES "False"
+            | InfixCon {} <- con_args = mkPromotedTy gHC_TYPES "False"
+            | RecCon (L _ rec) <- con_args
+            , not (null rec) = mkPromotedTy gHC_TYPES "True"
+            | RecCon (L _ _rec) <- con_args = mkPromotedTy gHC_TYPES "False"
+    metaConsTy0 (L _ ConDeclGADT {}) =
+        error "Can't generate generic instances for data types with GADT's"
+    metaConsTy0 (L _ XConDecl {}) =
+        error "Can't generate generic instance for extended AST"
+    metaSelTy0 :: Maybe [LFieldOcc GhcPs] -> LHsType GhcPs -> LHsType GhcPs
+    metaSelTy0 mbLbs a =
+        mkHsAppTys
+            ms0
+            [mbRecordName, srcUnpackedness, srcStrictness, decidedStrictness]
+      where
+        mbRecordName
+            | Just [l] <- mbLbs =
+                mkHsAppTy
+                    (mkGenPromotedTy "Just")
+                    (mkStrLit $
+                     occNameString $
+                     rdrNameOcc $ unLoc $ rdrNameFieldOcc $ unLoc l)
+            | otherwise = mkGenPromotedTy "Nothing"
+        HsSrcBang _st su ss = getBangStrictness a
+        srcUnpackedness =
+            case su of
+                SrcUnpack -> mkGenCon sourceUnpackDataConName
+                SrcNoUnpack -> mkGenCon sourceNoUnpackDataConName
+                NoSrcUnpack -> mkGenCon noSourceUnpackednessDataConName
+        srcStrictness =
+            case ss of
+                SrcLazy -> mkGenCon sourceLazyDataConName
+                SrcStrict -> mkGenCon sourceStrictDataConName
+                NoSrcStrict -> mkGenCon noSourceStrictnessDataConName
+        decidedStrictness = mkGenCon decidedLazyDataConName -- TODO (drsk) we don't know decided strictness at parsing, we need to remove the field.
+
+    -- Generic method generation
+    ----------------------------
+    from = undefined
+    to = undefined
+
+generateGenericInstanceFor _genClass _n _pkgName _mod _tyVars XHsDataDefn {} =
+    error "Can't generate generic instance for extended AST"

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Options.hs
@@ -73,7 +73,7 @@ data Options = Options
 toCompileOpts :: Options -> Compile.IdeOptions
 toCompileOpts Options{..} =
     Compile.IdeOptions
-      { optPreprocessor = damlPreprocessor
+      { optPreprocessor = damlPreprocessor optMbPackageName
       , optGhcSession = do
             env <- liftIO $ runGhcFast $ do
                 setupDamlGHC optImportPath optMbPackageName optGhcCustomOpts

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -27,13 +27,21 @@ isInternal (GHC.moduleNameString -> x)
     x `elem` ["Control.Exception.Base", "Data.String", "LibraryModules", "DA.Types"]
 
 mayImportInternal :: [GHC.ModuleName]
-mayImportInternal = map GHC.mkModuleName ["Prelude", "DA.Time", "DA.Date", "DA.Record", "DA.TextMap", "Special"]
+mayImportInternal =
+    map GHC.mkModuleName
+        [ "Prelude"
+        , "DA.Time"
+        , "DA.Date"
+        , "DA.Record"
+        , "DA.TextMap"
+        , "DA.Generics"
+        ]
 
 -- | Apply all necessary preprocessors
 damlPreprocessor :: Maybe String -> GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
 damlPreprocessor mbPkgName x
-    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], genericsPreprocessor mbPkgName x)
-    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ genericsPreprocessor mbPkgName $ importDamlPreprocessor x)
+    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], x)
+    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName $ x)
     where name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -8,6 +8,7 @@ module DA.Daml.GHC.Compiler.Preprocessor
   ) where
 
 import           DA.Daml.GHC.Compiler.Records
+import           DA.Daml.GHC.Compiler.Generics
 
 import DA.Daml.GHC.Compiler.UtilGHC
 
@@ -26,13 +27,13 @@ isInternal (GHC.moduleNameString -> x)
     x `elem` ["Control.Exception.Base", "Data.String", "LibraryModules", "DA.Types"]
 
 mayImportInternal :: [GHC.ModuleName]
-mayImportInternal = map GHC.mkModuleName ["Prelude", "DA.Time", "DA.Date", "DA.Record", "DA.TextMap"]
+mayImportInternal = map GHC.mkModuleName ["Prelude", "DA.Time", "DA.Date", "DA.Record", "DA.TextMap", "Special"]
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
-damlPreprocessor x
-    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], x)
-    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ importDamlPreprocessor x)
+damlPreprocessor :: Maybe String -> GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
+damlPreprocessor mbPkgName x
+    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], genericsPreprocessor mbPkgName x)
+    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ genericsPreprocessor mbPkgName $ importDamlPreprocessor x)
     where name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 
 

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Preprocessor.hs
@@ -41,7 +41,7 @@ mayImportInternal =
 damlPreprocessor :: Maybe String -> GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
 damlPreprocessor mbPkgName x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], x)
-    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName $ x)
+    | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName x)
     where name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 
 

--- a/daml-foundations/daml-ghc/tests/Generics.daml
+++ b/daml-foundations/daml-ghc/tests/Generics.daml
@@ -2,15 +2,11 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE EmptyCase #-}
-
-
 
 daml 1.2
 module Generics where
 
-import Prelude
 import DA.Generics
 
 ----------------------------------------------------------------------------------------------------
@@ -30,7 +26,7 @@ data NestedR = NestedRA | NestedRB Int deriving Generic
 type GenericNested a = Rec0 a :*: (U1 :+: Rec0 Int)
 
 ----------------------------------------------------------------------------------------------------
--- Recursive data strucutres
+-- Recursive data structures
 ----------------------------------------------------------------------------------------------------
 
 data Tree a = Leaf a | Node (Node0 a) deriving (Generic, Eq)

--- a/daml-foundations/daml-ghc/tests/Generics.daml
+++ b/daml-foundations/daml-ghc/tests/Generics.daml
@@ -25,8 +25,6 @@ data NestedL a = NestedL {unNestedL : a} deriving Generic
 
 data NestedR = NestedRA | NestedRB Int deriving Generic
 
-type GenericNested a = Rec0 a :*: (U1 :+: Rec0 Int)
-
 ----------------------------------------------------------------------------------------------------
 -- Recursive data structures
 ----------------------------------------------------------------------------------------------------
@@ -34,10 +32,11 @@ type GenericNested a = Rec0 a :*: (U1 :+: Rec0 Int)
 data Tree a = Leaf a | Node (Node0 a) deriving (Generic, Eq)
 data Node0 a = Node0 {l : Tree a, r : Tree a} deriving (Generic, Eq)
 
-testTree : Tree Int
-testTree = Node $ Node0 (Leaf 1) (Node $ Node0 (Leaf 2) (Leaf 3))
-
 test = scenario do
-  assert $ (to $ from $ Unit ()) == Unit ()
-  assert $ (to $ from $ UnitRec {}) == UnitRec {}
-  assert $ (to $ from testTree) == testTree
+  assert $ (from $ Unit ()) == M1 ( M1 (M1 (K1 ()))) && to (M1 ( M1 (M1 (K1 ())))) == Unit ()
+  assert $ (from $ UnitRec) == M1 (M1 U1) && to (M1 (M1 U1)) == UnitRec
+  assert $ (from $ Leaf 1) == M1 (L1 (M1 (M1 (K1 1)))) && to (M1 (L1 (M1 (M1 (K1 1))))) == Leaf 1
+  assert $ (from $ Node (Node0 {l = Leaf 1, r = Leaf 2})) == M1 (R1 (M1 (M1 (K1 (Node0 {l = Leaf 1, r = Leaf 2})))))
+              && to (M1 (R1 (M1 (M1 (K1 (Node0 {l = Leaf 1, r = Leaf 2})))))) == Node (Node0 {l = Leaf 1, r = Leaf 2})
+  assert $ (from $ Node0 {l = Leaf 1, r = Leaf 2}) == M1 (M1 (P1 (M1 (K1 (Leaf 1))) (M1 (K1 (Leaf 2)))))
+              && to (M1 (M1 (P1 (M1 (K1 (Leaf 1))) (M1 (K1 (Leaf 2)))))) == Node0 {l = Leaf 1, r = Leaf 2}

--- a/daml-foundations/daml-ghc/tests/Generics.daml
+++ b/daml-foundations/daml-ghc/tests/Generics.daml
@@ -1,0 +1,44 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE EmptyCase #-}
+
+
+
+daml 1.2
+module Generics where
+
+import Prelude
+import DA.Generics
+
+----------------------------------------------------------------------------------------------------
+-- Non-recursive data structures
+----------------------------------------------------------------------------------------------------
+
+data Void deriving Generic
+
+data Unit = Unit () deriving (Generic, Eq)
+
+data Nested a = Nested {nestedL : NestedL a, nestedR : NestedR} deriving Generic
+
+data NestedL a = NestedL {unNestedL : a} deriving Generic
+
+data NestedR = NestedRA | NestedRB Int deriving Generic
+
+type GenericNested a = Rec0 a :*: (U1 :+: Rec0 Int)
+
+----------------------------------------------------------------------------------------------------
+-- Recursive data strucutres
+----------------------------------------------------------------------------------------------------
+
+data Tree a = Leaf a | Node (Node0 a) deriving (Generic, Eq)
+data Node0 a = Node0 {l : Tree a, r : Tree a} deriving (Generic, Eq)
+
+testTree : Tree Int
+testTree = Node $ Node0 (Leaf 1) (Node $ Node0 (Leaf 2) (Leaf 3))
+
+test = scenario do
+  assert $ (to $ from $ Unit ()) == Unit ()
+  assert $ (to $ from testTree) == testTree

--- a/daml-foundations/daml-ghc/tests/Generics.daml
+++ b/daml-foundations/daml-ghc/tests/Generics.daml
@@ -17,6 +17,8 @@ data Void deriving Generic
 
 data Unit = Unit () deriving (Generic, Eq)
 
+data UnitRec = UnitRec {} deriving (Generic, Eq)
+
 data Nested a = Nested {nestedL : NestedL a, nestedR : NestedR} deriving Generic
 
 data NestedL a = NestedL {unNestedL : a} deriving Generic
@@ -37,4 +39,5 @@ testTree = Node $ Node0 (Leaf 1) (Node $ Node0 (Leaf 2) (Leaf 3))
 
 test = scenario do
   assert $ (to $ from $ Unit ()) == Unit ()
+  assert $ (to $ from $ UnitRec {}) == UnitRec {}
   assert $ (to $ from testTree) == testTree

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
@@ -66,7 +66,6 @@ class DarReaderTest extends WordSpec with Matchers with Inside with BazelRunfile
           "GHC.Tuple",
           "GHC.Err",
           "GHC.Base",
-          "GHC.Generics",
           "LibraryModules"
         )
     }


### PR DESCRIPTION
This implements deriving of instances of the DA.Generics type class. It's implemented as part of the pre-processor. It traverses the GHC parsed AST and for each data type with a generic derivation, it constructs the associated generic type and the from/to instances of the type DA.Generic type class. After, it removes the derivation clauses from the AST to make sure that GHC's own deriving mechanism doesn't interfere. A lot of the code is taken directly from GHC and modified such that it works on the parsed AST instead of the renamed AST. This PR also moves the definition of Generics from GHC.Generics in daml-prim to DA.Generics in the daml-stdlib and adds a test.

Still outstanding is: 
- I think the fixity annotation is somewhere hidden in the parser AST but I haven't found it yet.
- Deriving of Generic1
- We might need standalone deriving clauses.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
