### PR TITLE
Add an option to the IDE to disable the scenario service

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -526,8 +526,8 @@ hazel_repositories(
             # lsp-test work with our custom-methods of haskell-lsp.
             hazel_github(
                 "lsp-test",
-                "4a665666642cebb574fad5035e5e22385e6eae12",
-                "4c46f21139b96ce49251a958db8061ee76a108defb43ee0082ba765339b09b0c",
+                "a325a6860f38c9f533c33f5b37ee9b73580ae68b",
+                "5553d30607ab8942c5aa77c4de08a0dafce345f5bf70b0cba4e47af4d55ba6b3",
             ),
         pkgs = packages,
     ),

--- a/build.ps1
+++ b/build.ps1
@@ -78,7 +78,8 @@ bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/test_execution_w
     //daml-foundations/daml-ghc:module-tree-memory `
     //daml-foundations/daml-ghc:tasty-test `
     //daml-foundations/daml-tools/da-hs-daml-cli `
-    //daml-foundations/daml-tools/da-hs-damlc-app/...
+    //daml-foundations/daml-tools/da-hs-damlc-app/... `
+    //compiler/lsp-tests/...
     # Disabled since there seems to be an issue with starting up the scenario service.
     # See https://github.com/digital-asset/daml/issues/1354
     # //daml-foundations/daml-ghc:daml-ghc-shake-test-ci

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -24,6 +24,7 @@ da_haskell_test(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/haskell-ide-core",
         "//daml-foundations/daml-ghc/test-lib",
         "//libs-haskell/bazel-runfiles",
     ],

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -7,18 +7,19 @@ module Main (main) where
 
 import DA.Bazel.Runfiles
 import qualified Data.Text as T
-import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import System.FilePath
 import System.Info.Extra
 import System.IO.Extra
 import Test.Tasty
 import Test.Tasty.HUnit
+import System.Environment.Blank
 
 import Daml.Lsp.Test.Util
 
 main :: IO ()
 main = do
+    setEnv "TASTY_NUM_THREADS" "1" True
     damlcPath <- locateRunfiles $
         mainWorkspace </> "daml-foundations" </> "daml-tools" </>
         "da-hs-damlc-app" </> "da-hs-damlc-app"
@@ -37,7 +38,7 @@ main = do
         conf = defaultConfig
             -- If you uncomment this you can see all messages
             -- which can be quite useful for debugging.
-            -- { logMessages = True }
+            -- { logMessages = True, logColor = False, logStdErr = True }
 
 diagnosticTests :: (forall a. Session a -> IO a) -> TestTree
 diagnosticTests run = testGroup "diagnostics"

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -170,15 +170,11 @@ withIdeState
     -> (Event -> IO ())
     -> (IdeState -> IO a)
     -> IO a
-withIdeState compilerOpts loggerH eventHandler f = withScenarioService' $ \mbScenarioService -> do
-    vfs <- makeVFSHandle
-    ideState <- getIdeState compilerOpts mbScenarioService loggerH eventHandler vfs
-    f ideState
-    where
-        withScenarioService' f
-            | getEnableScenarioService (optScenarioService compilerOpts) =
-              Scenario.withScenarioService loggerH (f . Just)
-            | otherwise = f Nothing
+withIdeState compilerOpts loggerH eventHandler f =
+    Scenario.withScenarioService' (optScenarioService compilerOpts) loggerH $ \mbScenarioService -> do
+        vfs <- makeVFSHandle
+        ideState <- getIdeState compilerOpts mbScenarioService loggerH eventHandler vfs
+        f ideState
 
 -- | Adapter to the IDE logger module.
 toIdeLogger :: Logger.Handle IO -> IdeLogger.Handle

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Scenario.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Scenario.hs
@@ -7,9 +7,12 @@
 -- | Compiles, generates and creates scenarios for DAML-LF
 module DA.Service.Daml.Compiler.Impl.Scenario (
     SS.Handle
+  , EnableScenarioService(..)
   , withScenarioService
+  , withScenarioService'
   ) where
 
+import DA.Daml.GHC.Compiler.Options
 import qualified DA.Daml.LF.ScenarioServiceClient as SS
 import qualified DA.Service.Logger                          as Logger
 import           Control.Monad.IO.Class                     (liftIO)
@@ -31,3 +34,12 @@ withScenarioService loggerH f = do
           , optLogError = wrapLog Logger.logError
           }
     SS.withScenarioService opts f
+
+withScenarioService'
+    :: EnableScenarioService
+    -> Logger.Handle IO
+    -> (Maybe SS.Handle -> IO a)
+    -> IO a
+withScenarioService' (EnableScenarioService enable) loggerH f
+    | enable = withScenarioService loggerH (f . Just)
+    | otherwise = f Nothing

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Options.hs
@@ -11,9 +11,11 @@ import Options.Applicative.Extended
 import Data.List
 import Text.Read
 import qualified DA.Pretty           as Pretty
+import DA.Daml.GHC.Compiler.Options
 import qualified DA.Daml.LF.Ast.Version as LF
 import DAML.Project.Consts
 import DAML.Project.Types
+
 
 -- | Pretty-printing documents with syntax-highlighting annotations.
 type Document = Pretty.Doc Pretty.SyntaxClass
@@ -312,3 +314,7 @@ projectOpts name = ProjectOpts <$> projectRootOpt <*> projectCheckOpt name
         projectCheckOpt cmdName = fmap (ProjectCheck cmdName) . switch $
                help "Check if running in DAML project."
             <> long "project-check"
+
+enableScenarioOpt :: Parser EnableScenarioService
+enableScenarioOpt = EnableScenarioService <$>
+    flagYesNoAuto "scenarios" True "Enable/disable support for running scenarios" idm

--- a/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Server.hs
+++ b/libs-haskell/da-hs-language-server/src/DA/LanguageServer/Server.hs
@@ -199,7 +199,9 @@ handlers chan = def
     , LSP.didCloseTextDocumentNotificationHandler = emit LSP.NotDidCloseTextDocument
     , LSP.didSaveTextDocumentNotificationHandler = emit LSP.NotDidSaveTextDocument
     , LSP.initializedHandler = emit LSP.NotInitialized
-    , LSP.exitNotificationHandler = emit LSP.NotExit
+    , LSP.exitNotificationHandler = Nothing
+    -- If the exit notification handler is set to `Nothing`
+    -- haskell-lsp will take care of shutting down the server for us.
     , LSP.customRequestHandler = emit LSP.ReqCustomClient
     }
     where


### PR DESCRIPTION
This is useful for several reasons:

1. We currently have to disable all tests using the scenario service
on Windows since they are extremely flaky due to issues we haven’t
been able to solve so far. This allows us to run at least a subset of
tests on CI.

2. The LSP tests currently start a new instance of damlc for each
test (we might want to revisit this but it seems to be sufficiently
fast so far) and not starting the scenario service allows us to speed
things up a bit.

3. On large projects, this could be useful to avoid having the IDE use
up even more memory and speed things up a bit. However, this PR does
not yet expose this in a convenient way so there is more work to be
done (in separate PRs) to make that a viable option.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
