### PR TITLE
windows: daml-assistant tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,7 @@ bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution
     @haskell_c2hs//... `
     //3rdparty/... `
     //nix/third-party/gRPC-haskell:grpc-haskell `
-    //daml-assistant:daml `
+    //daml-assistant/... `
     //daml-foundations/... `
     //compiler/... `
     //daml-lf/... `
@@ -68,7 +68,7 @@ bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/test_execution_w
     //ledger/ledger-api-common/... `
     //ledger-api/... `
     //navigator/backend/... `
-    //daml-assistant/integration-tests/... `
+    //daml-assistant/... `
     //daml-foundations/daml-ghc:daml-ghc-deterministic `
     //daml-foundations/daml-ghc:compile-subdir `
     //daml-foundations/daml-ghc:bond-trading-memory `


### PR DESCRIPTION
- Fixes daml-assistant tests on Windows.
- Adds build & test of whole `//daml-assistant/...` to CI.
- Cleans up integration-tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
