### PR TITLE
introduce participant-state interface v2 

### DIFF
--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Configuration.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Configuration.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+/** Ledger configuration describing the ledger's time model.
+  * Emitted in [[com.daml.ledger.participant.state.v2.Update.ConfigurationChanged]].
+  */
+final case class Configuration(
+    /** The time model of the ledger. Specifying the time-to-live bounds for Ledger API commands. */
+    timeModel: TimeModel
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/LedgerInitialConditions.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/LedgerInitialConditions.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** The initial conditions of the ledger before anything has been committed.
+  *
+  * @param ledgerId: The static ledger identifier.
+  * @param config: The initial ledger configuration
+  * @param initialRecordTime: The initial record time prior to any [[Update]] event.
+  */
+final case class LedgerInitialConditions(
+    ledgerId: LedgerId,
+    config: Configuration,
+    initialRecordTime: Timestamp
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Offset.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.digitalasset.daml.lf.data.Ref.LedgerString
+import com.digitalasset.daml.lf.data.Ref
+
+/** Offsets into streams with hierarchical addressing.
+  *
+  * We use these [[Offset]]'s to address changes to the participant state.
+  * We allow for array of [[Int]] to allow for hierarchical addresses.
+  * These [[Int]] values are expected to be positive. Offsets are ordered by
+  * lexicographic ordering of the array elements.
+  *
+  * A typical use case for [[Offset]]s would be addressing a transaction in a
+  * blockchain by `[<blockheight>, <transactionId>]`. Depending on the
+  * structure of the underlying ledger these offsets are more or less
+  * nested, which is why we use an array of [[Int]]s. The expectation is
+  * though that there usually are few elements in the array.
+  *
+  */
+final case class Offset(private val xs: Array[Long]) extends Ordered[Offset] {
+  def toLedgerString: Ref.LedgerString =
+    // It is safe to concatenate number and "-" to obtain a valid transactionId
+    Ref.LedgerString.assertFromString(components.mkString("-"))
+
+  override def toString: String = toLedgerString
+
+  def components: Iterable[Long] = xs
+
+  override def equals(that: Any): Boolean = that match {
+    case o: Offset => this.compare(o) == 0
+    case _ => false
+  }
+
+  def compare(that: Offset): Int =
+    scala.math.Ordering.Iterable[Long].compare(this.xs.toIterable, that.xs.toIterable)
+}
+
+object Offset {
+
+  /** Create an offset from a string of form 1-2-3. Throws
+    * NumberFormatException on misformatted strings.
+    */
+  def assertFromString(s: LedgerString): Offset =
+    Offset(s.split('-').map(_.toLong))
+
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/PartyAllocationResult.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.digitalasset.ledger.api.domain.PartyDetails
+
+sealed abstract class PartyAllocationResult extends Product with Serializable
+
+object PartyAllocationResult {
+
+  /** The party was successfully allocated */
+  final case class Ok(result: PartyDetails) extends PartyAllocationResult
+
+  /** Synchronous party allocation is not supported */
+  final case object NotSupported extends PartyAllocationResult
+
+  /** The requested party name already exists */
+  final case object AlreadyExists extends PartyAllocationResult
+
+  /** The requested party name is not valid */
+  final case object InvalidName extends PartyAllocationResult
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ReadService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ReadService.scala
@@ -1,0 +1,169 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+/** An interface for reading the state of a ledger participant.
+  *
+  * The state of a ledger participant is communicated as a stream of state
+  * [[Update]]s. That stream is accessible via [[ReadService!.stateUpdates]].
+  * Commonly that stream is processed by a single consumer that keeps track of
+  * the current state and creates indexes to satisfy read requests against
+  * that state.
+  *
+  * See [[com.daml.ledger.participant.state.v2]] for further architectural
+  * information. See [[Update]] for a description of the state updates
+  * communicated by [[ReadService!.stateUpdates]].
+  *
+  */
+trait ReadService {
+
+  /** Retrieve the static initial conditions of the ledger, containing
+    * the ledger identifier and the initial the ledger record time.
+    *
+    * Returns a single element Source since the implementation may need to
+    * first establish connectivity to the underlying ledger. The implementer
+    * may assume that this method is called only once, or very rarely.
+    * Source is being used instead of Future as this is in line with [[stateUpdates]],
+    * and is easy to implement from both Java and Scala.
+    */
+  def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed]
+
+  /** Get the stream of state [[Update]]s starting from the beginning or right
+    * after the given [[Offset]]
+    *
+    * This is where the meat of the implementation effort lies. Please take your time
+    * to read carefully through the properties required from correct implementations.
+    * These properties fall into two categories:
+    *
+    * 1. properties about the sequence of [[(Offset, Update)]] tuples
+    *    in a stream read from the beginning, and
+    * 2. properties relating the streams obtained from two separate alls
+    *   to [[ReadService.stateUpdates]].
+    *
+    * The first class of properties are invariants of a single stream:
+    *
+    * - *strictly increasing [[Offset]]s*:
+    *   for any two consecutive tuples `(o1, u1)` and `(o2, u2)`, `o1` is
+    *   strictly smaller than `o2`.
+    *
+    * - *initialize before transaction acceptance*: before any
+    *   [[Update.TransactionAccepted]], there is a [[Update.ConfigurationChanged]] update
+    *   and [[Update.PublicPackageUploaded]] updates for all packages referenced by
+    *   the [[Update.TransactionAccepted]].
+    *
+    * - *monotonic record time*: for any update `u1` with an associated record
+    *   time `rt1` before an update `u2` with an associated record time `rt2`
+    *   in the stream, it holds that `rt1 <= rt2`. The updates with an
+    *   associated record time are [[Update.Heartbeat]] and [[Update.TransactionAccepted]],
+    *   which both store the record time in the `recordTime` field.
+    *
+    * - *no duplicate transaction acceptance*: there are no two separate
+    *   [[Update.TransactionAccepted]] updates with associated [[SubmitterInfo]]
+    *   records that agree on the `submitter`, `applicationId` and
+    *   `commandId` fields.  This implies that transaction submissions must be
+    *   deduplicated w.r.t. the `(submitter, applicationId, commandId)` tuples.
+    *
+    *   TODO (SM): we would like to weaken this requirement to allow multiple
+    *   [[Update.TransactionAccepted]] updates provided
+    *   the transactions are sub-transactions of each other. Thereby enabling
+    *   the after-the-fact communication of extra details about a transaction
+    *   in case a party is newly hosted at a participant.
+    *   See https://github.com/digital-asset/daml/issues/430
+    *
+    * - *rejection finality*: if there is a [[Update.CommandRejected]] update
+    *   with [[SubmitterInfo]] `info`, then there is no later
+    *   [[Update.TransactionAccepted]] with the same associated [[SubmitterInfo]]
+    *   `info`. Note that in contrast to *no duplicate transaction acceptance*
+    *   this only holds wrt the full [[SubmitterInfo]], as a resubmission of a
+    *   transaction with a higher `maximumRecordTime` must be allowed.
+    *
+    * - *acceptance finality*: if there is a [[Update.TransactionAccepted]] with
+    *   an associated [[SubmitterInfo]] `info1`, then for every later
+    *   [[Update.CommandRejected]] with [[SubmitterInfo]] `info2` that agrees with
+    *   `info1` on the `submitter`, `applicationId`, and `commandId` fields,
+    *   it holds that the rejection reason is
+    *   [[RejectionReason.DuplicateCommand]]. Simply put: the only reason for
+    *   a signalling a rejection of an accepted transaction is a duplicate
+    *   submission of that transaction.
+    *
+    * - *maximum record time enforced*: for all [[Update.TransactionAccepted]]
+    *   updates `u` with associated [[SubmitterInfo]] `info`, it holds that
+    *   `u.recordTime <= info.maximumRecordTime`. Together with *monotonic
+    *   record time* this implies that transactions with a maximum record time
+    *   `mrt` will not be accepted after an update with an associated record
+    *   time larger than `mrt` has been observed.
+    *
+    * The second class of properties relates multiple calls to
+    * [[stateUpdates]]s, and thereby provides constraints on which [[Update]]s
+    * need to be persisted. Before explaining them in detail we provide
+    * intuition.
+    *
+    * All [[Update]]s other than [[Update.Heartbeat]] and [[Update.CommandRejected]] must
+    * always be persisted by the backends implementing the [[ReadService]].
+    * For heartbeats and command rejections, the situation is more
+    * nuanced, as we want to provide the backends with additional
+    * implementation leeway.
+    *
+    * [[Update.CommandRejected]] messages are advisory messages to submitters of
+    * transactions to inform them in a timely fashion that their transaction
+    * has been rejected. The failure of transactions submissions for which no
+    * explicit [[Update.CommandRejected]] message is provided can be detected via
+    * [[Update.Heartbeat]]s, as explained in the 'maximum record time enforced'
+    * property above. In that context, it is also such that only the latest
+    * [[Update.Heartbeat]] with the highest record time matters.
+    *
+    * Given this intuition for the desired mechanism, we advise participant
+    * state implementations to aim to always provide timely
+    * [[Update.CommandRejected]] messages and regular heartbeats at a
+    * granularity that supports timely detection of maximum record time
+    * violation. Concrete values need to be recommended by implementors.
+    *
+    * Implementations are free to not persist
+    * [[Update.CommandRejected]] and [[Update.Heartbeat]] updates provided their
+    * [[Offset]]s are not reused. This is relevant for the case where a
+    * consumer rebuilds his view of the state by starting from a fresh
+    * call to [[ReadService.stateUpdates]]; e.g., because it or the
+    * stream provider crashed.
+    *
+    * Formally, we capture the expected relation between two calls
+    * `s1 = stateUpdates(o1)` and `s2 = stateUpdates(o2)` for `o1 <= o2` as
+    * follows.
+    *
+    * - *unique offsets*: for any update `u1` with offset `uo` in `s1` and any
+    *   update `u2` with the same offset `uo` in `se2` it holds that `u1 == u2`.
+    *   This means that offsets can never be reused. Together with
+    *   *strictly increasing [[Offset]]* this also implies that the order of
+    *   elements present in both `s1` and `s2` cannot change.
+    *
+    * - *persistent updates*: any update other than [[Update.Heartbeat]] and
+    *   [[Update.CommandRejected]] in `s2` must also be present in `s1`.
+    *
+    *
+    * Last but not least, there is an expectation about the relation between streams visible
+    * on *separate* participant state implementations connected to the same ledger.
+    * The expectation is that two parties hosted on separate participant nodes are in sync
+    * on transaction nodes and contracts that they can both see. The more formal definition
+    * is based on the notion of projections of transactions
+    * (see https://docs.daml.com/concepts/ledger-model/ledger-privacy.html), as follows.
+    *
+    * Assume that there is
+    * - a party `A` hosted at participant `p1`,
+    * - a party `B` hosted at participant `p2`, and
+    * - an accepted transaction with identifier `tid` evidenced to both participants `p1` and `p2`
+    *   in their state update streams after the [[Update.PartyAddedToParticipant]] updates for
+    *   `A`, respectively `B`.
+    * The projections of `tx1` and `tx2` to the nodes visible to both `A` and `B` is the same.
+    *
+    * Note that the the transaction `tx1` associated to `tid` on `p1` is not required to be the same as
+    * the transaction `tx2` associated to `tid` on `p2`, as these two participants do not necessarily
+    * host the same parties; and some implementations ensure data segregation on the ledger. Requiring
+    * only the projections to sets of parties to be equal leaves just enough leeway for this
+    * data segregation.
+    *
+    */
+  def stateUpdates(beginAfter: Option[Offset]): Source[(Offset, Update), NotUsed]
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/RejectionReason.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/RejectionReason.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+/** Reasons for rejections of transaction submission.
+  *
+  * Used to provide details for [[Update.CommandRejected]].
+  */
+sealed trait RejectionReason extends Product with Serializable {
+  def description: String
+}
+
+object RejectionReason {
+
+  /** The transaction relied on contracts being active that were no longer
+    * active at the point where it was sequenced.  See
+    * https://docs.daml.com/concepts/ledger-model/ledger-integrity.html
+    * for the definition of ledger consistency.
+    */
+  final case object Inconsistent extends RejectionReason {
+    override def description: String = "Inconsistent"
+  }
+
+  /** The transaction has been disputed.
+    *
+    * This means that the underlying ledger and its validation logic
+    * considered the transaction potentially invalid. This can be due to a bug
+    * in the submission or validation logic, or due to malicious behaviour.
+    */
+  final case class Disputed(reason: String) extends RejectionReason {
+    override def description: String = "Disputed: " + reason
+  }
+
+  /** The Participant node did not have sufficient resources with the
+    * ledger to submit the transaction.
+    */
+  final case object ResourcesExhausted extends RejectionReason {
+    override def description: String = "Resources exhausted"
+  }
+
+  /** The transaction submission exceeded its maximum record time.
+    *
+    * This means the 'maximumRecordTime' was smaller than the record time
+    * in the ledger state at which the transaction was sequenced.
+    */
+  final case object MaximumRecordTimeExceeded extends RejectionReason {
+    override def description: String =
+      "The maximum record time of the command exceeded"
+  }
+
+  /** The participant or ledger has already accepted a transaction with the
+    * same command-id.
+
+    * The guarantee provided by the ledger is to never store two transactions
+    * with [[SubmitterInfo]] with the same '(submitter, applicationId,
+    * commandId)' tuple.
+    *
+    * This is used to protect against duplicate submissions of transactions
+    * that do not consume any contract; e.g., a transaction creating a
+    * contract. These transactions can be sometimes submitted twice in case
+    * of faults in the submitting application.
+    */
+  final case object DuplicateCommand extends RejectionReason {
+    override def description: String = "Duplicate command"
+  }
+
+  /** A party mentioned as a stakeholder or actor has not been on-boarded on
+    * the ledger.
+    *
+    * This rejection reason is available for ledger that do require some
+    * explicit on-boarding steps for a party to exist; e.g., generating key
+    * material and registering the party with the ledger-wise
+    * identity-manager.
+    *
+    */
+  final case object PartyNotKnownOnLedger extends RejectionReason {
+    override def description: String = "Party not known on ledger"
+  }
+
+  /** The submitter cannot act via this participant.
+    *
+    * @param details: details on why the submitter cannot act; e.g., because
+    *   it is not hosted on the participant or because its write access to
+    *   the ledger has been deactivated.
+    *
+    */
+  final case class SubmitterCannotActViaParticipant(details: String) extends RejectionReason {
+    override def description: String = "Submitter cannot act via participant: " + details
+  }
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmissionResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmissionResult.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+sealed abstract class SubmissionResult extends Product with Serializable
+
+object SubmissionResult {
+
+  /** The request has been received */
+  final case object Acknowledged extends SubmissionResult
+
+  /** The system is overloaded, clients should back off exponentially */
+  final case object Overloaded extends SubmissionResult
+
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** Information provided by the submitter of changes submitted to the ledger.
+  *
+  * Note that this is used for party-originating changes only. They are
+  * usually issued via the Ledger API.
+  *
+  * @param submitter: the party that submitted the change.
+  *
+  * @param applicationId: an identifier for the DAML application that
+  *   submitted the command. This is used for monitoring and to allow DAML
+  *   applications subscribe to their own submissions only.
+  *
+  * @param commandId: a submitter provided identifier that he can use to
+  *   correlate the stream of changes to the participant state with the
+  *   changes he submitted.
+  *
+  * @param maxRecordTime: the maximum record time (inclusive) until which
+  *   the submitted change can be validly added to the ledger. This is used
+  *   by DAML applications to deduce from the record time reported by the
+  *   ledger whether a change that they submitted has been lost in transit.
+  *
+  */
+final case class SubmitterInfo(
+    submitter: Party,
+    applicationId: ApplicationId,
+    commandId: CommandId,
+    maxRecordTime: Timestamp //TODO: this should be a regular Instant
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/TimeModel.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/TimeModel.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import java.time.{Duration, Instant}
+
+trait TimeModel {
+
+  def minTransactionLatency: Duration
+
+  def futureAcceptanceWindow: Duration
+
+  def maxClockSkew: Duration
+
+  def minTtl: Duration
+
+  def maxTtl: Duration
+
+}
+
+trait TimeModelChecker {
+
+  /**
+    * Validates that the given ledger effective time is within an acceptable time window of the current system time.
+    *
+    * @param currentTime              the current time
+    * @param givenLedgerEffectiveTime The ledger effective time to validate.
+    * @param givenMaximumRecordTime   The maximum record time to validate.
+    * @return true if successful
+    */
+  def checkLet(
+      currentTime: Instant,
+      givenLedgerEffectiveTime: Instant,
+      givenMaximumRecordTime: Instant): Boolean
+
+  /**
+    * Validates that the ttl of the given times is within bounds.
+    * The ttl of a command is defined as the duration between
+    * the ledger effective time and maximum record time.
+    *
+    * @param givenLedgerEffectiveTime The given ledger effective time.
+    * @param givenMaximumRecordTime   The given maximum record time.
+    * @return true if successful
+    */
+  def checkTtl(givenLedgerEffectiveTime: Instant, givenMaximumRecordTime: Instant): Boolean
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/TransactionMeta.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+
+/** Meta-data of a transaction visible to all parties that can see a part of
+  * the transaction.
+  *
+  * @param ledgerEffectiveTime: the submitter-provided time at which the
+  *   transaction should be interpreted. This is the time returned by the
+  *   DAML interpreter on a `getTime :: Update Time` call. See the docs on
+  *   [[WriteService.submitTransaction]] for how it relates to the notion of
+  *   `recordTime`.
+  *
+  * @param workflowId: a submitter-provided identifier used for monitoring
+  *   and to traffic-shape the work handled by DAML applications
+  *   communicating over the ledger.
+  *
+  */
+final case class TransactionMeta(ledgerEffectiveTime: Timestamp, workflowId: Option[WorkflowId])

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
@@ -1,0 +1,126 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger
+package participant.state.v2
+
+import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml_lf.DamlLf
+
+/** An update to the (abstract) participant state.
+  *
+  * [[Update]]'s are used in [[ReadService.stateUpdates]] to communicate
+  * changes to abstract participant state to consumers. We describe
+  *
+  * We describe the possible updates in the comments of
+  * each of the case classes implementing [[Update]].
+  *
+  */
+sealed trait Update extends Product with Serializable {
+
+  /** Short human-readable one-line description summarizing the state updates content. */
+  def description: String
+}
+
+object Update {
+
+  /** Signal aliveness and the current record time.  */
+  final case class Heartbeat(recordTime: Timestamp) extends Update {
+    override def description: String = s"Heartbeat: $recordTime"
+  }
+
+  /** Signal that the current [[Configuration]] has changed. */
+  final case class ConfigurationChanged(newConfiguration: Configuration) extends Update {
+    override def description: String =
+      s"Configuration changed to: $newConfiguration"
+  }
+
+  /** Signal that a party is hosted at this participant.
+    *
+    * As explained in the note on [[ReadService.stateUpdates]], the
+    * state updates are only expected to signal all updates pertaining
+    * to data affecting the parties hosted at the participant.
+    *
+    */
+  final case class PartyAddedToParticipant(party: Party) extends Update {
+    override def description: String = s"Add party '$party' to participant"
+  }
+
+  /** Signal the uploading of a package that is publicly visible.
+    *
+    * We expect that ledger or participant-node administrators issue such
+    * public uploads. The 'public' qualifier refers to the fact that all
+    * parties hosted by a participant (or even all parties connected to a
+    * ledger) will see the uploaded package. It is in contrast to a future
+    * extension where we plan to support per-party package visibility
+    * https://github.com/digital-asset/daml/issues/311.
+    *
+    */
+  final case class PublicPackageUploaded(archive: DamlLf.Archive) extends Update {
+    override def description: String = s"Public package ${archive.getHash} uploaded"
+  }
+
+  /** Signal the acceptance of a transaction.
+    *
+    * @param optSubmitterInfo:
+    *   The information provided by the submitter of the command that
+    *   created this transaction. It must be provided if the submitter is
+    *   hosted at this participant. It can be elided otherwise. This allows
+    *   ledgers to implement a fine-grained privacy model.
+    *
+    * @param transactionMeta:
+    *   the metadata of the transaction that was provided by the submitter.
+    *   It is visible to all parties that can see the transaction.
+    *
+    * @param transaction:
+    *   the view of the transaction that was accepted. This view must
+    *   include at least the projection of the accepted transaction to the
+    *   set of all parties hosted at this participant. See
+    *   https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
+    *   on how these views are computed.
+    *
+    *   Note that ledgers with weaker privacy models can decide to forgo
+    *   projections of transactions and always show the complete
+    *   transaction.
+    *
+    * @param recordTime:
+    *   The ledger-provided timestamp at which the transaction was recorded.
+    *   The last [[Configuration]] set before this [[TransactionAccepted]]
+    *   determines how this transaction's recordTime relates to its
+    *   [[TransactionMeta.ledgerEffectiveTime]].
+    *
+    * @param referencedContracts:
+    *   A list of all contracts that were created before this transaction
+    *   and referenced by it (via fetch, consuming, or non-consuming
+    *   exercise nodes). This list is provided to enable consumers of
+    *   [[ReadService.stateUpdates]] to implement the divulgence semantics
+    *   as described here:
+    *   https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
+    *
+    */
+  final case class TransactionAccepted(
+      optSubmitterInfo: Option[SubmitterInfo],
+      transactionMeta: TransactionMeta,
+      transaction: CommittedTransaction,
+      transactionId: TransactionId,
+      recordTime: Timestamp,
+      referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)]
+  ) extends Update {
+    override def description: String = s"Accept transaction $transactionId"
+  }
+
+  /** Signal that a command submitted via [[WriteService]] was rejected.
+    *
+    * See the different [[RejectionReason]] for why a command can be
+    * rejected.
+    */
+  final case class CommandRejected(
+      submitterInfo: SubmitterInfo,
+      reason: RejectionReason,
+  ) extends Update {
+    override def description: String = {
+      s"Reject command ${submitterInfo.commandId}: $reason"
+    }
+  }
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import java.util.concurrent.CompletionStage
+
+/** An interface to change a ledger via a participant.
+  *
+  * The methods in this interface are all methods that are supported
+  * *uniformly* across all ledger participant implementations. Methods for
+  * uploading packages, on-boarding parties, and changing ledger-wide
+  * configuration are specific to a ledger and therefore to a participant
+  * implementation. Moreover, these methods usually require admin-level
+  * privileges, whose granting is also specific to a ledger.
+  *
+  * If a ledger is run for testing only, there is the option for quite freely
+  * allowing the on-boarding of parties and uploading of packages. There are
+  * plans to make this functionality uniformly available: see the roadmap for
+  * progress information https://github.com/digital-asset/daml/issues/121.
+  *
+  * As of now there are two methods for changing the state of a DAML ledger:
+  * - submitting a transaction using [[WriteService!.submitTransaction]].
+  * - allocating a new party using [[WriteService!.allocateParty]]
+  *
+  */
+trait WriteService {
+
+  /** Submit a transaction for acceptance to the ledger.
+    *
+    * This method must be thread-safe, not throw, and not block on IO. It is
+    * though allowed to perform significant computation. The expectation is
+    * that callers call this method on a thread dedicated to getting this transaction
+    * ready for acceptance to the ledger, which typically requires some
+    * preparation steps (decomposition, serialization) by the implementation
+    * of the [[WriteService]].
+    *
+    * The result of the transaction submission is communicated asynchronously
+    * via a [[ReadService]] implementation backed by the same participant
+    * state as this [[WriteService]]. Successful transaction acceptance is
+    * communicated using a [[Update.TransactionAccepted]] message. Failed
+    * transaction acceptance is communicated when possible via a
+    * [[Update.CommandRejected]] message referencing the same `submitterInfo` as
+    * provided in the submission. There can be failure modes where a
+    * transaction submission is lost in transit, and no [[Update.CommandRejected]] is
+    * generated. These failures are communicated via [[Update.Heartbeat]]s signalling
+    * that the `maximumRecordTime` provided in the submitter info has been
+    * exceeded. See the comments on [[ReadService.stateUpdates]] for further details.
+    *
+    * A note on ledger effective time and record time: transactions are
+    * submitted together with a `ledgerEffectiveTime` provided as part of the
+    * `transactionMeta` information. The ledger-effective time is used by the
+    * DAML Engine to resolve calls to the `getTime :: Update Time`
+    * function. Letting the submitter freely choose the ledger-effective time
+    * is though a problem for the other stakeholders in the contracts affected
+    * by the submitted transaction. The submitter can in principle choose to
+    * submit transactions that are effective far in the past or future
+    * relative to the wall-clock time of the other participants. This gives
+    * the submitter an unfair advantage and make the semantics of `getTime`
+    * quite surprising. We've chosen the following solution to provide useful
+    * guarantees for contracts relying on `getTime`.
+    *
+    * The ledger is charged with (1) associating record-time stamps to accepted
+    * transactions and (2) to provide a guarantee on the maximal skew between the
+    * ledger effective time and the record time stamp associated to an
+    * accepted transaction. The ledger is also expected to provide guarantees
+    * on the distribution of the maximal skew between record time stamps on
+    * accepted transactions and the wall-clock time at delivery of accepted transactions to a ledger
+    * participant. Thereby providing ledger participants with a guarantee on the
+    * maximal skew between the ledger effective time of an accepted
+    * transaction and the wall-clock time at delivery to these participants.
+    *
+    * Concretely, we typically expect the allowed skew between record time and
+    * ledger effective time to be in the minute range. Thereby leaving ample
+    * time for submitting and validating large transactions before they are
+    * timestamped with their record time.
+    *
+    * @param submitterInfo   : the information provided by the submitter for
+    *                        correlating this submission with its acceptance or rejection on the
+    *                        associated [[ReadService]].
+    * @param transactionMeta : the meta-data accessible to all consumers of the
+    *   transaction. See [[TransactionMeta]] for more information.
+    * @param transaction     : the submitted transaction. This transaction can
+    *                        contain contract-ids that are relative to this transaction itself.
+    *                        These are used to refer to contracts created in the transaction
+    *   itself. The participant state implementation is expected to convert
+    *                        these into absolute contract-ids that are guaranteed to be unique.
+    *                        This typically happens after a transaction has been assigned a
+    *                        globally unique id, as then the contract-ids can be derived from that
+    *                        transaction id.
+    *
+    * @return an async result of a SubmissionResult
+    */
+  def submitTransaction(
+      submitterInfo: SubmitterInfo,
+      transactionMeta: TransactionMeta,
+      transaction: SubmittedTransaction): CompletionStage[SubmissionResult]
+
+  /**
+    * Adds a new party to the set managed by the ledger.
+    *
+    * Caller specifies a party identifier suggestion, the actual identifier
+    * allocated might be different and is implementation specific.
+    *
+    * In particular, a ledger may:
+    * - Disregard the given hint and choose a completely new party identifier
+    * - Construct a new unique identifier from the given hint, e.g., by appending a UUID
+    * - Use the given hint as is, and reject the call if such a party already exists
+    *
+    * @param hint A party identifier suggestion
+    * @param displayName A human readable name of the new party
+    *
+    * @return an async result of a PartyAllocationResult
+    */
+  def allocateParty(
+      hint: Option[String],
+      displayName: Option[String]
+  ): CompletionStage[PartyAllocationResult]
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/v2.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/v2.scala
@@ -19,40 +19,30 @@ import com.digitalasset.daml.lf.value.Value
   * which is why we talk about an abstract participant state. It abstracts
   * over the different implementations of DAML ledger participants.
   *
+  * This is version v2 of the [[com.daml.ledger.participant.state]]
+  * interfaces.
+  * - v1 is kept as is to serve the needs of //ledger/api-server-damlonx.
+  * It will be deprecated and dropped as soon as Sandbox ledger API server
+  * becomes a common backbone of all daml-on-x implementations.
+  * - v2 is under development and evolving to serve the needs of merging the
+  * Sandbox ledger API server with the DAML on X API server as per
+  * https://github.com/digital-asset/daml/issues/1273
+  *
   * The interfaces are optimized for easy implementation. The
-  * [[v1.WriteService]] interface contains the methods for changing the
+  * [[v2.WriteService]] interface contains the methods for changing the
   * participant state (and potentially the state of the DAML ledger), which
   * all ledger participants must support. These methods are for example
   * exposed via the DAML Ledger API. Actual ledger participant implementations
   * likely support more implementation-specific methods. They are however not
-  * exposed via the DAML Ledger API. The [[v1.ReadService]] interface contains
-  * the one method [[v1.ReadService.stateUpdates]] to read the state of a ledger
+  * exposed via the DAML Ledger API. The [[v2.ReadService]] interface contains
+  * the one method [[v2.ReadService.stateUpdates]] to read the state of a ledger
   * participant. It represents the participant state as a stream of
-  * [[v1.Update]]s to an initial participant state. The typical consumer of this
-  * method is a class that subscribes to this stream of [[v1.Update]]s and
+  * [[v2.Update]]s to an initial participant state. The typical consumer of this
+  * method is a class that subscribes to this stream of [[v2.Update]]s and
   * reconstructs (a view of) the actual participant state. See the comments
-  * on [[v1.Update]] and [[v1.ReadService.stateUpdates]] for details about the kind
+  * on [[v2.Update]] and [[v2.ReadService.stateUpdates]] for details about the kind
   * of updates and the guarantees given to consumers of the stream of
-  * [[v1.Update]]s.
-  *
-  * We provide a reference implementation of a participant state in
-  * [[com.daml.ledger.participant.state.v2.impl.reference.Ledger]]. There we
-  * model an in-memory ledger, which has by construction a single participant,
-  * which hosts all parties. See its comments for details on how that is done,
-  * and how its implementation can be used as a blueprint for implementing
-  * your own participant state.
-  *
-  * We do expect the interfaces provided in
-  * [[com.daml.ledger.participant.state]] to evolve, which is why we
-  * provide them all in the
-  * [[com.daml.ledger.participant.state.v2]] package.  Where possible
-  * we will evolve them in a backwards compatible fashion, so that a simple
-  * recompile suffices to upgrade to a new version. Where that is not
-  * possible, we plan to introduce new version of this API in a separate
-  * package and maintain it side-by-side with the existing version if
-  * possible. There can therefore potentially be multiple versions of
-  * participant state APIs at the same time. We plan to deprecate and drop old
-  * versions on separate and appropriate timelines.
+  * [[v2.Update]]s.
   *
   */
 package object v2 {

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/v2.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/v2.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state
+
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
+import com.digitalasset.daml.lf.value.Value
+
+/** Interfaces to read from and write to an (abstract) participant state.
+  *
+  * A DAML ledger participant is code that allows to actively participate in
+  * the evolution of a shared DAML ledger. Each such participant maintains a
+  * particular view onto the state of the DAML ledger. We call this view the
+  * participant state.
+  *
+  * Actual implementations of a DAML ledger participant will likely maintain
+  * more state than what is exposed through the interfaces in this package,
+  * which is why we talk about an abstract participant state. It abstracts
+  * over the different implementations of DAML ledger participants.
+  *
+  * The interfaces are optimized for easy implementation. The
+  * [[v1.WriteService]] interface contains the methods for changing the
+  * participant state (and potentially the state of the DAML ledger), which
+  * all ledger participants must support. These methods are for example
+  * exposed via the DAML Ledger API. Actual ledger participant implementations
+  * likely support more implementation-specific methods. They are however not
+  * exposed via the DAML Ledger API. The [[v1.ReadService]] interface contains
+  * the one method [[v1.ReadService.stateUpdates]] to read the state of a ledger
+  * participant. It represents the participant state as a stream of
+  * [[v1.Update]]s to an initial participant state. The typical consumer of this
+  * method is a class that subscribes to this stream of [[v1.Update]]s and
+  * reconstructs (a view of) the actual participant state. See the comments
+  * on [[v1.Update]] and [[v1.ReadService.stateUpdates]] for details about the kind
+  * of updates and the guarantees given to consumers of the stream of
+  * [[v1.Update]]s.
+  *
+  * We provide a reference implementation of a participant state in
+  * [[com.daml.ledger.participant.state.v2.impl.reference.Ledger]]. There we
+  * model an in-memory ledger, which has by construction a single participant,
+  * which hosts all parties. See its comments for details on how that is done,
+  * and how its implementation can be used as a blueprint for implementing
+  * your own participant state.
+  *
+  * We do expect the interfaces provided in
+  * [[com.daml.ledger.participant.state]] to evolve, which is why we
+  * provide them all in the
+  * [[com.daml.ledger.participant.state.v2]] package.  Where possible
+  * we will evolve them in a backwards compatible fashion, so that a simple
+  * recompile suffices to upgrade to a new version. Where that is not
+  * possible, we plan to introduce new version of this API in a separate
+  * package and maintain it side-by-side with the existing version if
+  * possible. There can therefore potentially be multiple versions of
+  * participant state APIs at the same time. We plan to deprecate and drop old
+  * versions on separate and appropriate timelines.
+  *
+  */
+package object v2 {
+
+  /** Identifier for the ledger, MUST match regexp [a-zA-Z0-9-]. */
+  type LedgerId = String
+
+  /** Identifiers for transactions.
+    * Currently unrestricted unicode (See issue #398). */
+  type TransactionId = Ref.TransactionIdString
+
+  /** Identifiers used to correlate submission with results.
+    * Currently unrestricted unicode (See issue #398). */
+  type CommandId = Ref.LedgerString
+
+  /** Identifiers used for correlating submission with a workflow.
+    * Currently unrestricted unicode (See issue #398).  */
+  type WorkflowId = Ref.LedgerString
+
+  /** Identifiers for submitting client applications.
+    * Currently unrestricted unicode (See issue #398). */
+  type ApplicationId = Ref.LedgerString
+
+  /** Identifiers for nodes in a transaction. */
+  type NodeId = Transaction.NodeId
+
+  /** Identifiers for packages. */
+  type PackageId = Ref.PackageId
+
+  /** Identifiers for parties. */
+  type Party = Ref.Party
+
+  /** A transaction with relative and absolute contract identifiers.
+    *
+    *  See [[WriteService.submitTransaction]] for details.
+    */
+  type SubmittedTransaction = Transaction.Transaction
+
+  /** A transaction with absolute contract identifiers only.
+    *
+    * Used to communicate transactions that have been accepted to the ledger.
+    * See [[WriteService.submitTransaction]] for details on relative and
+    * absolute contract identifiers.
+    */
+  type CommittedTransaction =
+    GenTransaction.WithTxValue[NodeId, Value.AbsoluteContractId]
+
+  /** A contract instance with absolute contract identifiers only. */
+  type AbsoluteContractInst =
+    Value.ContractInst[Value.VersionedValue[Value.AbsoluteContractId]]
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.index.v2.{
   IndexPackagesService,
   _
 }
-import com.daml.ledger.participant.state.v1.WriteService
+import com.daml.ledger.participant.state.v2.WriteService
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.engine._

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
@@ -5,8 +5,8 @@ package com.digitalasset.platform.sandbox.services
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceLogging
 import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.index.v2.ContractStore
-import com.daml.ledger.participant.state.v1.SubmissionResult.{Acknowledged, Overloaded}
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.SubmissionResult.{Acknowledged, Overloaded}
+import com.daml.ledger.participant.state.v2.{
   SubmissionResult,
   SubmitterInfo,
   TransactionMeta,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutor.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger
 
-import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
 import com.digitalasset.daml.lf.command.Commands
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/CommandExecutorImpl.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger
 
-import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
 import com.digitalasset.daml.lf.command._
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Time.Timestamp

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.{
   SubmissionResult,
   SubmittedTransaction,
   SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.{
   SubmissionResult,
   SubmittedTransaction,
   SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SandboxIndexAndWriteService.scala
@@ -10,12 +10,12 @@ import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, _}
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.{
   PartyAllocationResult,
   SubmittedTransaction,
   WriteService
 }
-import com.daml.ledger.participant.state.{v1 => ParticipantState}
+import com.daml.ledger.participant.state.{v2 => ParticipantState}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party, TransactionIdString}
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.{
   SubmissionResult,
   SubmittedTransaction,
   SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -9,7 +9,7 @@ import akka.stream.QueueOfferResult.{Dropped, Enqueued, QueueClosed}
 import akka.stream.scaladsl.{GraphDSL, Keep, MergePreferred, Sink, Source, SourceQueueWithComplete}
 import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult, SourceShape}
 import akka.{Done, NotUsed}
-import com.daml.ledger.participant.state.v1.{
+import com.daml.ledger.participant.state.v2.{
   SubmissionResult,
   SubmittedTransaction,
   SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.TransactionId
+import com.daml.ledger.participant.state.v2.TransactionId
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.Node

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.sandbox.stores.ledger
 import java.time.Instant
 
 import akka.stream.scaladsl.Sink
-import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.v2.{SubmissionResult, SubmitterInfo, TransactionMeta}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}


### PR DESCRIPTION
introduce participant-state interface v2 to allow splitting daml-on-x workstream from sandbox.
- v1 is going to be used by daml-on-x tactically to deliver a few integrations in the next couple of weeks
- v2 is going to be the official future interface, used in sandbox codebase and everywhere long-term