### PR TITLE
correct broken ledger-api-introduction links

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -322,9 +322,15 @@ java_binary(
 )
 
 daml_test(
-    name = "ledger-api-introduction-daml-test",
-    srcs = glob(["source/app-dev/ledger-api-introduction/code-snippets/**/*.daml"]),
+    name = "ledger-api-daml-test",
+    srcs = glob(["source/app-dev/code-snippets/**/*.daml"]),
 )
+
+daml_test(
+    name = "bindings-java-daml-test",
+    srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
+)
+
 
 daml_test(
     name = "patterns-daml-test",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -331,7 +331,6 @@ daml_test(
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
 )
 
-
 daml_test(
     name = "patterns-daml-test",
     srcs = glob(["source/daml/patterns/daml/**/*.daml"]),

--- a/docs/redirects.map
+++ b/docs/redirects.map
@@ -18,10 +18,12 @@ packages/da-docs-example-bond-trading/index.html -> /examples/bond-trading/index
 packages/da-docs-example-bond-trading/automation-introduction.html -> /examples/bond-trading/automation-introduction.html
 packages/da-docs-example-bond-trading/automation-implementation.html -> /examples/bond-trading/automation-implementation.html
 packages/da-docs-example-bond-trading/bond-trading-model.html -> /examples/bond-trading/bond-trading-model.html
-packages/ledger-api-introduction/index.html -> /app-dev/ledger-api-introduction/index.html
-packages/ledger-api-introduction/changelog.html -> /app-dev/ledger-api-introduction/changelog.html
+packages/ledger-api-introduction/index.html -> /app-dev/grpc/index.html
 packages/ledger-api-introduction/daml-to-ledger-api.html -> /app-dev/grpc/daml-to-ledger-api.html
-packages/ledger-api-introduction/proto-docs.html -> /app-dev/ledger-api-introduction/proto-docs.html
+packages/ledger-api-introduction/proto-docs.html -> /app-dev/grpc/proto-docs.html
+app-dev/ledger-api-introduction/index.html -> /app-dev/grpc/proto-docs.html
+app-dev/ledger-api-introduction/daml-to-ledger-api.html -> /app-dev/grpc/daml-to-ledger-api.html
+app-dev/ledger-api-introduction/proto-docs.html -> /app-dev/grpc/proto-docs.html
 packages/da-docs-example-repo-market/daml-implementation.html -> /examples/repo-market/daml-implementation.html
 packages/da-docs-example-repo-market/index.html -> /examples/repo-market/index.html
 packages/da-docs-example-repo-market/repo-trading-model.html -> /examples/repo-market/repo-trading-model.html

--- a/docs/source/app-dev/bindings-java/code-snippets/Templates.daml
+++ b/docs/source/app-dev/bindings-java/code-snippets/Templates.daml
@@ -10,6 +10,8 @@ template Bar
     owner: Party
     name: Text
   where
+    signatory owner
+    
     controller owner can
       Bar_SomeChoice: Bool
         with

--- a/ledger-api/README.md
+++ b/ledger-api/README.md
@@ -15,6 +15,6 @@ This is the API code for the ledger, which contains:
 
 # Documentation
 
-The [Ledger API Introduction](https://docs.daml.com/app-dev/ledger-api-introduction/index.html) contains introductory material as well as links to the protodocs reference documentation.
+The [Ledger API Introduction](https://docs.daml.com/app-dev/grpc/index.html) contains introductory material as well as links to the protodocs reference documentation.
 
 See [the docs README](/docs/README.md) for more about how to preview and publish documentation.


### PR DESCRIPTION
Correct some broke ledger-api-introduction links for folder that has been renamed to `grpc` (return 404s from search and from some inter-linkage withint eh docs site -- i spotted it from the DAML Integration Kit)

`app-dev/ledger-api-introduction/` becomes `app-dev/grpc`apart from CHANGELOG page, which is gone