### PR TITLE
extractor: reduce large dar test to fail on 5MB, succeed on 10MB

### DIFF
--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -60,11 +60,11 @@ genrule(
     name = "VeryLargeArchive_src",
     outs = ["VeryLargeArchive/Blobs.daml"] + ["VeryLargeArchive/Blob%s.daml" % n for n in range(
         1,
-        71 + 1,
+        32 + 1,
     )],
     cmd =
         '''
-        filecount=71
+        filecount=32
         outs=($(OUTS))
         main="$${outs[0]}"
         echo 'daml 1.2
@@ -74,7 +74,7 @@ import VeryLargeArchive.Blob1' > "$$main"
         echo 'daml 1.2
 module VeryLargeArchive.Blob1 where
 ' > "$$firstfil"
-        { for linen in `seq 1 4096`; do
+        { for linen in `seq 1 1024`; do
             echo -n "x$$linen = "\\"
             for charn in `seq 1 16`; do
                 echo -n qqqqqqqq

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/VeryLargeArchiveSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/VeryLargeArchiveSpec.scala
@@ -43,8 +43,8 @@ class VeryLargeArchiveSpec
   // future editors of this test should not feel obliged to synthesize a failure
   // if the system design has really changed so failures of this nature cannot
   // happen.
-  val failMB = 50
-  val successMB = 60
+  val failMB = 5
+  val successMB = 10
 
   s"${failMB}MiB" should "fail" in {
     val e = the[StatusRuntimeException] thrownBy runWithInboundLimit(failMB * 1024 * 1024) {


### PR DESCRIPTION
VeryLargeArchive.dar generates/builds in 17s. Followup to #1551 discussion.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
