### PR TITLE
webide: build webide image when sdk releases

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -6,6 +6,16 @@ trigger: none
 pr: none
 
 jobs:
+  - job: latest_webide
+    timeoutInMinutes: 20
+    pool:
+      name: 'linux-pool'
+    steps:
+      - checkout: self
+      - bash: ci/check-update-build-webide.sh
+        displayName: 'Check for updated SDK and build webide with latest version'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
   - job: docs
     timeoutInMinutes: 50
     pool:

--- a/ci/build-webide.sh
+++ b/ci/build-webide.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+[ -z $1 ] && echo "usage build-webide [version] [latest:defaults true] [test:defaults true]" && exit 1
+
+echo "building webide image with $@"
+VERSION=$1
+LATEST=${2:-true}
+TEST=${3:-true}
+PUSH=${4:-true}
+DOCKER_FILE="$(dirname "${BASH_SOURCE[0]}")/../web-ide/ide-server/"
+
+fail() {
+    stopDocker
+    exit 1
+}
+
+ensureDockerStarted() {
+    local IMAGE_ID=$1
+    local limit=10
+    local i=0
+    local RESULT="START"
+    while [ $i -lt $limit -a $RESULT != "Up" ]; do
+        sleep 1
+        i=$(($i+1))
+        RESULT=$(docker container ls --filter=ancestor=$IMAGE_ID --format {{.Status}} | cut -c1-2)
+    done
+    if [ $i -eq $limit ]; then
+        echo "Could not start docker container: ls result='$RESULT'"
+        fail
+    fi
+}
+
+ensureWebideStarted() {
+    echo "ensuring endpoint is responsive"
+    local limit=10
+    local i=0
+    local RESULT=1
+    which curl > /dev/null 2>&1 #ensure dev-env does its thing before sending request
+    while [ $i -lt $limit -a $RESULT -ne 0 ]; do
+        sleep 1
+        i=$(($i+1))
+        curl -I http://localhost:8443
+        RESULT=$?
+    done
+    if [ $RESULT -ne 0 ]; then
+        echo "Could not start webide"
+        fail
+    fi
+}
+
+stopDocker() {
+    echo "stopping docker"
+    docker stop $(docker ps --format {{.ID}})
+}
+
+which docker > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "docker not installed!"
+    exit 1
+fi
+
+if [ "$LATEST" = true ]; then
+    docker build --rm --build-arg DAML_VERSION=$VERSION -t gcr.io/da-gcp-web-ide-project/daml-webide:$VERSION -t gcr.io/da-gcp-web-ide-project/daml-webide:latest $DOCKER_FILE
+else
+    docker build --rm --build-arg DAML_VERSION=$VERSION  -t gcr.io/da-gcp-web-ide-project/daml-webide:$VERSION $DOCKER_FILE
+fi
+
+if [ "$TEST" = true ]; then
+    IMAGE_ID=$(docker image ls --filter=reference="gcr.io/da-gcp-web-ide-project/daml-webide:$VERSION" --format "{{.ID}}")
+    echo "running container for image $IMAGE_ID"
+    docker run --rm -p 8443:8443 $IMAGE_ID > /dev/null 2>&1 &
+    sleep 5
+
+    ensureDockerStarted $IMAGE_ID
+    ensureWebideStarted
+
+    echo "!!!!!!!!!!! Test passed !!!!!!!!!!!!!!!!!"
+    stopDocker
+fi
+
+if [ "$PUSH" = true ]; then
+    docker push gcr.io/da-gcp-web-ide-project/daml-webide:$VERSION
+    if [ "$LATEST" = true ]; then
+        docker push gcr.io/da-gcp-web-ide-project/daml-webide:latest
+    fi
+fi
+
+exit 0

--- a/ci/check-update-build-webide.sh
+++ b/ci/check-update-build-webide.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-""}
+GOOGLE_APPLICATION_CREDENTIALS_CONTENT=${GOOGLE_APPLICATION_CREDENTIALS_CONTENT:-""}
+
+#sets LATEST_SDK_WITH_TIME
+getLatestSdk() {
+  local TMP_FILE=$(mktemp)
+  local JQ_COMMAND='. | map(select(.prerelease == false)) | map([.tag_name,.published_at]) | map(.[0] + "," + .[1] + "," + (.[1]|fromdate|tostring))[]'
+  if [ -n "$GITHUB_API_TOKEN" ]; then
+    $(curl -H "Authorization: $GITHUB_API_TOKEN" https://api.github.com/repos/digital-asset/daml/releases -s > "$TMP_FILE")
+  else
+    $(curl https://api.github.com/repos/digital-asset/daml/releases -s > "$TMP_FILE")
+  fi
+  local RELEASES=$(jq -r "$JQ_COMMAND" "$TMP_FILE")
+  local LAST_COMMAND_RESULT=$?
+  if [ $LAST_COMMAND_RESULT -eq 2 ]; then
+    echo "ERROR: could not read daml releases `cat $TMP_FILE`"
+    return 1
+  fi
+  LATEST_SDK_WITH_TIME=$(echo $RELEASES | awk '{if(substr($1,1,1)=="v") print substr($1,2); else print substr($1,1);}')
+}
+
+dockerAuth() {
+  if [ -n "$GOOGLE_APPLICATION_CREDENTIALS_CONTENT" ]; then
+    GCS_KEY=$(mktemp)
+    echo "$GOOGLE_APPLICATION_CREDENTIALS_CONTENT" > $GCS_KEY
+    gcloud auth activate-service-account --key-file=$GCS_KEY
+
+    docker-credential-gcr config --token-source="gcloud"
+    docker-credential-gcr configure-docker
+  fi
+}
+
+#sets WEBIDE_TS
+getImageTimestampByVersion() {
+  local VERSION=$1
+  local TMP_FILE=$(mktemp)
+  #complications here are parsing the datetime and conforming it to strptime readable dates
+  local JQ_COMMAND=". | map(select(.tags as \$t | \"$VERSION\" | IN(\$t[]))) | map(.timestamp.datetime)[] | sub(\" \";\"T\") | sub(\"(?<before>.*):\"; (.before)) | strptime(\"%Y-%m-%dT%H:%M:%S%z\") | todate | fromdate"
+  #echo "running jq command: $JQ_COMMAND"
+  $(gcloud container images list-tags gcr.io/da-gcp-web-ide-project/daml-webide --format=json > $TMP_FILE)
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+  WEBIDE_TS=$(TZ=/usr/share/zoneinfo/UTC jq -r "$JQ_COMMAND" $TMP_FILE)
+}
+
+build() {
+  bash $(dirname "${BASH_SOURCE[0]}")/build-webide.sh $@
+}
+
+#####################################################################################
+echo "Loading dev-env..."
+eval "$(dev-env/bin/dade-assist)"
+
+getLatestSdk
+SDK_VERSION=${LATEST_SDK_WITH_TIME%,*,*} # retain the part before the comma
+SDK_TS=${LATEST_SDK_WITH_TIME##*,} # retain the part after the comma
+[ -z "$SDK_VERSION" ] && echo "Could not find latest sdk version" && exit 1
+
+echo "got latest release SDK_VERSION=$SDK_VERSION, SDK_TIMESTAMP=$SDK_TS"
+
+dockerAuth
+
+getImageTimestampByVersion $SDK_VERSION
+if [ -z "$WEBIDE_TS" ] || [ $WEBIDE_TS < $SDK_TS ]; then
+  if [ -n "$WEBIDE_TS" ]; then
+    echo "webide image version $SDK_VERSION exists with timestamp $WEBIDE_TS (`date -r $WEBIDE_TS`) < $SDK_TS (`date -r $SDK_TS`)"
+  else 
+    echo "webide version $SDK_VERSION does not exist."
+  fi
+  build $SDK_VERSION
+else
+  echo "webide image version $SDK_VERSION already exists with timestamp `date -r $WEBIDE_TS`"
+fi
+
+


### PR DESCRIPTION
* add scripts which check the latest version of sdk. If webide docker
image version does not exist or is older than the sdk version, it will
kick off a build of the webide docker image

* add job to azure cron

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
