### PR TITLE
Set support expectations more clearly

### DIFF
--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -1,8 +1,6 @@
 .. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-.. _support-landing-page:
-
 Support and feedback
 ====================
 
@@ -20,6 +18,8 @@ Have questions or feedback? You're in the right place.
   - Join the DAML community on `Slack <https://damldriven.slack.com/sso/saml/start>`_.
   - Ask us for help using the `Support <javascript:open_feedback()>`_ link on any documentation page.
 
+When you're in the community Slack or on Stack Overflow, please keep to the `Code of Conduct <https://github.com/digital-asset/daml/blob/master/CODE_OF_CONDUCT.md>`__. 
+
 Support expectations
 --------------------
 
@@ -28,10 +28,9 @@ For community users (ie on Slack and Stack Overflow):
 - **Timing**: We'll try to get back to you in two business days.
 
   Our main offices are in Zurich and New York, and we don't consider public holidays in those locations to be business days.
-
 - **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_. 
 
-  We do not answer questions in private messages or over email, so please only ask questions in the ``#public`` channel.
+  We can't answer questions in private messages or over email, so please only ask questions in the ``#public`` channel.
 - **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application.
 
 If you need private support, or want consultation from DA about how to build your DAML application, we offer paid support. Please contact us to ask about pricing.

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -31,7 +31,7 @@ For community users (ie on Slack and Stack Overflow):
 
 - **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_. 
 
-  We do not answer questions in private messages, so please only ask questions in the ``#public`` channel.
+  We do not answer questions in private messages or over email, so please only ask questions in the ``#public`` channel.
 - **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application.
 
 If you need private support, or want consultation from DA about how to build your DAML application, we offer paid support. Please contact us to ask about pricing.

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -8,14 +8,30 @@ Support and feedback
 
 Have questions or feedback? You're in the right place.
 
-Questions: Stack Overflow
-	For “how do I?”, “why does something work this way” or “I’ve got a programming problem I’m trying to solve” questions, the `daml tag on Stack Overflow <https://stackoverflow.com/questions/tagged/daml>`_ is the best place to ask. 
+- **Questions: Stack Overflow**
 
-	If you're not sure what makes a good question, take a look at `this checklist <https://codeblog.jonskeet.uk/2012/11/24/stack-overflow-question-checklist/>`_. 
-Help and feedback: Slack, or Support widget
-	If you want to give feedback, or have questions that aren't right for Stack Overflow, you can: 
+  For “how do I?”, “why does something work this way” or “I’ve got a programming problem I’m trying to solve” questions, the `daml tag on Stack Overflow <https://stackoverflow.com/questions/tagged/daml>`_ is the best place to ask. 
 
-	- Join the DAML community on `Slack <https://damldriven.slack.com/sso/saml/start>`_.
-	- Ask us for help using the `Support <javascript:open_feedback()>`_ link on any documentation page.
-Feedback: Email
-	If you'd rather use email, you can contact us at `sdk-feedback@digitalasset.com <mailto:sdk-feedback@digitalasset.com>`_.
+  If you're not sure what makes a good question, take a look at `this checklist <https://codeblog.jonskeet.uk/2012/11/24/stack-overflow-question-checklist/>`_. 
+- ** Help and feedback: Slack, or Support widget**
+
+  If you want to give feedback, or have questions that aren't right for Stack Overflow, you can: 
+
+  - Join the DAML community on `Slack <https://damldriven.slack.com/sso/saml/start>`_.
+  - Ask us for help using the `Support <javascript:open_feedback()>`_ link on any documentation page.
+
+Support expectations
+--------------------
+
+For community users (ie on Slack and Stack Overflow):
+
+- **Timing**: We'll try to get back to you in two business days.
+
+  Our main offices are in Zurich and New York, and we don't consider public holidays in those locations to be business days.
+
+- **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_. 
+
+  We do not answer questions in private messages, so please only ask questions in the ``#public`` channel.
+- **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application.
+
+If you need private support, or want consultation from DA about how to build your DAML application, we offer paid support. Please contact us to ask about pricing.

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -25,12 +25,12 @@ Support expectations
 
 For community users (ie on Slack and Stack Overflow):
 
-- **Timing**: We'll try to get back to you in two business days.
+- **Timing**: You can enjoy the support of the community, which is provided for you out of their own good will and free time. On top of that, a Digital Asset employee will try to reply to unanswered questions within two business days.
 
-  Our main offices are in Zurich and New York, and we don't consider public holidays in those locations to be business days.
+  Business days are affected by public holidays. Engineers contributing to DAML are mostly located in Zurich and New York, so please be mindful of the public holidays in those locations (`timeanddate.com <https://www.timeanddate.com>`_ maintains an unofficial list of holidays for both `Switzerland <https://www.timeanddate.com/holidays/switzerland/>`_ and the `United States <https://www.timeanddate.com/holidays/us/>`_).
 - **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_. 
 
   We can't answer questions in private messages or over email, so please only ask questions in the ``#public`` channel.
-- **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application.
+- **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application or the languages, frameworks, libraries and tools you may use to build it.
 
 If you need private support, or want consultation from DA about how to build your DAML application, we offer paid support. Please contact us to ask about pricing.

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -13,7 +13,7 @@ Have questions or feedback? You're in the right place.
   For “how do I?”, “why does something work this way” or “I’ve got a programming problem I’m trying to solve” questions, the `daml tag on Stack Overflow <https://stackoverflow.com/questions/tagged/daml>`_ is the best place to ask. 
 
   If you're not sure what makes a good question, take a look at `this checklist <https://codeblog.jonskeet.uk/2012/11/24/stack-overflow-question-checklist/>`_. 
-- ** Help and feedback: Slack, or Support widget**
+- **Help and feedback: Slack, or Support widget**
 
   If you want to give feedback, or have questions that aren't right for Stack Overflow, you can: 
 


### PR DESCRIPTION
This PR:

- Removes mention of email support
- Adds expectations about

  - timing
  - public support only
  - level of questions we're happy to answer
- Adds suggestion that people can pay for support if they want more

I'm also considering adding some "help us to help you" stuff about asking good questions, what information we need etc, but I think that this PR can be standalone.