### PR TITLE
Removing damlc dependency from quickstart-scala

### DIFF
--- a/language-support/scala/examples/quickstart-scala/project/Versions.scala
+++ b/language-support/scala/examples/quickstart-scala/project/Versions.scala
@@ -16,11 +16,6 @@ object Versions {
     .getOrElse(new sbt.File(s"./dist/${projectNameFromConfig(): String}.dar"))
   println(s"$darFileKey = ${darFile.getAbsolutePath: String}")
 
-  lazy val detectedOs: String = sys.props("os.name") match {
-    case "Mac OS X" => "osx"
-    case _ => "linux"
-  }
-
   private def sdkVersionFromFile(): String =
     "10" + sbt.IO.read(new sbt.File("./SDK_VERSION").getAbsoluteFile).trim
 

--- a/language-support/scala/examples/quickstart-scala/project/daml.sbt
+++ b/language-support/scala/examples/quickstart-scala/project/daml.sbt
@@ -4,6 +4,5 @@ import Artifactory._
 resolvers ++= daResolvers
 
 libraryDependencies ++= Seq(
-  "com.digitalasset" % "damlc" % daSdkVersion classifier detectedOs,
   "com.daml.scala" %% "codegen-main" % daSdkVersion,
 )


### PR DESCRIPTION
quickstart-scala example does not buld DAR from SBT

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
