### PR TITLE
Remove useless version paramater from LF.World.initSelfWorld

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -55,8 +55,8 @@ initWorld importedPkgs version =
       ref@PRImport{} -> ref
 
 -- | Create a World with an initial self package
-initWorldSelf :: [(PackageId, Package)] -> Version -> Package -> World
-initWorldSelf a b c = (initWorld a b){_worldSelf = c}
+initWorldSelf :: [(PackageId, Package)] -> Package -> World
+initWorldSelf importedPkgs pkg = (initWorld importedPkgs $ packageLfVersion pkg){_worldSelf = pkg}
 
 -- | Extend the 'World' by a module in the current package.
 extendWorldSelf :: Module -> World -> World

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -156,7 +156,7 @@ generateDalfRule =
         -- The file argument isn’t used in the rule, so we leave it empty to increase caching.
         pkgMap <- useE GeneratePackageMap ""
         let pkgs = [(pId, pkg) | (pId, pkg, _bs, _fp) <- Map.elems pkgMap]
-        let world = LF.initWorldSelf pkgs lfVersion pkg
+        let world = LF.initWorldSelf pkgs pkg
         unsimplifiedRawDalf <- useE GenerateRawDalf file
         let rawDalf = LF.simplifyModule unsimplifiedRawDalf
         lift $ setPriority PriorityGenerateDalf
@@ -254,11 +254,10 @@ contextForFile file = do
 
 worldForFile :: FilePath -> Action LF.World
 worldForFile file = do
-    lfVersion <- getDamlLfVersion
     pkg <- use_ GeneratePackage file
     pkgMap <- use_ GeneratePackageMap ""
     let pkgs = [ (pId, pkg) | (pId, pkg, _, _) <- Map.elems pkgMap ]
-    pure $ LF.initWorldSelf pkgs lfVersion pkg
+    pure $ LF.initWorldSelf pkgs pkg
 
 data ScenarioBackendException = ScenarioBackendException
     { scenarioNote :: String

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Visual.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Visual.hs
@@ -11,7 +11,6 @@ module DA.Cli.Visual
 
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Ast.World as AST 
-import DA.Daml.LF.Ast.Version
 import qualified Data.NameMap as NM
 import qualified Data.Set as Set
 import qualified DA.Pretty as DAP
@@ -98,7 +97,7 @@ dalfBytesToPakage bytes = case Archive.decodeArchive $ BSL.toStrict bytes of
     Left err -> error (show err)
 
 darToWorld :: ManifestData -> LF.Package -> LF.World
-darToWorld manifest pkg = AST.initWorldSelf pkgs version1_4 pkg
+darToWorld manifest pkg = AST.initWorldSelf pkgs pkg
     where 
         pkgs = map dalfBytesToPakage (dalfsCotent manifest)
     


### PR DESCRIPTION
That parameter should have never been there in the first place since it is
completely useless.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1601)
<!-- Reviewable:end -->
