### PR TITLE
Normalize URIs to avoid issues caused by inconsistent percent-encoding

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -443,9 +443,9 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 # For the time being we build with GMP. See https://github.com/digital-asset/daml/issues/106
 use_integer_simple = not is_windows
 
-HASKELL_LSP_COMMIT = "491d8d2e33572b3868078f57a3375b2ac621f958"
+HASKELL_LSP_COMMIT = "fc239a1289159e36c746079c7a1843361d32ddd9"
 
-HASKELL_LSP_HASH = "581dd4d3d6d5611448a4d071575b730aa874480c19c1525fcb2c9f8e8319dd11"
+HASKELL_LSP_HASH = "3c97ae3da090c897c4ddef07c2b5c18442fd52a2ed08bc4779ec6084c5399a17"
 
 hazel_repositories(
     core_packages = dicts.add(
@@ -507,17 +507,14 @@ hazel_repositories(
             hazel_hackage("terminal-progress-bar", "0.4.0.1", "c5a9720fcbcd9d83f9551e431ee3975c61d7da6432aa687aef0c0e04e59ae277") +
             hazel_hackage("rope-utf16-splay", "0.3.1.0", "cbf878098355441ed7be445466fcb72d45390073a298b37649d762de2a7f8cc6") +
             hazel_hackage("unix-compat", "0.5.1", "a39d0c79dd906763770b80ba5b6c5cb710e954f894350e9917de0d73f3a19c52") +
-            # This corresponds to our custom-methods branch that adds support for custom RPC methods
-            # like daml/keepAlive. Once the corresponding PR has been merged
-            # https://github.com/alanz/haskell-lsp/pull/171 we can switch back to upstream.
-            hazel_github_external(
-                "alanz",
+            # This corresponds to our normalize-uri branch that enforces a consistent
+            # precent-encoding for URIs used as keys.
+            hazel_github(
                 "haskell-lsp",
                 HASKELL_LSP_COMMIT,
                 HASKELL_LSP_HASH,
             ) +
-            hazel_github_external(
-                "alanz",
+            hazel_github(
                 "haskell-lsp",
                 HASKELL_LSP_COMMIT,
                 HASKELL_LSP_HASH,
@@ -528,8 +525,8 @@ hazel_repositories(
             # lsp-test work with the custom methods changes in haskell-lsp.
             hazel_github(
                 "lsp-test",
-                "8d9dbdeaab97162262e3f8a0a02e9e32b3b85340",
-                "bb25ae3559245861c13e12c3ad1d8f13843577bf16de4f286e5a8f2f23cf5445",
+                "50c43452e19e494d71ccba1f7922d0b3b3fc69c3",
+                "65a56b35ddc8fa4deab10ac42efcdcbd36e875b715bb504d10b020a1e5fffd2c",
             ),
         pkgs = packages,
     ),

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
@@ -78,7 +78,7 @@ srcSpanToFilename (RealSrcSpan real) = FS.unpackFS $ srcSpanFile real
 
 srcSpanToLocation :: SrcSpan -> Location
 srcSpanToLocation src =
-  Location (D.filePathToUri' $ srcSpanToFilename src) (srcSpanToRange src)
+  Location (fromNormalizedUri $ D.filePathToUri' $ srcSpanToFilename src) (srcSpanToRange src)
 
 -- | Convert a GHC severity to a DAML compiler Severity. Severities below
 -- "Warning" level are dropped (returning Nothing).

--- a/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
@@ -43,9 +43,9 @@ import Language.Haskell.LSP.VFS
 -- the builtin VFS without spawning up an LSP server. To be able to test things
 -- like `setBufferModified` we abstract over the VFS implementation.
 data VFSHandle = VFSHandle
-    { getVirtualFile :: Uri -> IO (Maybe VirtualFile)
-    , setVirtualFileContents :: Uri -> T.Text -> IO ()
-    , removeVirtualFile :: Uri -> IO ()
+    { getVirtualFile :: NormalizedUri -> IO (Maybe VirtualFile)
+    , setVirtualFileContents :: NormalizedUri -> T.Text -> IO ()
+    , removeVirtualFile :: NormalizedUri -> IO ()
     }
 
 instance IsIdeGlobal VFSHandle

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
@@ -403,7 +403,7 @@ publishDiagnosticsNotification :: FilePath -> [Diagnostic] -> LSP.FromServerMess
 publishDiagnosticsNotification fp diags =
     LSP.NotPublishDiagnostics $
     LSP.NotificationMessage "2.0" LSP.TextDocumentPublishDiagnostics $
-    LSP.PublishDiagnosticsParams (filePathToUri' fp) (List diags)
+    LSP.PublishDiagnosticsParams (fromNormalizedUri $ filePathToUri' fp) (List diags)
 
 setPriority :: (Enum a) => a -> Action ()
 setPriority p =

--- a/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
+++ b/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
@@ -10,8 +10,6 @@ module Daml.Lsp.Test.Util
 
     , openDoc'
     , replaceDoc
-    , getCodeLenses
-    , getDefinitions
     , waitForScenarioDidChange
     , scenarioUri
     , openScenario
@@ -20,15 +18,13 @@ module Daml.Lsp.Test.Util
     ) where
 
 import Control.Applicative.Combinators
-import Control.Exception
 import Control.Lens hiding (List)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Aeson (Result(..), fromJSON)
 import qualified Data.Map.Strict as Map
-import Data.Maybe
 import qualified Data.Text as T
-import Language.Haskell.LSP.Test hiding (getDefinitions, getDocUri, message, openDoc')
+import Language.Haskell.LSP.Test hiding (message, openDoc')
 import qualified Language.Haskell.LSP.Test as LspTest
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Lens as Lsp
@@ -37,7 +33,6 @@ import Test.Tasty.HUnit
 
 import DA.Test.Util
 import Development.IDE.State.Rules.Daml (VirtualResourceChangedParams(..))
-import Development.IDE.Types.Diagnostics
 
 -- | (0-based line number, 0-based column number)
 type Cursor = (Int, Int)
@@ -61,7 +56,7 @@ requireDiagnostic actuals expected@(severity, cursor, expectedMsg) = do
 
 expectDiagnostics :: [(FilePath, [(DiagnosticSeverity, Cursor, T.Text)])] -> Session ()
 expectDiagnostics expected = do
-    expected' <- Map.fromListWith (<>) <$> traverseOf (traverse . _1) getDocUri expected
+    expected' <- Map.fromListWith (<>) <$> traverseOf (traverse . _1) (fmap toNormalizedUri . getDocUri) expected
     go expected'
     where
         go m
@@ -69,7 +64,7 @@ expectDiagnostics expected = do
             | otherwise = do
                   diagsNot <- skipManyTill anyMessage LspTest.message :: Session PublishDiagnosticsNotification
                   let fileUri = diagsNot ^. params . uri
-                  case Map.lookup (diagsNot ^. params . uri) m of
+                  case Map.lookup (diagsNot ^. params . uri . to toNormalizedUri) m of
                       Nothing -> liftIO $ assertFailure $
                           "Got diagnostics for " <> show fileUri <>
                           " but only expected diagnostics for " <> show (Map.keys m)
@@ -81,7 +76,7 @@ expectDiagnostics expected = do
                               "Incorrect number of diagnostics for " <> show fileUri <>
                               ", expected " <> show expected <>
                               " but got " <> show actual
-                          go $ Map.delete (diagsNot ^. params . uri) m
+                          go $ Map.delete (diagsNot ^. params . uri . to toNormalizedUri) m
 
 damlId :: String
 damlId = "daml"
@@ -96,28 +91,6 @@ openDoc' file languageId contents = do
     let item = TextDocumentItem uri (T.pack languageId) 0 contents
     sendNotification TextDocumentDidOpen (DidOpenTextDocumentParams item)
     pure $ TextDocumentIdentifier uri
-
-getDocUri :: FilePath -> Session Uri
-getDocUri file = do
-    -- We have our own version of getDocUri to ensure that it uses filePathToUri'
-    uri <- LspTest.getDocUri file
-    Just fp <- pure $ uriToFilePath uri
-    pure $ filePathToUri' fp
-
-getCodeLenses :: TextDocumentIdentifier -> Session [CodeLens]
-getCodeLenses tId = do
-    rsp <- request TextDocumentCodeLens (CodeLensParams tId) :: Session CodeLensResponse
-    case rsp ^. result of
-        Nothing -> liftIO $ throwIO (UnexpectedResponseError (rsp ^. Lsp.id) (fromJust $ rsp ^. Lsp.error))
-        Just (List res) -> pure res
-
-getDefinitions :: TextDocumentIdentifier -> Position -> Session [Location]
-getDefinitions doc pos = do
-    rsp <- request TextDocumentDefinition (TextDocumentPositionParams doc pos)
-    case rsp ^. result of
-        Nothing -> liftIO $ throwIO (UnexpectedResponseError (rsp ^. Lsp.id) (fromJust $ rsp ^. Lsp.error))
-        Just (SingleLoc loc) -> pure [loc]
-        Just (MultiLoc locs) -> pure locs
 
 waitForScenarioDidChange :: Session VirtualResourceChangedParams
 waitForScenarioDidChange = do

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -108,7 +108,7 @@ handleNotification lspFuncs (IHandle stateRef loggerH compilerH) = \case
 
         case Compiler.uriToFilePath' uri of
           Just filePath -> do
-            mbVirtual <- getVirtualFileFunc lspFuncs uri
+            mbVirtual <- getVirtualFileFunc lspFuncs $ toNormalizedUri uri
             let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
             Compiler.onFileModified compilerH filePath (Just contents)
             Logger.logInfo loggerH


### PR DESCRIPTION
This implements the first step of #1507. It also adds a test to the
lsp-tests where we use an insane percent-encoding and verify things
work nevertheless.

I also tested this in the IDE on Linux and Windows.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
