### PR TITLE
daml_test: Take damlc runfiles into account

### DIFF
--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -111,7 +111,11 @@ def _daml_test_impl(ctx):
         output = ctx.outputs.executable,
         content = script,
     )
-    runfiles = ctx.runfiles(files = ctx.files.srcs + [ctx.executable.damlc])
+    damlc_runfiles = ctx.attr.damlc[DefaultInfo].data_runfiles
+    runfiles = ctx.runfiles(
+        collect_data = True,
+        files = ctx.files.srcs,
+    ).merge(damlc_runfiles)
     return [DefaultInfo(runfiles = runfiles)]
 
 daml_test = rule(


### PR DESCRIPTION
Closes #1593

Previously, `daml_test` did not capture the `runfiles` dependencies of `damlc`. Now these dependencies are tracked explicitly.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
