### PR TITLE
Fix various issues with the reference daml-on-x implementation

### DIFF
--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXCommandCompletionService.scala
@@ -113,7 +113,10 @@ class DamlOnXCommandCompletionService private (indexService: IndexService)(
         Code.INVALID_ARGUMENT
       case RejectionReason.PartyNotKnownOnLedger => Code.INVALID_ARGUMENT
     }
-    Completion(commandId, Some(Status(code.value(), error.description)), traceContext = None)
+    Completion(
+      commandId,
+      Some(Status(code.value(), "Error: " + error.description)),
+      traceContext = None)
   }
 
   override def close(): Unit = {

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -232,8 +232,9 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
           Future.successful(result)
 
         case None =>
+          logger.error("lookupTransactionTreeById: Failing with NOT_FOUND")
           Future.failed(
-            Status.INVALID_ARGUMENT
+            Status.NOT_FOUND
               .withDescription(s"$txId could not be found")
               .asRuntimeException)
       }
@@ -260,8 +261,9 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
             acceptedToFlat(offset, trans, blindingInfo, verbose = true, eventFilter))
 
         case None =>
+          logger.error("lookupTransactionTreeById: Failing with NOT_FOUND")
           Future.failed(
-            Status.INVALID_ARGUMENT
+            Status.NOT_FOUND
               .withDescription(s"$txId could not be found")
               .asRuntimeException)
       }

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/DamlOnXTransactionService.scala
@@ -122,6 +122,7 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
           },
           verbose
         )
+        .flatMap(eventFilter.filterEvent(_).toList)
 
     val submitterIsSubscriber =
       trans.optSubmitterInfo
@@ -280,6 +281,8 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
       end: Option[LedgerOffset],
       filter: TransactionFilter): Source[(Offset, (TransactionAccepted, BlindingInfo)), NotUsed] = {
 
+    logger.trace(s"runTransactionPipeline: begin=$begin, end=$end, filter=$filter")
+
     val ledgerBounds =
       indexService.getLedgerBeginning
         .flatMap { b =>
@@ -293,12 +296,17 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
         case (ledgerBegin, ledgerEnd) =>
           OffsetSection(begin, end)(getOffsetHelper(ledgerBegin, ledgerEnd)) match {
             case Failure(exception) =>
+              logger.error(s"offset section fail: $exception")
               Source.failed(exception)
             case Success(value) =>
               value match {
                 case OffsetSection.Empty =>
+                  logger.warn(
+                    s"runTransactionPipeline: Empty OffsetSection from $begin to $end, given bounds $ledgerBegin and $ledgerEnd")
                   Source.empty
                 case OffsetSection.NonEmpty(subscribeFrom, subscribeUntil) =>
+                  logger.trace(
+                    s"runTransactionPipeline: getAcceptedTransactions with $subscribeFrom to $subscribeUntil")
                   indexService
                     .getAcceptedTransactions(Some(subscribeFrom), subscribeUntil, filter)
 
@@ -342,7 +350,7 @@ class DamlOnXTransactionService private (val indexService: IndexService, paralle
       Tag.subst(trans.optSubmitterInfo.map(_.applicationId)),
       trans.optSubmitterInfo.map(_.submitter),
       trans.transactionMeta.workflowId.map(WorkflowId(_)),
-      trans.recordTime.toInstant,
+      trans.transactionMeta.ledgerEffectiveTime.toInstant,
       None
     )
 

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/backport/GrpcTransactionService.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/services/backport/GrpcTransactionService.scala
@@ -73,7 +73,7 @@ class GrpcTransactionService(
   private def optionalVisibleToApiTx(visibleTxO: Option[VisibleTransaction]) =
     visibleTxO.fold {
       throw new ApiException(
-        Status.INVALID_ARGUMENT.withDescription("Transaction not found, or not visible."))
+        Status.NOT_FOUND.withDescription("Transaction not found, or not visible."))
     }(v => GetTransactionResponse(Some(visibleToApiTxTree(v, "", true))))
 
   private def visibleToApiTxTree(
@@ -104,7 +104,7 @@ class GrpcTransactionService(
   private def optionalTransactionToApiResponse(txO: Option[Transaction]) =
     txO.fold {
       throw new ApiException(
-        Status.INVALID_ARGUMENT.withDescription("Transaction not found, or not visible."))
+        Status.NOT_FOUND.withDescription("Transaction not found, or not visible."))
     }(t => GetFlatTransactionResponse(Some(t)))
 
   override protected def getTransactionTreesSource(

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -144,6 +144,7 @@ class TransactionServiceRequestValidator(
       req: GetTransactionByIdRequest): Result[transaction.GetTransactionByIdRequest] = {
     for {
       ledgerId <- matchId(LedgerId(req.ledgerId))
+      _ <- requireNonEmptyString(req.transactionId, "transaction_id")
       trId <- requireLedgerString(req.transactionId)
       _ <- requireNonEmpty(req.requestingParties, "requesting_parties")
       parties <- partyValidator.requireKnownParties(req.requestingParties)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -144,7 +144,6 @@ class TransactionServiceRequestValidator(
       req: GetTransactionByIdRequest): Result[transaction.GetTransactionByIdRequest] = {
     for {
       ledgerId <- matchId(LedgerId(req.ledgerId))
-      _ <- requireNumber(req.transactionId, "transaction_id")
       trId <- requireLedgerString(req.transactionId)
       _ <- requireNonEmpty(req.requestingParties, "requesting_parties")
       parties <- partyValidator.requireKnownParties(req.requestingParties)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -943,13 +943,13 @@ class TransactionServiceIT
             response.transaction should not be empty
             inside(notVisibleError) {
               case sre: StatusRuntimeException =>
-                sre.getStatus.getCode shouldEqual Status.INVALID_ARGUMENT.getCode
+                sre.getStatus.getCode shouldEqual Status.NOT_FOUND.getCode
                 sre.getStatus.getDescription shouldEqual "Transaction not found, or not visible."
             }
           }
       }
 
-      "return INVALID_ARGUMENT if it does not exist" in allFixtures { context =>
+      "return NOT_FOUND if it does not exist" in allFixtures { context =>
         context.transactionClient
           .getTransactionById(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -1038,13 +1038,13 @@ class TransactionServiceIT
             response.transaction should not be empty
             inside(notVisibleError) {
               case sre: StatusRuntimeException =>
-                sre.getStatus.getCode shouldEqual Status.INVALID_ARGUMENT.getCode
+                sre.getStatus.getCode shouldEqual Status.NOT_FOUND.getCode
                 sre.getStatus.getDescription shouldEqual "Transaction not found, or not visible."
             }
           }
       }
 
-      "return INVALID_ARGUMENT if it does not exist" in allFixtures { context =>
+      "return NOT_FOUND if it does not exist" in allFixtures { context =>
         context.transactionClient
           .getFlatTransactionById(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -1112,7 +1112,7 @@ class TransactionServiceIT
 
           inside(notVisibleError) {
             case sre: StatusRuntimeException =>
-              sre.getStatus.getCode shouldEqual Status.INVALID_ARGUMENT.getCode
+              sre.getStatus.getCode shouldEqual Status.NOT_FOUND.getCode
               sre.getStatus.getDescription shouldEqual "Transaction not found, or not visible."
           }
         }
@@ -1125,13 +1125,13 @@ class TransactionServiceIT
           .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
 
-      "return INVALID_ARGUMENT if it does not exist" in allFixtures { context =>
+      "return NOT_FOUND if it does not exist" in allFixtures { context =>
         context.transactionClient
           .getTransactionByEventId(
             "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:000",
             List("party"))
           .failed
-          .map(IsStatusException(Status.INVALID_ARGUMENT))
+          .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
@@ -1177,7 +1177,7 @@ class TransactionServiceIT
 
           inside(notVisibleError) {
             case sre: StatusRuntimeException =>
-              sre.getStatus.getCode shouldEqual Status.INVALID_ARGUMENT.getCode
+              sre.getStatus.getCode shouldEqual Status.NOT_FOUND.getCode
               sre.getStatus.getDescription shouldEqual "Transaction not found, or not visible."
           }
         }
@@ -1190,13 +1190,13 @@ class TransactionServiceIT
           .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
 
-      "return INVALID_ARGUMENT if it does not exist" in allFixtures { context =>
+      "return NOT_FOUND if it does not exist" in allFixtures { context =>
         context.transactionClient
           .getFlatTransactionByEventId(
             "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:000",
             List("party"))
           .failed
-          .map(IsStatusException(Status.INVALID_ARGUMENT))
+          .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -955,7 +955,7 @@ class TransactionServiceIT
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             List("party"))
           .failed
-          .map(IsStatusException(Status.INVALID_ARGUMENT))
+          .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
@@ -1050,7 +1050,7 @@ class TransactionServiceIT
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             List("party"))
           .failed
-          .map(IsStatusException(Status.INVALID_ARGUMENT))
+          .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -213,7 +213,6 @@ class TransactionServiceIT
 
             _ = secondSection should have size commandsPerSection.toLong
             ledgerEndAfterSecondSection = lastOffsetIn(secondSection).value
-
             completeSequence <- client
               .getTransactions(
                 ledgerEndResponse.getOffset,

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -90,15 +90,18 @@ client_server_test(
         # NOTE(GP): our CI has a tendency to be more unpredictable than local
         # machine with timeouts, we value lack of flakes on CI.
         "--timeout-scale-factor=10",
+        "--all-tests",
     ],
 
     # Data files available to both client and server.
     data = [
         "//ledger/ledger-api-integration-tests:SemanticTests.dar",
+        "//ledger/sandbox:Test.dar",
     ],
     server = "//ledger/api-server-damlonx/reference:reference",
     server_args = [
         "$(rootpath //ledger/ledger-api-integration-tests:SemanticTests.dar)",
+        "$(rootpath //ledger/sandbox:Test.dar)",
     ],
     tags = [
         # NOTE(JM,GP): As this test is somewhat heavy and has timeouts, run it

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/ApiTransactionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/ApiTransactionService.scala
@@ -86,7 +86,7 @@ class ApiTransactionService private (
       .split(request.eventId.unwrap)
       .fold(
         Future.failed[TransactionTree](
-          Status.INVALID_ARGUMENT
+          Status.NOT_FOUND
             .withDescription(s"invalid eventId: ${request.eventId}")
             .asRuntimeException())) {
         case TransactionIdWithIndex(transactionId, index) =>
@@ -105,7 +105,7 @@ class ApiTransactionService private (
       .split(request.eventId.unwrap)
       .fold(
         Future.failed[Transaction](
-          Status.INVALID_ARGUMENT
+          Status.NOT_FOUND
             .withDescription(s"invalid eventId: ${request.eventId}")
             .asRuntimeException())) {
         case TransactionIdWithIndex(transactionId, _) =>
@@ -132,7 +132,7 @@ class ApiTransactionService private (
 
         case None =>
           Future.failed(
-            Status.INVALID_ARGUMENT
+            Status.NOT_FOUND
               .withDescription("Transaction not found, or not visible.")
               .asRuntimeException())
       }
@@ -148,7 +148,7 @@ class ApiTransactionService private (
 
         case None =>
           Future.failed(
-            Status.INVALID_ARGUMENT
+            Status.NOT_FOUND
               .withDescription("Transaction not found, or not visible.")
               .asRuntimeException())
       }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -33,7 +33,6 @@ import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry.{Checkpoint, 
 import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryWithLedgerEndIncrement
 import com.digitalasset.platform.sandbox.stores.ledger.{Ledger, LedgerEntry, LedgerSnapshot}
 import com.digitalasset.platform.sandbox.stores.{ActiveContracts, ActiveContractsInMemory}
-import com.digitalasset.platform.server.api.validation.ErrorFactories
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -204,7 +203,7 @@ class InMemoryLedger(
 
     Try(transactionId.toLong) match {
       case Failure(_) =>
-        Future.failed(ErrorFactories.notFound(transactionId))
+        Future.successful(None)
       case Success(n) =>
         Future.successful(
           entries

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -33,9 +33,11 @@ import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry.{Checkpoint, 
 import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryWithLedgerEndIncrement
 import com.digitalasset.platform.sandbox.stores.ledger.{Ledger, LedgerEntry, LedgerSnapshot}
 import com.digitalasset.platform.sandbox.stores.{ActiveContracts, ActiveContractsInMemory}
+import com.digitalasset.platform.server.api.validation.ErrorFactories
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 /** This stores all the mutable data that we need to run a ledger: the PCS, the ACS, and the deduplicator.
   *
@@ -198,14 +200,21 @@ class InMemoryLedger(
   override def close(): Unit = ()
 
   override def lookupTransaction(
-      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =
-    Future.successful(
-      entries
-        .getEntryAt(transactionId.toLong)
-        .collect[(Long, LedgerEntry.Transaction)] {
-          case t: LedgerEntry.Transaction =>
-            (transactionId.toLong, t) // the transaction id is also the offset
-        })
+      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] = {
+
+    Try(transactionId.toLong) match {
+      case Failure(_) =>
+        Future.failed(ErrorFactories.notFound(transactionId))
+      case Success(n) =>
+        Future.successful(
+          entries
+            .getEntryAt(n)
+            .collect[(Long, LedgerEntry.Transaction)] {
+              case t: LedgerEntry.Transaction =>
+                (n, t) // the transaction id is also the offset
+            })
+    }
+  }
 
   override def parties: Future[List[PartyDetails]] =
     Future.successful(this.synchronized {


### PR DESCRIPTION
- Add authorization check to submission to catch authorization errors early
- Fix filtering by templates in transaction service
- Loosen the transaction_id validation to accept transaction_ids as used by
  the reference implementation
- Fix handling of ledger end
- Add caching to archive decoding
- Enable TransactionIT for the reference implementation
- Fix time service event dedup
- fix validation layer for transaction fetching to deal properly with empty strings
- fix transaction fetching tests on sandbox that assumed that transaction ids would be verified as numbers by the api validation layer
- return NOT_FOUND in all places where a non-existing transaction id or event id is used to fetch transactions

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
