### PR TITLE
Group chat daml model

### DIFF
--- a/language-support/hs/bindings/examples/chat/README.md
+++ b/language-support/hs/bindings/examples/chat/README.md
@@ -3,7 +3,12 @@
 
 Another example ledger App, written in Haskell.
 
-A chat room, where the ledger plays the role of distibuting messages, and maintaining history
+A chat room, where the ledger plays the role of distributing messages, and maintaining history.
+
+This chat-room model is *very* simplistic. There is no concept of distinct groups, just the ability to broadcast a message to multiple parties at once. Also, the messages contain no authority to indicate that the recipients accept the message being sent to them.
+
+For a more interesting chat-room model under development, see: ../group-chat/
+
 
 ## Build
 

--- a/language-support/hs/bindings/examples/group-chat/BUILD.bazel
+++ b/language-support/hs/bindings/examples/group-chat/BUILD.bazel
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_test")
+load("//rules_daml:daml.bzl", "daml_compile")
+
+daml_compile(
+    name = "GroupChat",
+    srcs = glob(["daml/*.daml"]),
+    main_src = "daml/GroupChat.daml",
+)

--- a/language-support/hs/bindings/examples/group-chat/README.md
+++ b/language-support/hs/bindings/examples/group-chat/README.md
@@ -1,0 +1,10 @@
+
+# `group-chat`
+
+DAML chat-room model, with support for:
+
+- Multiple chat-groups
+- Group entry by invitation
+- Messages containing recipient authority.
+
+Currently there is no Ledger-App for this Model, but we should be able to knock one up fairly quickly, by taking the simple chat app (in: ../chat/) as a starting point.

--- a/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
+++ b/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
@@ -61,6 +61,7 @@ template Membership
         choice Membership_Join : () with joiner : Party, invitation : Invitation
             controller joiner
             do
+                assert (invitation.owner == owner)
                 assert (joiner `elem` invitation.invitees)
                 create Membership with owner, gid, members = joiner :: members
                 return ()

--- a/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
+++ b/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
@@ -58,10 +58,9 @@ template Membership
         maintainer key._1
 
         -- You can join the Membership, if you have an Invitation...
-        choice Membership_Join : () with joiner : Party, iid : ContractId Invitation
+        choice Membership_Join : () with joiner : Party, invitation : Invitation
             controller joiner
             do
-                invitation <- fetch iid
                 assert (joiner `elem` invitation.invitees)
                 create Membership with owner, gid, members = joiner :: members
                 return ()
@@ -110,11 +109,10 @@ fetchMembership gid = do
     (membership,_) <- fetchByKey @Membership (group.owner,gid)
     return membership
 
-acceptJoin : Party -> ContractId Invitation -> Update ()
-acceptJoin joiner iid = do
-    invitation <- fetch iid
+acceptJoin : Party -> Invitation -> Update ()
+acceptJoin joiner invitation = do
     mid <- fetchMembership invitation.gid
-    exercise mid Membership_Join with joiner, iid
+    exercise mid Membership_Join with joiner, invitation
 
 leaveGroup : Party -> ContractId Group -> Update ()
 leaveGroup leaver gid = do

--- a/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
+++ b/language-support/hs/bindings/examples/group-chat/daml/GroupChat.daml
@@ -1,0 +1,136 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+
+-- DAML chat-room model, with support for multiple chat-groups with entry by invitation.
+
+module GroupChat where
+
+-- A Chat Group is identified by the ContractId of a contract instance.
+template Group
+    with
+        owner : Party
+        name : Text -- no uniqueness requirement, just descriptive text
+    where
+        signatory owner
+
+-- An invitation to a join a chat group.
+template Invitation
+    with
+        owner : Party
+        gid : ContractId Group
+        invitees : [Party]
+    where
+        signatory owner
+        observer invitees
+
+-- A Message sent to a chat group.
+-- Interestingly, the sender and all recipients are signatories to a Message.
+-- The idea is that when a party joins a group, both:
+-- (a) The party is able to send messages to the group.
+-- (b) The party is authorising the receipt of messages from the group.
+template Message
+    with
+        sender : Party
+        recipients : [Party]
+        gid : ContractId Group
+        body : Text
+    where
+        signatory sender::recipients
+
+-- The current membership of a group.
+-- A party may join the group if invited by the group owner.
+-- The membership list changes over time as parties join and leave the group.
+-- To model this `mutable' data, we use DAML contract-keys.
+-- A Membership contract contains a reference to the underlying Group contract.
+-- The contact-key ensures at most one Membership contract is active for a given Group at one time.
+
+template Membership
+    with
+        owner : Party
+        gid : ContractId Group
+        members : [Party]
+    where
+        -- All members are signatories, so messages can be created.
+        signatory owner, members
+        key (owner,gid) : (Party,ContractId Group)
+        maintainer key._1
+
+        -- You can join the Membership, if you have an Invitation...
+        choice Membership_Join : () with joiner : Party, iid : ContractId Invitation
+            controller joiner
+            do
+                invitation <- fetch iid
+                assert (joiner `elem` invitation.invitees)
+                create Membership with owner, gid, members = joiner :: members
+                return ()
+
+        -- A member can voluntarily leave the Membership.
+        -- Or a member can be evicted by the owner.
+        choice Membership_Leave : () with leaver : Party
+            controller leaver, owner
+            do
+                assert (leaver `elem` members)
+                create Membership with owner, gid, members = filter (/= leaver) members
+                return ()
+
+        -- Messages are sent to a group with the authority of the Membership.
+        -- Created Messages are signed by all receiptients as required.
+        nonconsuming choice Membership_SendMessage : ContractId Message with sender : Party, body : Text
+            controller sender
+            do
+                assert (sender `elem` members)
+                create Message with sender, recipients = members, gid, body
+
+        -- Only the group owner can shutdown a group.
+        -- Once shutdown, no more messages can be sent to this group.
+        choice Membership_Shutdown : ()
+            controller owner
+            do
+                archive gid
+
+-- Utility functions, which setup and maintain the links between Membership and Group.
+
+newGroup : Party -> Text -> Update (ContractId Group)
+newGroup owner name = do
+    gid <- create Group with owner, name
+    group <- fetch gid
+    _ <- create Membership with owner, gid, members = [owner]
+    return gid
+
+makeInvitation : ContractId Group -> [Party] -> Update (ContractId Invitation)
+makeInvitation gid invitees = do
+    group <- fetch gid
+    create Invitation with owner = group.owner, gid, invitees
+
+fetchMembership : ContractId Group -> Update (ContractId Membership)
+fetchMembership gid = do
+    group <- fetch gid
+    (membership,_) <- fetchByKey @Membership (group.owner,gid)
+    return membership
+
+acceptJoin : Party -> ContractId Invitation -> Update ()
+acceptJoin joiner iid = do
+    invitation <- fetch iid
+    mid <- fetchMembership invitation.gid
+    exercise mid Membership_Join with joiner, iid
+
+leaveGroup : Party -> ContractId Group -> Update ()
+leaveGroup leaver gid = do
+    mid <- fetchMembership gid
+    exercise mid Membership_Leave with leaver
+
+sendMessage : Party -> ContractId Group -> Text -> Update (ContractId Message)
+sendMessage sender gid body = do
+    mid <- fetchMembership gid
+    exercise mid Membership_SendMessage with sender, body
+
+shutdownGroup : ContractId Group -> Update ()
+shutdownGroup gid = do
+    mid <- fetchMembership gid
+    group <- fetch gid
+    exercise mid Membership_SendMessage with
+        sender = group.owner
+        body = "Chat group (" <> group.name <> ") is shutting down."
+    exercise mid Membership_Shutdown

--- a/language-support/hs/bindings/examples/nim-console/demo.md
+++ b/language-support/hs/bindings/examples/nim-console/demo.md
@@ -221,14 +221,14 @@ And indeed we see the earlier game offered by Alice is accepted.
 
 Robot Bob's moves are random, so indicated by `???` above.
 
-## 18. Alice also goes on holiday, so replace her with Robot Alice
+## 19. Alice also goes on holiday, so replace her with Robot Alice
 
     Alice> C-c
     $ clear; bazel-bin/language-support/hs/bindings/nim --robot Alice
 
 The robots complete the game!
 
-## 19. As Alice, check in to see who won
+## 20. As Alice, check in to see who won
 
     C-c
     $ clear; bazel-bin/language-support/hs/bindings/nim Alice

--- a/language-support/hs/bindings/examples/nim-console/src/Domain.hs
+++ b/language-support/hs/bindings/examples/nim-console/src/Domain.hs
@@ -13,6 +13,7 @@ module Domain(Player(..), partyOfPlayer,
               deduceMoves,
              ) where
 
+import Data.List.Extra(zipWithFrom)
 import DA.Ledger.Types
 import DA.Ledger.Valuable(Valuable(..))
 import qualified Data.Text.Lazy as Text
@@ -78,7 +79,5 @@ legalMovesOfGame Game{piles} = do
 deduceMoves :: Game -> Game -> [Move]
 deduceMoves Game{piles=p1} Game{piles=p2} =
     filter (\Move{howMany} -> howMany > 0)
-    $ map (\(pileNum,howMany) -> Move {pileNum, howMany})
-    $ zip [1..]
-    $ map (\(x,y) -> x - y)
+    $ zipWithFrom (\pileNum (x,y) -> Move {pileNum, howMany = x - y}) 1
     $ zip p1 p2


### PR DESCRIPTION

First attempt at how I think chat groups could be modelled in DAML, using contract keys to manage the changing membership, and taking a perhaps novel approach to having messages contain recipient authority.


## Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
