### PR TITLE
Introduce a newtype for file paths with normalized slashes

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -92,7 +92,7 @@ getSrcSpanInfos
     :: IdeOptions
     -> ParsedModule
     -> HscEnv
-    -> [(Located ModuleName, Maybe FilePath)]
+    -> [(Located ModuleName, Maybe NormalizedFilePath)]
     -> TcModuleResult
     -> IO [SpanInfo]
 getSrcSpanInfos opt mod env imports tc =

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/GHCError.hs
@@ -50,7 +50,7 @@ mkDiag dflags src e =
   case toDSeverity $ errMsgSeverity e of
     Nothing        -> Nothing
     Just bSeverity ->
-      Just $ (srcSpanToFilename $ errMsgSpan e,)
+      Just $ (toNormalizedFilePath $ srcSpanToFilename (errMsgSpan e),)
         Diagnostic
         { _range    = srcSpanToRange $ errMsgSpan e
         , _severity = Just bSeverity
@@ -78,7 +78,7 @@ srcSpanToFilename (RealSrcSpan real) = FS.unpackFS $ srcSpanFile real
 
 srcSpanToLocation :: SrcSpan -> Location
 srcSpanToLocation src =
-  Location (fromNormalizedUri $ D.filePathToUri' $ srcSpanToFilename src) (srcSpanToRange src)
+  Location (filePathToUri $ srcSpanToFilename src) (srcSpanToRange src)
 
 -- | Convert a GHC severity to a DAML compiler Severity. Severities below
 -- "Warning" level are dropped (returning Nothing).

--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/SpanInfo.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/SpanInfo.hs
@@ -21,6 +21,7 @@ import           Desugar
 import           GHC
 import           GhcMonad
 import           FastString (mkFastString)
+import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.SpanInfo
 import           Development.IDE.Functions.GHCError (zeroSpan)
 import           Prelude hiding (mod)
@@ -29,7 +30,7 @@ import           Var
 
 -- | Get ALL source spans in the module.
 getSpanInfo :: GhcMonad m
-            => [(Located ModuleName, Maybe FilePath)] -- ^ imports
+            => [(Located ModuleName, Maybe NormalizedFilePath)] -- ^ imports
             -> TypecheckedModule
             -> m [SpanInfo]
 getSpanInfo mods tcm =
@@ -94,17 +95,17 @@ getTypeLPat _ pat =
       (Named (dataConName dc), spn)
     getSpanSource _ = (NoSource, noSrcSpan)
 
-importInfo :: [(Located ModuleName, Maybe FilePath)]
+importInfo :: [(Located ModuleName, Maybe NormalizedFilePath)]
            -> [(SpanSource, SrcSpan, Maybe Type)]
 importInfo = mapMaybe (uncurry wrk) where
-  wrk :: Located ModuleName -> Maybe FilePath -> Maybe (SpanSource, SrcSpan, Maybe Type)
+  wrk :: Located ModuleName -> Maybe NormalizedFilePath -> Maybe (SpanSource, SrcSpan, Maybe Type)
   wrk modName = \case
     Nothing -> Nothing
-    Just afp -> Just (afpToSpanSource afp, getLoc modName, Nothing)
+    Just fp -> Just (fpToSpanSource $ fromNormalizedFilePath fp, getLoc modName, Nothing)
 
   -- TODO make this point to the module name
-  afpToSpanSource :: FilePath -> SpanSource
-  afpToSpanSource afp = Span $ RealSrcSpan $ zeroSpan $ mkFastString afp
+  fpToSpanSource :: FilePath -> SpanSource
+  fpToSpanSource fp = Span $ RealSrcSpan $ zeroSpan $ mkFastString fp
 
 -- | Get ALL source spans in the source.
 listifyAllSpans :: Typeable a

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -27,6 +27,7 @@ import qualified Development.IDE.Logger as Logger
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import           Development.IDE.Functions.GHCError
+import Development.IDE.Types.Diagnostics (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 import qualified Language.Haskell.LSP.Messages as LSP
 
@@ -39,7 +40,7 @@ import           Development.IDE.State.Shake
 data Env = Env
     { envOptions       :: IdeOptions
       -- ^ Compiler options.
-    , envOfInterestVar :: Var (Set FilePath)
+    , envOfInterestVar :: Var (Set NormalizedFilePath)
       -- ^ The files of interest.
     , envUniqSupplyVar :: Var UniqSupply
       -- ^ The unique supply of names used by the compiler.
@@ -107,7 +108,7 @@ runActions x = join . shakeRun x
 
 
 -- | Set the files-of-interest which will be built and kept-up-to-date.
-setFilesOfInterest :: IdeState -> Set FilePath -> IO ()
+setFilesOfInterest :: IdeState -> Set NormalizedFilePath -> IO ()
 setFilesOfInterest state files = do
     Env{..} <- getIdeGlobalState state
     -- update vars synchronously

--- a/compiler/haskell-ide-core/src/Development/IDE/Types/LSP.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/LSP.hs
@@ -10,7 +10,7 @@ module Development.IDE.Types.LSP
 
 import Control.DeepSeq
 import qualified Data.Text as T
-import Development.IDE.Types.Diagnostics (uriToFilePath')
+import Development.IDE.Types.Diagnostics
 import GHC.Generics
 import Language.Haskell.LSP.Messages
 import Language.Haskell.LSP.Types
@@ -30,9 +30,9 @@ getHoverTextContent = \case
 
 -- | Virtual resources
 data VirtualResource = VRScenario
-    { vrScenarioFile :: !FilePath
+    { vrScenarioFile :: !NormalizedFilePath
     , vrScenarioName :: !T.Text
-    } deriving (Eq, Ord, Read, Show, Generic)
+    } deriving (Eq, Ord, Show, Generic)
     -- ^ VRScenario identifies a scenario in a given file.
     -- This virtual resource is associated with the HTML result of
     -- interpreting the corresponding scenario.

--- a/compiler/haskell-ide-core/test/Demo.hs
+++ b/compiler/haskell-ide-core/test/Demo.hs
@@ -35,7 +35,7 @@ import GHC.Paths
 
 main :: IO ()
 main = do
-    (ghcOptions, files) <- getCmdLine
+    (ghcOptions, map toNormalizedFilePath -> files) <- getCmdLine
 
     -- lock to avoid overlapping output on stdout
     lock <- newLock
@@ -66,7 +66,7 @@ main = do
 -- | Print an LSP event.
 showEvent :: Lock -> FromServerMessage -> IO ()
 showEvent _ (EventFileDiagnostics _ []) = return ()
-showEvent lock (EventFileDiagnostics file diags) =
+showEvent lock (EventFileDiagnostics (toNormalizedFilePath -> file) diags) =
     withLock lock $ T.putStrLn $ showDiagnosticsColored $ map (file,) diags
 showEvent lock e = withLock lock $ print e
 

--- a/daml-foundations/daml-ghc/damldoc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/damldoc/BUILD.bazel
@@ -56,6 +56,7 @@ da_haskell_library(
     src_strip_prefix = "test",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/haskell-ide-core",
         "//daml-foundations/daml-ghc/damldoc",
         "//daml-foundations/daml-ghc/ghc-compiler",
         "//daml-foundations/daml-ghc/test-lib",

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -36,12 +36,12 @@ damlDocDriver :: InputFormat
               -> DocFormat
               -> Maybe FilePath
               -> [DocOption]
-              -> [FilePath]
+              -> [NormalizedFilePath]
               -> IO ()
 damlDocDriver cInputFormat output cFormat prefixFile options files = do
 
     let printAndExit errMsg = do
-            putStrLn $ "Error processing input from " <> unwords files <> "\n"
+            putStrLn $ "Error processing input from " <> unwords (map fromNormalizedFilePath files) <> "\n"
                      <> errMsg
             fail "Aborted."
 
@@ -51,7 +51,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
 
     docData <- case cInputFormat of
             InputJson -> do
-                input <- mapM BS.readFile files
+                input <- mapM (BS.readFile . fromNormalizedFilePath) files
                 let mbData = map AE.eitherDecode input :: [Either String [ModuleDoc]]
                 concatMapM (either printAndExit pure) mbData
 

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -31,7 +31,7 @@ import           Data.Tuple.Extra                          (second)
 
 -- | Parse, and process documentation in, a dependency graph of modules.
 mkDocs :: IdeOptions ->
-          [FilePath] ->
+          [NormalizedFilePath] ->
           Ex.ExceptT [FileDiagnostic] IO [ModuleDoc]
 mkDocs opts fp = do
   parsed <- haddockParse opts fp
@@ -118,7 +118,7 @@ collectDocs = go Nothing []
 --   Not using the cached file store, as it is expected to run stand-alone
 --   invoked by a CLI tool.
 haddockParse :: IdeOptions ->
-                [FilePath] ->
+                [NormalizedFilePath] ->
                 Ex.ExceptT [FileDiagnostic] IO [ParsedModule]
 haddockParse opts f = ExceptT $ do
   vfs <- makeVFSHandle

--- a/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -12,6 +12,7 @@ import           DA.Daml.GHC.Damldoc.HaddockParse
 import           DA.Daml.GHC.Damldoc.Render
 import           DA.Daml.GHC.Damldoc.Types
 import           DA.Test.Util
+import Development.IDE.Types.Diagnostics
 
 import           Control.Monad.Except
 import qualified Data.Aeson.Encode.Pretty as AP
@@ -227,7 +228,7 @@ damldocExpect testname input check =
     opts <- defaultOptionsIO Nothing
 
     -- run the doc generator on that file
-    mbResult <- runExceptT $ mkDocs (toCompileOpts opts) [testfile]
+    mbResult <- runExceptT $ mkDocs (toCompileOpts opts) [toNormalizedFilePath testfile]
 
     case mbResult of
       Left err -> assertFailure $ unlines

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -122,7 +122,7 @@ conversionError :: String -> ConvertM e
 conversionError msg = do
   ConversionEnv{..} <- ask
   let addFpIfExists =
-        (fromMaybe noFilePath convModuleFilePath,)
+        (toNormalizedFilePath $ fromMaybe noFilePath convModuleFilePath,)
   throwError $ addFpIfExists $ Diagnostic
       { _range = maybe noRange sourceLocToRange convRange
       , _severity = Just DsError

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/RuleTypes/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/RuleTypes/Daml.hs
@@ -23,6 +23,7 @@ import Development.Shake
 import GHC.Generics (Generic)
 import "ghc-lib-parser" Module (UnitId)
 
+import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.LSP
 import Development.IDE.State.RuleTypes
 
@@ -51,16 +52,16 @@ type instance RuleResult CreateScenarioContext = SS.ContextId
 -- used for executing scenarios in A. We use this when running the scenarios
 -- in transitive dependencies of the files of interest so that we only need
 -- one scenario context per file of interest.
-type instance RuleResult GetScenarioRoots = Map FilePath FilePath
+type instance RuleResult GetScenarioRoots = Map NormalizedFilePath NormalizedFilePath
 
 -- ^ The root for the given file based on GetScenarioRoots.
 -- This is a separate rule so we can avoid rerunning scenarios if
 -- only the roots of other files have changed.
-type instance RuleResult GetScenarioRoot = FilePath
+type instance RuleResult GetScenarioRoot = NormalizedFilePath
 
 -- | These rules manage access to the global state in
 -- envOfInterestVar and envOpenVirtualResources.
-type instance RuleResult GetFilesOfInterest = Set FilePath
+type instance RuleResult GetFilesOfInterest = Set NormalizedFilePath
 type instance RuleResult GetOpenVirtualResources = Set VirtualResource
 
 data GenerateDalf = GenerateDalf

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -26,6 +26,7 @@ import Development.IDE.State.Service hiding (initialise)
 import Development.IDE.State.FileStore
 import qualified Development.IDE.State.Service as IDE
 import Development.IDE.State.Shake
+import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.LSP
 import qualified Language.Haskell.LSP.Messages as LSP
 
@@ -36,7 +37,7 @@ import qualified DA.Daml.LF.ScenarioServiceClient as SS
 data DamlEnv = DamlEnv
   { envScenarioService :: Maybe SS.Handle
   , envOpenVirtualResources :: Var (Set VirtualResource)
-  , envScenarioContexts :: Var (Map FilePath SS.ContextId)
+  , envScenarioContexts :: Var (Map NormalizedFilePath SS.ContextId)
   -- ^ This is a map from the file for which the context was created to
   -- the context id. We use this to track which scenario contexts
   -- are active so that we can GC inactive scenarios.

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
@@ -28,8 +28,8 @@ handle
     -> IO (List CodeLens)
 handle loggerH compilerH (CodeLensParams (TextDocumentIdentifier uri)) = do
     mbResult <- case uriToFilePath' uri of
-        Just filePath -> do
-          Logger.logInfo loggerH $ "CodeLens request for file: " <> T.pack filePath
+        Just (toNormalizedFilePath -> filePath) -> do
+          Logger.logInfo loggerH $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)
           vrs <- Compiler.getAssociatedVirtualResources compilerH filePath
           pure $ mapMaybe virtualResourceToCodeLens vrs
         Nothing       -> pure []

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Definition.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Definition.hs
@@ -27,10 +27,10 @@ handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri
 
 
     mbResult <- case uriToFilePath' uri of
-        Just filePath -> do
+        Just (toNormalizedFilePath -> filePath) -> do
           Logger.logInfo loggerH $
             "Definition request at position " <> renderPlain (prettyPosition pos)
-            <> " in file: " <> T.pack filePath
+            <> " in file: " <> T.pack (fromNormalizedFilePath filePath)
           Compiler.gotoDefinition compilerH filePath pos
         Nothing       -> pure Nothing
 

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Hover.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/Hover.hs
@@ -29,10 +29,10 @@ handle
     -> IO (Maybe Hover)
 handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
     mbResult <- case uriToFilePath' uri of
-        Just filePath -> do
+        Just (toNormalizedFilePath -> filePath) -> do
           Logger.logInfo loggerH $
               "Hover request at position " <> renderPlain (prettyPosition pos)
-              <> " in file: " <> T.pack filePath
+              <> " in file: " <> T.pack (fromNormalizedFilePath filePath)
           Compiler.atPoint compilerH filePath pos
         Nothing       -> pure Nothing
 

--- a/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
@@ -23,6 +23,7 @@ import System.Environment.Blank (setEnv)
 import Control.Monad.IO.Class
 
 import DA.Service.Daml.Compiler.Impl.Scenario as SS
+import Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.LSP
 import qualified DA.Service.Logger.Impl.Pure as Logger
 import Development.IDE.State.API.Testing
@@ -214,7 +215,7 @@ basicTests mbScenarioService = Tasty.testGroup "Basic tests"
             b <- makeFile "B.daml" "daml 1.2 module B where"
             expectWarning (a,0,25) "The import of ‘B’ is redundant"
             expectNoErrors
-            liftIO $ removeFile b
+            liftIO $ removeFile (fromNormalizedFilePath b)
             expectOnlyDiagnostics
                 [(DsError, (a,0,32), "Could not find module")
                 -- the warning says around because of DEL-7199

--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -107,6 +107,7 @@ da_haskell_test(
     visibility = ["//visibility:private"],
     deps = [
         ":da-hs-daml-cli",
+        "//compiler/haskell-ide-core",
         "//daml-foundations/daml-ghc/ghc-compiler",
         "//libs-haskell/da-hs-base",
     ],

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Command/Damldoc.hs
@@ -8,6 +8,7 @@ module DA.Cli.Damlc.Command.Damldoc(cmdDamlDoc, cmdRenderDoc) where
 import           DA.Cli.Damlc.Base(Command)
 import           DA.Cli.Options
 import           DA.Daml.GHC.Damldoc.Driver
+import Development.IDE.Types.Diagnostics
 
 import           Options.Applicative
 import Data.Maybe
@@ -123,7 +124,7 @@ data CmdArgs = Damldoc { cInputFormat :: InputFormat
              deriving (Eq, Show, Read)
 
 exec :: CmdArgs -> Command
-exec Damldoc{..} = damlDocDriver cInputFormat cOutput cFormat cPrefix options cMainFiles
+exec Damldoc{..} = damlDocDriver cInputFormat cOutput cFormat cPrefix options (map toNormalizedFilePath cMainFiles)
   where options =
           [ IncludeModules cIncludeMods | not $ null cIncludeMods] <>
           [ ExcludeModules cExcludeMods | not $ null cExcludeMods] <>

--- a/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/tests/DamlcTest.hs
@@ -15,6 +15,7 @@ import Test.Tasty.HUnit
 
 import qualified DA.Cli.Damlc.Test as Damlc
 import DA.Daml.GHC.Compiler.Options
+import Development.IDE.Types.Diagnostics
 
 main :: IO ()
 main = do
@@ -40,7 +41,7 @@ tests = testGroup
               , "module Foo where"
               , "abc"
               ]
-            shouldThrowExitFailure (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
+            shouldThrowExitFailure (Damlc.execTest [toNormalizedFilePath path] (Damlc.UseColor False) Nothing opts)
     , testCase "File with failing scenario" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -48,7 +49,7 @@ tests = testGroup
               , "module Foo where"
               , "x = scenario $ assert False"
               ]
-            shouldThrowExitFailure (Damlc.execTest [path] (Damlc.UseColor False) Nothing opts)
+            shouldThrowExitFailure (Damlc.execTest [toNormalizedFilePath path] (Damlc.UseColor False) Nothing opts)
     ]
 
 shouldThrowExitFailure :: IO () -> IO ()


### PR DESCRIPTION
This implements part 2 of #1507 and fixes the daml-ghc-test-dev test
suite on Windows (not enabled on CI due to GRPC issues).

I have also tested this in the IDE on Windows and Linux.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
