### PR TITLE
Add exerciseWhenKey to stdlib

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -85,6 +85,21 @@ exerciseByKey k e = do
     (c, cc) <- fetchByKey @c k
     internalExerciseWithActors (choiceController cc e) c e
 
+-- | Eexercise a choice on a contract given by its key, conditional on it existing.
+--
+-- The `c` needs to be passed using an explicit type application. For
+-- instance, if you want to exercise a choice `Withdraw` on a contract of
+-- template `Account` given by its key `k`, you must call
+-- `exerciseWhenKey @Account k Withdraw`.
+exerciseWhenKey : forall c k e r.(TemplateKey c k, Choice c e r) => k -> e -> Update (Optional r)
+exerciseWhenKey k e = do
+  ocid <- lookupByKey @c k
+  case ocid of
+    None -> return None
+    Some cid -> do
+      r <- exercise cid e
+      return (Some r)
+
 class Template c where
 
     -- | Predicate that must hold for the succesful creation of the contract.

--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -85,7 +85,7 @@ exerciseByKey k e = do
     (c, cc) <- fetchByKey @c k
     internalExerciseWithActors (choiceController cc e) c e
 
--- | Eexercise a choice on a contract given by its key, conditional on it existing.
+-- | Exercise a choice on a contract given by its key, conditional on it existing.
 --
 -- The `c` needs to be passed using an explicit type application. For
 -- instance, if you want to exercise a choice `Withdraw` on a contract of


### PR DESCRIPTION
A useful new standard library function -- see code comments for description.

I'm using pattern matching rather than `sequence` to flip `Update` and `Optional` to avoid importing non-internal modules in `DA.Internal`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
