### PR TITLE
Correctly implement hashCode for ImmArray and FrontStack

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -106,6 +106,9 @@ final class BackStack[+A] private (fq: BQ[A], len: Int) {
     case _ => false
   }
 
+
+  override def hashCode(): Int = toImmArray.hashCode()
+
   /** O(n) */
   override def toString: String =
     "BackQueue(" + toImmArray.iterator.map(_.toString).mkString(",") + ")"

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -106,7 +106,6 @@ final class BackStack[+A] private (fq: BQ[A], len: Int) {
     case _ => false
   }
 
-
   override def hashCode(): Int = toImmArray.hashCode()
 
   /** O(n) */

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -109,6 +109,8 @@ final class FrontStack[+A] private (fq: FQ[A], len: Int) {
     case _ => false
   }
 
+  override def hashCode(): Int = toImmArray.hashCode()
+
   /** O(n) */
   override def toString: String = "FrontStack(" + iterator.map(_.toString).mkString(",") + ")"
 }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -332,7 +332,7 @@ final class ImmArray[+A] private (
   def filter(f: A => Boolean): ImmArray[A] =
     collect { case x if f(x) => x }
 
-  override def hashCode(): Int = iterator.toList.hashCode()
+  override def hashCode(): Int = toSeq.hashCode()
 }
 
 object ImmArray {

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -3,10 +3,8 @@
 
 package com.digitalasset.daml.lf.data
 
-import scala.language.higherKinds
-import scala.collection.{IndexedSeqLike, IndexedSeqOptimized, mutable}
-import scalaz.{Applicative, Equal, Foldable, Traverse}
 import scalaz.syntax.applicative._
+import scalaz.{Applicative, Equal, Foldable, Traverse}
 
 import scala.annotation.tailrec
 import scala.collection.generic.{
@@ -16,6 +14,8 @@ import scala.collection.generic.{
   IndexedSeqFactory
 }
 import scala.collection.immutable.IndexedSeq
+import scala.collection.{IndexedSeqLike, IndexedSeqOptimized, mutable}
+import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 /** Simple immutable array. The intention is that all the operations have the "obvious"
@@ -332,7 +332,7 @@ final class ImmArray[+A] private (
   def filter(f: A => Boolean): ImmArray[A] =
     collect { case x if f(x) => x }
 
-  override def hashCode(): Int = array.hashCode() // TODO is this fast?
+  override def hashCode(): Int = iterator.toList.hashCode()
 }
 
 object ImmArray {

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
@@ -138,9 +138,9 @@ class ImmArrayTest extends FlatSpec with Matchers with Checkers {
 
   it should "implement equals and hashCode correctly" in {
     val long = ImmArray(1, 2, 3, 4)
-    val shortened = long.relaxedSlice(0, 2)
+    val shortened = long.relaxedSlice(1, 3)
 
-    val short = ImmArray(1, 2)
+    val short = ImmArray(2, 3)
 
     shortened.hashCode() shouldBe short.hashCode()
     shortened shouldEqual short

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
@@ -136,6 +136,16 @@ class ImmArrayTest extends FlatSpec with Matchers with Checkers {
     ImmArray[Int](1).relaxedSlice(0, -1) shouldBe ImmArray.empty[Int]
   }
 
+  it should "implement equals and hashCode correctly" in {
+    val long = ImmArray(1, 2, 3, 4)
+    val shortened = long.relaxedSlice(0, 2)
+
+    val short = ImmArray(1, 2)
+
+    shortened.hashCode() shouldBe short.hashCode()
+    shortened shouldEqual short
+  }
+
   behavior of "ImmArraySeq"
 
   it should "use CanBuildFrom of ImmArraySeq" in {

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -9,6 +9,12 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+Sandbox
+~~~~~~~
+
+- Fixed a bug in an internal data structure that broke contract keys.
+  See `#1623 <https://github.com/digital-asset/daml/issues/1623>`__.
+
 0.12.25 — 2019-06-13
 --------------------
 
@@ -29,8 +35,6 @@ Sandbox
 
 - Introduced a new API for party management.
   See `#1312 <https://github.com/digital-asset/daml/issues/1312>`__.
-- Fixed a bug in an internal data structure that broke contract keys.
-  See `#1623 <https://github.com/digital-asset/daml/issues/1623>`__.
 
 Scala bindings
 ~~~~~~~~~~~~~~

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -29,6 +29,8 @@ Sandbox
 
 - Introduced a new API for party management.
   See `#1312 <https://github.com/digital-asset/daml/issues/1312>`__.
+- Fixed a bug in an internal data structure that broke contract keys.
+  See `#1623 <https://github.com/digital-asset/daml/issues/1623>`__.
 
 Scala bindings
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
ImmArray and FrontStack violated the contract between equals and
hashCode. ImmArray had a wrong implementation of hashCode, and
FrontStack had no implementation at all.

Fixes #1623.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
