### PR TITLE
java-codegen: Add support for enum types

### DIFF
--- a/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
+++ b/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
@@ -18,4 +18,14 @@ module Enum {
 
   enum Nothing = ;
 
+  variant @serializable OptionalColor = NoColor: Unit | SomeColor: Enum:Color;
+
+  variant @serializable ColoredTree = Leaf: Unit | Node : Enum:ColoredTree.Node;
+
+  record @serializable ColoredTree.Node = {
+    color: Enum:Color,
+    left: Enum:ColoredTree,
+    right: Enum:ColoredTree
+  };
+
 }

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -291,6 +291,7 @@ object Queries {
         case e @ V.ValueEnum(_, _) =>
           // FixMe (RH) https://github.com/digital-asset/daml/issues/105
           throw new NotImplementedError("Enum types not supported")
+
         case o @ V.ValueOptional(_) =>
           Fragment(
             "?::jsonb",

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlEnum.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlEnum.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.digitalasset.ledger.api.v1.ValueOuterClass;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class DamlEnum extends Value {
+
+    private final Optional<Identifier> enumId;
+
+    private final String constructor;
+
+    public DamlEnum(@NonNull Identifier enumId, @NonNull String constructor){
+        this.enumId = Optional.of(enumId);
+        this.constructor = constructor;
+    }
+
+    public DamlEnum(@NonNull String constructor){
+        this.enumId = Optional.empty();
+        this.constructor = constructor;
+    }
+
+    public static DamlEnum fromProto(ValueOuterClass.Enum value) {
+        String constructor = value.getConstructor();
+        if (value.hasEnumId()) {
+            Identifier variantId = Identifier.fromProto(value.getEnumId());
+            return new DamlEnum(variantId, constructor);
+        } else {
+            return new DamlEnum(constructor);
+        }
+    }
+
+    @NonNull
+    public Optional<Identifier> getEnumId() {
+        return enumId;
+    }
+
+    @NonNull
+    public String getConstructor() {
+        return constructor;
+    }
+
+
+    @Override
+    public ValueOuterClass.Value toProto() {
+        return ValueOuterClass.Value.newBuilder().setEnum(this.toProtoEnum()).build();
+    }
+
+    public ValueOuterClass.Enum toProtoEnum() {
+        ValueOuterClass.Enum.Builder builder = ValueOuterClass.Enum.newBuilder();
+        builder.setConstructor(this.getConstructor());
+        this.getEnumId().ifPresent(identifier -> builder.setEnumId(identifier.toProto()));
+        return builder.build();
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DamlEnum value = (DamlEnum) o;
+        return Objects.equals(enumId, value.enumId) && Objects.equals(constructor, value.constructor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enumId, constructor);
+    }
+
+    @Override
+    public String toString() {
+        return "Enum{" + "variantId=" + enumId + ", constructor='" + constructor + "'}";
+    }
+
+}
+

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
@@ -69,6 +69,10 @@ public abstract class Value {
         return (this instanceof Variant) ? Optional.of((Variant) this) : Optional.empty();
     }
 
+    public final Optional<DamlEnum> asEnum() {
+        return (this instanceof DamlEnum) ? Optional.of((DamlEnum) this): Optional.empty();
+    }
+
     public final Optional<ContractId> asContractId() {
         return (this instanceof ContractId) ? Optional.of((ContractId) this) : Optional.empty();
     }

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -121,15 +121,52 @@ scala_source_jar(
     srcs = [],
 )
 
-daml_lf_target_versions = [
+test_daml_lf_target_versions = [
     "1.0",
     "1.1",
-    "latest",
+    "1.3",
+    "1.dev",
+]
+
+[
+    [
+        dar_to_java(
+            name = "test-model-%s" % target,
+            src = "//daml-lf/encoder:testing-dar-%s" % target,
+            package_prefix = "test",
+        ),
+    ]
+    for target in test_daml_lf_target_versions
+]
+
+[
+    java_test(
+        name = "tests-%s" % target,
+        srcs = glob([
+            "src/test/java-%s/**/*.java" % target,
+        ]),
+        test_class = "com.digitalasset.lf_%s.AllTests" % mangle_for_java(target),
+        deps = [
+            ":test-model-%s.jar" % target,
+            "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+            "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_api",
+            "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_engine",
+            "//3rdparty/jvm/org/junit/platform:junit_platform_runner",
+            "//language-support/java/bindings:bindings-java",
+        ],
+    )
+    for target in ["1.dev"]
 ]
 
 ########################################################
 ####  Integration Tests
 ########################################################
+
+it_daml_lf_target_versions = [
+    "1.0",
+    "1.1",
+    "latest",
+]
 
 # This file was created using
 # DAML_SDK_VERSION=0.12.12 daml damlc package src/it/daml/Lib.daml integration-tests-model-1.0 --target=1.0 --output src/it/dar/integration-tests-model-1.0.dar
@@ -170,7 +207,7 @@ daml_compile(
             package_prefix = "lf_%s" % mangle_for_java(target),
         ),
     ]
-    for target in daml_lf_target_versions
+    for target in it_daml_lf_target_versions
 ]
 
 [
@@ -192,7 +229,7 @@ daml_compile(
             "//ledger/sandbox:sandbox-scala-tests-lib",
         ],
     )
-    for target in daml_lf_target_versions
+    for target in it_daml_lf_target_versions
 ]
 
 ########################################################

--- a/language-support/java/codegen/src/it/daml/Lib.daml
+++ b/language-support/java/codegen/src/it/daml/Lib.daml
@@ -10,6 +10,7 @@ import Tests.RecordTest
 import Tests.OptionalTest
 import Tests.ListTest
 import Tests.VariantTest
+
 import Tests.Import
 import Tests.Escape
 import Tests.MapTest

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -47,9 +47,13 @@ object ClassForType extends StrictLogging {
         javaFile(typeWithContext, javaPackage, tpe) ::
           constructors.map(cons => javaFile(typeWithContext, subPackage, cons))
 
-      case Some(Normal(DefDataType(typeVars, enum: Enum))) =>
-        // FixMe (RH) https://github.com/digital-asset/daml/issues/105
-        throw new NotImplementedError("Enum types not supported")
+      case Some(Normal(DefDataType(_, enum: Enum))) =>
+        val subPackage = className.packageName() + "." + JavaEscaper.escapeString(
+          className.simpleName().toLowerCase)
+        List(
+          JavaFile
+            .builder(javaPackage, EnumClass.generate(className, typeWithContext.identifier, enum))
+            .build())
 
       case Some(Template(record, template)) =>
         val typeSpec =

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.codegen.backend.java.inner
+
+import com.daml.ledger.javaapi
+import com.digitalasset.daml.lf.data.Ref.Identifier
+import com.digitalasset.daml.lf.iface
+import com.squareup.javapoet._
+import com.typesafe.scalalogging.StrictLogging
+import javax.lang.model.element.Modifier
+
+import scala.collection.JavaConverters._
+
+private[inner] object EnumClass extends StrictLogging {
+
+  def generate(
+      className: ClassName,
+      identifier: Identifier,
+      enum: iface.Enum,
+  ): TypeSpec = {
+
+    logger.info("Start")
+    val enumType = TypeSpec.enumBuilder(className).addModifiers(Modifier.PUBLIC)
+    enum.constructors.foreach(c => enumType.addEnumConstant(c.toUpperCase()))
+    enumType.addField(generateValuesArray(enum))
+    enumType.addMethod(generateEnumsMapBuilder(enum))
+    enumType.addField(generateEnumsMap(className))
+    enumType.addMethod(generateFromValue(className, enum))
+    enumType.addMethod(generateToValue(className))
+    logger.debug("End")
+    enumType.build()
+  }
+
+  private def generateValuesArray(enum: iface.Enum): FieldSpec = {
+    val fieldSpec = FieldSpec.builder(ArrayTypeName.of(classOf[javaapi.data.DamlEnum]), "__values$")
+    fieldSpec.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+    val constructorValues = enum.constructors
+      .map(c => CodeBlock.of("new $T($S)", classOf[javaapi.data.DamlEnum], c))
+      .asJava
+    fieldSpec.initializer(constructorValues.stream().collect(CodeBlock.joining(", ", "{", "}")))
+    fieldSpec.build()
+  }
+
+  private def generateEnumsMap(className: ClassName): FieldSpec =
+    FieldSpec
+      .builder(classOf[java.util.Map[Any, Any]], "__enums$")
+      .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+      .initializer("$T.__buildEnumsMap$$()", className)
+      .build()
+
+  private def generateEnumsMapBuilder(enum: iface.Enum): MethodSpec = {
+    val builder = MethodSpec.methodBuilder("__buildEnumsMap$")
+    builder.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+    builder.returns(classOf[java.util.Map[Any, Any]])
+    builder.addStatement(
+      "$T m = new $T()",
+      classOf[java.util.Map[Any, Any]],
+      classOf[java.util.HashMap[Any, Any]])
+    enum.constructors.foreach(c => builder.addStatement(s"""m.put("$c", ${c.toUpperCase()})"""))
+    builder.addStatement("return m")
+    builder.build()
+  }
+
+  private def generateFromValue(
+      className: ClassName,
+      enum: iface.Enum
+  ): MethodSpec = {
+    logger.debug(s"Generating fromValue static method for $enum")
+
+    MethodSpec
+      .methodBuilder("fromValue")
+      .addModifiers(Modifier.STATIC, Modifier.PUBLIC, Modifier.FINAL)
+      .returns(className)
+      .addParameter(classOf[javaapi.data.Value], "value$")
+      .addStatement(
+        "$T constructor$$ = value$$.asEnum().orElseThrow(() -> new $T($S)).getConstructor()",
+        classOf[String],
+        classOf[IllegalArgumentException],
+        s"Expected DamlEnum to build an instance of the  ${className.simpleName()}"
+      )
+      .addStatement(
+        "if (!$T.__enums$$.containsKey(constructor$$)) throw new $T($S + constructor$$)",
+        className,
+        classOf[IllegalArgumentException],
+        s"Expected a DamlEnum with ${className.simpleName()} constructor, found "
+      )
+      .addStatement("return ($T) $T.__enums$$.get(constructor$$)", className, className)
+      .build()
+
+  }
+
+  private def generateToValue(className: ClassName): MethodSpec =
+    MethodSpec
+      .methodBuilder("toValue")
+      .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+      .returns(classOf[javaapi.data.DamlEnum])
+      .addStatement("return $T.__values$$[ordinal()]", className)
+      .build()
+
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/EnumClass.scala
@@ -19,17 +19,18 @@ private[inner] object EnumClass extends StrictLogging {
       identifier: Identifier,
       enum: iface.Enum,
   ): TypeSpec = {
-
-    logger.info("Start")
-    val enumType = TypeSpec.enumBuilder(className).addModifiers(Modifier.PUBLIC)
-    enum.constructors.foreach(c => enumType.addEnumConstant(c.toUpperCase()))
-    enumType.addField(generateValuesArray(enum))
-    enumType.addMethod(generateEnumsMapBuilder(enum))
-    enumType.addField(generateEnumsMap(className))
-    enumType.addMethod(generateFromValue(className, enum))
-    enumType.addMethod(generateToValue(className))
-    logger.debug("End")
-    enumType.build()
+    TrackLineage.of("enum", className.simpleName()) {
+      logger.info("Start")
+      val enumType = TypeSpec.enumBuilder(className).addModifiers(Modifier.PUBLIC)
+      enum.constructors.foreach(c => enumType.addEnumConstant(c.toUpperCase()))
+      enumType.addField(generateValuesArray(enum))
+      enumType.addMethod(generateEnumsMapBuilder(enum))
+      enumType.addField(generateEnumsMap(className))
+      enumType.addMethod(generateFromValue(className, enum))
+      enumType.addMethod(generateToValue(className))
+      logger.debug("End")
+      enumType.build()
+    }
   }
 
   private def generateValuesArray(enum: iface.Enum): FieldSpec = {

--- a/language-support/java/codegen/src/test/java-1.dev/com/digitalasset/lf_1_dev/AllTests.java
+++ b/language-support/java/codegen/src/test/java-1.dev/com/digitalasset/lf_1_dev/AllTests.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.lf_1_dev;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        EnumTest.class
+})
+public class AllTests {
+}

--- a/language-support/java/codegen/src/test/java-1.dev/com/digitalasset/lf_1_dev/EnumTest.java
+++ b/language-support/java/codegen/src/test/java-1.dev/com/digitalasset/lf_1_dev/EnumTest.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.lf_1_dev;
+
+
+import com.daml.ledger.javaapi.data.DamlEnum;
+import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.Record;
+import com.daml.ledger.javaapi.data.Variant;
+import com.daml.ledger.javaapi.data.Unit;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import test.enum$.*;
+import test.enum$.optionalcolor.*;
+import test.enum$.coloredtree.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(JUnitPlatform.class)
+public class EnumTest {
+
+    @Test
+    void enum2Value2Enum() {
+        for(Color c: new Color[]{Color.RED, Color.GREEN, Color.BLUE}) {
+            Box record = new Box(c, "party");
+            OptionalColor variant = new SomeColor(c);
+            ColoredTree variantRecord = new Node(Color.RED, new Leaf(Unit.getInstance()), new Leaf(Unit.getInstance()));
+            assertEquals(Color.fromValue(c.toValue()), c);
+            assertEquals(Box.fromValue(record.toValue()), record);
+            assertEquals(OptionalColor.fromValue(variant.toValue()), variant);
+            assertEquals(ColoredTree.fromValue(variantRecord.toValue()), variantRecord);
+        }
+    }
+
+    @Test
+    void value2Enum2value() {
+        for(String s: new String[]{"Red", "Green", "Blue"}) {
+            DamlEnum damlEnum = new DamlEnum(s);
+            Record record = new Record(
+                    new Record.Field("x", damlEnum),
+                    new Record.Field("party", new Party("party"))
+            );
+            Variant variant = new Variant("SomeColor", damlEnum);
+            Variant leaf = new Variant("Leaf", Unit.getInstance());
+            Record node = new Record(
+                    new Record.Field("color", damlEnum),
+                    new Record.Field("left", leaf),
+                    new Record.Field("right", leaf)
+            );
+            Variant tree = new Variant("Node", node);
+            assertEquals(Color.fromValue(damlEnum).toValue(), damlEnum);
+            assertEquals(Box.fromValue(record).toValue(), record);
+            assertEquals(OptionalColor.fromValue(variant).toValue(), variant);
+            assertEquals(ColoredTree.fromValue(tree).toValue(), tree);
+        }
+    }
+
+    @Test
+    void badValue2Enum() {
+        DamlEnum value = new DamlEnum("Yellow");
+        assertThrows(IllegalArgumentException.class, () -> Color.fromValue(value));
+    }
+
+
+}


### PR DESCRIPTION
This PR continue the effort to add `Enum` type to the SDK (See issue #105)

This PR add `Enum` type support for the java and codegen .  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
