### PR TITLE
Remove one level of tracking files of interest and open VRs

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -13,7 +13,7 @@ module Development.IDE.State.Service(
     getServiceEnv,
     IdeState, initialise, shutdown,
     runAction, runActions,
-    setFilesOfInterest,
+    setFilesOfInterest, modifyFilesOfInterest,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
     logDebug, logSeriousError
@@ -26,6 +26,8 @@ import           Development.IDE.State.FileStore
 import qualified Development.IDE.Logger as Logger
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
+import qualified Data.Text as T
+import Data.Tuple.Extra
 import           Development.IDE.Functions.GHCError
 import Development.IDE.Types.Diagnostics (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
@@ -109,12 +111,13 @@ runActions x = join . shakeRun x
 
 -- | Set the files-of-interest which will be built and kept-up-to-date.
 setFilesOfInterest :: IdeState -> Set NormalizedFilePath -> IO ()
-setFilesOfInterest state files = do
-    Env{..} <- getIdeGlobalState state
-    -- update vars synchronously
-    modifyVar_ envOfInterestVar $ const $ return files
+setFilesOfInterest state files = modifyFilesOfInterest state (const files)
 
-    -- run shake to update results regarding the files of interest
+modifyFilesOfInterest :: IdeState -> (Set NormalizedFilePath -> Set NormalizedFilePath) -> IO ()
+modifyFilesOfInterest state f = do
+    Env{..} <- getIdeGlobalState state
+    files <- modifyVar envOfInterestVar $ pure . dupe . f
+    logDebug state $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
     void $ shakeRun state []
 
 getServiceEnv :: Action Env

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -8,9 +8,11 @@ module DA.Service.Daml.Compiler.Impl.Handle
     IdeState
   , getIdeState
   , withIdeState
-  , setFilesOfInterest
+  , CompilerService.setFilesOfInterest
+  , CompilerService.modifyFilesOfInterest
   , onFileModified
-  , setOpenVirtualResources
+  , CompilerService.setOpenVirtualResources
+  , CompilerService.modifyOpenVirtualResources
   , getAssociatedVirtualResources
   , gotoDefinition
   , atPoint
@@ -124,23 +126,6 @@ toIdeLogger h = IdeLogger.Handle {
 
 ------------------------------------------------------------------------------
 
--- | Update the files-of-interest, which we recieve asynchronous notifications for.
-setFilesOfInterest
-    :: IdeState
-    -> [NormalizedFilePath]
-    -> IO ()
-setFilesOfInterest service files = do
-    CompilerService.logDebug service $ "Setting files of interest to: " <> T.pack (show files)
-    CompilerService.setFilesOfInterest service (S.fromList files)
-
-setOpenVirtualResources
-    :: IdeState
-    -> [VirtualResource]
-    -> IO ()
-setOpenVirtualResources service vrs = do
-    CompilerService.logDebug service $ "Setting vrs of interest to: " <> T.pack (show vrs)
-    CompilerService.setOpenVirtualResources service (S.fromList vrs)
-
 getAssociatedVirtualResources
   :: IdeState
   -> NormalizedFilePath
@@ -195,7 +180,7 @@ compileFile service fp = do
     -- We need to mark the file we are compiling as a file of interest.
     -- Otherwise all diagnostics produced during compilation will be garbage
     -- collected afterwards.
-    liftIO $ setFilesOfInterest service [fp]
+    liftIO $ CompilerService.setFilesOfInterest service (S.singleton fp)
     liftIO $ CompilerService.logDebug service $ "Compiling: " <> T.pack (fromNormalizedFilePath fp)
     res <- liftIO $ CompilerService.runAction service (CompilerService.getDalf fp)
     case res of

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -12,7 +12,9 @@ module Development.IDE.State.API
     , getDefinition
     , shutdown
     , setFilesOfInterest
+    , modifyFilesOfInterest
     , setOpenVirtualResources
+    , modifyOpenVirtualResources
     , setBufferModified
     , runAction
     , runActions

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -1,5 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
 module Development.IDE.State.Service.Daml(
     Env(..),
     getServiceEnv,
@@ -7,7 +8,7 @@ module Development.IDE.State.Service.Daml(
     getDamlServiceEnv,
     IdeState, initialise, shutdown,
     runAction, runActions,
-    setFilesOfInterest, setOpenVirtualResources,
+    setFilesOfInterest, modifyFilesOfInterest, setOpenVirtualResources, modifyOpenVirtualResources,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
     logDebug, logSeriousError
@@ -19,6 +20,8 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Text as T
+import Data.Tuple.Extra
 import Development.Shake
 
 import qualified Development.IDE.Logger as Logger
@@ -70,9 +73,13 @@ getDamlServiceEnv :: Action DamlEnv
 getDamlServiceEnv = getIdeGlobalAction
 
 setOpenVirtualResources :: IdeState -> Set VirtualResource -> IO ()
-setOpenVirtualResources state resources = do
+setOpenVirtualResources state resources = modifyOpenVirtualResources state (const resources)
+
+modifyOpenVirtualResources :: IdeState -> (Set VirtualResource -> Set VirtualResource) -> IO ()
+modifyOpenVirtualResources state f = do
     DamlEnv{..} <- getIdeGlobalState state
-    modifyVar_ envOpenVirtualResources $ const $ return resources
+    vrs <- modifyVar envOpenVirtualResources $ pure . dupe . f
+    logDebug state $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
     void $ shakeRun state []
 
 initialise

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -14,6 +14,7 @@ import qualified DA.Pretty
 import DA.Cli.Damlc.Base
 import Data.Maybe
 import Data.List.Extra
+import qualified Data.Set as S
 import Data.Tuple.Extra
 import Control.Monad.Extra
 import           DA.Service.Daml.Compiler.Impl.Handle as Compiler
@@ -54,7 +55,7 @@ execTest inFiles color mbJUnitOutput cliOptions = do
 testRun :: IdeState -> [NormalizedFilePath] -> LF.Version -> UseColor -> Maybe FilePath -> IO ()
 testRun h inFiles lfVersion color mbJUnitOutput  = do
     -- make sure none of the files disappear
-    liftIO $ Compiler.setFilesOfInterest h inFiles
+    liftIO $ Compiler.setFilesOfInterest h (S.fromList inFiles)
 
     -- take the transitive closure of all imports and run on all of them
     -- If some dependencies can't be resolved we'll get a Diagnostic out anyway, so don't worry


### PR DESCRIPTION
Previously we tracked this both at the Shake level and at the LSP
level which doesn’t make any sense. This PR removes the outer LSP
layer.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
