### PR TITLE
language: derive generic instances for all data declarations.

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Generics.daml
@@ -724,7 +724,7 @@ module DA.Generics (
   -- , Datatype(..), Constructor(..), Selector(..)
   , Fixity(..), FixityI(..), Associativity(..), prec
   , SourceUnpackedness(..), SourceStrictness(..), DecidedStrictness(..)
-  , Meta(..), MetaData0(..), MetaCons0(..), MetaSel0(..)
+  , Meta(..), MetaData0(..), MetaCons0(..), MetaSel0(..), Bool(..), Optional(..)
 
   -- * Generic type classes
   , Generic(..), Generic1(..)

--- a/daml-foundations/daml-ghc/tests/CustomOptional.daml
+++ b/daml-foundations/daml-ghc/tests/CustomOptional.daml
@@ -4,5 +4,5 @@
 daml 1.2
 module Test where
 
-data OptionalInteger = SomeInteger Int | None
+data OptionalInteger = SomeInteger Int | NoInt
   deriving (Eq, Show)

--- a/daml-foundations/daml-ghc/tests/No_concat_clash.daml
+++ b/daml-foundations/daml-ghc/tests/No_concat_clash.daml
@@ -14,7 +14,8 @@ import DA.Foldable  -- for `concat`.
 
 template T
   with
-    ps, qs : [Prelude.Party]
+    ps : [Prelude.Party]
+    qs : [Prelude.Party]
   where
     signatory ps, qs
     observer (concat [Prelude.signatory this])


### PR DESCRIPTION
We derive generic instances for all data declarations. We will need them
to generate upgrade code. I'm aware that this might affect compile
times. If the impact is too big, we might think about adding a flag to
damlc to only derive generic instances for building but not for the IDE.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
