### PR TITLE
terraform files for hoogle server

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -26,3 +26,13 @@ To avoid holding the secret key into the store, creating the key has to be
 done through the UI.
 
 This can be done here: https://console.cloud.google.com/iam-admin/serviceaccounts/details/104272946446260011088?project=da-dev-gcp-daml-language
+
+## Setting up credentials
+
+In order to interact with these Terraform files, you will need security to give
+you access to the relevant GCP project (`da-dev-gcp-daml-language`), and login
+via `gcloud` by running:
+
+```bash
+gcloud auth application-default login --account your.name@gcloud-domain.com
+```

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -1,0 +1,249 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+resource "google_compute_network" "hoogle" {
+  name = "hoogle-network"
+}
+
+resource "google_compute_firewall" "hoogle" {
+  name        = "hoogle-firewall"
+  network     = "${google_compute_network.hoogle.name}"
+  target_tags = ["hoogle"]
+
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080", "8081"]
+  }
+}
+
+resource "google_compute_instance_template" "hoogle" {
+  name_prefix  = "hoogle-"
+  machine_type = "n1-standard-1"
+  tags         = ["hoogle"]
+  labels       = "${local.labels}"
+
+  disk {
+    boot         = true
+    disk_size_gb = 20
+    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+  }
+
+  metadata_startup_script = <<STARTUP
+#! /bin/bash
+apt-get update
+apt-get -y upgrade
+### stackdriver
+curl -sSL https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+### nginx
+apt-get -y install nginx
+cat > /etc/nginx/nginx.conf <<NGINX
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+events {
+  worker_connections 768;
+}
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+  server {
+    listen 8081 default_server;
+    server_name _;
+    return 307 https://hoogle.daml.com$request_uri;
+  }
+}
+NGINX
+service nginx restart
+### hoogle
+apt-get -y install curl git
+useradd hoogle
+mkdir /home/hoogle
+chown hoogle:hoogle /home/hoogle
+cd /home/hoogle
+curl -sSL https://get.haskellstack.org/ | sh
+runuser -u hoogle bash <<HOOGLE_SETUP
+git clone https://github.com/ndmitchell/hoogle.git
+cd hoogle
+stack init --resolver=nightly
+stack build
+stack install
+export PATH=/home/hoogle/.local/bin:$PATH
+mkdir daml
+curl https://docs.daml.com/hoogle_db/base.txt --output daml/base.txt
+hoogle generate --database=daml.hoo --local=daml
+nohup hoogle server --database=daml.hoo --log=.log.txt --port=8080 >> out.txt &
+HOOGLE_SETUP
+cat > /home/hoogle/refresh-db.sh <<CRON
+#!/usr/bin/env bash
+set -euxo pipefail
+log() {
+  echo "[$(date -Is)] $1" >> /home/hoogle/cron_log.txt
+}
+log "Checking for new DAML version..."
+cd /home/hoogle/hoogle
+mkdir new-daml
+curl -s https://docs.daml.com/hoogle_db/base.txt --output new-daml/base.txt
+if ! diff -rq daml new-daml; then
+  log "New version detected. Creating database..."
+  rm -rf daml
+  mv new-daml daml
+  rm daml.hoo
+  /home/hoogle/.local/bin/hoogle generate --database=daml.hoo --local=daml
+  log "Killing running instance..."
+  killall hoogle
+  log "Stating new server..."
+  nohup /home/hoogle/.local/bin/hoogle server --database=daml.hoo --log=.log.txt --port=8080 >> out.txt &
+  log "New server started."
+else
+  log "No change detected."
+  rm -rf new-daml
+fi
+log "Done."
+CRON
+chown hoogle:hoogle /home/hoogle/refresh-db.sh
+echo "*/5 * * * * /home/hoogle/refresh-db.sh" | crontab -u hoogle -
+STARTUP
+
+  network_interface {
+    network       = "${google_compute_network.hoogle.name}"
+    access_config = {}
+  }
+
+  service_account {
+    email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
+    scopes = ["cloud-platform"]
+  }
+
+  scheduling {
+    automatic_restart   = false
+    on_host_maintenance = "TERMINATE"
+    preemptible         = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "hoogle" {
+  provider           = "google-beta"
+  name               = "hoogle"
+  base_instance_name = "hoogle"
+  zone               = "${local.zone}"
+  target_size        = "3"
+
+  version {
+    name              = "hoogle"
+    instance_template = "${google_compute_instance_template.hoogle.self_link}"
+  }
+
+  named_port {
+    name = "https"
+    port = "8080"
+  }
+
+  named_port {
+    name = "http"
+    port = "8081"
+  }
+
+  update_policy {
+    type            = "OPPORTUNISTIC"
+    minimal_action  = "REPLACE"
+    max_surge_fixed = 1
+  }
+}
+
+resource "google_compute_global_address" "hoogle" {
+  name       = "hoogle"
+  ip_version = "IPV4"
+}
+
+resource "google_compute_health_check" "hoogle-http" {
+  name               = "hoogle-http"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = 8081
+  }
+}
+
+resource "google_compute_backend_service" "hoogle-http" {
+  name          = "hoogle-http"
+  health_checks = ["${google_compute_health_check.hoogle-http.self_link}"]
+  port_name     = "http"
+
+  backend {
+    group = "${google_compute_instance_group_manager.hoogle.instance_group}"
+  }
+}
+
+resource "google_compute_url_map" "hoogle-http" {
+  name            = "hoogle-http"
+  default_service = "${google_compute_backend_service.hoogle-http.self_link}"
+}
+
+resource "google_compute_target_http_proxy" "hoogle-http" {
+  name    = "hoogle-http"
+  url_map = "${google_compute_url_map.hoogle-http.self_link}"
+}
+
+resource "google_compute_global_forwarding_rule" "hoogle_http" {
+  name       = "hoogle-http"
+  target     = "${google_compute_target_http_proxy.hoogle-http.self_link}"
+  ip_address = "${google_compute_global_address.hoogle.address}"
+  port_range = "80"
+}
+
+resource "google_compute_health_check" "hoogle-https" {
+  name               = "hoogle-https"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = 8080
+  }
+}
+
+resource "google_compute_backend_service" "hoogle-https" {
+  name          = "hoogle-https"
+  health_checks = ["${google_compute_health_check.hoogle-https.self_link}"]
+  port_name     = "https"
+
+  backend {
+    group = "${google_compute_instance_group_manager.hoogle.instance_group}"
+  }
+}
+
+resource "google_compute_url_map" "hoogle-https" {
+  name            = "hoogle-https"
+  default_service = "${google_compute_backend_service.hoogle-https.self_link}"
+}
+
+resource "google_compute_target_https_proxy" "hoogle-https" {
+  name    = "hoogle-https"
+  url_map = "${google_compute_url_map.hoogle-https.self_link}"
+
+  ssl_certificates = ["${local.ssl_certificate_hoogle}"]
+}
+
+resource "google_compute_global_forwarding_rule" "hoogle_https" {
+  name       = "hoogle-https"
+  target     = "${google_compute_target_https_proxy.hoogle-https.self_link}"
+  ip_address = "${google_compute_global_address.hoogle.address}"
+  port_range = "443"
+}
+
+output "hoogle_address" {
+  value = "${google_compute_global_address.hoogle.address}"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -35,4 +35,6 @@ locals {
 
   // maintained by DA security
   ssl_certificate = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/da-ext-wildcard"
+
+  ssl_certificate_hoogle = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/daml-lang-hoogle-app-service-https-cert"
 }


### PR DESCRIPTION
We currently have a server for https://hoogle.daml.com. It is not very well defined: there are a few (broken) Terraform files in a private repo managed by the security team to define the machine itseld, a bash script of `gcloud` commands for defining its network configuration, and some instructions Neil has given me on Slack for the setup of the hoogle app within the machine. I am likely the only person right now with access to all of those sources, which is not great, but een for me there are a lot of blanks and missing pieces between them. This PR is an attempt at gathering all of the information regarding this machine within this repo.

Apart from the inherent problems of the above state of affairs, the main reason for doing this is to provide a good foundation to add some sort of automated update of the hoogle database when we publish a new release.