### PR TITLE
prevent hourly build from running on pr or merge

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -1,5 +1,10 @@
 # Azure Pipelines file, see https://aka.ms/yaml
 
+# Do not run on PRs
+pr: none
+# Do not run on merge to master
+trigger: none
+# Do run on a schedule (hourly)
 schedules:
 - cron: "0 * * * *"
   displayName: hourly cron


### PR DESCRIPTION
The new cron syntax is nice, but it seems to have come with some side effects: the cron build is now triggered for _some_ merges into master and _some_ PRs. I can't see a clear pattern.

It's a bit hard to know the exact semantics of this as the documentation has not been published yet—though they have already removed the ability to change schedule times through the web UI, and added a link to where the documentation will (should?) be.

According to what documentation there is, this should explicitly tell Azure this pipeline should not run on PRs and master merges.