### PR TITLE
Move LanguageServer into haskell-ide-core

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/LSP/Definition.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Go to the definition of a variable.
-module DA.Service.Daml.LanguageServer.Definition
+module Development.IDE.LSP.Definition
     ( handle
     ) where
 

--- a/compiler/haskell-ide-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/LSP/Hover.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Display information on hover.
-module DA.Service.Daml.LanguageServer.Hover
+module Development.IDE.LSP.Hover
     ( handle
     ) where
 

--- a/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 -- WARNING: A copy of DA.Service.Daml.LanguageServer, try to keep them in sync
--- This version removes the daml: handling and SDK version output
+-- This version removes the daml: handling
 module Development.IDE.LSP.LanguageServer
     ( runLanguageServer
     ) where

--- a/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -1,0 +1,151 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Development.IDE.LSP.LanguageServer
+    ( runLanguageServer
+    ) where
+
+import           Development.IDE.LSP.Protocol
+import           Development.IDE.LSP.Server
+
+import Control.Monad.IO.Class
+import qualified Development.IDE.LSP.Definition as LS.Definition
+import qualified Development.IDE.LSP.Hover      as LS.Hover
+import qualified Development.IDE.Logger as Logger
+import Development.IDE.State.Service
+
+import qualified Data.Aeson                                as Aeson
+import qualified Data.Rope.UTF16 as Rope
+import qualified Data.Set                                  as S
+import qualified Data.Text as T
+
+import Development.IDE.State.FileStore
+import Development.IDE.Types.Diagnostics
+
+import qualified Network.URI                               as URI
+
+import qualified System.Exit
+
+import Language.Haskell.LSP.Core (LspFuncs(..))
+import Language.Haskell.LSP.Messages
+import Language.Haskell.LSP.VFS
+
+textShow :: Show a => a -> T.Text
+textShow = T.pack . show
+
+------------------------------------------------------------------------
+-- Request handlers
+------------------------------------------------------------------------
+
+handleRequest
+    :: Logger.Handle
+    -> IdeState
+    -> (forall resp. resp -> ResponseMessage resp)
+    -> (ErrorCode -> ResponseMessage ())
+    -> ServerRequest
+    -> IO FromServerMessage
+handleRequest loggerH compilerH makeResponse makeErrorResponse = \case
+    Shutdown -> do
+      Logger.logInfo loggerH "Shutdown request received, terminating."
+      System.Exit.exitSuccess
+
+    KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
+
+    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle loggerH compilerH params
+    Hover params -> RspHover . makeResponse <$> LS.Hover.handle loggerH compilerH params
+
+    req -> do
+        Logger.logWarning loggerH ("Method not found" <> T.pack (show req))
+        pure $ RspError $ makeErrorResponse MethodNotFound
+
+
+handleNotification :: LspFuncs () -> Logger.Handle -> IdeState -> ServerNotification -> IO ()
+handleNotification lspFuncs loggerH compilerH = \case
+
+    DidOpenTextDocument (DidOpenTextDocumentParams item) -> do
+        case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
+          Just uri
+              | URI.uriScheme uri == "file:"
+              -> handleDidOpenFile item
+
+              | otherwise
+              -> Logger.logWarning loggerH $ "Unknown scheme in URI: "
+                    <> textShow uri
+
+          _ -> Logger.logSeriousError loggerH $ "Invalid URI in DidOpenTextDocument: "
+                    <> textShow (_uri (item :: TextDocumentItem))
+
+    DidChangeTextDocument (DidChangeTextDocumentParams docId _) -> do
+        let uri = _uri (docId :: VersionedTextDocumentIdentifier)
+
+        case uriToFilePath' uri of
+          Just (toNormalizedFilePath -> filePath) -> do
+            mbVirtual <- getVirtualFileFunc lspFuncs $ toNormalizedUri uri
+            let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
+            onFileModified compilerH filePath (Just contents)
+            Logger.logInfo loggerH
+              $ "Updated text document: " <> textShow (fromNormalizedFilePath filePath)
+
+          Nothing ->
+            Logger.logSeriousError loggerH
+              $ "Invalid file path: " <> textShow (_uri (docId :: VersionedTextDocumentIdentifier))
+
+    DidCloseTextDocument (DidCloseTextDocumentParams (TextDocumentIdentifier uri)) ->
+        case URI.parseURI $ T.unpack $ getUri uri of
+          Just uri'
+              | URI.uriScheme uri' == "file:" -> do
+                    Just fp <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
+                    handleDidCloseFile fp
+              | otherwise -> Logger.logWarning loggerH $ "Unknown scheme in URI: " <> textShow uri
+
+          _ -> Logger.logSeriousError loggerH
+                 $    "Invalid URI in DidCloseTextDocument: "
+                   <> textShow uri
+
+    DidSaveTextDocument _params ->
+      pure ()
+
+    UnknownNotification _method _params -> return ()
+  where
+    -- Note that the state changes here are not atomic.
+    -- When we have parallel compilation we could manage the state
+    -- changes in STM so that we can atomically change the state.
+    -- Internally it should be done via the IO oracle. See PROD-2808.
+    handleDidOpenFile (TextDocumentItem uri _ _ contents) = do
+        Just filePath <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
+        onFileModified compilerH filePath (Just contents)
+        modifyFilesOfInterest compilerH (S.insert filePath)
+        Logger.logInfo loggerH $ "Opened text document: " <> textShow filePath
+
+    handleDidCloseFile filePath = do
+         Logger.logInfo loggerH $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
+         onFileModified compilerH filePath Nothing
+         modifyFilesOfInterest compilerH (S.delete filePath)
+
+-- | Manages the file store (caching compilation results and unsaved content).
+onFileModified
+    :: IdeState
+    -> NormalizedFilePath
+    -> Maybe T.Text
+    -> IO ()
+onFileModified service fp mbContents = do
+    logDebug service $ "File modified " <> T.pack (show fp)
+    setBufferModified service fp mbContents
+
+------------------------------------------------------------------------
+-- Server execution
+------------------------------------------------------------------------
+
+runLanguageServer
+    :: Logger.Handle
+    -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
+    -> IO ()
+runLanguageServer loggerH getIdeState = do
+    let getHandlers lspFuncs = do
+            compilerH <- getIdeState (sendFunc lspFuncs) (makeLSPVFSHandle lspFuncs)
+            pure $ Handlers (handleRequest loggerH compilerH) (handleNotification lspFuncs loggerH compilerH)
+    liftIO $ runServer loggerH getHandlers

--- a/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes #-}
 
+-- WARNING: A copy of DA.Service.Daml.LanguageServer, try to keep them in sync
+-- This version removes the daml: handling and SDK version output
 module Development.IDE.LSP.LanguageServer
     ( runLanguageServer
     ) where

--- a/compiler/haskell-ide-core/test/Demo.hs
+++ b/compiler/haskell-ide-core/test/Demo.hs
@@ -16,6 +16,7 @@ import Development.IDE.Types.Options
 import Development.IDE.Logger
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
+import Development.IDE.LSP.LanguageServer
 import System.Environment
 import Data.List
 import Data.Maybe
@@ -63,10 +64,6 @@ main = do
         -- so we sleep briefly to wait for it to have been written
         sleep 0.01
         putStrLn "Done"
-
-
-runLanguageServer :: a
-runLanguageServer = undefined
 
 
 -- | Print an LSP event.

--- a/daml-foundations/daml-ghc/language-server/BUILD.bazel
+++ b/daml-foundations/daml-ghc/language-server/BUILD.bazel
@@ -31,7 +31,6 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/haskell-ide-core",
-        "//daml-assistant:daml-project-config",
         "//daml-foundations/daml-ghc/daml-compiler",
         "//daml-foundations/daml-ghc/ide",
     ],

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes #-}
 
+-- WARNING: A copy of Development.IDE.LSP.LanguageServer, try to keep them in sync
 module DA.Service.Daml.LanguageServer
     ( runLanguageServer
     ) where

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -10,8 +10,6 @@ module DA.Service.Daml.LanguageServer
     ( runLanguageServer
     ) where
 
-import Control.Exception.Safe
-
 import           Development.IDE.LSP.Protocol
 import           Development.IDE.LSP.Server
 
@@ -20,7 +18,6 @@ import qualified DA.Service.Daml.LanguageServer.CodeLens   as LS.CodeLens
 import qualified Development.IDE.LSP.Definition as LS.Definition
 import qualified Development.IDE.LSP.Hover      as LS.Hover
 import qualified Development.IDE.Logger as Logger
-import DAML.Project.Consts
 
 import qualified Data.Aeson                                as Aeson
 import qualified Data.Rope.UTF16 as Rope
@@ -170,8 +167,6 @@ runLanguageServer
     -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
     -> IO ()
 runLanguageServer loggerH getIdeState = do
-    sdkVersion <- liftIO (getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)"))
-    liftIO $ Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
     let getHandlers lspFuncs = do
             compilerH <- getIdeState (sendFunc lspFuncs) (makeLSPVFSHandle lspFuncs)
             pure $ Handlers (handleRequest loggerH compilerH) (handleNotification lspFuncs loggerH compilerH)

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -16,8 +16,8 @@ import           Development.IDE.LSP.Server
 
 import Control.Monad.IO.Class
 import qualified DA.Service.Daml.LanguageServer.CodeLens   as LS.CodeLens
-import qualified DA.Service.Daml.LanguageServer.Definition as LS.Definition
-import qualified DA.Service.Daml.LanguageServer.Hover      as LS.Hover
+import qualified Development.IDE.LSP.Definition as LS.Definition
+import qualified Development.IDE.LSP.Hover      as LS.Hover
 import qualified Development.IDE.Logger as Logger
 import DAML.Project.Consts
 

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -11,6 +11,7 @@ module DA.Cli.Damlc (main) where
 import Control.Monad.Except
 import Control.Monad.Extra (whenM)
 import DA.Cli.Damlc.Base
+import Control.Exception.Safe (catchIO)
 import Data.Maybe
 import Control.Exception
 import qualified "cryptonite" Crypto.Hash as Crypto
@@ -239,6 +240,8 @@ execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
         withScenarioService' enableScenarioService loggerH $ \mbScenarioService -> do
             -- TODO we should allow different LF versions in the IDE.
             execInit LF.versionDefault (ProjectOpts Nothing (ProjectCheck "" False)) (InitPkgDb True)
+            sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
+            Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
             Daml.LanguageServer.runLanguageServer (toIdeLogger loggerH)
                 (getIdeState opts mbScenarioService loggerH)
 


### PR DESCRIPTION
This patch:

* Moves things like Definition/Hover into haskell-ide-core
* Removes SDK version printing out of language-server
* Copy LanguageServer into haskell-ide-core dropping the daml: thing

We should clean up the LanguageServer to have an extensible virtual resource mechanism, but that's going to require some clever design and a greater understanding of what the current thing does.