### PR TITLE
Don't error on goto definition for another package

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Types/Options.hs
@@ -7,6 +7,7 @@
 module Development.IDE.Types.Options
   ( IdeOptions(..)
   , IdePkgLocationOptions(..)
+  , defaultIdePkgLocationOptions
   ) where
 
 import Development.Shake
@@ -38,3 +39,7 @@ data IdePkgLocationOptions = IdePkgLocationOptions
   -- used to lookup settings like importDirs. For DAML, we place them in the package DB.
   -- For cabal this could point somewhere in ~/.cabal/packages.
   }
+
+defaultIdePkgLocationOptions :: IdePkgLocationOptions
+defaultIdePkgLocationOptions = IdePkgLocationOptions f f
+    where f _ _ = return Nothing

--- a/compiler/haskell-ide-core/test/Demo.hs
+++ b/compiler/haskell-ide-core/test/Demo.hs
@@ -59,7 +59,7 @@ main = do
             ,optWriteIface = False
             ,optGhcSession = liftIO $ newSession' cradle
             ,optExtensions = ["hs"]
-            ,optPkgLocationOpts = error "optPkgLocationOpts not implemented yet"
+            ,optPkgLocationOpts = defaultIdePkgLocationOptions
             ,optThreads = 0
             ,optShakeProfiling = Nothing -- Just "output.html"
             }


### PR DESCRIPTION
Before we threw an error. Now we return Nothing.