### PR TITLE
Fixed SDK docs pointing to canton

### DIFF
--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -118,14 +118,11 @@ support for running DAML.
      - `Digital Asset <https://digitalasset.com/>`__
      - `PostgreSQL <https://www.postgresql.org/>`__ backend coming soon
        (`GitHub Milestone <https://github.com/digital-asset/daml/milestone/10>`__)
-   * - Canton
+   * - `Canton <https://www.canton.io>`__
      - In Development
      - `Digital Asset <https://digitalasset.com/>`__
      - native support for :doc:`DAML's fine-grained privacy model
-       </concepts/ledger-model/ledger-privacy>`; whitepaper coming soon
-       (contact `Ratko Veprek <mailto:ratko.veprek@digitalasset.com>`__  for a
-       preview)
-
+       </concepts/ledger-model/ledger-privacy>`
 
 .. _integration-kit_implementing:
 


### PR DESCRIPTION
Before, the section mentioned my name and didn't mention the web-page.
Now we point people directly to the Canton web-page.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
