### PR TITLE
Proposal - isParties: added instance for Optional to make it consistent with List

### DIFF
--- a/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/daml-foundations/daml-ghc/daml-stdlib-src/DA/Internal/Template.daml
@@ -179,6 +179,10 @@ instance IsParties Party where
 instance IsParties [Party] where
   toParties ps = ps
 
+instance IsParties (Optional Party) where
+  toParties None = []
+  toParties (Some p) = [p]
+
 class Template c => TemplateKey c k | c -> k where
     -- | The key of a contract.
     key : c -> k


### PR DESCRIPTION
I propose adding an instance of `IsParties` for `Optional` with behaviour consistent with List.

Alternatively we can put it in module `Optional` - although `Optional` feel intrinsic, so my pref is prelude.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
