### PR TITLE
Double gRPC limit in the scenario service

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 object ScenarioServiceMain extends App {
-  val maxMessageSize = 64 * 1024 * 1024 // 64MB
+  val maxMessageSize = 128 * 1024 * 1024 // 128MB
   val server =
     ServerBuilder
       .forPort(0) // any free port

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -15,6 +15,12 @@ Sandbox
 - Fixed a bug in an internal data structure that broke contract keys.
   See `#1623 <https://github.com/digital-asset/daml/issues/1623>`__.
 
+DAML Studio
+~~~~~~~~~~~
+
+- Double the gRPC message limit used for the scenario service. This
+  avoids issues on large projects.
+
 0.12.25 — 2019-06-13
 --------------------
 


### PR DESCRIPTION
This is a temporary fix to unblock users that have run into this
limit. The long-term solution here is to use compression and/or make
the limit configurable.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
