### PR TITLE
Simplify daml version output

### DIFF
--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -146,7 +146,7 @@ handleCommand env@Env{..} = \case
             envVersions = catMaybes
                 [ envSdkVersion
                 , envLatestStableSdkVersion
-                , asstVersion
+                , guard vAssistant >> asstVersion
                 ]
 
             latestVersionM
@@ -159,14 +159,14 @@ handleCommand env@Env{..} = \case
                     Right vs -> (`elem` vs)
 
             versionAttrs v = catMaybes
-                [ "active"
-                    <$ guard (Just v == envSdkVersion)
-                , "default"
-                    <$ guard (Just v == defaultVersionM)
-                , "assistant"
-                    <$ guard (Just v == asstVersion)
+                [ "project SDK version from daml.yaml"
+                    <$ guard (Just v == envSdkVersion && isJust envProjectPath)
+                , "default SDK version for new projects"
+                    <$ guard (Just v == defaultVersionM && isNothing envProjectPath)
+                , "daml assistant version"
+                    <$ guard (Just v == asstVersion && vAssistant)
                 , "latest release"
-                    <$ guard (Just v == latestVersionM)
+                    <$ guard (Just v == latestVersionM && not (isInstalled v))
                 , "not installed"
                     <$ guard (not (isInstalled v))
                 ]

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -157,9 +157,14 @@ handleCommand env@Env{..} = \case
                 , envVersions
                 ]
 
-            isInstalled =
+            isNotInstalled = -- defaults to False if "installed version" list is not available
                 case installedVersionsE of
-                    Left _ -> const True
+                    Left _ -> const False
+                    Right vs -> (`notElem` vs)
+
+            isAvailable = -- defaults to False if "available version" list is not available
+                case availableVersionsE of
+                    Left _ -> const False
                     Right vs -> (`elem` vs)
 
             versionAttrs v = catMaybes
@@ -170,9 +175,9 @@ handleCommand env@Env{..} = \case
                 , "daml assistant version"
                     <$ guard (Just v == asstVersion && vAssistant)
                 , "latest release"
-                    <$ guard (Just v == latestVersionM && not (isInstalled v))
+                    <$ guard (Just v == latestVersionM && isNotInstalled v && isAvailable v)
                 , "not installed"
-                    <$ guard (not (isInstalled v))
+                    <$ guard (isNotInstalled v)
                 ]
 
             versions = nubSort . concat $

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -141,12 +141,15 @@ handleCommand env@Env{..} = \case
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
         availableVersionsE <- tryAssistant $ refreshAvailableSdkVersions envDamlPath
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
+        projectVersionM <- mapM getSdkVersionFromProjectPath envProjectPath
 
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion
             envVersions = catMaybes
                 [ envSdkVersion
                 , envLatestStableSdkVersion
                 , guard vAssistant >> asstVersion
+                , projectVersionM
+                , defaultVersionM
                 ]
 
             latestVersionM
@@ -160,7 +163,7 @@ handleCommand env@Env{..} = \case
 
             versionAttrs v = catMaybes
                 [ "project SDK version from daml.yaml"
-                    <$ guard (Just v == envSdkVersion && isJust envProjectPath)
+                    <$ guard (Just v == projectVersionM && isJust envProjectPath)
                 , "default SDK version for new projects"
                     <$ guard (Just v == defaultVersionM && isNothing envProjectPath)
                 , "daml assistant version"

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -25,7 +25,6 @@ import Data.List.Extra
 import Data.Either.Extra
 import qualified Data.Text as T
 import Control.Monad.Extra
-import Control.Applicative
 import Safe
 
 -- | Run the assistant and exit.
@@ -152,9 +151,11 @@ handleCommand env@Env{..} = \case
                 , defaultVersionM
                 ]
 
-            latestVersionM
-                = maximumMay (fromRight [] availableVersionsE)
-                <|> envLatestStableSdkVersion
+            latestVersionM = maximumMay $ concat
+                [ fromRight [] availableVersionsE
+                , fromRight [] installedVersionsE
+                , envVersions
+                ]
 
             isInstalled =
                 case installedVersionsE of

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -80,6 +80,7 @@ commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
 versionParser :: Parser VersionOptions
 versionParser = VersionOptions
     <$> flagYesNoAuto "all" False "Display all available versions." idm
+    <*> flagYesNoAuto "assistant" False "Display DAML assistant version." idm
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions
@@ -94,7 +95,6 @@ installParser = InstallOptions
 uninstallParser :: Parser SdkVersion
 uninstallParser =
     argument readSdkVersion (metavar "VERSION" <> help "The SDK version to uninstall.")
-
 
 readSdkVersion :: ReadM SdkVersion
 readSdkVersion =

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -76,6 +76,7 @@ newtype UserCommandArgs = UserCommandArgs
 -- | Command-line options for daml version command.
 data VersionOptions = VersionOptions
     { vAll :: Bool -- ^ list all available versions
+    , vAssistant :: Bool -- ^ show assistant version
     } deriving (Eq, Show)
 
 -- | Command-line options for daml install command.


### PR DESCRIPTION
Goal is to make the output of `daml version` less confusing and more self-evident. To this end:

* Explain `active`, `default`, `assistant` tags in words (`project SDK version from daml.yaml`, `default SDK version for new projects`, `daml assistant version` respectively)
* Only show tags when relevant:
    * `project SDK version from daml.yaml` is only shown when in a project
    * `default SDK version for new projects` is only shown when not in a project
    * `daml assistant version` is only shown when requested with `--assistant` flag
    * `latest release` is only shown when the latest released version isn't yet installed
 