### PR TITLE
Remove exposed-modules from skeleton project

### DIFF
--- a/templates/skeleton/daml.yaml.template
+++ b/templates/skeleton/daml.yaml.template
@@ -6,8 +6,6 @@ parties:
   - Alice
   - Bob
 version: 1.0.0
-exposed-modules:
-  - Main
 dependencies:
   - daml-prim
   - daml-stdlib


### PR DESCRIPTION
This leads to build errors if `Main` is changed to something else and appears to confuse users.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
