### PR TITLE
added missing closure for checkpointQueue in SqlLedger

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -14,6 +14,8 @@ Sandbox
 
 - Fixed a bug in an internal data structure that broke contract keys.
   See `#1623 <https://github.com/digital-asset/daml/issues/1623>`__.
+- Fixed a bug of not closing a resource properly when shutting down the Sandbox.
+  See `#1702 <https://github.com/digital-asset/daml/pull/1702>`__.
 
 0.12.25 — 2019-06-13
 --------------------

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -210,6 +210,7 @@ private class SqlLedger(
 
   override def close(): Unit = {
     persistenceQueue.complete()
+    checkpointQueue.complete()
     ledgerDao.close()
   }
 


### PR DESCRIPTION
The `checkpointQueue` in `SqlLedger` was not closed properly causing annoying errors like: ```ERROR c.d.p.s.stores.ledger.sql.SqlLedger - checkpoint queue has been closed with a failure! 
akka.stream.StreamDetachedException: Stream is terminated. Materialized value is detached.``` when stopping the Sandbox.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
