### PR TITLE
Allow slashes in ledger strings

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -164,7 +164,7 @@ object Ref {
     * construct some by concatenating the others.
     */
   // We allow space because the navigator's applicationId used it.
-  val LedgerString = ConcatenableMatchingStringModule("._:-# ".contains(_), 255)
+  val LedgerString = ConcatenableMatchingStringModule("._:-#/ ".contains(_), 255)
   type LedgerString = LedgerString.T
 
   /** Identifier for a contractId */

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -75,7 +75,7 @@ class RefTest extends FreeSpec with Matchers {
 
     val packageIdChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ "
     val partyIdChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:-_ "
-    val ledgerStringChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-# "
+    val ledgerStringChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-#/ "
 
     def makeString(c: Char): String = s"the character $c is not US-ASCII"
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -21,6 +21,12 @@ DAML Studio
 - Double the gRPC message limit used for the scenario service. This
   avoids issues on large projects.
 
+Ledger API
+~~~~~~~~~~
+
+- Slash (/) is now an allowed character in contract, workflow, application
+  and command identifiers.
+
 0.12.25 — 2019-06-13
 --------------------
 

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/value.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/value.proto
@@ -20,7 +20,7 @@ option java_package = "com.digitalasset.ledger.api.v1";
 // - NameStrings are strings that match the regexp ``[A-Za-z\$_][A-Za-z0-9\$_]*``.
 // - PackageIdStrings are strings that match the regexp ``[A-Za-z0-9\-_ ]+``.
 // - PartyIdStrings are strings that match the regexp ``[A-Za-z0-9:\-_ ]+``.
-// - LedgerStrings are strings that match the regexp ``[A-Za-z0-9#:\-_ ]+``.
+// - LedgerStrings are strings that match the regexp ``[A-Za-z0-9#:\-_/ ]+``.
 //
 message Value {
   oneof Sum {


### PR DESCRIPTION
Using '/' as the divider is a natural choice for some ledger backend
implementations and in application/workflow etc. identifiers.

Root cause for this change was use of a slash in contract identifiers in one
of the ledger integrations.

I'd like this to land in 0.13.0 (#1704).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
