### PR TITLE
Don't pass the same argument twice

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/Functions/Compile.hs
@@ -133,14 +133,13 @@ getPackage dflags p =
 -- | Typecheck a single module using the supplied dependencies and packages.
 typecheckModule
     :: IdeOptions
-    -> ParsedModule
     -> HscEnv
     -> [TcModuleResult]
     -> ParsedModule
     -> IO ([FileDiagnostic], Maybe TcModuleResult)
-typecheckModule opt mod packageState deps pm =
+typecheckModule opt packageState deps pm =
     fmap (either (, Nothing) (second Just)) $ Ex.runExceptT $
-    runGhcSessionExcept opt (Just mod) packageState $
+    runGhcSessionExcept opt (Just pm) packageState $
         catchSrcErrors $ do
             setupEnv deps
             (warnings, tcm) <- withWarnings "Typechecker" $ \tweak ->

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -288,7 +288,7 @@ typeCheckRule =
         setPriority PriorityTypeCheck
         packageState <- use_ GhcSession ""
         opt <- getOpts
-        liftIO $ Compile.typecheckModule opt pm packageState tms pm
+        liftIO $ Compile.typecheckModule opt packageState tms pm
 
 
 generateCoreRule :: Rules ()


### PR DESCRIPTION
We passed an identical argument twice, then used different versions of it in different places.