### PR TITLE
Load core-package dependencies in da-ghci

### DIFF
--- a/bazel_tools/haskell_ghci_repl_toolchain_lib.patch
+++ b/bazel_tools/haskell_ghci_repl_toolchain_lib.patch
@@ -1,0 +1,65 @@
+diff --git a/haskell/private/haskell_impl.bzl b/haskell/private/haskell_impl.bzl
+index 42f9f0f..af58c03 100644
+--- a/haskell/private/haskell_impl.bzl
++++ b/haskell/private/haskell_impl.bzl
+@@ -689,10 +689,14 @@ def haskell_import_impl(ctx):
+         # XXX Empty set of conf and cache files only works for global db.
+         package_databases = set.empty(),
+         version_macros = version_macros,
++        source_files = set.empty(),
++        import_dirs = depset(),
++        extra_source_files = depset(),
+         static_libraries = [],
+         static_libraries_prof = [],
+         dynamic_libraries = set.empty(),
+         interface_dirs = set.empty(),
++        compile_flags = [],
+         prebuilt_dependencies = set.empty(),
+         direct_prebuilt_deps = set.empty(),
+         cc_dependencies = empty_HaskellCcInfo(),
+diff --git a/haskell/repl.bzl b/haskell/repl.bzl
+index 4746d3c..fa57cf8 100644
+--- a/haskell/repl.bzl
++++ b/haskell/repl.bzl
+@@ -1,5 +1,6 @@
+ """Multi target Haskell REPL."""
+ 
++load("@bazel_skylib//lib:dicts.bzl", "dicts")
+ load("@bazel_skylib//lib:paths.bzl", "paths")
+ load("@bazel_skylib//lib:shell.bzl", "shell")
+ load("@io_tweag_rules_haskell//haskell:private/context.bzl", "haskell_context", "render_env")
+@@ -250,6 +251,7 @@ def _create_repl(hs, ctx, repl_info, output):
+         repl_info.transitive_cc_dependencies,
+         path_prefix = "$RULES_HASKELL_EXEC_ROOT",
+     )
++    ghc_env = dicts.add(hs.env, ghc_env)
+     library_path = [paths.dirname(lib.path) for lib in library_deps]
+     ld_library_path = [paths.dirname(lib.path) for lib in ld_library_deps]
+ 
+@@ -319,6 +321,8 @@ def _create_repl(hs, ctx, repl_info, output):
+     extra_inputs.extend(set.to_list(repl_info.dep_info.package_databases))
+     extra_inputs.extend(library_deps)
+     extra_inputs.extend(ld_library_deps)
++    if hs.toolchain.locale_archive:
++        extra_inputs.append(hs.toolchain.locale_archive)
+     return [DefaultInfo(
+         executable = output,
+         runfiles = ctx.runfiles(
+@@ -328,13 +332,15 @@ def _create_repl(hs, ctx, repl_info, output):
+     )]
+ 
+ def _haskell_repl_aspect_impl(target, ctx):
+-    if HaskellInfo not in target or HaskellPrebuiltPackageInfo in target:
++    if HaskellInfo not in target:
+         return []
+ 
+     target_info = _create_HaskellReplCollectInfo(target, ctx)
+     deps_infos = [
+         dep[HaskellReplCollectInfo]
+-        for dep in ctx.rule.attr.deps
++        for deps in [getattr(ctx.rule.attr, "deps", None)]
++        if deps
++        for dep in deps
+         if HaskellReplCollectInfo in dep
+     ]
+     collect_info = _merge_HaskellReplCollectInfo([target_info] + deps_infos)

--- a/compiler/haskell-ide-core/BUILD.bazel
+++ b/compiler/haskell-ide-core/BUILD.bazel
@@ -57,16 +57,16 @@ da_haskell_library(
     name = "haskell-ide-core-public",
     srcs = glob(["src/**/*.hs"]),
     compiler_flags = ["-DGHC_STABLE"],
+    hazel_deps = depends + [
+        "ghc",
+        "ghc-boot",
+        "ghc-boot-th",
+    ],
     # Override the -hide-package flags defined in WORKSPACE
     #   -hide-package=ghc-boot-th -hide-package=ghc-boot
     repl_ghci_args = [
         "-package=ghc-boot",
         "-package=ghc-boot-th",
-    ],
-    hazel_deps = depends + [
-        "ghc",
-        "ghc-boot",
-        "ghc-boot-th",
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],

--- a/compiler/haskell-ide-core/BUILD.bazel
+++ b/compiler/haskell-ide-core/BUILD.bazel
@@ -57,6 +57,12 @@ da_haskell_library(
     name = "haskell-ide-core-public",
     srcs = glob(["src/**/*.hs"]),
     compiler_flags = ["-DGHC_STABLE"],
+    # Override the -hide-package flags defined in WORKSPACE
+    #   -hide-package=ghc-boot-th -hide-package=ghc-boot
+    repl_ghci_args = [
+        "-package=ghc-boot",
+        "-package=ghc-boot-th",
+    ],
     hazel_deps = depends + [
         "ghc",
         "ghc-boot",

--- a/deps.bzl
+++ b/deps.bzl
@@ -46,6 +46,10 @@ def daml_deps():
                 "@com_github_digital_asset_daml//bazel_tools:haskell-drop-fake-static.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell-keep-hs-extra-libs.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell_public_ghci_repl_wrapper.patch",
+                # XXX: Remove once rules_haskell is upgraded to include
+                #   https://github.com/tweag/rules_haskell/pull/950 and
+                #   https://github.com/tweag/rules_haskell/pull/952
+                "@com_github_digital_asset_daml//bazel_tools:haskell_ghci_repl_toolchain_lib.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,

--- a/dev-env/bin/da-ghcid
+++ b/dev-env/bin/da-ghcid
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Bazel aware wrapper for ghcid
+
+Calls ghcid on da-ghci on the given target. See da-ghci --help for further information.
+
+To pass additional arguments to da-ghci use the following form:
+
+    da-ghcid //my:target -- -package extra-package
+
 """
 
 import argparse


### PR DESCRIPTION
Closes #1656

- Load core-package dependencies in `haskell_repl` `ghci`.
- Fix locale issue in ghci.
- Clarify how to pass arguments to ghci in `da-ghcid`.
    > Would also be great if da-ghcid could pass GHC flags on to da-ghci, just like da-ghci already can.

    @neil-da This is already possible using `da-ghcid -- <extra args>`. I've add this to the help message.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
