### PR TITLE
debugging perf-test failures

### DIFF
--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/LargeTransactionBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/LargeTransactionBench.scala
@@ -4,9 +4,8 @@
 package com.digitalasset.platform.sandbox.perf
 
 import com.digitalasset.platform.PlatformApplications
+import com.digitalasset.platform.sandbox.perf.TestHelper._
 import org.openjdk.jmh.annotations._
-
-import TestHelper._
 
 import scala.concurrent.Await
 
@@ -51,10 +50,18 @@ class LargeTransactionBench {
   //note that when running this with Postgres the bottleneck seems to originate from the fact the we traverse the huge
   //Transaction and execute SQL queries one after another. We could potentially partition the transaction so we can have batch queries instead.
   @Benchmark
-  def manySmallContracts(state: RangeOfIntsCreatedState): Unit =
-    Await.result(
-      rangeOfIntsExerciseCommand(state, state.workflowId, "ToListOfIntContainers", None),
-      perfTestTimeout)
+  def manySmallContracts(state: RangeOfIntsCreatedState): Unit = {
+    try {
+      Await.result(
+        rangeOfIntsExerciseCommand(state, state.workflowId, "ToListOfIntContainers", None),
+        perfTestTimeout)
+    } catch {
+      case t: Throwable => //TODO: this is just temporary to debug flakiness
+        println(s"manySmallContracts bench blew up! ${t.getMessage} ")
+        t.printStackTrace()
+        throw t
+    }
+  }
 
   @Benchmark
   def listOfNInts(state: ListOfNIntsCreatedState): Unit =


### PR DESCRIPTION
Putting some debug entries around the postgres fixture so we can see a bit more info when the interrupt comes during a failed perf-test run.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
