### PR TITLE
Ledger API tests: option for non-unique identifiers

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
@@ -7,8 +7,16 @@ import akka.stream.scaladsl.Sink
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString}
 import com.digitalasset.daml.lf.value.Value
-import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ValueContractId, ValueParty, ValueRecord}
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundEach}
+import com.digitalasset.daml.lf.value.Value.{
+  AbsoluteContractId,
+  ValueContractId,
+  ValueParty,
+  ValueRecord
+}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  SuiteResourceManagementAroundEach
+}
 import com.digitalasset.ledger.api.v1
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.commands._
@@ -16,7 +24,12 @@ import com.digitalasset.ledger.api.v1.ledger_offset._
 import com.digitalasset.ledger.api.v1.transaction_filter._
 import com.digitalasset.ledger.client.services.acs.ActiveContractSetClient
 import com.digitalasset.ledger.client.services.transactions.TransactionClient
-import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestIdsGenerator, TestTemplateIds}
+import com.digitalasset.platform.apitesting.{
+  LedgerContext,
+  MultiLedgerFixture,
+  TestIdsGenerator,
+  TestTemplateIds
+}
 import com.digitalasset.platform.participant.util.LfEngineToApi
 import com.google.protobuf.timestamp.Timestamp
 import org.scalatest.Inside.inside
@@ -151,7 +164,7 @@ class DivulgenceIT
   private def createDivulgence1(ctx: LedgerContext, workflowId: String): Future[ContractIdString] =
     create(
       ctx,
-      s"create-Divulgence1-$runSuffix",
+      commandIdUnifier("create-Divulgence1"),
       workflowId,
       "alice",
       templateIds.divulgence1,
@@ -161,7 +174,7 @@ class DivulgenceIT
   private def createDivulgence2(ctx: LedgerContext, workflowId: String): Future[ContractIdString] =
     create(
       ctx,
-      s"create-Divulgence2-$runSuffix",
+      s"create-Divulgence2-${runCommandSuffix}",
       workflowId,
       "bob",
       templateIds.divulgence2,
@@ -179,7 +192,7 @@ class DivulgenceIT
       workflowId: String): Future[Unit] =
     exercise(
       ctx,
-      s"exercise-Divulgence2Fetch-$runSuffix",
+      s"exercise-Divulgence2Fetch-${runCommandSuffix}",
       workflowId,
       "alice",
       templateIds.divulgence2,
@@ -197,7 +210,7 @@ class DivulgenceIT
       workflowId: String): Future[Unit] =
     exercise(
       ctx,
-      s"exercise-Divulgence2Fetch-$runSuffix",
+      s"exercise-Divulgence2Fetch-${runCommandSuffix}",
       workflowId,
       "alice",
       templateIds.divulgence2,
@@ -217,7 +230,7 @@ class DivulgenceIT
     Map("alice" -> Filters.defaultInstance, "bob" -> Filters.defaultInstance))
 
   "should not expose divulged contracts in flat stream" in allFixtures { ctx =>
-    val wfid = s"divulgence-test-workflow-id-$runSuffix"
+    val wfid = workflowIdUnifier("divulgence-test-workflow-id")
     for {
       beforeTest <- transactionClient(ctx).getLedgerEnd.map(_.getOffset)
       div1Cid <- createDivulgence1(ctx, wfid)
@@ -310,7 +323,7 @@ class DivulgenceIT
   }
 
   "should not expose divulged contracts in ACS" in allFixtures { ctx =>
-    val wfid = s"divulgence-test-workflow-id-$runSuffix"
+    val wfid = workflowIdUnifier("divulgence-test-workflow-id")
     for {
       beforeTest <- transactionClient(ctx).getLedgerEnd.map(_.getOffset)
       div1Cid <- createDivulgence1(ctx, wfid)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
@@ -44,7 +44,6 @@ class DivulgenceIT
     extends AsyncFreeSpec
     with AkkaBeforeAndAfterAll
     with MultiLedgerFixture
-    with TestIdsGenerator
     with SuiteResourceManagementAroundEach
     with ScalaFutures
     with AsyncTimeLimitedTests
@@ -54,6 +53,7 @@ class DivulgenceIT
 
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
+  protected val testIdsGenerator = new TestIdsGenerator(config)
 
   private implicit def party(s: String): Ref.Party = Ref.Party.assertFromString(s)
   private implicit def pkgId(s: String): Ref.PackageId = Ref.PackageId.assertFromString(s)
@@ -164,7 +164,7 @@ class DivulgenceIT
   private def createDivulgence1(ctx: LedgerContext, workflowId: String): Future[ContractIdString] =
     create(
       ctx,
-      commandIdUnifier("create-Divulgence1"),
+      testIdsGenerator.testCommandId("create-Divulgence1"),
       workflowId,
       "alice",
       templateIds.divulgence1,
@@ -174,7 +174,7 @@ class DivulgenceIT
   private def createDivulgence2(ctx: LedgerContext, workflowId: String): Future[ContractIdString] =
     create(
       ctx,
-      s"create-Divulgence2-${runCommandSuffix}",
+      testIdsGenerator.testCommandId("create-Divulgence2"),
       workflowId,
       "bob",
       templateIds.divulgence2,
@@ -192,7 +192,7 @@ class DivulgenceIT
       workflowId: String): Future[Unit] =
     exercise(
       ctx,
-      s"exercise-Divulgence2Fetch-${runCommandSuffix}",
+      testIdsGenerator.testCommandId("exercise-Divulgence2Fetch"),
       workflowId,
       "alice",
       templateIds.divulgence2,
@@ -210,7 +210,7 @@ class DivulgenceIT
       workflowId: String): Future[Unit] =
     exercise(
       ctx,
-      s"exercise-Divulgence2Fetch-${runCommandSuffix}",
+      testIdsGenerator.testCommandId("exercise-Divulgence2Fetch"),
       workflowId,
       "alice",
       templateIds.divulgence2,
@@ -230,7 +230,7 @@ class DivulgenceIT
     Map("alice" -> Filters.defaultInstance, "bob" -> Filters.defaultInstance))
 
   "should not expose divulged contracts in flat stream" in allFixtures { ctx =>
-    val wfid = workflowIdUnifier("divulgence-test-workflow-id")
+    val wfid = testIdsGenerator.testWorkflowId("divulgence-test-workflow-id")
     for {
       beforeTest <- transactionClient(ctx).getLedgerEnd.map(_.getOffset)
       div1Cid <- createDivulgence1(ctx, wfid)
@@ -323,7 +323,7 @@ class DivulgenceIT
   }
 
   "should not expose divulged contracts in ACS" in allFixtures { ctx =>
-    val wfid = workflowIdUnifier("divulgence-test-workflow-id")
+    val wfid = testIdsGenerator.testWorkflowId("divulgence-test-workflow-id")
     for {
       beforeTest <- transactionClient(ctx).getLedgerEnd.map(_.getOffset)
       div1Cid <- createDivulgence1(ctx, wfid)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/DivulgenceIT.scala
@@ -3,22 +3,12 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api
 
-import java.util.UUID
-
 import akka.stream.scaladsl.Sink
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString}
 import com.digitalasset.daml.lf.value.Value
-import com.digitalasset.daml.lf.value.Value.{
-  AbsoluteContractId,
-  ValueContractId,
-  ValueParty,
-  ValueRecord
-}
-import com.digitalasset.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  SuiteResourceManagementAroundEach
-}
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ValueContractId, ValueParty, ValueRecord}
+import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundEach}
 import com.digitalasset.ledger.api.v1
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.commands._
@@ -26,7 +16,7 @@ import com.digitalasset.ledger.api.v1.ledger_offset._
 import com.digitalasset.ledger.api.v1.transaction_filter._
 import com.digitalasset.ledger.client.services.acs.ActiveContractSetClient
 import com.digitalasset.ledger.client.services.transactions.TransactionClient
-import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestTemplateIds}
+import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestIdsGenerator, TestTemplateIds}
 import com.digitalasset.platform.participant.util.LfEngineToApi
 import com.google.protobuf.timestamp.Timestamp
 import org.scalatest.Inside.inside
@@ -41,6 +31,7 @@ class DivulgenceIT
     extends AsyncFreeSpec
     with AkkaBeforeAndAfterAll
     with MultiLedgerFixture
+    with TestIdsGenerator
     with SuiteResourceManagementAroundEach
     with ScalaFutures
     with AsyncTimeLimitedTests
@@ -156,8 +147,6 @@ class DivulgenceIT
   // check that this divulgence is not visible in the ACS / flat transaction stream,
   // but that it is visible in the transaction trees.
   case class Setup(div1Cid: String, div2Cid: String)
-
-  private val runSuffix: UUID = UUID.randomUUID
 
   private def createDivulgence1(ctx: LedgerContext, workflowId: String): Future[ContractIdString] =
     create(

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
@@ -41,16 +41,16 @@ class PackageManagementServiceIT
     extends AsyncFreeSpec
     with AkkaBeforeAndAfterAll
     with MultiLedgerFixture
-    with TestIdsGenerator
     with SuiteResourceManagementAroundAll
     with AsyncTimeLimitedTests
     with Matchers
     with BazelRunfiles {
 
   override protected def config: Config = Config.default.copy(darFiles = Nil)
+  protected val testIdsGenerator = new TestIdsGenerator(config)
 
   private def commandNodeIdUnifier(testName: String, nodeId: String) =
-    commandIdUnifier(s"ledger-api-test-tool-$testName-$nodeId")
+    testIdsGenerator.testCommandId(s"ledger-api-test-tool-$testName-$nodeId")
 
   private def packageManagementService(stub: PackageManagementService): PackageManagementClient =
     new PackageManagementClient(stub)
@@ -134,7 +134,7 @@ class PackageManagementServiceIT
   }
 
   "should accept commands using the uploaded package" in allFixtures { ctx =>
-    val party = partyNameUnifier("operator")
+    val party = testIdsGenerator.testPartyName("operator")
     val createArg = Record(fields = List(RecordField("operator", party.asParty)))
     def createCmd =
       CreateCommand(Some(Identifier(testPackageId, "", "Test", "Dummy")), Some(createArg)).wrap

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
@@ -13,7 +13,11 @@ import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml_lf.DamlLf.Archive
 
 import scala.util.Try
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, IsStatusException, SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  IsStatusException,
+  SuiteResourceManagementAroundAll
+}
 import com.digitalasset.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc.PackageManagementService
 import com.digitalasset.ledger.api.v1.commands.CreateCommand
 import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
@@ -141,7 +145,8 @@ class PackageManagementServiceIT
       _ <- client.uploadDarFile(ByteString.copyFrom(testDarBytes))
       createTx <- ctx.testingHelpers.submitAndListenForSingleResultOfCommand(
         ctx.testingHelpers
-          .submitRequestWithId(commandNodeIdUnifier("PackageManagementServiceIT_commands", "create"))
+          .submitRequestWithId(
+            commandNodeIdUnifier("PackageManagementServiceIT_commands", "create"))
           .update(
             _.commands.commands := List(createCmd),
             _.commands.party := party

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
@@ -8,7 +8,10 @@ import java.time.Instant
 import akka.stream.scaladsl.Sink
 import com.digitalasset.api.util.TimestampConversion.fromInstant
 import com.digitalasset.grpc.adapter.client.akka.ClientAdapter
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  SuiteResourceManagementAroundAll
+}
 import com.digitalasset.ledger.api.v1.testing.time_service.{GetTimeRequest, SetTimeRequest}
 import com.digitalasset.platform.apitesting.MultiLedgerFixture
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
@@ -8,10 +8,7 @@ import java.time.Instant
 import akka.stream.scaladsl.Sink
 import com.digitalasset.api.util.TimestampConversion.fromInstant
 import com.digitalasset.grpc.adapter.client.akka.ClientAdapter
-import com.digitalasset.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  SuiteResourceManagementAroundAll
-}
+import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
 import com.digitalasset.ledger.api.v1.testing.time_service.{GetTimeRequest, SetTimeRequest}
 import com.digitalasset.platform.apitesting.MultiLedgerFixture
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
@@ -21,7 +18,6 @@ import org.scalatest._
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-
 import scalaz.syntax.tag._
 
 @SuppressWarnings(

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -72,13 +72,10 @@ class TransactionServiceIT
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
 
-  val runSuffix = "-" + Random.alphanumeric.take(10).mkString
-  val partyNameMangler =
-    (partyText: String) => partyText + runSuffix + Random.alphanumeric.take(10).mkString
+  val runSuffix = if (config.uniqueIdentifiers) "-" + Random.alphanumeric.take(10).mkString else ""
+  val partyNameMangler = (partyText: String) => partyText + runSuffix
   val commandIdMangler: ((QualifiedName, Int, Ledger.ScenarioNodeId) => String) =
-    (testName, stepId, nodeId) => {
-      s"ledger-api-test-tool-$testName-$stepId-$nodeId-$runSuffix"
-    }
+    (scenario, stepId, nodeId) => s"ledger-api-test-tool-$scenario-$stepId-${nodeId}${runSuffix}"
 
   override val timeLimit: Span = scaled(300.seconds)
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -11,7 +11,12 @@ import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{EventId, LedgerId}
 import com.digitalasset.ledger.api.testing.utils.MockMessages.{party, _}
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, IsStatusException, MockMessages, SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  IsStatusException,
+  MockMessages,
+  SuiteResourceManagementAroundAll
+}
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.commands.Command.Command.Create
 import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
@@ -28,7 +33,12 @@ import com.digitalasset.ledger.client.services.commands.CommandUpdater
 import com.digitalasset.ledger.client.services.transactions.TransactionClient
 import com.digitalasset.platform.api.v1.event.EventOps._
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
-import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestIdsGenerator, TestTemplateIds}
+import com.digitalasset.platform.apitesting.{
+  LedgerContext,
+  MultiLedgerFixture,
+  TestIdsGenerator,
+  TestTemplateIds
+}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
@@ -309,7 +319,7 @@ class TransactionServiceIT
       "expose transactions to non-submitting stakeholders without the commandId" in allFixtures {
         c =>
           c.submitCreateAndReturnTransaction(
-              s"Checking_commandId_visibility_for_non-submitter_party-${runCommandSuffix}",
+              commandIdUnifier("Checking_commandId_visibility_for_non-submitter_party"),
               templateIds.agreementFactory,
               List("receiver" -> party1.asParty, "giver" -> party2.asParty).asRecordFields,
               party2,
@@ -320,7 +330,7 @@ class TransactionServiceIT
       }
 
       "expose only the requested templates to the client" in allFixtures { context =>
-        val commandId = s"Client_should_see_only_the_Dummy_create-${runCommandSuffix}"
+        val commandId = commandIdUnifier("Client_should_see_only_the_Dummy_create")
         val templateInSubscription = templateIds.dummy
         val otherTemplateCreated = templateIds.dummyFactory
         for {
@@ -343,8 +353,8 @@ class TransactionServiceIT
 
       "expose contract Ids that are ready to be used for exercising choices" in allFixtures {
         context =>
-          val factoryCreation = s"Creating_factory-${runCommandSuffix}"
-          val exercisingChoice = s"Exercising_choice_on_factory-${runCommandSuffix}"
+          val factoryCreation = commandIdUnifier("Creating_factory")
+          val exercisingChoice = commandIdUnifier("Exercising_choice_on_factory")
           val exercisedTemplate = templateIds.dummyFactory
           for {
             createdEvent <- context.submitCreate(
@@ -369,8 +379,8 @@ class TransactionServiceIT
 
       "expose contract Ids that are results of exercising choices when filtering by template" in allFixtures {
         context =>
-          val factoryCreation = s"Creating_second_factory-${runCommandSuffix}"
-          val exercisingChoice = s"Exercising_choice_on_second_factory-${runCommandSuffix}"
+          val factoryCreation = commandIdUnifier("Creating_second_factory")
+          val exercisingChoice = commandIdUnifier("Exercising_choice_on_second_factory")
           val exercisedTemplate = templateIds.dummyFactory
           for {
             creation <- context.submitCreate(
@@ -413,7 +423,7 @@ class TransactionServiceIT
       "reject exercising a choice where an assertion fails" in allFixtures { c =>
         for {
           dummy <- c.submitCreate(
-            s"Create_for_assertion_failing_test-${runCommandSuffix}",
+            commandIdUnifier("Create_for_assertion_failing_test"),
             templateIds.dummy,
             List("operator" -> party.asParty).asRecordFields,
             party)
@@ -442,7 +452,7 @@ class TransactionServiceIT
         val expectedArg = paramShowcaseArgsWithoutLabels
         for {
           create <- c.submitCreate(
-            s"Creating_contract_with_a_multitude_of_param_types-${runCommandSuffix}",
+            commandIdUnifier("Creating_contract_with_a_multitude_of_param_types"),
             template,
             paramShowcaseArgs(templateIds.testPackageId),
             "party",
@@ -459,7 +469,7 @@ class TransactionServiceIT
 
         for {
           create <- c.submitCreate(
-            s"Creating_contract_with_a_multitude_of_verbose_param_types-${runCommandSuffix}",
+            commandIdUnifier("Creating_contract_with_a_multitude_of_verbose_param_types"),
             template,
             arg,
             "party",
@@ -512,7 +522,7 @@ class TransactionServiceIT
         val template = templateIds.parameterShowcase
         for {
           create <- c.submitCreate(
-            s"Huge_command_with_a_long_list-${runCommandSuffix}",
+            commandIdUnifier("Huge_command_with_a_long_list"),
             template,
             arg,
             "party"
@@ -527,7 +537,7 @@ class TransactionServiceIT
         val giver = "Alice"
         for {
           created <- c.submitCreateWithListenerAndReturnEvent(
-            s"Creating_Agreement_Factory-${runCommandSuffix}",
+            commandIdUnifier("Creating_Agreement_Factory"),
             templateIds.agreementFactory,
             List("receiver" -> receiver.asParty, "giver" -> giver.asParty).asRecordFields,
             giver,
@@ -536,7 +546,7 @@ class TransactionServiceIT
 
           choiceResult <- c.testingHelpers.submitAndListenForSingleResultOfCommand(
             c.command(
-                s"Calling_non-consuming_choice-${runCommandSuffix}",
+                commandIdUnifier("Calling_non-consuming_choice"),
                 List(
                   ExerciseCommand(
                     Some(templateIds.agreementFactory),
@@ -562,7 +572,7 @@ class TransactionServiceIT
 
         for {
           branchingSignatories <- c.submitCreateWithListenerAndReturnEvent(
-            s"BranchingSignatoriesTrue-${runCommandSuffix}",
+            commandIdUnifier("BranchingSignatoriesTrue"),
             templateIds.branchingSignatories,
             branchingSignatoriesArg,
             party1,
@@ -576,7 +586,7 @@ class TransactionServiceIT
         val branchingSignatoriesArg =
           getBranchingSignatoriesArg(false, party1, party2)
         c.submitCreateWithListenerAndAssertNotVisible(
-          s"BranchingSignatoriesFalse-${runCommandSuffix}",
+          commandIdUnifier("BranchingSignatoriesFalse"),
           templateIds.branchingSignatories,
           branchingSignatoriesArg,
           party2,
@@ -589,7 +599,7 @@ class TransactionServiceIT
         val expectedArg = branchingControllersArgs.map(_.copy(label = ""))
         for {
           branchingControllers <- c.submitCreateWithListenerAndReturnEvent(
-            s"BranchingControllersTrue-${runCommandSuffix}",
+            commandIdUnifier("BranchingControllersTrue"),
             templateId,
             branchingControllersArgs,
             party1,
@@ -604,7 +614,7 @@ class TransactionServiceIT
         val branchingControllersArgs =
           getBranchingControllerArgs(party1, party2, party3, false)
         c.submitCreateWithListenerAndAssertNotVisible(
-          s"BranchingControllersFalse-${runCommandSuffix}",
+          commandIdUnifier("BranchingControllersFalse"),
           templateId,
           branchingControllersArgs,
           party1,
@@ -624,7 +634,7 @@ class TransactionServiceIT
           .sequence(observers.map(observer =>
             for {
               withObservers <- c.submitCreateWithListenerAndReturnEvent(
-                s"Obs1create:${observer}-${runCommandSuffix}",
+                commandIdUnifier(s"Obs1create:${observer}"),
                 templateIds.withObservers,
                 withObserversArg,
                 giver,
@@ -645,7 +655,7 @@ class TransactionServiceIT
         val expectedArgs = createArguments.map(_.copy(label = ""))
 
         c.submitCreate(
-            s"Creating_contract_with_a_Nothing_argument-${runCommandSuffix}",
+            commandIdUnifier("Creating_contract_with_a_Nothing_argument"),
             templateIds.nothingArgument,
             createArguments,
             "party")
@@ -663,7 +673,7 @@ class TransactionServiceIT
       "expose the default agreement text in CreatedEvents for templates with no explicit agreement text" in allFixtures {
         c =>
           val resultF = c.submitCreate(
-            s"Creating_dummy_contract_for_default_agreement_text_test-${runCommandSuffix}",
+            commandIdUnifier("Creating_dummy_contract_for_default_agreement_text_test"),
             templateIds.dummy,
             List(RecordField("operator", party1.asParty)),
             party1)
@@ -691,7 +701,7 @@ class TransactionServiceIT
       "not expose the contract key in CreatedEvents for templates that do not have them" in allFixtures {
         c =>
           val resultF = c.submitCreate(
-            s"Creating_CallablePayout_contract_for_contract_key_test-${runSuffix}",
+            commandIdUnifier("Creating_CallablePayout_contract_for_contract_key_test"),
             templateIds.callablePayout,
             List(
               RecordField("giver", party1.asParty),
@@ -705,7 +715,7 @@ class TransactionServiceIT
 
       "expose the contract key in CreatedEvents for templates that have them" in allFixtures { c =>
         val resultF = c.submitCreate(
-          s"Creating_TextKey_contract_for_contract_key_test-${runSuffix}",
+          commandIdUnifier("Creating_TextKey_contract_for_contract_key_test"),
           templateIds.textKey,
           List(
             RecordField("tkParty", party1.asParty),
@@ -736,12 +746,12 @@ class TransactionServiceIT
         for {
           agreement <- createAgreement(c, "MA1", receiver, giver)
           triProposal <- c.submitCreate(
-            s"MA1proposal-${runCommandSuffix}",
+            commandIdUnifier("MA1proposal"),
             templateIds.triProposal,
             triProposalArg,
             operator)
           tx <- c.submitExercise(
-            s"MA1acceptance-${runCommandSuffix}",
+            commandIdUnifier("MA1acceptance"),
             templateIds.agreement,
             List("cid" -> Value(ContractId(triProposal.contractId))).asRecordValue,
             "AcceptTriProposal",
@@ -762,12 +772,12 @@ class TransactionServiceIT
           val expectedArg = triProposalArg.map(_.copy(label = ""))
           for {
             triProposal <- c.submitCreate(
-              s"MA2proposal-${runCommandSuffix}",
+              commandIdUnifier("MA2proposal"),
               templateIds.triProposal,
               triProposalArg,
               operator)
             tx <- c.submitExercise(
-              s"MA2acceptance-${runCommandSuffix}",
+              commandIdUnifier("MA2acceptance"),
               templateIds.triProposal,
               unitArg,
               "TriProposalAccept",
@@ -784,7 +794,7 @@ class TransactionServiceIT
         val triProposalArg = mkTriProposalArg(operator, receiver, giver)
         for {
           triProposal <- c.submitCreate(
-            s"MA3proposal-${runCommandSuffix}",
+            commandIdUnifier("MA3proposal"),
             templateIds.triProposal,
             triProposalArg,
             operator)
@@ -815,7 +825,7 @@ class TransactionServiceIT
         for {
           agreement <- createAgreement(c, "MA4", receiver, giver)
           triProposal <- c.submitCreate(
-            s"MA4proposal-${runCommandSuffix}",
+            commandIdUnifier("MA4proposal"),
             templateIds.triProposal,
             triProposalArg,
             operator)
@@ -840,12 +850,12 @@ class TransactionServiceIT
         val arguments = List("street", "city", "state", "zip")
         for {
           dummy <- c.submitCreate(
-            s"Create_dummy_for_creating_AddressWrapper-${runCommandSuffix}",
+            commandIdUnifier("Create_dummy_for_creating_AddressWrapper"),
             templateIds.dummy,
             List("operator" -> party.asParty).asRecordFields,
             party)
           exercise <- c.submitExercise(
-            s"Creating_AddressWrapper-${runCommandSuffix}",
+            commandIdUnifier("Creating_AddressWrapper"),
             templateIds.dummy,
             List("address" -> arguments.map(e => e -> e.asText).asRecordValue).asRecordValue,
             "WrapWithAddress",
@@ -906,13 +916,13 @@ class TransactionServiceIT
           val createAndFetchTid = templateIds.createAndFetch
           for {
             createdEvent <- context.submitCreate(
-              s"CreateAndFetch_Create-$runCommandSuffix",
+              commandIdUnifier("CreateAndFetch_Create"),
               createAndFetchTid,
               List("p" -> party.asParty).asRecordFields,
               party)
             cid = createdEvent.contractId
             exerciseTx <- context.submitExercise(
-              s"CreateAndFetch_Run-$runCommandSuffix",
+              commandIdUnifier("CreateAndFetch_Run"),
               createAndFetchTid,
               Value(Value.Sum.Record(Record())),
               "CreateAndFetch_Run",
@@ -1551,7 +1561,7 @@ class TransactionServiceIT
       prefix: String,
       commandsPerSection: Int,
       context: LedgerContext): Future[Done] = {
-    insertCommands(s"${prefix}-${runCommandSuffix}", commandsPerSection, context)
+    insertCommands(commandIdUnifier(prefix), commandsPerSection, context)
   }
 
   private def lastOffsetIn(secondSection: immutable.Seq[Transaction]): Option[LedgerOffset] = {
@@ -1642,7 +1652,7 @@ class TransactionServiceIT
   ): Future[CreatedEvent] = {
     for {
       agreementFactory <- c.submitCreate(
-        commandId + s"factory_creation-${runCommandSuffix}",
+        commandId + commandIdUnifier("factory_creation"),
         templateIds.agreementFactory,
         List(
           "receiver" -> receiver.asParty,
@@ -1651,7 +1661,7 @@ class TransactionServiceIT
         giver
       )
       tx <- c.submitExercise(
-        commandId + s"_acceptance-${runCommandSuffix}",
+        commandId + commandIdUnifier("_acceptance"),
         templateIds.agreementFactory,
         unitArg,
         "AgreementFactoryAccept",
@@ -1675,7 +1685,7 @@ class TransactionServiceIT
   ): Future[Assertion] =
     c.testingHelpers.assertCommandFailsWithCode(
       c.command(
-          s"${commandId}-${runCommandSuffix}",
+          commandIdUnifier(commandId),
           List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap))
         .update(
           _.commands.party := submitter
@@ -1693,7 +1703,8 @@ class TransactionServiceIT
 
     for {
       creation <- context.submitCreate(
-        s"Creating_contract_with_a_multitude_of_param_types_for_exercising-${runCommandSuffix}_$choice#$lbl",
+        commandIdUnifier(
+          s"Creating_contract_with_a_multitude_of_param_types_for_exercising_$choice#$lbl"),
         templateIds.parameterShowcase,
         paramShowcaseArgs(templateIds.testPackageId),
         MockMessages.party
@@ -1708,7 +1719,7 @@ class TransactionServiceIT
       exerciseTx <- context.testingHelpers.submitAndListenForSingleResultOfCommand(
         context
           .command(
-            s"Exercising_with_a_multitiude_of_params-${runCommandSuffix}_$choice#$lbl",
+            commandIdUnifier(s"Exercising_with_a_multitiude_of_params_$choice#$lbl"),
             List(exerciseCommand)),
         getAllContracts
       )

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -11,12 +11,7 @@ import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{EventId, LedgerId}
 import com.digitalasset.ledger.api.testing.utils.MockMessages.{party, _}
-import com.digitalasset.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  IsStatusException,
-  MockMessages,
-  SuiteResourceManagementAroundAll
-}
+import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, IsStatusException, MockMessages, SuiteResourceManagementAroundAll}
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.commands.Command.Command.Create
 import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
@@ -33,7 +28,7 @@ import com.digitalasset.ledger.client.services.commands.CommandUpdater
 import com.digitalasset.ledger.client.services.transactions.TransactionClient
 import com.digitalasset.platform.api.v1.event.EventOps._
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
-import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestTemplateIds}
+import com.digitalasset.platform.apitesting.{LedgerContext, MultiLedgerFixture, TestIdsGenerator, TestTemplateIds}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
@@ -48,13 +43,13 @@ import scalaz.{ICons, NonEmptyList, Tag}
 
 import scala.collection.{breakOut, immutable}
 import scala.concurrent.Future
-import scala.util.Random
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class TransactionServiceIT
     extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
     with MultiLedgerFixture
+    with TestIdsGenerator
     with SuiteResourceManagementAroundAll
     with Inside
     with AsyncTimeLimitedTests
@@ -69,11 +64,6 @@ class TransactionServiceIT
   protected val helpers = new TransactionServiceHelpers(config)
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
-
-  val runSuffix = Random.alphanumeric.take(10).mkString
-  val runCommandSuffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
-  val partyNameMangler = (partyText: String) =>
-    partyText + (if (config.uniquePartyIdentifiers) "-" + runSuffix else "")
 
   override val timeLimit: Span = scaled(300.seconds)
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
@@ -5,7 +5,11 @@ package com.digitalasset.platform.tests.integration.ledger.api.transaction
 
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.{Sink, Source}
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, MockMessages, SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  MockMessages,
+  SuiteResourceManagementAroundAll
+}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.LEDGER_BEGIN
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
@@ -55,7 +59,7 @@ class TransactionBackpressureIT
           .throttle(10, 1.second)
           .mapAsync(10)(i =>
             commandClient.submitSingleCommand(
-              testCommands.oneKbCommandRequest(ctx.ledgerId, s"command-$i-$runSuffix")))
+              testCommands.oneKbCommandRequest(ctx.ledgerId, commandIdUnifier(s"command-$i"))))
           .runWith(Sink.ignore)
 
       def subscribe(begin: LedgerOffset, rate: Int) =

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
@@ -3,19 +3,13 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api.transaction
 
-import java.util.UUID
-
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.{Sink, Source}
-import com.digitalasset.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  MockMessages,
-  SuiteResourceManagementAroundAll
-}
+import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, MockMessages, SuiteResourceManagementAroundAll}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.LEDGER_BEGIN
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
-import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestCommands}
+import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestCommands, TestIdsGenerator}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
@@ -33,7 +27,8 @@ class TransactionBackpressureIT
     with ScalaFutures
     with AkkaBeforeAndAfterAll
     with SuiteResourceManagementAroundAll
-    with MultiLedgerFixture {
+    with MultiLedgerFixture
+    with TestIdsGenerator {
 
   protected val testCommands = new TestCommands(config)
 
@@ -47,8 +42,6 @@ class TransactionBackpressureIT
   private val begin = LedgerOffset(Boundary(LEDGER_BEGIN))
 
   "The transaction service when serving multiple subscriptions" should {
-
-    val runSuffix = UUID.randomUUID()
 
     "handle back pressure" in allFixtures { ctx =>
       val noOfCommands = 1000

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
@@ -31,10 +31,10 @@ class TransactionBackpressureIT
     with ScalaFutures
     with AkkaBeforeAndAfterAll
     with SuiteResourceManagementAroundAll
-    with MultiLedgerFixture
-    with TestIdsGenerator {
+    with MultiLedgerFixture {
 
   protected val testCommands = new TestCommands(config)
+  protected val testIdsGenerator = new TestIdsGenerator(config)
 
   override def timeLimit: Span = scaled(300.seconds)
 
@@ -58,8 +58,8 @@ class TransactionBackpressureIT
         Source(1 to noOfCommands)
           .throttle(10, 1.second)
           .mapAsync(10)(i =>
-            commandClient.submitSingleCommand(
-              testCommands.oneKbCommandRequest(ctx.ledgerId, commandIdUnifier(s"command-$i"))))
+            commandClient.submitSingleCommand(testCommands
+              .oneKbCommandRequest(ctx.ledgerId, testIdsGenerator.testCommandId(s"command-$i"))))
           .runWith(Sink.ignore)
 
       def subscribe(begin: LedgerOffset, rate: Int) =

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
@@ -41,7 +41,8 @@ object PlatformApplications {
       persistenceEnabled: Boolean = false,
       maxNumberOfAcsContracts: Option[Int] = None,
       commandConfiguration: CommandConfiguration = SandboxConfig.defaultCommandConfig,
-      uniqueIdentifiers: Boolean = true,
+      uniqueCommandIdentifiers: Boolean = true,
+      uniquePartyIdentifiers: Boolean = true,
       remoteApiEndpoint: Option[RemoteApiEndpoint] = None) {
     require(
       Duration.ofSeconds(timeModel.minTtl.getSeconds) == timeModel.minTtl &&
@@ -57,7 +58,11 @@ object PlatformApplications {
 
     def withLedgerIdMode(mode: LedgerIdMode): Config = copy(ledgerId = mode)
 
-    def withUniqueIdentifiers(uniqueIdentifiers: Boolean): Config = copy(uniqueIdentifiers = uniqueIdentifiers)
+    def withUniquePartyIdentifiers(uniqueIdentifiers: Boolean): Config =
+      copy(uniquePartyIdentifiers = uniqueIdentifiers)
+
+    def withUniqueCommandIdentifiers(uniqueIdentifiers: Boolean): Config =
+      copy(uniqueCommandIdentifiers = uniqueIdentifiers)
 
     def withParties(p1: String, rest: String*) = copy(parties = NonEmptyList(p1, rest: _*))
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
@@ -41,6 +41,7 @@ object PlatformApplications {
       persistenceEnabled: Boolean = false,
       maxNumberOfAcsContracts: Option[Int] = None,
       commandConfiguration: CommandConfiguration = SandboxConfig.defaultCommandConfig,
+      uniqueIdentifiers: Boolean = true,
       remoteApiEndpoint: Option[RemoteApiEndpoint] = None) {
     require(
       Duration.ofSeconds(timeModel.minTtl.getSeconds) == timeModel.minTtl &&
@@ -55,6 +56,8 @@ object PlatformApplications {
     def withTimeProvider(tpt: TimeProviderType) = copy(timeProviderType = tpt)
 
     def withLedgerIdMode(mode: LedgerIdMode): Config = copy(ledgerId = mode)
+
+    def withUniqueIdentifiers(uniqueIdentifiers: Boolean): Config = copy(uniqueIdentifiers = uniqueIdentifiers)
 
     def withParties(p1: String, rest: String*) = copy(parties = NonEmptyList(p1, rest: _*))
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -56,6 +56,7 @@ abstract class CommandTransactionChecks
     extends AsyncWordSpec
         with AkkaBeforeAndAfterAll
         with MultiLedgerFixture
+        with TestIdsGenerator
         with SuiteResourceManagementAroundEach
         with ScalaFutures
         with AsyncTimeLimitedTests
@@ -104,8 +105,6 @@ abstract class CommandTransactionChecks
 
   private val emptyRecordValue = Value(Value.Sum.Record(Record()))
 
-  private val runSuffix = UUID.randomUUID()
-
   def assertCompletionIsSuccessful(completion: Completion): Assertion = {
     inside(completion) {
       case c => c.getStatus should have('code (0))
@@ -116,7 +115,7 @@ abstract class CommandTransactionChecks
     "reading completions" should {
       "return the completion of submitted commands for the submitting application" in allFixtures {
         ctx =>
-          val commandId = s"Submitting_application_sees_this-$runSuffix"
+          val commandId = commandIdUnifier("Submitting_application_sees_this")
           val request = createCommandWithId(ctx, commandId)
           for {
             commandClient <- ctx.commandClient()

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -132,7 +132,7 @@ abstract class CommandTransactionChecks
       }
 
       "not expose completions of submitted commands to other applications" in allFixtures { ctx =>
-        val commandId = s"The_other_application_does_not_see_this-$runSuffix"
+        val commandId = commandIdUnifier("The_other_application_does_not_see_this")
         val request = createCommandWithId(ctx, commandId)
         for {
           commandClient <- ctx.commandClient()
@@ -151,7 +151,7 @@ abstract class CommandTransactionChecks
       "not expose completions of submitted commands to the application if it down't include the submitting party" in allFixtures {
         ctx =>
           val commandId =
-            s"The_application_should_subscribe_with_the_submitting_party_to_see_this-$runSuffix"
+            commandIdUnifier("The_application_should_subscribe_with_the_submitting_party_to_see_this")
           val request = createCommandWithId(ctx, commandId)
           for {
             commandClient <- ctx.commandClient()
@@ -175,15 +175,15 @@ abstract class CommandTransactionChecks
           // note that the submitting party is not a stakeholder in any event,
           // so this test relies on the sandbox exposing the transactions to the
           // submitter.
-          val factoryCreation = s"Creating_factory_Trees-$runSuffix"
-          val exercisingChoice = s"Exercising_choice_on_factory_Trees-$runSuffix"
+          val factoryCreation = commandIdUnifier("Creating_factory_Trees")
+          val exercisingChoice = commandIdUnifier("Exercising_choice_on_factory_Trees")
           for {
             factoryContractId <- findCreatedEventInResultOf(
               ctx,
               factoryCreation,
               templateIds.dummyFactory)
             transaction <- ctx.testingHelpers.submitAndListenForSingleTreeResultOfCommand(
-              requestToCallExerciseWithId(ctx, factoryContractId.contractId, s"$exercisingChoice-$runSuffix"),
+              requestToCallExerciseWithId(ctx, factoryContractId.contractId, commandIdUnifier(exercisingChoice)),
               getAllContracts)
           } yield {
             val exercisedEvent = ctx.testingHelpers.topLevelExercisedIn(transaction).head
@@ -247,7 +247,7 @@ abstract class CommandTransactionChecks
       }
 
       "run callable payout and return the right events" in allFixtures { ctx =>
-        val commandId = s"callable_payout_command-$runSuffix"
+        val commandId = commandIdUnifier("callable_payout_command")
         val arg = Record(
           Some(templateIds.callablePayout),
           List(
@@ -291,7 +291,7 @@ abstract class CommandTransactionChecks
       "expose transactions to non-submitting stakeholders without the commandId" in allFixtures { ctx =>
         val receiver = "receiver"
         val giver = "giver"
-        val commandId = s"Testing_if_non-submitting_stakeholder_sees_the_commandId-$runSuffix"
+        val commandId = commandIdUnifier("Testing_if_non-submitting_stakeholder_sees_the_commandId")
         val createCmd = createAgreementFactory(ctx, receiver, giver, commandId)
         ctx.testingHelpers.submitAndListenForSingleResultOfCommand(
           createCmd,
@@ -306,12 +306,12 @@ abstract class CommandTransactionChecks
         for {
           agreement <- createAgreement(ctx, "MA1", receiver, giver)
           triProposal <- ctx.testingHelpers.simpleCreate(
-            s"MA1proposal-$runSuffix",
+            commandIdUnifier("MA1proposal"),
             operator,
             templateIds.triProposal,
             triProposalArg)
           tx <- ctx.testingHelpers.simpleExercise(
-            s"MA1acceptance-$runSuffix",
+            commandIdUnifier("MA1acceptance"),
             giver,
             templateIds.agreement,
             agreement.contractId,
@@ -336,12 +336,12 @@ abstract class CommandTransactionChecks
         val triProposalArg = mkTriProposalArg(operator, giver, giver)
         for {
           triProposal <- ctx.testingHelpers.simpleCreate(
-            s"MA2proposal-$runSuffix",
+            commandIdUnifier("MA2proposal"),
             operator,
             templateIds.triProposal,
             triProposalArg)
           tx <- ctx.testingHelpers.simpleExercise(
-            s"MA2acceptance-$runSuffix",
+            commandIdUnifier("MA2acceptance"),
             giver,
             templateIds.triProposal,
             triProposal.contractId,
@@ -364,12 +364,12 @@ abstract class CommandTransactionChecks
         val triProposalArg = mkTriProposalArg(operator, receiver, giver)
         for {
           triProposal <- ctx.testingHelpers.simpleCreate(
-            s"MA3proposal-$runSuffix",
+            commandIdUnifier("MA3proposal"),
             operator,
             templateIds.triProposal,
             triProposalArg)
           assertion <- ctx.testingHelpers.failingExercise(
-            s"MA3acceptance-$runSuffix",
+            commandIdUnifier("MA3acceptance"),
             giver,
             templateIds.triProposal,
             triProposal.contractId,
@@ -391,14 +391,14 @@ abstract class CommandTransactionChecks
       "reject exercising a multi-actor choice with too many authorizers" ignore allFixtures { ctx =>
         val triProposalArg = mkTriProposalArg(operator, giver, giver)
         for {
-          agreement <- createAgreement(ctx, s"MA4-$runSuffix", receiver, giver)
+          agreement <- createAgreement(ctx, commandIdUnifier("MA4"), receiver, giver)
           triProposal <- ctx.testingHelpers.simpleCreate(
-            s"MA4proposal-$runSuffix",
+            commandIdUnifier("MA4proposal"),
             operator,
             templateIds.triProposal,
             triProposalArg)
           assertion <- ctx.testingHelpers.failingExercise(
-            s"MA4acceptance-$runSuffix",
+            commandIdUnifier("MA4acceptance"),
             giver,
             templateIds.agreement,
             agreement.contractId,
@@ -423,17 +423,17 @@ abstract class CommandTransactionChecks
           pf("delegate", delegate)
         )
         val delegatedCreate = ctx.testingHelpers.simpleCreate(
-          s"SDVl3-$runSuffix",
+          commandIdUnifier("SDVl3"),
           owner,
           templateIds.delegated,
           Record(Some(templateIds.delegated), Seq(pf("owner", owner), RecordField(value = Some(Value(Value.Sum.Text(key)))))))
         val delegationCreate = ctx.testingHelpers.simpleCreate(
-          s"SDVl4-$runSuffix",
+          commandIdUnifier("SDVl4"),
           owner,
           templateIds.delegation,
           Record(Some(templateIds.delegation), odArgs))
         val showIdCreate = ctx.testingHelpers.simpleCreate(
-          s"SDVl5-$runSuffix",
+          commandIdUnifier("SDVl5"),
           owner,
           templateIds.showDelegated,
           Record(Some(templateIds.showDelegated), odArgs))
@@ -456,7 +456,7 @@ abstract class CommandTransactionChecks
             )
           )
           _ <- ctx.testingHelpers.simpleExercise(
-            s"SDVl6-$runSuffix",
+            commandIdUnifier("SDVl6"),
             submitter = owner,
             template = templateIds.showDelegated,
             contractId = showIdEv.contractId,
@@ -464,7 +464,7 @@ abstract class CommandTransactionChecks
             arg = Value(Value.Sum.Record(fetchArg)),
           )
           _ <- ctx.testingHelpers.simpleExercise(
-            s"SDVl7-$runSuffix",
+            commandIdUnifier("SDVl7"),
             submitter = delegate,
             template = templateIds.delegation,
             contractId = delegationEv.contractId,
@@ -472,7 +472,7 @@ abstract class CommandTransactionChecks
             arg = Value(Value.Sum.Record(fetchArg)),
           )
           _ <- ctx.testingHelpers.simpleExercise(
-            s"SDVl8-$runSuffix",
+            commandIdUnifier("SDVl8"),
             submitter = delegate,
             template = templateIds.delegation,
             contractId = delegationEv.contractId,
@@ -489,12 +489,12 @@ abstract class CommandTransactionChecks
         // unique keys. This is not so great though, it'd be better to have a clean environment.
         val key = s"${UUID.randomUUID.toString}-key"
         val delegatedCreate = ctx.testingHelpers.simpleCreate(
-          s"TDVl3-$runSuffix",
+          commandIdUnifier("TDVl3"),
           owner,
           templateIds.delegated,
           Record(Some(templateIds.delegated), Seq(pf("owner", owner), RecordField(value = Some(Value(Value.Sum.Text(key)))))))
         val delegationCreate = ctx.testingHelpers.simpleCreate(
-          s"TDVl4-$runSuffix",
+          commandIdUnifier("TDVl4"),
           owner,
           templateIds.delegation,
           Record(Some(templateIds.delegation), Seq(pf("owner", owner), pf("delegate", delegate))))
@@ -516,7 +516,7 @@ abstract class CommandTransactionChecks
             )
           )
           fetchResult <- ctx.testingHelpers.failingExercise(
-            s"TDVl5-$runSuffix",
+            commandIdUnifier("TDVl5"),
             submitter = delegate,
             template = templateIds.delegation,
             contractId = delegationEv.contractId,
@@ -526,7 +526,7 @@ abstract class CommandTransactionChecks
             pattern = "dependency error: couldn't find contract"
           )
           _ <- ctx.testingHelpers.simpleExercise(
-            s"TDVl6-$runSuffix",
+            commandIdUnifier("TDVl6"),
             submitter = delegate,
             template = templateIds.delegation,
             contractId = delegationEv.contractId,
@@ -537,7 +537,7 @@ abstract class CommandTransactionChecks
       }
 
       "DAML engine returns Unit as argument to Nothing" in allFixtures { ctx =>
-        val commandId = s"Creating_contract_with_a_Nothing_argument-$runSuffix"
+        val commandId = commandIdUnifier("Creating_contract_with_a_Nothing_argument")
 
         val variantId = None
 
@@ -596,7 +596,7 @@ abstract class CommandTransactionChecks
             f flatMap { _ =>
               for {
                 withObservers <- ctx.testingHelpers.simpleCreateWithListener(
-                  s"Obs1create:$observer-$runSuffix",
+                  commandIdUnifier(s"Obs1create:$observer"),
                   giver,
                   observer,
                   templateIds.withObservers,
@@ -618,12 +618,12 @@ abstract class CommandTransactionChecks
             f flatMap { _ =>
               for {
                 withObservers <- ctx.testingHelpers.simpleCreate(
-                  s"Obs2create:$observer-$runSuffix",
+                  commandIdUnifier(s"Obs2create:$observer"),
                   giver,
                   templateIds.withObservers,
                   withObserversArg)
                 tx <- ctx.testingHelpers.simpleExerciseWithListener(
-                  s"Obs2exercise:$observer-$runSuffix",
+                  commandIdUnifier(s"Obs2exercise:$observer"),
                   giver,
                   observer,
                   templateIds.withObservers,
@@ -658,14 +658,14 @@ abstract class CommandTransactionChecks
           Value(Value.Sum.Record(Record(fields = List(RecordField(value = p.asParty), RecordField(value = s"$keyPrefix-$k".asText)))))
         for {
           cid1 <- ctx.testingHelpers.simpleCreate(
-            s"CK-test-cid1-$runSuffix",
+            commandIdUnifier("CK-test-cid1"),
             alice,
             templateIds.textKey,
             textKeyRecord(alice, key, List(bob))
           )
           // duplicate keys are not ok
           _ <- ctx.testingHelpers.failingCreate(
-             s"CK-test-duplicate-key-$runSuffix",
+             commandIdUnifier("CK-test-duplicate-key"),
              alice,
              templateIds.textKey,
              textKeyRecord(alice, key, List(bob)),
@@ -674,12 +674,12 @@ abstract class CommandTransactionChecks
            )
           // create handles to perform lookups / fetches
           aliceTKO <- ctx.testingHelpers.simpleCreate(
-              s"CK-test-aliceTKO-$runSuffix",
+              commandIdUnifier("CK-test-aliceTKO"),
               alice,
               templateIds.textKeyOperations,
               Record(fields = List(RecordField(value = alice.asParty))))
           bobTKO <- ctx.testingHelpers.simpleCreate(
-              s"CK-test-bobTKO-$runSuffix",
+              commandIdUnifier("CK-test-bobTKO"),
               bob,
               templateIds.textKeyOperations,
               Record(fields = List(RecordField(value = bob.asParty)))
@@ -689,7 +689,7 @@ abstract class CommandTransactionChecks
           lookupNone = Value(Value.Sum.Optional(Optional(None)))
           lookupSome = (cid: String) => Value(Value.Sum.Optional(Optional(Some(cid.asContractId))))
           _ <- ctx.testingHelpers.failingExercise(
-            s"CK-test-bob-unauthorized-1-$runSuffix",
+            commandIdUnifier("CK-test-bob-unauthorized-1"),
             bob,
             templateIds.textKeyOperations,
             bobTKO.contractId,
@@ -703,7 +703,7 @@ abstract class CommandTransactionChecks
           )
           // ..and non-existing ones
           _ <- ctx.testingHelpers.failingExercise(
-            s"CK-test-bob-unauthorized-2-$runSuffix",
+            commandIdUnifier("CK-test-bob-unauthorized-2"),
             bob,
             templateIds.textKeyOperations,
             bobTKO.contractId,
@@ -717,7 +717,7 @@ abstract class CommandTransactionChecks
             "requires authorizers")
           // successful, authorized lookup
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-lookup-found-$runSuffix",
+            commandIdUnifier("CK-test-alice-lookup-found"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -729,7 +729,7 @@ abstract class CommandTransactionChecks
                   RecordField(value = lookupSome(cid1.contractId)))))))
           // successful fetch
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-fetch-found-$runSuffix",
+            commandIdUnifier("CK-test-alice-fetch-found"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -741,7 +741,7 @@ abstract class CommandTransactionChecks
                   RecordField(value = cid1.contractId.asContractId))))))
           // failing, authorized lookup
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-lookup-not-found-$runSuffix",
+            commandIdUnifier("CK-test-alice-lookup-not-found"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -753,7 +753,7 @@ abstract class CommandTransactionChecks
                   RecordField(value = lookupNone))))))
           // failing fetch
           _ <- ctx.testingHelpers.failingExercise(
-            s"CK-test-alice-fetch-not-found-$runSuffix",
+            commandIdUnifier("CK-test-alice-fetch-not-found"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -768,14 +768,14 @@ abstract class CommandTransactionChecks
           // now we exercise the contract, thus archiving it, and then verify
           // that we cannot look it up anymore
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-consume-cid1-$runSuffix",
+            commandIdUnifier("CK-test-alice-consume-cid1"),
             alice,
             templateIds.textKey,
             cid1.contractId,
             "TextKeyChoice",
             emptyRecordValue)
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-lookup-after-consume-$runSuffix",
+            commandIdUnifier("CK-test-alice-lookup-after-consume"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -786,13 +786,13 @@ abstract class CommandTransactionChecks
                   RecordField(value = textKeyKey(alice, key)),
                   RecordField(value = lookupNone))))))
           cid2 <- ctx.testingHelpers.simpleCreate(
-            s"CK-test-cid2-$runSuffix",
+            commandIdUnifier("CK-test-cid2"),
             alice,
             templateIds.textKey,
             textKeyRecord(alice, "test-key-2", List(bob))
           )
           _ <- ctx.testingHelpers.simpleExercise(
-            s"CK-test-alice-consume-and-lookup-$runSuffix",
+            commandIdUnifier("CK-test-alice-consume-and-lookup"),
             alice,
             templateIds.textKeyOperations,
             aliceTKO.contractId,
@@ -805,7 +805,7 @@ abstract class CommandTransactionChecks
           )
           // failing create when a maintainer is not a signatory
           _ <- ctx.testingHelpers.failingCreate(
-            s"CK-test-alice-create-maintainer-not-signatory-$runSuffix",
+            commandIdUnifier("CK-test-alice-create-maintainer-not-signatory"),
             alice,
             templateIds.maintainerNotSignatory,
             Record(fields = List(RecordField(value = alice.asParty), RecordField(value = bob.asParty))),
@@ -820,7 +820,7 @@ abstract class CommandTransactionChecks
         val alice = "Alice"
         for {
           _ <- ctx.testingHelpers.failingCreate(
-            s"Decimal-scale-$runSuffix",
+            commandIdUnifier("Decimal-scale"),
             alice,
             templateIds.decimalRounding,
             Record(fields = List(RecordField(value = Some(alice.asParty)), RecordField(value = Some("0.00000000005".asDecimal)))),
@@ -828,7 +828,7 @@ abstract class CommandTransactionChecks
             "Could not read Decimal string"
           )
           _ <- ctx.testingHelpers.failingCreate(
-            s"Decimal-bounds-positive-$runSuffix",
+            commandIdUnifier("Decimal-bounds-positive"),
             alice,
             templateIds.decimalRounding,
             Record(fields = List(RecordField(value = Some(alice.asParty)), RecordField(value = Some("10000000000000000000000000000.0000000000".asDecimal)))),
@@ -836,7 +836,7 @@ abstract class CommandTransactionChecks
             "Could not read Decimal string"
           )
           _ <- ctx.testingHelpers.failingCreate(
-            s"Decimal-bounds-negative-$runSuffix",
+            commandIdUnifier("Decimal-bounds-negative"),
             alice,
             templateIds.decimalRounding,
             Record(fields = List(RecordField(value = Some(alice.asParty)), RecordField(value = Some("-10000000000000000000000000000.0000000000".asDecimal)))),
@@ -864,7 +864,7 @@ abstract class CommandTransactionChecks
           Value(Value.Sum.Record(Record(fields = List(RecordField(value = p.asParty), RecordField(value = s"$keyPrefix-$k".asText)))))
         for {
           _ <- ctx.testingHelpers.failingExerciseByKey(
-            s"EK-test-alice-exercise-before-create-$runSuffix",
+            commandIdUnifier("EK-test-alice-exercise-before-create"),
             alice,
             templateIds.textKey,
             textKeyKey(alice, key),
@@ -874,7 +874,7 @@ abstract class CommandTransactionChecks
             "couldn't find key"
           )
           _ <- ctx.testingHelpers.simpleCreate(
-            s"EK-test-cid1-$runSuffix",
+            commandIdUnifier("EK-test-cid1"),
             alice,
             templateIds.textKey,
             textKeyRecord(alice, key, List(bob))
@@ -882,14 +882,14 @@ abstract class CommandTransactionChecks
           // now we exercise by key, thus archiving it, and then verify
           // that we cannot look it up anymore
           _ <- ctx.testingHelpers.simpleExerciseByKey(
-            s"EK-test-alice-exercise-$runSuffix",
+            commandIdUnifier("EK-test-alice-exercise"),
             alice,
             templateIds.textKey,
             textKeyKey(alice, key),
             "TextKeyChoice",
             emptyRecordValue)
           _ <- ctx.testingHelpers.failingExerciseByKey(
-            s"EK-test-alice-exercise-consumed-$runSuffix",
+            commandIdUnifier("EK-test-alice-exercise-consumed"),
             alice,
             templateIds.textKey,
             textKeyKey(alice, key),
@@ -918,7 +918,7 @@ abstract class CommandTransactionChecks
         .update(_.commands.ledgerId := context.ledgerId.unwrap)
 
       "process valid commands successfully" in allFixtures{ c =>
-        val cmdId = s"valid-create-and-exercise-cmd-$runSuffix"
+        val cmdId = commandIdUnifier("valid-create-and-exercise-cmd")
         val request = newRequest(c, validCreateAndExercise)
           .update(_.commands.commandId := cmdId)
 
@@ -958,7 +958,7 @@ abstract class CommandTransactionChecks
       "fail for invalid create arguments" in allFixtures{ implicit c =>
         val createAndExercise = validCreateAndExercise.copy(createArguments = Some(Record()))
         val request = newRequest(c, createAndExercise)
-          .update(_.commands.commandId := s"fail-for-invalid-create-args-$runSuffix")
+          .update(_.commands.commandId := commandIdUnifier("fail-for-invalid-create-args"))
 
         val response = submitCommand(c, request)
         response.map(_.getStatus should have('code (Code.INVALID_ARGUMENT.value)))
@@ -969,7 +969,7 @@ abstract class CommandTransactionChecks
           validCreateAndExercise.copy(choiceArgument = Some(Value(Value.Sum.Bool(false))))
         val request = newRequest(c, createAndExercise)
           .update(_.commands.commands := Seq[Command](Command(Command.Command.CreateAndExercise(createAndExercise))))
-          .update(_.commands.commandId := s"fail-for-invalid-choice-args-$runSuffix")
+          .update(_.commands.commandId := commandIdUnifier("fail-for-invalid-choice-args"))
 
         val response = submitCommand(c, request)
         response.map(_.getStatus should have('code (Code.INVALID_ARGUMENT.value)))
@@ -980,7 +980,7 @@ abstract class CommandTransactionChecks
 
         val request = newRequest(c, createAndExercise)
           .update(_.commands.commands := Seq[Command](Command(Command.Command.CreateAndExercise(createAndExercise))))
-          .update(_.commands.commandId := s"fail-for-invalid-choice-$runSuffix")
+          .update(_.commands.commandId := commandIdUnifier("fail-for-invalid-choice"))
 
         val response = submitCommand(c, request)
         response.map(_.getStatus should have('code (Code.INVALID_ARGUMENT.value)))
@@ -1043,12 +1043,12 @@ abstract class CommandTransactionChecks
     ).asRecordOf(templateIds.agreementFactory)
     for {
       agreementFactory <- ctx.testingHelpers.simpleCreate(
-        s"$commandId-factory-$runSuffix",
+        commandIdUnifier(s"$commandId-factory"),
         giver,
         templateIds.agreementFactory,
         agreementFactoryArg)
       tx <- ctx.testingHelpers.simpleExercise(
-        s"$commandId-agreement-$runSuffix",
+        commandIdUnifier(s"$commandId-agreement"),
         receiver,
         templateIds.agreementFactory,
         agreementFactory.contractId,
@@ -1122,7 +1122,7 @@ abstract class CommandTransactionChecks
     val command: SubmitRequest =
       createParamShowcaseWith(
         ctx,
-        s"Creating_contract_with_a_multitude_of_param_types_for_exercising__$choice#$lbl-$runSuffix",
+        commandIdUnifier(s"Creating_contract_with_a_multitude_of_param_types_for_exercising__$choice#$lbl"),
         paramShowcaseArgs)
     for {
       tx <- ctx.testingHelpers.submitAndListenForSingleResultOfCommand(command, getAllContracts)
@@ -1134,7 +1134,7 @@ abstract class CommandTransactionChecks
         choice,
         exerciseArg).wrap
       tx <- ctx.testingHelpers.submitAndListenForSingleTreeResultOfCommand(
-        ctx.testingHelpers.submitRequestWithId(s"Exercising_with_a_multitiude_of_params__$choice#$lbl-$runSuffix")
+        ctx.testingHelpers.submitRequestWithId(commandIdUnifier(s"Exercising_with_a_multitiude_of_params__$choice#$lbl"))
             .update(_.commands.update(_.commands := List(exercise))),
         getAllContracts,
         true

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
@@ -1,0 +1,13 @@
+package com.digitalasset.platform.apitesting
+
+import scala.util.Random
+
+trait TestIdsGenerator {
+  self: MultiLedgerFixture =>
+
+  lazy val runSuffix = Random.alphanumeric.take(10).mkString
+  lazy val runCommandSuffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
+  lazy val runPartySuffix = if (config.uniquePartyIdentifiers) "-" + runSuffix else ""
+  def partyNameUnifier(partyText: String) = partyText + runPartySuffix
+  def commandIdUnifier(commandId: String) = commandId + runCommandSuffix
+}

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
@@ -1,13 +1,26 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.platform.apitesting
 
 import scala.util.Random
 
+/**
+  * Provides a mechanism to randomize various identifiers used in testing per run of a process.
+  *
+  * It enables Ledger API Test Tool to be ran against a persistent Ledger API endpoint repeatedly by avoiding
+  * duplication of identifiers.
+  */
 trait TestIdsGenerator {
   self: MultiLedgerFixture =>
 
   lazy val runSuffix = Random.alphanumeric.take(10).mkString
   lazy val runCommandSuffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
+  // Using runCommandSuffix, since there does not seem to be a need to treat workflow ids differently than command ids.
+  // Yet lets wrap those identifiers into an appropriate function so we could do it in the future.
+  lazy val runWorkflowSuffix = runCommandSuffix
   lazy val runPartySuffix = if (config.uniquePartyIdentifiers) "-" + runSuffix else ""
   def partyNameUnifier(partyText: String) = partyText + runPartySuffix
   def commandIdUnifier(commandId: String) = commandId + runCommandSuffix
+  def workflowIdUnifier(workflowId: String) = workflowId + runWorkflowSuffix
 }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestIdsGenerator.scala
@@ -3,24 +3,24 @@
 
 package com.digitalasset.platform.apitesting
 
+import com.digitalasset.platform.PlatformApplications
+
 import scala.util.Random
 
 /**
   * Provides a mechanism to randomize various identifiers used in testing per run of a process.
   *
-  * It enables Ledger API Test Tool to be ran against a persistent Ledger API endpoint repeatedly by avoiding
+  * It enables Ledger API Test Tool to be run against a persistent Ledger API endpoint repeatedly by avoiding
   * duplication of identifiers.
   */
-trait TestIdsGenerator {
-  self: MultiLedgerFixture =>
-
+class TestIdsGenerator(config: PlatformApplications.Config) {
   lazy val runSuffix = Random.alphanumeric.take(10).mkString
   lazy val runCommandSuffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
   // Using runCommandSuffix, since there does not seem to be a need to treat workflow ids differently than command ids.
   // Yet lets wrap those identifiers into an appropriate function so we could do it in the future.
   lazy val runWorkflowSuffix = runCommandSuffix
   lazy val runPartySuffix = if (config.uniquePartyIdentifiers) "-" + runSuffix else ""
-  def partyNameUnifier(partyText: String) = partyText + runPartySuffix
-  def commandIdUnifier(commandId: String) = commandId + runCommandSuffix
-  def workflowIdUnifier(workflowId: String) = workflowId + runWorkflowSuffix
+  def testPartyName(partyText: String) = partyText + runPartySuffix
+  def testCommandId(commandId: String) = commandId + runCommandSuffix
+  def testWorkflowId(workflowId: String) = workflowId + runWorkflowSuffix
 }

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -47,13 +47,10 @@ class SandboxSemanticTestsLfRunner
   }
 
   s"a ledger launched with $darFile" should {
-    val runSuffix = "-" + Random.alphanumeric.take(10).mkString
-    val partyNameMangler =
-      (partyText: String) => partyText + runSuffix + Random.alphanumeric.take(10).mkString
+    val runSuffix = if (config.uniqueIdentifiers) "-" + Random.alphanumeric.take(10).mkString else ""
+    val partyNameMangler = (partyText: String) => partyText + runSuffix
     val commandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) =
-      (scenario, stepId, nodeId) => {
-        s"ledger-api-test-tool-$scenario-$stepId-$nodeId-$runSuffix"
-      }
+      (scenario, stepId, nodeId) => s"ledger-api-test-tool-$scenario-$stepId-${nodeId}${runSuffix}"
     for {
       (pkgId, names) <- SemanticTester.scenarios(Map(mainPkgId -> packages(mainPkgId))) // we only care about the main pkg
       name <- names

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -47,10 +47,14 @@ class SandboxSemanticTestsLfRunner
   }
 
   s"a ledger launched with $darFile" should {
-    val runSuffix = if (config.uniqueIdentifiers) "-" + Random.alphanumeric.take(10).mkString else ""
-    val partyNameMangler = (partyText: String) => partyText + runSuffix
-    val commandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) =
-      (scenario, stepId, nodeId) => s"ledger-api-test-tool-$scenario-$stepId-${nodeId}${runSuffix}"
+    val runSuffix = Random.alphanumeric.take(10).mkString
+    val partyNameMangler = (partyText: String) =>
+      partyText + (if (config.uniquePartyIdentifiers) "-" + runSuffix else "")
+    val commandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) = {
+      val suffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
+      (scenario, stepId, nodeId) =>
+        s"ledger-api-test-tool-$scenario-$stepId-${nodeId}${suffix}"
+    }
     for {
       (pkgId, names) <- SemanticTester.scenarios(Map(mainPkgId -> packages(mainPkgId))) // we only care about the main pkg
       name <- names

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -10,7 +10,10 @@ import com.digitalasset.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.digitalasset.daml.lf.data.Ref.QualifiedName
 import com.digitalasset.daml.lf.engine.testing.SemanticTester
 import com.digitalasset.daml.lf.types.{Ledger => L}
-import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  SuiteResourceManagementAroundAll
+}
 import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestIdsGenerator}
 import com.digitalasset.platform.services.time.TimeProviderType
 import org.scalatest.concurrent.ScalaFutures
@@ -44,7 +47,8 @@ class SandboxSemanticTestsLfRunner
 
   s"a ledger launched with $darFile" should {
     val scenarioCommandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) =
-      (scenario, stepId, nodeId) => commandIdUnifier( s"ledger-api-test-tool-$scenario-$stepId-${nodeId}")
+      (scenario, stepId, nodeId) =>
+        commandIdUnifier(s"ledger-api-test-tool-$scenario-$stepId-${nodeId}")
     for {
       (pkgId, names) <- SemanticTester.scenarios(Map(mainPkgId -> packages(mainPkgId))) // we only care about the main pkg
       name <- names

--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -10,21 +10,17 @@ import com.digitalasset.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.digitalasset.daml.lf.data.Ref.QualifiedName
 import com.digitalasset.daml.lf.engine.testing.SemanticTester
 import com.digitalasset.daml.lf.types.{Ledger => L}
-import com.digitalasset.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  SuiteResourceManagementAroundAll
-}
-import com.digitalasset.platform.apitesting.MultiLedgerFixture
+import com.digitalasset.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
+import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestIdsGenerator}
 import com.digitalasset.platform.services.time.TimeProviderType
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{AsyncWordSpec, Matchers}
-
-import scala.util.Random
 
 class SandboxSemanticTestsLfRunner
     extends AsyncWordSpec
     with Matchers
     with MultiLedgerFixture
+    with TestIdsGenerator
     with SuiteResourceManagementAroundAll
     with ScalaFutures
     with AkkaBeforeAndAfterAll {
@@ -47,14 +43,8 @@ class SandboxSemanticTestsLfRunner
   }
 
   s"a ledger launched with $darFile" should {
-    val runSuffix = Random.alphanumeric.take(10).mkString
-    val partyNameMangler = (partyText: String) =>
-      partyText + (if (config.uniquePartyIdentifiers) "-" + runSuffix else "")
-    val commandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) = {
-      val suffix = if (config.uniqueCommandIdentifiers) "-" + runSuffix else ""
-      (scenario, stepId, nodeId) =>
-        s"ledger-api-test-tool-$scenario-$stepId-${nodeId}${suffix}"
-    }
+    val scenarioCommandIdMangler: ((QualifiedName, Int, L.ScenarioNodeId) => String) =
+      (scenario, stepId, nodeId) => commandIdUnifier( s"ledger-api-test-tool-$scenario-$stepId-${nodeId}")
     for {
       (pkgId, names) <- SemanticTester.scenarios(Map(mainPkgId -> packages(mainPkgId))) // we only care about the main pkg
       name <- names
@@ -71,8 +61,8 @@ class SandboxSemanticTestsLfRunner
                 commandSubmissionTtlScaleFactor = config.commandSubmissionTtlScaleFactor),
             pkgId,
             packages,
-            partyNameMangler,
-            commandIdMangler
+            partyNameUnifier,
+            scenarioCommandIdMangler
           ).testScenario(name)
         } yield succeed
       }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -78,11 +78,17 @@ object Cli {
       .action((_, c) => c.copy(verbose = true))
       .text("Prints full stacktraces on failures.")
 
-    opt[Unit]("stable-identifiers")
-      .abbr("s")
-      .action((_, c) => c.copy(uniqueIdentifiers = false))
-      .text(
-        """Use the same party and command identifiers for each run. By default
+    opt[Unit]("stable-party-identifiers")
+      .abbr("sp")
+      .action((_, c) => c.copy(uniquePartyIdentifiers = false))
+      .text("""Use the same party identifiers for each run. By default
+          |those are randomized for each execution of the tool to ensure that
+          |the tests are not being failed by command and party deduplication mechanisms.""".stripMargin)
+
+    opt[Unit]("stable-command-identifiers")
+      .abbr("sc")
+      .action((_, c) => c.copy(uniqueCommandIdentifiers = false))
+      .text("""Use the same command identifiers for each run. By default
           |those are randomized for each execution of the tool to ensure that
           |the tests are not being failed by command and party deduplication mechanisms.""".stripMargin)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -78,6 +78,14 @@ object Cli {
       .action((_, c) => c.copy(verbose = true))
       .text("Prints full stacktraces on failures.")
 
+    opt[Unit]("stable-identifiers")
+      .abbr("s")
+      .action((_, c) => c.copy(uniqueIdentifiers = false))
+      .text(
+        """Use the same party and command identifiers for each run. By default
+          |those are randomized for each execution of the tool to ensure that
+          |the tests are not being failed by command and party deduplication mechanisms.""".stripMargin)
+
     opt[Unit]("must-fail")
       .action((_, c) => c.copy(mustFail = true))
       .text("""Reverse success status logic of the tool. Use this flag if you expect one or

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -20,7 +20,8 @@ final case class Config(
     excluded: Set[String],
     included: Set[String],
     listTests: Boolean,
-    allTests: Boolean
+    allTests: Boolean,
+    uniqueIdentifiers: Boolean
 )
 
 object Config {
@@ -37,6 +38,7 @@ object Config {
     excluded = Set.empty,
     included = Set.empty,
     listTests = false,
-    allTests = false
+    allTests = false,
+    uniqueIdentifiers = true,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -21,7 +21,8 @@ final case class Config(
     included: Set[String],
     listTests: Boolean,
     allTests: Boolean,
-    uniqueIdentifiers: Boolean
+    uniquePartyIdentifiers: Boolean,
+    uniqueCommandIdentifiers: Boolean
 )
 
 object Config {
@@ -39,6 +40,7 @@ object Config {
     included = Set.empty,
     listTests = false,
     allTests = false,
-    uniqueIdentifiers = true,
+    uniquePartyIdentifiers = true,
+    uniqueCommandIdentifiers = true,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -45,6 +45,7 @@ object LedgerApiTestTool {
       .withTimeProvider(TimeProviderType.WallClock)
       .withLedgerIdMode(LedgerIdMode.Dynamic())
       .withCommandSubmissionTtlScaleFactor(toolConfig.commandSubmissionTtlScaleFactor)
+      .withUniqueIdentifiers(toolConfig.uniqueIdentifiers)
       .withRemoteApiEndpoint(
         RemoteApiEndpoint.default
           .withHost(toolConfig.host)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -45,7 +45,8 @@ object LedgerApiTestTool {
       .withTimeProvider(TimeProviderType.WallClock)
       .withLedgerIdMode(LedgerIdMode.Dynamic())
       .withCommandSubmissionTtlScaleFactor(toolConfig.commandSubmissionTtlScaleFactor)
-      .withUniqueIdentifiers(toolConfig.uniqueIdentifiers)
+      .withUniquePartyIdentifiers(toolConfig.uniquePartyIdentifiers)
+      .withUniqueCommandIdentifiers(toolConfig.uniqueCommandIdentifiers)
       .withRemoteApiEndpoint(
         RemoteApiEndpoint.default
           .withHost(toolConfig.host)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -129,16 +129,11 @@ object LedgerApiTestTool {
       name =>
         new SandboxSemanticTestsLfRunner {
           override def suiteName: String = name
-
           override def actorSystemName = s"${name}TestToolActorSystem"
-
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
-
           override implicit lazy val patienceConfig: PatienceConfig =
             PatienceConfig(Span(60L, Seconds))
-
           override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
-
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(semanticTestsResource))
       }

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,23 +10,6 @@ HEAD — ongoing
 --------------
 
 - [Sandbox] Added `--log-level` command line flag.
-- [Navigator] Contract details now show signatories and observers.
-  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
-- [Scala Bindings] Reflect addition of signatories and observers to the bindings.
-  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
-- [Java Codegen] Generated code supports signatories and observers as exposed by the bindings.
-  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
-- [Java Bindings] Reflect addition of signatories and observers to the bindings.
-  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
-- [Ledger API] Expose signatories and observers for a contract in ``CreatedEvent``.
-  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
-- [DAML Compiler] **BREAKING CHANGE**: Drop support for DAML-LF 1.4. Compiling to DAML-LF 1.5 should work without any code changes, although we highly recommend not specifying a target DAML-LF version at all. (The ledger server still supports DAML-LF 1.4.)
-- [Sandbox] Made the archive CLI arguments optional. 
-  See `#1905 <https://github.com/digital-asset/daml/issues/1905>`__.
-- [DAML-LF] **BREAKING CHANGE**: Specify pretty C# namespaces in archive protos. C# bindings will end up in a different namespace than the default one.
-  See `#1900 <https://github.com/digital-asset/daml/issues/1900>`__.
-- [Ledger API] **BREAKING CHANGE**: Specify pretty C# namespaces in ledger api protos. C# bindings will end up in a different namespace than the default one.
-  See `#1901 <https://github.com/digital-asset/daml/issues/1901>`__.
 - [Ledger API] Added new CLI flags ``--stable-party-identifiers`` and
   ``--stable-command-identifiers`` to the :doc:`Ledger API Test Tool
   </tools/ledger-api-test-tool/index>` to allow disabling randomization of party

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,3 +10,25 @@ HEAD — ongoing
 --------------
 
 - [Sandbox] Added `--log-level` command line flag.
+- [Navigator] Contract details now show signatories and observers.
+  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
+- [Scala Bindings] Reflect addition of signatories and observers to the bindings.
+  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
+- [Java Codegen] Generated code supports signatories and observers as exposed by the bindings.
+  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
+- [Java Bindings] Reflect addition of signatories and observers to the bindings.
+  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
+- [Ledger API] Expose signatories and observers for a contract in ``CreatedEvent``.
+  See `#1269 <https://github.com/digital-asset/daml/issues/1269>`__.
+- [DAML Compiler] **BREAKING CHANGE**: Drop support for DAML-LF 1.4. Compiling to DAML-LF 1.5 should work without any code changes, although we highly recommend not specifying a target DAML-LF version at all. (The ledger server still supports DAML-LF 1.4.)
+- [Sandbox] Made the archive CLI arguments optional. 
+  See `#1905 <https://github.com/digital-asset/daml/issues/1905>`__.
+- [DAML-LF] **BREAKING CHANGE**: Specify pretty C# namespaces in archive protos. C# bindings will end up in a different namespace than the default one.
+  See `#1900 <https://github.com/digital-asset/daml/issues/1900>`__.
+- [Ledger API] **BREAKING CHANGE**: Specify pretty C# namespaces in ledger api protos. C# bindings will end up in a different namespace than the default one.
+  See `#1901 <https://github.com/digital-asset/daml/issues/1901>`__.
+- [Ledger API] Added new CLI flags ``--stable-party-identifiers`` and
+  ``--stable-command-identifiers`` to the :doc:`Ledger API Test Tool
+  </tools/ledger-api-test-tool/index>` to allow disabling randomization of party
+  and command identifiers. It is useful for testing of ledgers which are
+  configured with a predefined static set of parties.


### PR DESCRIPTION
Added new CLI flags `--stable-party-identifiers` and `--stable-command-identifiers` to the Ledger API Test Tool to allow disabling randomization of party and command identifiers. It is useful for testing of ledgers which are configured with a predefined static set of parties. This is supported by appropriate `PlatformApplications.Config` fields and plumbing in `TransactionServiceIT` and `SandboxSemanticTestsLfRunner`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
