### PR TITLE
Make runActions return Return as soon as results are available

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/FileStore.hs
@@ -161,7 +161,7 @@ setBufferModified state absFile mbContents = do
     case mbContents of
         Nothing -> removeVirtualFile (filePathToUri' absFile)
         Just contents -> setVirtualFileContents (filePathToUri' absFile) contents
-    void $ shakeRun state []
+    void $ shakeRun state [] (const $ pure ())
 
 
 -- would be nice to do this more efficiently...

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -112,9 +112,9 @@ runAction service action = head <$> runActions service [action]
 -- e.g., the ofInterestRule.
 runActions :: IdeState -> [Action a] -> IO [a]
 runActions x acts = do
-    var <- newEmptyMVar
-    _ <- shakeRun x acts (putMVar var)
-    takeMVar var
+    var <- newBarrier
+    _ <- shakeRun x acts (signalBarrier var)
+    waitBarrier var
 
 -- | This is a synchronous variant of `runAction`. See
 -- `runActionsSync` of more details.

--- a/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Service.hs
@@ -13,7 +13,7 @@ module Development.IDE.State.Service(
     getServiceEnv,
     IdeState, initialise, shutdown,
     runAction, runActions,
-    runActionSynchronous, runActionsSynchronous,
+    runActionSync, runActionsSync,
     setFilesOfInterest, modifyFilesOfInterest,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
@@ -117,16 +117,16 @@ runActions x acts = do
     takeMVar var
 
 -- | This is a synchronous variant of `runAction`. See
--- `runActionsSynchronous` of more details.
-runActionSynchronous :: IdeState -> Action a -> IO a
-runActionSynchronous s a = head <$> runActionsSynchronous s [a]
+-- `runActionsSync` of more details.
+runActionSync :: IdeState -> Action a -> IO a
+runActionSync s a = head <$> runActionsSync s [a]
 
--- | `runActionsSynchronous` is similar to `runActions` but it will
+-- | `runActionsSync` is similar to `runActions` but it will
 -- wait for all rules (so in particular the `ofInterestRule`) to
 -- finish running. This is mainly useful in tests, where you want
 -- to wait for all rules to fire so you can check diagnostics.
-runActionsSynchronous :: IdeState -> [Action a] -> IO [a]
-runActionsSynchronous s acts = join $ shakeRun s acts (const $ pure ())
+runActionsSync :: IdeState -> [Action a] -> IO [a]
+runActionsSync s acts = join $ shakeRun s acts (const $ pure ())
 
 -- | Set the files-of-interest which will be built and kept-up-to-date.
 setFilesOfInterest :: IdeState -> Set NormalizedFilePath -> IO ()

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -18,8 +18,8 @@ module Development.IDE.State.API
     , setBufferModified
     , runAction
     , runActions
-    , runActionSynchronous
-    , runActionsSynchronous
+    , runActionSync
+    , runActionsSync
     , writeProfile
     , getDiagnostics
     , unsafeClearDiagnostics

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -18,6 +18,8 @@ module Development.IDE.State.API
     , setBufferModified
     , runAction
     , runActions
+    , runActionSynchronous
+    , runActionsSynchronous
     , writeProfile
     , getDiagnostics
     , unsafeClearDiagnostics

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -8,7 +8,7 @@ module Development.IDE.State.Service.Daml(
     getDamlServiceEnv,
     IdeState, initialise, shutdown,
     runAction, runActions,
-    runActionSynchronous, runActionsSynchronous,
+    runActionSync, runActionsSync,
     setFilesOfInterest, modifyFilesOfInterest, setOpenVirtualResources, modifyOpenVirtualResources,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -8,6 +8,7 @@ module Development.IDE.State.Service.Daml(
     getDamlServiceEnv,
     IdeState, initialise, shutdown,
     runAction, runActions,
+    runActionSynchronous, runActionsSynchronous,
     setFilesOfInterest, modifyFilesOfInterest, setOpenVirtualResources, modifyOpenVirtualResources,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
@@ -80,7 +81,7 @@ modifyOpenVirtualResources state f = do
     DamlEnv{..} <- getIdeGlobalState state
     vrs <- modifyVar envOpenVirtualResources $ pure . dupe . f
     logDebug state $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
-    void $ shakeRun state []
+    void $ shakeRun state [] (const $ pure ())
 
 initialise
     :: Rules ()

--- a/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
@@ -212,7 +212,7 @@ getDiagnostics :: ShakeTest [D.FileDiagnostic]
 getDiagnostics = ShakeTest $ do
     service <- Reader.asks steService
     liftIO $ do
-        void $ API.runActionsSynchronous service []
+        void $ API.runActionsSync service []
         API.getDiagnostics service
 
 -- | Everything that rebuilt in the last execution must pass the predicate
@@ -222,7 +222,7 @@ expectLastRebuilt predicate = ShakeTest $ do
     testDir <- Reader.asks steTestDirPath
     liftIO $ withTempDir $ \dir -> do
         let file = dir </> "temp.json"
-        void $ API.runActionsSynchronous service []
+        void $ API.runActionsSync service []
         API.writeProfile service file
         rebuilt <- either error (return . parseShakeProfileJSON testDir) =<< Aeson.eitherDecodeFileStrict' file
         -- ignore those which are set to alwaysRerun - not interesting
@@ -262,7 +262,7 @@ getVirtualResources = ShakeTest $ do
     service <- Reader.asks steService
     virtualResources <- Reader.asks steVirtualResources
     liftIO $ do
-      void $ API.runActionsSynchronous service []
+      void $ API.runActionsSync service []
       readTVarIO virtualResources
 
 -- | Convenient grouping of file path, 0-based line number, 0-based column number.
@@ -400,7 +400,7 @@ expectGoToDefinition cursorRange pattern' = do
     checkPath (cursorRangeFilePath cursorRange)
     service <- ShakeTest $ Reader.asks steService
     forM_ (cursorRangeList cursorRange) $ \cursor -> do
-        maybeLoc <- ShakeTest . liftIO . API.runActionSynchronous service $
+        maybeLoc <- ShakeTest . liftIO . API.runActionSync service $
             API.getDefinition (cursorFilePath cursor) (cursorPosition cursor)
         unless (matchGoToDefinitionPattern pattern' maybeLoc) $
             throwError (ExpectedDefinition cursor pattern' maybeLoc)
@@ -419,7 +419,7 @@ expectTextOnHover cursorRange expectedInfo = do
     checkPath path
     service <- ShakeTest $ Reader.asks steService
     forM_ (cursorRangeList cursorRange) $ \cursor -> do
-        mbInfo <- ShakeTest . liftIO . API.runActionSynchronous service $
+        mbInfo <- ShakeTest . liftIO . API.runActionSync service $
                     API.getAtPoint path (cursorPosition cursor)
         let actualInfo :: [T.Text] = maybe [] (map API.getHoverTextContent . snd) mbInfo
         unless (hoverPredicate actualInfo) $

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -310,7 +310,7 @@ mainProj TestArguments{..} service outdir log file = do
     let lfPrettyPrint = timed log "LF pretty-printing" . liftIO . writeFile (outdir </> proj <.> "pdalf") . renderPretty
 
     Compile.setFilesOfInterest service (Set.singleton file)
-    Compile.runAction service $ do
+    Compile.runActionSync service $ do
             cores <- ghcCompile log file
             corePrettyPrint cores
             lf <- lfConvert log file


### PR DESCRIPTION
Previously, we were waiting for all rules to finish, in particular the
ofInterestRule. That doesn’t really make any sense, e.g., a goto
definition request should not be waiting for all scenarios to run.

The next step will be to change the LSP side such that requests and
notifications are processed in parallel where possible.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
