### PR TITLE
Send didClose notifications when the scenario view is closed

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -23,6 +23,13 @@ Release Procedure
   as part of the CI/CD.
   See `#1745 <https://github.com/digital-asset/daml/issues/1745>`__
 
+DAML Studio
+~~~~~~~~~~~
+
+- Closing and reopening scenario results will now show the results
+  instead of an empty view.
+  See `#1606 <https://github.com/digital-asset/daml/issues/1606>`__.
+
 .. _release-0-13-3:
 
 0.13.3 - 2019-06-18


### PR DESCRIPTION
This fixes #1606 which was caused by the fact that VSCode does not
send a close notification if the webview is closed.

The logic here is still a giant mess and has a bunch of stuff leftover
from previous VSCode APIs but I’ll clean it up in a separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
