### PR TITLE
Use a less generic directory name in damlc-dist.jar

### DIFF
--- a/daml-foundations/daml-tools/damlc-jar/BUILD.bazel
+++ b/daml-foundations/daml-tools/damlc-jar/BUILD.bazel
@@ -33,9 +33,11 @@ genrule(
     ],
     outs = ["damlc-dist.jar"],
     cmd = """
-    mkdir tmp
-    $(location @tar_dev_env//:tar) xzf $< -C tmp
-    $(location @bazel_tools//tools/jdk:jar) c0Mf $@ -C tmp .
+    TMP_DIR=damlc-jar-tmp
+    rm -rf "$$TMP_DIR"
+    mkdir "$$TMP_DIR"
+    $(location @tar_dev_env//:tar) xzf $< -C "$$TMP_DIR"
+    $(location @bazel_tools//tools/jdk:jar) c0Mf $@ -C "$$TMP_DIR" .
   """,
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     tools = [


### PR DESCRIPTION
This should fix issues on Windows due to that already existing. The
reason why we don’t just use mktemp -d is that this would make it easy
to end up with a lot of temporary directories and something like a
withTempDir is annoying to do in bash.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
