### PR TITLE
Move unreleased user-facing features to its own file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 - [ ] Include appropriate tests
 - [ ] Set a descriptive title and thorough description
 - [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
-- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate
+- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
 
 NOTE: CI is not automatically run on non-members pull-requests for security
 reasons. The reviewer will have to comment with `/AzurePipelines run` to

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,3 @@
 Please have a look at https://docs.daml.com/support/release-notes.html.
+
+Unreleased changes are tracked in [unreleased.rst](./unreleased.rst).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,10 @@ For Git commit messages, our principle is that `git log --pretty=oneline` should
 - Does your PR include appropriate tests?
 - Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
 - If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
-- If your PR includes user-facing changes, you must add a line describing the change to the [release notes](unreleased.rst) as part of your PR.
+- If your PR includes user-facing changes, you must add a line describing the change to [unreleased.rst](unreleased.rst) as part of your PR. Each entry in this document must start with the component to which is belongs, as in the following example:
+
+      - [Sandbox] Introduced a new API for package management.
+        See `#1311 <https://github.com/digital-asset/daml/issues/1311>`__.
 
 ## Working with issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ For Git commit messages, our principle is that `git log --pretty=oneline` should
 - Does your PR include appropriate tests?
 - Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
 - If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
-- If your PR includes user-facing changes, you must add a line describing the change to the [release notes](docs/source/support/release-notes.rst) as part of your PR.
+- If your PR includes user-facing changes, you must add a line describing the change to the [release notes](unreleased.rst) as part of your PR.
 
 ## Working with issues
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -6,9 +6,6 @@ Release notes
 
 This page contains release notes for the SDK.
 
-HEAD — ongoing
---------------
-
 DAML Assistant
 ~~~~~~~~~~~~~~
 

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -3,6 +3,8 @@
 1. Make a PR that bumps the version number in the `VERSION`
    file and adds a new header and label for the new version in
    `docs/source/support/release-notes.rst` (see previous releases as examples).
+   Release notes should be cut and pasted under the new header from `unreleased.rst`.
+   Please make sure the content you are pasting is properly formatted RST.
    It is important that the PR only changes `VERSION` and `release-notes.rst`.
 1. "Squash and merge" the PR.
 1. Once CI has passed for the corresponding master build, the release should be

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -4,7 +4,7 @@
    file and adds a new header and label for the new version in
    `docs/source/support/release-notes.rst` (see previous releases as examples).
    Release notes should be cut and pasted under the new header from `unreleased.rst`.
-   Please make sure the content you are pasting is properly formatted RST.
+   Please make sure the content you are pasting is properly formatted RST and that duplicate sections are merged.
    It is important that the PR only changes `VERSION` and `release-notes.rst`.
 1. "Squash and merge" the PR.
 1. Once CI has passed for the corresponding master build, the release should be

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -4,7 +4,7 @@
    file and adds a new header and label for the new version in
    `docs/source/support/release-notes.rst` (see previous releases as examples).
    Release notes should be cut and pasted under the new header from `unreleased.rst`.
-   Please make sure the content you are pasting is properly formatted RST and that duplicate sections are merged.
+   Each change outlined in `unreleased.rst` is preceded by the section to which it belongs: create one entry per section and add all pertaining items (without the section tag) to the release notes.
    It is important that the PR only changes `VERSION`, `release-notes.rst` and `unreleased.rst`.
 1. "Squash and merge" the PR.
 1. Once CI has passed for the corresponding master build, the release should be

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -5,7 +5,7 @@
    `docs/source/support/release-notes.rst` (see previous releases as examples).
    Release notes should be cut and pasted under the new header from `unreleased.rst`.
    Please make sure the content you are pasting is properly formatted RST and that duplicate sections are merged.
-   It is important that the PR only changes `VERSION` and `release-notes.rst`.
+   It is important that the PR only changes `VERSION`, `release-notes.rst` and `unreleased.rst`.
 1. "Squash and merge" the PR.
 1. Once CI has passed for the corresponding master build, the release should be
    available on bintray and GitHub, as well as properly tagged.

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -382,9 +382,9 @@ isReleaseCommit = do
     let isRelease = "VERSION" `elem` files
                  && "unreleased.rst" `elem` files
                  && "docs/source/support/release-notes.rst" `elem` files
-                 && length files == 2
+                 && length files == 3
     if "VERSION" `elem` files && not isRelease
-    then throwIO $ CIException "Release commit should only change VERSION and release-notes.rst."
+    then throwIO $ CIException "Release commit should only change VERSION, release-notes.rst and unreleased.rst."
     else return isRelease
 
 runFastLoggingT :: LoggingT IO c -> IO c

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -380,6 +380,7 @@ isReleaseCommit :: MonadCI m => m Bool
 isReleaseCommit = do
     files <- gitChangedFiles "HEAD"
     let isRelease = "VERSION" `elem` files
+                 && "unreleased.rst" `elem` files
                  && "docs/source/support/release-notes.rst" `elem` files
                  && length files == 2
     if "VERSION" `elem` files && not isRelease

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,8 +9,3 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
-Release Procedure
-~~~~~~~~~~~~~~~~~
-
-- Fixes to the CI/CD release procedure. 
-  See `#1755 <https://github.com/digital-asset/daml/issues/1755>__.`

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -1,0 +1,16 @@
+.. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Release notes
+#############
+
+This page contains release notes for the SDK.
+
+HEAD — ongoing
+--------------
+
+Release Procedure
+~~~~~~~~~~~~~~~~~
+
+- Fixes to the CI/CD release procedure. 
+  See `#1755 <https://github.com/digital-asset/daml/issues/1755>__.`


### PR DESCRIPTION
docs/source/support/release-notes.rst unfortunately represents a "global
lock" when it comes to submitting contributions: if another contribution
changed it while another was going through the CI/review process, the
latter would have to go again through the CI build after resolving the
conflict and merging the resulting commit.

The contributors originally tried to address this problem by letting the
system automatically performing this operation, but this failed because
release notes were moved to the wrong section by mistake.

This simple change would allow the contributors to let the system take
care of merging on its own, because existing release notes will no
longer be corrupted by the process.

There is a caveat: the automatic merging could result in invalid RST
(mostly because of missing newlines). This would push the task of
ensuring the release notes are valid RST to the release. I would argue
this can be done quite easily and that this is checked automatically
when rendering RST to HTML, so it could be a nuisance during release but
it would make the day-to-day contributions easier.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
