### PR TITLE
minor fix for scala typecheck 

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -187,8 +187,10 @@ private[validation] object Typing {
         cons match {
           case DataRecord(fields, template) =>
             env.checkRecordType(fields)
-            template.foreach(
-              env.checkTemplate(TypeConName(pkgId, QualifiedName(mod.name, dfnName)), _))
+            template.foreach { tmpl =>
+              if (params.nonEmpty) throw EExpectedTemplatableType(env.ctx, tyConName)
+              env.checkTemplate(tyConName, tmpl)
+            }
           case DataVariant(fields) =>
             env.checkVariantType(fields)
           case DataEnum(values) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -306,7 +306,7 @@ final case class PartyLiteral(party: Party) extends PartyLiteralRef
 final case class ValRefWithPartyLiterals(valueRef: ValueRef) extends PartyLiteralRef
 final case class EForbiddenPartyLiterals(context: Context, ref: PartyLiteralRef)
     extends ValidationError {
-  protected def prettyInternal: String = s"Found forbidden party literals"
+  protected def prettyInternal: String = s"Found forbidden party literals in ${ref}"
 }
 /* Collision */
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -578,6 +578,19 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           (\ (key: PositiveTestCase9:TBis) -> Cons @Party [(PositiveTestCase9:T {person} this), 'Alice'] (Nil @Party)  )
         } ;
       }
+
+      module PositiveTestCase10 {
+        record @serializable T (a: *) = {x: a};
+
+        // in the next line, T should be first order.
+        template (this : T) =  {
+          precondition True,
+          signatories Cons @Party ['Bob'] (Nil @Party),
+          observers Cons @Party ['Alice'] (Nil @Party),
+          agreement "Agreement",
+          choices { }
+        } ;
+      }
       """
 
       val world = new World(Map(defaultPackageId -> pkg))
@@ -613,6 +626,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         checkModule(pkg.updateVersion(version1_3), "PositiveTestCase6"))
       checkModule(pkg, "PositiveTestCase6")
       an[EUnknownExprVar] shouldBe thrownBy(checkModule(pkg, "PositiveTestCase9"))
+      an[EExpectedTemplatableType] shouldBe thrownBy(checkModule(pkg, "PositiveTestCase10"))
     }
 
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -582,7 +582,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
       module PositiveTestCase10 {
         record @serializable T (a: *) = {x: a};
 
-        // in the next line, T should be first order.
+        // in the next line, T must have kind *.
         template (this : T) =  {
           precondition True,
           signatories Cons @Party ['Bob'] (Nil @Party),


### PR DESCRIPTION
In this PR we fix a bug in the scala typechecker. Now the type checker reject parametric template type.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/docs/source/support/release-notes.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
