### PR TITLE
Run a final sync in damlc test

### DIFF
--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -48,6 +48,10 @@ execTest inFiles color mbJUnitOutput cliOptions = do
     Compiler.withIdeState opts loggerH eventLogger $ \h -> do
         let lfVersion = Compiler.optDamlLfVersion cliOptions
         testRun h inFiles lfVersion color mbJUnitOutput
+        -- Run synchronously at the end to make sure that all gRPC requests
+        -- finish properly. We have seen segfaults on CI sometimes
+        -- which are probably caused by not doing this.
+        CompilerService.runActionSync h (pure ())
         diags <- CompilerService.getDiagnostics h
         when (any ((Just DsError ==) . _severity . snd) diags) exitFailure
 


### PR DESCRIPTION
We have seen a few segfaults and assertion failures at the end of test
suites that use damlc test. I haven’t been able to reproduce them
locally but I’m hoping that this fixes them. It looks like this might
also been fixed in newer gRPC releases but my attempts to upgrade
turned into a mess that is at least going to take quite some time to
fix, see https://github.com/digital-asset/daml/pull/1771.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
