### PR TITLE
Fix up the release notes according to new guidelines.

### DIFF
--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -6,19 +6,6 @@ Release notes
 
 This page contains release notes for the SDK.
 
-DAML Assistant
-~~~~~~~~~~~~~~
-
-- Added `--install-assistant` flag to `daml install` command, changing the default
-  behavior of `daml install` to be "install the assistant whenever we are installing
-  a newer version of the SDK". Deprecated the `--activate` flag.
-
-DAML Studio
-~~~~~~~~~~~
-
-- Opening an already open scenario will now focus it rather than opening
-  it in a new empty tab which is never updated with results.
-
 .. _release-0-13-5:
 
 0.13.5 - 2019-06-19

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,8 +10,8 @@ HEAD — ongoing
 --------------
 
 - [DAML Assistant] Added ``--install-assistant`` flag to ``daml install`` command,
-  changing the default behavior of ``daml install`` to be "install the assistant
-  whenever we are installing newer version of the SDK". Deprecated the
+  changing the default behavior of ``daml install`` to install the assistant
+  whenever we are installing newer version of the SDK. Deprecated the
   ``--activate`` flag.
 - [DAML Studio] Opening an already open scenario will now focus it rather than opening
   it in a new empty tab which is never updated with results.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -11,7 +11,7 @@ HEAD — ongoing
 
 - [DAML Assistant] Added ``--install-assistant`` flag to ``daml install`` command,
   changing the default behavior of ``daml install`` to install the assistant
-  whenever we are installing newer version of the SDK. Deprecated the
+  whenever we are installing a newer version of the SDK. Deprecated the
   ``--activate`` flag.
 - [DAML Studio] Opening an already open scenario will now focus it rather than opening
   it in a new empty tab which is never updated with results.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,9 +9,12 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
-DAML Studio
-~~~~~~~~~~~
-
-- The selected view for scenario results (table or transaction) is now
+- [DAML Assistant] Added ``--install-assistant`` flag to ``daml install`` command,
+  changing the default behavior of ``daml install`` to be "install the assistant
+  whenever we are installing newer version of the SDK". Deprecated the
+  ``--activate`` flag.
+- [DAML Studio] Opening an already open scenario will now focus it rather than opening
+  it in a new empty tab which is never updated with results.
+- [DAML Studio] The selected view for scenario results (table or transaction) is now
   preserved when the scenario results are updated.
   See `#1675 <https://github.com/digital-asset/daml/issues/1675>`__.


### PR DESCRIPTION
Fixing up the unreleased release notes to work with our new release procedure, by moving them to `unreleased` and moving the section headers inline, in square brackets. Also, fixing up some DAML Assistant notes that were in Markdown accidentally. 🙃 