### PR TITLE
Use BadDependency consistently

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Shake.hs
@@ -331,7 +331,6 @@ isBadDependency x
     | Just (_ :: BadDependency) <- fromException x = True
     | otherwise = False
 
-
 newtype Q k = Q (k, NormalizedFilePath)
     deriving (Eq,Hashable,NFData)
 

--- a/daml-foundations/daml-ghc/damldoc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/damldoc/BUILD.bazel
@@ -28,6 +28,7 @@ da_haskell_library(
         "mtl",
         "prettyprinter",
         "text",
+        "transformers",
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -20,8 +20,8 @@ import qualified "ghc-lib-parser" DynFlags                        as DF
 import           "ghc-lib-parser" Bag (bagToList)
 
 import           Control.Monad.Except             as Ex
+import Control.Monad.Trans.Maybe
 import           Data.Char (isSpace)
-import Data.Either.Extra
 import           Data.List.Extra
 import           Data.Maybe
 import qualified Data.Map.Strict as MS
@@ -125,13 +125,13 @@ haddockParse opts f = ExceptT $ do
   service <- Service.initialise Service.mainRule (const $ pure ()) Logger.makeNopHandle opts vfs
   Service.setFilesOfInterest service (Set.fromList f)
   parsed  <- Service.runAction service $
-             Ex.runExceptT $
+             runMaybeT $
              -- We only _parse_ the modules, the documentation generator is syntax-directed
              do deps <- Service.usesE Service.GetDependencies f
                 Service.usesE Service.GetParsedModule $ nubOrd $ f ++ concatMap Service.transitiveModuleDeps deps
                 -- The DAML compiler always parses with Opt_Haddock on
   diags <- Service.getDiagnostics service
-  pure (mapLeft (const diags) parsed)
+  pure (maybe (Left diags) Right parsed)
 
 -- | Pair up all doc decl.s from a parsed module with their referred-to
 --   declaration. See Haddock's equivalent Haddock.Interface.Create.collectDocs

--- a/daml-foundations/daml-ghc/ide/BUILD.bazel
+++ b/daml-foundations/daml-ghc/ide/BUILD.bazel
@@ -33,6 +33,7 @@ da_haskell_library(
         "temporary",
         "text",
         "time",
+        "transformers",
         "utf8-string",
         "vector",
     ],


### PR DESCRIPTION
Previously we had a weird mix of using ExceptT to shortcircuit on
failed dependencies where the list of diagnostics was always empty and
throwing BadDependency exceptions.

This PR switches everything over to use BadDependency for failed
dependencies and removes a lot of conversions from one style to the
other.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
