### PR TITLE
Clean up the Handle module

### DIFF
--- a/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
+++ b/compiler/haskell-ide-core/src/Development/IDE/State/Rules.hs
@@ -19,7 +19,6 @@ module Development.IDE.State.Rules(
     getAtPoint,
     getDefinition,
     getDependencies,
-    getDalfDependencies,
     getParsedModule,
     fileFromParsedModule
     ) where
@@ -50,7 +49,6 @@ import Development.IDE.State.RuleTypes
 import           GHC
 import Development.IDE.Compat
 import           UniqSupply
-import           Module                         as M
 import NameCache
 
 import qualified Development.IDE.Functions.AtPoint as AtPoint
@@ -104,10 +102,7 @@ getGhcCore file = runMaybeT $ do
 getDependencies :: NormalizedFilePath -> Action (Maybe [NormalizedFilePath])
 getDependencies file = fmap transitiveModuleDeps <$> use GetDependencies file
 
-getDalfDependencies :: NormalizedFilePath -> Action (Maybe [InstalledUnitId])
-getDalfDependencies file = fmap transitivePkgDeps <$> use GetDependencies file
-
--- | -- | Try to get hover text for the name under point.
+-- | Try to get hover text for the name under point.
 getAtPoint :: NormalizedFilePath -> Position -> Action (Maybe (Maybe Range, [HoverText]))
 getAtPoint file pos = fmap join $ runMaybeT $ do
   files <- transitiveModuleDeps <$> useE GetDependencies file


### PR DESCRIPTION
Handle is kind of a mess at the moment, this is a first step towards
cleaning it up:

1. We had two functions called getDalfDependencies with one wrapping
the other. This PR merges them into one to make this less confusing.

2. buildDar called runAction a bunch of times directly and via other
functions. This PR switches it to use a single call to runAction.

3. The logic for turning a Maybe into an `ExceptT [FileDiagnostic]`
was duplicated in various places. This PR factor out the logic into a
single function.

There is certainly more cleanup to be done (e.g., I don’t think
ExceptT buys us anything here, that module should probably die
completely with the logic being moved to other modules, …) but I’d
like to do it incrementally.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
