### PR TITLE
detect whether docs update should run

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -63,11 +63,22 @@ jobs:
 
           echo "Loading dev-env..."
           eval "$(dev-env/bin/dade-assist)"
+
+          echo "Checking for new version..."
+          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
+          GH_VERSIONS=$(mktemp)
+          DOCS_VERSIONS=$(mktemp)
+          curl -s https://docs.daml.com/versions.json | jq -r 'keys | .[]' | sort > $DOCS_VERSIONS
+          echo $RELEASES | sed 's/ /\n/g' | sort > $GH_VERSIONS
+          if diff $DOCS_VERSIONS $GH_VERSIONS; then
+            echo "No new version found, skipping."
+            exit 0
+          fi
+
           echo "Building docs listing"
           DOCDIR=$(Build.StagingDirectory)/docs
           mkdir -p $DOCDIR
           LOG=$(Build.StagingDirectory)/log.txt
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
           LATEST=$(echo $RELEASES | awk '{print $1}')
           JSON_BODY=$(echo $RELEASES | sed -e 's/ /\n/g' | sed -e 's/v\(.*\)/"\1": "\1",'/g)
           echo "Building latest docs: $LATEST"


### PR DESCRIPTION
We currently rebuild the entire documentation every hour. This takes about 20 minutes and is mostly a huge waste of computing resources. The aim of this change is to reduce the waste by first checking if a new version has been published, and aborting if not.