### PR TITLE
Add grpc-netty as dep for bindings-java. publish daml-lf-archive

### DIFF
--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -60,6 +60,7 @@ da_java_library(
         "//visibility:public",
     ],
     deps = [
+        "//3rdparty/jvm/io/grpc:grpc_netty",
         "//3rdparty/jvm/io/grpc:grpc_protobuf",
         "//3rdparty/jvm/io/grpc:grpc_stub",
         "//3rdparty/jvm/org/checkerframework:checker",

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -1,5 +1,6 @@
 - target: //daml-lf/archive:daml_lf_archive_java
   type: jar
+  mavenUpload: True
 - target: //daml-lf/data:data
   type: jar
 - target: //daml-foundations/daml-tools/da-hs-damlc-app:damlc-dist

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -23,3 +23,4 @@ HEAD — ongoing
   also includes the protobuf-java library used as a dependency.
 - [Ledger API] Added additional Ledger API integration tests to Ledger API Test Tool.
 - [DAML Studio] Goto definition now works on the export list of modules.
+- [Java Bindings] The artefact ``com.daml.ledger:bindings-java`` now has ``grpc-netty`` as dependency so that users don't need to explicitly add it.


### PR DESCRIPTION
We add a dependency in bindings-java to grpc-netty, so it is
automatically available in the classpath for users. Otherwise they get
an error like [0] if they don't add it explicitly.

We also publish daml-lf-archive-java to maven central.

[0] io.grpc.ManagedChannelProvider$ProviderNotFoundException: No
functional channel service provider found. Try adding a dependency
on the grpc-okhttp, grpc-netty, or grpc-netty-shaded artifact

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
