### PR TITLE
Move LSP stress tests to lsp-tests

### DIFF
--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -37,5 +37,6 @@ da_haskell_test(
         "//daml-foundations/daml-ghc/ide",
         "//daml-foundations/daml-ghc/test-lib",
         "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -37,6 +37,5 @@ da_haskell_test(
         "//daml-foundations/daml-ghc/ide",
         "//daml-foundations/daml-ghc/test-lib",
         "//libs-haskell/bazel-runfiles",
-        "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -10,7 +10,7 @@ import Control.Monad (forM, forM_, void)
 import Control.Monad.IO.Class
 import DA.Bazel.Runfiles
 import Data.Aeson (toJSON)
-import qualified Data.Text.Extended as T
+import qualified Data.Text as T
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Lens
 import Network.URI
@@ -427,8 +427,8 @@ stressTests run _runScenarios = testGroup "Stress tests"
             ]
         foos <- forM [1 .. 99 :: Int] $ \i ->
             makeModule ("Foo" ++ show i)
-                [ "import Foo" <> T.show (i+1)
-                , "foo" <> T.show i <> " = foo" <> T.show (i+1)
+                [ "import Foo" <> T.pack (show (i+1))
+                , "foo" <> T.pack (show i) <> " = foo" <> T.pack (show (i+1))
                 ]
         foo100 <- makeModule "Foo100"
             [ "foo100 : Bool"

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -434,7 +434,7 @@ stressTests run _runScenarios = testGroup "Stress tests"
             [ "foo100 : Bool"
             , "foo100 = False"
             ]
-        withTimeout 180 $ do -- This takes way too long. Can we get it down?
+        withTimeout 30 $ do
             expectDiagnostics [("Foo0.daml", [(DsError, (4, 7), "Couldn't match expected type")])]
             void $ replaceDoc foo0 $ moduleContent "Foo0"
                 [ "import Foo1"

--- a/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
@@ -17,7 +17,6 @@ import qualified Test.Tasty.HUnit    as Tasty
 import qualified Data.Text.Extended  as T
 
 import Data.Either
-import Control.Monad
 import System.Directory
 import System.Environment.Blank (setEnv)
 import Control.Monad.IO.Class
@@ -45,7 +44,6 @@ ideTests mbScenarioService =
         , goToDefinitionTests mbScenarioService
         , onHoverTests mbScenarioService
         , scenarioTests mbScenarioService
-        , stressTests mbScenarioService
         ]
 
 -- | Tasty test case from a ShakeTest.
@@ -676,66 +674,6 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
             expectNoVirtualResource vr
             setOpenVirtualResources [vr]
             expectVirtualResource vr "Return value: {}"
-    ]
-    where
-        testCase' = testCase mbScenarioService
-
--- | Do extreme things to the compiler service.
-stressTests :: Maybe SS.Handle -> Tasty.TestTree
-stressTests mbScenarioService = Tasty.testGroup "Stress tests"
-    [   testCase' "Modify a file 2000 times" $ do
-            let fooValue :: Int -> T.Text
-                fooValue i = T.pack (show (i `div` 2))
-                          <> if i `mod` 2 == 0 then "" else ".5"
-                fooContent i = T.unlines
-                    [ "daml 1.2"
-                    , "module Foo where"
-                    , "foo : Int"
-                    , "foo = " <> fooValue i
-                    ]
-            foo <- makeFile "Foo.daml" $ fooContent 0
-            setFilesOfInterest [foo]
-            expectNoErrors
-            forM_ [1 .. 999] $ \i ->
-                void $ makeFile "Foo.daml" $ fooContent i
-            expectOneError (foo,3,6) "Couldn't match expected type"
-            forM_ [1000 .. 2000] $ \i ->
-                void $ makeFile "Foo.daml" $ fooContent i
-            expectNoErrors
-
-    ,   testCase' "Set 10 files of interest" $ do
-            foos <- forM [1 .. 10 :: Int] $ \i ->
-                makeModule ("Foo" ++ show i) ["foo = 10"]
-            timedSection 30 $ do
-                setFilesOfInterest foos
-                expectNoErrors
-
-    ,   testCase' "Type check 100-deep module chain" $ do
-            -- The idea for this test is we have 101 modules named Foo0 through Foo100.
-            -- Foo0 imports Foo1, which imports Foo2, which imports Foo3, and so on to Foo100.
-            -- Each FooN has a definition fooN that depends on fooN+1, except Foo100.
-            -- But the type of foo0 doesn't match the type of foo100. So we expect a type error.
-            -- Then we modify the type of foo0 to clear the type error.
-            foo0 <- makeModule "Foo0"
-                ["import Foo1"
-                ,"foo0 : Int"
-                ,"foo0 = foo1"]
-            forM_ [1 .. 99 :: Int] $ \i ->
-                makeModule ("Foo" ++ show i)
-                    ["import Foo" <> T.show (i+1)
-                    ,"foo" <> T.show i <> " = foo" <> T.show (i+1)]
-            void $ makeModule "Foo100"
-                ["foo100 : Bool"
-                ,"foo100 = False"]
-            timedSection 180 $ do -- This takes way too long. Can we get it down?
-                setFilesOfInterest [foo0]
-                expectOneError (foo0,4,7) "Couldn't match expected type"
-                void $ makeModule "Foo0"
-                    ["import Foo1"
-                    ,"foo0 : Bool"
-                    ,"foo0 = foo1"]
-                expectNoErrors
-
     ]
     where
         testCase' = testCase mbScenarioService


### PR DESCRIPTION
- Moves the LSP stress tests from `//daml-foundations/daml-ghc:daml-ghc-shake-test-ci` to `//compiler/lsp-tests:lsp-test`.
- The `IDE.State` offered direct access to the list of diagnostics which allowed for `expectNoErrors`. I didn't find a direct translation for this check for the LSP tests, because the language server won't send any diagnostics in certain cases. Meaning that e.g. `expectDiagnostics [("Foo.daml", [])]` would hang. I've translated those tests to an initial failing state where we can expect error diagnostics, followed by a change which fixes the errors so we can expect empty diagnostics.
- One of the test cases had a 180 s timeout. The test now takes less than 3 seconds on my machine, so I've reduced the timeout.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
