### PR TITLE
Remove the feedback widget as a valid source of support

### DIFF
--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -1,24 +1,21 @@
 .. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Support and feedback
-====================
+Support
+=======
 
 Have questions or feedback? You're in the right place.
 
 - **Questions: Stack Overflow**
 
-  For “how do I?”, “why does something work this way” or “I’ve got a programming problem I’m trying to solve” questions, the `daml tag on Stack Overflow <https://stackoverflow.com/questions/tagged/daml>`_ is the best place to ask. 
+  For “how do I?”, “why does something work this way” or “I’ve got a programming problem I’m trying to solve” questions, the `daml tag on Stack Overflow <https://stackoverflow.com/questions/tagged/daml>`_ is the best place to ask.
 
-  If you're not sure what makes a good question, take a look at `this checklist <https://codeblog.jonskeet.uk/2012/11/24/stack-overflow-question-checklist/>`_. 
-- **Help and feedback: Slack, or Support widget**
+  If you're not sure what makes a good question, take a look at `this checklist <https://codeblog.jonskeet.uk/2012/11/24/stack-overflow-question-checklist/>`_.
+- **Help and feedback: Slack**
 
-  If you want to give feedback, or have questions that aren't right for Stack Overflow, you can: 
+  If you want to give feedback, or have questions that aren't right for Stack Overflow, you can join the DAML community on `Slack <https://damldriven.slack.com/sso/saml/start>`_ and talk to us in the ``#public`` channel.
 
-  - Join the DAML community on `Slack <https://damldriven.slack.com/sso/saml/start>`_.
-  - Ask us for help using the `Support <javascript:open_feedback()>`_ link on any documentation page.
-
-When you're in the community Slack or on Stack Overflow, please keep to the `Code of Conduct <https://github.com/digital-asset/daml/blob/master/CODE_OF_CONDUCT.md>`__. 
+When you're in the community Slack or on Stack Overflow, please keep to the `Code of Conduct <https://github.com/digital-asset/daml/blob/master/CODE_OF_CONDUCT.md>`__.
 
 Support expectations
 --------------------
@@ -28,7 +25,7 @@ For community users (ie on Slack and Stack Overflow):
 - **Timing**: You can enjoy the support of the community, which is provided for you out of their own good will and free time. On top of that, a Digital Asset employee will try to reply to unanswered questions within two business days.
 
   Business days are affected by public holidays. Engineers contributing to DAML are mostly located in Zurich and New York, so please be mindful of the public holidays in those locations (`timeanddate.com <https://www.timeanddate.com>`_ maintains an unofficial list of holidays for both `Switzerland <https://www.timeanddate.com/holidays/switzerland/>`_ and the `United States <https://www.timeanddate.com/holidays/us/>`_).
-- **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_. 
+- **Public support**: We only offer public support - for example, on the ``#public`` channel in `Slack <https://damldriven.slack.com/sso/saml/start>`_.
 
   We can't answer questions in private messages or over email, so please only ask questions in the ``#public`` channel.
 - **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application or the languages, frameworks, libraries and tools you may use to build it.


### PR DESCRIPTION
Clear up that there are two valid sources, slack and StackOverflow.