### PR TITLE
[hs-ledger-bindings tests] Read the main dalf from the DAR manifest

### DIFF
--- a/compiler/daml-lf-reader/BUILD.bazel
+++ b/compiler/daml-lf-reader/BUILD.bazel
@@ -1,0 +1,23 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel_tools:haskell.bzl", "da_haskell_library")
+
+da_haskell_library(
+    name = "daml-lf-reader",
+    srcs = glob(["src/**/*.hs"]),
+    hazel_deps = [
+        "base",
+        "bytestring",
+        "extra",
+        "filepath",
+        "unordered-containers",
+        "utf8-string",
+        "zip-archive",
+    ],
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler/daml-lf-ast",
+    ],
+)

--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -1,0 +1,50 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.LF.Reader
+    ( Manifest(..)
+    , ManifestData(..)
+    , manifestFromDar
+    ) where
+
+import Codec.Archive.Zip
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
+import qualified Data.HashMap.Strict as Map
+import Data.List.Extra
+import System.FilePath
+
+data Manifest = Manifest
+    { mainDalf :: FilePath
+    , dalfs :: [FilePath]
+    } deriving (Show)
+
+data ManifestData = ManifestData
+    { mainDalfContent :: BSL.ByteString
+    , dalfsContent :: [BSL.ByteString]
+    } deriving (Show)
+
+lineToKeyValue :: String -> (String, String)
+lineToKeyValue line = case splitOn ":" line of
+    [l, r] -> (trim l , trim r)
+    _ -> error $ "Expected two fields in line " <> line
+
+manifestMapToManifest :: Map.HashMap String String -> Manifest
+manifestMapToManifest hash = Manifest mainDalf dependDalfs
+    where
+        mainDalf = Map.lookupDefault "unknown" "Main-Dalf" hash
+        dependDalfs = map trim $ delete mainDalf (splitOn "," (Map.lookupDefault "unknown" "Dalfs" hash))
+
+manifestDataFromDar :: Archive -> Manifest -> ManifestData
+manifestDataFromDar archive manifest = ManifestData manifestDalfByte dependencyDalfBytes
+    where
+        manifestDalfByte = head [fromEntry e | e <- zEntries archive, ".dalf" `isExtensionOf` eRelativePath e  && eRelativePath e  == mainDalf manifest]
+        dependencyDalfBytes = [fromEntry e | e <- zEntries archive, ".dalf" `isExtensionOf` eRelativePath e  && elem (trim (eRelativePath e))  (dalfs manifest)]
+
+manifestFromDar :: Archive -> ManifestData
+manifestFromDar dar =  manifestDataFromDar dar manifest
+    where
+        manifestEntry = head [fromEntry e | e <- zEntries dar, ".MF" `isExtensionOf` eRelativePath e]
+        linesStr = lines $ UTF8.toString manifestEntry
+        manifest = manifestMapToManifest $ Map.fromList $ map lineToKeyValue (filter (\a -> a /= "" ) linesStr)
+

--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -53,6 +53,7 @@ da_haskell_library(
         "//:sdk-version-hs-lib",
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
+        "//compiler/daml-lf-reader",
         "//compiler/daml-lf-tools",
         "//compiler/haskell-ide-core",
         "//compiler/scenario-service/client",

--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -72,6 +72,7 @@ da_haskell_test(
     hazel_deps = [
         "async",
         "base",
+        "bytestring",
         "filepath",
         "directory",
         "extra",
@@ -82,11 +83,15 @@ da_haskell_test(
         "text",
         "time",
         "uuid",
+        "zip-archive",
     ],
     main_function = "DA.Ledger.Tests.main",
     src_strip_prefix = "test",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto",
+        "//compiler/daml-lf-reader",
         "//language-support/hs/bindings:hs-ledger",
         "//libs-haskell/bazel-runfiles",
     ],

--- a/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
@@ -12,7 +12,7 @@ module DA.Ledger.Sandbox ( -- Run a sandbox for testing on a dynamically selecte
 
 import Trace
 
-import Control.Monad(when)
+import Control.Monad
 import Control.Exception (bracket, evaluate, onException)
 import DA.Bazel.Runfiles
 import DA.Ledger (Port (..), unPort)


### PR DESCRIPTION
Previously, we got the package id by listing all packages and taking
the first. That is not a valid assumption and broke with a PR. This PR
changes the tests to use the DAR reader that we already used for
visualization (now factored into a separate library) and reads the
main dalf using that.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
