### PR TITLE
Write generic instances to separate modules on the fly

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -199,14 +199,12 @@ packagingTests tmpDir = testGroup "packaging"
             [ "daml 1.2"
             , "module Main where"
             , "data OnlyA"
-            -- TODO (drsk) for now no templates because we still need to generate the generic
-            -- instances.
-            --, "template Foo"
-            --, "  with"
-            --, "    a : Int"
-            --, "    p : Party"
-            --, "  where"
-            --, "    signatory p"
+            , "template Foo"
+            , "  with"
+            , "    a : Int"
+            , "    p : Party"
+            , "  where"
+            , "    signatory p"
             ]
         writeFileUTF8 (projectA </> "daml.yaml") $ unlines
             [ "sdk-version: " <> sdkVersion
@@ -226,14 +224,12 @@ packagingTests tmpDir = testGroup "packaging"
             [ "daml 1.2"
             , "module Main where"
             , "data OnlyB"
-            -- TODO (drsk) for now no templates because we still need to generate the generic
-            -- instances.
-            --, "template Foo"
-            --, "  with"
-            --, "    a : Int"
-            --, "    p : Party"
-            --, "  where"
-            --, "    signatory p"
+            , "template Foo"
+            , "  with"
+            , "    a : Int"
+            , "    p : Party"
+            , "  where"
+            , "    signatory p"
             ]
         writeFileUTF8 (projectB </> "daml.yaml") $ unlines
             [ "sdk-version: " <> sdkVersion

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Upgrade.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Upgrade.hs
@@ -4,17 +4,47 @@
 
 module DA.Daml.GHC.Compiler.Upgrade
     ( generateUpgradeModule
+    , generateGenInstancesModule
     ) where
 
+import DA.Daml.GHC.Compiler.Generics
 import Data.Maybe
 import "ghc-lib" GHC
 import "ghc-lib-parser" Name
 import "ghc-lib-parser" RdrName
+import "ghc-lib-parser" PrelNames
+import "ghc-lib-parser" Outputable (showSDocUnsafe, ppr)
+
+-- | Generate a module containing generic instances for data types that don't have them already.
+generateGenInstancesModule :: String -> (String, ParsedSource) -> String
+generateGenInstancesModule qual (pkg, L _l src) =
+    unlines $ header ++ map (showSDocUnsafe . ppr) genericInstances
+  where
+    modName = moduleNameString $ unLoc $ fromMaybe (error "missing module name") $ hsmodName src
+    header =
+        [ "{-# LANGUAGE EmptyCase #-}"
+        , "daml 1.2"
+        , "module " <> modName <> "Instances" <> qual <> " where"
+        , "import \"" <> pkg <> "\" " <> modName
+        , "import DA.Generics"
+        ]
+
+    genericInstances =
+        [ generateGenericInstanceFor
+            (nameOccName genClassName)
+            tcdLName
+            pkg
+            (fromMaybe (error "Missing module name") $ hsmodName src)
+            tcdTyVars
+            tcdDataDefn
+        | L _ (TyClD _x DataDecl {..}) <- hsmodDecls src
+        ]
 
 -- | Generate non-consuming choices to upgrade all templates defined in the module.
 generateUpgradeModule ::
        (String, ParsedSource) -> (String, ParsedSource) -> String
-generateUpgradeModule (pkgA, L _lA srcA) (pkgB, L _lB srcB) = unlines $ header ++ concatMap upgradeTemplate names
+generateUpgradeModule (pkgA, L _lA srcA) (pkgB, L _lB srcB) =
+    unlines $ header ++ concatMap upgradeTemplate names
   where
     names = [n | n <- allTemplateDataNames srcA, n `elem` allTemplateDataNames srcB]
     modName = moduleNameString $ unLoc $ fromMaybe (error "missing module name") $ hsmodName srcA
@@ -37,28 +67,31 @@ generateUpgradeModule (pkgA, L _lA srcA) (pkgB, L _lB srcB) = unlines $ header +
                   (mkModuleName "DA.Internal.Desugar")
                   (mkOccName tcClsName "Template")
         ]
-
     header =
         [ "daml 1.2"
         , "module " <> modName <> " where"
         , "import \"" <> pkgA <> "\" " <> modName <> " qualified as A"
         , "import \"" <> pkgB <> "\" " <> modName <> " qualified as B"
+        , "import " <> modName <> "InstancesA()"
+        , "import " <> modName <> "InstancesB()"
         , "import DA.Next.Set"
         , "import DA.Upgrade"
         ]
-    upgradeTemplate n =
-      [ "template " <> n <> "Upgrade"
-      , "    with"
-      , "        op : Party"
-      , "    where"
-      , "        signatory op"
-      , "        nonconsuming choice Upgrade: ContractId B." <> n
-      , "            with"
-      , "                inC : ContractId A." <> n
-      , "                sigs : [Party]"
-      , "            controller sigs"
-      , "                do"
-      , "                    d <- fetch inC"
-      , "                    assert $ fromList sigs == fromList (signatory d)"
-      , "                    create $ conv d"
-      ]
+
+upgradeTemplate :: String -> [String]
+upgradeTemplate n =
+  [ "template " <> n <> "Upgrade"
+  , "    with"
+  , "        op : Party"
+  , "    where"
+  , "        signatory op"
+  , "        nonconsuming choice Upgrade: ContractId B." <> n
+  , "            with"
+  , "                inC : ContractId A." <> n
+  , "                sigs : [Party]"
+  , "            controller sigs"
+  , "                do"
+  , "                    d <- fetch inC"
+  , "                    assert $ fromList sigs == fromList (signatory d)"
+  , "                    create $ conv d"
+  ]

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -642,12 +642,17 @@ execMigrate opts inFile1 inFile2 mbDir = do
                     (pkg1, pm_parsed_source parsedMod1)
                     (pkg2, pm_parsed_source parsedMod2)
         let generatedInstancesMod1 =
-                generateGenInstancesModule "A" (pkg1, pm_parsed_source parsedMod1)
+                generateGenInstancesModule
+                    "A"
+                    (pkg1, pm_parsed_source parsedMod1)
         let generatedInstancesMod2 =
-                generateGenInstancesModule "B" (pkg2, pm_parsed_source parsedMod2)
-        forM [ (upgradeModPath, generatedUpgradeMod)
-             , (instancesModPath1, generatedInstancesMod1)
-             , (instancesModPath2, generatedInstancesMod2)
+                generateGenInstancesModule
+                    "B"
+                    (pkg2, pm_parsed_source parsedMod2)
+        forM_
+            [ (upgradeModPath, generatedUpgradeMod)
+            , (instancesModPath1, generatedInstancesMod1)
+            , (instancesModPath2, generatedInstancesMod2)
             ] $ \(path, mod) -> do
             createDirectoryIfMissing True $ takeDirectory path
             writeFile path mod

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -594,6 +594,7 @@ execInspectDar inFile = do
         putStrLn $
             (dropExtension $ takeFileName $ eRelativePath dalfEntry) <> " " <>
             show (LF.unPackageId pkgId)
+
 execMigrate ::
        Compiler.Options -> FilePath -> FilePath -> Maybe FilePath -> Command
 execMigrate opts inFile1 inFile2 mbDir = do
@@ -625,17 +626,31 @@ execMigrate opts inFile1 inFile2 mbDir = do
     forM_ pairs $ \(e1, e2) -> do
         let path1 = eRelativePath e1
         let path2 = eRelativePath e2
-        let generatedPath =
+        let upgradeModPath =
                 joinPath $ fromMaybe "" mbDir : (tail $ splitPath path1)
+        let instancesModPath1 =
+                replaceBaseName upgradeModPath $
+                takeBaseName path1 <> "InstancesA"
+        let instancesModPath2 =
+                replaceBaseName upgradeModPath $
+                takeBaseName path2 <> "InstancesB"
         opts' <- Compiler.mkOptions opts
         parsedMod1 <- parse opts' loggerH path1
         parsedMod2 <- parse opts' loggerH path2
-        let generatedMod =
+        let generatedUpgradeMod =
                 generateUpgradeModule
                     (pkg1, pm_parsed_source parsedMod1)
                     (pkg2, pm_parsed_source parsedMod2)
-        createDirectoryIfMissing True $ takeDirectory generatedPath
-        writeFile generatedPath generatedMod
+        let generatedInstancesMod1 =
+                generateGenInstancesModule "A" (pkg1, pm_parsed_source parsedMod1)
+        let generatedInstancesMod2 =
+                generateGenInstancesModule "B" (pkg2, pm_parsed_source parsedMod2)
+        forM [ (upgradeModPath, generatedUpgradeMod)
+             , (instancesModPath1, generatedInstancesMod1)
+             , (instancesModPath2, generatedInstancesMod2)
+            ] $ \(path, mod) -> do
+            createDirectoryIfMissing True $ takeDirectory path
+            writeFile path mod
   where
     parse opts' loggerH fp =
         Compiler.withIdeState opts' loggerH (const $ pure ()) $ \hDamlGhc -> do


### PR DESCRIPTION
The migrate command generates generic instances of data types and puts
them in a separate module. For now this only works if the data type
doesn't have a generic instance already, we'll deal with this case in
the next PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
