### PR TITLE
switch to Python 3.7 everywhere

### DIFF
--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -52,7 +52,7 @@ rec {
 
   sphinx183 = import ./tools/sphinx183 {
     inherit pkgs;
-    pythonPackages = pkgs.python36Packages;
+    pythonPackages = pkgs.python37Packages;
   };
 
   # Custom combination of latex packages for our latex needs

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -107,7 +107,7 @@ in rec {
     # Nix development
     cabal2nix = pkgs.cabal2nix;
 
-    pypi2nix  = pkgs.pypi2nix.override { pythonPackages = pkgs.python36Packages; };
+    pypi2nix  = pkgs.pypi2nix.override { pythonPackages = pkgs.python37Packages; };
 
     # Web development
     node        = bazel_dependencies.nodejs;
@@ -134,13 +134,13 @@ in rec {
     chromedriver = pkgs.callPackage ./tools/chromedriver/default.nix {};
 
     # Python development
-    pip3        = python36;
-    python      = python36;
-    python3     = python36;
-    python36    = pkgs.python36Packages.python;
+    pip3        = python37;
+    python      = python37;
+    python3     = python37;
+    python37    = pkgs.python37Packages.python;
 
-    flake8 = pkgs.python36Packages.flake8;
-    yapf = pkgs.python36Packages.yapf;
+    flake8 = pkgs.python37Packages.flake8;
+    yapf = pkgs.python37Packages.yapf;
 
     # Pex packaging has been submitted upsteam as
     # https://github.com/NixOS/nixpkgs/pull/45497.
@@ -153,13 +153,13 @@ in rec {
     cqlsh     = cassandra;
     nodetool  = cassandra;
 
-    sphinx            = pkgs.python36.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]);
+    sphinx            = pkgs.python37.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]);
     sphinx-build      = sphinx;
     sphinx-quickstart = sphinx;
 
     sphinx-autobuild = import ./tools/sphinx-autobuild {
       inherit pkgs;
-      pythonPackages = pkgs.python36Packages;
+      python37Packages = pkgs.python37Packages;
     };
 
     sphinx183 = bazel_dependencies.sphinx183;
@@ -229,7 +229,7 @@ in rec {
     base64 = pkgs.coreutils;
     sha1sum = pkgs.coreutils;
     xmlstarlet = pkgs.xmlstarlet;
-    
+
     # Cryptography tooling
     gnupg = pkgs.gnupg;
     gpg   = gnupg;
@@ -269,7 +269,7 @@ in rec {
   cached = bazel_dependencies // {
     # Python packages used via 'python3.6-da'.
     pythonPackages = {
-      inherit (pkgs.python36Packages)
+      inherit (pkgs.python37Packages)
         pyyaml semver GitPython;
     };
     # Packages used in command-line tools, e.g. `dade-info`.

--- a/nix/tools/python36/default.nix
+++ b/nix/tools/python36/default.nix
@@ -1,5 +1,5 @@
 { pkgs, src }:
-let python = pkgs.python36.override {
+let python = pkgs.python37.override {
   packageOverrides = self: super: rec {
     # This override can be removed once pygraphviz is on v1.5
     pygraphviz = super.callPackage ./pygraphviz { };

--- a/nix/tools/sphinx-autobuild/default.nix
+++ b/nix/tools/sphinx-autobuild/default.nix
@@ -6,7 +6,7 @@
 #
 
 { pkgs
-, pythonPackages
+, python37Packages
 }:
 
 let
@@ -18,7 +18,7 @@ let
   commonDoCheck = false;
 
   python = {
-    mkDerivation = pythonPackages.buildPythonPackage;
+    mkDerivation = python37Packages.buildPythonPackage;
   };
 
   generated = self: {

--- a/nix/tools/sphinx183/default.nix
+++ b/nix/tools/sphinx183/default.nix
@@ -18,7 +18,7 @@ let
   import "${toString pkgs.path}/pkgs/top-level/python-packages.nix" {
     inherit pkgs;
     inherit (pkgs) stdenv;
-    python = pkgs.python36;
+    python = pkgs.python37;
     # patching pip so it does not try to remove files when running nix-shell
     overrides =
       self: super: {
@@ -37,7 +37,7 @@ let
     let
       pkgs = builtins.removeAttrs pkgs' ["__unfix__"];
       interpreter = pythonPackages.buildPythonPackage {
-        name = "python36-interpreter";
+        name = "python37-interpreter";
         buildInputs = [ makeWrapper ] ++ (builtins.attrValues pkgs);
         buildCommand = ''
           mkdir -p $out/bin


### PR DESCRIPTION
The `docs/scripts/live-preview.sh` command has been broken since [this commit](https://github.com/digital-asset/daml/commit/55d5fa5dea5cdefd331cd604052224b1b626a1d5). I believe the reason is that, when updating the nixpkgs version, the default Python 3 version was upgraded from 3.6.8 to 3.7.3. However, we were still setting the packages for Python 3.6, so the virtualenv package ended up missing for Python 3.7 (which was used by the autobuild feature of Sphinx, because we do not explicitly choose a version in `nix/tools/sphinx-autobuild`).

I'm not quite sure about what I'm doing here but I think this is explicitly selecting Python 3.7 everywhere. At the very least, it fixes the live-preview script on my machine.