### PR TITLE
Handle SIGINT in daml commands.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -83,6 +83,7 @@
     - DA.Sdk.Cli.System
     - DA.Sdk.Cli.Version
     - DAML.Assistant.Install.Path
+    - DamlHelper.Signals
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat
   - {name: ImplicitParams, within: []}
@@ -107,7 +108,6 @@
 # Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
 # - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
 
-
 # Turn on hints that are off by default
 #
 # Ban "module X(module X) where", to require a real export list
@@ -119,11 +119,9 @@
 # Generalise map to fmap, ++ to <>
 # - group: {name: generalise, enabled: true}
 
-
 # Ignore some builtin hints
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
-
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_test")
 load("//bazel_tools:packaging/packaging.bzl", "package_app")
+load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_library(
     name = "daml-helper-lib",
@@ -28,7 +29,7 @@ da_haskell_library(
         "safe-exceptions",
         "text",
         "yaml",
-    ],
+    ] + ([] if is_windows else ["unix"]),
     visibility = ["//visibility:public"],
     deps = [
         "//daml-assistant:daml-project-config",

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -60,8 +60,6 @@ import DAML.Project.Consts
 import DAML.Project.Types
 import DAML.Project.Util
 
-import DamlHelper.Signals
-
 data DamlHelperError = DamlHelperError
     { errMessage :: T.Text
     , errInternal :: Maybe T.Text
@@ -137,7 +135,6 @@ shouldReplaceExtension replaceExt dir =
 
 runJar :: FilePath -> [String] -> IO ()
 runJar jarPath remainingArguments = do
-    installSignalHandlers
     exitCode <- withJar jarPath remainingArguments waitForProcess
     exitWith exitCode
 
@@ -548,7 +545,6 @@ runStart (OpenBrowser shouldOpenBrowser) = withProjectRoot Nothing (ProjectCheck
     assistant <- getDamlAssistant
     callCommand (unwords $ assistant : ["build", "-o", darPath])
     let scenarioArgs = maybe [] (\scenario -> ["--scenario", scenario]) mbScenario
-    installSignalHandlers
     withSandbox sandboxPort (darPath : scenarioArgs) $ \sandboxPh -> do
         parties <- getProjectParties
         withTempDir $ \confDir -> do

--- a/daml-assistant/daml-helper/src/DamlHelper.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper.hs
@@ -137,6 +137,7 @@ shouldReplaceExtension replaceExt dir =
 
 runJar :: FilePath -> [String] -> IO ()
 runJar jarPath remainingArguments = do
+    installSignalHandlers
     exitCode <- withJar jarPath remainingArguments waitForProcess
     exitWith exitCode
 
@@ -144,7 +145,6 @@ withJar :: FilePath -> [String] -> (ProcessHandle -> IO a) -> IO a
 withJar jarPath args a = do
     sdkPath <- getSdkPath
     let absJarPath = sdkPath </> jarPath
-    installSignalHandlers
     (withCreateProcess (proc "java" ("-jar" : absJarPath : args)) $ \_ _ _ -> a) `catchIO`
         (\e -> hPutStrLn stderr "Failed to start java. Make sure it is installed and in the PATH." *> throwIO e)
 

--- a/daml-assistant/daml-helper/src/DamlHelper/Signals.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Signals.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE CPP #-}
+
+-- | Module that turns SIGTERM into a UserInterrput exception in unix.
+module DamlHelper.Signals
+    ( installSignalHandlers
+    ) where
+
+#ifndef mingw32_HOST_OS
+import System.Posix.Signals
+import Control.Exception
+import Control.Concurrent
+import Control.Monad
+#endif
+
+-- | Turn SIGTERM into a UserInterrput exception in Unix. Does nothing on Windows.
+installSignalHandlers :: IO ()
+
+#ifdef mingw32_HOST_OS
+installSignalHandlers = pure ()
+#else
+installSignalHandlers = do
+    mainThread <- myThreadId
+    void $ installHandler sigTERM (Catch $ throwTo mainThread UserInterrupt) Nothing
+#endif
+

--- a/daml-assistant/daml-helper/src/DamlHelper/Signals.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Signals.hs
@@ -1,6 +1,9 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 {-# LANGUAGE CPP #-}
 
--- | Module that turns SIGTERM into a UserInterrput exception in unix.
+-- | Module that turns SIGTERM into a UserInterrupt exception in Unix.
 module DamlHelper.Signals
     ( installSignalHandlers
     ) where

--- a/daml-assistant/daml-helper/src/Main.hs
+++ b/daml-assistant/daml-helper/src/Main.hs
@@ -10,14 +10,19 @@ import System.Exit
 import System.IO
 
 import DamlHelper
+import DamlHelper.Signals
 
 main :: IO ()
-main = withProgName "daml" $ go `catch` \(e :: DamlHelperError) -> do
-    hPutStrLn stderr (displayException e)
-    exitFailure
+main =
+    withProgName "daml" $ go `catch` \(e :: DamlHelperError) -> do
+        hPutStrLn stderr (displayException e)
+        exitFailure
   where
-      parserPrefs = prefs showHelpOnError
-      go = runCommand =<< customExecParser parserPrefs (info (commandParser <**> helper) idm)
+    parserPrefs = prefs showHelpOnError
+    go = do
+         installSignalHandlers
+         command <- customExecParser parserPrefs (info (commandParser <**> helper) idm)
+         runCommand command
 
 data Command
     = DamlStudio { replaceExtension :: ReplaceExtension, remainingArguments :: [String] }


### PR DESCRIPTION
Fixes #1794 for `daml start`, `daml sandbox`, and `daml navigator`, allowing signal -2 to be used on the `daml` executable to shut off the entire process tree, in Unix. We achieve this by treating SIGTERM as SIGINT in daml-helper and throwing a UserInterrupt exception to the main thread, when running jars and when running `daml start`.

The reason this works is because `daml` invokes `daml-helper` and waits for it to finish, so a SIGINT in `daml` results in a SIGTERM in `daml-helper`. But SIGTERM by default does not run finalizers, so we work around this by installing our own signal handler and raising an `UserInterrupt` exception asynchronously.

(This PR does nothing for `daml-head` since that's a separate bash script and bash gets a separate pid, but as long you invoke it `daml` directly (instead of invoking `daml-head`) you get the benefits of this PR, even if it's just version 0.0.0.)

Thanks to @cocreature for helping me figure out what was going on with the signals and process handling. No thanks to `System.Process` for not making this easy and pretty much lying about the effects of `delegate_ctl` (all it does is ignore `SIGINT` and `SIGQUIT` signals, it doesn't delegate anything).