### PR TITLE
Inline the EnumType and EnumCon types in Haskell's DAML-LF AST

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -47,6 +47,9 @@
 - warn: {lhs: Data.Text.Lazy.writeFile, rhs: Data.Text.Extended.writeFileUtf8}
 - warn: {lhs: System.Environment.setEnv, rhs: System.Environment.Blank.setEnv}
 
+# Hints that do not always make sense
+- ignore: {name: "Use if", within: [DA.Daml.LF.Proto3.EncodeV1, DA.Daml.LF.Ast.Pretty]}
+
 # Specify additional command line arguments
 #
 # - arguments: [--color, --cpp-simple, -XQuasiQuotes]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -134,12 +134,6 @@ data Kind
   | KArrow Kind Kind
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
--- | Enumeration types like Bool and Unit.
-data EnumType
-  = ETUnit
-  | ETBool
-  deriving (Eq, Data, Generic, NFData, Ord, Show)
-
 -- | Builtin type.
 data BuiltinType
   = BTInt64
@@ -148,7 +142,8 @@ data BuiltinType
   | BTTimestamp
   | BTDate
   | BTParty
-  | BTEnum EnumType
+  | BTUnit
+  | BTBool
   | BTList
   | BTUpdate
   | BTScenario
@@ -190,13 +185,6 @@ data TypeConApp = TypeConApp
   }
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
--- | Constructors of builtin 'EnumType's.
-data EnumCon
-  = ECUnit   -- ∷ Unit
-  | ECFalse  -- ∷ Bool
-  | ECTrue   -- ∷ Bool
-  deriving (Eq, Data, Generic, NFData, Ord, Show)
-
 data E10
 instance HasResolution E10 where
   resolution _ = 10000000000 -- 10^-10 resolution
@@ -210,7 +198,8 @@ data BuiltinExpr
   | BETimestamp  !Int64          -- :: Timestamp, microseconds since unix epoch
   | BEParty      !PartyLiteral   -- :: Party
   | BEDate       !Int32          -- :: Date, days since unix epoch
-  | BEEnumCon    !EnumCon        -- see 'EnumCon' above
+  | BEUnit                       -- :: Unit
+  | BEBool       !Bool           -- :: Bool
 
   -- Polymorphic functions
   | BEError                      -- :: ∀a. Text -> a
@@ -441,7 +430,7 @@ data CaseAlternative = CaseAlternative
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 data CasePattern
-  -- | Match on constructor of variant type.
+  -- | Match on a constructor of a variant type.
   = CPVariant
     { patTypeCon :: !(Qualified TypeConName)
       -- ^ Type constructor of the type to match on.
@@ -450,7 +439,10 @@ data CasePattern
     , patBinder  :: !ExprVarName
       -- ^ Variable to bind the variant constructor argument to.
     }
-  | CPEnumCon !EnumCon
+  -- | Match on the unit type.
+  | CPUnit
+  -- | Match on the bool type.
+  | CPBool !Bool
   -- | Match on empty list.
   | CPNil
   -- | Match on head and tail of non-empty list.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -110,7 +110,6 @@ instance {-# OVERLAPPING #-} MonoTraversable ModuleRef FilePath where monoTraver
 
 -- NOTE(MH): Builtins are not supposed to contain references to other modules.
 instance MonoTraversable ModuleRef Kind where monoTraverse _ = pure
-instance MonoTraversable ModuleRef EnumCon where monoTraverse _ = pure
 instance MonoTraversable ModuleRef BuiltinType where monoTraverse _ = pure
 instance MonoTraversable ModuleRef BuiltinExpr where monoTraverse _ = pure
 instance MonoTraversable ModuleRef SourceLoc where monoTraverse _ = pure

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -115,11 +115,6 @@ instance Pretty TypeConApp where
       pretty con
       <-> hsep (map (pPrintPrec lvl (succ precTApp)) args)
 
-instance Pretty EnumType where
-  pPrint = \case
-    ETUnit -> "Unit"
-    ETBool -> "Bool"
-
 instance Pretty BuiltinType where
   pPrint = \case
     BTInt64          -> "Int64"
@@ -127,7 +122,8 @@ instance Pretty BuiltinType where
     BTText           -> "Text"
     BTTimestamp      -> "Timestamp"
     BTParty          -> "Party"
-    BTEnum etype -> pretty etype
+    BTUnit -> "Unit"
+    BTBool -> "Bool"
     BTList -> "List"
     BTUpdate -> "Update"
     BTScenario -> "Scenario"
@@ -183,19 +179,14 @@ prettyAltArrow    = "->"
 instance Pretty PartyLiteral where
   pPrint = quotes . pretty . unPartyLiteral
 
-instance Pretty EnumCon where
-  pPrint = \case
-    ECUnit  -> "Unit"
-    ECFalse -> "False"
-    ECTrue  -> "True"
-
 instance Pretty BuiltinExpr where
   pPrintPrec _lvl prec = \case
     BEInt64 n -> pretty (toInteger n)
     BEDecimal dec -> string (show dec)
     BEText t -> string (show t) -- includes the double quotes, and escapes characters
     BEParty p -> pretty p
-    BEEnumCon c -> pretty c
+    BEUnit -> keyword_ "unit"
+    BEBool b -> keyword_ $ case b of { False -> "false"; True -> "true" }
     BEError -> "ERROR"
     BEEqual t     -> maybeParens (prec > precEApp) ("EQUAL"      <-> prettyBTyArg t)
     BELess t      -> maybeParens (prec > precEApp) ("LESS"       <-> prettyBTyArg t)
@@ -269,7 +260,8 @@ instance Pretty CasePattern where
     CPVariant tcon con var ->
       pretty tcon <> "." <> pretty con
       <-> pretty var
-    CPEnumCon con -> pretty con
+    CPUnit -> keyword_ "unit"
+    CPBool b -> keyword_ $ case b of { False -> "false"; True -> "true" }
     CPNil -> keyword_ "nil"
     CPCons hdVar tlVar -> keyword_ "cons" <-> pretty hdVar <-> pretty tlVar
     CPDefault -> keyword_ "default"

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -104,26 +104,21 @@ mkEmptyText = EBuiltin (BEText "")
 mkIf :: Expr -> Expr -> Expr -> Expr
 mkIf cond0 then0 else0 =
   ECase cond0
-  [ CaseAlternative (CPEnumCon ECTrue ) then0
-  , CaseAlternative (CPEnumCon ECFalse) else0
+  [ CaseAlternative (CPBool True ) then0
+  , CaseAlternative (CPBool False) else0
   ]
 
-mkBoolEC :: Bool -> EnumCon
-mkBoolEC = \case
-  False -> ECFalse
-  True  -> ECTrue
-
 mkBool :: Bool -> Expr
-mkBool = EBuiltin . BEEnumCon . mkBoolEC
+mkBool = EBuiltin . BEBool
 
 pattern EUnit :: Expr
-pattern EUnit = EBuiltin (BEEnumCon ECUnit)
+pattern EUnit = EBuiltin BEUnit
 
 pattern ETrue :: Expr
-pattern ETrue = EBuiltin (BEEnumCon ECTrue)
+pattern ETrue = EBuiltin (BEBool True)
 
 pattern EFalse :: Expr
-pattern EFalse = EBuiltin (BEEnumCon ECFalse)
+pattern EFalse = EBuiltin (BEBool False)
 
 mkNot :: Expr -> Expr
 mkNot arg = mkIf arg (mkBool False) (mkBool True)
@@ -158,8 +153,8 @@ pattern (:->) :: Type -> Type -> Type
 pattern a :-> b = TArrow `TApp` a `TApp` b
 
 pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow :: Type
-pattern TUnit       = TBuiltin (BTEnum ETUnit)
-pattern TBool       = TBuiltin (BTEnum ETBool)
+pattern TUnit       = TBuiltin BTUnit
+pattern TBool       = TBuiltin BTBool
 pattern TInt64      = TBuiltin BTInt64
 pattern TDecimal    = TBuiltin BTDecimal
 pattern TText       = TBuiltin BTText

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -164,7 +164,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
   LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
-  LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual (BTEnum ETBool)
+  LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
@@ -269,8 +269,11 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
   LF1.ExprSumVal val -> EVal <$> decodeValName val
   LF1.ExprSumBuiltin (Proto.Enumerated (Right bi)) -> EBuiltin <$> decodeBuiltinFunction bi
   LF1.ExprSumBuiltin (Proto.Enumerated (Left num)) -> Left (UnknownEnum "ExprSumBuiltin" num)
-  LF1.ExprSumPrimCon (Proto.Enumerated (Right con)) ->
-    EBuiltin . BEEnumCon <$> decodePrimCon con
+  LF1.ExprSumPrimCon (Proto.Enumerated (Right con)) -> pure $ EBuiltin $ case con of
+    LF1.PrimConCON_UNIT -> BEUnit
+    LF1.PrimConCON_TRUE -> BEBool True
+    LF1.PrimConCON_FALSE -> BEBool False
+
   LF1.ExprSumPrimCon (Proto.Enumerated (Left num)) -> Left (UnknownEnum "ExprSumPrimCon" num)
   LF1.ExprSumPrimLit lit ->
     EBuiltin <$> decodePrimLit lit
@@ -428,8 +431,10 @@ decodeCaseAlt LF1.CaseAlt{..} = do
     LF1.CaseAltSumEnum _ ->
       -- FixMe (RH) https://github.com/digital-asset/daml/issues/105
       Left (ParseError "Enum type not supported")
-    LF1.CaseAltSumPrimCon (Proto.Enumerated (Right pcon)) ->
-      CPEnumCon <$> decodePrimCon pcon
+    LF1.CaseAltSumPrimCon (Proto.Enumerated (Right pcon)) -> pure $ case pcon of
+      LF1.PrimConCON_UNIT -> CPUnit
+      LF1.PrimConCON_TRUE -> CPBool True
+      LF1.PrimConCON_FALSE -> CPBool False
     LF1.CaseAltSumPrimCon (Proto.Enumerated (Left idx)) ->
       Left (UnknownEnum "CaseAltSumPrimCon" idx)
     LF1.CaseAltSumNil LF1.Unit -> pure CPNil
@@ -470,12 +475,6 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumParty p          -> pure $ BEParty $ PartyLiteral $ TL.toStrict p
   LF1.PrimLitSumDate days -> pure $ BEDate days
 
-decodePrimCon :: LF1.PrimCon -> Decode EnumCon
-decodePrimCon = pure . \case
-  LF1.PrimConCON_UNIT -> ECUnit
-  LF1.PrimConCON_TRUE -> ECTrue
-  LF1.PrimConCON_FALSE -> ECFalse
-
 decodeKind :: LF1.Kind -> Decode Kind
 decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumStar LF1.Unit -> pure KStar
@@ -490,8 +489,8 @@ decodePrim = pure . \case
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
-  LF1.PrimTypeUNIT    -> BTEnum ETUnit
-  LF1.PrimTypeBOOL    -> BTEnum ETBool
+  LF1.PrimTypeUNIT    -> BTUnit
+  LF1.PrimTypeBOOL    -> BTBool
   LF1.PrimTypeLIST    -> BTList
   LF1.PrimTypeUPDATE  -> BTUpdate
   LF1.PrimTypeSCENARIO -> BTScenario

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -107,7 +107,8 @@ safetyStep = \case
       BETimestamp _       -> Safe 0
       BEParty _           -> Safe 0
       BEDate _            -> Safe 0
-      BEEnumCon _         -> Safe 0
+      BEUnit              -> Safe 0
+      BEBool _            -> Safe 0
       BEError             -> Safe 0
       BEEqual _           -> Safe 2
       BELess _            -> Safe 2

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -108,7 +108,8 @@ kindOfBuiltin = \case
   BTText -> KStar
   BTTimestamp -> KStar
   BTParty -> KStar
-  BTEnum _ -> KStar
+  BTUnit -> KStar
+  BTBool -> KStar
   BTDate -> KStar
   BTList -> KStar `KArrow` KStar
   BTUpdate -> KStar `KArrow` KStar
@@ -137,12 +138,6 @@ kindOf = \case
   TForall (v, k) t1 -> introTypeVar v k $ checkType t1 KStar $> KStar
   TTuple recordType -> checkRecordType recordType $> KStar
 
-typeOfEnumCon :: EnumCon -> Type
-typeOfEnumCon = \case
-  ECUnit  -> TUnit
-  ECFalse -> TBool
-  ECTrue  -> TBool
-
 typeOfBuiltin :: MonadGamma m => BuiltinExpr -> m Type
 typeOfBuiltin = \case
   BEInt64 _          -> pure TInt64
@@ -151,7 +146,8 @@ typeOfBuiltin = \case
   BETimestamp _      -> pure TTimestamp
   BEParty   _        -> pure TParty
   BEDate _           -> pure TDate
-  BEEnumCon con      -> pure $ typeOfEnumCon con
+  BEUnit             -> pure TUnit
+  BEBool _           -> pure TBool
   BEError            -> pure $ TForall (alpha, KStar) (TText :-> tAlpha)
   BEEqual     btype  -> pure $ tComparison btype
   BELess      btype  -> pure $ tComparison btype
@@ -314,11 +310,14 @@ introCasePattern scrutType patn cont = case patn of
     let subst1 = map (\((v, _k), t) -> (v, t)) subst0
     let varType = substitute (Map.fromList subst1) conArgType
     introExprVar var varType cont
-  CPEnumCon con
-    | alphaEquiv scrutType conType -> cont
+  CPUnit
+    | scrutType == TUnit -> cont
     | otherwise ->
-        throwWithContext ETypeMismatch{foundType = scrutType, expectedType = conType, expr = Nothing}
-    where conType = typeOfEnumCon con
+        throwWithContext ETypeMismatch{foundType = scrutType, expectedType = TUnit, expr = Nothing}
+  CPBool _
+    | scrutType == TBool -> cont
+    | otherwise ->
+        throwWithContext ETypeMismatch{foundType = scrutType, expectedType = TBool, expr = Nothing}
   CPNil -> do
     _ :: Type <- match _TList (EExpectedListType scrutType) scrutType
     cont

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -86,7 +86,8 @@ serializabilityConditionsType world0 version mbModNameTpls vars = go
         BTTimestamp -> noConditions
         BTDate -> noConditions
         BTParty -> noConditions
-        BTEnum _ -> noConditions
+        BTUnit -> noConditions
+        BTBool -> noConditions
         BTList -> Left URList  -- 'List' is used as a higher-kinded type constructor.
         BTOptional -> Left UROptional  -- 'Optional' is used as a higher-kinded type constructor.
         BTMap -> Left URMap  -- 'Map' is used as a higher-kinded type constructor.

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -1056,10 +1056,10 @@ convertUnitId _thisUnitId pkgMap unitId = case unitId of
 convertAlt :: Env -> LF.Type -> Alt Var -> ConvertM CaseAlternative
 convertAlt env ty (DEFAULT, [], x) = CaseAlternative CPDefault <$> convertExpr env x
 convertAlt env ty (DataAlt con, [], x)
-    | is con == "True" = CaseAlternative (CPEnumCon ECTrue) <$> convertExpr env x
-    | is con == "False" = CaseAlternative (CPEnumCon ECFalse) <$> convertExpr env x
+    | is con == "True" = CaseAlternative (CPBool True) <$> convertExpr env x
+    | is con == "False" = CaseAlternative (CPBool False) <$> convertExpr env x
     | is con == "[]" = CaseAlternative CPNil <$> convertExpr env x
-    | is con == "()" = CaseAlternative (CPEnumCon ECUnit) <$> convertExpr env x
+    | is con == "()" = CaseAlternative CPUnit <$> convertExpr env x
     | isBuiltinName "None" con
     = CaseAlternative CPNone <$> convertExpr env x
 convertAlt env ty (DataAlt con, [a,b], x)

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/UtilLF.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/UtilLF.hs
@@ -112,7 +112,7 @@ ghcPrim = Module
       , dvalBody = EVariantCon
           { varTypeCon = TypeConApp (qual (dataTypeCon dataVoid)) []
           , varVariant = conName
-          , varArg = EBuiltin (BEEnumCon ECUnit)
+          , varArg = EBuiltin BEUnit
           }
       }
 
@@ -144,7 +144,7 @@ ghcTypes = Module
       , dvalBody = EVariantCon
           { varTypeCon = TypeConApp (qual (dataTypeCon dataOrdering)) []
           , varVariant = mkVariantCon con
-          , varArg = EBuiltin (BEEnumCon ECUnit)
+          , varArg = EBuiltin BEUnit
           }
       }
     dataProxy = DefDataType


### PR DESCRIPTION
My primary goal is to avoid confusion when starting to support DAML-LF's
enum types. I also think these types were never particularly useful,
although I introduced them myself...

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1822)
<!-- Reviewable:end -->
