### PR TITLE
fix escaping in Docker existence check

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -135,7 +135,7 @@ jobs:
           DIR=$(pwd)
           VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -s)
           for version in $(echo $RELEASES | sed -e 's/ /\n/g'); do
-            EXISTS=$(echo $VERSIONS | jq -r '[.results[].name == "${version#v}"] | any')
+            EXISTS=$(echo $VERSIONS | jq -r '[.results[].name == "'${version#v}'"] | any')
             if [ "$EXISTS" == "true" ]; then
               echo "${version#v} already exists, skipping."
             else


### PR DESCRIPTION
Current code is not escaped properly, so it's checking for the literal string `${version#v}`, which obviously doesn't exist.

This PR properly fixes that as evidenced by [this build](https://dev.azure.com/digitalasset/daml/_build/results?buildId=9421), where the relevant `bash` step took all of 2 seconds.