### PR TITLE
Make hie-core Compile simpler

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -189,7 +189,7 @@ runGhcSession
     -> HscEnv
     -> Ghc a
     -> IO a
-runGhcSession IdeOptions{..} modu env act = runGhcEnv env $ do
+runGhcSession _ modu env act = runGhcEnv env $ do
     modifyDynFlags $ \x -> x
         {importPaths = nubOrd $ maybeToList (moduleImportPaths =<< modu) ++ importPaths x}
     act

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -45,7 +45,7 @@ import           TidyPgm
 import qualified GHC.LanguageExtensions as LangExt
 
 import Control.DeepSeq
-import           Control.Exception                        as E
+import           Control.Exception
 import           Control.Monad
 import Control.Monad.Trans.Except
 import           Data.IORef
@@ -108,7 +108,7 @@ computePackageDeps packageState iuid =
 getPackage :: DynFlags -> InstalledUnitId -> IO PackageConfig
 getPackage dflags p =
   case lookupInstalledPackage dflags p of
-    Nothing -> E.throwIO $ CmdLineError (missingPackageMsg p)
+    Nothing -> throwIO $ CmdLineError (missingPackageMsg p)
     Just pkg -> return pkg
   where
     missingPackageMsg p = showSDoc dflags $ text "unknown package:" <+> ppr p

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -24,6 +24,7 @@ import           Development.IDE.Types.Diagnostics
 import qualified Development.IDE.Import.FindImports as FindImports
 import           Development.IDE.GHC.Error
 import           Development.IDE.Spans.Calculate
+import Development.IDE.GHC.Orphans()
 import Development.IDE.GHC.Util
 import Development.IDE.GHC.Compat
 import Development.IDE.Types.Options
@@ -76,6 +77,12 @@ data TcModuleResult = TcModuleResult
     { tmrModule     :: TypecheckedModule
     , tmrModInfo    :: HomeModInfo
     }
+instance Show TcModuleResult where
+    show = show . pm_mod_summary . tm_parsed_module . tmrModule
+
+instance NFData TcModuleResult where
+    rnf = rwhnf
+
 
 -- | Get source span info, used for e.g. AtPoint and Goto Definition.
 getSrcSpanInfos

--- a/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
@@ -44,8 +44,7 @@ import Language.Haskell.LSP.VFS
 -- like `setBufferModified` we abstract over the VFS implementation.
 data VFSHandle = VFSHandle
     { getVirtualFile :: NormalizedUri -> IO (Maybe VirtualFile)
-    , setVirtualFileContents :: NormalizedUri -> T.Text -> IO ()
-    , removeVirtualFile :: NormalizedUri -> IO ()
+    , setVirtualFileContents :: NormalizedUri -> Maybe T.Text -> IO ()
     }
 
 instance IsIdeGlobal VFSHandle
@@ -58,17 +57,16 @@ makeVFSHandle = do
               (_nextVersion, vfs) <- readVar vfsVar
               pure $ Map.lookup uri vfs
         , setVirtualFileContents = \uri content ->
-              modifyVar_ vfsVar $ \(nextVersion, vfs) ->
-                  pure (nextVersion + 1, Map.insert uri (VirtualFile nextVersion (Rope.fromText content) Nothing) vfs)
-        , removeVirtualFile = \uri -> modifyVar_ vfsVar $ \(nextVersion, vfs) -> pure (nextVersion, Map.delete uri vfs)
+              modifyVar_ vfsVar $ \(nextVersion, vfs) -> pure $ (nextVersion + 1, ) $
+                  case content of
+                    Nothing -> Map.delete uri vfs
+                    Just content -> Map.insert uri (VirtualFile nextVersion (Rope.fromText content) Nothing) vfs
         }
 
 makeLSPVFSHandle :: LspFuncs c -> VFSHandle
 makeLSPVFSHandle lspFuncs = VFSHandle
     { getVirtualFile = getVirtualFileFunc lspFuncs
     , setVirtualFileContents = \_ _ -> pure ()
-    -- ^ Handled internally by haskell-lsp.
-    , removeVirtualFile = \_ -> pure ()
     -- ^ Handled internally by haskell-lsp.
     }
 
@@ -162,11 +160,9 @@ fileStoreRules vfs = do
 
 -- | Notify the compiler service of a modified buffer
 setBufferModified :: IdeState -> NormalizedFilePath -> Maybe T.Text -> IO ()
-setBufferModified state absFile mbContents = do
+setBufferModified state absFile contents = do
     VFSHandle{..} <- getIdeGlobalState state
-    case mbContents of
-        Nothing -> removeVirtualFile (filePathToUri' absFile)
-        Just contents -> setVirtualFileContents (filePathToUri' absFile) contents
+    setVirtualFileContents (filePathToUri' absFile) contents
     void $ shakeRun state [] (const $ pure ())
 
 

--- a/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
@@ -7,7 +7,7 @@ module Development.IDE.Core.FileStore(
     getFileExists, getFileContents,
     setBufferModified,
     fileStoreRules,
-    VFSHandle(..),
+    VFSHandle,
     makeVFSHandle,
     makeLSPVFSHandle,
     ) where

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -12,7 +12,7 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
-import           Development.IDE.Core.Compile             (TcModuleResult, GhcModule)
+import           Development.IDE.Core.Compile             (TcModuleResult)
 import           Development.IDE.Import.FindImports         (Import(..))
 import           Development.IDE.Import.DependencyInformation
 import           Data.Hashable
@@ -51,7 +51,7 @@ type instance RuleResult TypeCheck = TcModuleResult
 type instance RuleResult GetSpanInfo = [SpanInfo]
 
 -- | Convert to Core, requires TypeCheck*
-type instance RuleResult GenerateCore = GhcModule
+type instance RuleResult GenerateCore = CoreModule
 
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnv

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -13,7 +13,7 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
-import           Development.IDE.Core.Compile             (TcModuleResult, GhcModule, LoadPackageResult(..))
+import           Development.IDE.Core.Compile             (TcModuleResult, GhcModule)
 import qualified Development.IDE.Core.Compile             as Compile
 import           Development.IDE.Import.FindImports         (Import(..))
 import           Development.IDE.Import.DependencyInformation
@@ -170,12 +170,6 @@ instance NFData Import where
 
 instance Hashable InstalledUnitId where
   hashWithSalt salt = hashWithSalt salt . installedUnitIdString
-
-instance Show LoadPackageResult where
-  show = installedUnitIdString . lprInstalledUnitId
-
-instance NFData LoadPackageResult where
-    rnf = rwhnf
 
 instance Show HieFile where
     show = show . hie_module

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | A Shake implementation of the compiler service, built
 --   using the "Shaker" abstraction layer for in-memory use.
@@ -14,7 +13,6 @@ module Development.IDE.Core.RuleTypes(
 
 import           Control.DeepSeq
 import           Development.IDE.Core.Compile             (TcModuleResult, GhcModule)
-import qualified Development.IDE.Core.Compile             as Compile
 import           Development.IDE.Import.FindImports         (Import(..))
 import           Development.IDE.Import.DependencyInformation
 import           Data.Hashable
@@ -26,7 +24,6 @@ import           GHC.Generics                             (Generic)
 
 import           GHC
 import Development.IDE.GHC.Compat
-import           Module
 
 import           Development.IDE.Spans.Type
 
@@ -131,48 +128,3 @@ data GetHieFile = GetHieFile FilePath
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetHieFile
 instance NFData   GetHieFile
-
-------------------------------------------------------------
--- Orphan Instances
-
-instance NFData (GenLocated SrcSpan ModuleName) where
-    rnf = rwhnf
-
-instance Show TcModuleResult where
-    show = show . pm_mod_summary . tm_parsed_module . Compile.tmrModule
-
-instance NFData TcModuleResult where
-    rnf = rwhnf
-
-instance Show ModSummary where
-    show = show . ms_mod
-
-instance Show ParsedModule where
-    show = show . pm_mod_summary
-
-instance NFData ModSummary where
-    rnf = rwhnf
-
-instance Show HscEnv where
-    show _ = "HscEnv"
-
-instance NFData HscEnv where
-    rnf = rwhnf
-
-instance NFData ParsedModule where
-    rnf = rwhnf
-
-instance NFData SpanInfo where
-    rnf = rwhnf
-
-instance NFData Import where
-  rnf = rwhnf
-
-instance Hashable InstalledUnitId where
-  hashWithSalt salt = hashWithSalt salt . installedUnitIdString
-
-instance Show HieFile where
-    show = show . hie_module
-
-instance NFData HieFile where
-    rnf = rwhnf

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -92,8 +92,7 @@ getGhcCore :: NormalizedFilePath -> Action (Maybe [CoreModule])
 getGhcCore file = runMaybeT $ do
     files <- transitiveModuleDeps <$> useE GetDependencies file
     pms   <- usesE GetParsedModule $ files ++ [file]
-    cores <- usesE GenerateCore $ map fileFromParsedModule pms
-    pure (map Compile.gmCore cores)
+    usesE GenerateCore $ map fileFromParsedModule pms
 
 
 

--- a/compiler/hie-core/src/Development/IDE/GHC/Orphans.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Orphans.hs
@@ -8,10 +8,12 @@
 --   Note that the 'NFData' instances may not be law abiding.
 module Development.IDE.GHC.Orphans() where
 
-import           GHC                         hiding (convertLit)
-import           GhcPlugins                  as GHC hiding (fst3, (<>))
+import GHC
+import GhcPlugins
+import Development.IDE.GHC.Compat
 import qualified StringBuffer as SB
 import Control.DeepSeq
+import Data.Hashable
 import Development.IDE.GHC.Util
 
 
@@ -32,3 +34,33 @@ instance Show Module where
 
 instance Show (GenLocated SrcSpan ModuleName) where show = prettyPrint
 instance Show Name where show = prettyPrint
+
+instance NFData (GenLocated SrcSpan ModuleName) where
+    rnf = rwhnf
+
+instance Show ModSummary where
+    show = show . ms_mod
+
+instance Show ParsedModule where
+    show = show . pm_mod_summary
+
+instance NFData ModSummary where
+    rnf = rwhnf
+
+instance Show HscEnv where
+    show _ = "HscEnv"
+
+instance NFData HscEnv where
+    rnf = rwhnf
+
+instance NFData ParsedModule where
+    rnf = rwhnf
+
+instance Hashable InstalledUnitId where
+  hashWithSalt salt = hashWithSalt salt . installedUnitIdString
+
+instance Show HieFile where
+    show = show . hie_module
+
+instance NFData HieFile where
+    rnf = rwhnf

--- a/compiler/hie-core/src/Development/IDE/Import/FindImports.hs
+++ b/compiler/hie-core/src/Development/IDE/Import/FindImports.hs
@@ -24,6 +24,7 @@ import qualified GHC.LanguageExtensions.Type as GHC
 import           Packages
 import           Outputable                  (showSDoc, ppr, pprPanic)
 import           Finder
+import Control.DeepSeq
 
 -- standard imports
 import           Control.Monad.Extra
@@ -32,9 +33,14 @@ import qualified Control.Monad.Trans.Except            as Ex
 import           System.FilePath
 
 data Import
-  = FileImport NormalizedFilePath
-  | PackageImport M.InstalledUnitId
+  = FileImport !NormalizedFilePath
+  | PackageImport !M.InstalledUnitId
   deriving (Show)
+
+instance NFData Import where
+  rnf (FileImport x) = rnf x
+  rnf (PackageImport x) = rnf x
+
 
 -- | GhcMonad function to chase imports of a module given as a StringBuffer. Returns given module's
 -- name and its imports.

--- a/compiler/hie-core/src/Development/IDE/Spans/Type.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/Type.hs
@@ -12,6 +12,7 @@ module Development.IDE.Spans.Type(
   ) where
 
 import GHC
+import Control.DeepSeq
 import Data.Maybe
 import OccName
 
@@ -37,6 +38,10 @@ data SpanInfo =
            }
 instance Show SpanInfo where
   show (SpanInfo sl sc el ec t n) = show [show sl, show sc, show el, show ec, show $ isJust t, show n]
+
+instance NFData SpanInfo where
+    rnf = rwhnf
+
 
 -- we don't always get a name out so sometimes manually annotating source is more appropriate
 data SpanSource = Named Name

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -82,10 +82,10 @@ import           DA.Daml.GHC.Compiler.Primitives
 import           DA.Daml.GHC.Compiler.UtilGHC
 import           DA.Daml.GHC.Compiler.UtilLF
 
-import Development.IDE.Core.Compile (GhcModule(..))
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
 import           Development.IDE.GHC.Util
+import           Development.IDE.GHC.Orphans()
 
 import           Control.Applicative
 import           Control.Lens
@@ -248,13 +248,12 @@ convertRational num denom
     upperBound128Bit = 10 ^ (38 :: Integer)
     maxPrecision = 10 :: Integer
 
-convertModule :: LF.Version -> MS.Map UnitId T.Text -> NormalizedFilePath -> GhcModule -> Either FileDiagnostic LF.Module
-convertModule lfVersion pkgMap file mod0 = runConvertM (ConversionEnv file Nothing) $ do
+convertModule :: LF.Version -> MS.Map UnitId T.Text -> NormalizedFilePath -> CoreModule -> Either FileDiagnostic LF.Module
+convertModule lfVersion pkgMap file x = runConvertM (ConversionEnv file Nothing) $ do
     definitions <- concatMapM (convertBind env) $ filter (not . isTypeableInfo) $ cm_binds x
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types x))
-    pure (LF.moduleFromDefinitions lfModName (gmPath mod0) flags (types ++ definitions))
+    pure (LF.moduleFromDefinitions lfModName (Just $ fromNormalizedFilePath file) flags (types ++ definitions))
     where
-        x = gmCore mod0
         ghcModName = GHC.moduleName $ cm_module x
         thisUnitId = GHC.moduleUnitId $ cm_module x
         lfModName = convertModuleName ghcModName

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -25,7 +25,7 @@ module Development.IDE.State.API
     , getDependencies
     , logDebug
     , logSeriousError
-    , VFSHandle(..)
+    , VFSHandle
     , makeVFSHandle
     , makeLSPVFSHandle
     ) where

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -168,7 +168,7 @@ generateRawDalfRule =
         pkgMap <- use_ GeneratePackageMap ""
         let pkgMap0 = Map.map (\(pId, _pkg, _bs, _fp) -> LF.unPackageId pId) pkgMap
         -- GHC Core to DAML LF
-        case convertModule lfVersion pkgMap0 core of
+        case convertModule lfVersion pkgMap0 file core of
             Left e -> return ([e], Nothing)
             Right v -> return ([], Just v)
 


### PR DESCRIPTION
A bunch of changes aimed at trimming the fat in the Compile module, which houses a lot of the scary GHC interaction bits. Now it's smaller, by removing redundant stuff.