### PR TITLE
scala-codegen: add support for enum type

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -110,8 +110,9 @@ private[validation] object Serializability {
       case DataVariant(variants) =>
         if (variants.isEmpty) env.unserializable(URUninhabitatedType)
         else variants.iterator.map(_._2)
-      case DataEnum(_) =>
-        Iterator.empty
+      case DataEnum(constructors) =>
+        if (constructors.isEmpty) env.unserializable(URUninhabitatedType)
+        else Iterator.empty
       case DataRecord(fields, _) =>
         fields.iterator.map(_._2)
     }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.ledger.client.binding
 
 import com.digitalasset.ledger.api.v1.{value => rpcvalue}

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
@@ -1,0 +1,35 @@
+package com.digitalasset.ledger.client.binding
+
+import com.digitalasset.ledger.api.v1.{value => rpcvalue}
+import com.digitalasset.ledger.client.binding.encoding.{LfEncodable, LfTypeEncoding}
+import scalaz.Liskov.<~<
+
+abstract class EnumCompanion[T](implicit isEnum: T <~< EnumRef) extends ValueRefCompanion {
+
+  val firstValue: T
+  val otherValues: Vector[T]
+
+  final def values: Vector[T] = firstValue +: otherValues
+
+  implicit final lazy val `the enum Value`: Value[T] = new `Value ValueRef`[T] {
+    private[this] val readers = values.map(e => (isEnum(e).constructor: String) -> e).toMap
+
+    override def read(argValue: rpcvalue.Value.Sum): Option[T] =
+      argValue.enum flatMap (e => readers.get(e.constructor))
+
+    private[this] val rpcValues = values.map(e => ` enum`(isEnum(e).constructor))
+
+    override def write(enum: T): rpcvalue.Value.Sum =
+      rpcValues(isEnum(enum).index)
+  }
+
+  implicit final val `the enum LfEncodable`: LfEncodable[T] = new LfEncodable[T] {
+    override def encoding(lte: LfTypeEncoding): lte.Out[T] =
+      lte.enumAll(
+        ` dataTypeId`,
+        lte.enumCase(isEnum(firstValue).constructor)(firstValue),
+        otherValues.map(v => lte.enumCase(isEnum(v).constructor)(v)): _*
+      )
+  }
+
+}

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumCompanion.scala
@@ -30,8 +30,8 @@ abstract class EnumCompanion[T](implicit isEnum: T <~< EnumRef) extends ValueRef
     override def encoding(lte: LfTypeEncoding): lte.Out[T] =
       lte.enumAll(
         ` dataTypeId`,
-        lte.enumCase(isEnum(firstValue).constructor)(firstValue),
-        otherValues.map(v => lte.enumCase(isEnum(v).constructor)(v)): _*
+        lte.enumCase(isEnum(firstValue).constructor)(firstValue, values.contains(_: T)),
+        otherValues.map(v => lte.enumCase(isEnum(v).constructor)(v, values.contains(_: T))): _*
       )
   }
 

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumRef.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumRef.scala
@@ -1,0 +1,6 @@
+package com.digitalasset.ledger.client.binding
+
+abstract class EnumRef extends ValueRef {
+  val constructor: String
+  val index: Int
+}

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumRef.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/EnumRef.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.ledger.client.binding
 
 abstract class EnumRef extends ValueRef {

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -44,7 +44,7 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
 
   def toNamedArguments(associatedType: T): rpcvalue.Record
 
-  override protected lazy val ` recordOrVariantId` = TemplateId.unwrap(id)
+  override protected lazy val ` dataTypeId` = TemplateId.unwrap(id)
 
   def fromNamedArguments(namedArguments: rpcvalue.Record): Option[T]
 
@@ -81,7 +81,7 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
     Primitive.exercise(this, receiver, choiceId, arguments getOrElse Value.encode(()))
 
   protected final def ` arguments`(elems: (String, rpcvalue.Value)*): rpcvalue.Record =
-    Primitive.arguments(` recordOrVariantId`, elems)
+    Primitive.arguments(` dataTypeId`, elems)
 }
 
 object TemplateCompanion {
@@ -93,6 +93,6 @@ object TemplateCompanion {
     @SuppressWarnings(Array("org.wartremover.warts.Any"))
     override def fieldEncoding(lte: LfTypeEncoding): view[lte.Field] = RecordView.Empty
     override def encoding(lte: LfTypeEncoding)(view: view[lte.Field]): lte.Out[T] =
-      lte.emptyRecord(` recordOrVariantId`, () => onlyInstance)
+      lte.emptyRecord(` dataTypeId`, () => onlyInstance)
   }
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
@@ -165,11 +165,11 @@ abstract class ValueRefCompanion {
   @SuppressWarnings(Array("org.wartremover.warts.LeakingSealed"))
   protected abstract class `Value ValueRef`[A] extends Value[A]
 
-  protected val ` recordOrVariantId`: rpcvalue.Identifier
+  protected val ` dataTypeId`: rpcvalue.Identifier
   // recordId and variantId are optional when submitting commands, according to
   // value.proto
 
-  protected final def ` mkRecordOrVariantId`(
+  protected final def ` mkDataTypeId`(
       packageId: String,
       moduleName: String,
       entityName: String): rpcvalue.Identifier =
@@ -180,12 +180,15 @@ abstract class ValueRefCompanion {
       entityName = entityName)
 
   protected final def ` record`(elements: (String, rpcvalue.Value)*): VSum.Record =
-    VSum.Record(Primitive.arguments(` recordOrVariantId`, elements))
+    VSum.Record(Primitive.arguments(` dataTypeId`, elements))
 
   protected final def ` variant`(constructor: String, value: rpcvalue.Value): VSum.Variant =
     VSum.Variant(
       rpcvalue
-        .Variant(variantId = Some(` recordOrVariantId`), constructor = constructor, Some(value)))
+        .Variant(variantId = Some(` dataTypeId`), constructor = constructor, Some(value)))
+
+  protected final def ` enum`(constructor: String): VSum.Enum =
+    VSum.Enum(rpcvalue.Enum(enumId = Some(` dataTypeId`), constructor))
 
   protected final def ` createVariantOfSynthRecord`(
       k: String,
@@ -193,5 +196,5 @@ abstract class ValueRefCompanion {
     ` variant`(
       k,
       rpcvalue.Value(
-        VSum.Record(Primitive.arguments(Value.splattedVariantId(` recordOrVariantId`, k), o))))
+        VSum.Record(Primitive.arguments(Value.splattedVariantId(` dataTypeId`, k), o))))
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/LfTypeEncoding.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/LfTypeEncoding.scala
@@ -5,7 +5,6 @@ package com.digitalasset.ledger.client.binding
 package encoding
 
 import scala.language.higherKinds
-
 import scalaz.{OneAnd, Plus}
 import scalaz.syntax.foldable1._
 import com.digitalasset.ledger.api.v1.{value => rpcvalue}
@@ -68,7 +67,7 @@ trait LfTypeEncoding {
 
   /** Pull a enum case into the language of enum cases.
     */
-  def enumCase[A](caseName: String)(a: A): EnumCases[A]
+  def enumCase[A](caseName: String)(inject: A, select: A => Boolean): EnumCases[A]
 
   /** "Finalize" a variant set. */
   def variant[A](variantId: rpcvalue.Identifier, cases: VariantCases[A]): Out[A]
@@ -149,8 +148,8 @@ object LfTypeEncoding {
     override def enum[A](enumId: rpcvalue.Identifier, cases: EnumCases[A]): Out[A] =
       (fst.enum(enumId, cases._1), snd.enum(enumId, cases._2))
 
-    override def enumCase[A](caseName: String)(a: A): EnumCases[A] =
-      (fst.enumCase(caseName)(a), snd.enumCase(caseName)(a))
+    override def enumCase[A](caseName: String)(select: A, inject: A => Boolean): EnumCases[A] =
+      (fst.enumCase(caseName)(select, inject), snd.enumCase(caseName)(select, inject))
 
     override def variant[A](variantId: rpcvalue.Identifier, cases: VariantCases[A]): Out[A] =
       (fst.variant(variantId, cases._1), snd.variant(variantId, cases._2))

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -28,6 +28,7 @@ dar_to_scala(
     srcs = [
         ":MyMain.dar",
         ":MySecondMain.dar",
+        "//daml-lf/encoder:testing-dar-1.dev",
     ],
     package_prefix = "com.digitalasset.sample",
     srcjar_out = "MyMain.srcjar",

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
@@ -1,0 +1,43 @@
+package com.digitalasset.codegen
+
+import com.digitalasset.ledger.client.binding.{Value, Primitive => P}
+import com.digitalasset.sample.{Enum, Record, Variant}
+import org.scalatest.{Matchers, WordSpec}
+
+class DataTypeIT extends WordSpec with Matchers {
+
+  "Value.decode follows by Value.encode" should {
+
+    "idempotent on records" in {
+      import Record.Pair._
+
+      type T = Record.Pair[P.Int64, P.Decimal]
+
+      val record: T = Record.Pair(1, 1.1)
+
+      Value.decode[T](Value.encode(record)) shouldBe Some(record)
+    }
+
+    "idempotent on variants" in {
+      import Variant.Either._
+
+      type T = Variant.Either[P.Int64, P.Decimal]
+
+      val variant1: T = Variant.Either.Left(1)
+      val variant2: T = Variant.Either.Right(1.1)
+
+      Value.decode[T](Value.encode(variant1)) shouldBe Some(variant1)
+      Value.decode[T](Value.encode(variant2)) shouldBe Some(variant2)
+    }
+
+    "enums" in {
+      import Enum.Color._
+
+      for (color <- List(Enum.Color.Red, Enum.Color.Blue, Enum.Color.Green))
+        Value.decode(Value.encode(color)) shouldBe Some(color)
+
+    }
+
+  }
+
+}

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.codegen
 
 import com.digitalasset.ledger.client.binding.{Value, Primitive => P}

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncoding.scala
@@ -20,6 +20,8 @@ abstract class EqualityEncoding extends LfTypeEncoding {
 
   type VariantCases[A] = Fn[A]
 
+  type EnumCases[A] = Fn[A]
+
   override def record[A](recordId: Identifier, fi: RecordFields[A]): Out[A] = fi
 
   override def emptyRecord[A](recordId: Identifier, element: () => A): Out[A] = (_, _) => true
@@ -27,6 +29,11 @@ abstract class EqualityEncoding extends LfTypeEncoding {
   override def field[A](fieldName: String, o: Out[A]): Field[A] = o
 
   override def fields[A](fi: Field[A]): RecordFields[A] = fi
+
+  def enum[A](enumId: Identifier, cases: EnumCases[A]): Out[A] = cases
+
+  override def enumCase[A](caseName: String)(a: A): EnumCases[A] =
+    (a1: A, a2: A) => a == a1 && a == a2
 
   override def variant[A](variantId: Identifier, cases: VariantCases[A]): Out[A] = cases
 
@@ -42,6 +49,8 @@ abstract class EqualityEncoding extends LfTypeEncoding {
   override val RecordFields: InvariantApply[RecordFields] = new RecordFieldsImpl
 
   override val VariantCases: Plus[VariantCases] = new VariantCasesImpl
+
+  override val EnumCases: Plus[EnumCases] = new VariantCasesImpl
 
   override val primitive: ValuePrimitiveEncoding[Out] = new primitiveImpl
 }

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/EqualityEncoding.scala
@@ -32,8 +32,8 @@ abstract class EqualityEncoding extends LfTypeEncoding {
 
   def enum[A](enumId: Identifier, cases: EnumCases[A]): Out[A] = cases
 
-  override def enumCase[A](caseName: String)(a: A): EnumCases[A] =
-    (a1: A, a2: A) => a == a1 && a == a2
+  override def enumCase[A](caseName: String)(inject: A, select: A => Boolean): EnumCases[A] =
+    (a1: A, a2: A) => select(a1) && select(a2) && a1 == a2
 
   override def variant[A](variantId: Identifier, cases: VariantCases[A]): Out[A] = cases
 

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/GenEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/GenEncoding.scala
@@ -41,7 +41,8 @@ abstract class GenEncoding extends LfTypeEncoding {
   override def enum[A](variantId: rpcvalue.Identifier, cases: Vector[A]): Out[A] =
     Gen.oneOf(cases)
 
-  override def enumCase[A](caseName: String)(a: A): EnumCases[A] = Vector(a)
+  override def enumCase[A](caseName: String)(select: A, inject: A => Boolean): EnumCases[A] =
+    Vector(select)
 
   override def variant[A](variantId: rpcvalue.Identifier, cases: VariantCases[A]): Out[A] =
     cases.tail match {

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala
@@ -50,15 +50,16 @@ abstract class ShowEncoding extends LfTypeEncoding {
 
   override def enum[A](enumId: Identifier, cases: EnumCases[A]): Out[A] = cases
 
-  override def enumCase[A](caseName: String)(a: A): EnumCases[A] = new Show[A] { (b: A) =>
-    if (a == b) Cord(caseName) else Cord.empty
+  override def enumCase[A](caseName: String)(inject: A, select: A => Boolean): EnumCases[A] = show {
+    _ =>
+      Cord(caseName)
   }
 
   override def variant[A](variantId: Identifier, cases: VariantCases[A]): Out[A] = cases
 
   override def variantCase[B, A](caseName: String, o: Out[B])(inject: B => A)(
       select: A PartialFunction B): VariantCases[A] =
-    new Show[A] { (a: A) =>
+    show { a: A =>
       select.lift(a).fold(Cord.empty)(b => Cord(caseName, "(", o.show(b), ")"))
     }
 
@@ -86,7 +87,8 @@ object ShowEncoding extends ShowEncoding {
   }
 
   class EnumCasesImpl extends Plus[EnumCases] {
-    def plus[A](a: Show[A], b: => Show[A]): Show[A] = new Show[A] { (f: A) => a.show(f) ++ b.show(f)
+    def plus[A](a: Show[A], b: => Show[A]): Show[A] = show { f: A =>
+      a.show(f) ++ b.show(f)
     }
   }
 

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/LfTypeEncodingSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/encoding/LfTypeEncodingSpec.scala
@@ -418,7 +418,8 @@ object LfTypeEncodingSpec {
           av.enum flatMap (e => readers.get(e.constructor))
       }
 
-    def enumCase[A](caseName: String)(a: A): EnumCases[A] = Vector(caseName -> a)
+    def enumCase[A](caseName: String)(select: A, inject: A => Boolean): EnumCases[A] =
+      Vector(caseName -> select)
 
     def variant[A](variantId: rpcvalue.Identifier, cases: VariantCases[A]): Out[A] =
       new Value.InternalImpl[A] {

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -92,3 +92,4 @@ da_scala_test_suite(
         "//daml-lf/transaction-scalacheck",
     ],
 )
+

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -92,4 +92,3 @@ da_scala_test_suite(
         "//daml-lf/transaction-scalacheck",
     ],
 )
-

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
@@ -136,7 +136,7 @@ object Util {
 
   final case class WriteParams[+TmplI](
       supportedTemplateIds: Map[Ref.Identifier, TmplI],
-      recordsAndVariants: Iterable[lf.ScopedDataType.FWT])
+      definitions: List[lf.ScopedDataType.FWT])
 
   val reservedNames: Set[String] =
     Set("id", "template", "namedArguments", "archive")

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
@@ -28,7 +28,8 @@ object DamlContractTemplateGen {
       util: LFUtil,
       templateId: Identifier,
       templateInterface: DefTemplateWithRecord.FWT,
-      companionMembers: Iterable[Tree]): (File, Iterable[Tree]) = {
+      companionMembers: Iterable[Tree]
+  ): (File, Set[Tree], Iterable[Tree]) = {
 
     val templateName = util.mkDamlScalaName(Util.Template, templateId)
     val contractName = util.mkDamlScalaName(Util.Contract, templateId)
@@ -85,7 +86,7 @@ object DamlContractTemplateGen {
       q"protected[this] override def templateCompanion(implicit ` d`: _root_.scala.Predef.DummyImplicit) = ${TermName(templateName.name)}"
     )
 
-    DamlRecordOrVariantTypeGen.generate(
+    DamlDataTypeGen.generate(
       util,
       ScopedDataType(templateId, ImmArraySeq.empty, templateInterface.`type`),
       isTemplate = true,

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
@@ -23,7 +23,7 @@ import scala.reflect.runtime.{universe => runUni}
   *
   *  See the comments below for more details on what classes/methods/types are generated.
   */
-object DamlRecordOrVariantTypeGen {
+object DamlDataTypeGen {
 
   import LFUtil.{domainApiAlias, generateIds, rpcValueAlias}
 
@@ -33,12 +33,12 @@ object DamlRecordOrVariantTypeGen {
 
   type FieldWithType = (Ref.Name, iface.Type)
   type VariantField = List[FieldWithType] \/ iface.Type
-  type RecordOrVariant = ScopedDataType.DT[iface.Type, VariantField]
+  type DataType = ScopedDataType.DT[iface.Type, VariantField]
 
   def generate(
       util: LFUtil,
-      recordOrVariant: RecordOrVariant,
-      companionMembers: Iterable[Tree]): (File, Iterable[Tree]) =
+      recordOrVariant: DataType,
+      companionMembers: Iterable[Tree]): (File, Set[Tree], Iterable[Tree]) =
     generate(
       util,
       recordOrVariant,
@@ -53,10 +53,10 @@ object DamlRecordOrVariantTypeGen {
     */
   private[lf] def generate(
       util: LFUtil,
-      typeDecl: RecordOrVariant,
+      typeDecl: DataType,
       isTemplate: Boolean,
       rootClassChildren: Seq[Tree],
-      companionChildren: Iterable[Tree]): (File, Iterable[Tree]) = {
+      companionChildren: Iterable[Tree]): (File, Set[Tree], Iterable[Tree]) = {
 
     logger.debug(s"generate typeDecl: $typeDecl")
 
@@ -82,7 +82,8 @@ object DamlRecordOrVariantTypeGen {
       if (isTemplate)
         (
           tq"$domainApiAlias.Template[${TypeName(damlScalaName.name)}]",
-          tq"$domainApiAlias.TemplateCompanion[${TypeName(damlScalaName.name)}]")
+          tq"$domainApiAlias.TemplateCompanion[${TypeName(damlScalaName.name)}]"
+        )
       else
         (tq"$domainApiAlias.ValueRef", tq"$domainApiAlias.ValueRefCompanion")
 
@@ -90,8 +91,8 @@ object DamlRecordOrVariantTypeGen {
     val idField =
       if (isTemplate) None
       else Some(q"""
-      override protected val ` recordOrVariantId` =
-        ` mkRecordOrVariantId`($packageIdRef, ${moduleName.dottedName}, ${baseName.dottedName})
+      override protected val ` dataTypeId` =
+        ` mkDataTypeId`($packageIdRef, ${moduleName.dottedName}, ${baseName.dottedName})
     """)
 
     /**
@@ -135,10 +136,55 @@ object DamlRecordOrVariantTypeGen {
     }
 
     /**
+      *  The generated class for a DAML enum type contains:
+      *  - the definition of a "Value" trait
+      *  - the definition of a _case object_ for each constructor of the DAML enum
+      *  - A type class instance (i.e. implicit object) for serializing/deserializing
+      *    to/from the ArgumentValue type (see typed-ledger-api project)
+      */
+    def toScalaDamlEnumType(constructors: List[Ref.Name]): (Set[Tree], (Tree, Tree)) = {
+      val className = damlScalaName.name.capitalize
+
+      val klass =
+        q"""
+          sealed abstract class ${TypeName(className)}(
+            override val constructor: String,
+            override val index: Int
+          ) extends ${tq"$domainApiAlias.EnumRef"} {
+            ..$rootClassChildren
+          }"""
+
+      val (imports, companionObject) = constructors match {
+        case firstValue :: otherValues =>
+          Set(LFUtil.domainApiImport) ->
+            q"""
+            object ${TermName(className)} extends
+              ${tq"$domainApiAlias.EnumCompanion[$appliedValueType]"} {
+              ..${constructors.zipWithIndex.map {
+              case (c, i) =>
+                q"""case object ${TermName(c.capitalize)} extends $appliedValueType($c, $i) """
+            }}
+            
+              val firstValue: $appliedValueType = ${TermName(firstValue.capitalize)}
+              val otherValues:  Vector[$appliedValueType] =
+                ${otherValues.map(c => q"${TermName(c.capitalize)}").toVector}
+
+              ..${idField.toList}
+              ..$companionChildren  
+            }"""
+        case _ =>
+          throw new IllegalAccessException("empty Enum not allowed")
+      }
+
+      (imports, (klass, companionObject))
+
+    }
+
+    /**
       *  The generated class for a DAML variant type contains:
       *  - the definition of a "Value" trait
       *  - the definition of a _case class_ for each variant constructor of the DAML variant
-      *  - "smart constructors" that create values for each cosntructor automatically up-casting
+      *  - "smart constructors" that create values for each constructor automatically up-casting
       *     to the Value (trait) type
       *  - A type class instance (i.e. implicit object) for serializing/deserializing
       *    to/from the ArgumentValue type (see typed-ledger-api project)
@@ -410,7 +456,7 @@ object DamlRecordOrVariantTypeGen {
         viewsByName,
         recordFieldsByName,
         recordFieldDefsByName)}
-              lte.variantAll(` recordOrVariantId`,
+              lte.variantAll(` dataTypeId`,
                 ..${generateVariantCaseDefList(util)(
         appliedValueType,
         typeArgs,
@@ -437,7 +483,7 @@ object DamlRecordOrVariantTypeGen {
 
       def generateEncodingBody: Tree =
         if (fields.isEmpty) {
-          q"lte.emptyRecord(` recordOrVariantId`, () => $appliedValueType())"
+          q"lte.emptyRecord(` dataTypeId`, () => $appliedValueType())"
         } else {
           q"""
             ${generateRecordFieldsDef(
@@ -446,7 +492,7 @@ object DamlRecordOrVariantTypeGen {
             appliedValueType,
             damlScalaName.qualifiedTermName,
             fieldDefs)}
-            lte.record(` recordOrVariantId`, $recordFields)
+            lte.record(` dataTypeId`, $recordFields)
           """
         }
 
@@ -481,16 +527,14 @@ object DamlRecordOrVariantTypeGen {
         """)
     }
 
-    val (klass, companion) = typeDecl.dataType match {
-      case iface.Record(fields) => toScalaDamlRecordType(fields)
-      case iface.Variant(fields) => toScalaDamlVariantType(fields.toList)
-      case iface.Enum(values @ _) =>
-        // FixMe (RH) https://github.com/digital-asset/daml/issues/105
-        throw new NotImplementedError("Enum types not supported")
+    val (imports, (klass, companion)) = typeDecl.dataType match {
+      case iface.Record(fields) => defaultImports -> toScalaDamlRecordType(fields)
+      case iface.Variant(fields) => defaultImports -> toScalaDamlVariantType(fields.toList)
+      case iface.Enum(values) => toScalaDamlEnumType(values.toList)
     }
 
     val filePath = damlScalaName.toFileName
-    (filePath, Seq(klass, companion))
+    (filePath, imports, Seq(klass, companion))
   }
 
   private def generateViewDef(
@@ -608,7 +652,7 @@ object DamlRecordOrVariantTypeGen {
     val variantType: Tree = q"${TermName(caseName)}[..$typeArgs]"
     q"""
       lte.variantRecordCase[$variantType, $appliedValueType]($caseName,
-        ` recordOrVariantId`, $recordFieldsName) {
+        ` dataTypeId`, $recordFieldsName) {
         case x @ ${TermName(caseName)}(..$placeHolders) =>  x
       }
     """
@@ -631,4 +675,6 @@ object DamlRecordOrVariantTypeGen {
 
   private[this] val optionType: Tree = tq"_root_.scala.Option"
   private[this] val emptyTuple: Tree = q"()"
+
+  private[this] val defaultImports = Set(LFUtil.domainApiImport, LFUtil.rpcValueImport)
 }

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
@@ -25,7 +25,7 @@ import scala.reflect.runtime.{universe => runUni}
   */
 object DamlDataTypeGen {
 
-  import LFUtil.{domainApiAlias, generateIds, rpcValueAlias}
+  import LFUtil.{domainApiAlias, generateIds, rpcValueAlias, stdVectorType}
 
   import runUni._
 
@@ -154,7 +154,7 @@ object DamlDataTypeGen {
             ..$rootClassChildren
           }"""
 
-      val (imports, companionObject) = constructors match {
+      val (imports, companionObject) = (constructors: List[Ref.Name]) match {
         case firstValue :: otherValues =>
           Set(LFUtil.domainApiImport) ->
             q"""
@@ -166,7 +166,7 @@ object DamlDataTypeGen {
             }}
             
               val firstValue: $appliedValueType = ${TermName(firstValue.capitalize)}
-              val otherValues:  Vector[$appliedValueType] =
+              val otherValues:  $stdVectorType[$appliedValueType] =
                 ${otherValues.map(c => q"${TermName(c.capitalize)}").toVector}
 
               ..${idField.toList}

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
@@ -380,6 +380,7 @@ object LFUtil {
   val primitiveObject: Tree = q"$domainApiAlias.Primitive"
   val stdMapType = tq"_root_.scala.collection.immutable.Map"
   val stdMapCompanion = q"_root_.scala.collection.immutable.Map"
+  val stdVectorType = tq"_root_.scala.collection.immutable.Vector"
   val stdSeqCompanion = q"_root_.scala.collection.immutable.Seq"
 
   def toTypeDef(s: String): TypeDef = q"type ${TypeName(s)}"

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/UsedTypeParams.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/UsedTypeParams.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.codegen.lf
 
-import com.digitalasset.codegen.lf.DamlRecordOrVariantTypeGen.RecordOrVariant
+import com.digitalasset.codegen.lf.DamlDataTypeGen.DataType
 import com.digitalasset.daml.lf.iface.{Type, TypeVar, TypeCon, TypePrim}
 import scalaz.Monoid
 import scalaz.std.list._
@@ -16,12 +16,12 @@ import scalaz.syntax.monoid._
 object UsedTypeParams {
 
   /**
-    * Returns only type parameters that specified in fields, not relying on `RecordOrVariant.typeVars`.
+    * Returns only type parameters that specified in fields, not relying on `DataType.typeVars`.
     */
-  def collectTypeParamsInUse(typeDecl: RecordOrVariant): Set[String] =
+  def collectTypeParamsInUse(typeDecl: DataType): Set[String] =
     foldMapGenTypes(typeDecl)(collectTypeParams)
 
-  private def foldMapGenTypes[Z: Monoid](typeDecl: RecordOrVariant)(f: Type => Z): Z = {
+  private def foldMapGenTypes[Z: Monoid](typeDecl: DataType)(f: Type => Z): Z = {
     val notAGT = (s: String) => mzero[Z]
     typeDecl.foldMap(_.bifoldMap(f)(_.bifoldMap(_ foldMap (_.bifoldMap(notAGT)(f)))(f)))
   }

--- a/language-support/scala/docs/codegen/source/leo/CallablePayout.scala
+++ b/language-support/scala/docs/codegen/source/leo/CallablePayout.scala
@@ -89,7 +89,7 @@ package com.digitalasset.sample {
           };
           new $anon()
         };
-        override protected val ` recordOrVariantId` = _root_.scala.Some(
+        override protected val ` dataTypeId` = _root_.scala.Some(
           ` rpcvalue`.Identifier(
             "e6a98a45832f0d7060c64f41909c181f2c94bb156232fdde869ca4161cac29a8",
             "Main.CallablePayout.Transfer"))


### PR DESCRIPTION
This PR continue the effort to add `Enum` type to the SDK (See issue #105)

This PR add `Enum` type support for the scala and codegen .  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
