### PR TITLE
Fix cross package goto definition

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -285,7 +285,7 @@ getHieFileRule =
     defineNoFile $ \(GetHieFile f) -> do
         u <- liftIO $ mkSplitUniqSupply 'a'
         let nameCache = initNameCache u []
-        liftIO $ fmap fst $ readHieFile nameCache f
+        liftIO $ fmap (hie_file_result . fst) $ readHieFile nameCache f
 
 -- | A rule that wires per-file rules together
 mainRule :: Rules ()

--- a/compiler/hie-core/src/Development/IDE/GHC/Compat.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Compat.hs
@@ -5,12 +5,18 @@
 
 -- | Attempt at hiding the GHC version differences we can.
 module Development.IDE.GHC.Compat(
+    HieFileResult(..),
     HieFile(..),
     mkHieFile,
     writeHieFile,
     readHieFile
     ) where
 
+#ifndef GHC_STABLE
+import HieAst
+import HieBin
+import HieTypes
+#else
 import GHC
 import GhcPlugins
 import NameCache
@@ -24,7 +30,9 @@ mkHieFile _ _ _ = return (HieFile () [])
 writeHieFile :: FilePath -> HieFile -> IO ()
 writeHieFile _ _ = return ()
 
-readHieFile :: NameCache -> FilePath -> IO (HieFile, ())
-readHieFile _ _ = return (HieFile () [], ())
+readHieFile :: NameCache -> FilePath -> IO (HieFileResult, ())
+readHieFile _ _ = return (HieFileResult (HieFile () []), ())
 
 data HieFile = HieFile {hie_module :: (), hie_exports :: [AvailInfo]}
+data HieFileResult = HieFileResult { hie_file_result :: HieFile }
+#endif

--- a/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
@@ -439,9 +439,6 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
             expectGoToDefinition (foo,1,[17..17]) (At (foo,4,0))
             -- B
             expectGoToDefinition (foo,1,[19..19]) (At (foo,4,9))
-{-
-    -- Disabled for now. See issue
-    -- https://github.com/digital-asset/daml/issues/1582
     ,    testCase' "Cross-package goto definition" $ do
             foo <- makeModule "Foo"
                 [ "test = scenario do"
@@ -451,7 +448,6 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
             setFilesOfInterest [foo]
             expectNoErrors
             expectGoToDefinition (foo, 3, [7..14]) (In "DA.Internal.LF")
--}
     ]
     where
         testCase' = testCase mbScenarioService


### PR DESCRIPTION
The reason for why it was broken was rather simple: We just lost the
non-compat logic somewhere along the way.

fixes #1582

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
