### PR TITLE
Add options for scripting with daml start

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,6 +13,8 @@ HEAD — ongoing
   changing the default behavior of ``daml install`` to install the assistant
   whenever we are installing a newer version of the SDK. Deprecated the
   ``--activate`` flag.
+- [DAML Assistant] Added ``--start-navigator``, ``--on-start``, and ``--wait-for-signal``
+  options to ``daml start``, to make scripting and testing with the sandbox much easier.
 - [DAML Studio] Opening an already open scenario will now focus it rather than opening
   it in a new empty tab which is never updated with results.
 - [DAML Studio] The selected view for scenario results (table or transaction) is now
@@ -24,3 +26,4 @@ HEAD — ongoing
 - [Ledger API] Added additional Ledger API integration tests to Ledger API Test Tool.
 - [DAML Studio] Goto definition now works on the export list of modules.
 - [Java Bindings] The artefact ``com.daml.ledger:bindings-java`` now has ``grpc-netty`` as dependency so that users don't need to explicitly add it.
+


### PR DESCRIPTION
Added three options to `daml start`:

* `--start-navigator` to control whether navigator is started (defaults to yes)
* `--on-start` to run a command after sandbox and navigator are started (before the browser is opened, which is optional anyway)
* `--wait-for-signal` to control whether to wait for Ctrl+C or an interrupt at the end (defaults to yes)

TODO (later once sandbox ports / navigator ports get determined automatically): pass the ports in the environment