### PR TITLE
Clean up the logging in hie-core

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -76,34 +76,34 @@ library
     hs-source-dirs:
         src
     exposed-modules:
-        Development.IDE.Types.Logger
-        Development.IDE.GHC.Util
-        Development.IDE.Spans.AtPoint
         Development.IDE.Core.Compile
-        Development.IDE.GHC.CPP
-        Development.IDE.GHC.Orphans
-        Development.IDE.Import.DependencyInformation
-        Development.IDE.Spans.Documentation
-        Development.IDE.Import.FindImports
-        Development.IDE.GHC.Error
-        Development.IDE.Spans.Calculate
-        Development.IDE.GHC.Warnings
         Development.IDE.Core.FileStore
+        Development.IDE.Core.OfInterest
         Development.IDE.Core.Rules
-        Development.IDE.GHC.Compat
-        Development.IDE.LSP.LanguageServer
-        Development.IDE.LSP.Definition
-        Development.IDE.LSP.Hover
-        Development.IDE.LSP.Protocol
-        Development.IDE.LSP.Server
-        Development.IDE.Types.Options
         Development.IDE.Core.RuleTypes
         Development.IDE.Core.Service
         Development.IDE.Core.Shake
-        Development.IDE.Core.OfInterest
+        Development.IDE.GHC.Compat
+        Development.IDE.GHC.CPP
+        Development.IDE.GHC.Error
+        Development.IDE.GHC.Orphans
+        Development.IDE.GHC.Util
+        Development.IDE.GHC.Warnings
+        Development.IDE.Import.DependencyInformation
+        Development.IDE.Import.FindImports
+        Development.IDE.LSP.Definition
+        Development.IDE.LSP.Hover
+        Development.IDE.LSP.LanguageServer
+        Development.IDE.LSP.Protocol
+        Development.IDE.LSP.Server
+        Development.IDE.Spans.AtPoint
+        Development.IDE.Spans.Calculate
+        Development.IDE.Spans.Documentation
+        Development.IDE.Spans.Type
         Development.IDE.Types.Diagnostics
         Development.IDE.Types.Location
-        Development.IDE.Spans.Type
+        Development.IDE.Types.Logger
+        Development.IDE.Types.Options
 
 executable hie-core
     default-language:   Haskell2010

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -100,6 +100,7 @@ library
         Development.IDE.Core.RuleTypes
         Development.IDE.Core.Service
         Development.IDE.Core.Shake
+        Development.IDE.Core.OfInterest
         Development.IDE.Types.Diagnostics
         Development.IDE.Types.Location
         Development.IDE.Spans.Type

--- a/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
@@ -1,0 +1,81 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- | A Shake implementation of the compiler service, built
+--   using the "Shaker" abstraction layer for in-memory use.
+--
+module Development.IDE.Core.OfInterest(
+    ofInterestRules,
+    getFilesOfInterest, setFilesOfInterest, modifyFilesOfInterest,
+    ) where
+
+import           Control.Concurrent.Extra
+import           Control.Monad.Except
+import Data.Hashable
+import Control.DeepSeq
+import GHC.Generics
+import Data.Typeable
+import qualified Data.ByteString.UTF8 as BS
+import Control.Exception
+import Development.IDE.Types.Location
+import Development.IDE.Types.Logger
+import           Data.Set                                 (Set)
+import qualified Data.Set                                 as Set
+import qualified Data.Text as T
+import Data.Tuple.Extra
+import Development.IDE.Types.Location (NormalizedFilePath)
+import           Development.Shake                        hiding (Diagnostic, Env, newCache)
+
+import           Development.IDE.Core.Shake
+
+
+
+newtype OfInterestVar = OfInterestVar (Var (Set NormalizedFilePath))
+instance IsIdeGlobal OfInterestVar
+
+
+type instance RuleResult GetFilesOfInterest = Set NormalizedFilePath
+
+
+data GetFilesOfInterest = GetFilesOfInterest
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetFilesOfInterest
+instance NFData   GetFilesOfInterest
+
+
+ofInterestRules :: Rules ()
+ofInterestRules = do
+    defineEarlyCutoff $ \GetFilesOfInterest _file -> assert (null $ fromNormalizedFilePath _file) $ do
+        alwaysRerun
+        filesOfInterest <- getFilesOfInterestUntracked
+        pure (Just $ BS.fromString $ show filesOfInterest, ([], Just filesOfInterest))
+
+
+getFilesOfInterest :: Action (Set NormalizedFilePath)
+getFilesOfInterest = use_ GetFilesOfInterest ""
+
+
+
+------------------------------------------------------------
+-- Exposed API
+
+-- | Set the files-of-interest which will be built and kept-up-to-date.
+setFilesOfInterest :: IdeState -> Set NormalizedFilePath -> IO ()
+setFilesOfInterest state files = modifyFilesOfInterest state (const files)
+
+getFilesOfInterestUntracked :: Action (Set NormalizedFilePath)
+getFilesOfInterestUntracked = do
+    OfInterestVar var <- getIdeGlobalAction
+    liftIO $ readVar var
+
+modifyFilesOfInterest :: IdeState -> (Set NormalizedFilePath -> Set NormalizedFilePath) -> IO ()
+modifyFilesOfInterest state f = do
+    OfInterestVar var <- getIdeGlobalState state
+    files <- modifyVar var $ pure . dupe . f
+    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
+    void $ shakeRun state [] (const $ pure ())

--- a/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
@@ -28,7 +28,6 @@ import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
 import Data.Tuple.Extra
-import Development.IDE.Types.Location (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 
 import           Development.IDE.Core.Shake

--- a/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
@@ -50,6 +50,7 @@ instance NFData   GetFilesOfInterest
 
 ofInterestRules :: Rules ()
 ofInterestRules = do
+    addIdeGlobal . OfInterestVar =<< liftIO (newVar Set.empty)
     defineEarlyCutoff $ \GetFilesOfInterest _file -> assert (null $ fromNormalizedFilePath _file) $ do
         alwaysRerun
         filesOfInterest <- getFilesOfInterestUntracked

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -17,8 +17,6 @@ import           Development.IDE.Import.FindImports         (Import(..))
 import           Development.IDE.Import.DependencyInformation
 import           Data.Hashable
 import           Data.Typeable
-import Development.IDE.Types.Location
-import Data.Set(Set)
 import           Development.Shake                        hiding (Env, newCache)
 import           GHC.Generics                             (Generic)
 
@@ -68,14 +66,6 @@ type instance RuleResult ReportImportCycles = ()
 -- | Read the given HIE file.
 type instance RuleResult GetHieFile = HieFile
 
-
-type instance RuleResult GetFilesOfInterest = Set NormalizedFilePath
-
-
-data GetFilesOfInterest = GetFilesOfInterest
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetFilesOfInterest
-instance NFData   GetFilesOfInterest
 
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -272,7 +272,7 @@ generateCoreRule =
 loadGhcSession :: Rules ()
 loadGhcSession =
     defineNoFile $ \GhcSession -> do
-        opts <- envOptions <$> getServiceEnv
+        opts <- getOpts
         Compile.optGhcSession opts
 
 

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -32,8 +32,6 @@ import Development.IDE.Import.FindImports
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Types.Diagnostics as Base
 import Development.IDE.Types.Location
-import qualified Data.ByteString.UTF8 as BS
-import Control.Exception
 import Data.Bifunctor
 import Data.Either.Extra
 import Data.Maybe
@@ -76,13 +74,6 @@ defineNoFile f = define $ \k file -> do
 
 ------------------------------------------------------------
 -- Exposed API
-
-getFilesOfInterestRule :: Rules ()
-getFilesOfInterestRule = do
-    defineEarlyCutoff $ \GetFilesOfInterest _file -> assert (null $ fromNormalizedFilePath _file) $ do
-        alwaysRerun
-        filesOfInterest <- getFilesOfInterest
-        pure (Just $ BS.fromString $ show filesOfInterest, ([], Just filesOfInterest))
 
 
 -- | Generate the GHC Core for the supplied file and its dependencies.
@@ -292,7 +283,6 @@ mainRule = do
     generateCoreRule
     loadGhcSession
     getHieFileRule
-    getFilesOfInterestRule
 
 ------------------------------------------------------------
 

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -34,7 +34,6 @@ import           Development.IDE.Types.Diagnostics as Base
 import Development.IDE.Types.Location
 import qualified Data.ByteString.UTF8 as BS
 import Control.Exception
-import Control.Concurrent.Extra
 import Data.Bifunctor
 import Data.Either.Extra
 import Data.Maybe
@@ -82,8 +81,7 @@ getFilesOfInterestRule :: Rules ()
 getFilesOfInterestRule = do
     defineEarlyCutoff $ \GetFilesOfInterest _file -> assert (null $ fromNormalizedFilePath _file) $ do
         alwaysRerun
-        Env{..} <- getServiceEnv
-        filesOfInterest <- liftIO $ readVar envOfInterestVar
+        filesOfInterest <- getFilesOfInterest
         pure (Just $ BS.fromString $ show filesOfInterest, ([], Just filesOfInterest))
 
 

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -34,8 +34,6 @@ import Development.IDE.Types.Location (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 import qualified Language.Haskell.LSP.Messages as LSP
 
-import           UniqSupply
-
 import           Development.IDE.Core.Shake
 
 
@@ -45,8 +43,6 @@ data Env = Env
       -- ^ Compiler options.
     , envOfInterestVar :: Var (Set NormalizedFilePath)
       -- ^ The files of interest.
-    , envUniqSupplyVar :: Var UniqSupply
-      -- ^ The unique supply of names used by the compiler.
     }
 instance IsIdeGlobal Env
 
@@ -54,11 +50,9 @@ instance IsIdeGlobal Env
 mkEnv :: IdeOptions -> IO Env
 mkEnv options = do
     ofInterestVar <- newVar Set.empty
-    uniqSupplyVar <- mkSplitUniqSupply 'a' >>= newVar
     return Env
         { envOptions       = options
         , envOfInterestVar = ofInterestVar
-        , envUniqSupplyVar = uniqSupplyVar
         }
 
 getDiagnostics :: IdeState -> IO [FileDiagnostic]

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -25,9 +25,6 @@ import Development.IDE.Types.Options (IdeOptions(..))
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.OfInterest
 import Development.IDE.Types.Logger
-import           Data.Set                                 (Set)
-import qualified Data.Set                                 as Set
-import Development.IDE.Types.Location (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 import qualified Language.Haskell.LSP.Messages as LSP
 
@@ -38,18 +35,14 @@ import           Development.IDE.Core.Shake
 data Env = Env
     { envOptions       :: IdeOptions
       -- ^ Compiler options.
-    , envOfInterestVar :: Var (Set NormalizedFilePath)
-      -- ^ The files of interest.
     }
 instance IsIdeGlobal Env
 
 
 mkEnv :: IdeOptions -> IO Env
 mkEnv options = do
-    ofInterestVar <- newVar Set.empty
     return Env
         { envOptions       = options
-        , envOfInterestVar = ofInterestVar
         }
 
 

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -28,7 +28,6 @@ import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
 import Data.Tuple.Extra
-import Development.IDE.Types.Diagnostics(FileDiagnostic)
 import Development.IDE.Types.Location (NormalizedFilePath)
 import           Development.Shake                        hiding (Diagnostic, Env, newCache)
 import qualified Language.Haskell.LSP.Messages as LSP
@@ -53,12 +52,6 @@ mkEnv options = do
         { envOptions       = options
         , envOfInterestVar = ofInterestVar
         }
-
-getDiagnostics :: IdeState -> IO [FileDiagnostic]
-getDiagnostics = getAllDiagnostics
-
-unsafeClearDiagnostics :: IdeState -> IO ()
-unsafeClearDiagnostics = unsafeClearAllDiagnostics
 
 
 ------------------------------------------------------------

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -15,7 +15,7 @@ module Development.IDE.Core.Service(
     IdeState, initialise, shutdown,
     runAction, runActions,
     runActionSync, runActionsSync,
-    setFilesOfInterest, modifyFilesOfInterest,
+    getFilesOfInterest, setFilesOfInterest, modifyFilesOfInterest,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
     ideLogger
@@ -126,6 +126,11 @@ runActionsSync s acts = join $ shakeRun s acts (const $ pure ())
 -- | Set the files-of-interest which will be built and kept-up-to-date.
 setFilesOfInterest :: IdeState -> Set NormalizedFilePath -> IO ()
 setFilesOfInterest state files = modifyFilesOfInterest state (const files)
+
+getFilesOfInterest :: Action (Set NormalizedFilePath)
+getFilesOfInterest = do
+    Env{..} <- getIdeGlobalAction
+    liftIO $ readVar envOfInterestVar
 
 modifyFilesOfInterest :: IdeState -> (Set NormalizedFilePath -> Set NormalizedFilePath) -> IO ()
 modifyFilesOfInterest state f = do

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -24,7 +24,7 @@ import           Control.Concurrent.Extra
 import           Control.Monad.Except
 import Development.IDE.Types.Options (IdeOptions(..))
 import           Development.IDE.Core.FileStore
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import           Data.Set                                 (Set)
 import qualified Data.Set                                 as Set
 import qualified Data.Text as T
@@ -74,7 +74,7 @@ unsafeClearDiagnostics = unsafeClearAllDiagnostics
 -- | Initialise the Compiler Service.
 initialise :: Rules ()
            -> (LSP.FromServerMessage -> IO ())
-           -> Logger.Handle
+           -> Logger
            -> IdeOptions
            -> VFSHandle
            -> IO IdeState
@@ -136,7 +136,7 @@ modifyFilesOfInterest :: IdeState -> (Set NormalizedFilePath -> Set NormalizedFi
 modifyFilesOfInterest state f = do
     Env{..} <- getIdeGlobalState state
     files <- modifyVar envOfInterestVar $ pure . dupe . f
-    Logger.logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
+    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
     void $ shakeRun state [] (const $ pure ())
 
 getServiceEnv :: Action Env

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -11,6 +11,7 @@
 module Development.IDE.Core.Service(
     Env(..),
     getServiceEnv,
+    getIdeOptions,
     IdeState, initialise, shutdown,
     runAction, runActions,
     runActionSync, runActionsSync,
@@ -135,3 +136,6 @@ modifyFilesOfInterest state f = do
 
 getServiceEnv :: Action Env
 getServiceEnv = getIdeGlobalAction
+
+getIdeOptions :: Action IdeOptions
+getIdeOptions = envOptions <$> getServiceEnv

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -17,7 +17,7 @@ module Development.IDE.Core.Service(
     setFilesOfInterest, modifyFilesOfInterest,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
-    logDebug, logSeriousError
+    ideLogger
     ) where
 
 import           Control.Concurrent.Extra
@@ -136,7 +136,7 @@ modifyFilesOfInterest :: IdeState -> (Set NormalizedFilePath -> Set NormalizedFi
 modifyFilesOfInterest state f = do
     Env{..} <- getIdeGlobalState state
     files <- modifyVar envOfInterestVar $ pure . dupe . f
-    logDebug state $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
+    Logger.logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ Set.toList files)
     void $ shakeRun state [] (const $ pure ())
 
 getServiceEnv :: Action Env

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -9,8 +9,6 @@
 --   using the "Shaker" abstraction layer for in-memory use.
 --
 module Development.IDE.Core.Service(
-    Env(..),
-    getServiceEnv,
     getIdeOptions,
     IdeState, initialise, shutdown,
     runAction, runActions,

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -31,7 +31,7 @@ module Development.IDE.Core.Shake(
     use, uses,
     use_, uses_,
     define, defineEarlyCutoff,
-    getAllDiagnostics, unsafeClearAllDiagnostics,
+    getDiagnostics, unsafeClearDiagnostics,
     reportSeriousError,
     IsIdeGlobal, addIdeGlobal, getIdeGlobalState, getIdeGlobalAction,
     garbageCollect,
@@ -269,14 +269,14 @@ useStale IdeState{shakeExtras=ShakeExtras{state}} k fp =
     join <$> getValues state k fp
 
 
-getAllDiagnostics :: IdeState -> IO [FileDiagnostic]
-getAllDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} = do
+getDiagnostics :: IdeState -> IO [FileDiagnostic]
+getDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} = do
     val <- readVar diagnostics
     return $ D.getAllDiagnostics val
 
 -- | FIXME: This function is temporary! Only required because the files of interest doesn't work
-unsafeClearAllDiagnostics :: IdeState -> IO ()
-unsafeClearAllDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
+unsafeClearDiagnostics :: IdeState -> IO ()
+unsafeClearDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
     writeVar diagnostics mempty
 
 -- | Clear the results for all files that do not match the given predicate.

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -32,7 +32,7 @@ module Development.IDE.Core.Shake(
     use_, uses_,
     define, defineEarlyCutoff,
     getAllDiagnostics, unsafeClearAllDiagnostics,
-    reportSeriousError, reportSeriousErrorDie,
+    reportSeriousError,
     IsIdeGlobal, addIdeGlobal, getIdeGlobalState, getIdeGlobalAction,
     garbageCollect,
     setPriority,
@@ -310,12 +310,6 @@ reportSeriousError :: String -> Action ()
 reportSeriousError t = do
     ShakeExtras{logger} <- getShakeExtras
     liftIO $ Logger.logSeriousError logger $ T.pack t
-
-reportSeriousErrorDie :: String -> Action a
-reportSeriousErrorDie t = do
-    ShakeExtras{logger} <- getShakeExtras
-    liftIO $ Logger.logSeriousError logger $ T.pack t
-    fail t
 
 
 -- | When we depend on something that reported an error, and we fail as a direct result, throw BadDependency

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -37,8 +37,7 @@ module Development.IDE.Core.Shake(
     garbageCollect,
     setPriority,
     sendEvent,
-    Development.IDE.Core.Shake.logDebug,
-    Development.IDE.Core.Shake.logSeriousError,
+    ideLogger,
     FileVersion(..),
     vfsVersion
     ) where
@@ -167,7 +166,6 @@ data IdeState = IdeState
     ,shakeClose :: IO ()
     ,shakeExtras :: ShakeExtras
     }
-
 
 profileDir :: Maybe FilePath
 profileDir = Nothing -- set to Just the directory you want profile reports to appear in
@@ -424,14 +422,9 @@ sendEvent e = do
     ShakeExtras{eventer} <- getShakeExtras
     liftIO $ eventer e
 
--- | bit of an odd signature because we're trying to remove priority
-sl :: (Handle -> T.Text -> IO ()) -> IdeState -> T.Text -> IO ()
-sl f IdeState{shakeExtras=ShakeExtras{logger}} p = f logger p
+ideLogger :: IdeState -> Logger.Handle
+ideLogger IdeState{shakeExtras=ShakeExtras{logger}} = logger
 
-logDebug, logSeriousError
-    :: IdeState -> T.Text -> IO ()
-logDebug = sl Logger.logDebug
-logSeriousError = sl Logger.logSeriousError
 
 data GetModificationTime = GetModificationTime
     deriving (Eq, Show, Generic)

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -15,8 +15,6 @@ import qualified Development.IDE.Types.Logger as Logger
 import Development.IDE.Core.Rules
 
 import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Text
 
 -- | Go to the definition of a variable.
 handle
@@ -31,7 +29,7 @@ handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri
         Just (toNormalizedFilePath -> filePath) -> do
           Logger.logInfo loggerH $
             "Definition request at position " <>
-            renderStrict (layoutPretty defaultLayoutOptions $ prettyPosition pos) <>
+            T.pack (showPosition pos) <>
             " in file: " <> T.pack (fromNormalizedFilePath filePath)
           runAction compilerH (getDefinition filePath pos)
         Nothing       -> pure Nothing

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -11,23 +11,23 @@ module Development.IDE.LSP.Definition
 import           Development.IDE.LSP.Protocol
 import Development.IDE.Types.Location
 
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import Development.IDE.Core.Rules
 
 import qualified Data.Text as T
 
 -- | Go to the definition of a variable.
 handle
-    :: Logger.Handle
+    :: Logger
     -> IdeState
     -> TextDocumentPositionParams
     -> IO LocationResponseParams
-handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
+handle logger compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
 
 
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
-          Logger.logInfo loggerH $
+          logInfo logger $
             "Definition request at position " <>
             T.pack (showPosition pos) <>
             " in file: " <> T.pack (fromNormalizedFilePath filePath)

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -12,7 +12,7 @@ import Development.IDE.LSP.Protocol hiding (Hover)
 import Language.Haskell.LSP.Types (Hover(..))
 import Development.IDE.Types.Location
 
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 
 import qualified Data.Text as T
 
@@ -20,14 +20,14 @@ import Development.IDE.Core.Rules
 
 -- | Display information on hover.
 handle
-    :: Logger.Handle
+    :: Logger
     -> IdeState
     -> TextDocumentPositionParams
     -> IO (Maybe Hover)
 handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
-          Logger.logInfo loggerH $
+          logInfo loggerH $
               "Hover request at position " <>
               T.pack (showPosition pos) <>
               " in file: " <> T.pack (fromNormalizedFilePath filePath)

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -15,8 +15,6 @@ import Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger as Logger
 
 import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Text
 
 import Development.IDE.Core.Rules
 
@@ -31,7 +29,7 @@ handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri
         Just (toNormalizedFilePath -> filePath) -> do
           Logger.logInfo loggerH $
               "Hover request at position " <>
-              renderStrict (layoutPretty defaultLayoutOptions $ prettyPosition pos) <>
+              T.pack (showPosition pos) <>
               " in file: " <> T.pack (fromNormalizedFilePath filePath)
           runAction compilerH $ getAtPoint filePath pos
         Nothing       -> pure Nothing

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -17,7 +17,7 @@ import           Development.IDE.LSP.Server
 import Control.Monad.IO.Class
 import qualified Development.IDE.LSP.Definition as LS.Definition
 import qualified Development.IDE.LSP.Hover      as LS.Hover
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import Development.IDE.Core.Service
 import Development.IDE.Types.Location
 
@@ -44,30 +44,30 @@ textShow = T.pack . show
 ------------------------------------------------------------------------
 
 handleRequest
-    :: Logger.Handle
+    :: Logger
     -> IdeState
     -> (forall resp. resp -> ResponseMessage resp)
     -> (ErrorCode -> ResponseMessage ())
     -> ServerRequest
     -> IO FromServerMessage
-handleRequest loggerH compilerH makeResponse makeErrorResponse = \case
+handleRequest logger compilerH makeResponse makeErrorResponse = \case
     Shutdown -> do
-      Logger.logInfo loggerH "Shutdown request received, terminating."
+      logInfo logger "Shutdown request received, terminating."
       System.Exit.exitSuccess
 
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
-    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle loggerH compilerH params
-    Hover params -> RspHover . makeResponse <$> LS.Hover.handle loggerH compilerH params
+    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle logger compilerH params
+    Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
     CodeLens _params -> pure $ RspCodeLens $ makeResponse mempty
 
     req -> do
-        Logger.logWarning loggerH ("Method not found" <> T.pack (show req))
+        logWarning logger ("Method not found" <> T.pack (show req))
         pure $ RspError $ makeErrorResponse MethodNotFound
 
 
-handleNotification :: LspFuncs () -> Logger.Handle -> IdeState -> ServerNotification -> IO ()
-handleNotification lspFuncs loggerH compilerH = \case
+handleNotification :: LspFuncs () -> Logger -> IdeState -> ServerNotification -> IO ()
+handleNotification lspFuncs logger compilerH = \case
 
     DidOpenTextDocument (DidOpenTextDocumentParams item) -> do
         case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
@@ -76,10 +76,10 @@ handleNotification lspFuncs loggerH compilerH = \case
               -> handleDidOpenFile item
 
               | otherwise
-              -> Logger.logWarning loggerH $ "Unknown scheme in URI: "
+              -> logWarning logger $ "Unknown scheme in URI: "
                     <> textShow uri
 
-          _ -> Logger.logSeriousError loggerH $ "Invalid URI in DidOpenTextDocument: "
+          _ -> logSeriousError logger $ "Invalid URI in DidOpenTextDocument: "
                     <> textShow (_uri (item :: TextDocumentItem))
 
     DidChangeTextDocument (DidChangeTextDocumentParams docId _) -> do
@@ -90,11 +90,11 @@ handleNotification lspFuncs loggerH compilerH = \case
             mbVirtual <- getVirtualFileFunc lspFuncs $ toNormalizedUri uri
             let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
             onFileModified compilerH filePath (Just contents)
-            Logger.logInfo loggerH
+            logInfo logger
               $ "Updated text document: " <> textShow (fromNormalizedFilePath filePath)
 
           Nothing ->
-            Logger.logSeriousError loggerH
+            logSeriousError logger
               $ "Invalid file path: " <> textShow (_uri (docId :: VersionedTextDocumentIdentifier))
 
     DidCloseTextDocument (DidCloseTextDocumentParams (TextDocumentIdentifier uri)) ->
@@ -103,9 +103,9 @@ handleNotification lspFuncs loggerH compilerH = \case
               | URI.uriScheme uri' == "file:" -> do
                     Just fp <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
                     handleDidCloseFile fp
-              | otherwise -> Logger.logWarning loggerH $ "Unknown scheme in URI: " <> textShow uri
+              | otherwise -> logWarning logger $ "Unknown scheme in URI: " <> textShow uri
 
-          _ -> Logger.logSeriousError loggerH
+          _ -> logSeriousError logger
                  $    "Invalid URI in DidCloseTextDocument: "
                    <> textShow uri
 
@@ -122,10 +122,10 @@ handleNotification lspFuncs loggerH compilerH = \case
         Just filePath <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
         onFileModified compilerH filePath (Just contents)
         modifyFilesOfInterest compilerH (S.insert filePath)
-        Logger.logInfo loggerH $ "Opened text document: " <> textShow filePath
+        logInfo logger $ "Opened text document: " <> textShow filePath
 
     handleDidCloseFile filePath = do
-         Logger.logInfo loggerH $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
+         logInfo logger $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
          onFileModified compilerH filePath Nothing
          modifyFilesOfInterest compilerH (S.delete filePath)
 
@@ -136,7 +136,7 @@ onFileModified
     -> Maybe T.Text
     -> IO ()
 onFileModified service fp mbContents = do
-    Logger.logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
+    logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
     setBufferModified service fp mbContents
 
 ------------------------------------------------------------------------
@@ -144,7 +144,7 @@ onFileModified service fp mbContents = do
 ------------------------------------------------------------------------
 
 runLanguageServer
-    :: Logger.Handle
+    :: Logger
     -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
     -> IO ()
 runLanguageServer loggerH getIdeState = do

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -136,7 +136,7 @@ onFileModified
     -> Maybe T.Text
     -> IO ()
 onFileModified service fp mbContents = do
-    logDebug service $ "File modified " <> T.pack (show fp)
+    Logger.logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
     setBufferModified service fp mbContents
 
 ------------------------------------------------------------------------

--- a/compiler/hie-core/src/Development/IDE/LSP/Protocol.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Protocol.hs
@@ -6,7 +6,6 @@ module Development.IDE.LSP.Protocol
     ( module Language.Haskell.LSP.Types
     , ServerRequest(..)
     , ServerNotification(..)
-    , prettyPosition
     , pattern EventFileDiagnostics
     ) where
 
@@ -15,7 +14,7 @@ import qualified Data.Text        as T
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Language.Haskell.LSP.Messages
-import Data.Text.Prettyprint.Doc
+
 
 import Language.Haskell.LSP.Types hiding
     ( CodeLens
@@ -53,9 +52,6 @@ data ServerNotification
 ----------------------------------------------------------------------------------------------------
 -- Pretty printing
 ----------------------------------------------------------------------------------------------------
-
-prettyPosition :: Position -> Doc a
-prettyPosition Position{..} = pretty (_line + 1) <> colon <> pretty (_character + 1)
 
 -- | Pattern synonym to make it a bit more convenient to match on diagnostics
 -- in things like damlc test.

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.STM
 import Data.Default
 
 import           Development.IDE.LSP.Protocol
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 
 import qualified Data.Aeson                       as Aeson
 import qualified Data.Aeson.Text as Aeson
@@ -49,7 +49,7 @@ data Handlers = Handlers
     }
 
 runServer
-    :: Logger.Handle
+    :: Logger
     -> (LSP.LspFuncs () -> IO Handlers)
     -- ^ Notification handler for language server notifications
     -> IO ()
@@ -93,7 +93,7 @@ runServer loggerH getHandlers = do
             _ <- flip forkFinally (const exitClientMsg) $ forever $ do
                 msg <- atomically $ readTChan clientMsgChan
                 case convClientMsg msg of
-                    Nothing -> Logger.logSeriousError loggerH $ "Unknown client msg: " <> T.pack (show msg)
+                    Nothing -> logSeriousError loggerH $ "Unknown client msg: " <> T.pack (show msg)
                     Just (Left notif) -> notificationHandler notif
                     Just (Right req) -> sendFunc =<< requestHandler' req
             pure Nothing

--- a/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
@@ -8,9 +8,7 @@ module Development.IDE.Types.Diagnostics (
   FileDiagnostic,
   LSP.DiagnosticSeverity(..),
   DiagnosticStore,
-  DiagnosticRelatedInformation(..),
   List(..),
-  StoreItem(..),
   ideErrorText,
   ideErrorPretty,
   errorDiag,
@@ -35,7 +33,6 @@ import Language.Haskell.LSP.Types as LSP (
     DiagnosticSeverity(..)
   , Diagnostic(..)
   , List(..)
-  , DiagnosticRelatedInformation(..)
   )
 import Language.Haskell.LSP.Diagnostics
 import Data.Text.Prettyprint.Doc.Render.Text

--- a/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
@@ -11,7 +11,6 @@ module Development.IDE.Types.Diagnostics (
   List(..),
   ideErrorText,
   ideErrorPretty,
-  errorDiag,
   showDiagnostics,
   showDiagnosticsColored,
   ) where
@@ -35,14 +34,10 @@ import Development.IDE.Types.Location
 
 
 ideErrorText :: NormalizedFilePath -> T.Text -> FileDiagnostic
-ideErrorText fp = errorDiag fp "Ide Error"
+ideErrorText fp msg = (fp, diagnostic noRange LSP.DsError "Ide Error" msg)
 
 ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . Pretty.prettyShow
-
-errorDiag :: NormalizedFilePath -> T.Text -> T.Text -> FileDiagnostic
-errorDiag fp src msg =
-  (fp,  diagnostic noRange LSP.DsError src msg)
 
 -- | This is for compatibility with our old diagnostic type
 diagnostic :: Range

--- a/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
@@ -34,26 +34,17 @@ import Development.IDE.Types.Location
 
 
 ideErrorText :: NormalizedFilePath -> T.Text -> FileDiagnostic
-ideErrorText fp msg = (fp, diagnostic noRange LSP.DsError "Ide Error" msg)
+ideErrorText fp msg = (fp, LSP.Diagnostic {
+    _range = noRange,
+    _severity = Just LSP.DsError,
+    _code = Nothing,
+    _source = Just "compiler",
+    _message = msg,
+    _relatedInformation = Nothing
+    })
 
 ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . Pretty.prettyShow
-
--- | This is for compatibility with our old diagnostic type
-diagnostic :: Range
-           -> LSP.DiagnosticSeverity
-           -> T.Text -- ^ source
-           -> T.Text -- ^ message
-           -> LSP.Diagnostic
-diagnostic rng sev src msg
-    = LSP.Diagnostic {
-          _range = rng,
-          _severity = Just sev,
-          _code = Nothing,
-          _source = Just src,
-          _message = msg,
-          _relatedInformation = Nothing
-          }
 
 
 -- | Human readable diagnostics for a specific file.

--- a/compiler/hie-core/src/Development/IDE/Types/Location.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Location.hs
@@ -9,6 +9,7 @@ module Development.IDE.Types.Location
     , noFilePath
     , noRange
     , Position(..)
+    , prettyPosition
     , Range(..)
     , Uri(..)
     , NormalizedUri
@@ -24,8 +25,7 @@ module Development.IDE.Types.Location
     ) where
 
 import Language.Haskell.LSP.Types (Location(..), Range(..), Position(..))
-
-
+import Data.Text.Prettyprint.Doc
 import Control.DeepSeq
 import Data.Maybe as Maybe
 import Data.Hashable
@@ -84,3 +84,7 @@ noFilePath = "<unknown>"
 -- A dummy range to use when range is unknown
 noRange :: Range
 noRange =  Range (Position 0 0) (Position 100000 0)
+
+
+prettyPosition :: Position -> Doc a
+prettyPosition Position{..} = pretty (_line + 1) <> colon <> pretty (_character + 1)

--- a/compiler/hie-core/src/Development/IDE/Types/Location.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Location.hs
@@ -9,7 +9,7 @@ module Development.IDE.Types.Location
     , noFilePath
     , noRange
     , Position(..)
-    , prettyPosition
+    , showPosition
     , Range(..)
     , Uri(..)
     , NormalizedUri
@@ -25,7 +25,6 @@ module Development.IDE.Types.Location
     ) where
 
 import Language.Haskell.LSP.Types (Location(..), Range(..), Position(..))
-import Data.Text.Prettyprint.Doc
 import Control.DeepSeq
 import Data.Maybe as Maybe
 import Data.Hashable
@@ -86,5 +85,5 @@ noRange :: Range
 noRange =  Range (Position 0 0) (Position 100000 0)
 
 
-prettyPosition :: Position -> Doc a
-prettyPosition Position{..} = pretty (_line + 1) <> colon <> pretty (_character + 1)
+showPosition :: Position -> String
+showPosition Position{..} = show (_line + 1) ++ ":" ++ show (_character + 1)

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -6,23 +6,23 @@
 -- concrete choice of logging framework so users can plug in whatever
 -- framework they want to.
 module Development.IDE.Types.Logger
-  ( Handle(..)
-  , makeOneHandle
-  , makeNopHandle
+  ( Logger(..)
+  , makeOneLogger
+  , makeNopLogger
   ) where
 
 import qualified Data.Text as T
 import GHC.Stack
 
-data Handle = Handle {
+data Logger = Logger {
       logSeriousError :: HasCallStack => T.Text -> IO ()
     , logInfo :: HasCallStack => T.Text -> IO ()
     , logDebug :: HasCallStack => T.Text -> IO ()
     , logWarning :: HasCallStack => T.Text -> IO ()
     }
 
-makeNopHandle :: Handle
-makeNopHandle = makeOneHandle $ const $ pure ()
+makeNopLogger :: Logger
+makeNopLogger = makeOneLogger $ const $ pure ()
 
-makeOneHandle :: (HasCallStack => T.Text -> IO ()) -> Handle
-makeOneHandle x = Handle x x x x
+makeOneLogger :: (HasCallStack => T.Text -> IO ()) -> Logger
+makeOneLogger x = Logger x x x x

--- a/compiler/hie-core/test/Demo.hs
+++ b/compiler/hie-core/test/Demo.hs
@@ -14,7 +14,6 @@ import Development.IDE.Core.Shake
 import Development.IDE.Core.RuleTypes
 import Development.IDE.LSP.Protocol
 import Development.IDE.Types.Location
-import Data.String
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Options
 import Development.IDE.Types.Logger
@@ -47,7 +46,7 @@ main = do
     args <- getArgs
     -- lock to avoid overlapping output on stdout
     lock <- newLock
-    let logger = makeOneHandle $ withLock lock . T.putStrLn
+    let logger = makeOneLogger $ withLock lock . T.putStrLn
 
     dir <- getCurrentDirectory
     hPutStrLn stderr dir
@@ -75,7 +74,7 @@ main = do
 
 kick :: Action ()
 kick = do
-    files <- use_ GetFilesOfInterest $ fromString ""
+    files <- getFilesOfInterest
     void $ uses TypeCheck $ Set.toList files
 
 -- | Print an LSP event.

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -101,8 +101,8 @@ withIdeState compilerOpts loggerH eventHandler f =
         f ideState
 
 -- | Adapter to the IDE logger module.
-toIdeLogger :: Logger.Handle IO -> IdeLogger.Handle
-toIdeLogger h = IdeLogger.Handle {
+toIdeLogger :: Logger.Handle IO -> IdeLogger.Logger
+toIdeLogger h = IdeLogger.Logger {
        logSeriousError = Logger.logError h
      , logInfo = Logger.logInfo h
      , logDebug = Logger.logDebug h

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -143,7 +143,7 @@ compileFile service fp = do
     -- Otherwise all diagnostics produced during compilation will be garbage
     -- collected afterwards.
     liftIO $ setFilesOfInterest service (S.singleton fp)
-    liftIO $ logDebug service $ "Compiling: " <> T.pack (fromNormalizedFilePath fp)
+    liftIO $ IdeLogger.logDebug (ideLogger service) $ "Compiling: " <> T.pack (fromNormalizedFilePath fp)
     actionToExceptT service (getDalf fp)
 
 -- | Parse the supplied file to a ghc ParsedModule.
@@ -153,7 +153,7 @@ parseFile
     -> ExceptT [FileDiagnostic] IO ParsedModule
 parseFile service fp = do
     liftIO $ setFilesOfInterest service (S.singleton fp)
-    liftIO $ logDebug service $ "Parsing: " <> T.pack (fromNormalizedFilePath fp)
+    liftIO $ IdeLogger.logDebug (ideLogger service) $ "Parsing: " <> T.pack (fromNormalizedFilePath fp)
     actionToExceptT service (getParsedModule fp)
 
 newtype UseDalf = UseDalf{unUseDalf :: Bool}
@@ -175,7 +175,7 @@ buildDar ::
 buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInput = do
   let file' = fromNormalizedFilePath file
   liftIO $
-    logDebug service $
+    IdeLogger.logDebug (ideLogger service) $
     "Creating dar: " <> T.pack file'
   if unUseDalf dalfInput
     then liftIO $ do
@@ -193,7 +193,7 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       let pkgModuleNames = S.fromList $ map T.unpack $ LF.packageModuleNames pkg
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
       unless (S.null missingExposed) $ do
-          liftIO $ logSeriousError service $
+          liftIO $ IdeLogger.logSeriousError (ideLogger service) $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               T.pack (show $ S.toList missingExposed)
           fail ""

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -11,7 +11,7 @@ import Development.IDE.Core.FileStore
 import qualified Development.IDE.Core.Service     as Service
 import qualified Development.IDE.Core.Rules     as Service
 import           Development.IDE.Types.Diagnostics
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import Development.IDE.Types.Location
 
 
@@ -123,7 +123,7 @@ haddockParse :: IdeOptions ->
                 Ex.ExceptT [FileDiagnostic] IO [ParsedModule]
 haddockParse opts f = ExceptT $ do
   vfs <- makeVFSHandle
-  service <- Service.initialise Service.mainRule (const $ pure ()) Logger.makeNopHandle opts vfs
+  service <- Service.initialise Service.mainRule (const $ pure ()) makeNopLogger opts vfs
   Service.setFilesOfInterest service (Set.fromList f)
   parsed  <- Service.runAction service $
              runMaybeT $

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/API.hs
@@ -23,8 +23,7 @@ module Development.IDE.State.API
     , unsafeClearDiagnostics
     , generatePackageMap
     , getDependencies
-    , logDebug
-    , logSeriousError
+    , ideLogger
     , VFSHandle
     , makeVFSHandle
     , makeLSPVFSHandle

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -411,7 +411,6 @@ ofInterestRule = do
     action $ use OfInterest ""
     defineNoFile $ \OfInterest -> do
         setPriority PriorityFilesOfInterest
-        Env{..} <- getServiceEnv
         DamlEnv{..} <- getDamlServiceEnv
         -- query for files of interest
         files   <- use_ GetFilesOfInterest ""

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -11,6 +11,7 @@ import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe
+import Development.IDE.Core.OfInterest
 import DA.Daml.GHC.Compiler.Options
 import Development.IDE.Types.Location as Base
 import Data.Aeson hiding (Options)
@@ -353,7 +354,7 @@ encodeModule lfVersion m =
 getScenarioRootsRule :: Rules ()
 getScenarioRootsRule =
     defineNoFile $ \GetScenarioRoots -> do
-        filesOfInterest <- use_ GetFilesOfInterest ""
+        filesOfInterest <- getFilesOfInterest
         openVRs <- use_ GetOpenVirtualResources ""
         let files = Set.toList (filesOfInterest `Set.union` Set.map vrScenarioFile openVRs)
         deps <- forP files $ \file -> do
@@ -413,7 +414,7 @@ ofInterestRule = do
         setPriority PriorityFilesOfInterest
         DamlEnv{..} <- getDamlServiceEnv
         -- query for files of interest
-        files   <- use_ GetFilesOfInterest ""
+        files   <- getFilesOfInterest
         openVRs <- use_ GetOpenVirtualResources ""
         let vrFiles = Set.map vrScenarioFile openVRs
         -- We run scenarios for all files of interest to get diagnostics

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Development.IDE.Core.Service.Daml(
-    Env(..),
     VirtualResource(..),
     DamlEnv(..),
     getDamlServiceEnv,

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -29,7 +29,7 @@ import qualified Data.Text as T
 import Data.Tuple.Extra
 import Development.Shake
 
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import Development.IDE.Core.Service hiding (initialise)
 import Development.IDE.Core.FileStore
 import qualified Development.IDE.Core.Service as IDE
@@ -95,13 +95,13 @@ modifyOpenVirtualResources :: IdeState -> (Set VirtualResource -> Set VirtualRes
 modifyOpenVirtualResources state f = do
     DamlEnv{..} <- getIdeGlobalState state
     vrs <- modifyVar envOpenVirtualResources $ pure . dupe . f
-    Logger.logDebug (ideLogger state) $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
+    logDebug (ideLogger state) $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
     void $ shakeRun state [] (const $ pure ())
 
 initialise
     :: Rules ()
     -> (LSP.FromServerMessage -> IO ())
-    -> Logger.Handle
+    -> Logger
     -> Options
     -> VFSHandle
     -> Maybe SS.Handle

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -4,7 +4,6 @@
 
 module Development.IDE.Core.Service.Daml(
     Env(..),
-    getServiceEnv,
     VirtualResource(..),
     DamlEnv(..),
     getDamlServiceEnv,

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Service/Daml.hs
@@ -14,7 +14,7 @@ module Development.IDE.Core.Service.Daml(
     setFilesOfInterest, modifyFilesOfInterest, setOpenVirtualResources, modifyOpenVirtualResources,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
-    logDebug, logSeriousError
+    ideLogger
     ) where
 
 import Control.Concurrent.Extra
@@ -95,7 +95,7 @@ modifyOpenVirtualResources :: IdeState -> (Set VirtualResource -> Set VirtualRes
 modifyOpenVirtualResources state f = do
     DamlEnv{..} <- getIdeGlobalState state
     vrs <- modifyVar envOpenVirtualResources $ pure . dupe . f
-    logDebug state $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
+    Logger.logDebug (ideLogger state) $ "Set vrs of interest to: " <> T.pack (show $ Set.toList vrs)
     void $ shakeRun state [] (const $ pure ())
 
 initialise

--- a/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
@@ -43,7 +43,7 @@ import qualified Development.IDE.Types.Diagnostics as D
 import qualified Development.IDE.Types.Location as D
 import DA.Service.Daml.Compiler.Impl.Scenario as SS
 import Development.IDE.Core.Rules.Daml
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import DA.Daml.GHC.Compiler.Options (defaultOptionsIO)
 import Development.IDE.Core.Service.Daml(VirtualResource(..))
 import DA.Test.Util (standardizeQuotes)
@@ -122,7 +122,7 @@ runShakeTest mbScenarioService (ShakeTest m) = do
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()
     vfs <- API.makeVFSHandle
-    service <- API.initialise (mainRule options) (atomically . eventLogger) Logger.makeNopHandle options vfs mbScenarioService
+    service <- API.initialise (mainRule options) (atomically . eventLogger) makeNopLogger options vfs mbScenarioService
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv
                 { steService = service

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -155,7 +155,7 @@ onFileModified
     -> Maybe T.Text
     -> IO ()
 onFileModified service fp mbContents = do
-    logDebug service $ "File modified " <> T.pack (show fp)
+    Logger.logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
     setBufferModified service fp mbContents
 
 ------------------------------------------------------------------------

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -17,7 +17,7 @@ import Control.Monad.IO.Class
 import qualified DA.Service.Daml.LanguageServer.CodeLens   as LS.CodeLens
 import qualified Development.IDE.LSP.Definition as LS.Definition
 import qualified Development.IDE.LSP.Hover      as LS.Hover
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 
 import qualified Data.Aeson                                as Aeson
 import qualified Data.Rope.UTF16 as Rope
@@ -46,30 +46,30 @@ textShow = T.pack . show
 ------------------------------------------------------------------------
 
 handleRequest
-    :: Logger.Handle
+    :: Logger
     -> IdeState
     -> (forall resp. resp -> ResponseMessage resp)
     -> (ErrorCode -> ResponseMessage ())
     -> ServerRequest
     -> IO FromServerMessage
-handleRequest loggerH compilerH makeResponse makeErrorResponse = \case
+handleRequest logger compilerH makeResponse makeErrorResponse = \case
     Shutdown -> do
-      Logger.logInfo loggerH "Shutdown request received, terminating."
+      logInfo logger "Shutdown request received, terminating."
       System.Exit.exitSuccess
 
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
-    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle loggerH compilerH params
-    Hover params -> RspHover . makeResponse <$> LS.Hover.handle loggerH compilerH params
-    CodeLens params -> RspCodeLens . makeResponse <$> LS.CodeLens.handle loggerH compilerH params
+    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle logger compilerH params
+    Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
+    CodeLens params -> RspCodeLens . makeResponse <$> LS.CodeLens.handle logger compilerH params
 
     req -> do
-        Logger.logWarning loggerH ("Method not found" <> T.pack (show req))
+        logWarning logger ("Method not found" <> T.pack (show req))
         pure $ RspError $ makeErrorResponse MethodNotFound
 
 
-handleNotification :: LspFuncs () -> Logger.Handle -> IdeState -> ServerNotification -> IO ()
-handleNotification lspFuncs loggerH compilerH = \case
+handleNotification :: LspFuncs () -> Logger -> IdeState -> ServerNotification -> IO ()
+handleNotification lspFuncs logger compilerH = \case
 
     DidOpenTextDocument (DidOpenTextDocumentParams item) -> do
         case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
@@ -81,10 +81,10 @@ handleNotification lspFuncs loggerH compilerH = \case
               -> handleDidOpenVirtualResource uri
 
               | otherwise
-              -> Logger.logWarning loggerH $ "Unknown scheme in URI: "
+              -> logWarning logger $ "Unknown scheme in URI: "
                     <> textShow uri
 
-          _ -> Logger.logSeriousError loggerH $ "Invalid URI in DidOpenTextDocument: "
+          _ -> logSeriousError logger $ "Invalid URI in DidOpenTextDocument: "
                     <> textShow (_uri (item :: TextDocumentItem))
 
     DidChangeTextDocument (DidChangeTextDocumentParams docId _) -> do
@@ -95,11 +95,11 @@ handleNotification lspFuncs loggerH compilerH = \case
             mbVirtual <- getVirtualFileFunc lspFuncs $ toNormalizedUri uri
             let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
             onFileModified compilerH filePath (Just contents)
-            Logger.logInfo loggerH
+            logInfo logger
               $ "Updated text document: " <> textShow (fromNormalizedFilePath filePath)
 
           Nothing ->
-            Logger.logSeriousError loggerH
+            logSeriousError logger
               $ "Invalid file path: " <> textShow (_uri (docId :: VersionedTextDocumentIdentifier))
 
     DidCloseTextDocument (DidCloseTextDocumentParams (TextDocumentIdentifier uri)) ->
@@ -109,9 +109,9 @@ handleNotification lspFuncs loggerH compilerH = \case
                     Just fp <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
                     handleDidCloseFile fp
               | URI.uriScheme uri' == "daml:" -> handleDidCloseVirtualResource uri'
-              | otherwise -> Logger.logWarning loggerH $ "Unknown scheme in URI: " <> textShow uri
+              | otherwise -> logWarning logger $ "Unknown scheme in URI: " <> textShow uri
 
-          _ -> Logger.logSeriousError loggerH
+          _ -> logSeriousError logger
                  $    "Invalid URI in DidCloseTextDocument: "
                    <> textShow uri
 
@@ -128,24 +128,24 @@ handleNotification lspFuncs loggerH compilerH = \case
         Just filePath <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
         onFileModified compilerH filePath (Just contents)
         modifyFilesOfInterest compilerH (S.insert filePath)
-        Logger.logInfo loggerH $ "Opened text document: " <> textShow filePath
+        logInfo logger $ "Opened text document: " <> textShow filePath
 
     handleDidOpenVirtualResource uri = do
          case uriToVirtualResource uri of
-           Nothing -> Logger.logWarning loggerH $ "Failed to parse virtual resource URI: " <> textShow uri
+           Nothing -> logWarning logger $ "Failed to parse virtual resource URI: " <> textShow uri
            Just vr -> do
-               Logger.logInfo loggerH $ "Opened virtual resource: " <> textShow vr
+               logInfo logger $ "Opened virtual resource: " <> textShow vr
                modifyOpenVirtualResources compilerH (S.insert vr)
 
     handleDidCloseFile filePath = do
-         Logger.logInfo loggerH $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
+         logInfo logger $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
          onFileModified compilerH filePath Nothing
          modifyFilesOfInterest compilerH (S.delete filePath)
 
     handleDidCloseVirtualResource uri = do
-        Logger.logInfo loggerH $ "Closed virtual resource: " <> textShow uri
+        logInfo logger $ "Closed virtual resource: " <> textShow uri
         case uriToVirtualResource uri of
-           Nothing -> Logger.logWarning loggerH "Failed to parse virtual resource URI!"
+           Nothing -> logWarning logger "Failed to parse virtual resource URI!"
            Just vr -> modifyOpenVirtualResources compilerH (S.delete vr)
 
 -- | Manages the file store (caching compilation results and unsaved content).
@@ -155,7 +155,7 @@ onFileModified
     -> Maybe T.Text
     -> IO ()
 onFileModified service fp mbContents = do
-    Logger.logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
+    logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
     setBufferModified service fp mbContents
 
 ------------------------------------------------------------------------
@@ -163,11 +163,11 @@ onFileModified service fp mbContents = do
 ------------------------------------------------------------------------
 
 runLanguageServer
-    :: Logger.Handle
+    :: Logger
     -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
     -> IO ()
-runLanguageServer loggerH getIdeState = do
+runLanguageServer logger getIdeState = do
     let getHandlers lspFuncs = do
             compilerH <- getIdeState (sendFunc lspFuncs) (makeLSPVFSHandle lspFuncs)
-            pure $ Handlers (handleRequest loggerH compilerH) (handleNotification lspFuncs loggerH compilerH)
-    liftIO $ runServer loggerH getHandlers
+            pure $ Handlers (handleRequest logger compilerH) (handleNotification lspFuncs logger compilerH)
+    liftIO $ runServer logger getHandlers

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
@@ -15,19 +15,19 @@ import Data.Foldable
 import Data.Maybe
 import qualified Data.Text as T
 import qualified DA.Service.Daml.Compiler.Impl.Handle as Compiler
-import qualified Development.IDE.Types.Logger as Logger
+import Development.IDE.Types.Logger
 import Development.IDE.Types.Location
 
 -- | Gather code lenses like scenario execution for a DAML file.
 handle
-    :: Logger.Handle
+    :: Logger
     -> Compiler.IdeState
     -> CodeLensParams
     -> IO (List CodeLens)
-handle loggerH compilerH (CodeLensParams (TextDocumentIdentifier uri)) = do
+handle logger compilerH (CodeLensParams (TextDocumentIdentifier uri)) = do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
-          Logger.logInfo loggerH $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)
+          logInfo logger $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)
           vrs <- Compiler.getAssociatedVirtualResources compilerH filePath
           pure $ mapMaybe virtualResourceToCodeLens vrs
         Nothing       -> pure []

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -163,6 +163,7 @@ testCase args version getService outdir registerTODO file = singleTest file . Te
       , resultTime = 0
       }
     else do
+      -- FIXME: Use of unsafeClearDiagnostics is only because we don't naturally lose them when we change setFilesOfInterest
       Compile.unsafeClearDiagnostics service
       ex <- try $ mainProj args service outdir log (toNormalizedFilePath file) :: IO (Either SomeException Package)
       diags <- Compile.getDiagnostics service

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -132,7 +132,7 @@ getIntegrationTests registerTODO scenarioService version = do
     vfs <- Compile.makeVFSHandle
     pure $
       withResource
-      (Compile.initialise (Compile.mainRule opts) (const $ pure ()) IdeLogger.makeNopHandle opts vfs (Just scenarioService))
+      (Compile.initialise (Compile.mainRule opts) (const $ pure ()) IdeLogger.makeNopLogger opts vfs (Just scenarioService))
       Compile.shutdown $ \service ->
       withTestArguments $ \args -> testGroup ("Tests for DAML-LF " ++ renderPretty version) $
         map (testCase args version service outdir registerTODO) allTestFiles


### PR DESCRIPTION
Less duplicate names and confusing clashes. Also moved a bit of diagnostics stuff around and made more stuff non-exported.