### PR TITLE
Only fix paths when running in a bazel environment.

### DIFF
--- a/bazel_tools/runfiles/src/main/scala/com/digitalasset/daml/bazeltools/BazelRunfiles.scala
+++ b/bazel_tools/runfiles/src/main/scala/com/digitalasset/daml/bazeltools/BazelRunfiles.scala
@@ -9,7 +9,12 @@ trait BazelRunfiles {
 
   private val MainWorkspace = "com_github_digital_asset_daml"
 
-  def rlocation(path: String): String = Runfiles.create.rlocation(MainWorkspace + "/" + path)
+  private val inBazelEnvironment =
+    Set("RUNFILES_DIR", "JAVA_RUNFILES", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY").exists(
+      sys.env.contains)
+
+  def rlocation(path: String): String =
+    if (inBazelEnvironment) Runfiles.create.rlocation(MainWorkspace + "/" + path) else path
 
 }
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -24,3 +24,5 @@ HEAD — ongoing
 - [Ledger API] Added additional Ledger API integration tests to Ledger API Test Tool.
 - [DAML Studio] Goto definition now works on the export list of modules.
 - [Java Bindings] The artefact ``com.daml.ledger:bindings-java`` now has ``grpc-netty`` as dependency so that users don't need to explicitly add it.
+- [DAML Integration Kit] Fixed a bug in the test tool that prevented users from running the tests.
+  See `#1841 <https://github.com/digital-asset/daml/issues/1841>`__


### PR DESCRIPTION
Running the tests via the ledger-api-test-tool results in a nasty
runtime exception. This check only fixes paths if it detects a bazel
environment.

Fixes #1841

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
