### PR TITLE
Ledger API: scale all timeLimits in tests with ScaledTimeSpans

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -160,3 +160,20 @@ will still print information about failed tests.
 
 We used this flag during tool development to ensure that the tool does not
 always return success.
+
+Tuning the testing behaviour of the tool
+========================================
+
+Use the command line options ``--timeout-scale-factor`` and
+``--command-submission-ttl-scale-factor`` to tune timeouts applied by the tool.
+
+- Set ``--timeout-scale-factor`` to a floating point value higher than 1.0 to make
+  the tool wait longer for expected events coming from the DAML ledger
+  implementation under test. Conversely use values smaller than 1.0 to make it
+  wait shorter.
+- Set ``--command-submission-ttl-scale-factor`` to a value higher than 1.0 to
+  make the test tool generate Ledger API Commands with higher than default
+  maximum record time, which might be necessary for DAML ledger implementations
+  which take a long time to commit a proposed transaction. Conversely use values
+  smaller than 1.0 to make it give less time for a DAML ledger implementation to
+  commit a proposed transaction.

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.platform.akkastreams.FutureTimeouts
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.{OneAfterAnother, RangeSource}
-import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{Assertion, AsyncWordSpec, BeforeAndAfter, Matchers}
@@ -34,6 +34,7 @@ class DispatcherSpec
     with BeforeAndAfter
     with Matchers
     with FutureTimeouts
+    with ScaledTimeSpans
     with AsyncTimeLimitedTests {
 
   // Newtype wrappers to avoid type mistakes
@@ -376,5 +377,5 @@ class DispatcherSpec
     }
   }
 
-  override def timeLimit: Span = 30.seconds
+  override def timeLimit: Span = scaled(30.seconds)
 }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
@@ -10,7 +10,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import org.awaitility.Awaitility.await
 import org.awaitility.Duration
-import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{FutureOutcome, Matchers, fixture}
@@ -20,6 +20,7 @@ class SignalDispatcherTest
     extends fixture.AsyncWordSpec
     with Matchers
     with AkkaBeforeAndAfterAll
+    with ScaledTimeSpans
     with AsyncTimeLimitedTests {
 
   "SignalDispatcher" should {
@@ -74,5 +75,5 @@ class SignalDispatcherTest
   }
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = test.apply(SignalDispatcher())
   override type FixtureParam = SignalDispatcher
-  override def timeLimit: Span = 10.seconds
+  override def timeLimit: Span = scaled(10.seconds)
 }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ActiveContractsServiceIT.scala
@@ -47,7 +47,7 @@ class ActiveContractsServiceIT
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 60.seconds
+  override def timeLimit: Span = scaled(60.seconds)
 
   protected val testCommands = new TestCommands(config)
   protected val templateIds = testCommands.templateIds

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerConfigurationServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerConfigurationServiceIT.scala
@@ -32,7 +32,7 @@ class LedgerConfigurationServiceIT
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 5.seconds
+  override def timeLimit: Span = scaled(5.seconds)
 
   private def client(ctx: LedgerContext): LedgerConfigurationClient =
     new LedgerConfigurationClient(ctx.ledgerId, ctx.ledgerConfigurationService)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageServiceIT.scala
@@ -32,7 +32,7 @@ class PackageServiceIT
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 5.seconds
+  override def timeLimit: Span = scaled(5.seconds)
 
   private def client(ctx: LedgerContext): PackageClient = {
     new PackageClient(ctx.ledgerId, ctx.packageService)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PartyManagementServiceIT.scala
@@ -41,7 +41,7 @@ class PartyManagementServiceIT
     with Inside
     with OptionValues {
 
-  override def timeLimit: Span = 15.seconds
+  override def timeLimit: Span = scaled(15.seconds)
 
   override protected def config: Config = Config.default
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
@@ -33,12 +33,12 @@ class ResetServiceIT
     with InfiniteRetries
     with Matchers
     with AkkaBeforeAndAfterAll
-    with MultiLedgerFixture // TODO: this suite shoul not be using LedgerContext, as it is smart and hides too much of the reset mechanism
+    with MultiLedgerFixture // TODO: this suite should not be using LedgerContext, as it is smart and hides too much of the reset mechanism
     with ScalaFutures
     with TestCommands
     with SuiteResourceManagementAroundEach {
 
-  override def timeLimit: Span = 30.seconds
+  override def timeLimit: Span = scaled(30.seconds)
 
   override protected val config: Config =
     Config.default.withLedgerIdMode(LedgerIdMode.Dynamic())

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/SemanticLedgerConfigurationIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/SemanticLedgerConfigurationIT.scala
@@ -41,7 +41,7 @@ class SemanticLedgerConfigurationIT
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 5.seconds
+  override def timeLimit: Span = scaled(5.seconds)
 
   private def configClient(ctx: LedgerContext): LedgerConfigurationClient =
     new LedgerConfigurationClient(ctx.ledgerId, ctx.ledgerConfigurationService)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceDisabledIT.scala
@@ -41,7 +41,7 @@ class TimeServiceDisabledIT
     with Inside
     with OptionValues {
 
-  override def timeLimit: Span = 15.seconds
+  override def timeLimit: Span = scaled(15.seconds)
 
   override protected def config: Config = Config.default.withTimeProvider(WallClock)
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TimeServiceIT.scala
@@ -42,7 +42,7 @@ class TimeServiceIT
     with Inside
     with OptionValues {
 
-  override def timeLimit: Span = 15.seconds
+  override def timeLimit: Span = scaled(15.seconds)
 
   override protected def config: Config = Config.default
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -80,7 +80,7 @@ class TransactionServiceIT
       s"ledger-api-test-tool-$testName-$stepId-$nodeId-$runSuffix"
     }
 
-  override val timeLimit: Span = 300.seconds
+  override val timeLimit: Span = scaled(300.seconds)
 
   private def newClient(stub: TransactionService, ledgerId: LedgerId): TransactionClient =
     new TransactionClient(ledgerId, stub)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
@@ -44,7 +44,7 @@ class TransactionServiceLargeCommandIT
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
 
-  override val timeLimit: Span = 300.seconds
+  override val timeLimit: Span = scaled(300.seconds)
 
   private val getAllContracts = transactionFilter
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandStaticTimeIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandStaticTimeIT.scala
@@ -51,7 +51,7 @@ class CommandStaticTimeIT
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
 
-  override def timeLimit: Span = 15.seconds
+  override def timeLimit: Span = scaled(15.seconds)
 
   private val tenDays: time.Duration = java.time.Duration.ofDays(10L)
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandSubmissionServiceIT.scala
@@ -30,7 +30,7 @@ class CommandSubmissionServiceIT
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 5.seconds
+  override def timeLimit: Span = scaled(5.seconds)
 
   override protected def config: Config = Config.default
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/transaction/TransactionBackpressureIT.scala
@@ -37,7 +37,7 @@ class TransactionBackpressureIT
 
   protected val testCommands = new TestCommands(config)
 
-  override def timeLimit: Span = 300.seconds
+  override def timeLimit: Span = scaled(300.seconds)
 
   override protected def config: Config = Config.default
 

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/identity/LedgerIdentityServiceITBase.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/identity/LedgerIdentityServiceITBase.scala
@@ -29,7 +29,7 @@ trait LedgerIdentityServiceITBase
     with Matchers
     with OptionValues {
 
-  override def timeLimit: Span = 5.seconds
+  override def timeLimit: Span = scaled(5.seconds)
 
   protected lazy val givenId =
     Ref.LedgerString.assertFromString(s"ledger-${UUID.randomUUID().toString}")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -69,7 +69,7 @@ object Cli {
     opt[Double](name = "timeout-scale-factor")
       .optional()
       .action((v, c) => c.copy(timeoutScaleFactor = v))
-      .text("""Scale factor for timeouts used in "SemanticTests" suite. Useful to tune timeouts
+      .text("""Scale factor for timeouts used in all test suites. Useful to tune timeouts
           |depending on the environment and the Ledger implementation under test.
           |Defaults to 1.0. Use numbers higher than 1.0 to make test timeouts more lax,
           |use numbers lower than 1.0 to make test timeouts more strict.""".stripMargin)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -154,6 +154,7 @@ object LedgerApiTestTool {
           override def suiteName: String = name
           override def actorSystemName = s"${name}ToolActorSystem"
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
+          override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(integrationTestResource))
       }
@@ -166,6 +167,7 @@ object LedgerApiTestTool {
           override def suiteName: String = name
           override def actorSystemName = s"${name}ToolActorSystem"
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
+          override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(integrationTestResource))
       }
@@ -178,6 +180,7 @@ object LedgerApiTestTool {
           override def suiteName: String = name
           override def actorSystemName = s"${name}ToolActorSystem"
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
+          override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(integrationTestResource))
       }
@@ -190,6 +193,7 @@ object LedgerApiTestTool {
           override def suiteName: String = name
           override def actorSystemName = s"${name}ToolActorSystem"
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
+          override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(integrationTestResource))
       }
@@ -202,6 +206,7 @@ object LedgerApiTestTool {
           override def suiteName: String = name
           override def actorSystemName = s"${name}ToolActorSystem"
           override def fixtureIdsEnabled: Set[LedgerBackend] = Set(LedgerBackend.RemoteApiProxy)
+          override def spanScaleFactor: Double = toolConfig.timeoutScaleFactor
           override protected def config: Config =
             commonConfig.withDarFile(resourceAsFile(integrationTestResource))
       }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -56,7 +56,7 @@ class ImplicitPartyAdditionIT
     with Matchers
     with MetricsAround {
 
-  override def timeLimit: Span = 60.seconds
+  override def timeLimit: Span = scaled(60.seconds)
 
   private val ledgerId: LedgerId = LedgerId("ledgerId")
   private val timeProvider = TimeProvider.Constant(Instant.EPOCH.plusSeconds(10))

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -47,7 +47,7 @@ class TransactionMRTComplianceIT
     with Matchers
     with MetricsAround {
 
-  override def timeLimit: Span = 60.seconds
+  override def timeLimit: Span = scaled(60.seconds)
 
   val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("ledgerId"))
   val timeProvider = TimeProvider.Constant(Instant.EPOCH.plusSeconds(10))

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -9,12 +9,11 @@ import com.digitalasset.platform.sandbox.MetricsAround
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundEach
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.platform.sandbox.stores.InMemoryActiveContracts
-import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
 import scala.concurrent.duration._
-
 import com.digitalasset.ledger.api.domain.LedgerId
 
 class SqlLedgerSpec
@@ -23,9 +22,10 @@ class SqlLedgerSpec
     with Matchers
     with PostgresAroundEach
     with AkkaBeforeAndAfterAll
+    with ScaledTimeSpans
     with MetricsAround {
 
-  override val timeLimit: Span = 60.seconds
+  override val timeLimit: Span = scaled(60.seconds)
 
   private val queueDepth = 128
 

--- a/ledger/test-common/src/main/scala/com.digitalasset.platform.testing/MultiFixtureBase.scala
+++ b/ledger/test-common/src/main/scala/com.digitalasset.platform.testing/MultiFixtureBase.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
 import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
 import org.scalatest._
-import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.time.Span
 
 import scala.collection.immutable.Iterable
@@ -19,6 +19,7 @@ import scala.util.control.{NoStackTrace, NonFatal}
 trait MultiFixtureBase[FixtureId, TestContext]
     extends Assertions
     with BeforeAndAfterAll
+    with ScaledTimeSpans
     with AsyncTimeLimitedTests {
   self: AsyncTestSuite =>
 
@@ -38,7 +39,7 @@ trait MultiFixtureBase[FixtureId, TestContext]
     def context(): TestContext = createContext()
   }
 
-  def timeLimit: Span = 30.seconds
+  def timeLimit: Span = scaled(30.seconds)
 
   object TestFixture {
     def apply(id: FixtureId, createContext: () => TestContext): TestFixture =


### PR DESCRIPTION
This ensures that more tests will be automatically scaled with `--timeout-scale-factor` command line option.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
