### PR TITLE
increasing default JMH timeout for manySmallContracts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,38 +69,38 @@ jobs:
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
-#  - job: perf
-#    timeoutInMinutes: 60
-#    pool:
-#      name: 'linux-pool'
-#    steps:
-#      - checkout: self
-#      - bash: ci/dev-env-install.sh
-#        displayName: 'Build/Install the Developer Environment'
-#      - bash: ci/configure-bazel.sh
-#        displayName: 'Configure Bazel'
-#        env:
-#          IS_FORK: $(System.PullRequest.IsFork)
-#          # to upload to the bazel cache
-#          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
-#      - bash: |
-#          set -euo pipefail
-#          eval "$(./dev-env/bin/dade-assist)"
-#          bazel run -- //ledger/sandbox-perf -foe true -i1 -f1 -wi 1 -bm avgt -rf csv -rff "$(Build.StagingDirectory)/sandbox-perf.csv"
-#      - task: PublishBuildArtifacts@1
-#        condition: succeededOrFailed()
-#        inputs:
-#          pathtoPublish: '$(Build.StagingDirectory)'
-#          artifactName: 'Perf test logs'
-#      - bash: |
-#          set -euo pipefail
-#          MESSAGE=$(git log --pretty=format:%s -n1)
-#          curl -XPOST \
-#               -i \
-#               -H 'Content-type: application/json' \
-#               --data "{\"text\":\"<!here> *FAILED* perf: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
-#               $(Slack.URL)
-#        condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
+  - job: perf
+    timeoutInMinutes: 60
+    pool:
+      name: 'linux-pool'
+    steps:
+      - checkout: self
+      - bash: ci/dev-env-install.sh
+        displayName: 'Build/Install the Developer Environment'
+      - bash: ci/configure-bazel.sh
+        displayName: 'Configure Bazel'
+        env:
+          IS_FORK: $(System.PullRequest.IsFork)
+          # to upload to the bazel cache
+          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bazel run -- //ledger/sandbox-perf -foe true -i1 -f1 -wi 1 -bm avgt -rf csv -rff "$(Build.StagingDirectory)/sandbox-perf.csv"
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        inputs:
+          pathtoPublish: '$(Build.StagingDirectory)'
+          artifactName: 'Perf test logs'
+      - bash: |
+          set -euo pipefail
+          MESSAGE=$(git log --pretty=format:%s -n1)
+          curl -XPOST \
+               -i \
+               -H 'Content-type: application/json' \
+               --data "{\"text\":\"<!here> *FAILED* perf: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+               $(Slack.URL)
+        condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
 
   - job: Windows_signing
     # Signing is a separate job so that we can make sure that we only sign on releases.
@@ -137,7 +137,7 @@ jobs:
           targetPath: $(Build.StagingDirectory)/$(signing.artifact-windows-installer)
           artifactName: $(signing.artifact-windows-installer)
   - job: release
-    dependsOn: [ "Linux", "macOS", "Windows", "Windows_signing"] #, "perf"]
+    dependsOn: [ "Linux", "macOS", "Windows", "Windows_signing", "perf"]
     pool:
       vmImage: "Ubuntu-16.04"
     condition: and(succeeded(),

--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/LargeTransactionBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/LargeTransactionBench.scala
@@ -3,6 +3,8 @@
 
 package com.digitalasset.platform.sandbox.perf
 
+import java.util.concurrent.TimeUnit
+
 import com.digitalasset.platform.PlatformApplications
 import com.digitalasset.platform.sandbox.perf.TestHelper._
 import org.openjdk.jmh.annotations._
@@ -49,18 +51,12 @@ class LargeTransactionBench {
 
   //note that when running this with Postgres the bottleneck seems to originate from the fact the we traverse the huge
   //Transaction and execute SQL queries one after another. We could potentially partition the transaction so we can have batch queries instead.
+  @Timeout(time = 20, timeUnit = TimeUnit.MINUTES) // we have a rare issue where this test runs extremely long with 100k contracts, making the test fail due to JMH timeout
   @Benchmark
   def manySmallContracts(state: RangeOfIntsCreatedState): Unit = {
-    try {
-      Await.result(
-        rangeOfIntsExerciseCommand(state, state.workflowId, "ToListOfIntContainers", None),
-        perfTestTimeout)
-    } catch {
-      case t: Throwable => //TODO: this is just temporary to debug flakiness
-        println(s"manySmallContracts bench blew up! ${t.getMessage} ")
-        t.printStackTrace()
-        throw t
-    }
+    Await.result(
+      rangeOfIntsExerciseCommand(state, state.workflowId, "ToListOfIntContainers", None),
+      perfTestTimeout)
   }
 
   @Benchmark

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
@@ -50,7 +50,7 @@ trait TestHelper {
     entityName = "ListUtil")
 
   val setupTimeout = 30.seconds
-  val perfTestTimeout = 15.minutes
+  val perfTestTimeout = 20.minutes
 
   val transactionFilter = TransactionFilter(Map(party -> Filters()))
 


### PR DESCRIPTION
The test `manySmallContracts ` runs for about 12 minutes instead of 50 seconds in some rare cases (1 in 20) making the JMH timeout expire and fail the build. This change increases the timeout so we can reenable the perf-tests, while we are investigating the issue.

See this reproduced failure with timestamps: https://dev.azure.com/digitalasset/daml/_build/results?buildId=9556

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
