### PR TITLE
Don't import LSP.Protocol

### DIFF
--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -8,7 +8,7 @@ module Development.IDE.LSP.Definition
     ( handle
     ) where
 
-import           Development.IDE.LSP.Protocol
+import           Language.Haskell.LSP.Types
 import Development.IDE.Types.Location
 
 import Development.IDE.Types.Logger

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -8,8 +8,7 @@ module Development.IDE.LSP.Hover
     ( handle
     ) where
 
-import Development.IDE.LSP.Protocol hiding (Hover)
-import Language.Haskell.LSP.Types (Hover(..))
+import Language.Haskell.LSP.Types
 import Development.IDE.Types.Location
 
 import Development.IDE.Types.Logger


### PR DESCRIPTION
Import the more specific module where you can get away with it.