### PR TITLE
Exit from daml start if on-start command returns non-zero code.

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -560,8 +560,11 @@ runStart (StartNavigator shouldStartNavigator) (OpenBrowser shouldOpenBrowser) o
             let navigatorConfPath = confDir </> "navigator-config.json"
             writeFileUTF8 navigatorConfPath (T.unpack $ navigatorConfig parties)
             withNavigator' sandboxPh sandboxPort navigatorPort navigatorConfPath [] $ \navigatorPh -> do
-                whenJust onStartM $ \onStart ->
-                    void $ withCreateProcess (shell onStart) $ \ _ _ _ -> waitForProcess
+
+                whenJust onStartM $ \onStart -> do
+                    exitCode <- withCreateProcess (shell onStart) $ \ _ _ _ -> waitForProcess
+                    when (exitCode /= ExitSuccess) $
+                        exitWith exitCode
 
                 when (shouldStartNavigator && shouldOpenBrowser) $
                     void $ openBrowser (navigatorURL navigatorPort)


### PR DESCRIPTION
Implementing a suggestion from @cocreature -- if the `--on-start` command returns non-zero exit code, `daml start` will exit with that code as well. This should make `daml start --on-start=... --wait-for-signal=no --open-browser=no` useful for running tests with a sandbox (and navigator, optionally).