### PR TITLE
Remove navigator configs.

### DIFF
--- a/docs/source/getting-started/quickstart/template-root/ui-backend.conf
+++ b/docs/source/getting-started/quickstart/template-root/ui-backend.conf
@@ -1,7 +1,0 @@
-users
-  {
-    Alice { party = "Alice" },
-    Bob { party = "Bob" },
-    USD Bank { party = "USD_Bank" },
-    EUR Bank { party = "EUR_Bank" }
-  }

--- a/templates/skeleton/ui-backend.conf
+++ b/templates/skeleton/ui-backend.conf
@@ -1,5 +1,0 @@
-users
-  {
-    Alice { party = "Alice" },
-    Bob { party = "Bob" }
-  }


### PR DESCRIPTION
Since #1458, Navigator reads `daml.yaml` to get the list of parties, so we no longer need to generate navigator config files in `daml start`, or include these configs in templates.