### PR TITLE
Significantly alter the hie-core LanguageServer

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -89,6 +89,7 @@ library
         Development.IDE.LSP.Definition
         Development.IDE.LSP.Hover
         Development.IDE.LSP.LanguageServer
+        Development.IDE.LSP.Notifications
         Development.IDE.LSP.Protocol
         Development.IDE.LSP.Server
         Development.IDE.Spans.AtPoint

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -17,6 +17,7 @@ import Development.IDE.Core.Rules
 import Development.IDE.Core.Service
 import Development.IDE.LSP.Server
 import qualified Language.Haskell.LSP.Core as LSP
+import Language.Haskell.LSP.Messages
 
 import qualified Data.Text as T
 
@@ -40,5 +41,5 @@ gotoDefinition ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos)
 
 addGotoDefinition :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
 addGotoDefinition RunHandler{..} x = return x{
-    LSP.definitionHandler = newNotification gotoDefinition
+    LSP.definitionHandler = addResponse RspDefinition gotoDefinition
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -6,7 +6,7 @@
 -- | Go to the definition of a variable.
 module Development.IDE.LSP.Definition
     ( gotoDefinition
-    , addGotoDefinition
+    , setHandlersDefinition
     ) where
 
 import           Language.Haskell.LSP.Types
@@ -39,7 +39,7 @@ gotoDefinition ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos)
         Just loc -> SingleLoc loc
 
 
-addGotoDefinition :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
-addGotoDefinition RunHandler{..} x = return x{
+setHandlersDefinition :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
+setHandlersDefinition RunHandler{..} x = return x{
     LSP.definitionHandler = addResponse RspDefinition gotoDefinition
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -39,7 +39,7 @@ gotoDefinition ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos)
         Just loc -> SingleLoc loc
 
 
-setHandlersDefinition :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
-setHandlersDefinition RunHandler{..} x = return x{
-    LSP.definitionHandler = addResponse RspDefinition gotoDefinition
+setHandlersDefinition :: WithMessage -> LSP.Handlers -> IO LSP.Handlers
+setHandlersDefinition WithMessage{..} x = return x{
+    LSP.definitionHandler = withResponse RspDefinition gotoDefinition
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -43,7 +43,7 @@ onHover ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
 
         Nothing -> pure Nothing
 
-setHandlersHover :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
-setHandlersHover RunHandler{..} x = return x{
-    LSP.hoverHandler = addResponse RspHover onHover
+setHandlersHover :: WithMessage -> LSP.Handlers -> IO LSP.Handlers
+setHandlersHover WithMessage{..} x = return x{
+    LSP.hoverHandler = withResponse RspHover onHover
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -6,7 +6,7 @@
 -- | Display information on hover.
 module Development.IDE.LSP.Hover
     ( onHover
-    , addOnHover
+    , setHandlersHover
     ) where
 
 import Language.Haskell.LSP.Types
@@ -43,7 +43,7 @@ onHover ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
 
         Nothing -> pure Nothing
 
-addOnHover :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
-addOnHover RunHandler{..} x = return x{
+setHandlersHover :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
+setHandlersHover RunHandler{..} x = return x{
     LSP.hoverHandler = addResponse RspHover onHover
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -15,6 +15,7 @@ import Development.IDE.Core.Service
 import Development.IDE.LSP.Server
 import Development.IDE.Types.Logger
 import qualified Language.Haskell.LSP.Core as LSP
+import Language.Haskell.LSP.Messages
 
 import qualified Data.Text as T
 
@@ -44,5 +45,5 @@ onHover ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
 
 addOnHover :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
 addOnHover RunHandler{..} x = return x{
-    LSP.hoverHandler = newNotification onHover
+    LSP.hoverHandler = addResponse RspHover onHover
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -5,32 +5,33 @@
 
 -- | Display information on hover.
 module Development.IDE.LSP.Hover
-    ( handle
+    ( onHover
+    , addOnHover
     ) where
 
 import Language.Haskell.LSP.Types
 import Development.IDE.Types.Location
-
+import Development.IDE.Core.Service
+import Development.IDE.LSP.Server
 import Development.IDE.Types.Logger
+import qualified Language.Haskell.LSP.Core as LSP
 
 import qualified Data.Text as T
 
 import Development.IDE.Core.Rules
 
 -- | Display information on hover.
-handle
-    :: Logger
-    -> IdeState
+onHover
+    :: IdeState
     -> TextDocumentPositionParams
     -> IO (Maybe Hover)
-handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
+onHover ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
-          logInfo loggerH $
-              "Hover request at position " <>
-              T.pack (showPosition pos) <>
+          logInfo (ideLogger ide) $
+              "Hover request at position " <> T.pack (showPosition pos) <>
               " in file: " <> T.pack (fromNormalizedFilePath filePath)
-          runAction compilerH $ getAtPoint filePath pos
+          runAction ide $ getAtPoint filePath pos
         Nothing       -> pure Nothing
 
     case mbResult of
@@ -40,3 +41,8 @@ handle loggerH compilerH (TextDocumentPositionParams (TextDocumentIdentifier uri
                         mbRange
 
         Nothing -> pure Nothing
+
+addOnHover :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
+addOnHover RunHandler{..} x = return x{
+    LSP.hoverHandler = newNotification onHover
+    }

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -70,7 +70,7 @@ handleRequest logger compilerH makeResponse makeErrorResponse = \case
 
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
-    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle logger compilerH params
+    Definition params -> RspDefinition . makeResponse <$> LS.Definition.gotoDefinition compilerH params
     Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
     CodeLens _params -> pure $ RspCodeLens $ makeResponse mempty
 

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -10,7 +10,7 @@ module Development.IDE.LSP.LanguageServer
     ( runLanguageServer
     ) where
 
-import           Development.IDE.LSP.Protocol
+import           Language.Haskell.LSP.Types
 import           Development.IDE.LSP.Server hiding (runServer)
 import qualified Language.Haskell.LSP.Control as LSP
 import qualified Language.Haskell.LSP.Core as LSP

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -103,6 +103,8 @@ mergeHandlers = foldl f (\_ a -> return a)
     where f x1 x2 r a = x1 r a >>= x2 r
 
 
+-- | A message that we need to deal with - the pieces are split up with existentials to gain additional type safety
+--   and defer precise processing until later (allows us to keep at a higher level of abstraction slightly longer)
 data Message
     = forall m req resp . Response (RequestMessage m req resp) (ResponseMessage resp -> FromServerMessage) (IdeState -> req -> IO resp)
     | forall m req . Notification (NotificationMessage m req) (IdeState -> req -> IO ())

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -161,7 +161,7 @@ runLanguageServer
     -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
     -> IO ()
 runLanguageServer loggerH getIdeState = do
-    -- DEL-6257: Move stdout to another file descriptor and duplicate stderr
+    -- Move stdout to another file descriptor and duplicate stderr
     -- to stdout. This guards against stray prints from corrupting the JSON-RPC
     -- message stream.
     newStdout <- hDuplicate stdout

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -47,7 +47,10 @@ runLanguageServer getIdeState = do
     -- the language server tests without the redirection.
     putStr " " >> hFlush stdout
 
+    -- Send everything over a channel, since you need to wait until after initialise before
+    -- LspFuncs is available
     clientMsgChan :: Chan Message <- newChan
+
     -- These barriers are signaled when the threads reading from these chans exit.
     -- This should not happen but if it does, we will make sure that the whole server
     -- dies and can be restarted instead of losing threads silently.

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -22,8 +22,8 @@ import           GHC.IO.Handle                    (hDuplicate, hDuplicateTo)
 import System.IO
 import Control.Monad
 
-import qualified Development.IDE.LSP.Definition as LS.Definition
-import qualified Development.IDE.LSP.Hover      as LS.Hover
+import Development.IDE.LSP.Definition
+import Development.IDE.LSP.Hover
 import Development.IDE.LSP.Notifications
 import Development.IDE.Core.Service
 import Development.IDE.Core.FileStore
@@ -56,7 +56,7 @@ runLanguageServer getIdeState = do
     let runHandler = RunHandler
             (\wrap f -> Just $ \r -> atomically $ writeTChan clientMsgChan $ AddResponse r wrap f)
             (\f -> Just $ \r -> atomically $ writeTChan clientMsgChan $ AddNotification r f)
-    handlers <- mergeHandlers [LS.Definition.addGotoDefinition, LS.Hover.addOnHover, addNotifications, addIgnored] runHandler def
+    handlers <- mergeHandlers [setHandlersDefinition, setHandlersHover, addNotifications, addIgnored] runHandler def
 
     void $ waitAnyCancel =<< traverse async
         [ void $ LSP.runWithHandles

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -12,7 +12,20 @@ module Development.IDE.LSP.LanguageServer
     ) where
 
 import           Development.IDE.LSP.Protocol
-import           Development.IDE.LSP.Server
+import           Development.IDE.LSP.Server hiding (runServer)
+import qualified Language.Haskell.LSP.Control as LSP
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Types as LSP
+import Control.Concurrent.STM
+import Control.Concurrent.Extra
+import Control.Concurrent.Async
+import Data.Default
+import qualified Data.Aeson.Text as Aeson
+import qualified Data.Text.Lazy as TL
+import           GHC.IO.Handle                    (hDuplicate, hDuplicateTo)
+import System.IO
+import Control.Monad
 
 import Control.Monad.IO.Class
 import qualified Development.IDE.LSP.Definition as LS.Definition
@@ -153,3 +166,162 @@ runLanguageServer loggerH getIdeState = do
             compilerH <- getIdeState (sendFunc lspFuncs) (makeLSPVFSHandle lspFuncs)
             pure $ Handlers (handleRequest loggerH compilerH) (handleNotification lspFuncs loggerH compilerH)
     liftIO $ runServer loggerH getHandlers
+
+runServer
+    :: Logger
+    -> (LSP.LspFuncs () -> IO Handlers)
+    -- ^ Notification handler for language server notifications
+    -> IO ()
+runServer loggerH getHandlers = do
+    -- DEL-6257: Move stdout to another file descriptor and duplicate stderr
+    -- to stdout. This guards against stray prints from corrupting the JSON-RPC
+    -- message stream.
+    newStdout <- hDuplicate stdout
+    stderr `hDuplicateTo` stdout
+
+    -- Print out a single space to assert that the above redirection works.
+    -- This is interleaved with the logger, hence we just print a space here in
+    -- order not to mess up the output too much. Verified that this breaks
+    -- the language server tests without the redirection.
+    putStr " " >> hFlush stdout
+    clientMsgChan <- newTChanIO
+    -- These barriers are signaled when the threads reading from these chans exit.
+    -- This should not happen but if it does, we will make sure that the whole server
+    -- dies and can be restarted instead of losing threads silently.
+    clientMsgBarrier <- newBarrier
+    void $ waitAnyCancel =<< traverse async
+        [ void $ LSP.runWithHandles
+            stdin
+            newStdout
+            ( const $ Right ()
+            , handleInit (signalBarrier clientMsgBarrier ()) clientMsgChan
+            )
+            (handlers clientMsgChan)
+            options
+            Nothing
+        , void $ waitBarrier clientMsgBarrier
+        ]
+    where
+        handleInit :: IO () -> TChan LSP.FromClientMessage -> LSP.LspFuncs () -> IO (Maybe LSP.ResponseError)
+        handleInit exitClientMsg clientMsgChan lspFuncs@LSP.LspFuncs{..} = do
+            Handlers{..} <- getHandlers lspFuncs
+            let requestHandler' (req, reqId) = requestHandler
+                    (\res -> ResponseMessage "2.0" (responseId reqId) (Just res) Nothing)
+                    (\err -> ResponseMessage "2.0" (responseId reqId) Nothing (Just $ ResponseError err "" Nothing))
+                    req
+            _ <- flip forkFinally (const exitClientMsg) $ forever $ do
+                msg <- atomically $ readTChan clientMsgChan
+                case convClientMsg msg of
+                    Nothing -> logSeriousError loggerH $ "Unknown client msg: " <> T.pack (show msg)
+                    Just (Left notif) -> notificationHandler notif
+                    Just (Right req) -> sendFunc =<< requestHandler' req
+            pure Nothing
+
+convClientMsg :: LSP.FromClientMessage -> Maybe (Either ServerNotification (ServerRequest, LspId))
+convClientMsg msg = case msg of
+    LSP.ReqInitialize m -> unknownReq m
+    LSP.ReqShutdown m -> Just $ Right (Shutdown, reqId m)
+
+    LSP.ReqHover m -> toReq Hover m
+
+    LSP.ReqCompletion m -> toReq Completion m
+    LSP.ReqCompletionItemResolve m -> unknownReq m
+
+    LSP.ReqSignatureHelp m -> toReq SignatureHelp m
+
+    LSP.ReqDefinition m -> toReq Definition m
+    LSP.ReqTypeDefinition m -> toReq Definition m
+    LSP.ReqImplementation m -> toReq Definition m
+
+    LSP.ReqFindReferences m -> toReq References m
+    LSP.ReqDocumentHighlights m -> unknownReq m
+    LSP.ReqDocumentSymbols m -> toReq DocumentSymbol m
+    LSP.ReqWorkspaceSymbols m -> toReq WorkspaceSymbol m
+    LSP.ReqCodeAction m -> unknownReq m
+
+    LSP.ReqCodeLens m -> toReq CodeLens m
+    LSP.ReqCodeLensResolve m -> unknownReq m
+
+    LSP.ReqDocumentLink m -> unknownReq m
+    LSP.ReqDocumentLinkResolve m -> unknownReq m
+    LSP.ReqDocumentColor m -> unknownReq m
+    LSP.ReqColorPresentation m -> unknownReq m
+
+    LSP.ReqDocumentFormatting m -> toReq Formatting m
+    LSP.ReqDocumentRangeFormatting m -> unknownReq m
+    LSP.ReqDocumentOnTypeFormatting m -> unknownReq m
+
+    LSP.ReqRename m -> toReq Rename m
+
+    LSP.ReqFoldingRange m -> unknownReq m
+    LSP.ReqExecuteCommand m -> unknownReq m
+    LSP.ReqWillSaveWaitUntil m -> unknownReq m
+    LSP.ReqCustomClient m -> case reqMethod m of
+        CustomClientMethod "daml/keepAlive" -> Just $ Right (KeepAlive, reqId m)
+        _ -> unknownReq m
+
+    LSP.NotInitialized m -> unknownNot m
+    LSP.NotExit m -> unknownNot m
+    LSP.NotCancelRequestFromClient m -> unknownNot m
+    LSP.NotDidChangeConfiguration m -> unknownNot m
+    LSP.NotDidOpenTextDocument m -> toNot DidOpenTextDocument m
+    LSP.NotDidChangeTextDocument m -> toNot DidChangeTextDocument m
+    LSP.NotDidCloseTextDocument m -> toNot DidCloseTextDocument m
+    LSP.NotWillSaveTextDocument m -> unknownNot m
+    LSP.NotDidSaveTextDocument m -> toNot DidSaveTextDocument m
+    LSP.NotDidChangeWatchedFiles m -> unknownNot m
+    LSP.NotDidChangeWorkspaceFolders m -> unknownNot m
+    LSP.NotProgressCancel m -> unknownNot m
+    LSP.NotCustomClient m -> unknownNot m
+
+    LSP.RspApplyWorkspaceEdit _ -> Nothing
+    LSP.RspFromClient _ -> Nothing
+  where toReq constr msg = Just $ Right (constr $ reqParams msg, reqId msg)
+        toNot constr msg = Just $ Left $ constr $ notParams msg
+        unknownReq (LSP.RequestMessage _ id method params) =
+            Just $ Right (UnknownRequest (TL.toStrict $ Aeson.encodeToLazyText method) (Aeson.toJSON params), id)
+        unknownNot (LSP.NotificationMessage _ method params) =
+            Just $ Left $ UnknownNotification (TL.toStrict $ Aeson.encodeToLazyText method) (Aeson.toJSON params)
+        -- Type-restricted wrappers to make DuplicateRecordFields less annoying.
+        reqParams :: RequestMessage m req resp -> req
+        reqParams = _params
+        reqId :: RequestMessage m req resp -> LspId
+        reqId = _id
+        reqMethod :: RequestMessage m req resp -> m
+        reqMethod = _method
+        notParams :: NotificationMessage m a -> a
+        notParams = _params
+
+handlers :: TChan LSP.FromClientMessage -> LSP.Handlers
+handlers chan = def
+    { LSP.hoverHandler = emit LSP.ReqHover
+    , LSP.definitionHandler = emit LSP.ReqDefinition
+    , LSP.codeLensHandler = emit LSP.ReqCodeLens
+    , LSP.didOpenTextDocumentNotificationHandler = emit LSP.NotDidOpenTextDocument
+    , LSP.didChangeTextDocumentNotificationHandler = emit LSP.NotDidChangeTextDocument
+    , LSP.didCloseTextDocumentNotificationHandler = emit LSP.NotDidCloseTextDocument
+    , LSP.didSaveTextDocumentNotificationHandler = emit LSP.NotDidSaveTextDocument
+    , LSP.initializedHandler = emit LSP.NotInitialized
+    , LSP.exitNotificationHandler = Nothing
+    -- If the exit notification handler is set to `Nothing`
+    -- haskell-lsp will take care of shutting down the server for us.
+    , LSP.customRequestHandler = emit LSP.ReqCustomClient
+    , LSP.cancelNotificationHandler = Just $ const $ pure ()
+    -- ^ We just ignore cancel requests which is allowed according to
+    -- the spec. Installing a handler avoids errors about the missing handler.
+    }
+    where
+        emit :: (a -> LSP.FromClientMessage) -> Maybe (LSP.Handler a)
+        emit f = Just $ atomically . writeTChan chan . f
+
+options :: LSP.Options
+options = def
+    { LSP.textDocumentSync = Just TextDocumentSyncOptions
+          { _openClose = Just True
+          , _change = Just TdSyncIncremental
+          , _willSave = Nothing
+          , _willSaveWaitUntil = Nothing
+          , _save = Just $ SaveOptions $ Just False
+          }
+    , LSP.codeLensProvider = Just $ CodeLensOptions $ Just False
+    }

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -95,6 +95,11 @@ setHandlersIgnore _ x = return x
     where none = Just $ const $ return ()
 
 
+mergeHandlers :: [RunHandler -> LSP.Handlers -> IO LSP.Handlers] -> RunHandler -> LSP.Handlers -> IO LSP.Handlers
+mergeHandlers = foldl f (\_ a -> return a)
+    where f x1 x2 r a = x1 r a >>= x2 r
+
+
 data AddItem
     = forall m req resp . AddResponse (RequestMessage m req resp) (ResponseMessage resp -> FromServerMessage) (IdeState -> req -> IO resp)
     | forall m req . AddNotification (NotificationMessage m req) (IdeState -> req -> IO ())

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -1,9 +1,8 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification  #-}
 
 -- WARNING: A copy of DA.Service.Daml.LanguageServer, try to keep them in sync
 -- This version removes the daml: handling
@@ -15,152 +14,27 @@ import           Development.IDE.LSP.Protocol
 import           Development.IDE.LSP.Server hiding (runServer)
 import qualified Language.Haskell.LSP.Control as LSP
 import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Messages as LSP
-import qualified Language.Haskell.LSP.Types as LSP
 import Control.Concurrent.STM
 import Control.Concurrent.Extra
 import Control.Concurrent.Async
 import Data.Default
-import qualified Data.Aeson.Text as Aeson
-import qualified Data.Text.Lazy as TL
 import           GHC.IO.Handle                    (hDuplicate, hDuplicateTo)
 import System.IO
 import Control.Monad
 
 import qualified Development.IDE.LSP.Definition as LS.Definition
 import qualified Development.IDE.LSP.Hover      as LS.Hover
-import Development.IDE.Types.Logger
+import Development.IDE.LSP.Notifications
 import Development.IDE.Core.Service
-import Development.IDE.Types.Location
-
-import qualified Data.Aeson                                as Aeson
-import qualified Data.Rope.UTF16 as Rope
-import qualified Data.Set                                  as S
-import qualified Data.Text as T
-
 import Development.IDE.Core.FileStore
-import Development.IDE.Core.OfInterest
-
-import qualified Network.URI                               as URI
-
-import qualified System.Exit
-
 import Language.Haskell.LSP.Core (LspFuncs(..))
 import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.VFS
 
-textShow :: Show a => a -> T.Text
-textShow = T.pack . show
-
-------------------------------------------------------------------------
--- Request handlers
-------------------------------------------------------------------------
-
-handleRequest
-    :: Logger
-    -> IdeState
-    -> (forall resp. resp -> ResponseMessage resp)
-    -> (ErrorCode -> ResponseMessage ())
-    -> ServerRequest
-    -> IO FromServerMessage
-handleRequest logger compilerH makeResponse makeErrorResponse = \case
-    Shutdown -> do
-      logInfo logger "Shutdown request received, terminating."
-      System.Exit.exitSuccess
-
-    KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
-
-    Definition params -> RspDefinition . makeResponse <$> LS.Definition.gotoDefinition compilerH params
-    Hover params -> RspHover . makeResponse <$> LS.Hover.onHover compilerH params
-    CodeLens _params -> pure $ RspCodeLens $ makeResponse mempty
-
-    req -> do
-        logWarning logger ("Method not found" <> T.pack (show req))
-        pure $ RspError $ makeErrorResponse MethodNotFound
-
-
-handleNotification :: LspFuncs () -> Logger -> IdeState -> ServerNotification -> IO ()
-handleNotification lspFuncs logger compilerH = \case
-
-    DidOpenTextDocument (DidOpenTextDocumentParams item) -> do
-        case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
-          Just uri
-              | URI.uriScheme uri == "file:"
-              -> handleDidOpenFile item
-
-              | otherwise
-              -> logWarning logger $ "Unknown scheme in URI: "
-                    <> textShow uri
-
-          _ -> logSeriousError logger $ "Invalid URI in DidOpenTextDocument: "
-                    <> textShow (_uri (item :: TextDocumentItem))
-
-    DidChangeTextDocument (DidChangeTextDocumentParams docId _) -> do
-        let uri = _uri (docId :: VersionedTextDocumentIdentifier)
-
-        case uriToFilePath' uri of
-          Just (toNormalizedFilePath -> filePath) -> do
-            mbVirtual <- getVirtualFileFunc lspFuncs $ toNormalizedUri uri
-            let contents = maybe "" (Rope.toText . (_text :: VirtualFile -> Rope.Rope)) mbVirtual
-            onFileModified compilerH filePath (Just contents)
-            logInfo logger
-              $ "Updated text document: " <> textShow (fromNormalizedFilePath filePath)
-
-          Nothing ->
-            logSeriousError logger
-              $ "Invalid file path: " <> textShow (_uri (docId :: VersionedTextDocumentIdentifier))
-
-    DidCloseTextDocument (DidCloseTextDocumentParams (TextDocumentIdentifier uri)) ->
-        case URI.parseURI $ T.unpack $ getUri uri of
-          Just uri'
-              | URI.uriScheme uri' == "file:" -> do
-                    Just fp <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
-                    handleDidCloseFile fp
-              | otherwise -> logWarning logger $ "Unknown scheme in URI: " <> textShow uri
-
-          _ -> logSeriousError logger
-                 $    "Invalid URI in DidCloseTextDocument: "
-                   <> textShow uri
-
-    DidSaveTextDocument _params ->
-      pure ()
-
-    UnknownNotification _method _params -> return ()
-  where
-    -- Note that the state changes here are not atomic.
-    -- When we have parallel compilation we could manage the state
-    -- changes in STM so that we can atomically change the state.
-    -- Internally it should be done via the IO oracle. See PROD-2808.
-    handleDidOpenFile (TextDocumentItem uri _ _ contents) = do
-        Just filePath <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
-        onFileModified compilerH filePath (Just contents)
-        modifyFilesOfInterest compilerH (S.insert filePath)
-        logInfo logger $ "Opened text document: " <> textShow filePath
-
-    handleDidCloseFile filePath = do
-         logInfo logger $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
-         onFileModified compilerH filePath Nothing
-         modifyFilesOfInterest compilerH (S.delete filePath)
-
--- | Manages the file store (caching compilation results and unsaved content).
-onFileModified
-    :: IdeState
-    -> NormalizedFilePath
-    -> Maybe T.Text
-    -> IO ()
-onFileModified service fp mbContents = do
-    logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
-    setBufferModified service fp mbContents
-
-------------------------------------------------------------------------
--- Server execution
-------------------------------------------------------------------------
 
 runLanguageServer
-    :: Logger
-    -> ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
+    :: ((FromServerMessage -> IO ()) -> VFSHandle -> IO IdeState)
     -> IO ()
-runLanguageServer loggerH getIdeState = do
+runLanguageServer getIdeState = do
     -- Move stdout to another file descriptor and duplicate stderr
     -- to stdout. This guards against stray prints from corrupting the JSON-RPC
     -- message stream.
@@ -172,11 +46,18 @@ runLanguageServer loggerH getIdeState = do
     -- order not to mess up the output too much. Verified that this breaks
     -- the language server tests without the redirection.
     putStr " " >> hFlush stdout
-    clientMsgChan <- newTChanIO
+
+    clientMsgChan :: TChan AddItem <- newTChanIO
     -- These barriers are signaled when the threads reading from these chans exit.
     -- This should not happen but if it does, we will make sure that the whole server
     -- dies and can be restarted instead of losing threads silently.
     clientMsgBarrier <- newBarrier
+
+    let runHandler = RunHandler
+            (\wrap f -> Just $ \r -> atomically $ writeTChan clientMsgChan $ AddResponse r wrap f)
+            (\f -> Just $ \r -> atomically $ writeTChan clientMsgChan $ AddNotification r f)
+    handlers <- mergeHandlers [LS.Definition.addGotoDefinition, LS.Hover.addOnHover, addNotifications] runHandler def
+
     void $ waitAnyCancel =<< traverse async
         [ void $ LSP.runWithHandles
             stdin
@@ -184,127 +65,28 @@ runLanguageServer loggerH getIdeState = do
             ( const $ Right ()
             , handleInit (signalBarrier clientMsgBarrier ()) clientMsgChan
             )
-            (handlers clientMsgChan)
+            handlers
             options
             Nothing
         , void $ waitBarrier clientMsgBarrier
         ]
     where
-        getHandlers lspFuncs = do
-            compilerH <- getIdeState (sendFunc lspFuncs) (makeLSPVFSHandle lspFuncs)
-            pure $ Handlers (handleRequest loggerH compilerH) (handleNotification lspFuncs loggerH compilerH)
-
-        handleInit :: IO () -> TChan LSP.FromClientMessage -> LSP.LspFuncs () -> IO (Maybe LSP.ResponseError)
+        handleInit :: IO () -> TChan AddItem -> LSP.LspFuncs () -> IO (Maybe err)
         handleInit exitClientMsg clientMsgChan lspFuncs@LSP.LspFuncs{..} = do
-            Handlers{..} <- getHandlers lspFuncs
-            let requestHandler' (req, reqId) = requestHandler
-                    (\res -> ResponseMessage "2.0" (responseId reqId) (Just res) Nothing)
-                    (\err -> ResponseMessage "2.0" (responseId reqId) Nothing (Just $ ResponseError err "" Nothing))
-                    req
+            ide <- getIdeState sendFunc (makeLSPVFSHandle lspFuncs)
             _ <- flip forkFinally (const exitClientMsg) $ forever $ do
                 msg <- atomically $ readTChan clientMsgChan
-                case convClientMsg msg of
-                    Nothing -> logSeriousError loggerH $ "Unknown client msg: " <> T.pack (show msg)
-                    Just (Left notif) -> notificationHandler notif
-                    Just (Right req) -> sendFunc =<< requestHandler' req
+                case msg of
+                    AddNotification NotificationMessage{_params} act -> act ide _params
+                    AddResponse RequestMessage{_id, _params} wrap act -> do
+                        res <- act ide _params
+                        sendFunc $ wrap $ ResponseMessage "2.0" (responseId _id) (Just res) Nothing
             pure Nothing
 
-convClientMsg :: LSP.FromClientMessage -> Maybe (Either ServerNotification (ServerRequest, LspId))
-convClientMsg msg = case msg of
-    LSP.ReqInitialize m -> unknownReq m
-    LSP.ReqShutdown m -> Just $ Right (Shutdown, reqId m)
+data AddItem
+    = forall m req resp . AddResponse (RequestMessage m req resp) (ResponseMessage resp -> FromServerMessage) (IdeState -> req -> IO resp)
+    | forall m req . AddNotification (NotificationMessage m req) (IdeState -> req -> IO ())
 
-    LSP.ReqHover m -> toReq Hover m
-
-    LSP.ReqCompletion m -> toReq Completion m
-    LSP.ReqCompletionItemResolve m -> unknownReq m
-
-    LSP.ReqSignatureHelp m -> toReq SignatureHelp m
-
-    LSP.ReqDefinition m -> toReq Definition m
-    LSP.ReqTypeDefinition m -> toReq Definition m
-    LSP.ReqImplementation m -> toReq Definition m
-
-    LSP.ReqFindReferences m -> toReq References m
-    LSP.ReqDocumentHighlights m -> unknownReq m
-    LSP.ReqDocumentSymbols m -> toReq DocumentSymbol m
-    LSP.ReqWorkspaceSymbols m -> toReq WorkspaceSymbol m
-    LSP.ReqCodeAction m -> unknownReq m
-
-    LSP.ReqCodeLens m -> toReq CodeLens m
-    LSP.ReqCodeLensResolve m -> unknownReq m
-
-    LSP.ReqDocumentLink m -> unknownReq m
-    LSP.ReqDocumentLinkResolve m -> unknownReq m
-    LSP.ReqDocumentColor m -> unknownReq m
-    LSP.ReqColorPresentation m -> unknownReq m
-
-    LSP.ReqDocumentFormatting m -> toReq Formatting m
-    LSP.ReqDocumentRangeFormatting m -> unknownReq m
-    LSP.ReqDocumentOnTypeFormatting m -> unknownReq m
-
-    LSP.ReqRename m -> toReq Rename m
-
-    LSP.ReqFoldingRange m -> unknownReq m
-    LSP.ReqExecuteCommand m -> unknownReq m
-    LSP.ReqWillSaveWaitUntil m -> unknownReq m
-    LSP.ReqCustomClient m -> case reqMethod m of
-        CustomClientMethod "daml/keepAlive" -> Just $ Right (KeepAlive, reqId m)
-        _ -> unknownReq m
-
-    LSP.NotInitialized m -> unknownNot m
-    LSP.NotExit m -> unknownNot m
-    LSP.NotCancelRequestFromClient m -> unknownNot m
-    LSP.NotDidChangeConfiguration m -> unknownNot m
-    LSP.NotDidOpenTextDocument m -> toNot DidOpenTextDocument m
-    LSP.NotDidChangeTextDocument m -> toNot DidChangeTextDocument m
-    LSP.NotDidCloseTextDocument m -> toNot DidCloseTextDocument m
-    LSP.NotWillSaveTextDocument m -> unknownNot m
-    LSP.NotDidSaveTextDocument m -> toNot DidSaveTextDocument m
-    LSP.NotDidChangeWatchedFiles m -> unknownNot m
-    LSP.NotDidChangeWorkspaceFolders m -> unknownNot m
-    LSP.NotProgressCancel m -> unknownNot m
-    LSP.NotCustomClient m -> unknownNot m
-
-    LSP.RspApplyWorkspaceEdit _ -> Nothing
-    LSP.RspFromClient _ -> Nothing
-  where toReq constr msg = Just $ Right (constr $ reqParams msg, reqId msg)
-        toNot constr msg = Just $ Left $ constr $ notParams msg
-        unknownReq (LSP.RequestMessage _ id method params) =
-            Just $ Right (UnknownRequest (TL.toStrict $ Aeson.encodeToLazyText method) (Aeson.toJSON params), id)
-        unknownNot (LSP.NotificationMessage _ method params) =
-            Just $ Left $ UnknownNotification (TL.toStrict $ Aeson.encodeToLazyText method) (Aeson.toJSON params)
-        -- Type-restricted wrappers to make DuplicateRecordFields less annoying.
-        reqParams :: RequestMessage m req resp -> req
-        reqParams = _params
-        reqId :: RequestMessage m req resp -> LspId
-        reqId = _id
-        reqMethod :: RequestMessage m req resp -> m
-        reqMethod = _method
-        notParams :: NotificationMessage m a -> a
-        notParams = _params
-
-handlers :: TChan LSP.FromClientMessage -> LSP.Handlers
-handlers chan = def
-    { LSP.hoverHandler = emit LSP.ReqHover
-    , LSP.definitionHandler = emit LSP.ReqDefinition
-    , LSP.codeLensHandler = emit LSP.ReqCodeLens
-    , LSP.didOpenTextDocumentNotificationHandler = emit LSP.NotDidOpenTextDocument
-    , LSP.didChangeTextDocumentNotificationHandler = emit LSP.NotDidChangeTextDocument
-    , LSP.didCloseTextDocumentNotificationHandler = emit LSP.NotDidCloseTextDocument
-    , LSP.didSaveTextDocumentNotificationHandler = emit LSP.NotDidSaveTextDocument
-    , LSP.initializedHandler = emit LSP.NotInitialized
-    , LSP.exitNotificationHandler = Nothing
-    -- If the exit notification handler is set to `Nothing`
-    -- haskell-lsp will take care of shutting down the server for us.
-    , LSP.customRequestHandler = emit LSP.ReqCustomClient
-    , LSP.cancelNotificationHandler = Just $ const $ pure ()
-    -- ^ We just ignore cancel requests which is allowed according to
-    -- the spec. Installing a handler avoids errors about the missing handler.
-    }
-    where
-        emit :: (a -> LSP.FromClientMessage) -> Maybe (LSP.Handler a)
-        emit f = Just $ atomically . writeTChan chan . f
 
 options :: LSP.Options
 options = def

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -71,7 +71,7 @@ handleRequest logger compilerH makeResponse makeErrorResponse = \case
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
     Definition params -> RspDefinition . makeResponse <$> LS.Definition.gotoDefinition compilerH params
-    Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
+    Hover params -> RspHover . makeResponse <$> LS.Hover.onHover compilerH params
     CodeLens _params -> pure $ RspCodeLens $ makeResponse mempty
 
     req -> do

--- a/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
@@ -1,0 +1,100 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Development.IDE.LSP.Notifications
+    ( addNotifications
+    ) where
+
+import           Development.IDE.LSP.Protocol
+import           Development.IDE.LSP.Server hiding (runServer)
+import qualified Language.Haskell.LSP.Core as LSP
+
+import Development.IDE.Types.Logger
+import Development.IDE.Core.Service
+import Development.IDE.Types.Location
+
+import qualified Data.Set                                  as S
+import qualified Data.Text as T
+
+import Development.IDE.Core.FileStore
+import Development.IDE.Core.OfInterest
+
+import qualified Network.URI                               as URI
+
+
+textShow :: Show a => a -> T.Text
+textShow = T.pack . show
+
+
+addNotifications :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
+addNotifications RunHandler{..} x = return x{
+    LSP.didOpenTextDocumentNotificationHandler = addNotification $ \ide (DidOpenTextDocumentParams item) -> do
+        case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
+          Just uri
+              | URI.uriScheme uri == "file:"
+              -> handleDidOpenFile ide item
+
+              | otherwise
+              -> logWarning (ideLogger ide) $ "Unknown scheme in URI: "
+                    <> textShow uri
+
+          _ -> logSeriousError (ideLogger ide) $ "Invalid URI in DidOpenTextDocument: "
+                    <> textShow (_uri (item :: TextDocumentItem))
+
+    ,LSP.didChangeTextDocumentNotificationHandler = addNotification $ \ide (DidChangeTextDocumentParams docId _) -> do
+        let uri = _uri (docId :: VersionedTextDocumentIdentifier)
+
+        case uriToFilePath' uri of
+          Just (toNormalizedFilePath -> filePath) -> do
+            onFileModified ide filePath
+            logInfo (ideLogger ide)
+              $ "Updated text document: " <> textShow (fromNormalizedFilePath filePath)
+
+          Nothing ->
+            logSeriousError (ideLogger ide)
+              $ "Invalid file path: " <> textShow (_uri (docId :: VersionedTextDocumentIdentifier))
+
+    ,LSP.didCloseTextDocumentNotificationHandler = addNotification $ \ide (DidCloseTextDocumentParams (TextDocumentIdentifier uri)) ->
+        case URI.parseURI $ T.unpack $ getUri uri of
+          Just uri'
+              | URI.uriScheme uri' == "file:" -> do
+                    Just fp <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
+                    handleDidCloseFile ide fp
+              | otherwise -> logWarning (ideLogger ide) $ "Unknown scheme in URI: " <> textShow uri
+
+          _ -> logSeriousError (ideLogger ide)
+                 $    "Invalid URI in DidCloseTextDocument: "
+                   <> textShow uri
+
+  }
+  where
+    -- Note that the state changes here are not atomic.
+    -- When we have parallel compilation we could manage the state
+    -- changes in STM so that we can atomically change the state.
+    -- Internally it should be done via the IO oracle. See PROD-2808.
+    handleDidOpenFile ide (TextDocumentItem uri _ _ _) = do
+        Just filePath <- pure $ toNormalizedFilePath <$> uriToFilePath' uri
+        onFileModified ide filePath
+        modifyFilesOfInterest ide (S.insert filePath)
+        logInfo (ideLogger ide) $ "Opened text document: " <> textShow filePath
+
+    handleDidCloseFile ide filePath = do
+         logInfo (ideLogger ide) $ "Closed text document: " <> textShow (fromNormalizedFilePath filePath)
+         onFileModified ide filePath
+         modifyFilesOfInterest ide (S.delete filePath)
+
+
+-- | Manages the file store (caching compilation results and unsaved content).
+onFileModified
+    :: IdeState
+    -> NormalizedFilePath
+    -> IO ()
+onFileModified service fp = do
+    logDebug (ideLogger service) $ "File modified " <> T.pack (show fp)
+    -- if we get here then we must be using the LSP framework, in which case we don't
+    -- need to bother sending file modifications, other than to force the database to rerun
+    setBufferModified service fp Nothing

--- a/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Development.IDE.LSP.Notifications
-    ( addNotifications
+    ( setHandlersNotifications
     ) where
 
 import           Development.IDE.LSP.Protocol
@@ -30,8 +30,8 @@ textShow :: Show a => a -> T.Text
 textShow = T.pack . show
 
 
-addNotifications :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
-addNotifications RunHandler{..} x = return x{
+setHandlersNotifications :: RunHandler -> LSP.Handlers -> IO LSP.Handlers
+setHandlersNotifications RunHandler{..} x = return x{
     LSP.didOpenTextDocumentNotificationHandler = addNotification $ \ide (DidOpenTextDocumentParams item) -> do
         case URI.parseURI $ T.unpack $ getUri $ _uri (item :: TextDocumentItem) of
           Just uri

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -8,7 +8,6 @@ module Development.IDE.LSP.Server
   ( runServer
   , Handlers(..)
   , RunHandler(..)
-  , makeResponse
   , mergeHandlers
   ) where
 
@@ -44,13 +43,10 @@ data RunHandler = RunHandler
     ,addNotification :: forall m req . (IdeState -> req -> IO ()) -> Maybe (LSP.Handler (NotificationMessage m req))
     }
 
-makeResponse :: LspId -> a -> ResponseMessage a
-makeResponse reqId res = ResponseMessage "2.0" (responseId reqId) (Just res) Nothing
 
 mergeHandlers :: [RunHandler -> LSP.Handlers -> IO LSP.Handlers] -> RunHandler -> LSP.Handlers -> IO LSP.Handlers
 mergeHandlers = foldl f (\_ a -> return a)
     where f x1 x2 r a = x1 r a >>= x2 r
-
 
 ------------------------------------------------------------------------
 -- Server execution

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -8,7 +8,6 @@ module Development.IDE.LSP.Server
   ( runServer
   , Handlers(..)
   , RunHandler(..)
-  , mergeHandlers
   ) where
 
 
@@ -43,10 +42,6 @@ data RunHandler = RunHandler
     ,addNotification :: forall m req . (IdeState -> req -> IO ()) -> Maybe (LSP.Handler (NotificationMessage m req))
     }
 
-
-mergeHandlers :: [RunHandler -> LSP.Handlers -> IO LSP.Handlers] -> RunHandler -> LSP.Handlers -> IO LSP.Handlers
-mergeHandlers = foldl f (\_ a -> return a)
-    where f x1 x2 r a = x1 r a >>= x2 r
 
 ------------------------------------------------------------------------
 -- Server execution

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -49,7 +49,7 @@ makeResponse reqId res = ResponseMessage "2.0" (responseId reqId) (Just res) Not
 
 mergeHandlers :: [RunHandler -> LSP.Handlers -> IO LSP.Handlers] -> RunHandler -> LSP.Handlers -> IO LSP.Handlers
 mergeHandlers = foldl f (\_ a -> return a)
-    where f x1 x2 = \r a -> x1 r a >>= x2 r
+    where f x1 x2 r a = x1 r a >>= x2 r
 
 
 ------------------------------------------------------------------------

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -7,7 +7,7 @@
 module Development.IDE.LSP.Server
   ( runServer
   , Handlers(..)
-  , RunHandler(..)
+  , WithMessage(..)
   ) where
 
 
@@ -37,9 +37,9 @@ import qualified Language.Haskell.LSP.Types as LSP
 import Development.IDE.Core.Service
 
 
-data RunHandler = RunHandler
-    {addResponse :: forall m req resp . (ResponseMessage resp -> LSP.FromServerMessage) -> (IdeState -> req -> IO resp) -> Maybe (LSP.Handler (RequestMessage m req resp))
-    ,addNotification :: forall m req . (IdeState -> req -> IO ()) -> Maybe (LSP.Handler (NotificationMessage m req))
+data WithMessage = WithMessage
+    {withResponse :: forall m req resp . (ResponseMessage resp -> LSP.FromServerMessage) -> (IdeState -> req -> IO resp) -> Maybe (LSP.Handler (RequestMessage m req resp))
+    ,withNotification :: forall m req . (IdeState -> req -> IO ()) -> Maybe (LSP.Handler (NotificationMessage m req))
     }
 
 

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -7,6 +7,8 @@
 module Development.IDE.LSP.Server
   ( runServer
   , Handlers(..)
+  , RunHandler(..)
+  , makeResponse
   ) where
 
 
@@ -33,6 +35,17 @@ import qualified Language.Haskell.LSP.Control as LSP
 import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Messages as LSP
 import qualified Language.Haskell.LSP.Types as LSP
+import Development.IDE.Core.Service
+
+
+data RunHandler = RunHandler
+    {newNotification :: forall m req resp . (IdeState -> req -> IO resp) -> Maybe (LSP.Handler (RequestMessage m req resp))
+    ,runResponse :: (IdeState -> IO LSP.FromServerMessage) -> IO ()
+    }
+
+makeResponse :: LspId -> a -> ResponseMessage a
+makeResponse reqId res = ResponseMessage "2.0" (responseId reqId) (Just res) Nothing
+
 
 ------------------------------------------------------------------------
 -- Server execution

--- a/compiler/hie-core/test/Demo.hs
+++ b/compiler/hie-core/test/Demo.hs
@@ -58,7 +58,7 @@ main = do
 
     if "--lsp" `elem` args then do
         hPutStrLn stderr "Starting IDE server"
-        runLanguageServer logger $ \event vfs -> do
+        runLanguageServer $ \event vfs -> do
             hPutStrLn stderr "Server started"
             initialise (mainRule >> action kick) event logger options vfs
     else do

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -59,7 +59,7 @@ handleRequest logger compilerH makeResponse makeErrorResponse = \case
 
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
-    Definition params -> RspDefinition . makeResponse <$> LS.Definition.handle logger compilerH params
+    Definition params -> RspDefinition . makeResponse <$> LS.Definition.gotoDefinition compilerH params
     Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
     CodeLens params -> RspCodeLens . makeResponse <$> LS.CodeLens.handle logger compilerH params
 

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -60,7 +60,7 @@ handleRequest logger compilerH makeResponse makeErrorResponse = \case
     KeepAlive -> pure $ RspCustomServer $ makeResponse Aeson.Null
 
     Definition params -> RspDefinition . makeResponse <$> LS.Definition.gotoDefinition compilerH params
-    Hover params -> RspHover . makeResponse <$> LS.Hover.handle logger compilerH params
+    Hover params -> RspHover . makeResponse <$> LS.Hover.onHover compilerH params
     CodeLens params -> RspCodeLens . makeResponse <$> LS.CodeLens.handle logger compilerH params
 
     req -> do


### PR DESCRIPTION
This patch changes us from having a set of handler functions, mapping that into an LSP provided list, mapping that into our internal list, and then operating on that. Avoiding the indirection is important if we ever want to be able to plug in new methods after the fact, which is key to the design of hie-core.

This work is not the end state, but I think it's valuable to merge as-is and then iterate on it, partly so reviewers can be more brutal on the fundamental design. I have tested it at the hie-core level. Things I still need to do (in a future patch):

* Abstract so that runLanguageServer takes the handlers as an argument, and probably the options too.
* Change the other LanguageServer to use the newly abstracted runLanguageServer to remove the code duplication.
* Massive amount of cleanup of everything that no longer makes sense.
* Revisit all the interactions, threads, channels etc - I have aimed to preserve semantics, but I suspect we can do a lot better.