### PR TITLE
started centralizing api Test utils

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -350,9 +350,9 @@ class TransactionServiceIT
             context
               .command(
                 commandId,
+                Alice,
                 List(templateInSubscription, otherTemplateCreated).map(tid =>
-                  Command(create(tid, List("operator" -> Alice.asParty)))))
-              .update(_.commands.party := Alice),
+                  Command(create(tid, List("operator" -> Alice.asParty))))),
             TransactionFilters.templatesByParty(Alice -> List(templateInSubscription))
           )
         } yield {
@@ -381,8 +381,8 @@ class TransactionServiceIT
               context
                 .command(
                   exercisingChoice,
-                  List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap))
-                .update(_.commands.party := Alice),
+                  Alice,
+                  List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap)),
               TransactionFilters.allForParties(Alice)
             )
           } yield {
@@ -411,8 +411,8 @@ class TransactionServiceIT
               context
                 .command(
                   exercisingChoice,
+                  Alice,
                   List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap))
-                .update(_.commands.party := Alice)
             )
 
             txsWithCreate <- context.testingHelpers.listenForResultOfCommand(
@@ -569,16 +569,16 @@ class TransactionServiceIT
 
           choiceResult <- c.testingHelpers.submitAndListenForSingleResultOfCommand(
             c.command(
-                testIdsGenerator.testCommandId("Calling_non-consuming_choice"),
-                List(
-                  ExerciseCommand(
-                    Some(templateIds.agreementFactory),
-                    created.contractId,
-                    "CreateAgreement",
-                    Some(unitArg)).wrap)
-              )
-              .update(_.commands.party := receiver),
-            TransactionFilter(Map(receiver -> Filters.defaultInstance))
+              testIdsGenerator.testCommandId("Calling_non-consuming_choice"),
+              receiver,
+              List(
+                ExerciseCommand(
+                  Some(templateIds.agreementFactory),
+                  created.contractId,
+                  "CreateAgreement",
+                  Some(unitArg)).wrap)
+            ),
+            TransactionFilters.allForParties(receiver)
           )
         } yield {
 
@@ -1731,11 +1731,9 @@ class TransactionServiceIT
   ): Future[Assertion] =
     c.testingHelpers.assertCommandFailsWithCode(
       c.command(
-          testIdsGenerator.testCommandId(commandId),
-          List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap))
-        .update(
-          _.commands.party := submitter
-        ),
+        testIdsGenerator.testCommandId(commandId),
+        submitter,
+        List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap)),
       code,
       pattern
     )
@@ -1766,8 +1764,8 @@ class TransactionServiceIT
         context
           .command(
             testIdsGenerator.testCommandId(s"Exercising_with_a_multitiude_of_params_$choice#$lbl"),
-            List(exerciseCommand))
-          .update(_.commands.party := Alice),
+            Alice,
+            List(exerciseCommand)),
         TransactionFilters.allForParties(Alice)
       )
     } yield {

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceIT.scala
@@ -10,7 +10,6 @@ import akka.stream.scaladsl.{Flow, Sink}
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{EventId, LedgerId}
-import com.digitalasset.ledger.api.testing.utils.MockMessages.{party, _}
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   IsStatusException,
@@ -24,7 +23,7 @@ import com.digitalasset.ledger.api.v1.event.Event.Event.{Archived, Created}
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree, TreeEvent}
-import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter, _}
+import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
 import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionService
 import com.digitalasset.ledger.api.v1.value.Value.Sum
 import com.digitalasset.ledger.api.v1.value.Value.Sum.{Bool, ContractId}
@@ -39,9 +38,11 @@ import com.digitalasset.platform.apitesting.{
   TestIdsGenerator,
   TestTemplateIds
 }
+import com.digitalasset.platform.apitesting._
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
+import com.digitalasset.platform.apitesting.LedgerOffsets._
 import com.google.rpc.code.Code
 import io.grpc.{Status, StatusRuntimeException}
 import org.scalatest._
@@ -49,10 +50,11 @@ import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import scalaz.syntax.tag._
-import scalaz.{ICons, NonEmptyList, Tag}
+import scalaz.Tag
 
 import scala.collection.{breakOut, immutable}
 import scala.concurrent.Future
+import com.digitalasset.platform.apitesting.TestParties._
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class TransactionServiceIT
@@ -80,21 +82,9 @@ class TransactionServiceIT
   private def newClient(stub: TransactionService, ledgerId: LedgerId): TransactionClient =
     new TransactionClient(ledgerId, stub)
 
-  private val getAllContracts = transactionFilter
-
-  private def filterSingleTemplate(templateClientSubscribedTo: Identifier) = {
-    TransactionFilter(
-      Map(party -> Filters(Some(InclusiveFilters(List(templateClientSubscribedTo))))))
-  }
-
-  private val NonEmptyList(party1, ICons(party2, ICons(party3, _))) = config.parties
-
   private val smallCommandCount = 5
 
-  private val configuredParties = config.parties.list.toList
-
-  private val filterForAllParties = TransactionFilter(
-    configuredParties.map(_ -> Filters.defaultInstance).toMap)
+  private val configuredParties = config.parties
 
   private val unitArg = Value(Sum.Record(Record.defaultInstance))
 
@@ -105,7 +95,10 @@ class TransactionServiceIT
       "serve an empty stream of transactions" in allFixtures { context =>
         for {
           transactions <- context.transactionClient
-            .getTransactions(ledgerBegin, Some(ledgerBegin), getAllContracts)
+            .getTransactions(
+              LedgerBegin,
+              Some(LedgerBegin),
+              TransactionFilters.allForParties(Alice))
             .runWith(Sink.seq)
         } yield {
           transactions shouldBe empty
@@ -125,7 +118,7 @@ class TransactionServiceIT
             context
           )
           transactions <- context.transactionClient
-            .getTransactions(ledgerBegin, None, getAllContracts)
+            .getTransactions(LedgerBegin, None, TransactionFilters.allForParties(Alice))
             .take(elemsToTake)
             .runWith(Sink.seq)
         } yield {
@@ -141,7 +134,7 @@ class TransactionServiceIT
             _ <- insertCommandsUnique("deduplicated", 1, context)
             _ = insertCommandsUnique("deduplicated", 1, context) // we don't wait for this since the result won't be seen
             txs <- client
-              .getTransactions(le.getOffset, None, getAllContracts)
+              .getTransactions(le.getOffset, None, TransactionFilters.allForParties(Alice))
               .takeWithin(2.seconds)
               .runWith(Sink.seq)
           } yield {
@@ -152,7 +145,7 @@ class TransactionServiceIT
       "return INVALID_ARGUMENT if TransactionFilter is empty" in allFixtures { context =>
         for {
           error <- context.transactionClient
-            .getTransactions(ledgerBegin, None, TransactionFilter())
+            .getTransactions(LedgerBegin, None, TransactionFilters.empty)
             .runWith(Sink.seq)
             .failed
         } yield {
@@ -162,7 +155,7 @@ class TransactionServiceIT
 
       "complete the stream by itself as soon as LedgerEnd is hit" in allFixtures { context =>
         val resultsF = context.transactionClient
-          .getTransactions(ledgerBegin, Some(ledgerEnd), getAllContracts)
+          .getTransactions(LedgerBegin, Some(LedgerEnd), TransactionFilters.allForParties(Alice))
           .runWith(Sink.seq)
 
         for {
@@ -185,7 +178,10 @@ class TransactionServiceIT
             ledgerEndResponse <- client.getLedgerEnd
             _ <- insertCommandsUnique(firstSectionPrefix, commandsPerSection, context)
             firstSection <- client
-              .getTransactions(ledgerEndResponse.getOffset, None, getAllContracts)
+              .getTransactions(
+                ledgerEndResponse.getOffset,
+                None,
+                TransactionFilters.allForParties(Alice))
               .filter(_.commandId.startsWith(sharedPrefix))
               .take(commandsPerSection.toLong)
               .runWith(Sink.seq)
@@ -195,7 +191,10 @@ class TransactionServiceIT
             _ <- insertCommandsUnique(sharedPrefix + "-2", commandsPerSection, context)
 
             secondSection <- client
-              .getTransactions(ledgerEndAfterFirstSection, None, getAllContracts)
+              .getTransactions(
+                ledgerEndAfterFirstSection,
+                None,
+                TransactionFilters.allForParties(Alice))
               .take(commandsPerSection.toLong)
               .runWith(Sink.seq)
 
@@ -205,7 +204,7 @@ class TransactionServiceIT
               .getTransactions(
                 ledgerEndResponse.getOffset,
                 Some(ledgerEndAfterSecondSection),
-                getAllContracts)
+                TransactionFilters.allForParties(Alice))
               .filter(_.commandId.startsWith(sharedPrefix))
               .completionTimeout(3.seconds)
               .runWith(Sink.seq)
@@ -226,7 +225,10 @@ class TransactionServiceIT
           _ <- insertCommandsUnique(commandPrefix, smallCommandCount, context)
           readTransactions = () =>
             client
-              .getTransactions(ledgerEndOnStart.getOffset, None, getAllContracts)
+              .getTransactions(
+                ledgerEndOnStart.getOffset,
+                None,
+                TransactionFilters.allForParties(Alice))
               .filter(_.commandId.startsWith(commandPrefix))
               .take(smallCommandCount.toLong)
               .runWith(Sink.seq)
@@ -248,7 +250,7 @@ class TransactionServiceIT
         val client = context.transactionClient
         val commandPrefix = "visibility-test"
 
-        val anotherParty = "Alice"
+        val anotherParty = TestParties.Bob
         for {
           ledgerEndResponse <- client.getLedgerEnd
           _ <- insertCommandsUnique(commandPrefix, 1, context)
@@ -273,9 +275,12 @@ class TransactionServiceIT
           val client = context.transactionClient
 
           for {
-            ledgerEnd <- client.getLedgerEnd
+            LedgerEnd <- client.getLedgerEnd
             transactions <- client
-              .getTransactions(ledgerEnd.getOffset, Some(ledgerEnd.getOffset), getAllContracts)
+              .getTransactions(
+                LedgerEnd.getOffset,
+                Some(LedgerEnd.getOffset),
+                TransactionFilters.allForParties(Alice))
               .runWith(Sink.seq)
           } yield {
             transactions shouldBe empty
@@ -287,7 +292,10 @@ class TransactionServiceIT
           for {
             savedLedgerEnd <- context.transactionClient.getLedgerEnd
             txs <- context.transactionClient
-              .getTransactions(savedLedgerEnd.getOffset, Some(ledgerEnd), getAllContracts)
+              .getTransactions(
+                savedLedgerEnd.getOffset,
+                Some(LedgerEnd),
+                TransactionFilters.allForParties(Alice))
               .runWith(Sink.seq)
           } yield {
             txs shouldBe empty
@@ -301,14 +309,17 @@ class TransactionServiceIT
           savedLedgerEnd <- client.getLedgerEnd
           _ <- insertCommandsUnique(s"end-before-start-test", 1, context)
           tx <- client
-            .getTransactions(savedLedgerEnd.getOffset, None, getAllContracts)
+            .getTransactions(
+              savedLedgerEnd.getOffset,
+              None,
+              TransactionFilters.allForParties(Alice))
             .runWith(Sink.head)
           higherLedgerOffset = tx.offset
           error <- client
             .getTransactions(
               LedgerOffset(LedgerOffset.Value.Absolute(higherLedgerOffset)),
               Some(savedLedgerEnd.getOffset),
-              getAllContracts)
+              TransactionFilters.allForParties(Alice))
             .runWith(Sink.head)
             .failed
         } yield {
@@ -322,9 +333,9 @@ class TransactionServiceIT
               testIdsGenerator.testCommandId(
                 "Checking_commandId_visibility_for_non-submitter_party"),
               templateIds.agreementFactory,
-              List("receiver" -> party1.asParty, "giver" -> party2.asParty).asRecordFields,
-              party2,
-              party1
+              List("receiver" -> Alice.asParty, "giver" -> Bob.asParty).asRecordFields,
+              Bob,
+              Alice
             )
             .map(_.commandId shouldBe empty)
 
@@ -336,11 +347,13 @@ class TransactionServiceIT
         val otherTemplateCreated = templateIds.dummyFactory
         for {
           tx <- context.testingHelpers.submitAndListenForSingleResultOfCommand(
-            context.command(
-              commandId,
-              List(templateInSubscription, otherTemplateCreated).map(tid =>
-                Command(create(tid, List("operator" -> "party".asParty))))),
-            filterSingleTemplate(templateInSubscription)
+            context
+              .command(
+                commandId,
+                List(templateInSubscription, otherTemplateCreated).map(tid =>
+                  Command(create(tid, List("operator" -> Alice.asParty)))))
+              .update(_.commands.party := Alice),
+            TransactionFilters.templatesByParty(Alice -> List(templateInSubscription))
           )
         } yield {
           val singleEvent = getHead(tx.events.map(_.event))
@@ -361,14 +374,16 @@ class TransactionServiceIT
             createdEvent <- context.submitCreate(
               factoryCreation,
               exercisedTemplate,
-              List("operator" -> "party".asParty).asRecordFields,
-              "party")
+              List("operator" -> Alice.asParty).asRecordFields,
+              Alice)
             factoryContractId = createdEvent.contractId
             exerciseTx <- context.testingHelpers.submitAndListenForSingleResultOfCommand(
-              context.command(
-                exercisingChoice,
-                List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap)),
-              getAllContracts
+              context
+                .command(
+                  exercisingChoice,
+                  List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap))
+                .update(_.commands.party := Alice),
+              TransactionFilters.allForParties(Alice)
             )
           } yield {
             val events = exerciseTx.events.map(_.event)
@@ -388,21 +403,25 @@ class TransactionServiceIT
             creation <- context.submitCreate(
               factoryCreation,
               exercisedTemplate,
-              List("operator" -> "party".asParty).asRecordFields,
-              "party")
+              List("operator" -> Alice.asParty).asRecordFields,
+              Alice)
             factoryContractId = creation.contractId
 
             offsetToListenFrom <- context.testingHelpers.submitSuccessfullyAndReturnOffset(
-              context.command(
-                exercisingChoice,
-                List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap)))
+              context
+                .command(
+                  exercisingChoice,
+                  List(exerciseCallChoice(exercisedTemplate, factoryContractId).wrap))
+                .update(_.commands.party := Alice)
+            )
 
             txsWithCreate <- context.testingHelpers.listenForResultOfCommand(
-              filterSingleTemplate(templateIds.dummyWithParam),
+              TransactionFilters.templatesByParty(Alice -> List(templateIds.dummyWithParam)),
               Some(exercisingChoice),
               offsetToListenFrom)
+
             txsWithArchive <- context.testingHelpers.listenForResultOfCommand(
-              filterSingleTemplate(templateIds.dummyFactory),
+              TransactionFilters.templatesByParty(Alice -> List(templateIds.dummyFactory)),
               Some(exercisingChoice),
               offsetToListenFrom)
 
@@ -427,12 +446,12 @@ class TransactionServiceIT
           dummy <- c.submitCreate(
             testIdsGenerator.testCommandId("Create_for_assertion_failing_test"),
             templateIds.dummy,
-            List("operator" -> party.asParty).asRecordFields,
-            party)
+            List("operator" -> Alice.asParty).asRecordFields,
+            Alice)
           assertion <- failingExercise(
             c,
             "Assertion_failing_exercise",
-            party,
+            Alice,
             templateIds.dummy,
             dummy.contractId,
             "ConsumeIfTimeIsBetween",
@@ -457,7 +476,7 @@ class TransactionServiceIT
             testIdsGenerator.testCommandId("Creating_contract_with_a_multitude_of_param_types"),
             template,
             paramShowcaseArgs(templateIds.testPackageId),
-            "party",
+            Alice,
             verbose = false
           )
         } yield {
@@ -476,7 +495,7 @@ class TransactionServiceIT
               "Creating_contract_with_a_multitude_of_verbose_param_types"),
             template,
             arg,
-            "party",
+            Alice,
             verbose = true)
         } yield {
           val args = create.getCreateArguments
@@ -529,7 +548,7 @@ class TransactionServiceIT
             testIdsGenerator.testCommandId("Huge_command_with_a_long_list"),
             template,
             arg,
-            "party"
+            Alice
           )
         } yield {
           create.getCreateArguments.fields shouldEqual expectedArg
@@ -537,7 +556,7 @@ class TransactionServiceIT
       }
 
       "not archive the exercised contract on non-consuming choices" in allFixtures { c =>
-        val receiver = "party"
+        val receiver = Alice
         val giver = "Alice"
         for {
           created <- c.submitCreateWithListenerAndReturnEvent(
@@ -571,7 +590,7 @@ class TransactionServiceIT
 
       "require only authorization of chosen branching signatory" in allFixtures { c =>
         val branchingSignatoriesArg =
-          getBranchingSignatoriesArg(true, party1, party2)
+          getBranchingSignatoriesArg(true, Alice, Bob)
         val expectedArg = branchingSignatoriesArg.map(_.copy(label = ""))
 
         for {
@@ -579,8 +598,8 @@ class TransactionServiceIT
             testIdsGenerator.testCommandId("BranchingSignatoriesTrue"),
             templateIds.branchingSignatories,
             branchingSignatoriesArg,
-            party1,
-            party1)
+            Alice,
+            Alice)
         } yield {
           branchingSignatories.getCreateArguments.fields shouldEqual expectedArg
         }
@@ -588,26 +607,26 @@ class TransactionServiceIT
 
       "not disclose create to non-chosen branching signatory" in allFixtures { c =>
         val branchingSignatoriesArg =
-          getBranchingSignatoriesArg(false, party1, party2)
+          getBranchingSignatoriesArg(false, Alice, Bob)
         c.submitCreateWithListenerAndAssertNotVisible(
           testIdsGenerator.testCommandId("BranchingSignatoriesFalse"),
           templateIds.branchingSignatories,
           branchingSignatoriesArg,
-          party2,
-          party1)
+          Bob,
+          Alice)
       }
 
       "disclose create to chosen branching controller" in allFixtures { c =>
         val templateId = templateIds.branchingControllers
-        val branchingControllersArgs = getBranchingControllerArgs(party1, party2, party3, true)
+        val branchingControllersArgs = getBranchingControllerArgs(Alice, Bob, Eve, true)
         val expectedArg = branchingControllersArgs.map(_.copy(label = ""))
         for {
           branchingControllers <- c.submitCreateWithListenerAndReturnEvent(
             testIdsGenerator.testCommandId("BranchingControllersTrue"),
             templateId,
             branchingControllersArgs,
-            party1,
-            party2)
+            Alice,
+            Bob)
         } yield {
           branchingControllers.getCreateArguments.fields shouldEqual expectedArg
         }
@@ -616,18 +635,18 @@ class TransactionServiceIT
       "not disclose create to non-chosen branching controller" in allFixtures { c =>
         val templateId = templateIds.branchingControllers
         val branchingControllersArgs =
-          getBranchingControllerArgs(party1, party2, party3, false)
+          getBranchingControllerArgs(Alice, Bob, Eve, false)
         c.submitCreateWithListenerAndAssertNotVisible(
           testIdsGenerator.testCommandId("BranchingControllersFalse"),
           templateId,
           branchingControllersArgs,
-          party1,
-          party2)
+          Alice,
+          Bob)
       }
 
       "disclose create to observers" in allFixtures { c =>
-        val giver = party1
-        val observers = List(party2, party3)
+        val giver = Alice
+        val observers = List(Bob, Eve)
         val withObserversArg =
           Vector(
             RecordField("giver", giver.asParty),
@@ -652,7 +671,7 @@ class TransactionServiceIT
       "DAML engine returns Unit as argument to Nothing" in allFixtures { c =>
         val createArguments =
           Vector(
-            RecordField("operator", "party".asParty),
+            RecordField("operator", Alice.asParty),
             RecordField("arg1", Value(Value.Sum.Optional(Optional(None))))
           )
 
@@ -662,15 +681,15 @@ class TransactionServiceIT
             testIdsGenerator.testCommandId("Creating_contract_with_a_Nothing_argument"),
             templateIds.nothingArgument,
             createArguments,
-            "party")
+            Alice)
           .map(_.getCreateArguments.fields shouldEqual expectedArgs)
       }
 
       "expose the agreement text in CreatedEvents for templates with an explicit agreement text" in allFixtures {
         c =>
-          createAgreement(c, "AgreementTextTest", party1, party2).map(
+          createAgreement(c, "AgreementTextTest", Alice, Bob).map(
             _.agreementText shouldBe Some(
-              s"'$party2' promise to pay the '$party1' on demand the sum of five pounds.")
+              s"'$Bob' promise to pay the '$Alice' on demand the sum of five pounds.")
           )
       }
 
@@ -680,10 +699,9 @@ class TransactionServiceIT
             testIdsGenerator.testCommandId(
               "Creating_dummy_contract_for_default_agreement_text_test"),
             templateIds.dummy,
-            List(RecordField("operator", party1.asParty)),
-            party1
+            List(RecordField("operator", Alice.asParty)),
+            Alice
           )
-
           resultF.map(_.agreementText shouldBe Some(""))
       }
 
@@ -692,15 +710,15 @@ class TransactionServiceIT
           testIdsGenerator.testCommandId("Creating_CallablePayout_contract_for_stakeholders_test"),
           templateIds.callablePayout,
           List(
-            RecordField("giver", party1.asParty),
-            RecordField("receiver", party2.asParty)
+            RecordField("giver", Alice.asParty),
+            RecordField("receiver", Bob.asParty)
           ),
-          party1
+          Alice
         )
 
         resultF.map(contract => {
-          contract.signatories should contain only party1
-          contract.observers should contain only party2
+          contract.signatories should contain only Alice
+          contract.observers should contain only Bob
         })
       }
 
@@ -711,10 +729,10 @@ class TransactionServiceIT
               "Creating_CallablePayout_contract_for_contract_key_test"),
             templateIds.callablePayout,
             List(
-              RecordField("giver", party1.asParty),
-              RecordField("receiver", party2.asParty)
+              RecordField("giver", Alice.asParty),
+              RecordField("receiver", Bob.asParty)
             ),
-            party1
+            Alice
           )
 
           resultF.map(_.contractKey shouldBe None)
@@ -725,11 +743,11 @@ class TransactionServiceIT
           testIdsGenerator.testCommandId("Creating_TextKey_contract_for_contract_key_test"),
           templateIds.textKey,
           List(
-            RecordField("tkParty", party1.asParty),
+            RecordField("tkParty", Alice.asParty),
             RecordField("tkKey", "some-fancy-key".asText),
             RecordField("tkDisclosedTo", Seq.empty[Value].asList)
           ),
-          party1
+          Alice
         )
 
         resultF.map(
@@ -739,13 +757,13 @@ class TransactionServiceIT
                 Record(
                   None,
                   Vector(
-                    RecordField("", Some(party1.asParty)),
+                    RecordField("", Some(Alice.asParty)),
                     RecordField("", Some("some-fancy-key".asText))))))
           ))
       }
 
       "accept exercising a well-authorized multi-actor choice" in allFixtures { c =>
-        val List(operator, receiver, giver) = List(party1, party2, party3)
+        val List(operator, receiver, giver) = List(Alice, Bob, Eve)
         val triProposalArg = mkTriProposalArg(operator, receiver, giver)
 
         val expectedArg = triProposalArg.map(_.copy(label = ""))
@@ -774,7 +792,7 @@ class TransactionServiceIT
 
       "accept exercising a well-authorized multi-actor choice with coinciding controllers" in allFixtures {
         c =>
-          val List(operator, receiver @ _, giver) = List(party1, party2, party3)
+          val List(operator, receiver @ _, giver) = List(Alice, Bob, Eve)
           val triProposalArg = mkTriProposalArg(operator, giver, giver)
           val expectedArg = triProposalArg.map(_.copy(label = ""))
           for {
@@ -797,7 +815,7 @@ class TransactionServiceIT
       }
 
       "reject exercising a multi-actor choice with missing authorizers" in allFixtures { c =>
-        val List(operator, receiver, giver) = List(party1, party2, party3)
+        val List(operator, receiver, giver) = List(Alice, Bob, Eve)
         val triProposalArg = mkTriProposalArg(operator, receiver, giver)
         for {
           triProposal <- c.submitCreate(
@@ -827,7 +845,7 @@ class TransactionServiceIT
       // in the future. Should we delete this test, we should also remove the
       // 'UnrestrictedAcceptTriProposal' choice from the 'Agreement' template.
       "reject exercising a multi-actor choice with too many authorizers" in allFixtures { c =>
-        val List(operator, receiver, giver) = List(party1, party2, party3)
+        val List(operator, receiver, giver) = List(Alice, Bob, Eve)
         val triProposalArg = mkTriProposalArg(operator, giver, giver)
         for {
           agreement <- createAgreement(c, "MA4", receiver, giver)
@@ -859,15 +877,15 @@ class TransactionServiceIT
           dummy <- c.submitCreate(
             testIdsGenerator.testCommandId("Create_dummy_for_creating_AddressWrapper"),
             templateIds.dummy,
-            List("operator" -> party.asParty).asRecordFields,
-            party)
+            List("operator" -> Alice.asParty).asRecordFields,
+            Alice)
           exercise <- c.submitExercise(
             testIdsGenerator.testCommandId("Creating_AddressWrapper"),
             templateIds.dummy,
             List("address" -> arguments.map(e => e -> e.asText).asRecordValue).asRecordValue,
             "WrapWithAddress",
             dummy.contractId,
-            party
+            Alice
           )
         } yield {
           val events = c.testingHelpers.createdEventsIn(exercise)
@@ -887,19 +905,18 @@ class TransactionServiceIT
 
       "serve the proper content for each party, regardless of single/multi party subscription" in allFixtures {
         c =>
-          val configuredParties = config.parties.list.toList
           for {
             mpResults <- c.transactionClient
               .getTransactions(
-                ledgerBegin,
-                Some(ledgerEnd),
+                LedgerBegin,
+                Some(LedgerEnd),
                 TransactionFilter(configuredParties.map(_ -> Filters.defaultInstance).toMap))
               .runWith(Sink.seq)
             spResults <- Future.sequence(configuredParties.map { party =>
               c.transactionClient
                 .getTransactions(
-                  ledgerBegin,
-                  Some(ledgerEnd),
+                  LedgerBegin,
+                  Some(LedgerEnd),
                   TransactionFilter(
                     Map(party -> Filters.defaultInstance)
                   ))
@@ -925,8 +942,8 @@ class TransactionServiceIT
             createdEvent <- context.submitCreate(
               testIdsGenerator.testCommandId("CreateAndFetch_Create"),
               createAndFetchTid,
-              List("p" -> party.asParty).asRecordFields,
-              party)
+              List("p" -> Alice.asParty).asRecordFields,
+              Alice)
             cid = createdEvent.contractId
             exerciseTx <- context.submitExercise(
               testIdsGenerator.testCommandId("CreateAndFetch_Run"),
@@ -934,7 +951,7 @@ class TransactionServiceIT
               Value(Value.Sum.Record(Record())),
               "CreateAndFetch_Run",
               cid,
-              party
+              Alice
             )
           } yield {
             val events = exerciseTx.events.map(_.event)
@@ -951,7 +968,7 @@ class TransactionServiceIT
 
       "fail with the expected status" in allFixtures { context =>
         newClient(context.transactionService, LedgerId("notLedgerId"))
-          .getTransactions(ledgerBegin, Some(ledgerEnd), getAllContracts)
+          .getTransactions(LedgerBegin, Some(LedgerEnd), TransactionFilters.allForParties(Alice))
           .runWith(Sink.head)
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
@@ -981,13 +998,13 @@ class TransactionServiceIT
           for {
             _ <- insertCommandsUnique("tree-provenance-by-id", 1, context)
             firstTransaction <- context.transactionClient
-              .getTransactions(beginOffset, None, transactionFilter)
+              .getTransactions(beginOffset, None, TransactionFilters.allForParties(Alice))
               .runWith(Sink.head)
             transactionId = firstTransaction.transactionId
             response <- context.transactionClient
-              .getTransactionById(transactionId, List("party"))
+              .getTransactionById(transactionId, List(Alice))
             notVisibleError <- context.transactionClient
-              .getTransactionById(transactionId, List("Alice"))
+              .getTransactionById(transactionId, List(Bob))
               .failed
           } yield {
             response.transaction should not be empty
@@ -1003,14 +1020,14 @@ class TransactionServiceIT
         context.transactionClient
           .getTransactionById(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            List("party"))
+            List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
         newClient(context.transactionService, LedgerId(s"not-${context.ledgerId.unwrap}"))
-          .getTransactionById(transactionId, List("party"))
+          .getTransactionById("invalid", List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
@@ -1018,16 +1035,20 @@ class TransactionServiceIT
       "fail with INVALID_ARGUMENT status if the requesting parties field is empty" in allFixtures {
         context =>
           context.transactionClient
-            .getTransactionById(transactionId, Nil)
+            .getTransactionById("invalid", Nil)
             .failed
             .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
 
       "return the same events for each tx as the transaction stream itself" in allFixtures {
         context =>
-          val requestingParties = transactionFilter.filtersByParty.keySet
+          val requestingParties = TransactionFilters.allForParties(Alice).filtersByParty.keySet
           context.transactionClient
-            .getTransactions(ledgerBegin, Some(ledgerEnd), transactionFilter, true)
+            .getTransactions(
+              LedgerBegin,
+              Some(LedgerEnd),
+              TransactionFilters.allForParties(Alice),
+              true)
             .mapAsyncUnordered(16) { tx =>
               context.transactionClient
                 .getTransactionById(tx.transactionId, requestingParties.toList)
@@ -1076,13 +1097,13 @@ class TransactionServiceIT
           for {
             _ <- insertCommandsUnique("flat-provenance-by-id", 1, context)
             firstTransaction <- context.transactionClient
-              .getTransactions(beginOffset, None, transactionFilter)
+              .getTransactions(beginOffset, None, TransactionFilters.allForParties(Alice))
               .runWith(Sink.head)
             transactionId = firstTransaction.transactionId
             response <- context.transactionClient
-              .getFlatTransactionById(transactionId, List("party"))
+              .getFlatTransactionById(transactionId, List(Alice))
             notVisibleError <- context.transactionClient
-              .getFlatTransactionById(transactionId, List("Alice"))
+              .getFlatTransactionById(transactionId, List(Bob))
               .failed
           } yield {
             response.transaction should not be empty
@@ -1098,14 +1119,14 @@ class TransactionServiceIT
         context.transactionClient
           .getFlatTransactionById(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            List("party"))
+            List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
         newClient(context.transactionService, LedgerId(s"not-${context.ledgerId.unwrap}"))
-          .getFlatTransactionById(transactionId, List("party"))
+          .getFlatTransactionById("invalid", List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
@@ -1113,16 +1134,20 @@ class TransactionServiceIT
       "fail with INVALID_ARGUMENT status if the requesting parties field is empty" in allFixtures {
         context =>
           context.transactionClient
-            .getFlatTransactionById(transactionId, Nil)
+            .getFlatTransactionById("invalid", Nil)
             .failed
             .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
 
       "return the same events for each tx as the transaction stream itself" in allFixtures {
         context =>
-          val requestingParties = transactionFilter.filtersByParty.keySet
+          val requestingParties = TransactionFilters.allForParties(Alice).filtersByParty.keySet
           context.transactionClient
-            .getTransactions(ledgerBegin, Some(ledgerEnd), transactionFilter, true)
+            .getTransactions(
+              LedgerBegin,
+              Some(LedgerEnd),
+              TransactionFilters.allForParties(Alice),
+              true)
             .mapAsyncUnordered(16) { tx =>
               context.transactionClient
                 .getFlatTransactionById(tx.transactionId, requestingParties.toList)
@@ -1142,7 +1167,7 @@ class TransactionServiceIT
         for {
           _ <- insertCommandsUnique("tree-provenance-by-event-id", 1, context)
           tx <- context.transactionClient
-            .getTransactions(beginOffset, None, transactionFilter)
+            .getTransactions(beginOffset, None, TransactionFilters.allForParties(Alice))
             .runWith(Sink.head)
           eventId = tx.events.headOption
             .map(_.event match {
@@ -1152,10 +1177,10 @@ class TransactionServiceIT
             })
             .value
           result <- context.transactionClient
-            .getTransactionByEventId(eventId, Seq(party))
+            .getTransactionByEventId(eventId, List(Alice))
 
           notVisibleError <- context.transactionClient
-            .getTransactionByEventId(eventId, List("Alice"))
+            .getTransactionByEventId(eventId, List(Bob))
             .failed
         } yield {
           result.transaction should not be empty
@@ -1170,7 +1195,7 @@ class TransactionServiceIT
 
       "return INVALID_ARGUMENT for invalid event IDs" in allFixtures { context =>
         context.transactionClient
-          .getTransactionByEventId("don't worry, be happy", List("party"))
+          .getTransactionByEventId("don't worry, be happy", List(Alice))
           .failed
           .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
@@ -1179,14 +1204,14 @@ class TransactionServiceIT
         context.transactionClient
           .getTransactionByEventId(
             "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:000",
-            List("party"))
+            List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
         newClient(context.transactionService, LedgerId(s"not-${context.ledgerId.unwrap}"))
-          .getTransactionByEventId("#42:0", List("party"))
+          .getTransactionByEventId("#42:0", List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
@@ -1194,7 +1219,7 @@ class TransactionServiceIT
       "fail with INVALID_ARGUMENT status if the requesting parties field is empty" in allFixtures {
         context =>
           context.transactionClient
-            .getTransactionByEventId(transactionId, Nil)
+            .getTransactionByEventId("invalid", Nil)
             .failed
             .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
@@ -1207,7 +1232,7 @@ class TransactionServiceIT
         for {
           _ <- insertCommandsUnique("flat-provenance-by-event-id", 1, context)
           tx <- context.transactionClient
-            .getTransactions(beginOffset, None, transactionFilter)
+            .getTransactions(beginOffset, None, TransactionFilters.allForParties(Alice))
             .runWith(Sink.head)
           eventId = tx.events.headOption
             .map(_.event match {
@@ -1217,10 +1242,10 @@ class TransactionServiceIT
             })
             .value
           result <- context.transactionClient
-            .getFlatTransactionByEventId(eventId, Seq(party))
+            .getFlatTransactionByEventId(eventId, Seq(Alice))
 
           notVisibleError <- context.transactionClient
-            .getFlatTransactionByEventId(eventId, List("Alice"))
+            .getFlatTransactionByEventId(eventId, List(Bob))
             .failed
         } yield {
           result.transaction should not be empty
@@ -1235,7 +1260,7 @@ class TransactionServiceIT
 
       "return INVALID_ARGUMENT for invalid event IDs" in allFixtures { context =>
         context.transactionClient
-          .getFlatTransactionByEventId("don't worry, be happy", List("party"))
+          .getFlatTransactionByEventId("don't worry, be happy", List(Alice))
           .failed
           .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
@@ -1244,14 +1269,14 @@ class TransactionServiceIT
         context.transactionClient
           .getFlatTransactionByEventId(
             "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:000",
-            List("party"))
+            List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
         newClient(context.transactionService, LedgerId(s"not-${context.ledgerId.unwrap}"))
-          .getFlatTransactionByEventId("#42:0", List("party"))
+          .getFlatTransactionByEventId("#42:0", List(Alice))
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
       }
@@ -1259,7 +1284,7 @@ class TransactionServiceIT
       "fail with INVALID_ARGUMENT status if the requesting parties field is empty" in allFixtures {
         context =>
           context.transactionClient
-            .getFlatTransactionByEventId(transactionId, Nil)
+            .getFlatTransactionByEventId("invalid", Nil)
             .failed
             .map(IsStatusException(Status.INVALID_ARGUMENT))
       }
@@ -1286,8 +1311,6 @@ class TransactionServiceIT
           }
         }
 
-      val configuredParties = config.parties.list.toList
-
       "not arrive out of order when using single party subscription " in allFixtures { c =>
         Future
           .sequence(
@@ -1297,8 +1320,8 @@ class TransactionServiceIT
                   () =>
                     c.transactionClient
                       .getTransactions(
-                        ledgerBegin,
-                        Some(ledgerEnd),
+                        LedgerBegin,
+                        Some(LedgerEnd),
                         TransactionFilter(
                           Map(p -> Filters.defaultInstance)
                         ))
@@ -1313,8 +1336,8 @@ class TransactionServiceIT
           () =>
             c.transactionClient
               .getTransactions(
-                ledgerBegin,
-                Some(ledgerEnd),
+                LedgerBegin,
+                Some(LedgerEnd),
                 TransactionFilter(configuredParties.map(_ -> Filters.defaultInstance).toMap))
               .runWith(Sink.seq)
               .map(_.flatMap(_.events.map(_.event)))
@@ -1326,14 +1349,20 @@ class TransactionServiceIT
 
       "serve an empty stream of transactions" in allFixtures { context =>
         context.transactionClient
-          .getTransactionTrees(ledgerBegin, Some(ledgerBegin), transactionFilter)
+          .getTransactionTrees(
+            LedgerBegin,
+            Some(LedgerBegin),
+            TransactionFilters.allForParties(Alice))
           .runWith(Sink.seq)
           .map(_ shouldBe empty)
       }
 
       "fail with the expected status on a ledger Id mismatch" in allFixtures { context =>
         new TransactionClient(LedgerId("notLedgerId"), context.transactionService)
-          .getTransactionTrees(ledgerBegin, Some(ledgerEnd), transactionFilter)
+          .getTransactionTrees(
+            LedgerBegin,
+            Some(LedgerEnd),
+            TransactionFilters.allForParties(Alice))
           .runWith(Sink.head)
           .failed
           .map(IsStatusException(Status.NOT_FOUND))
@@ -1347,7 +1376,7 @@ class TransactionServiceIT
           val commandsToSend = 14
 
           val resultsF = context.transactionClient
-            .getTransactionTrees(ledgerBegin, None, transactionFilter)
+            .getTransactionTrees(LedgerBegin, None, TransactionFilters.allForParties(Alice))
             .take(elemsToTake)
             .runWith(Sink.seq)
 
@@ -1361,13 +1390,16 @@ class TransactionServiceIT
           c =>
             for {
               mpResults <- c.transactionClient
-                .getTransactionTrees(ledgerBegin, Some(ledgerEnd), filterForAllParties)
+                .getTransactionTrees(
+                  LedgerBegin,
+                  Some(LedgerEnd),
+                  TransactionFilters.allForParties(configuredParties: _*))
                 .runWith(Sink.seq)
               spResults <- Future.sequence(configuredParties.map { party =>
                 c.transactionClient
                   .getTransactionTrees(
-                    ledgerBegin,
-                    Some(ledgerEnd),
+                    LedgerBegin,
+                    Some(LedgerEnd),
                     TransactionFilter(
                       Map(party -> Filters.defaultInstance)
                     ))
@@ -1409,11 +1441,17 @@ class TransactionServiceIT
 
           for {
             r1 <- context.transactionClient
-              .getTransactionTrees(ledgerBegin, Some(ledgerEnd), transactionFilter)
+              .getTransactionTrees(
+                LedgerBegin,
+                Some(LedgerEnd),
+                TransactionFilters.allForParties(Alice))
               .runWith(Sink.seq)
             _ <- insertCommandsUnique("complete_test", noOfCommands, context)
             r2 <- context.transactionClient
-              .getTransactionTrees(ledgerBegin, Some(ledgerEnd), transactionFilter)
+              .getTransactionTrees(
+                LedgerBegin,
+                Some(LedgerEnd),
+                TransactionFilters.allForParties(Alice))
               .runWith(Sink.seq)
           } yield {
             r2.size - r1.size shouldEqual (noOfCommands.toLong)
@@ -1425,14 +1463,14 @@ class TransactionServiceIT
         "serve a subset of the tree data in the flat stream" in allFixtures { context =>
           val treesF = context.transactionClient
             .getTransactionTrees(
-              ledgerBegin,
-              Some(ledgerEnd),
+              LedgerBegin,
+              Some(LedgerEnd),
               TransactionFilter(Map("Bob" -> Filters())))
             .runWith(Sink.seq)
           val txsF = context.transactionClient
             .getTransactions(
-              ledgerBegin,
-              Some(ledgerEnd),
+              LedgerBegin,
+              Some(LedgerEnd),
               TransactionFilter(Map("Bob" -> Filters())))
             .runWith(Sink.seq)
           for {
@@ -1471,8 +1509,8 @@ class TransactionServiceIT
         "serve a stream of transactions" in allFixtures { context =>
           val treesF = context.transactionClient
             .getTransactionTrees(
-              ledgerBegin,
-              Some(ledgerEnd),
+              LedgerBegin,
+              Some(LedgerEnd),
               TransactionFilter(Map("Bob" -> Filters())))
             .map(_.eventsById.values)
             .mapConcat(context.testingHelpers.exercisedEventsInNodes(_).toList)
@@ -1715,7 +1753,7 @@ class TransactionServiceIT
           s"Creating_contract_with_a_multitude_of_param_types_for_exercising_$choice#$lbl"),
         templateIds.parameterShowcase,
         paramShowcaseArgs(templateIds.testPackageId),
-        MockMessages.party
+        Alice
       )
       contractId = creation.contractId
       // first, verify that if we submit with the same inputs they're equal
@@ -1728,8 +1766,9 @@ class TransactionServiceIT
         context
           .command(
             testIdsGenerator.testCommandId(s"Exercising_with_a_multitiude_of_params_$choice#$lbl"),
-            List(exerciseCommand)),
-        getAllContracts
+            List(exerciseCommand))
+          .update(_.commands.party := Alice),
+        TransactionFilters.allForParties(Alice)
       )
     } yield {
       // check that we have the create

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
@@ -12,6 +12,7 @@ import com.digitalasset.ledger.api.v1.commands.Command.Command.Create
 import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand}
 import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
+import com.digitalasset.platform.apitesting.TestParties._
 import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestTemplateIds}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.participant.util.ValueConversions._
@@ -57,8 +58,9 @@ class TransactionServiceLargeCommandIT
         val superSizedCommand = c
           .command(
             "Huge-composite-command",
+            Alice,
             List.fill(targetNumberOfSubCommands)(
-              Command(create(templateIds.dummy, List("operator" -> "party".asParty)))))
+              Command(create(templateIds.dummy, List("operator" -> Alice.asParty)))))
           .update(_.commands.maximumRecordTime := Timestamp(60L, 0))
 
         c.testingHelpers

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceLargeCommandIT.scala
@@ -3,7 +3,6 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api
 
-import com.digitalasset.ledger.api.testing.utils.MockMessages._
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   SuiteResourceManagementAroundAll
@@ -13,7 +12,11 @@ import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand}
 import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.platform.apitesting.TestParties._
-import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestTemplateIds}
+import com.digitalasset.platform.apitesting.{
+  MultiLedgerFixture,
+  TestTemplateIds,
+  TransactionFilters
+}
 import com.digitalasset.platform.esf.TestExecutionSequencerFactory
 import com.digitalasset.platform.participant.util.ValueConversions._
 import com.digitalasset.platform.services.time.TimeProviderType
@@ -47,8 +50,6 @@ class TransactionServiceLargeCommandIT
 
   override val timeLimit: Span = scaled(300.seconds)
 
-  private val getAllContracts = transactionFilter
-
   "Transaction Service" when {
 
     "submitting and reading transactions" should {
@@ -64,7 +65,9 @@ class TransactionServiceLargeCommandIT
           .update(_.commands.maximumRecordTime := Timestamp(60L, 0))
 
         c.testingHelpers
-          .submitAndListenForSingleResultOfCommand(superSizedCommand, getAllContracts)
+          .submitAndListenForSingleResultOfCommand(
+            superSizedCommand,
+            TransactionFilters.allForParties(Alice))
           .map { tx =>
             tx.events.size shouldEqual targetNumberOfSubCommands
           }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/WitnessesIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/WitnessesIT.scala
@@ -3,23 +3,23 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api
 
-import scala.concurrent.Future
-import org.scalatest.{AsyncFreeSpec, Matchers}
 import com.digitalasset.ledger.api.testing.utils.{
-  SuiteResourceManagementAroundEach,
-  AkkaBeforeAndAfterAll
+  AkkaBeforeAndAfterAll,
+  SuiteResourceManagementAroundEach
 }
-import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
-import com.digitalasset.platform.apitesting.TestTemplateIds
-import com.digitalasset.platform.apitesting.{MultiLedgerFixture, LedgerContext}
-import com.digitalasset.ledger.client.services.commands.SynchronousCommandClient
-import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
-import com.digitalasset.platform.apitesting.LedgerContextExtensions._
 import com.digitalasset.ledger.api.v1.commands.{CreateCommand, ExerciseCommand}
-import com.digitalasset.ledger.api.v1.value.{Record, RecordField, Value}
-import com.digitalasset.platform.participant.util.ValueConversions._
-import com.digitalasset.ledger.api.v1.event.{ExercisedEvent}
+import com.digitalasset.ledger.api.v1.event.ExercisedEvent
 import com.digitalasset.ledger.api.v1.transaction.TreeEvent
+import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
+import com.digitalasset.ledger.api.v1.value.{Record, RecordField, Value}
+import com.digitalasset.platform.apitesting.LedgerContextExtensions._
+import com.digitalasset.platform.apitesting.TestParties._
+import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestTemplateIds}
+import com.digitalasset.platform.participant.util.ValueConversions._
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
+import org.scalatest.{AsyncFreeSpec, Matchers}
+
+import scala.concurrent.Future
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class WitnessesIT
@@ -35,34 +35,31 @@ class WitnessesIT
   protected val testTemplateIds = new TestTemplateIds(config)
   protected val templateIds = testTemplateIds.templateIds
 
-  private def commandClient(ctx: LedgerContext): SynchronousCommandClient =
-    new SynchronousCommandClient(ctx.commandService)
-
   private val filter = TransactionFilter(
     Map(
-      "alice" -> Filters.defaultInstance,
-      "bob" -> Filters.defaultInstance,
-      "charlie" -> Filters.defaultInstance,
+      Alice -> Filters.defaultInstance,
+      Bob -> Filters.defaultInstance,
+      Charlie -> Filters.defaultInstance,
     ))
 
   "disclosure rules are respected" in allFixtures { ctx =>
     val createArg = Record(
       fields = List(
-        RecordField("p_signatory", "alice".asParty),
-        RecordField("p_observer", "bob".asParty),
-        RecordField("p_actor", "charlie".asParty),
+        RecordField("p_signatory", Alice.asParty),
+        RecordField("p_observer", Bob.asParty),
+        RecordField("p_actor", Charlie.asParty)
       ))
     val exerciseArg = Value(Value.Sum.Record(Record()))
+
     def exercise(cid: String, choice: String): Future[ExercisedEvent] =
       ctx.testingHelpers
         .submitAndListenForSingleTreeResultOfCommand(
           ctx.testingHelpers
-            .submitRequestWithId(s"$choice-exercise")
+            .submitRequestWithId(s"$choice-exercise", Charlie)
             .update(
               _.commands.commands :=
                 List(
-                  ExerciseCommand(Some(templateIds.witnesses), cid, choice, Some(exerciseArg)).wrap),
-              _.commands.party := "charlie"
+                  ExerciseCommand(Some(templateIds.witnesses), cid, choice, Some(exerciseArg)).wrap)
             ),
           filter,
           false
@@ -73,15 +70,15 @@ class WitnessesIT
             case _ => fail("unexpected event")
           }
         }
+
     for {
       // Create Witnesses contract
       createTx <- ctx.testingHelpers.submitAndListenForSingleResultOfCommand(
         ctx.testingHelpers
-          .submitRequestWithId("create")
+          .submitRequestWithId("create", Alice)
           .update(
             _.commands.commands :=
-              List(CreateCommand(Some(templateIds.witnesses), Some(createArg)).wrap),
-            _.commands.party := "alice"
+              List(CreateCommand(Some(templateIds.witnesses), Some(createArg)).wrap)
           ),
         filter
       )
@@ -90,15 +87,14 @@ class WitnessesIT
       // see it by default.
       divulgeCreatedEv <- ctx.testingHelpers.simpleCreate(
         "create-divulge",
-        "charlie",
+        Charlie,
         templateIds.divulgeWitnesses,
         Record(
-          fields =
-            List(RecordField(value = "alice".asParty), RecordField(value = "charlie".asParty)))
+          fields = List(RecordField(value = Alice.asParty), RecordField(value = Charlie.asParty)))
       )
       _ <- ctx.testingHelpers.simpleExercise(
         "exercise-divulge",
-        "alice",
+        Alice,
         templateIds.divulgeWitnesses,
         divulgeCreatedEv.contractId,
         "Divulge",
@@ -111,14 +107,9 @@ class WitnessesIT
       // And then the consuming one
       consumingExerciseEv <- exercise(createdEv.contractId, "WitnessesChoice")
     } yield {
-      createdEv.witnessParties should contain theSameElementsAs List("alice", "bob") // stakeholders = signatories \cup observers
-      nonConsumingExerciseEv.witnessParties should contain theSameElementsAs List(
-        "alice",
-        "charlie") // signatories \cup actors
-      consumingExerciseEv.witnessParties should contain theSameElementsAs List(
-        "alice",
-        "bob",
-        "charlie") // stakeholders \cup actors
+      createdEv.witnessParties should contain theSameElementsAs List(Alice, Bob) // stakeholders = signatories \cup observers
+      nonConsumingExerciseEv.witnessParties should contain theSameElementsAs List(Alice, Charlie) // signatories \cup actors
+      consumingExerciseEv.witnessParties should contain theSameElementsAs List(Alice, Bob, Charlie) // stakeholders \cup actors
     }
   }
 }

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandClientIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandClientIT.scala
@@ -288,12 +288,14 @@ class CommandClientIT
           assertion <- c.testingHelpers.assertCommandFailsWithCode(
             c.command(
               "Double_spend_test_exercise_2",
+              submittingParty,
               List(
                 ExerciseCommand(
                   Some(templateIds.dummyFactory),
                   contract.contractId,
                   "DummyFactoryCall",
-                  Some(unit)).wrap)),
+                  Some(unit)).wrap)
+            ),
             Code.INVALID_ARGUMENT,
             "dependency",
             ignoreCase = true
@@ -309,6 +311,7 @@ class CommandClientIT
         val commandWithInvalidArgs =
           c.command(
             "Creating_contracts_for_invalid_arg_test",
+            submittingParty,
             List(CreateCommand(Some(templateIds.dummy), Some(Record())).wrap))
 
         c.testingHelpers.assertCommandFailsWithCode(
@@ -325,6 +328,7 @@ class CommandClientIT
           val command =
             c.command(
               "Boolean_param_with_wrong_type",
+              submittingParty,
               List(
                 CreateCommand(
                   Some(templateIds.dummy),
@@ -345,6 +349,7 @@ class CommandClientIT
         val command =
           c.command(
             "Param_with_wrong_name",
+            submittingParty,
             List(
               CreateCommand(
                 Some(templateIds.dummy),
@@ -396,6 +401,7 @@ class CommandClientIT
 
         val command = c.command(
           commandId,
+          submittingParty,
           List(
             CreateCommand(
               Some(templateIds.parameterShowcase),
@@ -418,6 +424,7 @@ class CommandClientIT
         val command =
           c.command(
             "Obligable_error",
+            submittingParty,
             List(
               CreateCommand(
                 Some(templateIds.dummy),
@@ -436,6 +443,7 @@ class CommandClientIT
         val command =
           c.command(
             "Exercise_contract_not_found",
+            submittingParty,
             List(
               ExerciseCommand(Some(templateIds.dummy), contractId, "DummyChoice1", Some(unit)).wrap)
           )
@@ -453,6 +461,7 @@ class CommandClientIT
           assertion <- c.testingHelpers.assertCommandFailsWithCode(
             c.command(
               "Bad_choice_test",
+              submittingParty,
               List(
                 ExerciseCommand(
                   Some(templateIds.dummyFactory),

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
@@ -110,7 +110,7 @@ class CommandCompletionServiceIT
 
       "emit checkpoints with exclusive offsets (results for coming back with the same offset will not contain the records)" in allFixtures {
         ctx =>
-          val configuredParties = config.parties.list.toList
+          val configuredParties = config.parties
 
           def completionsFrom(offset: LedgerOffset) =
             completionSource(

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
@@ -71,7 +71,7 @@ class CommandCompletionServiceIT
     "listening for completions" should {
 
       "handle multi party subscriptions" in allFixtures { ctx =>
-        val configuredParties = config.parties.list.toList
+        val configuredParties = config.parties
         for {
           commandClient <- ctx.commandClient(ctx.ledgerId)
           tracker <- commandClient.trackCommands[String](configuredParties)

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.tests.integration.ledger.api.commands
 import akka.NotUsed
 import akka.stream.scaladsl.{Sink, Source}
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.testing.utils.MockMessages.{applicationId, party}
+import com.digitalasset.ledger.api.testing.utils.MockMessages.applicationId
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   SuiteResourceManagementAroundAll
@@ -47,6 +47,7 @@ import scalaz.syntax.tag._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
+import com.digitalasset.platform.apitesting.TestParties._
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class CommandCompletionServiceIT
     extends AsyncWordSpec
@@ -89,7 +90,7 @@ class CommandCompletionServiceIT
             ctx.commandCompletionService,
             ctx.ledgerId,
             applicationId,
-            Seq(party),
+            Seq(Alice),
             Some(LedgerOffset(Boundary(LEDGER_BEGIN))))
 
         val recordTimes = completionService.collect {
@@ -175,13 +176,13 @@ class CommandCompletionServiceIT
               createArguments = Some(
                 Record(
                   fields = Seq(
-                    RecordField("operator", Some(Value(Value.Sum.Party(party))))
+                    RecordField("operator", Some(Value(Value.Sum.Party(Alice))))
                   )
                 ))
             )))
 
         def trackDummyCreation(client: CommandClient, context: LedgerContext, id: String) =
-          client.trackSingleCommand(context.command(id, Seq(createDummyCommand)))
+          client.trackSingleCommand(context.command(id, Alice, Seq(createDummyCommand)))
 
         def trackDummyCreations(client: CommandClient, context: LedgerContext, ids: List[String]) =
           Future.sequence(ids.map(trackDummyCreation(client, context, _)))
@@ -195,7 +196,7 @@ class CommandCompletionServiceIT
             CompletionStreamRequest(
               context.ledgerId.unwrap,
               applicationId,
-              Seq(party),
+              Seq(Alice),
               offset = None),
             streamObserver)
           future.map(_.get).collect {

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/commands/CommandCompletionServiceIT.scala
@@ -75,7 +75,7 @@ class CommandCompletionServiceIT
         for {
           commandClient <- ctx.commandClient(ctx.ledgerId)
           tracker <- commandClient.trackCommands[String](configuredParties)
-          commands = configuredParties.map(p => Ctx(p, ctx.command(p, Nil)))
+          commands = configuredParties.map(p => Ctx(p, ctx.command(p, p, Nil)))
           result <- Source(commands).via(tracker).runWith(Sink.seq)
         } yield {
           val expected = configuredParties.map(p => (p, 0))
@@ -132,7 +132,7 @@ class CommandCompletionServiceIT
             startingOffset = startingOffsetResponse.getOffset
             commandClient <- ctx.commandClient(ctx.ledgerId)
             commands = configuredParties
-              .map(p => ctx.command(p, Nil))
+              .map(p => ctx.command(p, p, Nil))
               .zipWithIndex
               .map { case (req, i) => req.update(_.commands.commandId := s"command-id-$i") }
             _ <- Future.sequence(

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/PlatformApplications.scala
@@ -14,10 +14,10 @@ import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.common.LedgerIdMode
 import com.digitalasset.platform.sandbox.config.{CommandConfiguration, SandboxConfig}
 import com.digitalasset.platform.services.time.{TimeModel, TimeProviderType}
-import scalaz.NonEmptyList
 
 import scala.concurrent.duration.{FiniteDuration, _}
 import com.digitalasset.ledger.api.domain.LedgerId
+import com.digitalasset.platform.apitesting.TestParties
 
 object PlatformApplications {
 
@@ -32,7 +32,7 @@ object PlatformApplications {
   final case class Config private (
       ledgerId: LedgerIdMode,
       darFiles: List[Path],
-      parties: NonEmptyList[String],
+      parties: List[String],
       committerParty: String,
       timeProviderType: TimeProviderType,
       timeModel: TimeModel,
@@ -64,7 +64,7 @@ object PlatformApplications {
     def withUniqueCommandIdentifiers(uniqueIdentifiers: Boolean): Config =
       copy(uniqueCommandIdentifiers = uniqueIdentifiers)
 
-    def withParties(p1: String, rest: String*) = copy(parties = NonEmptyList(p1, rest: _*))
+    def withParties(p1: String, rest: String*) = copy(parties = p1 +: rest.toList)
 
     def withCommitterParty(committer: String) = copy(committerParty = committer)
 
@@ -99,7 +99,7 @@ object PlatformApplications {
   object Config {
     val defaultLedgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("ledger-server"))
     val defaultDarFile = new File(rlocation("ledger/sandbox/Test.dar"))
-    val defaultParties = NonEmptyList("party", "Alice", "Bob")
+    val defaultParties = TestParties.AllParties
     val defaultTimeProviderType = TimeProviderType.Static
 
     def default: Config = {

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -53,14 +53,14 @@ import scala.concurrent.duration._
 // format: off
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 abstract class CommandTransactionChecks
-    extends AsyncWordSpec
-        with AkkaBeforeAndAfterAll
-        with MultiLedgerFixture
-        with SuiteResourceManagementAroundEach
-        with ScalaFutures
-        with AsyncTimeLimitedTests
-        with Matchers
-        with OptionValues {
+  extends AsyncWordSpec
+    with AkkaBeforeAndAfterAll
+    with MultiLedgerFixture
+    with SuiteResourceManagementAroundEach
+    with ScalaFutures
+    with AsyncTimeLimitedTests
+    with Matchers
+    with OptionValues {
   protected def submitCommand(ctx: LedgerContext, req: SubmitRequest): Future[Completion]
 
   protected val testTemplateIds = new TestTemplateIds(config)
@@ -237,9 +237,9 @@ abstract class CommandTransactionChecks
         val commandId = "Huge-composite-command"
         val originalCommand = createCommandWithId(ctx, commandId)
         val targetNumberOfSubCommands = 15000 // That's around the maximum gRPC input size
-        val superSizedCommand =
-          originalCommand.update(_.commands.update(_.commands.modify(original =>
-            List.fill(targetNumberOfSubCommands)(original.head))))
+      val superSizedCommand =
+        originalCommand.update(_.commands.update(_.commands.modify(original =>
+          List.fill(targetNumberOfSubCommands)(original.head))))
         ctx.testingHelpers.submitAndListenForSingleResultOfCommand(superSizedCommand, getAllContracts) map {
           tx =>
             tx.events.size shouldEqual targetNumberOfSubCommands
@@ -561,26 +561,26 @@ abstract class CommandTransactionChecks
           // only compare the field values since the server currently does not return the
           // record identifier or labels when the request does not set verbose=true .
           create.getCreateArguments.fields.map(_.value) shouldEqual
-              createArguments.fields.map(_.value)
+            createArguments.fields.map(_.value)
           succeed
         }
       }
 
       "having many transactions all of them has a unique event id" in allFixtures { ctx =>
         val eventIdsF = ctx.transactionClient
-            .getTransactions(
-              (LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))),
-              Some(LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))),
-              getAllContracts
-            )
-            .map(_.events
-                .map(_.event)
-                .collect {
-                  case Archived(ArchivedEvent(eventId, _, _, _)) => eventId
-                  case Created(CreatedEvent(eventId, _, _, _, _, _, _, _, _)) => eventId
-                })
-            .takeWithin(5.seconds) //TODO: work around as ledger end is broken. see DEL-3151
-            .runWith(Sink.seq)
+          .getTransactions(
+            (LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))),
+            Some(LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))),
+            getAllContracts
+          )
+          .map(_.events
+            .map(_.event)
+            .collect {
+              case Archived(ArchivedEvent(eventId, _, _, _)) => eventId
+              case Created(CreatedEvent(eventId, _, _, _, _, _, _, _, _)) => eventId
+            })
+          .takeWithin(5.seconds) //TODO: work around as ledger end is broken. see DEL-3151
+          .runWith(Sink.seq)
 
         eventIdsF map { eventIds =>
           val eventIdList = eventIds.flatten
@@ -647,10 +647,10 @@ abstract class CommandTransactionChecks
         def textKeyRecord(p: String, k: String, disclosedTo: List[String]): Record =
           Record(
             fields =
-                List(
-                  RecordField(value = p.asParty),
-                  RecordField(value = s"$keyPrefix-$k".asText),
-                  RecordField(value = disclosedTo.map(_.asParty).asList)))
+              List(
+                RecordField(value = p.asParty),
+                RecordField(value = s"$keyPrefix-$k".asText),
+                RecordField(value = disclosedTo.map(_.asParty).asList)))
         val key = "some-key"
         val alice = "Alice"
         val bob = "Bob"
@@ -684,6 +684,7 @@ abstract class CommandTransactionChecks
               templateIds.textKeyOperations,
               Record(fields = List(RecordField(value = bob.asParty)))
             )
+
           // unauthorized lookups are not OK
           // both existing lookups...
           lookupNone = Value(Value.Sum.Optional(Optional(None)))
@@ -1007,9 +1008,9 @@ abstract class CommandTransactionChecks
   }
 
   private def findCreatedEventInResultOf(
-      ctx: LedgerContext,
-      cid: String,
-      templateToLookFor: Identifier): Future[CreatedEvent] = {
+                                          ctx: LedgerContext,
+                                          cid: String,
+                                          templateToLookFor: Identifier): Future[CreatedEvent] = {
     for {
       tx <- createContracts(ctx, cid)
     } yield {
@@ -1018,9 +1019,9 @@ abstract class CommandTransactionChecks
   }
 
   private def requestToCallExerciseWithId(
-      ctx: LedgerContext,
-      factoryContractId: String,
-      commandId: String) = {
+                                           ctx: LedgerContext,
+                                           factoryContractId: String,
+                                           commandId: String) = {
     ctx.testingHelpers.submitRequestWithId(commandId).update(
       _.commands.commands := List(
         ExerciseCommand(
@@ -1032,11 +1033,11 @@ abstract class CommandTransactionChecks
 
   // Create an instance of the 'Agreement' template.
   private def createAgreement(
-      ctx: LedgerContext,
-      commandId: String,
-      receiver: String,
-      giver: String
-  ): Future[CreatedEvent] = {
+                               ctx: LedgerContext,
+                               commandId: String,
+                               receiver: String,
+                               giver: String
+                             ): Future[CreatedEvent] = {
     val agreementFactoryArg = List(
       "receiver" -> receiver.asParty,
       "giver" -> giver.asParty
@@ -1062,10 +1063,10 @@ abstract class CommandTransactionChecks
   }
 
   private def mkTriProposalArg(
-      operator: String,
-      receiver: String,
-      giver: String
-  ): Record =
+                                operator: String,
+                                receiver: String,
+                                giver: String
+                              ): Record =
     Record(
       Some(templateIds.triProposal),
       Vector(
@@ -1078,9 +1079,9 @@ abstract class CommandTransactionChecks
     List("cid" -> Value(ContractId(contractId))).asRecordValue
 
   private def mkWithObserversArg(
-      giver: String,
-      observers: List[String]
-  ): Record =
+                                  giver: String,
+                                  observers: List[String]
+                                ): Record =
     Record(
       Some(templateIds.withObservers),
       Vector(
@@ -1090,9 +1091,9 @@ abstract class CommandTransactionChecks
 
 
   private def createParamShowcaseWith(
-      ctx: LedgerContext,
-      commandId: String,
-      createArguments: Record) = {
+                                       ctx: LedgerContext,
+                                       commandId: String,
+                                       createArguments: Record) = {
     val commandList = List(
       CreateCommand(Some(templateIds.parameterShowcase), Some(createArguments)).wrap)
     ctx.testingHelpers.submitRequestWithId(commandId).update(
@@ -1103,22 +1104,22 @@ abstract class CommandTransactionChecks
     Value(
       Value.Sum.Record(
         args
-            .update(_.fields.modify { originalFields =>
-              originalFields.collect {
-                // prune "operator" -- we do not have it in the choice params
-                case original if original.label != "operator" =>
-                  val newLabel = "new" + original.label.capitalize
-                  RecordField(newLabel, original.value)
-              }
-            })
-            .update(_.recordId.set(templateIds.parameterShowcaseChoice1))))
+          .update(_.fields.modify { originalFields =>
+            originalFields.collect {
+              // prune "operator" -- we do not have it in the choice params
+              case original if original.label != "operator" =>
+                val newLabel = "new" + original.label.capitalize
+                RecordField(newLabel, original.value)
+            }
+          })
+          .update(_.recordId.set(templateIds.parameterShowcaseChoice1))))
 
   private def verifyParamShowcaseChoice(
-      ctx: LedgerContext,
-      choice: String,
-      lbl: String,
-      exerciseArg: Value,
-      expectedCreateArg: Record): Future[Assertion] = {
+                                         ctx: LedgerContext,
+                                         choice: String,
+                                         lbl: String,
+                                         exerciseArg: Value,
+                                         expectedCreateArg: Record): Future[Assertion] = {
     val command: SubmitRequest =
       createParamShowcaseWith(
         ctx,
@@ -1180,13 +1181,13 @@ abstract class CommandTransactionChecks
 
   private def createAgreementFactory(ctx: LedgerContext, receiver: String, giver: String, commandId: String) = {
     ctx.testingHelpers.submitRequestWithId(commandId)
-        .update(
-          _.commands.commands := List(
-            Command(
-              create(
-                templateIds.agreementFactory,
-                List(receiver -> receiver.asParty, giver -> giver.asParty)))),
-          _.commands.party := giver
-        )
+      .update(
+        _.commands.commands := List(
+          Command(
+            create(
+              templateIds.agreementFactory,
+              List(receiver -> receiver.asParty, giver -> giver.asParty)))),
+        _.commands.party := giver
+      )
   }
 }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestUtils.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestUtils.scala
@@ -37,7 +37,13 @@ object LedgerOffsets {
 object TestParties {
   val Alice = "Alice"
   val Bob = "Bob"
+  val Charlie = "Charlie"
+  val Dan = "Dan"
   val Eve = "Eve"
+  val Frank = "Frank"
+  val Grace = "Grace"
+  val Heidi = "Heidi"
+  val Ivan = "Ivan"
 
-  val AllParties = List(Alice, Bob, Eve)
+  val AllParties = List(Alice, Bob, Charlie, Dan, Eve, Frank, Grace, Heidi, Ivan)
 }

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestUtils.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/TestUtils.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.apitesting
+
+import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
+import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.{
+  LEDGER_BEGIN,
+  LEDGER_END
+}
+import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
+import com.digitalasset.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  TransactionFilter
+}
+import com.digitalasset.ledger.api.v1.value.Identifier
+
+object TransactionFilters {
+
+  def empty = TransactionFilter()
+
+  def allForParties(parties: String*) =
+    TransactionFilter(parties.map(_ -> Filters()).toMap)
+
+  def templatesByParty(templatesByParty: (String, Seq[Identifier])*) =
+    TransactionFilter(
+      templatesByParty.toMap.mapValues(templateIds => Filters(Some(InclusiveFilters(templateIds)))))
+
+}
+
+object LedgerOffsets {
+  val LedgerBegin = LedgerOffset(Boundary(LEDGER_BEGIN))
+  val LedgerEnd = LedgerOffset(Boundary(LEDGER_END))
+}
+
+object TestParties {
+  val Alice = "Alice"
+  val Bob = "Bob"
+  val Eve = "Eve"
+
+  val AllParties = List(Alice, Bob, Eve)
+}

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerTestingHelpers.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/LedgerTestingHelpers.scala
@@ -369,12 +369,8 @@ class LedgerTestingHelpers(
   ): Future[CreatedEvent] = {
     for {
       tx <- submitAndListenForSingleResultOfCommand(
-        submitRequestWithId(commandId)
-          .update(
-            _.commands.commands :=
-              List(CreateCommand(Some(template), Some(arg)).wrap),
-            _.commands.party := submitter
-          ),
+        submitRequestWithId(commandId, submitter)
+          .update(_.commands.commands := List(CreateCommand(Some(template), Some(arg)).wrap)),
         TransactionFilter(Map(listener -> Filters.defaultInstance))
       )
     } yield {
@@ -400,11 +396,10 @@ class LedgerTestingHelpers(
       pattern: String
   ): Future[Assertion] =
     assertCommandFailsWithCode(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(CreateCommand(Some(template), Some(arg)).wrap),
-          _.commands.party := submitter
+            List(CreateCommand(Some(template), Some(arg)).wrap)
         ),
       code,
       pattern
@@ -421,11 +416,10 @@ class LedgerTestingHelpers(
       arg: Value
   ): Future[TransactionTree] = {
     submitAndListenForSingleTreeResultOfCommand(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap),
-          _.commands.party := submitter
+            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap)
         ),
       TransactionFilter(Map(listener -> Filters.defaultInstance)),
       false
@@ -443,11 +437,10 @@ class LedgerTestingHelpers(
       arg: Value
   ): Future[TransactionTree] = {
     submitAndListenForSingleTreeResultOfCommand(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(ExerciseByKeyCommand(Some(template), Some(contractKey), choice, Some(arg)).wrap),
-          _.commands.party := submitter
+            List(ExerciseByKeyCommand(Some(template), Some(contractKey), choice, Some(arg)).wrap)
         ),
       TransactionFilter(Map(listener -> Filters.defaultInstance)),
       false
@@ -463,11 +456,10 @@ class LedgerTestingHelpers(
   ): Future[CreatedEvent] = {
     for {
       tx <- submitAndListenForSingleResultOfCommand(
-        submitRequestWithId(commandId)
+        submitRequestWithId(commandId, submitter)
           .update(
             _.commands.commands :=
-              List(CreateCommand(Some(template), Some(arg)).wrap),
-            _.commands.party := submitter
+              List(CreateCommand(Some(template), Some(arg)).wrap)
           ),
         TransactionFilter(Map(listener -> Filters.defaultInstance))
       )
@@ -525,11 +517,10 @@ class LedgerTestingHelpers(
       arg: Value
   ): Future[Seq[Transaction]] = {
     submitAndListenForTransactionResultOfCommand(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap),
-          _.commands.party := submitter
+            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap)
         ),
       TransactionFilter(Map(listener -> Filters.defaultInstance)),
       false
@@ -574,9 +565,11 @@ class LedgerTestingHelpers(
     }
   }
 
-  def submitRequestWithId(commandId: String): SubmitRequest =
+  def submitRequestWithId(commandId: String, submitter: String): SubmitRequest =
     M.submitRequest.update(
-      _.commands.modify(_.copy(commandId = commandId, ledgerId = context.ledgerId.unwrap)))
+      _.commands.party := submitter,
+      _.commands.commandId := commandId,
+      _.commands.ledgerId := context.ledgerId.unwrap)
 
   // Exercise a choice and return all resulting create events.
   def simpleExercise(
@@ -618,11 +611,10 @@ class LedgerTestingHelpers(
       pattern: String
   ): Future[Assertion] =
     assertCommandFailsWithCode(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap),
-          _.commands.party := submitter
+            List(ExerciseCommand(Some(template), contractId, choice, Some(arg)).wrap)
         ),
       code,
       pattern
@@ -640,11 +632,10 @@ class LedgerTestingHelpers(
       pattern: String
   ): Future[Assertion] =
     assertCommandFailsWithCode(
-      submitRequestWithId(commandId)
+      submitRequestWithId(commandId, submitter)
         .update(
           _.commands.commands :=
-            List(ExerciseByKeyCommand(Some(template), contractKey, choice, Some(arg)).wrap),
-          _.commands.party := submitter
+            List(ExerciseByKeyCommand(Some(template), contractKey, choice, Some(arg)).wrap)
         ),
       code,
       pattern

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/ParameterShowcaseTesting.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/ParameterShowcaseTesting.scala
@@ -14,6 +14,7 @@ import com.digitalasset.ledger.api.v1.value.{
 }
 import com.digitalasset.platform.participant.util.ValueConversions._
 
+import com.digitalasset.platform.apitesting.TestParties.Alice
 trait ParameterShowcaseTesting {
 
   protected val integerListRecordLabel = "integerList"
@@ -31,7 +32,7 @@ trait ParameterShowcaseTesting {
     val integerList = Vector(1, 2).map(_.toLong.asInt64).asList
     val optionalText = Optional(Value(Text("foo")))
     Vector(
-      RecordField("operator", "party".asParty),
+      RecordField("operator", Alice.asParty),
       RecordField("integer", 1.asInt64),
       RecordField("decimal", "1.1".asDecimal),
       RecordField("text", Value(Text("text"))),
@@ -49,7 +50,7 @@ trait ParameterShowcaseTesting {
     val integerList = Vector(1, 2).map(_.toLong.asInt64).asList
     val optionalText = Optional(Value(Text("foo")))
     Vector(
-      RecordField("", "party".asParty),
+      RecordField("", Alice.asParty),
       RecordField("", 1.asInt64),
       RecordField("", "1.1".asDecimal),
       RecordField("", Value(Text("text"))),

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceHelpers.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/tests/integration/ledger/api/TransactionServiceHelpers.scala
@@ -20,11 +20,13 @@ import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand}
 import com.digitalasset.ledger.api.v1.value.Value.Sum
 import com.digitalasset.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
 import com.digitalasset.platform.PlatformApplications
+import com.digitalasset.platform.apitesting.TestParties
 import org.scalatest.Matchers
 import scalaz.syntax.tag._
 
 import scala.concurrent.Future
 
+//TODO: move all the necessary logic from here into TestUtils
 class TransactionServiceHelpers(config: PlatformApplications.Config) extends Matchers {
   lazy val defaultDar: File = config.darFiles.head.toFile
 
@@ -50,6 +52,7 @@ class TransactionServiceHelpers(config: PlatformApplications.Config) extends Mat
 
   def submitAndWaitRequestWithId(id: String, command: Command, ledgerId: domain.LedgerId) =
     submitAndWaitRequest
+      .update(_.commands.party := TestParties.Alice)
       .update(_.commands.commandId := id)
       .update(_.commands.commands := Seq(command))
       .update(_.commands.ledgerId := ledgerId.unwrap)
@@ -60,7 +63,7 @@ class TransactionServiceHelpers(config: PlatformApplications.Config) extends Mat
       prefix: String,
       i: Int,
       ledgerId: domain.LedgerId,
-      party: String = "party")(implicit materializer: Materializer): Future[Done] = {
+      party: String = TestParties.Alice)(implicit materializer: Materializer): Future[Done] = {
     val arg =
       Record(Some(dummyTemplate), Vector(RecordField("operator", Some(Value(Sum.Party(party))))))
     val command = Create(CreateCommand(Some(dummyTemplate), Some(arg)))


### PR DESCRIPTION
contributes to #1746 

Centralises testing utilities around:
- transaction filters
- offsets
- parties

Note that TransactionServiceIT is the test bed of the changes, the rest of the test will be ported only after that. 


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
