### PR TITLE
daml-lf: fix lf decoder

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -394,6 +394,7 @@ private[archive] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPa
             decodeExpr(varCon.getVariantArg))
 
         case PLF.Expr.SumCase.ENUM_CON =>
+          assertSince("dev", "Expr.SumCase.ENUM_CON")
           val enumCon = lfExpr.getEnumCon
           EEnumCon(
             decodeTypeConName(enumCon.getTycon),
@@ -501,6 +502,7 @@ private[archive] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPa
             name(variant.getVariant),
             name(variant.getBinder))
         case PLF.CaseAlt.SumCase.ENUM =>
+          assertSince("dev", "CaseAlt.Enum")
           val enum = lfCaseAlt.getEnum
           CPEnum(decodeTypeConName(enum.getCon), name(enum.getConstructor))
         case PLF.CaseAlt.SumCase.PRIM_CON =>


### PR DESCRIPTION
This PR fixes the dam-lf decoder that currently do not check the daml-lf version for `enum` type litterals and `enum` type pattern matching. This was forgotten in #1397 and #1506. See #105 for more details about `enum` types. 

We do not consider this bug fix as breaking since  the version check for enum definition was in place (see [DecodeV1.scala#L115](https://github.com/digital-asset/daml/blob/19b2d5c86c3d434c54c1ce29c8fb2bb6f80eabcc/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala#L115)). In other word, it was not possible to create an LF program with `enum` that properly typechecks. 


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
