### PR TITLE
Refactor damldocs -- turn types into newtypes

### DIFF
--- a/daml-foundations/daml-ghc/damldoc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/damldoc/BUILD.bazel
@@ -4,8 +4,8 @@
 load(
     "//bazel_tools:haskell.bzl",
     "da_haskell_library",
-    "da_haskell_test",
     "da_haskell_repl",
+    "da_haskell_test",
 )
 
 da_haskell_library(

--- a/daml-foundations/daml-ghc/damldoc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/damldoc/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "//bazel_tools:haskell.bzl",
     "da_haskell_library",
     "da_haskell_test",
+    "da_haskell_repl",
 )
 
 da_haskell_library(
@@ -63,5 +64,14 @@ da_haskell_library(
         "//daml-foundations/daml-ghc/test-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+    ],
+)
+
+da_haskell_repl(
+    name = "repl",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":damldoc",
+        ":damldoc-testing",
     ],
 )

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
@@ -29,7 +29,7 @@ applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
 
         -- Bring Prelude module to the front.
         modulePriorityKey :: Modulename -> (Int,Modulename)
-        modulePriorityKey m = (if m == "Prelude" then 0 else 1, m)
+        modulePriorityKey m = (if unModulename m == "Prelude" then 0 else 1, m)
 
 applyHide :: [ModuleDoc] -> [ModuleDoc]
 applyHide = concatMap onModule
@@ -58,12 +58,12 @@ applyHide = concatMap onModule
 
 
 getAnn :: Maybe Markdown -> [T.Text]
-getAnn = maybe [] T.words
+getAnn = maybe [] (T.words . unMarkdown)
 
 isHide :: Maybe Markdown -> Bool
 isHide x = ["HIDE"] `isPrefixOf` getAnn x
 
-isMove :: Maybe Markdown -> Maybe T.Text
+isMove :: Maybe Markdown -> Maybe Modulename
 isMove x = case getAnn x of
-    "MOVE":y:_ -> Just y
+    "MOVE":y:_ -> Just (Modulename y)
     _ -> Nothing

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
@@ -57,13 +57,13 @@ applyHide = concatMap onModule
             | otherwise = [x]
 
 
-getAnn :: Maybe Markdown -> [T.Text]
-getAnn = maybe [] (T.words . unMarkdown)
+getAnn :: Maybe DocText -> [T.Text]
+getAnn = maybe [] (T.words . unDocText)
 
-isHide :: Maybe Markdown -> Bool
+isHide :: Maybe DocText -> Bool
 isHide x = ["HIDE"] `isPrefixOf` getAnn x
 
-isMove :: Maybe Markdown -> Maybe Modulename
+isMove :: Maybe DocText -> Maybe Modulename
 isMove x = case getAnn x of
     "MOVE":y:_ -> Just (Modulename y)
     _ -> Nothing

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Annotate.hs
@@ -29,7 +29,7 @@ applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
 
         -- Bring Prelude module to the front.
         modulePriorityKey :: Modulename -> (Int,Modulename)
-        modulePriorityKey m = (if unModulename m == "Prelude" then 0 else 1, m)
+        modulePriorityKey m = (if m == "Prelude" then 0 else 1, m)
 
 applyHide :: [ModuleDoc] -> [ModuleDoc]
 applyHide = concatMap onModule

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -9,7 +9,7 @@ module DA.Daml.GHC.Damldoc.Driver(
     , DocOption(..)
     ) where
 
-import           DA.Daml.GHC.Damldoc.Types
+import           DA.Daml.GHC.Damldoc.Types hiding (Markdown (..))
 import           DA.Daml.GHC.Damldoc.Render
 import           DA.Daml.GHC.Damldoc.HaddockParse
 import           DA.Daml.GHC.Damldoc.Transform
@@ -75,7 +75,7 @@ damlDocDriver cInputFormat output cFormat prefixFile options files = do
             Hoogle   -> write output $ T.concat $ map renderSimpleHoogle docData
             Markdown -> write output $ T.concat $ map renderSimpleMD docData
             Html -> sequence_
-                [ write (output </> hyphenated md_name <> ".html") $ renderSimpleHtml m
+                [ write (output </> hyphenated (unModulename md_name) <> ".html") $ renderSimpleHtml m
                 | m@ModuleDoc{..} <- docData ]
                     where hyphenated = T.unpack . T.replace "." "-"
     putStrLn "Done"

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Driver.hs
@@ -9,7 +9,7 @@ module DA.Daml.GHC.Damldoc.Driver(
     , DocOption(..)
     ) where
 
-import           DA.Daml.GHC.Damldoc.Types hiding (Markdown (..))
+import           DA.Daml.GHC.Damldoc.Types
 import           DA.Daml.GHC.Damldoc.Render
 import           DA.Daml.GHC.Damldoc.HaddockParse
 import           DA.Daml.GHC.Damldoc.Transform

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -54,8 +54,8 @@ mkDocs opts fp = do
           allChoices = Set.unions $ MS.elems choiceMap
           adtDocs = MS.elems (typeMap `MS.withoutKeys` tmpls `MS.withoutKeys` allChoices)
       in ModuleDoc
-           { md_name = T.pack . moduleNameString . moduleName . ms_mod . pm_mod_summary $ m
-           , md_descr = fmap docToText (modDoc m)
+           { md_name = Modulename . T.pack . moduleNameString . moduleName . ms_mod . pm_mod_summary $ m
+           , md_descr = fmap (Markdown . docToText) (modDoc m)
            , md_adts = adtDocs
            , md_templates = tmplDocs
            , md_functions = fctDocs
@@ -142,6 +142,12 @@ pairDeclDocs ParsedModule{..} = collectDocs (hsmodDecls . unLoc $ pm_parsed_sour
 
 ------------------------------------------------------------
 
+toMarkdown :: [T.Text] -> Maybe Markdown
+toMarkdown docs =
+    if null docs
+        then Nothing
+        else Just . Markdown . T.strip . T.unlines $ docs
+
 -- | Extracts the documentation of a function. Comments are either
 --   adjacent to a type signature, or to the actual function definition. If
 --   neither a comment nor a function type is in the source, we omit the
@@ -161,18 +167,17 @@ getFctDocs (decl, docs) = do
     _ ->
       Nothing
   Just $ FunctionDoc
-    { fct_name = idpToText name
+    { fct_name = Fieldname (idpToText name)
     , fct_context = hsTypeToContext =<< mbType
     , fct_type = fmap hsTypeToType mbType
-    , fct_descr = if null docs then Nothing
-                  else Just . T.strip $ T.unlines docs
+    , fct_descr = toMarkdown docs
     }
 
 getClsDocs :: (HsDecl GhcPs, [T.Text]) ->
                Maybe ClassDoc
 getClsDocs (TyClD _ c@ClassDecl{..}, docs) = Just ClassDoc
-      {cl_name = idpToText $ unLoc tcdLName
-      ,cl_descr = if null docs then Nothing else Just $ T.strip $ T.unlines docs
+      {cl_name = Typename . idpToText $ unLoc tcdLName
+      ,cl_descr = toMarkdown docs
       ,cl_super = case unLoc tcdCtxt of
         [] -> Nothing
         xs -> Just $ TypeTuple $ map hsTypeToType xs
@@ -201,9 +206,8 @@ getTypeDocs (TyClD _ decl, descrs)
   | SynDecl{..} <- decl =
       let name = idpToText $ unLoc tcdLName
       in Just . (unLoc tcdLName,) $ TypeSynDoc
-         { ad_name = name
-         , ad_descr = if null descrs then Nothing
-                      else Just . T.strip $ T.unlines descrs
+         { ad_name = Typename name
+         , ad_descr = toMarkdown descrs
          , ad_args = map (tyVarText . unLoc) $ hsq_explicit tcdTyVars
          , ad_rhs  = hsTypeToType tcdRhs
          }
@@ -211,10 +215,9 @@ getTypeDocs (TyClD _ decl, descrs)
   | DataDecl{..} <- decl =
       let name = idpToText $ unLoc tcdLName
       in Just . (unLoc tcdLName,) $ ADTDoc
-         { ad_name = name
+         { ad_name =  Typename name
          , ad_args   = map (tyVarText . unLoc) $ hsq_explicit tcdTyVars
-         , ad_descr  = if null descrs then Nothing
-                       else Just . T.strip $ T.unlines descrs
+         , ad_descr  = toMarkdown descrs
          , ad_constrs = map constrDoc . dd_cons $ tcdDataDefn
          }
   where
@@ -222,27 +225,27 @@ getTypeDocs (TyClD _ decl, descrs)
     constrDoc (L _ con) =
           case con_args con of
             PrefixCon args ->
-              PrefixC { ac_name = idpToText . unLoc $ con_name con
-                      , ac_descr = fmap (docToText . unLoc) $ con_doc con
+              PrefixC { ac_name = Typename . idpToText . unLoc $ con_name con
+                      , ac_descr = fmap (Markdown . docToText . unLoc) $ con_doc con
                       , ac_args = map hsTypeToType args
                       }
             InfixCon l r ->
-              PrefixC { ac_name = idpToText . unLoc $ con_name con
-                      , ac_descr = fmap (docToText . unLoc) $ con_doc con
+              PrefixC { ac_name = Typename . idpToText . unLoc $ con_name con
+                      , ac_descr = fmap (Markdown . docToText . unLoc) $ con_doc con
                       , ac_args = map hsTypeToType [l, r]
                       }
             RecCon (L _ fs) ->
-              RecordC { ac_name  = idpToText . unLoc $ con_name con
-                      , ac_descr = fmap (docToText . unLoc) $ con_doc con
+              RecordC { ac_name  = Typename. idpToText . unLoc $ con_name con
+                      , ac_descr = fmap (Markdown . docToText . unLoc) $ con_doc con
                       , ac_fields = mapMaybe (fieldDoc . unLoc) fs
                       }
 
     fieldDoc :: ConDeclField GhcPs -> Maybe FieldDoc
     fieldDoc ConDeclField{..} =
       Just $ FieldDoc
-      { fd_name = T.concat . map (toText . unLoc) $ cd_fld_names -- FIXME why more than one?
+      { fd_name = Fieldname . T.concat . map (toText . unLoc) $ cd_fld_names -- FIXME why more than one?
       , fd_type = hsTypeToType cd_fld_type
-      , fd_descr = fmap (docToText . unLoc) cd_fld_doc
+      , fd_descr = fmap (Markdown . docToText . unLoc) cd_fld_doc
       }
     fieldDoc XConDeclField{}  = Nothing
 getTypeDocs _other = Nothing
@@ -279,7 +282,7 @@ getTemplateDocs typeMap templates choiceMap = map mkTemplateDoc $ Set.toList tem
     -- returns a dummy ADT if the choice argument is not in the local type map
     -- (possible if choice instances are defined directly outside the template).
     -- This wouldn't be necessary if we used the type-checked AST.
-      where dummyDT = ADTDoc { ad_name    = "External:" <> idpToText n
+      where dummyDT = ADTDoc { ad_name    = Typename $ "External:" <> idpToText n
                              , ad_descr   = Nothing
                              , ad_args = []
                              , ad_constrs = []
@@ -419,13 +422,13 @@ hsTypeToType_ t = case t of
   HsTupleTy _ _con tys -> TypeTuple $ map hsTypeToType tys
 
   -- GHC specials. FIXME deal with them specially
-  HsRecTy _ _flds -> TypeApp (toText t) [] -- FIXME pprConDeclFields flds
+  HsRecTy _ _flds -> TypeApp (Typename $ toText t) [] -- FIXME pprConDeclFields flds
 
   HsSumTy _ _tys -> undefined -- FIXME tupleParens UnboxedTuple (pprWithBars ppr tys)
 
 
   -- straightforward base case
-  HsTyVar _ _ (L _ name) -> TypeApp (idpToText name) []
+  HsTyVar _ _ (L _ name) -> TypeApp (Typename $ idpToText name) []
 
   HsFunTy _ ty1 ty2 -> case hsTypeToType ty2 of
     TypeFun as -> TypeFun $ hsTypeToType ty1 : as
@@ -441,10 +444,10 @@ hsTypeToType_ t = case t of
   HsExplicitListTy _ _ _tys ->  unexpected "explicit list"
   HsExplicitTupleTy _ _tys  -> unexpected "explicit tuple"
 
-  HsTyLit _ ty      -> TypeApp (toText ty) []
+  HsTyLit _ ty      -> TypeApp (Typename $ toText ty) []
   -- kind things. Can be printed, not sure why we would
-  HsWildCardTy {}   -> TypeApp "_" []
-  HsStarTy _ _      -> TypeApp "*" []
+  HsWildCardTy {}   -> TypeApp (Typename "_") []
+  HsStarTy _ _      -> TypeApp (Typename "*") []
 
   HsAppTy _ fun_ty arg_ty ->
     case hsTypeToType fun_ty of
@@ -456,7 +459,7 @@ hsTypeToType_ t = case t of
   HsAppKindTy _ _ _ -> unexpected "kind application"
 
   HsOpTy _ ty1 (L _ op) ty2 ->
-    TypeApp (toText op) [ hsTypeToType ty1, hsTypeToType ty2 ]
+    TypeApp (Typename $ toText op) [ hsTypeToType ty1, hsTypeToType ty2 ]
 
   HsParTy _ ty  -> hsTypeToType ty
 

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render.hs
@@ -41,7 +41,7 @@ data DocFormat = Json | Rst | Markdown | Html | Hoogle
 renderSimpleHtml :: ModuleDoc -> T.Text
 renderSimpleHtml m@ModuleDoc{..} =
   wrapHtml t $ GFM.commonmarkToHtml [] [GFM.extTable] $ renderSimpleMD m
-  where t = "Module " <> md_name
+  where t = "Module " <> unModulename md_name
 
 wrapHtml :: T.Text -> T.Text -> T.Text
 wrapHtml pageTitle body =

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Anchor.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Anchor.hs
@@ -28,10 +28,10 @@ type Anchor = T.Text
 
 moduleAnchor :: Modulename -> Anchor
 -- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
-moduleAnchor m = T.intercalate "-" ["module", convertModulename m, hashText $ T.unpack m]
+moduleAnchor m = T.intercalate "-" ["module", convertModulename m, hashText . T.unpack . unModulename $ m]
 
 convertModulename :: Modulename -> T.Text
-convertModulename = T.toLower . T.replace "." "-" . T.replace "_" ""
+convertModulename = T.toLower . T.replace "." "-" . T.replace "_" "" . unModulename
 
 classAnchor    :: Modulename -> Typename  -> Anchor
 templateAnchor :: Modulename -> Typename  -> Anchor
@@ -40,17 +40,17 @@ dataAnchor     :: Modulename -> Typename  -> Anchor
 constrAnchor   :: Modulename -> Typename  -> Anchor
 functionAnchor :: Modulename -> Fieldname -> Maybe Type -> Anchor
 
-classAnchor    m n = anchor "class"    m n ()
-templateAnchor m n = anchor "template" m n ()
-typeAnchor     m n = anchor "type"     m n ()
-dataAnchor     m n = anchor "data"     m n ()
-constrAnchor   m n = anchor "constr"   m n ()
-functionAnchor     = anchor "function"
+classAnchor    m n = anchor "class"    m (unTypename n) ()
+templateAnchor m n = anchor "template" m (unTypename n) ()
+typeAnchor     m n = anchor "type"     m (unTypename n) ()
+dataAnchor     m n = anchor "data"     m (unTypename n) ()
+constrAnchor   m n = anchor "constr"   m (unTypename n) ()
+functionAnchor m n = anchor "function" m (unFieldname n)
 
 
 anchor :: Hashable v => T.Text -> Modulename -> T.Text -> v -> Anchor
 -- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
-anchor k m n v = T.intercalate "-" [k, convertModulename m, expandOps n, hashText (T.unpack k, T.unpack m, T.unpack n, v)]
+anchor k m n v = T.intercalate "-" [k, convertModulename m, expandOps n, hashText (T.unpack k, T.unpack (unModulename m), T.unpack n, v)]
   where
     expandOps :: T.Text -> T.Text
     expandOps = T.pack . replaceEmpty . concatMap expandOp . T.unpack

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Hoogle.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Hoogle.hs
@@ -9,6 +9,7 @@ module DA.Daml.GHC.Damldoc.Render.Hoogle
 
 import DA.Daml.GHC.Damldoc.Types
 import DA.Daml.GHC.Damldoc.Render.Anchor
+import DA.Daml.GHC.Damldoc.Render.Util
 
 import           Data.Maybe
 import qualified Data.Text as T
@@ -17,7 +18,7 @@ import qualified Data.Text as T
 hooglify :: Maybe Markdown -> [T.Text]
 hooglify Nothing = []
 hooglify (Just md) =
-    case T.lines md of
+    case T.lines (unMarkdown md) of
         [] -> []
         (x:xs) -> ("-- | " <>  x)
             : map ("--   " <>) xs
@@ -32,7 +33,7 @@ renderSimpleHoogle ModuleDoc{..}
 renderSimpleHoogle ModuleDoc{..} = T.unlines . concat $
   [ hooglify md_descr
   , [ urlTag (moduleAnchor md_name)
-    , "module " <> md_name
+    , "module " <> unModulename md_name
     , "" ]
   -- , concatMap tmpl2hoogle md_templates    -- just ignore templates
   , concatMap (adt2hoogle md_name) md_adts
@@ -44,13 +45,14 @@ adt2hoogle :: Modulename -> ADTDoc -> [T.Text]
 adt2hoogle md_name TypeSynDoc{..} = concat
     [ hooglify ad_descr
     , [ urlTag (typeAnchor md_name ad_name)
-      , T.unwords ("type" : wrapOp ad_name : ad_args ++ ["=", type2hoogle ad_rhs])
+      , T.unwords ("type" : wrapOp (unTypename ad_name) :
+          ad_args ++ ["=", type2hoogle ad_rhs])
       , "" ]
     ]
 adt2hoogle md_name ADTDoc{..} = concat
     [ hooglify ad_descr
     , [ urlTag (dataAnchor md_name ad_name)
-      , T.unwords ("data" : wrapOp ad_name : ad_args)
+      , T.unwords ("data" : wrapOp (unTypename ad_name) : ad_args)
       , "" ]
     , concatMap (adtConstr2hoogle md_name ad_name) ad_constrs
     ]
@@ -60,7 +62,7 @@ adtConstr2hoogle md_name typename PrefixC{..} = concat
     [ hooglify ac_descr
     , [ urlTag (constrAnchor md_name ac_name)
       , T.unwords
-            [ wrapOp ac_name
+            [ wrapOp (unTypename ac_name)
             , "::"
             , type2hoogle $ TypeFun (ac_args ++ [TypeApp typename []])
             ]
@@ -70,7 +72,7 @@ adtConstr2hoogle md_name typename RecordC{..} = concat
     [ hooglify ac_descr
     , [ urlTag (constrAnchor md_name ac_name)
       , T.unwords
-            [ wrapOp ac_name
+            [ wrapOp (unTypename ac_name)
             , "::"
             , type2hoogle $ TypeFun
                 (map fd_type ac_fields ++ [TypeApp typename []])
@@ -83,9 +85,9 @@ fieldDoc2hoogle :: Typename -> FieldDoc -> [T.Text]
 fieldDoc2hoogle typename FieldDoc{..} = concat
     [ hooglify fd_descr
     , [ T.unwords
-            [ "[" <> wrapOp fd_name <> "]"
+            [ "[" <> wrapOp (unFieldname fd_name) <> "]"
             , "::"
-            , wrapOp typename
+            , wrapOp (unTypename typename)
             , "->"
             , type2hoogle fd_type
             ]
@@ -99,7 +101,7 @@ cls2hoogle md_name ClassDoc{..} = concat
     , [ urlTag (classAnchor md_name cl_name)
       , T.unwords $ ["class"]
                  ++ maybe [] ((:["=>"]) . type2hoogle) cl_super
-                 ++ wrapOp cl_name : cl_args
+                 ++ wrapOp (unTypename cl_name) : cl_args
       , "" ]
     , concatMap (fct2hoogle md_name . addToContext) cl_functions
     ]
@@ -114,29 +116,17 @@ cls2hoogle md_name ClassDoc{..} = concat
         Just ctx -> Just (TypeTuple [contextTy, ctx])
 
     contextTy :: Type
-    contextTy = TypeApp cl_name [TypeApp arg [] | arg <- cl_args]
+    contextTy = TypeApp cl_name [TypeApp (Typename arg) [] | arg <- cl_args]
 
 fct2hoogle :: Modulename -> FunctionDoc -> [T.Text]
 fct2hoogle md_name FunctionDoc{..} = concat
     [ hooglify fct_descr
     , [ urlTag (functionAnchor md_name fct_name fct_type)
-      , T.unwords $ [wrapOp fct_name, "::"]
+      , T.unwords $ [wrapOp (unFieldname fct_name), "::"]
                  ++ maybe [] ((:["=>"]) . type2hoogle) fct_context
                  ++ maybe ["_"] ((:[]) . type2hoogle) fct_type -- FIXME(FM): what to do when missing type?
       , "" ]
     ]
-
--- | If name is an operator, wrap it.
-wrapOp :: T.Text -> T.Text
-wrapOp t =
-    if T.null t || isIdChar (T.head t)
-        then t
-        else codeParens t
-  where
-    isIdChar :: Char -> Bool
-    isIdChar c = ('A' <= c && c <= 'Z')
-              || ('a' <= c && c <= 'z')
-              || ('_' == c)
 
 -- | Render a type. Nested types are put in parentheses where appropriate.
 type2hoogle :: Type -> T.Text
@@ -147,14 +137,11 @@ type2hoogle = t2hg id id
 -- type applications with one or more arguments.
 t2hg :: (T.Text -> T.Text) -> (T.Text -> T.Text) -> Type -> T.Text
 t2hg f _ (TypeFun ts) = f $
-    T.intercalate " -> " $ map (t2hg codeParens id) ts
+    T.intercalate " -> " $ map (t2hg inParens id) ts
 t2hg _ _ (TypeList t1) =
     "[" <> t2hg id id t1 <> "]"
 t2hg _ _ (TypeTuple ts) =
     "(" <> T.intercalate ", " (map (t2hg id id) ts) <> ")"
-t2hg _ _ (TypeApp n []) = n
+t2hg _ _ (TypeApp n []) = unTypename n
 t2hg _ f (TypeApp name args) = f $
-    T.unwords (wrapOp name : map (t2hg codeParens codeParens) args)
-
-codeParens :: T.Text -> T.Text
-codeParens s = "(" <> s <> ")"
+    T.unwords (wrapOp (unTypename name) : map (t2hg inParens inParens) args)

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Hoogle.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Hoogle.hs
@@ -15,10 +15,10 @@ import           Data.Maybe
 import qualified Data.Text as T
 
 -- | Convert a markdown comment into hoogle text.
-hooglify :: Maybe Markdown -> [T.Text]
+hooglify :: Maybe DocText -> [T.Text]
 hooglify Nothing = []
 hooglify (Just md) =
-    case T.lines (unMarkdown md) of
+    case T.lines (unDocText md) of
         [] -> []
         (x:xs) -> ("-- | " <>  x)
             : map ("--   " <>) xs

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Markdown.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Markdown.hs
@@ -22,7 +22,7 @@ renderSimpleMD ModuleDoc{..}
 renderSimpleMD ModuleDoc{..} = T.unlines $
   [ "# " <> "Module " <> unModulename md_name
   , ""
-  , maybe "" unMarkdown md_descr
+  , maybe "" unDocText md_descr
   , "" ]
   <> concat
   [ if null md_templates then []
@@ -53,7 +53,7 @@ renderSimpleMD ModuleDoc{..} = T.unlines $
 tmpl2md :: TemplateDoc -> T.Text
 tmpl2md TemplateDoc{..} = T.unlines $
     [ "### Template " <> asCode (unTypename td_name)
-    , maybe "" (T.cons '\n' . unMarkdown) td_descr
+    , maybe "" (T.cons '\n' . unDocText) td_descr
     , ""
     , fieldTable td_payload
     , ""
@@ -65,7 +65,7 @@ tmpl2md TemplateDoc{..} = T.unlines $
     choiceBullet :: ChoiceDoc -> T.Text
     choiceBullet ChoiceDoc{..} = T.unlines
         [ prefix "* " $ asCode (unTypename cd_name)
-        , maybe "  " (flip T.snoc '\n' . indent 2 . unMarkdown) cd_descr
+        , maybe "  " (flip T.snoc '\n' . indent 2 . unDocText) cd_descr
         , indent 2 (fieldTable cd_fields)
         ]
 
@@ -75,7 +75,7 @@ cls2md ClassDoc{..} = T.unlines $
         <> maybe "" (\x -> type2md x <> " => ") cl_super
         <> T.unwords (unTypename cl_name : cl_args)
         <> " where"
-    , maybe "" (T.cons '\n' . indent 2 . unMarkdown) cl_descr
+    , maybe "" (T.cons '\n' . indent 2 . unDocText) cl_descr
     ] ++ map (indent 2 . fct2md) cl_functions
 
 adt2md :: ADTDoc -> T.Text
@@ -83,21 +83,21 @@ adt2md TypeSynDoc{..} = T.unlines $
     [ "### `type` "
         <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
     , "    = " <> type2md ad_rhs
-    ] ++ maybe [] ((:[]) . T.cons '\n' . indent 2 . unMarkdown) ad_descr
+    ] ++ maybe [] ((:[]) . T.cons '\n' . indent 2 . unDocText) ad_descr
 
 adt2md ADTDoc{..} = T.unlines $
     [ "### `data` "
         <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
-    , maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ad_descr
+    , maybe T.empty (T.cons '\n' . indent 2 . unDocText) ad_descr
     ] ++ map constrMdItem ad_constrs
 
 constrMdItem :: ADTConstr -> T.Text
 constrMdItem PrefixC{..} =
   ("* " <> T.unwords (asCode (unTypename ac_name) : map type2md ac_args))
-  <> maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ac_descr
+  <> maybe T.empty (T.cons '\n' . indent 2 . unDocText) ac_descr
 constrMdItem RecordC{..} =
   ("* " <> asCode (unTypename ac_name))
-  <> maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ac_descr
+  <> maybe T.empty (T.cons '\n' . indent 2 . unDocText) ac_descr
   <> "\n\n"
   <> indent 2 (fieldTable ac_fields)
 
@@ -123,7 +123,7 @@ fieldTable fds = header <> fieldRows <> "\n"
     fieldRows = T.unlines
       [ "| " <> adjust fLen (asCode (unFieldname fd_name))
         <> " | " <> type2md fd_type <> " |"
-        <> maybe "" (\desc -> "\n" <> col1Empty <> removeLineBreaks (unMarkdown desc) <> " |") fd_descr
+        <> maybe "" (\desc -> "\n" <> col1Empty <> removeLineBreaks (unDocText desc) <> " |") fd_descr
       | FieldDoc{..} <- fds ]
 
     -- Markdown does not support multi-row cells so we have to remove
@@ -151,7 +151,7 @@ type2md t = t2md id t
 fct2md :: FunctionDoc -> T.Text
 fct2md FunctionDoc{..} =
   "* " <> asCode (unFieldname fct_name) <> maybe "" ((" : " <>) . type2md) fct_type
-  <> maybe "" (("  \n" <>) . indent 2 . unMarkdown) fct_descr
+  <> maybe "" (("  \n" <>) . indent 2 . unDocText) fct_descr
   --             ^^ NB trailing whitespace to cause a line break
 
 ------------------------------------------------------------

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Markdown.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Markdown.hs
@@ -20,9 +20,9 @@ renderSimpleMD ModuleDoc{..}
     null md_adts && null md_functions &&
     isNothing md_descr = T.empty
 renderSimpleMD ModuleDoc{..} = T.unlines $
-  [ "# " <> "Module " <> md_name
+  [ "# " <> "Module " <> unModulename md_name
   , ""
-  , fromMaybe "" md_descr
+  , maybe "" unMarkdown md_descr
   , "" ]
   <> concat
   [ if null md_templates then []
@@ -52,47 +52,52 @@ renderSimpleMD ModuleDoc{..} = T.unlines $
 
 tmpl2md :: TemplateDoc -> T.Text
 tmpl2md TemplateDoc{..} = T.unlines $
-  "### Template " <> asCode td_name :
-  maybe "" (T.cons '\n') td_descr :
-  T.empty :
-  fieldTable td_payload :
-  "" :
-  "  #### Choices" :
-  "" :
-  map choiceBullet td_choices -- ends by "\n" because of unlines above
+    [ "### Template " <> asCode (unTypename td_name)
+    , maybe "" (T.cons '\n' . unMarkdown) td_descr
+    , ""
+    , fieldTable td_payload
+    , ""
+    , "  #### Choices"
+    , ""
+    ] ++ map choiceBullet td_choices -- ends by "\n" because of unlines above
 
   where
     choiceBullet :: ChoiceDoc -> T.Text
     choiceBullet ChoiceDoc{..} = T.unlines
-      [ prefix "* " $ asCode cd_name
-      , maybe T.empty (flip T.snoc '\n' . indent 2) cd_descr
-      , indent 2 (fieldTable cd_fields)
-      ]
+        [ prefix "* " $ asCode (unTypename cd_name)
+        , maybe "  " (flip T.snoc '\n' . indent 2 . unMarkdown) cd_descr
+        , indent 2 (fieldTable cd_fields)
+        ]
 
 cls2md :: ClassDoc -> T.Text
 cls2md ClassDoc{..} = T.unlines $
-  "### `class` " <> maybe "" (\x -> type2md x <> " => ") cl_super <> T.unwords (cl_name : cl_args) <> " where" :
-  maybe T.empty (T.cons '\n' . indent 2) cl_descr :
-  map (indent 2 . fct2md) cl_functions
+    [ "### `class` "
+        <> maybe "" (\x -> type2md x <> " => ") cl_super
+        <> T.unwords (unTypename cl_name : cl_args)
+        <> " where"
+    , maybe "" (T.cons '\n' . indent 2 . unMarkdown) cl_descr
+    ] ++ map (indent 2 . fct2md) cl_functions
 
 adt2md :: ADTDoc -> T.Text
 adt2md TypeSynDoc{..} = T.unlines $
-  "### `type` " <> asCode (ad_name <> (T.concat $ map (T.cons ' ') ad_args)) :
-  "    = " <> type2md ad_rhs :
-  maybe [] ((:[]) . T.cons '\n' . indent 2) ad_descr
-adt2md ADTDoc{..} = T.unlines $
-  "### `data` " <> asCode (ad_name <> (T.concat $ map (T.cons ' ') ad_args)) :
-  maybe T.empty (T.cons '\n' . indent 2) ad_descr :
-  map constrMdItem ad_constrs
+    [ "### `type` "
+        <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
+    , "    = " <> type2md ad_rhs
+    ] ++ maybe [] ((:[]) . T.cons '\n' . indent 2 . unMarkdown) ad_descr
 
+adt2md ADTDoc{..} = T.unlines $
+    [ "### `data` "
+        <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
+    , maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ad_descr
+    ] ++ map constrMdItem ad_constrs
 
 constrMdItem :: ADTConstr -> T.Text
 constrMdItem PrefixC{..} =
-  ("* " <> T.unwords (asCode ac_name : map type2md ac_args))
-  <> maybe T.empty (T.cons '\n' . indent 2) ac_descr
+  ("* " <> T.unwords (asCode (unTypename ac_name) : map type2md ac_args))
+  <> maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ac_descr
 constrMdItem RecordC{..} =
-  ("* " <> asCode ac_name)
-  <> maybe T.empty (T.cons '\n' . indent 2) ac_descr
+  ("* " <> asCode (unTypename ac_name))
+  <> maybe T.empty (T.cons '\n' . indent 2 . unMarkdown) ac_descr
   <> "\n\n"
   <> indent 2 (fieldTable ac_fields)
 
@@ -116,15 +121,16 @@ fieldTable fds = header <> fieldRows <> "\n"
       ]
 
     fieldRows = T.unlines
-      [ "| " <> adjust fLen (asCode fd_name) <> " | " <> type2md fd_type <> " |"
-        <> maybe "" (\desc -> "\n" <> col1Empty <> removeLineBreaks desc <> " |") fd_descr
+      [ "| " <> adjust fLen (asCode (unFieldname fd_name))
+        <> " | " <> type2md fd_type <> " |"
+        <> maybe "" (\desc -> "\n" <> col1Empty <> removeLineBreaks (unMarkdown desc) <> " |") fd_descr
       | FieldDoc{..} <- fds ]
 
     -- Markdown does not support multi-row cells so we have to remove
     -- line breaks.
     removeLineBreaks = T.unwords . T.lines
 
-    fLen = maximum $ 5 : map (T.length . asCode . fd_name) fds
+    fLen = maximum $ 5 : map (T.length . asCode . unFieldname . fd_name) fds
       -- 5 = length of "Field" header
 
     col1Empty = "| " <> T.replicate fLen " " <> " | "
@@ -137,17 +143,15 @@ type2md t = t2md id t
         t2md _ (TypeTuple ts) = "`(` " <>
                             T.concat (intersperse ", " $ map (t2md id) ts) <>
                             " `)`"
-        t2md _ (TypeApp n []) = asCode n
+        t2md _ (TypeApp n []) = asCode (unTypename n)
         t2md f (TypeApp name args) =
-          f $ T.unwords ( asCode name : map (t2md codeParens) args)
+          f $ T.unwords ( asCode (unTypename name) : map (t2md codeParens) args)
         codeParens s = "`(` " <> s <> " `)`"
-
-
 
 fct2md :: FunctionDoc -> T.Text
 fct2md FunctionDoc{..} =
-  "* " <> asCode fct_name <> maybe "" ((" : " <>) . type2md) fct_type
-  <> maybe "" (("  \n" <>) . indent 2) fct_descr
+  "* " <> asCode (unFieldname fct_name) <> maybe "" ((" : " <>) . type2md) fct_type
+  <> maybe "" (("  \n" <>) . indent 2 . unMarkdown) fct_descr
   --             ^^ NB trailing whitespace to cause a line break
 
 ------------------------------------------------------------

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Rst.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Rst.hs
@@ -34,7 +34,7 @@ renderSimpleRst ModuleDoc{..} = T.unlines $
   , renderAnchor (moduleAnchor md_name)
   , title
   , T.replicate (T.length title) "-"
-  , fromMaybe "" md_descr
+  , maybe "" markdownToRst md_descr
   ]
   <> concat
   [ if null md_templates
@@ -67,13 +67,13 @@ renderSimpleRst ModuleDoc{..} = T.unlines $
          ]
   ]
 
-  where title = "Module " <> md_name
+  where title = "Module " <> unModulename md_name
 
 tmpl2rst :: Modulename -> TemplateDoc -> T.Text
 tmpl2rst md_name TemplateDoc{..} = T.unlines $
   renderAnchor (templateAnchor md_name td_name) :
-  ("template " <> enclosedIn "**" td_name) :
-  maybe T.empty (T.cons '\n' . indent 2 . markdownToRst) td_descr :
+  ("template " <> enclosedIn "**" (unTypename td_name)) :
+  maybe "" (T.cons '\n' . indent 2 . markdownToRst) td_descr :
   "" :
   indent 2 (fieldTable td_payload) :
   "" :
@@ -82,43 +82,48 @@ tmpl2rst md_name TemplateDoc{..} = T.unlines $
 
 choiceBullet :: ChoiceDoc -> T.Text
 choiceBullet ChoiceDoc{..} = T.unlines
-  [ prefix "+ " $ enclosedIn "**" $ "Choice " <> cd_name
-  , maybe T.empty (flip T.snoc '\n' . indent 2 . markdownToRst) cd_descr
+  [ prefix "+ " $ enclosedIn "**" $ "Choice " <> unTypename cd_name
+  , maybe "" (flip T.snoc '\n' . indent 2 . markdownToRst) cd_descr
   , indent 2 (fieldTable cd_fields)
   ]
 
 cls2rst :: Modulename ->  ClassDoc -> T.Text
 cls2rst md_name ClassDoc{..} = T.unlines $
   renderAnchor (classAnchor md_name cl_name) :
-  "**class " <> maybe "" (\x -> type2rst x <> " => ") cl_super <> T.unwords (cl_name : cl_args) <> " where**" :
+  "**class " <> maybe "" (\x -> type2rst x <> " => ") cl_super <> T.unwords (unTypename cl_name : cl_args) <> " where**" :
   maybe [] ((:[""]) . indent 2 . markdownToRst) cl_descr ++
   map (indent 2 . fct2rst md_name) cl_functions
 
 adt2rst :: Modulename -> ADTDoc -> T.Text
 adt2rst md_name TypeSynDoc{..} = T.unlines $
-  renderAnchor (typeAnchor md_name ad_name) :
-  "type " <> enclosedIn "**" (ad_name <> (T.concat $ map (T.cons ' ') ad_args)) :
-  "    = " <> type2rst ad_rhs :
-  maybe [] ((:[]) . T.cons '\n' . indent 2 . markdownToRst) ad_descr
+    [ renderAnchor (typeAnchor md_name ad_name)
+    , "type " <> enclosedIn "**"
+        (T.unwords (unTypename ad_name : ad_args))
+    , "    = " <> type2rst ad_rhs
+    ] ++ maybe [] ((:[]) . T.cons '\n' . indent 2 . markdownToRst) ad_descr
 adt2rst md_name ADTDoc{..} = T.unlines $
-  renderAnchor (dataAnchor md_name ad_name) :
-  "data " <> enclosedIn "**" (ad_name <> (T.concat $ map (T.cons ' ') ad_args)) :
-  maybe T.empty (T.cons '\n' . indent 2 . markdownToRst) ad_descr :
-  map (indent 2 . T.cons '\n' . constr2rst md_name) ad_constrs
+    [ renderAnchor (dataAnchor md_name ad_name)
+    , "data " <> enclosedIn "**"
+        (T.unwords (unTypename ad_name : ad_args))
+    , maybe "" (T.cons '\n' . indent 2 . markdownToRst) ad_descr
+    ] ++ map (indent 2 . T.cons '\n' . constr2rst md_name) ad_constrs
 
 
 constr2rst :: Modulename -> ADTConstr -> T.Text
 constr2rst md_name PrefixC{..} = T.unlines $
-  renderAnchor (constrAnchor md_name ac_name) :
-  T.unwords (enclosedIn "**" ac_name : map type2rst ac_args) :
-  maybe [] ((:[]) . T.cons '\n' . markdownToRst) ac_descr
+    [ renderAnchor (constrAnchor md_name ac_name)
+    , T.unwords (enclosedIn "**" (unTypename ac_name) : map type2rst ac_args)
+        -- FIXME: Parentheses around args seems necessary here
+        -- if they are type application or function (see type2rst).
+    ] ++ maybe [] ((:[]) . T.cons '\n' . markdownToRst) ac_descr
+
 constr2rst md_name RecordC{..} = T.unlines
-  [ renderAnchor (constrAnchor md_name ac_name)
-  , enclosedIn "**" ac_name
-  , maybe T.empty (T.cons '\n' . markdownToRst) ac_descr
-  , ""
-  , fieldTable ac_fields
-  ]
+    [ renderAnchor (constrAnchor md_name ac_name)
+    , enclosedIn "**" (unTypename ac_name)
+    , maybe "" (T.cons '\n' . markdownToRst) ac_descr
+    , ""
+    , fieldTable ac_fields
+    ]
 
 
 {- | Render fields as an rst list-table (editing-friendly), like this:
@@ -150,41 +155,10 @@ fieldTable fds = T.unlines $ -- NB final empty line is essential and intended
                 , "  - Type"
                 , "  - Description" ]
     fieldRows = concat
-       [ [ prefix "* - " $ escapeTr_ fd_name
+       [ [ prefix "* - " $ escapeTr_ (unFieldname fd_name)
          , prefix "  - " $ type2rst fd_type
-         , prefix "  - " $ maybe " " (markdownToRst . T.unwords . T.lines) fd_descr ]
+         , prefix "  - " $ maybe " " (markdownToRst . Markdown . T.unwords . T.lines . unMarkdown) fd_descr ] -- FIXME: this makes no sense
        | FieldDoc{..} <- fds ]
-
-
--- | Render fields as a table, like this:
--- >  ============ ==============================
--- >  **Field**    **Type/Description**
--- >  ============ ==============================
--- >  **anA**      | *a*
--- >  **another**  | *a*
--- >               | another a
--- >  **andText**  | *Text*
--- >               | and text
--- >  ============ ==============================
-_fieldTableVerbatim :: [FieldDoc] -> T.Text
-_fieldTableVerbatim []  = "(no fields)"
-_fieldTableVerbatim fds = header <> fieldRows <> equalLines
-  where
-    equalLines = T.unwords (map (flip T.replicate "-") [fLen, 30])
-                 -- 30 because last overline can be shorter
-    fLen = 4 + (maximum $ map T.length $ fieldHdr : map fd_name fds)
-           -- +4 for field names in bold face
-    fieldHdr = "Field"
-    header = T.unlines
-      [ equalLines
-      , adjust fLen (enclosedIn "**" fieldHdr) <> " " <> "**Type/Description**"
-      , equalLines
-      ]
-    fieldRows = T.unlines
-      [ adjust fLen (enclosedIn "**" fd_name) <> " | "
-        <> enclosedIn "*" (type2rst fd_type)
-        <> maybe "" (\d -> "\n" <> indent (fLen + 1) (prefix "| " (markdownToRst d))) fd_descr
-      | FieldDoc{..} <- fds ]
 
 -- | Render a type. Nested type applications are put in parentheses.
 type2rst :: Type -> T.Text
@@ -193,28 +167,32 @@ type2rst = f (0 :: Int)
     -- 0 = no brackets
     -- 1 = brackets around function
     -- 2 = brackets around function AND application
-    f _ (TypeApp n []) = n
-    f i (TypeApp n as) = (if i >= 2 then inParens else id) $ T.unwords (n : map (f 2) as)
+    f _ (TypeApp n []) = unTypename n
+    f i (TypeApp n as) = (if i >= 2 then inParens else id) $ T.unwords (unTypename n : map (f 2) as)
     f i (TypeFun ts) = (if i >= 1 then inParens else id) $ T.intercalate " -> " $ map (f 1) ts
     f _ (TypeList t1) = "[" <> f 0 t1 <> "]"
     f _ (TypeTuple ts) = "(" <> T.intercalate ", " (map (f 0) ts) <>  ")"
 
 
 fct2rst :: Modulename -> FunctionDoc -> T.Text
-fct2rst md_name  FunctionDoc{..} =
-  renderAnchor (functionAnchor md_name fct_name fct_type) <> "\n"
-  <> enclosedIn "**" (if isAlpha (T.head fct_name) then fct_name else inParens fct_name) <> "\n  : "
-  <> maybe "" ((<> " => ") . type2rst) fct_context
-  <> maybe "" ((<> "\n\n") . type2rst) fct_type
-  <> maybe "" (indent 2 . markdownToRst) fct_descr
-  <> "\n"
+fct2rst md_name  FunctionDoc{..} = T.unlines
+    [ renderAnchor (functionAnchor md_name fct_name fct_type)
+    , enclosedIn "**" (wrapOp (unFieldname fct_name))
+    , T.concat
+        [ "  : "
+        , maybe "" ((<> " => ") . type2rst) fct_context
+        , maybe "" ((<> "\n\n") . type2rst) fct_type
+            -- FIXME: when would a function not have a type?
+        , maybe "" (indent 2 . markdownToRst) fct_descr
+        ]
+    ]
 
 ------------------------------------------------------------
 -- helpers
 
 -- TODO (MK) Handle doctest blocks. Currently the parse as nested blockquotes.
 markdownToRst :: Markdown -> T.Text
-markdownToRst = renderStrict . layoutPretty defaultLayoutOptions . render . commonmarkToNode opts exts
+markdownToRst = renderStrict . layoutPretty defaultLayoutOptions . render . commonmarkToNode opts exts . unMarkdown
   where
     opts = []
     exts = []

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Util.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Render/Util.hs
@@ -9,6 +9,7 @@ module DA.Daml.GHC.Damldoc.Render.Util
   , indent
   , enclosedIn
   , inParens
+  , wrapOp
   ) where
 
 import qualified Data.Text as T
@@ -35,3 +36,15 @@ adjust n t | l < n  = t <> T.replicate (n - l) " "
            | l == n = t
            | otherwise  = t -- error?
   where l = T.length t
+
+-- | If name is an operator, wrap it.
+wrapOp :: T.Text -> T.Text
+wrapOp t =
+    if T.null t || isIdChar (T.head t)
+        then t
+        else inParens t
+  where
+    isIdChar :: Char -> Bool
+    isIdChar c = ('A' <= c && c <= 'Z')
+              || ('a' <= c && c <= 'z')
+              || ('_' == c)

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Transform.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Transform.hs
@@ -79,7 +79,7 @@ applyTransform opts docs = maybeDoAnnotations opts' docs
 
     moduleMatchesAny :: [FilePattern] -> ModuleDoc -> Bool
     moduleMatchesAny ps m = any (?== name) ps
-      where name = withSlashes $ T.unpack $ md_name m
+      where name = withSlashes . T.unpack . unModulename . md_name $ m
 
     withSlashes :: String -> String
     withSlashes = replace "." [pathSeparator]

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
@@ -9,22 +9,23 @@ import Data.Aeson
 import           Data.Text              (Text)
 import           Data.Hashable
 import GHC.Generics
+import Data.String
 
--- | Markdown type, simple wrapper for now
-newtype Markdown = Markdown { unMarkdown :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON)
+-- | Doc text type, presumably Markdown format.
+newtype DocText = DocText { unDocText :: Text }
+    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Field name, starting with lowercase
 newtype Fieldname = Fieldname { unFieldname :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON)
+    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type name starting with uppercase
 newtype Typename = Typename { unTypename :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON)
+    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Module name, starting with uppercase, may have dots.
 newtype Modulename = Modulename { unModulename :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON)
+    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type expression, possibly a (nested) type application
 data Type = TypeApp Typename [Type] -- ^ Type application
@@ -40,7 +41,7 @@ instance Hashable Type where
 -- | Documentation data for a module
 data ModuleDoc = ModuleDoc
   { md_name      :: Modulename
-  , md_descr     :: Maybe Markdown
+  , md_descr     :: Maybe DocText
   , md_templates :: [TemplateDoc]
   , md_adts      :: [ADTDoc]
   , md_functions :: [FunctionDoc]
@@ -55,7 +56,7 @@ data ModuleDoc = ModuleDoc
 -- | Documentation data for a template
 data TemplateDoc = TemplateDoc
   { td_name    :: Typename
-  , td_descr   :: Maybe Markdown
+  , td_descr   :: Maybe DocText
   , td_payload :: [FieldDoc]
   , td_choices :: [ChoiceDoc]
   }
@@ -63,7 +64,7 @@ data TemplateDoc = TemplateDoc
 
 data ClassDoc = ClassDoc
   { cl_name :: Typename
-  , cl_descr :: Maybe Markdown
+  , cl_descr :: Maybe DocText
   , cl_super :: Maybe Type
   , cl_args :: [Text]
   , cl_functions :: [FunctionDoc]
@@ -73,13 +74,13 @@ data ClassDoc = ClassDoc
 -- | Documentation data for an ADT or type synonym
 data ADTDoc = ADTDoc
   { ad_name   :: Typename
-  , ad_descr  :: Maybe Markdown
+  , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_constrs :: [ADTConstr]  -- allowed to be empty
   }
   | TypeSynDoc
   { ad_name   :: Typename
-  , ad_descr  :: Maybe Markdown
+  , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_rhs    :: Type
   }
@@ -89,11 +90,11 @@ data ADTDoc = ADTDoc
 -- | Constructors (Record or Prefix)
 data ADTConstr =
     PrefixC { ac_name :: Typename
-            , ac_descr :: Maybe Markdown
+            , ac_descr :: Maybe DocText
             , ac_args :: [Type]   -- use retained var.names
             }
   | RecordC { ac_name :: Typename
-            , ac_descr :: Maybe Markdown
+            , ac_descr :: Maybe DocText
             , ac_fields :: [FieldDoc]
             }
   deriving (Eq, Show, Generic)
@@ -104,7 +105,7 @@ data ADTConstr =
 -- as the choice.
 data ChoiceDoc = ChoiceDoc
   { cd_name   :: Typename
-  , cd_descr  :: Maybe Markdown
+  , cd_descr  :: Maybe DocText
   , cd_fields :: [FieldDoc]
   }
   deriving (Eq, Show, Generic)
@@ -116,7 +117,7 @@ data FieldDoc = FieldDoc
   , fd_type  :: Type
     -- TODO align with GHC data structure. The type representation must use FQ
     -- names in components to enable links, and it Can use bound type var.s.
-  , fd_descr :: Maybe Markdown
+  , fd_descr :: Maybe DocText
   }
   deriving (Eq, Show, Generic)
 
@@ -126,7 +127,7 @@ data FunctionDoc = FunctionDoc
   { fct_name  :: Fieldname
   , fct_context :: Maybe Type
   , fct_type  :: Maybe Type
-  , fct_descr :: Maybe Markdown
+  , fct_descr :: Maybe DocText
   }
   deriving (Eq, Show, Generic)
 

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
@@ -1,6 +1,8 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE DerivingStrategies #-}
+
 module DA.Daml.GHC.Damldoc.Types(
     module DA.Daml.GHC.Damldoc.Types
     ) where
@@ -13,19 +15,19 @@ import Data.String
 
 -- | Doc text type, presumably Markdown format.
 newtype DocText = DocText { unDocText :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Field name, starting with lowercase
 newtype Fieldname = Fieldname { unFieldname :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type name starting with uppercase
 newtype Typename = Typename { unTypename :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Module name, starting with uppercase, may have dots.
 newtype Modulename = Modulename { unModulename :: Text }
-    deriving (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type expression, possibly a (nested) type application
 data Type = TypeApp Typename [Type] -- ^ Type application

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/Types.hs
@@ -11,23 +11,27 @@ import           Data.Hashable
 import GHC.Generics
 
 -- | Markdown type, simple wrapper for now
-type Markdown = Text
+newtype Markdown = Markdown { unMarkdown :: Text }
+    deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
 -- | Field name, starting with lowercase
-type Fieldname = Text
+newtype Fieldname = Fieldname { unFieldname :: Text }
+    deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
 -- | Type name starting with uppercase
-type Typename = Text
+newtype Typename = Typename { unTypename :: Text }
+    deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
 -- | Module name, starting with uppercase, may have dots.
-type Modulename = Text
+newtype Modulename = Modulename { unModulename :: Text }
+    deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
 -- | Type expression, possibly a (nested) type application
 data Type = TypeApp Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Hashable Type where
   hashWithSalt salt = hashWithSalt salt . show

--- a/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/daml-foundations/daml-ghc/damldoc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -205,7 +205,7 @@ testModHdr = T.pack $ "daml 1.2 module\n  " <> testModule <> " where\n"
 
 
 emptyDocs :: String -> ModuleDoc
-emptyDocs name = ModuleDoc { md_name = T.pack name
+emptyDocs name = ModuleDoc { md_name = Modulename (T.pack name)
                            , md_descr = Nothing
                            , md_templates = []
                            , md_adts = []


### PR DESCRIPTION
Renamed `Markdown` type to `DocText` (to avoid confusion with the `Markdown` constructor in Render.hs). Use newtypes for `DocText`, `Fieldname`, `Typename` and `Modulename`, instead of representing all these different types of text as type aliases of `Text`. Refactored some functions and deduplicated some code as well. *The goal was not to change the output, only the code.*

But I did find one bug in the process, which I fixed: module descriptions were being returned as Rst without conversion from Markdown first.