### PR TITLE
Fix CPP issue with default da-ghci

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,4 @@ bazel test -j 200 //... --test_tag_filters "$tag_filter" --experimental_executio
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null
 # Check that we can load damlc in ghci
-da-ghci --data yes damlc -e '()'
+da-ghci --data yes -e '()'

--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,4 @@ bazel test -j 200 //... --test_tag_filters "$tag_filter" --experimental_executio
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null
 # Check that we can load damlc in ghci
-da-ghci --data yes -e '()'
+da-ghci --data yes //:repl -e '()'


### PR DESCRIPTION
The default REPL target did not exclude the //nix targets that set the CPP language extensions. This PR fixes that by moving the corresponding defaults into `da_haskell_repl`. It also moves other defaults. Tests `da-ghci` on CI, instead of `da-ghci damlc`. Note, `da-ghci` subsumes `da-ghci damlc`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
