### PR TITLE
damlc: fix serializability of empty enum

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -106,6 +106,7 @@ serializabilityConditionsDataType world0 version mbModNameTpls (DefDataType _loc
     Just (v, k) -> Left (URHigherKinded v k)
     Nothing
       | DataVariant [] <- cons -> Left URUninhabitatedType
+      | DataEnum [] <- cons -> Left URUninhabitatedType
       | otherwise -> do
           let vars = HS.fromList (map fst params)
           mconcatMapM (serializabilityConditionsType world0 version mbModNameTpls vars) (toListOf dataConsType cons)


### PR DESCRIPTION
This PR fixes the serviceability inference of the compiler. 
Empty `enum` must be unserializable.  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
