### PR TITLE
Make hie-core outside an IDE work better

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -100,7 +100,7 @@
   - {name: unsafePerformIO, within: [DA.Daml.GHC.Compiler.UtilGHC]}
   - {name: unsafeInterleaveIO, within: []}
   - {name: unsafeDupablePerformIO, within: []}
-  - {name: setCurrentDirectory, within: [DAML.Assistant.Tests]}
+  - {name: setCurrentDirectory, within: [DAML.Assistant.Tests, Main]}
   - {name: unsafeCoerce, within: []}
 
 # Add custom hints for this project

--- a/compiler/hie-core/BUILD.bazel
+++ b/compiler/hie-core/BUILD.bazel
@@ -66,22 +66,23 @@ da_haskell_library(
 )
 
 da_haskell_binary(
-    name = "hie-core-demo",
-    srcs = glob(["test/**/*.hs"]),
+    name = "hie-core-exe",
+    srcs = glob(["exe/**/*.hs"]),
     hazel_deps = [
         "base",
         "containers",
         "data-default",
         "directory",
         "extra",
+        "filepath",
         "ghc-paths",
         "ghc",
         "haskell-lsp",
         "hie-bios",
+        "optparse-applicative",
         "shake",
         "text",
     ],
-    main_function = "Demo.main",
     src_strip_prefix = "test",
     visibility = ["//visibility:public"],
     deps = [

--- a/compiler/hie-core/README.md
+++ b/compiler/hie-core/README.md
@@ -10,7 +10,9 @@ Our vision is that you should build an IDE by combining:
 
 There are more details about our approach [in this blog post](https://4ta.uk/p/shaking-up-the-ide).
 
-## How to use it
+## Using it
+
+### Install `hie-core`
 
 First install the `hie-core` binary using `stack` or `cabal`, e.g.
 
@@ -20,9 +22,27 @@ First install the `hie-core` binary using `stack` or `cabal`, e.g.
 
 It's important that `hie-core` is compiled with the same compiler you use to build your projects.
 
-Next, check that `hie-bios` is able to load your project. This step is currently a bit difficult.
+### Test `hie-core`
 
-Next, set up an extension for your editor.
+Next, check that `hie-core` is capable of loading your code. Change to the project directory and run `hie-core`, which will try and load everything using the same code as the IDE, but in a way that's much easier to understand. For example, taking the example of [`shake`](https://github.com/ndmitchell/shake), running `hie-core` gives some error messages and warnings before reporting at the end:
+
+```
+Files that worked: 152
+Files that failed: 6
+ * .\model\Main.hs
+ * .\model\Model.hs
+ * .\model\Test.hs
+ * .\model\Util.hs
+ * .\output\docs\Main.hs
+ * .\output\docs\Part_Architecture_md.hs
+Done
+```
+
+Of the 158 files in Shake, as of this moment, 152 can be loaded by the IDE, but 6 can't (error messages for the reasons they can't be loaded are given earlier). The failing files are all prototype work or test output, meaning I can confidently use Shake.
+
+The `hie-core` executable mostly relies on [`hie-bios`](https://github.com/mpickering/hie-bios) to do the difficult work of setting up your GHC environment. If it doesn't work, see [the `hie-bios` manual](https://github.com/mpickering/hie-bios#readme) to get it working. My default fallback is to figure it out by hand and create a `direct` style [`hie.yaml`](https://github.com/ndmitchell/shake/blob/master/hie.yaml) listing the command line arguments to load the project.
+
+Once you have got `hie-core` working outside the editor, the next step is to pick which editor to integrate with.
 
 ### Using with VS Code
 
@@ -36,7 +56,7 @@ Install the VS code extension
 
 Now openning a `.hs` file should work with `hie-core`.
 
-### Emacs
+### Using with Emacs
 
 The frst step is to install required Emacs packages. If you don't already have [Melpa](https://melpa.org/#/) package installation configured in your `.emacs`, put this stanza at the top.
 
@@ -63,7 +83,7 @@ There are two things you can do about this warning:
 ;; Remember : to avoid package-not-found errors, refresh the package
 ;; database now and then with M-x package-refresh-contents.
 ```
-   
+
 When this is in your `.emacs` and evaluated, `M-x package-refresh-contents` to get the package database downloaded and then `M-x package-list-packages` to display the available packages. Click on a package to install it. You'll need to install the following packages:
 
 * `lsp-haskell`
@@ -93,13 +113,3 @@ Optionally, you may wish to add the following conveniences:
 (define-key flymake-mode-map (kbd "M-n") 'flymake-goto-next-error)
 (define-key flymake-mode-map (kbd "M-p") 'flymake-goto-prev-error)
 ```
-
-### Testing
-
-For testing, I've been using the `ghc-lib-gen` target of the [`ghc-lib` project](https://github.com/digital-asset/ghc-lib). Navigate to the root of `ghc-lib` and create an `hie.yaml` file with contents
-
-```yaml
-cradle: {cabal: {component: "exe:ghc-lib-gen"}}
-```
-
-Invoke `cabal new-configure -w ~/.stack/programs/~/.stack/programs/x86_64-osx/ghc-8.6.5/bin/ghc` (this is the `ghc` used by `stack` to build `hie-core` - consult `//compiler/hie-core/stack.yaml` to help work out what you should write here). This last step will create a file `cabal.project.local` with contents pointing `cabal` to use the desired `ghc`. You can build `ghc-lib-gen` from the `ghc-lib` directory with the command `cabal new-build` as you like. After creating `cabal.project.local`, you should be all set. Open `ghc-lib/ghc-lib-gen/src/Main.hs` in a buffer and, for example, hover should bring up type/definition info.

--- a/compiler/hie-core/exe/Arguments.hs
+++ b/compiler/hie-core/exe/Arguments.hs
@@ -1,0 +1,25 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Arguments(Arguments(..), getArguments) where
+
+import Options.Applicative
+
+
+data Arguments = Arguments
+    {argLSP :: Bool
+    ,argFiles :: [FilePath]
+    }
+
+getArguments :: IO Arguments
+getArguments = execParser opts
+  where
+    opts = info (arguments <**> helper)
+      ( fullDesc
+     <> progDesc "Used as a test bed to check your IDE will work"
+     <> header "hie-core - the core of a Haskell IDE")
+
+arguments :: Parser Arguments
+arguments = Arguments
+      <$> switch (long "lsp" <> help "Start talking to an LSP server")
+      <*> many (argument str (metavar "FILES..."))

--- a/compiler/hie-core/exe/Arguments.hs
+++ b/compiler/hie-core/exe/Arguments.hs
@@ -8,6 +8,7 @@ import Options.Applicative
 
 data Arguments = Arguments
     {argLSP :: Bool
+    ,argsCwd :: Maybe FilePath
     ,argFiles :: [FilePath]
     }
 
@@ -22,4 +23,5 @@ getArguments = execParser opts
 arguments :: Parser Arguments
 arguments = Arguments
       <$> switch (long "lsp" <> help "Start talking to an LSP server")
+      <*> optional (strOption $ long "cwd" <> metavar "DIR" <> help "Change to this directory")
       <*> many (argument str (metavar "FILES..."))

--- a/compiler/hie-core/exe/Arguments.hs
+++ b/compiler/hie-core/exe/Arguments.hs
@@ -24,4 +24,4 @@ arguments :: Parser Arguments
 arguments = Arguments
       <$> switch (long "lsp" <> help "Start talking to an LSP server")
       <*> optional (strOption $ long "cwd" <> metavar "DIR" <> help "Change to this directory")
-      <*> many (argument str (metavar "FILES..."))
+      <*> many (argument str (metavar "FILES/DIRS..."))

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Demo(main) where
+module Main(main) where
 
 import Data.Maybe
 import Control.Concurrent.Extra

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -45,7 +45,7 @@ main :: IO ()
 main = do
     -- WARNING: If you write to stdout before runLanguageServer
     --          then the language server will not work
-    hPutStrLn stderr "Starting hie-core Demo"
+    hPutStrLn stderr "Starting hie-core"
     Arguments{..} <- getArguments
     -- lock to avoid overlapping output on stdout
     lock <- newLock
@@ -59,9 +59,11 @@ main = do
     let options = defaultIdeOptions $ liftIO $ newSession' cradle
 
     if argLSP then do
-        hPutStrLn stderr "Starting IDE server"
+        t <- offsetTime
+        hPutStrLn stderr "Starting LSP server..."
         runLanguageServer def def $ \event vfs -> do
-            hPutStrLn stderr "Server started"
+            t <- t
+            hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
             initialise (mainRule >> action kick) event logger options vfs
     else do
         let files = map toNormalizedFilePath argFiles

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -6,7 +6,7 @@ module Main(main) where
 import Arguments
 import Data.Maybe
 import Control.Concurrent.Extra
-import Control.Monad
+import Control.Monad.Extra
 import Data.Default
 import System.Time.Extra
 import Development.IDE.Core.FileStore
@@ -51,6 +51,8 @@ main = do
     -- lock to avoid overlapping output on stdout
     lock <- newLock
     let logger = makeOneLogger $ withLock lock . T.putStrLn
+
+    whenJust argsCwd setCurrentDirectory
 
     dir <- getCurrentDirectory
     hPutStrLn stderr dir

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -103,8 +103,8 @@ library
 
 executable hie-core
     default-language:   Haskell2010
-    main-is: Demo.hs
-    ghc-options: -main-is Demo.main
+    hs-source-dirs:     exe
+    main-is: Main.hs
     build-depends:
         base == 4.*,
         containers,
@@ -123,5 +123,3 @@ executable hie-core
         TupleSections
         RecordWildCards
         ViewPatterns
-
-    hs-source-dirs:     test

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -116,6 +116,7 @@ executable hie-core
         ghc-paths,
         ghc,
         extra,
+        filepath,
         haskell-lsp,
         text,
         hie-core

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -109,6 +109,7 @@ executable hie-core
         base == 4.*,
         containers,
         directory,
+        optparse-applicative,
         hie-bios,
         shake,
         data-default,
@@ -118,6 +119,8 @@ executable hie-core
         haskell-lsp,
         text,
         hie-core
+    other-modules:
+        Arguments
 
     default-extensions:
         TupleSections


### PR DESCRIPTION
I added proper command line arguments, and made is so that running `hie-core` in a directory with no arguments just tries to load every `.hs` file and reports which ones work/don't. That's a really handy way to debug `hie-bios` and gives users a good sense of how their code will behave before they start the IDE.