### PR TITLE
Fix daml-assistant install script.

### DIFF
--- a/release/install.sh
+++ b/release/install.sh
@@ -2,4 +2,5 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-"$DIR/daml/daml" install "$DIR" $@
+"$DIR/daml/daml" install "$DIR" --install-assistant=yes $@
+

--- a/release/windows-installer/src/WindowsInstaller.hs
+++ b/release/windows-installer/src/WindowsInstaller.hs
@@ -40,12 +40,12 @@ installer sdkDir logo = do
         let dir = "$PLUGINSDIR" </> "daml-sdk-" <> sdkVersion
         setOutPath (fromString dir)
         file [Recursive] (fromString (sdkDir <> "\\*.*"))
-        -- install --activate will copy the SDK to the final location.
+        -- install --install-assistant=yes will copy the SDK to the final location.
         plugin "nsExec" "ExecToLog"
             [ fromString $ unwords
                   [ "\"" <> dir </> "daml" </> "daml.exe\""
                   , "install"
                   , "\"" <> dir <> "\""
-                  , "--activate"
+                  , "--install-assistant=yes"
                   ] :: Exp String
             ]


### PR DESCRIPTION
Should improve the `auto` logic to handle this case eventually, and capture this bug in a test.