### PR TITLE
Make CPP work better with hie-core

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -151,6 +151,11 @@ alias(
 )
 
 alias(
+    name = "hie-core",
+    actual = "//compiler/hie-core:hie-core-exe",
+)
+
+alias(
     name = "daml-lf-repl",
     actual = "//daml-lf/repl:repl",
 )

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -321,6 +321,10 @@ runCpp dflags filename contents = withTempDir $ \dir -> do
             -- and means location information is correct
             return filename
         Just contents -> do
+            -- Sad path, we have to copy the file to a temp location.
+            -- Relative includes probably aren't going to work, so we fix that by adding to the include path.
+            -- Location information is wrong, so we fix that by patching it afterwards.
+            -- Location macro is wrong, so we fix that too.
             let inp = dir </> takeFileName filename
             let f x = if SB.atEnd x then Nothing else Just $ SB.nextChar x
             liftIO $ writeFileUTF8 inp (unfoldr f contents)

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -329,8 +329,8 @@ parseFileContents
        -> FilePath  -- ^ the filename (for source locations)
        -> Maybe SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
        -> ExceptT [FileDiagnostic] m ([FileDiagnostic], ParsedModule)
-parseFileContents preprocessor filename contents = do
-   contents <- liftIO $ maybe (hGetStringBuffer filename) return contents
+parseFileContents preprocessor filename mbContents = do
+   contents <- liftIO $ maybe (hGetStringBuffer filename) return mbContents
    let loc  = mkRealSrcLoc (mkFastString filename) 1 1
    dflags  <- ExceptT $ parsePragmasIntoDynFlags filename contents
 

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -91,7 +91,7 @@ parseModule
     :: IdeOptions
     -> HscEnv
     -> FilePath
-    -> SB.StringBuffer
+    -> Maybe SB.StringBuffer
     -> IO ([FileDiagnostic], Maybe ParsedModule)
 parseModule IdeOptions{..} env file =
     fmap (either (, Nothing) (second Just)) .
@@ -327,9 +327,10 @@ parseFileContents
        :: GhcMonad m
        => (GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource))
        -> FilePath  -- ^ the filename (for source locations)
-       -> SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
+       -> Maybe SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
        -> ExceptT [FileDiagnostic] m ([FileDiagnostic], ParsedModule)
 parseFileContents preprocessor filename contents = do
+   contents <- liftIO $ maybe (hGetStringBuffer filename) return contents
    let loc  = mkRealSrcLoc (mkFastString filename) 1 1
    dflags  <- ExceptT $ parsePragmasIntoDynFlags filename contents
 

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -333,8 +333,8 @@ runCpp dflags filename contents = withTempDir $ \dir -> do
 
             -- Location information is wrong, so we fix that by patching it afterwards.
             let inp = dir </> "___HIE_CORE_MAGIC___"
-            let f x = if SB.atEnd x then Nothing else Just $ SB.nextChar x
-            liftIO $ writeFileUTF8 inp (unfoldr f contents)
+            withBinaryFile inp WriteMode $ \h ->
+                hPutStringBuffer h contents
             doCpp dflags True inp out
 
             -- Fix up the filename in lines like:

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -343,6 +343,8 @@ runCpp dflags filename contents = withTempDir $ \dir -> do
                     | Just x <- stripPrefix "# " x
                     , "___HIE_CORE_MAGIC___" `isInfixOf` x
                     , let num = takeWhile (not . isSpace) x
+                    -- important to use /, and never \ for paths, even on Windows, since then C escapes them
+                    -- and GHC gets all confused
                         = "# " <> num <> " \"" <> map (\x -> if isPathSeparator x then '/' else x) filename <> "\""
                     | otherwise = x
             stringToStringBuffer . unlines . map tweak . lines <$> readFileUTF8' out

--- a/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
@@ -128,9 +128,7 @@ getFileContentsRule vfs =
         time <- use_ GetModificationTime file
         res <- liftIO $ ideTryIOException file $ do
             mbVirtual <- getVirtualFile vfs $ filePathToUri' file
-            case mbVirtual of
-                Just (VirtualFile _ rope _) -> return $ Just $ textToStringBuffer $ Rope.toText rope
-                Nothing -> return Nothing
+            pure $ textToStringBuffer . Rope.toText . _text <$> mbVirtual
         case res of
             Left err -> return ([err], Nothing)
             Right contents -> return ([], Just (time, contents))

--- a/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/FileStore.hs
@@ -15,6 +15,7 @@ module Development.IDE.Core.FileStore(
 
 import           StringBuffer
 import Development.IDE.GHC.Orphans()
+import Development.IDE.GHC.Util
 
 import Control.Concurrent.Extra
 import qualified Data.Map.Strict as Map
@@ -31,7 +32,6 @@ import           GHC.Generics
 import Data.Either.Extra
 import System.IO.Error
 import qualified Data.ByteString.Char8 as BS
-import qualified StringBuffer as SB
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import qualified Data.Rope.UTF16 as Rope
@@ -180,8 +180,3 @@ setSomethingModified state = do
     when (isJust setVirtualFileContents) $
         fail "setSomethingModified can't be called on this type of VFSHandle"
     void $ shakeRun state [] (const $ pure ())
-
-
--- would be nice to do this more efficiently...
-textToStringBuffer :: T.Text -> SB.StringBuffer
-textToStringBuffer = SB.stringToStringBuffer . T.unpack

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -400,13 +400,13 @@ updateFileDiagnostics fp k ShakeExtras{diagnostics, state} current = do
             let newDiags = getFileDiagnostics fp newDiagsStore
             pure (newDiagsStore, (newDiags, oldDiags))
     when (newDiags /= oldDiags) $
-        sendEvent $ publishDiagnosticsNotification (fromNormalizedFilePath fp) newDiags
+        sendEvent $ publishDiagnosticsNotification fp newDiags
 
-publishDiagnosticsNotification :: FilePath -> [Diagnostic] -> LSP.FromServerMessage
+publishDiagnosticsNotification :: NormalizedFilePath -> [Diagnostic] -> LSP.FromServerMessage
 publishDiagnosticsNotification fp diags =
     LSP.NotPublishDiagnostics $
     LSP.NotificationMessage "2.0" LSP.TextDocumentPublishDiagnostics $
-    LSP.PublishDiagnosticsParams (LSP.filePathToUri fp) (List diags)
+    LSP.PublishDiagnosticsParams (fromNormalizedUri $ filePathToUri' fp) (List diags)
 
 setPriority :: (Enum a) => a -> Action ()
 setPriority p =

--- a/compiler/hie-core/src/Development/IDE/GHC/Compat.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Compat.hs
@@ -9,8 +9,11 @@ module Development.IDE.GHC.Compat(
     HieFile(..),
     mkHieFile,
     writeHieFile,
-    readHieFile
+    readHieFile,
+    hPutStringBuffer
     ) where
+
+import StringBuffer
 
 #ifndef GHC_STABLE
 import HieAst
@@ -22,7 +25,14 @@ import GhcPlugins
 import NameCache
 import Avail
 import TcRnTypes
+import System.IO
+import Foreign.ForeignPtr
 
+
+hPutStringBuffer :: Handle -> StringBuffer -> IO ()
+hPutStringBuffer hdl (StringBuffer buf len cur)
+    = withForeignPtr (plusForeignPtr buf cur) $ \ptr ->
+             hPutBuf hdl ptr len
 
 mkHieFile :: ModSummary -> TcGblEnv -> RenamedSource -> Hsc HieFile
 mkHieFile _ _ _ = return (HieFile () [])

--- a/compiler/hie-core/src/Development/IDE/GHC/Error.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Error.hs
@@ -70,7 +70,8 @@ srcSpanToFilename (RealSrcSpan real) = FS.unpackFS $ srcSpanFile real
 
 srcSpanToLocation :: SrcSpan -> Location
 srcSpanToLocation src =
-  Location (filePathToUri $ srcSpanToFilename src) (srcSpanToRange src)
+  -- important that the URI's we produce have been properly normalized, otherwise they point at weird places in VS Code
+  Location (fromNormalizedUri $ filePathToUri' $ toNormalizedFilePath $ srcSpanToFilename src) (srcSpanToRange src)
 
 -- | Convert a GHC severity to a DAML compiler Severity. Severities below
 -- "Warning" level are dropped (returning Nothing).

--- a/compiler/hie-core/src/Development/IDE/GHC/Util.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Util.hs
@@ -13,7 +13,8 @@ module Development.IDE.GHC.Util(
     modifyDynFlags,
     fakeDynFlags,
     prettyPrint,
-    runGhcEnv
+    runGhcEnv,
+    textToStringBuffer
     ) where
 
 import Config
@@ -25,6 +26,9 @@ import Data.IORef
 import Control.Exception
 import FileCleanup
 import Platform
+import qualified Data.Text as T
+import StringBuffer
+
 
 ----------------------------------------------------------------------
 -- GHC setup
@@ -46,6 +50,10 @@ lookupPackageConfig unitId env =
             -- from PackageState so we have to wrap it in DynFlags first.
             getPackageConfigMap $ hsc_dflags env
 
+
+-- would be nice to do this more efficiently...
+textToStringBuffer :: T.Text -> StringBuffer
+textToStringBuffer = stringToStringBuffer . T.unpack
 
 
 prettyPrint :: Outputable a => a -> String

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -114,6 +114,8 @@ data Message
 
 
 modifyOptions :: LSP.Options -> LSP.Options
-modifyOptions x = x{LSP.textDocumentSync = Just orig{_openClose=Just True, _change=Just TdSyncIncremental}}
-    where orig = fromMaybe tdsDefault $ LSP.textDocumentSync x
-          tdsDefault = TextDocumentSyncOptions Nothing Nothing Nothing Nothing Nothing
+modifyOptions x = x{LSP.textDocumentSync = Just $ tweak orig}
+    where
+        tweak x = x{_openClose=Just True, _change=Just TdSyncIncremental, _save=Just $ SaveOptions Nothing}
+        orig = fromMaybe tdsDefault $ LSP.textDocumentSync x
+        tdsDefault = TextDocumentSyncOptions Nothing Nothing Nothing Nothing Nothing

--- a/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
@@ -43,10 +43,15 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             setSomethingModified ide
             logInfo (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
+    ,LSP.didSaveTextDocumentNotificationHandler = withNotification (LSP.didSaveTextDocumentNotificationHandler x) $
+        \ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri}) -> do
+            setSomethingModified ide
+            logInfo (ideLogger ide) $ "Saved text document: " <> getUri _uri
+
     ,LSP.didCloseTextDocumentNotificationHandler = withNotification (LSP.didCloseTextDocumentNotificationHandler x) $
         \ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             setSomethingModified ide
             whenUriFile ide _uri $ \file ->
                 modifyFilesOfInterest ide (S.delete file)
             logInfo (ideLogger ide) $ "Closed text document: " <> getUri _uri
-  }
+    }

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -66,7 +66,6 @@ import DA.Cli.Damlc.Test
 import DA.Bazel.Runfiles
 import DA.Cli.Visual
 import "ghc-lib" GHC
-import "ghc-lib-parser" StringBuffer
 import Data.List
 
 --------------------------------------------------------------------------------
@@ -664,11 +663,10 @@ execMigrate opts inFile1 inFile2 mbDir = do
         errOrMod <-
             runGhcFast $
             runExceptT $ do
-                sb <- liftIO $ hGetStringBuffer fp
                 lift $ setupDamlGHC [] Nothing []
                 -- parse without any preprocessing, so that we can see which data definitions have
                 -- already generic instances.
-                parseFileContents ((,) []) fp sb
+                parseFileContents ((,) []) fp Nothing
         case errOrMod of
             Left err -> ioError $ userError $ show err
             Right (ds, mod) -> do


### PR DESCRIPTION
A bunch of things to make CPP work better - it now works great with Shake as my test case (before locations were wrong, goto definition didn't work etc). Steps include:

* Make `C:\\foo` get normalized to `C:\foo` (the double slash seems to enter into GHC via way of CPP line directives it gets slightly wrong)
* Make sure we are normalising things and never call `filePathToUri`.
* Instead of making all files produce a StringBuffer, instead just read it off disk when required if they have changed. This will drop memory usage a bit and also means we can have a happy path for unmodified files with CPP.
* For modified files with CPP, do some shenanigans to make locations and include paths work more like they weren't modified. It's not a perfect approximation, but it's close.