### PR TITLE
add authealing to hoogle cluster

### DIFF
--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -157,10 +157,17 @@ resource "google_compute_instance_group_manager" "hoogle" {
     port = "8081"
   }
 
+  auto_healing_policies {
+    health_check = "${google_compute_health_check.hoogle-https.self_link}"
+
+    # Compiling hoogle takes some time
+    initial_delay_sec = 2500
+  }
+
   update_policy {
-    type            = "OPPORTUNISTIC"
-    minimal_action  = "REPLACE"
-    max_surge_fixed = 1
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_unavailable_fixed = 1
   }
 }
 


### PR DESCRIPTION
This PR adds a health check to the Hoogle cluster manager. This means two things:

1. We can now deploy updates aggressively. In the existing setup, when a new version of the Terraform configuration is deployed, it creates a new _template_ for cluster machines, but it waits until the machines "naturally" die to create the new ones based on the new template (machines die "frequently" due to their preemptible nature). With a healthcheck, the manager now has a notion of how many machines are healthy and can therefore coordinate updates while keeping a reasonable number of healthy machines alive.
2. We get extra resilience: if for whatever reason the Hoogle process on a machine crashes, the manager will now be able to detect that and will kill that machine and create a new one to replace it.