### PR TITLE
Exclude protobuf-lite from grpc-protobuf

### DIFF
--- a/bazel_tools/pom_file.bzl
+++ b/bazel_tools/pom_file.bzl
@@ -28,6 +28,11 @@ _MAVEN_COORDINATES_PREFIX = "maven_coordinates="
 
 _SCALA_VERSION = "2.12"
 
+# Map from a dependency to the exclusions for that dependency.
+# The exclusions will be automatically inserted in every pom file that
+# depends on the target.
+EXCLUSIONS = {"io.grpc:grpc-protobuf": ["com.google.protobuf:protobuf-lite"]}
+
 def _maven_coordinates(targets):
     return [target[MavenInfo].maven_coordinates for target in targets if MavenInfo in target and target[MavenInfo].maven_coordinates]
 
@@ -141,6 +146,9 @@ DEP_BLOCK = """
   <groupId>{0}</groupId>
   <artifactId>{1}</artifactId>
   <version>{2}</version>
+  <exclusions>
+{3}
+  </exclusions>
 </dependency>
 """.strip()
 
@@ -151,7 +159,17 @@ CLASSIFIER_DEP_BLOCK = """
   <version>{2}</version>
   <type>{3}</type>
   <classifier>{4}</classifier>
+  <exclusions>
+{5}
+  </exclusions>
 </dependency>
+""".strip()
+
+EXCLUSION_BLOCK = """
+<exclusion>
+  <groupId>{0}</groupId>
+  <artifactId>{1}</artifactId>
+</exclusion>
 """.strip()
 
 def _pom_file(ctx):
@@ -174,7 +192,12 @@ def _pom_file(ctx):
             template = CLASSIFIER_DEP_BLOCK
         else:
             fail("Unknown dependency format: %s" % dep)
-
+        exclusions = EXCLUSIONS.get("{}:{}".format(parts[0], parts[1]), [])
+        formatted_exclusions = []
+        for exclusion in exclusions:
+            exclusion_parts = exclusion.split(":")
+            formatted_exclusions += [EXCLUSION_BLOCK.format(*exclusion_parts)]
+        parts += ["\n".join(["    " + l for l in "\n".join(formatted_exclusions).splitlines()])]
         formatted_deps.append(template.format(*parts))
 
     pom_file_tmpl = ctx.actions.declare_file(ctx.outputs.pom_file.path + ".tmpl")


### PR DESCRIPTION
I am not really sure how to test this but this is what the pom file for `bindings-java` looks like with this change:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.daml.ledger</groupId>
  <artifactId>bindings-java</artifactId>
  <version>100.13.7</version>
  <packaging>jar</packaging>

  <name>bindings-java</name>
  <description>TBD</description>
  <url>https://github.com/digital-asset/daml</url>

  <licenses>
    <license>
      <name>Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>

  <developers>
    <developer>
      <name>Digital Asset SDK Feedback</name>
      <email>sdk-feedback@digitalasset.com</email>
      <organization>Digital Asset (Switzerland) GmbH</organization>
      <organizationUrl>http://www.daml.com</organizationUrl>
    </developer>
  </developers>

  <scm>
    <connection>scm:git:git://github.com/digital-asset/daml.git</connection>
    <developerConnection>scm:git:ssh://github.com:digital-asset/daml.git</developerConnection>
    <url>http://github.com/digital-asset/daml/tree/master</url>
  </scm>

  <dependencies>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-netty</artifactId>
      <version>1.18.0</version>
      <exclusions>

      </exclusions>
    </dependency>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-protobuf</artifactId>
      <version>1.18.0</version>
      <exclusions>
        <exclusion>
          <groupId>com.google.protobuf</groupId>
          <artifactId>protobuf-lite</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-stub</artifactId>
      <version>1.18.0</version>
      <exclusions>

      </exclusions>
    </dependency>
    <dependency>
      <groupId>org.checkerframework</groupId>
      <artifactId>checker</artifactId>
      <version>2.5.4</version>
      <exclusions>

      </exclusions>
    </dependency>
  </dependencies>
</project>
```
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
