### PR TITLE
Dev version for LF value, transaction specs

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMinorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMinorVersion.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.daml.lf.language
 
-sealed abstract class LanguageMinorVersion extends Product with Serializable {
+sealed abstract class LanguageMinorVersion extends ProtoStableDevVersion {
   import LanguageMinorVersion._
   def toProtoIdentifier: String = this match {
     case Stable(id) => id
@@ -11,14 +11,9 @@ sealed abstract class LanguageMinorVersion extends Product with Serializable {
   }
 }
 
-object LanguageMinorVersion {
+object LanguageMinorVersion extends ProtoStableDevVersionCompanion[LanguageMinorVersion] {
   final case class Stable(identifier: String) extends LanguageMinorVersion
   case object Dev extends LanguageMinorVersion
-
-  def fromProtoIdentifier(identifier: String): LanguageMinorVersion = identifier match {
-    case "dev" => Dev
-    case _ => Stable(identifier)
-  }
 
   object Implicits {
     import scala.language.implicitConversions

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/ProtoStableDevVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/ProtoStableDevVersion.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.language
+
+abstract class ProtoStableDevVersion extends Product with Serializable {
+  def toProtoIdentifier: String
+  final def protoValue: String = toProtoIdentifier
+}
+
+abstract class ProtoStableDevVersionCompanion[Root] extends (String => Root) {
+  type Stable <: Root
+  val Stable: String => Stable
+  val Dev: Root
+
+  final def apply(identifier: String): Root = fromProtoIdentifier(identifier)
+
+  final def fromProtoIdentifier(identifier: String): Root = identifier match {
+    case "dev" => Dev
+    case _ => Stable(identifier)
+  }
+}

--- a/daml-lf/transaction-scalacheck/BUILD.bazel
+++ b/daml-lf/transaction-scalacheck/BUILD.bazel
@@ -19,6 +19,7 @@ da_scala_library(
         "//3rdparty/jvm/org/scalaz:scalaz_core",
         "//3rdparty/jvm/org/scalaz:scalaz_scalacheck_binding",
         "//daml-lf/data",
+        "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/transaction/src/main/protobuf:value_java_proto",
     ],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -4,10 +4,22 @@
 package com.digitalasset.daml.lf
 package transaction
 
-import com.digitalasset.daml.lf.value.Value.VersionedValue
 import com.digitalasset.daml.lf.value.ValueVersion
+import language.{ProtoStableDevVersion, ProtoStableDevVersionCompanion}
+import value.Value.VersionedValue
 
-final case class TransactionVersion(protoValue: String)
+sealed abstract class TransactionVersion extends ProtoStableDevVersion {
+  import TransactionVersion._
+  def toProtoIdentifier: String = this match {
+    case Stable(id) => id
+    case Dev => "dev"
+  }
+}
+
+object TransactionVersion extends ProtoStableDevVersionCompanion[TransactionVersion] {
+  final case class Stable(identifier: String) extends TransactionVersion
+  case object Dev extends TransactionVersion
+}
 
 /**
   * Currently supported versions of the DAML-LF transaction specification.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -53,8 +53,8 @@ private[lf] object VersionTimeline {
       That(LanguageVersion(LMV.V1, "4")),
       That(LanguageVersion(LMV.V1, "5")),
       This(That(TransactionVersion("8"))),
+      // add new versions above this line (but see more notes below)
       That(LanguageVersion(LMV.V1, Dev)),
-      // add new versions above this line
       // do *not* backfill to make more Boths, because such would
       // invalidate the timeline, except to accompany Dev language
       // versions; use This and That instead as needed.
@@ -67,10 +67,8 @@ private[lf] object VersionTimeline {
       // supported by this release".
     )
 
-  def foldRelease[Z: Semigroup](av: AllVersions[\&/])(
-      v: ValueVersion => Z,
-      t: TransactionVersion => Z,
-      l: LanguageVersion => Z): Z =
+  def foldRelease[Z: Semigroup](
+      av: Release)(v: ValueVersion => Z, t: TransactionVersion => Z, l: LanguageVersion => Z): Z =
     av.bifoldMap(_.bifoldMap(v)(t))(l)
 
   final case class SubVersion[A](inject: A => SpecifiedVersion, extract: Release => Option[A])

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -54,7 +54,7 @@ private[lf] object VersionTimeline {
       That(LanguageVersion(LMV.V1, "5")),
       This(That(TransactionVersion("8"))),
       // add new versions above this line (but see more notes below)
-      That(LanguageVersion(LMV.V1, Dev)),
+      Both(Both(ValueVersion.Dev, TransactionVersion.Dev), LanguageVersion(LMV.V1, Dev)),
       // do *not* backfill to make more Boths, because such would
       // invalidate the timeline, except to accompany Dev language
       // versions; use This and That instead as needed.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -6,10 +6,22 @@ package com.digitalasset.daml.lf.value
 import com.digitalasset.daml.lf.value.Value._
 import com.digitalasset.daml.lf.LfVersions
 import com.digitalasset.daml.lf.data.{FrontStack, FrontStackCons, ImmArray}
+import com.digitalasset.daml.lf.language.{ProtoStableDevVersion, ProtoStableDevVersionCompanion}
 
 import scala.annotation.tailrec
 
-final case class ValueVersion(protoValue: String)
+sealed abstract class ValueVersion extends ProtoStableDevVersion {
+  import ValueVersion._
+  def toProtoIdentifier: String = this match {
+    case Stable(id) => id
+    case Dev => "dev"
+  }
+}
+
+object ValueVersion extends ProtoStableDevVersionCompanion[ValueVersion] {
+  final case class Stable(identifier: String) extends ValueVersion
+  case object Dev extends ValueVersion
+}
 
 /**
   * Currently supported versions of the DAML-LF value specification.

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
@@ -5,18 +5,19 @@ package com.digitalasset.daml.lf
 package transaction
 
 import com.digitalasset.daml.lf.language._
-import value.ValueVersions
+import value.{ValueVersion, ValueVersions}
 
 import scala.language.higherKinds
 import scalaz.{ICons, INil, NonEmptyList}
 import scalaz.std.list._
 import scalaz.syntax.foldable._
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{Inside, Matchers, WordSpec}
 import org.scalatest.prop.PropertyChecks
+import scalaz.\&/.Both
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks {
+class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks with Inside {
   import VersionTimeline._
   import VersionTimelineSpec._
 
@@ -59,6 +60,14 @@ class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks {
 
       forEvery(versions)(v1 =>
         forEvery(versions)(v2 => LanguageVersion.ordering.lt(v1, v2) shouldBe (v1 precedes v2)))
+    }
+
+    "end with a set of dev versions" in {
+      inside(inAscendingOrder.last) {
+        case Both(
+            Both(ValueVersion("dev"), TransactionVersion("dev")),
+            LanguageVersion(_, LanguageMinorVersion.Dev)) =>
+      }
     }
 
   }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
@@ -65,7 +65,7 @@ class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks wit
     "end with a set of dev versions" in {
       inside(inAscendingOrder.last) {
         case Both(
-            Both(ValueVersion("dev"), TransactionVersion("dev")),
+            Both(ValueVersion.Dev, TransactionVersion.Dev),
             LanguageVersion(_, LanguageMinorVersion.Dev)) =>
       }
     }

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -49,6 +49,7 @@ da_scala_test_suite(
         "//daml-lf/archive:daml_lf_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/language",
         "//daml-lf/transaction",
         "//ledger-api/testing-utils",
         "//ledger/ledger-api-common",


### PR DESCRIPTION
People would like to stage value and transaction features as they do in the LF language.

* [x] Dev version representation
* [x] derive ValueVersions, TransactionVersions #2372 
* [ ] prevent selection of tx/value dev unless a flag is set on the ledger, and in sandbox
* [ ] spec how-to

cc @remyhaemmerle-da 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
