### PR TITLE
daml-lf: create value version 5 for enum types

### DIFF
--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -104,6 +104,7 @@ da_scala_binary(
         visibility = [
             "//daml-lf:__subpackages__",
             "//language-support:__subpackages__",
+             "//extractor:__subpackages__",
         ],
     )
     for target in lf_targets

--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -103,8 +103,8 @@ da_scala_binary(
         tools = [":encoder_binary"],
         visibility = [
             "//daml-lf:__subpackages__",
+            "//extractor:__subpackages__",
             "//language-support:__subpackages__",
-             "//extractor:__subpackages__",
         ],
     )
     for target in lf_targets

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/testing/archive/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/testing/archive/EncodeV1.scala
@@ -440,6 +440,13 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
         case ECase(scrut, alts) =>
           newBuilder.setCase(
             PLF.Case.newBuilder().setScrut(scrut).accumulateLeft(alts)(_ addAlts _))
+        case ELet(binding, body) =>
+          newBuilder.setLet(
+            PLF.Block
+              .newBuilder()
+              .accumulateLeft(List(binding))(_ addBindings _)
+              .setBody(body)
+          )
         case ENil(typ) =>
           newBuilder.setNil(PLF.Expr.Nil.newBuilder().setType(typ))
         case ECons(typ, front, tail) =>

--- a/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
+++ b/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
@@ -16,6 +16,14 @@ module Enum {
     }
   };
 
+
+  val createColoredContract: Scenario (ContractId Enum:Box)  =
+     let
+       redContractCreation: Update (ContractId Enum:Box) =
+         create @Enum:Box (Enum:Box { x = Enum:Color:Red, party = 'party' })
+     in
+       commit @(ContractId Enum:Box) 'party' redContractCreation;
+
   enum Nothing = ;
 
   variant @serializable OptionalColor = NoColor: Unit | SomeColor: Enum:Color;

--- a/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
+++ b/daml-lf/encoder/src/test/lf/since_1.dev/Enum.lf
@@ -16,13 +16,16 @@ module Enum {
     }
   };
 
+  val createColoredContract: Enum:Color -> Scenario (ContractId Enum:Box) = \ (color: Enum:Color) ->
+    commit @(ContractId Enum:Box) 'Bob' (create @Enum:Box (Enum:Box { x = color, party = 'Bob' }));
 
-  val createColoredContract: Scenario (ContractId Enum:Box)  =
-     let
-       redContractCreation: Update (ContractId Enum:Box) =
-         create @Enum:Box (Enum:Box { x = Enum:Color:Red, party = 'party' })
-     in
-       commit @(ContractId Enum:Box) 'party' redContractCreation;
+  val createContracts: Scenario Unit =
+    sbind
+      c1 : ContractId Enum:Box <- Enum:createColoredContract Enum:Color:Red ;
+      c2 : ContractId Enum:Box <- Enum:createColoredContract Enum:Color:Green ;
+      c3 : ContractId Enum:Box <- Enum:createColoredContract Enum:Color:Blue
+    in
+      spure @Unit () ;
 
   enum Nothing = ;
 

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/testing/archive/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/testing/archive/EncodeV1Spec.scala
@@ -108,6 +108,7 @@ class EncodeV1Spec extends WordSpec with Matchers with TableDrivenPropertyChecks
                      | Mod:Tree:Node node -> Some @a (Mod:Tree.Node @a { value } node);
            val aEnumMatch: Mod:Color -> Text = \(e: Mod:Color) ->
              case e of Mod:Color:Red -> "Red" | Mod:Color:Green -> "Green" | Mod:Color:Blue -> "Blue";
+           val aLet: Int64 = let i: Int64 = 42 in i;
 
            val aPureUpdate: forall (a: *). a -> Update a = /\ (a: *). \(x: a) ->
              upure @a x;

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -9,7 +9,7 @@ class EngineInfoTest extends WordSpec with Matchers {
   EngineInfo.getClass.getSimpleName should {
     "show supported LF, Transaction and Value versions" in {
       EngineInfo.show shouldBe
-        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8; Value versions: 1, 2, 3, 4"
+        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8; Value versions: 1, 2, 3, 4, 5"
     }
 
     "toString returns the same value as show" in {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -54,6 +54,7 @@ private[lf] object VersionTimeline {
       That(LanguageVersion(LMV.V1, "5")),
       This(That(TransactionVersion("8"))),
       That(LanguageVersion(LMV.V1, Dev)),
+      This(This(ValueVersion("5"))),
       // add new versions above this line
       // do *not* backfill to make more Boths, because such would
       // invalidate the timeline, except to accompany Dev language

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -53,8 +53,8 @@ private[lf] object VersionTimeline {
       That(LanguageVersion(LMV.V1, "4")),
       That(LanguageVersion(LMV.V1, "5")),
       This(That(TransactionVersion("8"))),
-      That(LanguageVersion(LMV.V1, Dev)),
       This(This(ValueVersion("5"))),
+      That(LanguageVersion(LMV.V1, Dev)),
       // add new versions above this line
       // do *not* backfill to make more Boths, because such would
       // invalidate the timeline, except to accompany Dev language

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -16,13 +16,14 @@ final case class ValueVersion(protoValue: String)
   */
 object ValueVersions
     extends LfVersions(
-      maxVersion = ValueVersion("4"),
-      previousVersions = List("1", "2", "3") map ValueVersion)(_.protoValue) {
+      maxVersion = ValueVersion("5"),
+      previousVersions = List("1", "2", "3", "4") map ValueVersion)(_.protoValue) {
 
   private[this] val minVersion = ValueVersion("1")
   private[this] val minOptional = ValueVersion("2")
   private[value] val minContractIdStruct = ValueVersion("3")
   private[this] val minMap = ValueVersion("4")
+  private[this] val minEnum = ValueVersion("5")
 
   def assignVersion[Cid](v0: Value[Cid]): Either[String, ValueVersion] = {
     import com.digitalasset.daml.lf.transaction.VersionTimeline.{maxVersion => maxVV}
@@ -51,8 +52,7 @@ object ValueVersions
               case ValueMap(map) =>
                 go(maxVV(minMap, currentVersion), map.values ++: values)
               case ValueEnum(_, _) =>
-                // FixMe (RH) https://github.com/digital-asset/daml/issues/105
-                throw new NotImplementedError("Enum types not supported")
+                go(maxVV(minEnum, currentVersion), values)
               // tuples are a no-no
               case ValueTuple(fields) =>
                 Left(s"Got tuple when trying to assign version. Fields: $fields")

--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -140,6 +140,7 @@ da_scala_test_suite(
     size = "medium",
     srcs = glob(["src/test/suite/**/*.scala"]),
     data = [
+        "//daml-lf/encoder:testing-dar-1.dev",
         "//extractor:PrimitiveTypes.dar",
         "//extractor:RecordsAndVariants.dar",
         "//extractor:TransactionExample.dar",

--- a/extractor/src/main/scala/com/digitalasset/extractor/Types.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Types.scala
@@ -4,6 +4,8 @@
 package com.digitalasset.extractor
 
 import com.digitalasset.daml.lf.iface
+import com.digitalasset.daml.lf.iface.{Enum, TypeConName}
+import com.digitalasset.extractor.ledger.LedgerReader.PackageStore
 import doobie.util.fragment.Fragment
 
 import scala.util.control.NoStackTrace
@@ -19,14 +21,33 @@ object Types {
   object FullyAppliedType {
     final case class TypePrim(typ: iface.PrimType, typArgs: List[FullyAppliedType])
         extends FullyAppliedType
-    final case class TypeCon(typ: iface.TypeConName, typArgs: List[FullyAppliedType])
+    final case class TypeCon(
+        typ: iface.TypeConName,
+        typArgs: List[FullyAppliedType],
+        isEnum: Boolean)
         extends FullyAppliedType
 
     object ops {
       final implicit class GenTypeOps(val genType: iface.Type) extends AnyVal {
-        def fat: FullyAppliedType = genType match {
-          case iface.TypePrim(typ, typArgs) => TypePrim(typ, typArgs.toList.map(_.fat))
-          case iface.TypeCon(typ, typArgs) => TypeCon(typ, typArgs.toList.map(_.fat))
+        private def isEnum(typeCon: TypeConName, packageStore: PackageStore) = {
+          val dataType = packageStore(typeCon.identifier.packageId)
+            .typeDecls(typeCon.identifier.qualifiedName)
+            .`type`
+            .dataType
+          dataType match {
+            case Enum(_) => true
+            case _ => false
+          }
+        }
+
+        def fat(packageStore: PackageStore): FullyAppliedType = genType match {
+          case iface.TypePrim(typ, typArgs) =>
+            TypePrim(typ, typArgs.toList.map(_.fat(packageStore)))
+          case iface.TypeCon(tyConName, typArgs) =>
+            TypeCon(
+              tyConName,
+              typArgs.toList.map(_.fat(packageStore)),
+              isEnum(tyConName, packageStore))
           case iface.TypeVar(_) =>
             throw new IllegalArgumentException(
               s"A `TypeVar` ($genType) cannot be converted to a `FullyAppliedType`"

--- a/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
@@ -4,12 +4,12 @@
 package com.digitalasset.extractor.json
 
 import com.digitalasset.daml.lf.data.{
-  Decimal => LfDecimal,
   FrontStack,
   ImmArray,
   Ref,
   SortedLookupList,
-  Time
+  Time,
+  Decimal => LfDecimal
 }
 import com.digitalasset.daml.lf.value.{Value => V}
 import com.digitalasset.extractor.ledger.types.{Identifier, LedgerValue}
@@ -43,6 +43,7 @@ object JsonConverters {
   implicit def valueEncoder[T <: LedgerValue]: Encoder[T] = {
     case r @ V.ValueRecord(_, _) => r.asJson
     case v @ V.ValueVariant(_, _, _) => v.asJson
+    case V.ValueEnum(_, constructor) => constructor.asJson
     case V.ValueList(value) => value.asJson
     case V.ValueOptional(value) => value.asJson
     case V.ValueMap(value) => value.asJson

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/MultiTableDataFormat.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/MultiTableDataFormat.scala
@@ -28,6 +28,7 @@ class MultiTableDataFormat(
     mergeIdentical: Boolean,
     stripPrefix: Option[String]
 ) extends DataFormat[MultiTableState] {
+
   import Queries._
   import Queries.MultiTable._
 
@@ -84,9 +85,9 @@ class MultiTableDataFormat(
       schemaOrErr.fold(
         e => (state, connection.raiseError[Unit](DataIntegrityError(e))), { schemaOpt =>
           val schema = schemaOpt.getOrElse(singleSchemaName)
-          val tableNames = TableName(s"${schema}.${tableName}", tableName)
+          val tableNames = TableName(s"$schema.$tableName", tableName)
 
-          val io = createIOForTable(tableNames.withSchema, params, id)
+          val io = createIOForTable(tableNames.withSchema, params, id, packageStore)
           val updatedState = state.copy(
             templateToTable = state.templateToTable + (id -> tableNames)
           )
@@ -213,7 +214,8 @@ class MultiTableDataFormat(
   private def createIOForTable(
       tableName: String,
       params: iface.Record.FWT,
-      templateId: Identifier
+      templateId: Identifier,
+      packageStore: PackageStore
   ): ConnectionIO[Unit] = {
     val drop = dropTableIfExists(tableName).update.run
 
@@ -225,7 +227,7 @@ class MultiTableDataFormat(
           uName :: acc
       }
       .reverse
-      .zip(mapColumnTypes(params))
+      .zip(mapColumnTypes(params, packageStore))
 
     val create = createContractTable(tableName, columnsWithTypes).update.run
     val setComment = setTableComment(
@@ -256,15 +258,15 @@ class MultiTableDataFormat(
         case iface.PrimTypeOptional => "JSONB"
         case iface.PrimTypeMap => "JSONB"
       }
-    case TypeCon(_, _) => "JSONB"
+    case TypeCon(_, _, true) => "TEXT"
+    case TypeCon(_, _, _) => "JSONB"
   }
 
-  private def mapColumnTypes(params: iface.Record.FWT): List[String] = {
-    params.fields.toList.map(_._2.fat).map {
+  private def mapColumnTypes(params: iface.Record.FWT, packageStore: PackageStore): List[String] =
+    params.fields.toList.map(_._2.fat(packageStore)).map {
       case TypePrim(iface.PrimTypeOptional, typeArg :: _) => mapSQLType(typeArg) + " NULL"
       case other => mapSQLType(other) + " NOT NULL"
     }
-  }
 
   private def uniqueName(takenNames: Set[String], baseName: String): String = {
     @tailrec

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -288,9 +288,12 @@ object Queries {
             "?::jsonb",
             toJsonString(v)
           )
+
         case e @ V.ValueEnum(_, _) =>
-          // FixMe (RH) https://github.com/digital-asset/daml/issues/105
-          throw new NotImplementedError("Enum types not supported")
+          Fragment(
+            "?::jsonb",
+            toJsonString(e)
+          )
 
         case o @ V.ValueOptional(_) =>
           Fragment(

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -289,11 +289,8 @@ object Queries {
             toJsonString(v)
           )
 
-        case e @ V.ValueEnum(_, _) =>
-          Fragment(
-            "?::jsonb",
-            toJsonString(e)
-          )
+        case e @ V.ValueEnum(_, constructor) =>
+          Fragment("?", constructor: String)
 
         case o @ V.ValueOptional(_) =>
           Fragment(

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
@@ -1,3 +1,55 @@
 package com.digitalasset.extractor
 
-class EnumSpec {}
+import java.io.File
+
+import com.digitalasset.daml.bazeltools.BazelRunfiles.rlocation
+import com.digitalasset.extractor.services.{CustomMatchers, ExtractorFixtureAroundAll}
+import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
+import io.circe.parser._
+import org.scalatest.{FlatSpec, Inside, Matchers, Suite}
+import scalaz.Scalaz._
+
+class EnumSpec
+    extends FlatSpec
+    with Suite
+    with PostgresAroundAll
+    with SuiteResourceManagementAroundAll
+    with ExtractorFixtureAroundAll
+    with Inside
+    with Matchers
+    with CustomMatchers {
+
+  override protected def darFile = new File(rlocation("daml-lf/encoder/test-1.dev.dar"))
+
+  override def scenario: Option[String] = Some("Enum:createContracts")
+
+  "Enum" should "be extracted" in {
+    getContracts should have length 3
+  }
+
+  it should "contain the correct JSON data" in {
+
+    val contractsJson = getContracts.map(_.create_arguments)
+
+    val expected = List(
+      """{
+      "x" : "Red",
+      "party" : "Bob"
+      }""",
+      """{
+      "x" : "Green",
+      "party" : "Bob"
+      }""",
+      """{
+      "x" : "Blue",
+      "party" : "Bob"
+      }"""
+    ).traverseU(parse)
+
+    expected should be('right) // That should only fail if this JSON^^ is ill-formatted
+
+    contractsJson should contain theSameElementsAs expected.right.get
+  }
+
+}

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.extractor
 
 import java.io.File

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/EnumSpec.scala
@@ -1,0 +1,3 @@
+package com.digitalasset.extractor
+
+class EnumSpec {}

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -182,6 +182,15 @@ case object DamlConstants {
     )
   )
 
+  val colorGD = DamlLfEnum(DamlLfImmArraySeq(name("Red"), name("Green"), name("Blue")))
+  val colorGC = DamlLfDefDataType(DamlLfImmArraySeq.empty, colorGD)
+  val colorId: DamlLfIdentifier = defRef("Color")
+  val redTC = DamlLfTypeCon(
+    DamlLfTypeConName(colorId),
+    DamlLfImmArraySeq.empty
+  )
+  val redV = ApiEnum(Some(colorId), "Red")
+
   // ------------------------------------------------------------------------------------------------------------------
   // DAML-LF: complex record containing all DAML types
   // ------------------------------------------------------------------------------------------------------------------
@@ -243,7 +252,8 @@ case object DamlConstants {
     simpleVariantId -> simpleVariantGC,
     complexRecordId -> complexRecordGC,
     treeId -> treeGC,
-    treeNodeId -> treeNodeGC
+    treeNodeId -> treeNodeGC,
+    colorId -> colorGC
   )
 
   // Note: these templates may not be valid DAML templates

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/json/ApiCodecCompressedSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/json/ApiCodecCompressedSpec.scala
@@ -67,6 +67,9 @@ class ApiCodecCompressedSpec extends WordSpec with Matchers {
       "work for Tree" in {
         serializeAndParse(C.treeV, C.treeTC) shouldBe Success(C.treeV)
       }
+      "work for Enum" in {
+        serializeAndParse(C.redV, C.redTC) shouldBe Success(C.redV)
+      }
       "work for Map" in {
         serializeAndParse(C.simpleMapV, C.simpleMapT(C.simpleInt64T)) shouldBe Success(C.simpleMapV)
       }


### PR DESCRIPTION
This PR continue the effort to add Enum type to the SDK (See issue #105)

This PR creates a new version for value that allows persisting `enum` types in the ledger.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
