### PR TITLE
Remove compileFile and get diagnostics from event logger

### DIFF
--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -13,7 +13,6 @@ module DA.Service.Daml.Compiler.Impl.Handle
   , setOpenVirtualResources
   , modifyOpenVirtualResources
   , getAssociatedVirtualResources
-  , compileFile
   , toIdeLogger
   , parseFile
   , UseDalf(..)
@@ -129,22 +128,6 @@ getAssociatedVirtualResources service filePath = do
             , let vr = VRScenario filePath name
             ]
 
-
--- | Compile the supplied file using the Compiler Service into a DAML LF Package.
--- TODO options and warnings
-compileFile
-    :: IdeState
-    -- -> Options
-    -- -> Bool -- ^ collect and display warnings
-    -> NormalizedFilePath
-    -> ExceptT [FileDiagnostic] IO LF.Package
-compileFile service fp = do
-    -- We need to mark the file we are compiling as a file of interest.
-    -- Otherwise all diagnostics produced during compilation will be garbage
-    -- collected afterwards.
-    liftIO $ setFilesOfInterest service (S.singleton fp)
-    liftIO $ IdeLogger.logDebug (ideLogger service) $ "Compiling: " <> T.pack (fromNormalizedFilePath fp)
-    actionToExceptT service (getDalf fp)
 
 -- | Parse the supplied file to a ghc ParsedModule.
 parseFile

--- a/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/BUILD.bazel
@@ -25,6 +25,7 @@ da_haskell_library(
         "ghc-lib",
         "ghc-lib-parser",
         "gitrev",
+        "haskell-lsp",
         "lens-aeson",
         "lens",
         "memory",

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc.hs
@@ -46,6 +46,8 @@ import qualified Data.List.Split as Split
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Development.IDE.Core.Compile
+import Development.IDE.Core.Service (runAction)
+import Development.IDE.Core.Rules.Daml (getDalf)
 import Development.IDE.LSP.Protocol
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
@@ -274,11 +276,16 @@ execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
 execCompile :: FilePath -> FilePath -> Compiler.Options -> Command
 execCompile inputFile outputFile opts = withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize -> do
     loggerH <- getLogger opts "compile"
-    inputFile <- relativize inputFile
+    inputFile <- toNormalizedFilePath <$> relativize inputFile
     opts' <- Compiler.mkOptions opts
-    Compiler.withIdeState opts' loggerH (const $ pure ()) $ \hDamlGhc -> do
-        errOrDalf <- runExceptT $ Compiler.compileFile hDamlGhc (toNormalizedFilePath inputFile)
-        either (reportErr "DAML-1.2 to LF compilation failed") write errOrDalf
+    Compiler.withIdeState opts' loggerH diagnosticsLogger $ \ide -> do
+        setFilesOfInterest ide (Set.singleton inputFile)
+        res <- runAction ide $ getDalf inputFile
+        case res of
+            Nothing -> do
+                hPutStrLn stderr "ERROR: Compilation failed."
+                exitFailure
+            Just dalf -> write dalf
   where
     write bs
       | outputFile == "-" = putStrLn $ render Colored $ DA.Pretty.pretty bs

--- a/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
+++ b/daml-foundations/daml-tools/da-hs-daml-cli/DA/Cli/Damlc/Test.hs
@@ -29,7 +29,6 @@ import qualified Development.Shake as Shake
 import qualified Development.IDE.State.API as CompilerService
 import qualified Development.IDE.Core.Rules.Daml as CompilerService
 import Development.IDE.Types.Diagnostics
-import Development.IDE.LSP.Protocol
 import Development.IDE.Types.Location
 import qualified ScenarioService as SS
 import System.Directory (createDirectoryIfMissing)
@@ -45,9 +44,7 @@ execTest :: [NormalizedFilePath] -> UseColor -> Maybe FilePath -> Compiler.Optio
 execTest inFiles color mbJUnitOutput cliOptions = do
     loggerH <- getLogger cliOptions "test"
     opts <- Compiler.mkOptions cliOptions
-    let eventLogger (EventFileDiagnostics fp diags) = printDiagnostics $ map (toNormalizedFilePath fp,) diags
-        eventLogger _ = return ()
-    Compiler.withIdeState opts loggerH eventLogger $ \h -> do
+    Compiler.withIdeState opts loggerH diagnosticsLogger $ \h -> do
         let lfVersion = Compiler.optDamlLfVersion cliOptions
         testRun h inFiles lfVersion color mbJUnitOutput
         -- Run synchronously at the end to make sure that all gRPC requests


### PR DESCRIPTION
Removes more things from the Handle module which I would prefer to
kill and also gets diagnostics via the event handler intead of via
getDiagnostics.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
