### PR TITLE
Replace the version placeholder in extension’s package.json by the actual version

### DIFF
--- a/daml-foundations/daml-tools/daml-extension/BUILD.bazel
+++ b/daml-foundations/daml-tools/daml-extension/BUILD.bazel
@@ -60,10 +60,15 @@ pkg_tar(
 # the tarball to get rid of the `.`.
 genrule(
     name = "dist",
-    srcs = [":dot-dist"],
+    srcs = [
+        ":dot-dist",
+        "//:VERSION",
+    ],
     outs = ["dist.tar.gz"],
     cmd = """
-        tar zxf $<
+        tar zxf $(location :dot-dist)
+        VERSION=$$(cat $(location //:VERSION))
+        sed -i "s/__VERSION__/$$VERSION/" daml-extension/package.json
         tar zcf $@ daml-extension
     """,
 )

--- a/daml-foundations/daml-tools/daml-extension/package.json
+++ b/daml-foundations/daml-tools/daml-extension/package.json
@@ -2,7 +2,7 @@
     "name": "daml",
     "displayName": "DAML",
     "description": "DAML editing and analysis tools",
-    "version": "HEAD",
+    "version": "__VERSION__",
     "publisher": "DigitalAssetHoldingsLLC",
     "repository": "https://github.com/digital-asset/daml/tree/master/daml-foundations/daml-tools/daml-extension",
     "icon": "images/daml-studio.png",


### PR DESCRIPTION
VSCode refuses to load an extension if it has a version that does not
have a semver format. Note that this always uses the version in
__VERSION__ even for daml-sdk-head but that is consistent with what we
do everything else and given that daml-sdk-head is intended for
development I don’t think there is any point in making it more
complicated than necessary.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
