### PR TITLE
fix #1915, somehow

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -24,10 +24,8 @@ module DA.Daml.LF.TypeChecker.Env(
 
 import           Control.Lens hiding (Context)
 import           Control.Monad.Error.Class (MonadError (..))
-import           Control.Monad.Extra
 import           Control.Monad.Reader
 import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMS
 
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.TypeChecker.Error
@@ -80,7 +78,6 @@ emptyGamma = Gamma ContextNone mempty mempty
 -- variable.
 introTypeVar :: MonadGamma m => TypeVarName -> Kind -> m a -> m a
 introTypeVar v k act = do
-  whenM (views tvars (HMS.member v)) $ throwWithContext (EShadowingTypeVar v)
   local (tvars . at v ?~ k) act
 
 -- -- | Introduce a fresh type variable to the environment. Uses the given name as


### PR DESCRIPTION
See #1915 for context.

Definitely need a good review on this one, from someone who knows more about the context.

Simply removing the line that says "throw an error" seems to fix it, but I don't know why that line was there. All tests are still passing. Hopefully, that means it parses it the only way I could write it and get a successful compile _without_ the alias, which is the one that makes the most sense to me (though it doesn't _quite_ make sense):
```
aIdentity : (forall f. Functor f => f Int) -> (forall f. Functor f => f Int)
```
It makes the most sense because, as `f` does not syntactically appear in the signature
```
A -> A
```
it should not introduce a magic link between the two types. It doesn't make sense, as a signature, though, because it essentially means `a -> b`: there is no reason to assume the `f` on either side is the same. (I know that's a valid type for a function that bottoms, like error, but still...)

I have unfortunately not found an easy way to check what the compiler really parses it as.