### PR TITLE
Mark Haskell bindings tests as flaky until #1927 is fixed

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -72,6 +72,7 @@ da_haskell_test(
         ":quickstart.dar",
         "//ledger/sandbox:sandbox-binary",
     ],
+    flaky = True,  # FIXME Remove this once #1927 is solved
     hazel_deps = [
         "async",
         "base",


### PR DESCRIPTION
Temporarily mark the Haskell bindings test as flaky until #1927 is resolved.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
