### PR TITLE
hie-core Logging and exceptions

### DIFF
--- a/compiler/hie-core/BUILD.bazel
+++ b/compiler/hie-core/BUILD.bazel
@@ -24,6 +24,7 @@ depends = [
     "prettyprinter",
     "prettyprinter-ansi-terminal",
     "rope-utf16-splay",
+    "safe-exceptions",
     "sorted-list",
     "shake",
     "stm",

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -22,6 +22,7 @@ import Development.IDE.Types.Location
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Options
 import Development.IDE.Types.Logger
+import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
 import Development.IDE.LSP.LanguageServer
@@ -52,7 +53,8 @@ main = do
 
     -- lock to avoid overlapping output on stdout
     lock <- newLock
-    let logger = makeOneLogger $ withLock lock . T.putStrLn
+    let logger = Logger $ \pri msg -> withLock lock $
+            T.putStrLn $ T.pack ("[" ++ upper (show pri) ++ "] ") <> msg
 
     whenJust argsCwd setCurrentDirectory
 

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -111,6 +111,7 @@ executable hie-core
         directory,
         optparse-applicative,
         hie-bios,
+        safe-exceptions,
         shake,
         data-default,
         ghc-paths,

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -32,7 +32,7 @@ module Development.IDE.Core.Shake(
     use_, uses_,
     define, defineEarlyCutoff,
     getDiagnostics, unsafeClearDiagnostics,
-    reportSeriousError,
+    reportInternalError,
     IsIdeGlobal, addIdeGlobal, getIdeGlobalState, getIdeGlobalAction,
     garbageCollect,
     setPriority,
@@ -307,8 +307,8 @@ uses_ key files = do
         Nothing -> liftIO $ throwIO BadDependency
         Just v -> return v
 
-reportSeriousError :: String -> Action ()
-reportSeriousError t = do
+reportInternalError :: String -> Action ()
+reportInternalError t = do
     ShakeExtras{logger} <- getShakeExtras
     liftIO $ logSeriousError logger $ T.pack t
 

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -32,12 +32,12 @@ module Development.IDE.Core.Shake(
     use_, uses_,
     define, defineEarlyCutoff,
     getDiagnostics, unsafeClearDiagnostics,
-    reportInternalError,
     IsIdeGlobal, addIdeGlobal, getIdeGlobalState, getIdeGlobalAction,
     garbageCollect,
     setPriority,
     sendEvent,
     ideLogger,
+    actionLogger,
     FileVersion(..)
     ) where
 
@@ -307,11 +307,6 @@ uses_ key files = do
         Nothing -> liftIO $ throwIO BadDependency
         Just v -> return v
 
-reportInternalError :: String -> Action ()
-reportInternalError t = do
-    ShakeExtras{logger} <- getShakeExtras
-    liftIO $ logError logger $ T.pack t
-
 
 -- | When we depend on something that reported an error, and we fail as a direct result, throw BadDependency
 --   which short-circuits the rest of the action
@@ -419,6 +414,11 @@ sendEvent e = do
 
 ideLogger :: IdeState -> Logger
 ideLogger IdeState{shakeExtras=ShakeExtras{logger}} = logger
+
+actionLogger :: Action Logger
+actionLogger = do
+    ShakeExtras{logger} <- getShakeExtras
+    return logger
 
 
 data GetModificationTime = GetModificationTime

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -310,7 +310,7 @@ uses_ key files = do
 reportInternalError :: String -> Action ()
 reportInternalError t = do
     ShakeExtras{logger} <- getShakeExtras
-    liftIO $ logSeriousError logger $ T.pack t
+    liftIO $ logError logger $ T.pack t
 
 
 -- | When we depend on something that reported an error, and we fail as a direct result, throw BadDependency

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -109,8 +109,8 @@ setHandlersIgnore = PartialHandlers $ \_ x -> return x
 -- | A message that we need to deal with - the pieces are split up with existentials to gain additional type safety
 --   and defer precise processing until later (allows us to keep at a higher level of abstraction slightly longer)
 data Message
-    = forall m req resp . Response (RequestMessage m req resp) (ResponseMessage resp -> FromServerMessage) (IdeState -> req -> IO resp)
-    | forall m req . Notification (NotificationMessage m req) (IdeState -> req -> IO ())
+    = forall m req resp . (Show m, Show req) => Response (RequestMessage m req resp) (ResponseMessage resp -> FromServerMessage) (IdeState -> req -> IO resp)
+    | forall m req . (Show m, Show req) => Notification (NotificationMessage m req) (IdeState -> req -> IO ())
 
 
 modifyOptions :: LSP.Options -> LSP.Options

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -17,8 +17,10 @@ import qualified Language.Haskell.LSP.Core as LSP
 import Control.Concurrent.Chan
 import Control.Concurrent.Extra
 import Control.Concurrent.Async
+import Control.Exception.Safe
 import Data.Default
 import Data.Maybe
+import qualified Data.Text as T
 import           GHC.IO.Handle                    (hDuplicate, hDuplicateTo)
 import System.IO
 import Control.Monad.Extra
@@ -27,6 +29,7 @@ import Development.IDE.LSP.Definition
 import Development.IDE.LSP.Hover
 import Development.IDE.LSP.Notifications
 import Development.IDE.Core.Service
+import Development.IDE.Types.Logger
 import Development.IDE.Core.FileStore
 import Language.Haskell.LSP.Core (LspFuncs(..))
 import Language.Haskell.LSP.Messages
@@ -89,10 +92,23 @@ runLanguageServer options userHandlers getIdeState = do
             _ <- flip forkFinally (const exitClientMsg) $ forever $ do
                 msg <- readChan clientMsgChan
                 case msg of
-                    Notification NotificationMessage{_params} act -> act ide _params
-                    Response RequestMessage{_id, _params} wrap act -> do
-                        res <- act ide _params
-                        sendFunc $ wrap $ ResponseMessage "2.0" (responseId _id) (Just res) Nothing
+                    Notification x@NotificationMessage{_params} act -> do
+                        catch (act ide _params) $ \(e :: SomeException) ->
+                            logError (ideLogger ide) $ T.pack $
+                                "Unexpected exception on notification, please report!\n" ++
+                                "Message: " ++ show x ++ "\n" ++
+                                "Exception: " ++ show e
+                    Response x@RequestMessage{_id, _params} wrap act ->
+                        catch (do
+                            res <- act ide _params
+                            sendFunc $ wrap $ ResponseMessage "2.0" (responseId _id) (Just res) Nothing
+                        ) $ \(e :: SomeException) -> do
+                            logError (ideLogger ide) $ T.pack $
+                                "Unexpected exception on request, please report!\n" ++
+                                "Message: " ++ show x ++ "\n" ++
+                                "Exception: " ++ show e
+                            sendFunc $ wrap $ ResponseMessage "2.0" (responseId _id) Nothing $
+                                Just $ ResponseError InternalError (T.pack $ show e) Nothing
             pure Nothing
 
 

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -18,11 +18,11 @@ import Development.IDE.Core.Service
 
 
 data WithMessage = WithMessage
-    {withResponse :: forall m req resp .
+    {withResponse :: forall m req resp . (Show m, Show req) =>
         (ResponseMessage resp -> LSP.FromServerMessage) -> -- how to wrap a response
         (IdeState -> req -> IO resp) -> -- actual work
         Maybe (LSP.Handler (RequestMessage m req resp))
-    ,withNotification :: forall m req .
+    ,withNotification :: forall m req . (Show m, Show req) =>
         Maybe (LSP.Handler (NotificationMessage m req)) -> -- old notification handler
         (IdeState -> req -> IO ()) -> -- actual work
         Maybe (LSP.Handler (NotificationMessage m req))

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -6,25 +6,49 @@
 -- concrete choice of logging framework so users can plug in whatever
 -- framework they want to.
 module Development.IDE.Types.Logger
-  ( Logger(..)
+  ( Priority(..)
+  , Logger(..)
+  , logError, logWarning, logInfo, logDebug
   , makeOneLogger
   , makeNopLogger
   ) where
 
 import qualified Data.Text as T
 
+
+data Priority
+-- Don't change the ordering of this type or you will mess up the Ord
+-- instance
+    = Debug -- ^ Verbose debug logging.
+    | Info  -- ^ Useful information in case an error has to be understood.
+    | Warning
+      -- ^ These error messages should not occur in a expected usage, and
+      -- should be investigated.
+    | Error -- ^ Such log messages must never occur in expected usage.
+    deriving (Eq, Show, Ord, Enum, Bounded)
+
+
 -- | Note that this is logging actions _of the program_, not of the user.
 --   You shouldn't call warning/error if the user has caused an error, only
 --   if our code has gone wrong and is itself erroneous (e.g. we threw an exception).
-data Logger = Logger {
-      logError :: T.Text -> IO ()
-    , logInfo :: T.Text -> IO ()
-    , logDebug :: T.Text -> IO ()
-    , logWarning :: T.Text -> IO ()
-    }
+data Logger = Logger {logPriority :: Priority -> T.Text -> IO ()}
+
+
+logError :: Logger -> T.Text -> IO ()
+logError x = logPriority x Error
+
+logWarning :: Logger -> T.Text -> IO ()
+logWarning x = logPriority x Warning
+
+logInfo :: Logger -> T.Text -> IO ()
+logInfo x = logPriority x Info
+
+logDebug :: Logger -> T.Text -> IO ()
+logDebug x = logPriority x Debug
+
 
 makeNopLogger :: Logger
-makeNopLogger = makeOneLogger $ const $ pure ()
+makeNopLogger = Logger $ \_ _ -> return ()
 
 makeOneLogger :: (T.Text -> IO ()) -> Logger
-makeOneLogger x = Logger x x x x
+makeOneLogger = Logger . const

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -14,8 +14,11 @@ module Development.IDE.Types.Logger
 import qualified Data.Text as T
 import GHC.Stack
 
+-- | Note that this is logging actions _of the program_, not of the user.
+--   You shouldn't call warning/error if the user has caused an error, only
+--   if our code has gone wrong and is itself erroneous (e.g. we threw an exception).
 data Logger = Logger {
-      logSeriousError :: HasCallStack => T.Text -> IO ()
+      logError :: HasCallStack => T.Text -> IO ()
     , logInfo :: HasCallStack => T.Text -> IO ()
     , logDebug :: HasCallStack => T.Text -> IO ()
     , logWarning :: HasCallStack => T.Text -> IO ()

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -10,7 +10,7 @@ module Development.IDE.Types.Logger
   , Logger(..)
   , logError, logWarning, logInfo, logDebug
   , makeOneLogger
-  , makeNopLogger
+  , noLogging
   ) where
 
 import qualified Data.Text as T
@@ -47,8 +47,8 @@ logDebug :: Logger -> T.Text -> IO ()
 logDebug x = logPriority x Debug
 
 
-makeNopLogger :: Logger
-makeNopLogger = Logger $ \_ _ -> return ()
+noLogging :: Logger
+noLogging = Logger $ \_ _ -> return ()
 
 makeOneLogger :: (T.Text -> IO ()) -> Logger
 makeOneLogger = Logger . const

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -9,7 +9,6 @@ module Development.IDE.Types.Logger
   ( Priority(..)
   , Logger(..)
   , logError, logWarning, logInfo, logDebug
-  , makeOneLogger
   , noLogging
   ) where
 
@@ -49,6 +48,3 @@ logDebug x = logPriority x Debug
 
 noLogging :: Logger
 noLogging = Logger $ \_ _ -> return ()
-
-makeOneLogger :: (T.Text -> IO ()) -> Logger
-makeOneLogger = Logger . const

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -19,9 +19,9 @@ import GHC.Stack
 --   if our code has gone wrong and is itself erroneous (e.g. we threw an exception).
 data Logger = Logger {
       logError :: HasCallStack => T.Text -> IO ()
+    , logWarning :: HasCallStack => T.Text -> IO ()
     , logInfo :: HasCallStack => T.Text -> IO ()
     , logDebug :: HasCallStack => T.Text -> IO ()
-    , logWarning :: HasCallStack => T.Text -> IO ()
     }
 
 makeNopLogger :: Logger

--- a/compiler/hie-core/src/Development/IDE/Types/Logger.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Logger.hs
@@ -12,20 +12,19 @@ module Development.IDE.Types.Logger
   ) where
 
 import qualified Data.Text as T
-import GHC.Stack
 
 -- | Note that this is logging actions _of the program_, not of the user.
 --   You shouldn't call warning/error if the user has caused an error, only
 --   if our code has gone wrong and is itself erroneous (e.g. we threw an exception).
 data Logger = Logger {
-      logError :: HasCallStack => T.Text -> IO ()
-    , logWarning :: HasCallStack => T.Text -> IO ()
-    , logInfo :: HasCallStack => T.Text -> IO ()
-    , logDebug :: HasCallStack => T.Text -> IO ()
+      logError :: T.Text -> IO ()
+    , logInfo :: T.Text -> IO ()
+    , logDebug :: T.Text -> IO ()
+    , logWarning :: T.Text -> IO ()
     }
 
 makeNopLogger :: Logger
 makeNopLogger = makeOneLogger $ const $ pure ()
 
-makeOneLogger :: (HasCallStack => T.Text -> IO ()) -> Logger
+makeOneLogger :: (T.Text -> IO ()) -> Logger
 makeOneLogger x = Logger x x x x

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -174,7 +174,8 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       pkg <- useE GeneratePackage file
       let pkgModuleNames = S.fromList $ map T.unpack $ LF.packageModuleNames pkg
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
-      unless (S.null missingExposed) $ do
+      unless (S.null missingExposed) $
+          -- FIXME: Should be producing a proper diagnostic
           fail $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               show (S.toList missingExposed)

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -101,12 +101,11 @@ withIdeState compilerOpts loggerH eventHandler f =
 
 -- | Adapter to the IDE logger module.
 toIdeLogger :: Logger.Handle IO -> IdeLogger.Logger
-toIdeLogger h = IdeLogger.Logger {
-       logError = Logger.logError h
-     , logInfo = Logger.logInfo h
-     , logDebug = Logger.logDebug h
-     , logWarning = Logger.logWarning h
-     }
+toIdeLogger h = IdeLogger.Logger $ \case
+    IdeLogger.Error -> Logger.logError h
+    IdeLogger.Warning -> Logger.logWarning h
+    IdeLogger.Info -> Logger.logInfo h
+    IdeLogger.Debug -> Logger.logDebug h
 
 ------------------------------------------------------------------------------
 

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -176,7 +176,7 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       let pkgModuleNames = S.fromList $ map T.unpack $ LF.packageModuleNames pkg
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
       unless (S.null missingExposed) $ do
-          liftIO $ IdeLogger.logSeriousError (ideLogger service) $
+          liftIO $ IdeLogger.logInfo (ideLogger service) $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               T.pack (show $ S.toList missingExposed)
           fail ""

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -175,10 +175,9 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       let pkgModuleNames = S.fromList $ map T.unpack $ LF.packageModuleNames pkg
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
       unless (S.null missingExposed) $ do
-          liftIO $ IdeLogger.logInfo (ideLogger service) $
+          fail $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
-              T.pack (show $ S.toList missingExposed)
-          fail ""
+              show (S.toList missingExposed)
       let dalf = encodeArchiveLazy pkg
       -- get all dalf dependencies.
       deps <- getDalfDependencies file

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -176,7 +176,7 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
       unless (S.null missingExposed) $
           -- FIXME: Should be producing a proper diagnostic
-          fail $
+          error $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               show (S.toList missingExposed)
       let dalf = encodeArchiveLazy pkg

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Handle.hs
@@ -102,7 +102,7 @@ withIdeState compilerOpts loggerH eventHandler f =
 -- | Adapter to the IDE logger module.
 toIdeLogger :: Logger.Handle IO -> IdeLogger.Logger
 toIdeLogger h = IdeLogger.Logger {
-       logSeriousError = Logger.logError h
+       logError = Logger.logError h
      , logInfo = Logger.logInfo h
      , logDebug = Logger.logDebug h
      , logWarning = Logger.logWarning h

--- a/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
+++ b/daml-foundations/daml-ghc/damldoc/src/DA/Daml/GHC/Damldoc/HaddockParse.hs
@@ -124,7 +124,7 @@ haddockParse :: IdeOptions ->
                 Ex.ExceptT [FileDiagnostic] IO [ParsedModule]
 haddockParse opts f = ExceptT $ do
   vfs <- makeVFSHandle
-  service <- Service.initialise Service.mainRule (const $ pure ()) makeNopLogger opts vfs
+  service <- Service.initialise Service.mainRule (const $ pure ()) noLogging opts vfs
   Service.setFilesOfInterest service (Set.fromList f)
   parsed  <- Service.runAction service $
              runMaybeT $

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -226,7 +226,10 @@ generatePackageMapRule opts =
         (errs, res) <-
             liftIO $ generatePackageMap (optPackageDbs opts)
         when (errs /= []) $
-            reportInternalError $ "Rule GeneratePackageMap generated errors " ++ show errs
+            reportInternalError $
+                "Rule GeneratePackageMap generated errors\n" ++
+                "Options: " ++ show (optPackageDbs opts) ++ "\n" ++
+                "Errors:\n" ++ unlines (map show errs)
         return res
 
 generatePackageRule :: Rules ()

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -226,8 +226,7 @@ generatePackageMapRule opts =
         (errs, res) <-
             liftIO $ generatePackageMap (optPackageDbs opts)
         when (errs /= []) $
-            reportSeriousError $
-            "Rule GeneratePackageMap generated errors " ++ show errs
+            reportInternalError $ "Rule GeneratePackageMap generated errors " ++ show errs
         return res
 
 generatePackageRule :: Rules ()

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/State/Rules/Daml.hs
@@ -12,6 +12,7 @@ import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe
 import Development.IDE.Core.OfInterest
+import Development.IDE.Types.Logger
 import DA.Daml.GHC.Compiler.Options
 import qualified Text.PrettyPrint.Annotated.HughesPJClass as Pretty
 import Development.IDE.Types.Location as Base
@@ -225,12 +226,14 @@ generatePackageMapRule opts =
     defineNoFile $ \GeneratePackageMap -> do
         (errs, res) <-
             liftIO $ generatePackageMap (optPackageDbs opts)
-        when (errs /= []) $
-            reportInternalError $
+        when (errs /= []) $ do
+            logger <- actionLogger
+            liftIO $ logError logger $ T.pack $
                 "Rule GeneratePackageMap generated errors\n" ++
                 "Options: " ++ show (optPackageDbs opts) ++ "\n" ++
                 "Errors:\n" ++ unlines (map show errs)
         return res
+
 
 generatePackageRule :: Rules ()
 generatePackageRule =

--- a/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
+++ b/daml-foundations/daml-ghc/ide/test/Development/IDE/State/API/Testing.hs
@@ -122,7 +122,7 @@ runShakeTest mbScenarioService (ShakeTest m) = do
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()
     vfs <- API.makeVFSHandle
-    service <- API.initialise (mainRule options) (atomically . eventLogger) makeNopLogger options vfs mbScenarioService
+    service <- API.initialise (mainRule options) (atomically . eventLogger) noLogging options vfs mbScenarioService
     result <- withSystemTempDirectory "shake-api-test" $ \testDirPath -> do
         let ste = ShakeTestEnv
                 { steService = service

--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -132,7 +132,7 @@ getIntegrationTests registerTODO scenarioService version = do
     vfs <- Compile.makeVFSHandle
     pure $
       withResource
-      (Compile.initialise (Compile.mainRule opts) (const $ pure ()) IdeLogger.makeNopLogger opts vfs (Just scenarioService))
+      (Compile.initialise (Compile.mainRule opts) (const $ pure ()) IdeLogger.noLogging opts vfs (Just scenarioService))
       Compile.shutdown $ \service ->
       withTestArguments $ \args -> testGroup ("Tests for DAML-LF " ++ renderPretty version) $
         map (testCase args version service outdir registerTODO) allTestFiles

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger.hs
@@ -55,10 +55,6 @@ data Handle m = Handle
       -- with the call trace as constructed with tagAction, and with
       -- the handle contexts constructed with tagHandle.
 
-    , tagAction :: !(forall a. T.Text -> m a -> m a)
-      -- ^ @tagAction handle tag action@ tags all log messages on @handle@
-      -- of @action@ with @tag@. Tagging can be nested.
-
     , tagHandle :: !(T.Text -> Handle m)
       -- ^ @tagHandle handle tag@ creates a sub-handle with the
       -- added @tag@.

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
@@ -78,7 +78,7 @@ ioLogJson ih threshold prio msg =
     when (prio >= threshold) $
     withMVar (ihOutputLock ih) $
     \_ -> do
-        tags <- return []
+        let tags = []
         now <- getCurrentTime
         let outH = ihOutputH ih
         System.IO.hPutStrLn outH

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module DA.Service.Logger.Impl.IO
-    ( newStdoutLogger
-    , newStderrLogger
+    ( newStderrLogger
     , newIOLogger
     ) where
 
@@ -29,10 +28,6 @@ import qualified System.IO
 ------------------------------------------------------------------------------
 -- IO Logger implementation
 ------------------------------------------------------------------------------
-
--- | Create a simple logger that outputs messages to 'stdout'.
-newStdoutLogger :: T.Text -> IO (Handle IO)
-newStdoutLogger = newIOLogger System.IO.stdout Nothing Debug
 
 -- | Create a simple logger that outputs messages to 'stderr'.
 newStderrLogger :: Priority -> T.Text -> IO (Handle IO)

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Service.Logger.Impl.Pure
     ( makeNopHandle

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
@@ -79,7 +79,6 @@ emptyState = LogState
 makeNopHandle :: Monad m => Logger.Handle m
 makeNopHandle = Logger.Handle
     { Logger.logJson = \_prio _msg -> return ()
-    , Logger.tagAction = \_tag action -> action
     , Logger.tagHandle = const makeNopHandle
     }
 
@@ -107,12 +106,6 @@ makeHandle logState handleTag = makeHandle' [handleTag]
               , _leTags     = tags
               }
             logState . lsMessages %= (:) entry
-
-        , Logger.tagAction = \tag action -> do
-            logState . lsTags %= (:) tag
-            result <- action
-            logState . lsTags %= tail
-            return result
 
         , Logger.tagHandle = \tag -> makeHandle' (tag : context)
         }

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/Pure.hs
@@ -5,75 +5,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module DA.Service.Logger.Impl.Pure
-    ( makeHandle
-    , makeNopHandle
-    , LogEntry(..)
-    , LogState(..)
-    , emptyState
-    , showState
+    ( makeNopHandle
     ) where
 
-import           Control.Lens                 (Lens', use, (%=))
-import           Control.Monad.State.Class    (MonadState)
-
-import qualified Data.Aeson                   as Aeson
-import           Data.Aeson.Encode.Pretty     (encodePretty)
-import qualified Data.ByteString.Lazy         as BSL
-import qualified Data.Map.Strict              as MS
-import qualified Data.Text.Extended           as T
-import qualified Data.Text.Encoding           as E
-
 import qualified DA.Service.Logger            as Logger
-
--- | Source locations, we can't use Parsec's built-in source location,
--- because they implement a silly (non pretty-print compatible) Show
--- instance.
-data Loc
-    = Loc FilePath Int Int
-    | NoLoc String -- reason for no location information
-    deriving (Show)
-
-
-callStackToLoc :: Loc
-callStackToLoc = NoLoc "N/A"
-
-
-------------------------------------------------------------------------------
--- Types
-------------------------------------------------------------------------------
-
-data LogEntry = LogEntry
-    { _leMessage   :: !Aeson.Value
-    , _lePriority  :: !Logger.Priority
-    , _leLoc       :: !Loc
-    , _leContext   :: ![T.Text]
-    , _leTags      :: ![T.Text]
-    }
-
-data LogState = LogState
-    { _lsMessages      :: ![LogEntry]
-    , _lsCounters      :: !(MS.Map T.Text Int)
-    , _lsGauges        :: !(MS.Map T.Text Int)
-    , _lsTags          :: ![T.Text]
-    }
-
-lsMessages :: Lens' LogState [LogEntry]
-lsMessages f logState = fmap (\msgs -> logState { _lsMessages = msgs }) (f (_lsMessages logState))
-
-lsTags :: Lens' LogState [T.Text]
-lsTags f logState = fmap (\tags -> logState { _lsTags = tags }) (f (_lsTags logState))
-
-emptyState :: LogState
-emptyState = LogState
-    { _lsMessages      = []
-    , _lsCounters      = MS.empty
-    , _lsGauges        = MS.empty
-    , _lsTags          = []
-    }
-
---------------------------------------------------------------------------------
--- Functions
---------------------------------------------------------------------------------
 
 -- | Create a pure no-op logger
 makeNopHandle :: Monad m => Logger.Handle m
@@ -81,53 +16,3 @@ makeNopHandle = Logger.Handle
     { Logger.logJson = \_prio _msg -> return ()
     , Logger.tagHandle = const makeNopHandle
     }
-
--- | Create a pure Logger handle within an arbitrary state monad.
-makeHandle
-    :: forall s m. MonadState s m
-    => Lens' s LogState
-    -- ^ Lens to LogState from 's'.
-    -> T.Text
-    -- ^ The handle tag
-    -> Logger.Handle m
-makeHandle logState handleTag = makeHandle' [handleTag]
-  where
-    makeHandle' :: [T.Text] -> Logger.Handle m
-    makeHandle' context =
-      Logger.Handle
-        { Logger.logJson = \prio msg -> do
-            tags <- use (logState . lsTags)
-            let !loc = callStackToLoc
-            let entry = LogEntry {
-                _leMessage  = Aeson.toJSON msg
-              , _lePriority = prio
-              , _leLoc      = loc
-              , _leContext  = context
-              , _leTags     = tags
-              }
-            logState . lsMessages %= (:) entry
-
-        , Logger.tagHandle = \tag -> makeHandle' (tag : context)
-        }
-
--- | Show the log state in printable format
-showState :: LogState -> T.Text
-showState state =
-    "Messages:\n\n" <> tmap prettyMessage (reverse $ _lsMessages state) <>
-    "Counters:\n\n" <> tmap prettyMetric (MS.toList (_lsCounters state)) <>
-    "\nGauges:\n\n" <> tmap prettyMetric (MS.toList (_lsGauges state))
-
-  where
-    tmap f = T.concat . map f
-
-    prettyMessage :: LogEntry -> T.Text
-    prettyMessage entry =
-        (T.show $ _lePriority entry) <>
-        " [" <> (T.unwords $ reverse $ _leContext entry) <> "]" <>
-        " [" <> (T.unwords $ reverse $ _leTags entry) <> "]" <>
-        " [" <> (T.show $ _leLoc entry) <> "]\n" <>
-        (E.decodeUtf8 $ BSL.toStrict $ encodePretty $ _leMessage entry) <>
-        "\n\n"
-
-    prettyMetric (metric, value) =
-       "   " <> metric <> " = " <> T.show value <> "\n"


### PR DESCRIPTION
Before we logged (to the server) a pretty random set of errors - things like the user not writing down enough exposed modules. Now we only only errors that are a serious failing on our part, and in particular if there is an exception, we log that. I also tidied up some of the logging code in da-hs-base, but it still needs a flamethrower taking to it at some point in the future.