### PR TITLE
Add "Remove import" code action

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -87,6 +87,7 @@ library
         Development.IDE.GHC.Warnings
         Development.IDE.Import.DependencyInformation
         Development.IDE.Import.FindImports
+        Development.IDE.LSP.CodeAction
         Development.IDE.LSP.Definition
         Development.IDE.LSP.Hover
         Development.IDE.LSP.LanguageServer

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -1,0 +1,47 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+-- | Go to the definition of a variable.
+module Development.IDE.LSP.CodeAction
+    ( setHandlersCodeAction
+    ) where
+
+import           Language.Haskell.LSP.Types
+
+import Development.IDE.Types.Logger
+import Development.IDE.Core.Rules
+import Development.IDE.Core.Service
+import Development.IDE.LSP.Server
+import qualified Data.HashMap.Strict as Map
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Types as LSP
+import Language.Haskell.LSP.Messages
+
+import qualified Data.Text as T
+
+-- | Go to the definition of a variable.
+codeAction
+    :: IdeState
+    -> CodeActionParams
+    -> IO (List CAResult)
+codeAction ide arg@(CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=CodeActionContext{_diagnostics=List xs}}) = do
+    logWarning (ideLogger ide) $ T.pack $ "Code action: " ++ show arg
+    pure $ List
+        [ CACodeAction $ CodeAction title (Just CodeActionQuickFix) (Just $ List [x]) (Just edit) Nothing
+        | x <- xs, (title, edit) <- suggestAction uri x]
+
+
+suggestAction :: Uri -> Diagnostic -> [(T.Text, LSP.WorkspaceEdit)]
+suggestAction uri Diagnostic{..}
+    | "The import of " `T.isInfixOf` _message
+    , " is redundant" `T.isInfixOf` _message
+    = [("Remove import", WorkspaceEdit (Just $ Map.singleton uri $ List [TextEdit _range ""]) Nothing)]
+
+
+setHandlersCodeAction :: PartialHandlers
+setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{
+    LSP.codeActionHandler = withResponse RspCodeAction codeAction
+    }

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -35,6 +35,10 @@ codeAction _ CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=
 
 suggestAction :: Uri -> Diagnostic -> [(T.Text, LSP.WorkspaceEdit)]
 suggestAction uri Diagnostic{..}
+-- File.hs:16:1: warning:
+--     The import of `Data.List' is redundant
+--       except perhaps to import instances from `Data.List'
+--     To import instances alone, use: import Data.List()
     | "The import of " `T.isInfixOf` _message
     , " is redundant" `T.isInfixOf` _message
     = [("Remove import", WorkspaceEdit (Just $ Map.singleton uri $ List [TextEdit _range ""]) Nothing)]

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -25,7 +25,7 @@ codeAction
     :: IdeState
     -> CodeActionParams
     -> IO (List CAResult)
-codeAction ide arg@CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=CodeActionContext{_diagnostics=List xs}} = do
+codeAction _ CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=CodeActionContext{_diagnostics=List xs}} = do
     -- disable logging as its quite verbose
     -- logInfo (ideLogger ide) $ T.pack $ "Code action req: " ++ show arg
     pure $ List
@@ -38,7 +38,7 @@ suggestAction uri Diagnostic{..}
     | "The import of " `T.isInfixOf` _message
     , " is redundant" `T.isInfixOf` _message
     = [("Remove import", WorkspaceEdit (Just $ Map.singleton uri $ List [TextEdit _range ""]) Nothing)]
-
+suggestAction _ _ = []
 
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -22,7 +22,7 @@ import Language.Haskell.LSP.Messages
 
 import qualified Data.Text as T
 
--- | Go to the definition of a variable.
+-- | Generate code actions.
 codeAction
     :: IdeState
     -> CodeActionParams

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -11,9 +11,7 @@ module Development.IDE.LSP.CodeAction
 
 import           Language.Haskell.LSP.Types
 
-import Development.IDE.Types.Logger
 import Development.IDE.Core.Rules
-import Development.IDE.Core.Service
 import Development.IDE.LSP.Server
 import qualified Data.HashMap.Strict as Map
 import qualified Language.Haskell.LSP.Core as LSP
@@ -27,8 +25,9 @@ codeAction
     :: IdeState
     -> CodeActionParams
     -> IO (List CAResult)
-codeAction ide arg@(CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=CodeActionContext{_diagnostics=List xs}}) = do
-    logWarning (ideLogger ide) $ T.pack $ "Code action: " ++ show arg
+codeAction ide arg@CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=CodeActionContext{_diagnostics=List xs}} = do
+    -- disable logging as its quite verbose
+    -- logInfo (ideLogger ide) $ T.pack $ "Code action req: " ++ show arg
     pure $ List
         [ CACodeAction $ CodeAction title (Just CodeActionQuickFix) (Just $ List [x]) (Just edit) Nothing
         | x <- xs, (title, edit) <- suggestAction uri x]

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -27,6 +27,7 @@ import Control.Monad.Extra
 
 import Development.IDE.LSP.Definition
 import Development.IDE.LSP.Hover
+import Development.IDE.LSP.CodeAction
 import Development.IDE.LSP.Notifications
 import Development.IDE.Core.Service
 import Development.IDE.Types.Logger
@@ -68,7 +69,7 @@ runLanguageServer options userHandlers getIdeState = do
     let withNotification old f = Just $ \r -> writeChan clientMsgChan $ Notification r (\ide x -> f ide x >> whenJust old ($ r))
     let PartialHandlers parts =
             setHandlersIgnore <> -- least important
-            setHandlersDefinition <> setHandlersHover <> -- useful features someone may override
+            setHandlersDefinition <> setHandlersHover <> setHandlersCodeAction <> -- useful features someone may override
             userHandlers <>
             setHandlersNotifications -- absolutely critical, join them with user notifications
     handlers <- parts WithMessage{withResponse, withNotification} def


### PR DESCRIPTION
If you get a warning that an import is unused, you can use a code action to remove it. Somewhat experimental for now. I still need to delete the blank line after (if the next line is indeed a blank line), but still figuring out how to do that in the haskell-lsp library (its trivial in the TypeScript library...).