### PR TITLE
More code actions for hie-core

### DIFF
--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -15,7 +15,6 @@ import Development.IDE.Core.Rules
 import Development.IDE.LSP.Server
 import qualified Data.HashMap.Strict as Map
 import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Types as LSP
 import Language.Haskell.LSP.Messages
 
 import qualified Data.Text as T
@@ -30,19 +29,21 @@ codeAction _ CodeActionParams{_textDocument=TextDocumentIdentifier uri,_context=
     -- logInfo (ideLogger ide) $ T.pack $ "Code action req: " ++ show arg
     pure $ List
         [ CACodeAction $ CodeAction title (Just CodeActionQuickFix) (Just $ List [x]) (Just edit) Nothing
-        | x <- xs, (title, edit) <- suggestAction uri x]
+        | x <- xs, (title, tedit) <- suggestAction x
+        , let edit = WorkspaceEdit (Just $ Map.singleton uri $ List tedit) Nothing
+        ]
 
 
-suggestAction :: Uri -> Diagnostic -> [(T.Text, LSP.WorkspaceEdit)]
-suggestAction uri Diagnostic{..}
+suggestAction :: Diagnostic -> [(T.Text, [TextEdit])]
+suggestAction Diagnostic{..}
 -- File.hs:16:1: warning:
 --     The import of `Data.List' is redundant
 --       except perhaps to import instances from `Data.List'
 --     To import instances alone, use: import Data.List()
     | "The import of " `T.isInfixOf` _message
     , " is redundant" `T.isInfixOf` _message
-    = [("Remove import", WorkspaceEdit (Just $ Map.singleton uri $ List [TextEdit _range ""]) Nothing)]
-suggestAction _ _ = []
+    = [("Remove import", [TextEdit _range ""])]
+suggestAction _ = []
 
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -50,7 +50,7 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
     , " is redundant" `T.isInfixOf` _message
     , let newlineAfter = maybe False (T.isPrefixOf "\n" . T.dropWhile (\x -> isSpace x && x /= '\n') . snd . textAtPosition _end) contents
     , let extend = newlineAfter && _character _start == 0 -- takes up an entire line, so remove the whole line
-    = [("Remove import", [TextEdit (if extend then Range _start (Position (_line _end + 1) 0) else _range) ""])]
+        = [("Remove import", [TextEdit (if extend then Range _start (Position (_line _end + 1) 0) else _range) ""])]
 
 suggestAction _ _ = []
 

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -10,10 +10,11 @@ module Development.IDE.LSP.CodeAction
     ) where
 
 import           Language.Haskell.LSP.Types
-
+import GHC.LanguageExtensions.Type
 import Development.IDE.Core.Rules
 import Development.IDE.LSP.Server
 import qualified Data.HashMap.Strict as Map
+import qualified Data.HashSet as Set
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
@@ -52,7 +53,35 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
     , let extend = newlineAfter && _character _start == 0 -- takes up an entire line, so remove the whole line
         = [("Remove import", [TextEdit (if extend then Range _start (Position (_line _end + 1) 0) else _range) ""])]
 
+-- File.hs:22:8: error:
+--     Illegal lambda-case (use -XLambdaCase)
+-- File.hs:22:6: error:
+--     Illegal view pattern:  x -> foo
+--     Use ViewPatterns to enable view patterns
+-- File.hs:26:8: error:
+--     Illegal `..' in record pattern
+--     Use RecordWildCards to permit this
+-- File.hs:53:28: error:
+--     Illegal tuple section: use TupleSections
+-- File.hs:238:29: error:
+--     * Can't make a derived instance of `Data FSATrace':
+--         You need DeriveDataTypeable to derive an instance for this class
+--     * In the data declaration for `FSATrace'
+-- C:\Neil\shake\src\Development\Shake\Command.hs:515:31: error:
+--     * Illegal equational constraint a ~ ()
+--       (Use GADTs or TypeFamilies to permit this)
+--     * In the context: a ~ ()
+--       While checking an instance declaration
+--       In the instance declaration for `Unit (m a)'
+    | exts@(_:_) <- filter (`Set.member` ghcExtensions) $ T.split (not . isAlpha) $ T.replace "-X" "" _message
+        = [("Add " <> x <> " extension", [TextEdit (Range (Position 0 0) (Position 0 0)) $ "{-# LANGUAGE " <> x <> " #-}\n"]) | x <- exts]
+
 suggestAction _ _ = []
+
+
+-- | All the GHC extensions
+ghcExtensions :: Set.HashSet T.Text
+ghcExtensions = Set.fromList $ map (T.pack . show) [Cpp .. StarIsType] -- use enumerate from GHC 8.8 and beyond
 
 
 textAtPosition :: Position -> T.Text -> (T.Text, T.Text)

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -47,5 +47,5 @@ suggestAction _ = []
 
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{
-    LSP.codeActionHandler = withResponse RspCodeAction codeAction
+    LSP.codeActionHandler = withResponse RspCodeAction $ const codeAction
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -18,7 +18,7 @@ import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
 import qualified Data.Rope.UTF16 as Rope
-
+import Data.Char
 import qualified Data.Text as T
 
 -- | Generate code actions.
@@ -40,15 +40,28 @@ codeAction lsp _ CodeActionParams{_textDocument=TextDocumentIdentifier uri,_cont
 
 
 suggestAction :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
-suggestAction _ Diagnostic{..}
+suggestAction contents Diagnostic{_range=_range@Range{..},..}
+
 -- File.hs:16:1: warning:
 --     The import of `Data.List' is redundant
 --       except perhaps to import instances from `Data.List'
 --     To import instances alone, use: import Data.List()
     | "The import of " `T.isInfixOf` _message
     , " is redundant" `T.isInfixOf` _message
-    = [("Remove import", [TextEdit _range ""])]
+    , let newlineAfter = maybe False (T.isPrefixOf "\n" . T.dropWhile (\x -> isSpace x && x /= '\n') . snd . textAtPosition _end) contents
+    , let extend = newlineAfter && _character _start == 0 -- takes up an entire line, so remove the whole line
+    = [("Remove import", [TextEdit (if extend then Range _start (Position (_line _end + 1) 0) else _range) ""])]
+
 suggestAction _ _ = []
+
+
+textAtPosition :: Position -> T.Text -> (T.Text, T.Text)
+textAtPosition (Position row col) x
+    | (preRow, mid:postRow) <- splitAt row $ T.splitOn "\n" x
+    , (preCol, postCol) <- T.splitAt col mid
+        = (T.intercalate "\n" $ preRow ++ [preCol], T.intercalate "\n" $ postCol : postRow)
+    | otherwise = (x, T.empty)
+
 
 setHandlersCodeAction :: PartialHandlers
 setHandlersCodeAction = PartialHandlers $ \WithMessage{..} x -> return x{

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -40,5 +40,5 @@ gotoDefinition ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos)
 
 setHandlersDefinition :: PartialHandlers
 setHandlersDefinition = PartialHandlers $ \WithMessage{..} x -> return x{
-    LSP.definitionHandler = withResponse RspDefinition gotoDefinition
+    LSP.definitionHandler = withResponse RspDefinition $ const gotoDefinition
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -44,5 +44,5 @@ onHover ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = do
 
 setHandlersHover :: PartialHandlers
 setHandlersHover = PartialHandlers $ \WithMessage{..} x -> return x{
-    LSP.hoverHandler = withResponse RspHover onHover
+    LSP.hoverHandler = withResponse RspHover $ const onHover
     }

--- a/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
@@ -32,24 +32,24 @@ whenUriFile ide uri act = case LSP.uriToFilePath uri of
 setHandlersNotifications :: PartialHandlers
 setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
     {LSP.didOpenTextDocumentNotificationHandler = withNotification (LSP.didOpenTextDocumentNotificationHandler x) $
-        \ide (DidOpenTextDocumentParams TextDocumentItem{_uri}) -> do
+        \_ ide (DidOpenTextDocumentParams TextDocumentItem{_uri}) -> do
             setSomethingModified ide
             whenUriFile ide _uri $ \file ->
                 modifyFilesOfInterest ide (S.insert file)
             logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
     ,LSP.didChangeTextDocumentNotificationHandler = withNotification (LSP.didChangeTextDocumentNotificationHandler x) $
-        \ide (DidChangeTextDocumentParams VersionedTextDocumentIdentifier{_uri} _) -> do
+        \_ ide (DidChangeTextDocumentParams VersionedTextDocumentIdentifier{_uri} _) -> do
             setSomethingModified ide
             logInfo (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
     ,LSP.didSaveTextDocumentNotificationHandler = withNotification (LSP.didSaveTextDocumentNotificationHandler x) $
-        \ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri}) -> do
+        \_ ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             setSomethingModified ide
             logInfo (ideLogger ide) $ "Saved text document: " <> getUri _uri
 
     ,LSP.didCloseTextDocumentNotificationHandler = withNotification (LSP.didCloseTextDocumentNotificationHandler x) $
-        \ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
+        \_ ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             setSomethingModified ide
             whenUriFile ide _uri $ \file ->
                 modifyFilesOfInterest ide (S.delete file)

--- a/compiler/hie-core/src/Development/IDE/LSP/Server.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Server.hs
@@ -20,11 +20,11 @@ import Development.IDE.Core.Service
 data WithMessage = WithMessage
     {withResponse :: forall m req resp . (Show m, Show req) =>
         (ResponseMessage resp -> LSP.FromServerMessage) -> -- how to wrap a response
-        (IdeState -> req -> IO resp) -> -- actual work
+        (LSP.LspFuncs () -> IdeState -> req -> IO resp) -> -- actual work
         Maybe (LSP.Handler (RequestMessage m req resp))
     ,withNotification :: forall m req . (Show m, Show req) =>
         Maybe (LSP.Handler (NotificationMessage m req)) -> -- old notification handler
-        (IdeState -> req -> IO ()) -> -- actual work
+        (LSP.LspFuncs () -> IdeState -> req -> IO ()) -> -- actual work
         Maybe (LSP.Handler (NotificationMessage m req))
     }
 

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer.hs
@@ -47,20 +47,20 @@ setHandlersKeepAlive = PartialHandlers $ \WithMessage{..} x -> return x
         case _method of
             CustomClientMethod "daml/keepAlive" ->
                 maybe (return ()) ($ msg) $
-                withResponse RspCustomServer (\_ _ -> return Aeson.Null)
+                withResponse RspCustomServer (\_ _ _ -> return Aeson.Null)
             _ -> whenJust (LSP.customRequestHandler x) ($ msg)
     }
 
 setHandlersVirtualResource :: PartialHandlers
 setHandlersVirtualResource = PartialHandlers $ \WithMessage{..} x -> return x
     {LSP.didOpenTextDocumentNotificationHandler = withNotification (LSP.didOpenTextDocumentNotificationHandler x) $
-        \ide (DidOpenTextDocumentParams TextDocumentItem{_uri}) ->
+        \_ ide (DidOpenTextDocumentParams TextDocumentItem{_uri}) ->
             withUriDaml _uri $ \vr -> do
                 logInfo (ideLogger ide) $ "Opened virtual resource NEIL: " <> textShow vr
                 modifyOpenVirtualResources ide (S.insert vr)
 
     ,LSP.didCloseTextDocumentNotificationHandler = withNotification (LSP.didCloseTextDocumentNotificationHandler x) $
-        \ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
+        \_ ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             withUriDaml _uri $ \vr -> do
                 logInfo (ideLogger ide) $ "Closed virtual resource: " <> textShow vr
                 modifyOpenVirtualResources ide (S.delete vr)

--- a/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
+++ b/daml-foundations/daml-ghc/language-server/src/DA/Service/Daml/LanguageServer/CodeLens.hs
@@ -61,5 +61,5 @@ virtualResourceToCodeLens (range, title, vr) =
 
 setHandlersCodeLens :: PartialHandlers
 setHandlersCodeLens = PartialHandlers $ \WithMessage{..} x -> return x{
-    LSP.codeLensHandler = withResponse RspCodeLens handle
+    LSP.codeLensHandler = withResponse RspCodeLens $ const handle
     }


### PR DESCRIPTION
Writing such code actions is strangely compelling.

I tidied up the import removal so it also removes the whole line if appropriate - that makes it actually usable. I also added one that enables extensions that GHC suggests. There are a few more that are visible from haskell-ide-core, but those seem the two most generally useful (since you can avoid breaking flow and visiting the top of the file).

The approach to splitting up text strings to find locations is a bit grim. We would ideally like to use the Rope directly, but it is all point-based not char-based, so the API it provides is not great.