### PR TITLE
Use install script in integration test for unix.

### DIFF
--- a/release/install.bat
+++ b/release/install.bat
@@ -1,5 +1,5 @@
 :: Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 :: SPDX-License-Identifier: Apache-2.0
 
-%~dp0daml\daml install %~dp0 --activate
+%~dp0daml\daml install %~dp0 --install-assistant=yes
 


### PR DESCRIPTION
Use the install script in integration test on Linux/Mac, to detect and avoid situations like the install script not installing the assistant on a fresh install. Fixes #1897. 
