### PR TITLE
The completion stream RPC defaults to the ledger end as offset

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/CommandCompletionClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/CommandCompletionClient.java
@@ -17,6 +17,7 @@ import java.util.Set;
 public interface CommandCompletionClient {
 
     Flowable<CompletionStreamResponse> completionStream(String applicationId, LedgerOffset offset, Set<String> parties);
+    Flowable<CompletionStreamResponse> completionStream(String applicationId, Set<String> parties);
 
     Single<CompletionEndResponse> completionEnd();
 }

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -177,7 +177,7 @@ public final class DamlLedgerClient implements LedgerClient {
         pool.close();
     }
 
-    public static void main(String[] args) throws SSLException {
+    public static void main(String[] args) {
         DamlLedgerClient ledgerClient = DamlLedgerClient.forHostWithLedgerIdDiscovery("localhost", 6865, Optional.empty());
         ledgerClient.connect();
         String ledgerId = ledgerClient.ledgerIdentityClient.getLedgerIdentity().blockingGet();

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandCompletionClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandCompletionClientImpl.java
@@ -41,6 +41,14 @@ public class CommandCompletionClientImpl implements CommandCompletionClient {
     }
 
     @Override
+    public Flowable<CompletionStreamResponse> completionStream(String applicationId, Set<String> parties) {
+        CommandCompletionServiceOuterClass.CompletionStreamRequest request = new CompletionStreamRequest(ledgerId, applicationId, parties).toProto();
+        return ClientPublisherFlowable
+                .create(request, serviceStub::completionStream, sequencerFactory)
+                .map(CompletionStreamResponse::fromProto);
+    }
+
+    @Override
     public Single<CompletionEndResponse> completionEnd() {
         CommandCompletionServiceOuterClass.CompletionEndRequest request = CommandCompletionServiceOuterClass.CompletionEndRequest.newBuilder().setLedgerId(ledgerId).build();
         return Single

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandCompletionClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/CommandCompletionClientImpl.java
@@ -32,20 +32,20 @@ public class CommandCompletionClientImpl implements CommandCompletionClient {
         serviceFutureStub = CommandCompletionServiceGrpc.newFutureStub(channel);
     }
 
-    @Override
-    public Flowable<CompletionStreamResponse> completionStream(String applicationId, LedgerOffset offset, Set<String> parties) {
-        CommandCompletionServiceOuterClass.CompletionStreamRequest request = new CompletionStreamRequest(ledgerId, applicationId, parties, offset).toProto();
+    private Flowable<CompletionStreamResponse> completionStream(CompletionStreamRequest request) {
         return ClientPublisherFlowable
-                .create(request, serviceStub::completionStream, sequencerFactory)
+                .create(request.toProto(), serviceStub::completionStream, sequencerFactory)
                 .map(CompletionStreamResponse::fromProto);
     }
 
     @Override
+    public Flowable<CompletionStreamResponse> completionStream(String applicationId, LedgerOffset offset, Set<String> parties) {
+        return completionStream(new CompletionStreamRequest(ledgerId, applicationId, parties, offset));
+    }
+
+    @Override
     public Flowable<CompletionStreamResponse> completionStream(String applicationId, Set<String> parties) {
-        CommandCompletionServiceOuterClass.CompletionStreamRequest request = new CompletionStreamRequest(ledgerId, applicationId, parties).toProto();
-        return ClientPublisherFlowable
-                .create(request, serviceStub::completionStream, sequencerFactory)
-                .map(CompletionStreamResponse::fromProto);
+        return completionStream(new CompletionStreamRequest(ledgerId, applicationId, parties));
     }
 
     @Override

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/tests/helpers/DummyLedgerClient.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/tests/helpers/DummyLedgerClient.scala
@@ -96,6 +96,10 @@ class DummyLedgerClient(
         offset: LedgerOffset,
         parties: util.Set[String]): Flowable[CompletionStreamResponse] =
       commandCompletions
+    override def completionStream(
+        applicationId: String,
+        parties: util.Set[String]): Flowable[CompletionStreamResponse] =
+      commandCompletions
 
     override def completionEnd(): Single[CompletionEndResponse] = ???
   }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CompletionStreamRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CompletionStreamRequest.java
@@ -7,6 +7,7 @@ import com.digitalasset.ledger.api.v1.CommandCompletionServiceOuterClass;
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public class CompletionStreamRequest {
@@ -17,7 +18,7 @@ public class CompletionStreamRequest {
 
     private final Set<String> parties;
 
-    private final LedgerOffset offset;
+    private final Optional<LedgerOffset> offset;
 
     public static CompletionStreamRequest fromProto(CommandCompletionServiceOuterClass.CompletionStreamRequest request) {
         String ledgerId = request.getLedgerId();
@@ -28,12 +29,13 @@ public class CompletionStreamRequest {
     }
 
     public CommandCompletionServiceOuterClass.CompletionStreamRequest toProto() {
-        return CommandCompletionServiceOuterClass.CompletionStreamRequest.newBuilder()
-                .setLedgerId(this.ledgerId)
-                .setApplicationId(this.applicationId)
-                .addAllParties(this.parties)
-                .setOffset(this.offset.toProto())
-                .build();
+        CommandCompletionServiceOuterClass.CompletionStreamRequest.Builder protoBuilder =
+                CommandCompletionServiceOuterClass.CompletionStreamRequest.newBuilder()
+                        .setLedgerId(this.ledgerId)
+                        .setApplicationId(this.applicationId)
+                        .addAllParties(this.parties);
+        this.offset.ifPresent(offset -> protoBuilder.setOffset(offset.toProto()));
+        return protoBuilder.build();
     }
 
     @Override
@@ -76,15 +78,27 @@ public class CompletionStreamRequest {
         return parties;
     }
 
+    /**
+     * @deprecated Legacy, nullable version of {@link #getLedgerOffset()}, which should be used instead.
+     */
+    @Deprecated
     public LedgerOffset getOffset() {
-        return offset;
+        return offset.orElse(null);
     }
 
-    public CompletionStreamRequest(String ledgerId, String applicationId, Set<String> parties, LedgerOffset offset) {
+    public Optional<LedgerOffset> getLedgerOffset() { return offset; }
 
+    public CompletionStreamRequest(String ledgerId, String applicationId, Set<String> parties) {
         this.ledgerId = ledgerId;
         this.applicationId = applicationId;
         this.parties = parties;
-        this.offset = offset;
+        this.offset = Optional.empty();
+    }
+
+    public CompletionStreamRequest(String ledgerId, String applicationId, Set<String> parties, LedgerOffset offset) {
+        this.ledgerId = ledgerId;
+        this.applicationId = applicationId;
+        this.parties = parties;
+        this.offset = Optional.of(offset);
     }
 }

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MockMessages.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MockMessages.scala
@@ -16,8 +16,8 @@ import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
 import com.digitalasset.ledger.api.v1.trace_context.TraceContext
 import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree, TreeEvent}
 import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
-import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.api.v1.value.Value.Sum.Text
+import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.google.protobuf.timestamp.Timestamp
 
 import scala.util.Random

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidator.scala
@@ -32,8 +32,7 @@ class CompletionServiceRequestValidator(ledgerId: LedgerId, partyNameChecker: Pa
         .map(invalidField("application_id", _))
       nonEmptyParties <- requireNonEmpty(request.parties, "parties")
       knownParties <- partyValidator.requireKnownParties(nonEmptyParties)
-      offset <- FieldValidations.requirePresence(request.offset, "offset")
-      convertedOffset <- LedgerOffsetValidator.validate(offset, "offset")
+      convertedOffset <- LedgerOffsetValidator.validateOptional(request.offset, "offset")
     } yield
       CompletionStreamRequest(
         ledgerId,

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/LedgerOffsetValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/LedgerOffsetValidator.scala
@@ -17,6 +17,14 @@ object LedgerOffsetValidator {
 
   private val boundary = "boundary"
 
+  def validateOptional(
+      ledgerOffset: Option[LedgerOffset],
+      fieldName: String): Either[StatusRuntimeException, Option[domain.LedgerOffset]] =
+    ledgerOffset
+      .map(validate(_, fieldName))
+      .fold[Either[StatusRuntimeException, Option[domain.LedgerOffset]]](Right(None))(
+        _.map(Some(_)))
+
   def validate(
       ledgerOffset: LedgerOffset,
       fieldName: String): Either[StatusRuntimeException, domain.LedgerOffset] = {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -55,9 +55,7 @@ class TransactionServiceRequestValidator(
       filter <- requirePresence(req.filter, "filter")
       requiredBegin <- requirePresence(req.begin, "begin")
       convertedBegin <- LedgerOffsetValidator.validate(requiredBegin, "begin")
-      convertedEnd <- req.end
-        .fold[Result[Option[domain.LedgerOffset]]](rightNone)(end =>
-          LedgerOffsetValidator.validate(end, "end").map(Some(_)))
+      convertedEnd <- LedgerOffsetValidator.validateOptional(req.end, "end")
       knownParties <- partyValidator.requireKnownParties(req.getFilter.filtersByParty.keySet)
     } yield
       PartialValidation(

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionStreamRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionStreamRequest.scala
@@ -10,5 +10,5 @@ case class CompletionStreamRequest(
     ledgerId: LedgerId,
     applicationId: ApplicationId,
     parties: Set[Ref.Party],
-    offset: LedgerOffset
+    offset: Option[LedgerOffset]
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiCommandCompletionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiCommandCompletionService.scala
@@ -45,8 +45,10 @@ class ApiCommandCompletionService private (
       subscriptionId: Any,
       request)
 
+    val offset = request.offset.getOrElse(LedgerOffset.LedgerEnd)
+
     completionsService
-      .getCompletions(request.offset, request.applicationId, request.parties)
+      .getCompletions(offset, request.applicationId, request.parties)
       .via(Slf4JLog(logger, s"Serving response for completion subscription $subscriptionId"))
   }
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,6 +9,9 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [Sandbox] The completion stream method of the command completion service uses the ledger end as a default value for the offset. See `#1913 <https://github.com/digital-asset/daml/issues/1913>`__.
+- [Java bindings] Added overloads to the Java bindings ``CompletionStreamRequest`` constructor and the ``CommandCompletionClient`` to accept a request without an explicit ledger offset. See `#1913 <https://github.com/digital-asset/daml/issues/1913>`__.
+- [Java bindings] **DEPRECATION**: the ``CompletionStreamRequest#getOffset`` method is deprecated in favor of the non-nullable ``CompletionStreamRequest#getLedgerOffset``. See `#1913 <https://github.com/digital-asset/daml/issues/1913>`__.
 - [Scala bindings] Contract keys are exposed on CreatedEvent. See `#1681 <https://github.com/digital-asset/daml/issues/1681>`__.
 - [Navigator] Contract keys are show in the contract details page. See `#1681 <https://github.com/digital-asset/daml/issues/1681>`__.
 - [DAML Standard Library] **BREAKING CHANGE**: Remove the deprecated modules ``DA.Map``, ``DA.Set``, ``DA.Experimental.Map`` and ``DA.Experimental.Set``. Please use ``DA.Next.Map`` and ``DA.Next.Set`` instead.


### PR DESCRIPTION
Fixes #1913

Relevant changes are propagated to the Java bindings (including
deprecating a method that would now return a nullable ledger end).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
