### PR TITLE
Allow shadowing of type variables in DAML and DAML-LF

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -497,8 +497,8 @@ checkExpr expr typ = void (checkExpr' expr typ)
 
 -- | Check that a type constructor definition is well-formed.
 checkDefDataType :: MonadGamma m => DefDataType -> m ()
-checkDefDataType (DefDataType _loc _name _serializable params dataCons) =
-  -- NOTE(MH): Duplicates in the @params@ list are caught by 'introTypeVar'.
+checkDefDataType (DefDataType _loc _name _serializable params dataCons) = do
+  checkUnique EDuplicateTypeParam $ map fst params
   foldr (uncurry introTypeVar) base params
   where
     base = case dataCons of

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Env.hs
@@ -24,10 +24,8 @@ module DA.Daml.LF.TypeChecker.Env(
 
 import           Control.Lens hiding (Context)
 import           Control.Monad.Error.Class (MonadError (..))
-import           Control.Monad.Extra
 import           Control.Monad.Reader
 import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMS
 
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.TypeChecker.Error
@@ -79,9 +77,7 @@ emptyGamma = Gamma ContextNone mempty mempty
 -- variable. Fails if the type variable would shadow some existing type
 -- variable.
 introTypeVar :: MonadGamma m => TypeVarName -> Kind -> m a -> m a
-introTypeVar v k act = do
-  whenM (views tvars (HMS.member v)) $ throwWithContext (EShadowingTypeVar v)
-  local (tvars . at v ?~ k) act
+introTypeVar v k = local (tvars . at v ?~ k)
 
 -- | Run a computation in the current enviroment extended by a new term
 -- variable/type binding. Does not fail on shadowing.

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -60,10 +60,10 @@ data UnserializabilityReason
 
 data Error
   = EUnknownTypeVar        !TypeVarName
-  | EShadowingTypeVar      !TypeVarName
   | EUnknownExprVar        !ExprVarName
   | EUnknownDefinition     !LookupError
   | ETypeConAppWrongArity  !TypeConApp
+  | EDuplicateTypeParam    !TypeVarName
   | EDuplicateField        !FieldName
   | EDuplicateConstructor  !VariantConName
   | EDuplicateModule       !ModuleName
@@ -166,10 +166,10 @@ instance Pretty Error where
       ]
 
     EUnknownTypeVar v -> "unknown type variable: " <> pretty v
-    EShadowingTypeVar v -> "shadowing type variable: " <> pretty v
     EUnknownExprVar v -> "unknown expr variable: " <> pretty v
     EUnknownDefinition e -> pretty e
     ETypeConAppWrongArity tapp -> "wrong arity in typecon application: " <> string (show tapp)
+    EDuplicateTypeParam name -> "duplicate type parameter: " <> pretty name
     EDuplicateField name -> "duplicate field: " <> pretty name
     EDuplicateConstructor name -> "duplicate constructor: " <> pretty name
     EDuplicateModule mname -> "duplicate module: " <> pretty mname

--- a/daml-foundations/daml-ghc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/BUILD.bazel
@@ -118,7 +118,7 @@ daml_ghc_compile_test(
 daml_ghc_compile_test(
     name = "bond-trading-memory",
     srcs = [":bond-trading"],
-    heap_limit = "120M" if is_windows else "100M",
+    heap_limit = "200M" if is_windows else "100M",
     main = "bond-trading/Test.daml",
     stack_limit = "35K",
 )

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Convert.hs
@@ -1384,7 +1384,7 @@ convFieldName = mkField . unpackFS . flLabel
 convTypeVar :: Var -> ConvertM (TypeVarName, LF.Kind)
 convTypeVar t = do
     k <- convertKind $ tyVarKind t
-    pure (mkTypeVar $ varPrettyPrint t, k)
+    pure (mkTypeVar $ show (varUnique t), k)
 
 convVar :: Var -> ExprVarName
 convVar = mkVar . varPrettyPrint

--- a/daml-foundations/daml-ghc/tests/TypeVarShadowing.daml
+++ b/daml-foundations/daml-ghc/tests/TypeVarShadowing.daml
@@ -1,0 +1,27 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that shadowing of type variables works.
+daml 1.2
+module TypeVarShadowing where
+
+-- This is basically the problem reported in #1915.
+type A = forall a. Eq a => a
+
+idA : A -> A
+idA x = x
+
+idA' : (forall a. Eq a => a) -> (forall a. Eq a => a)
+idA' x = x
+
+-- This breaks if we use the surface type variable names and not the unique names.
+type F f = forall a. f a
+
+shadow : forall a. F (Either a)
+shadow = error "shadow"
+
+-- This breaks if we don't allow for shadowing type variables in DAML-LF.
+type Kont a = forall r. (a -> r) -> r
+
+kont2 : Kont (Kont Int)
+kont2 x = kont2 x

--- a/daml-foundations/daml-ghc/util.bzl
+++ b/daml-foundations/daml-ghc/util.bzl
@@ -18,7 +18,7 @@ def _daml_ghc_compile_test_impl(ctx):
       }}
       trap cleanup EXIT
 
-      $DAMLC compile $MAIN -o $TMP/out +RTS {stack_opt} {heap_opt}
+      $DAMLC compile $MAIN -o $TMP/out +RTS -s {stack_opt} {heap_opt}
     """.format(
         damlc = ctx.executable.damlc.short_path,
         main = ctx.files.main[0].short_path,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -126,9 +126,10 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   "valid data variant identifier" should {
     "found and return the argument types" in {
       val id = Identifier(basicTestsPkgId, "BasicTests:Tree")
-      val Right((_, DataVariant(variants))) =
+      val Right((params, DataVariant(variants))) =
         PackageLookup.lookupVariant(basicTestsPkg, id.qualifiedName)
-      variants.find(_._1 == "Leaf") shouldBe Some(("Leaf", TVar("a")))
+      params should have length 1
+      variants.find(_._1 == "Leaf") shouldBe Some(("Leaf", TVar(params(0)._1)))
     }
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -183,6 +183,7 @@ private[validation] object Typing {
       case (dfnName, DDataType(_, params, cons)) =>
         val env =
           Env(mod.languageVersion, world, ContextTemplate(pkgId, mod.name, dfnName), params.toMap)
+        checkUniq[TypeVarName](params.keys, EDuplicateTypeParam(env.ctx, _))
         def tyConName = TypeConName(pkgId, QualifiedName(mod.name, dfnName))
         cons match {
           case DataRecord(fields, template) =>
@@ -219,8 +220,6 @@ private[validation] object Typing {
       LanguageVersion.ordering.gteq(languageVersion, LanguageVersion(LMV.V1, "4"))
 
     private def introTypeVar(v: TypeVarName, k: Kind): Env = {
-      if (tVars.isDefinedAt(v))
-        throw EShadowingTypeVar(ctx, v)
       copy(tVars = tVars + (v -> k))
     }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -143,9 +143,6 @@ abstract class ValidationError extends java.lang.RuntimeException with Product w
 final case class EUnknownTypeVar(context: Context, varName: TypeVarName) extends ValidationError {
   protected def prettyInternal: String = s"unknown type variable: $varName"
 }
-final case class EShadowingTypeVar(context: Context, varName: TypeVarName) extends ValidationError {
-  protected def prettyInternal: String = s"shadowing type variable: $varName"
-}
 final case class EIllegalShadowingExprVar(context: Context, varName: ExprVarName)
     extends ValidationError {
   protected def prettyInternal: String = s"illegal shadowing expr variable: $varName"
@@ -160,6 +157,10 @@ final case class EUnknownDefinition(context: Context, lookupError: LookupError)
 final case class ETypeConAppWrongArity(context: Context, expectedArity: Int, conApp: TypeConApp)
     extends ValidationError {
   protected def prettyInternal: String = s"wrong arity in typecon application: ${conApp.pretty}"
+}
+final case class EDuplicateTypeParam(context: Context, typeParam: TypeVarName)
+    extends ValidationError {
+  protected def prettyInternal: String = s"duplicate type parameter: $typeParam"
 }
 final case class EDuplicateField(context: Context, fieldName: FieldName) extends ValidationError {
   protected def prettyInternal: String = s"duplicate field: $fieldName"

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -60,12 +60,6 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         env.kindOf(typ) shouldBe expectedKind
       }
     }
-
-    "does not allow type variable shadowing" in {
-      // Here env contains the variable named "alpha"
-      an[EShadowingTypeVar] should be thrownBy env.kindOf(
-        t"forall (a:*). forall (a:*). alpha -> Bool")
-    }
   }
 
   "Checker.typeOf" should {


### PR DESCRIPTION
We relax the DAML-LF type checker to allow for shadowing of type variables.
This does not need big changes since the substitution we use already avoids
name capture. The test for alpha equivalence converts to de Bruijn indices
on the fly and is hence not a problem either.

We inline type synonyms during the conversion from GHC Core to DAML-LF. This
requires alpha renaming. The cheapest way to get this, is to use the unique
names of type variables instead of their surface names.

This fixes #1915.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/1962)
<!-- Reviewable:end -->
