### PR TITLE
Use published extension by default in daml studio.

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper/Main.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Main.hs
@@ -46,8 +46,8 @@ commandParser =
     where damlStudioCmd = DamlStudio
               <$> option readReplacement
                   (long "replace" <>
-                   help "Whether an existing extension should be overwritten. ('never', 'newer' or 'always', defaults to newer)" <>
-                   value ReplaceExtNewer
+                   help "Whether an existing extension should be overwritten. ('never', 'newer' or 'always' for bundled extension version, 'published' for official published version of extension, defaults to 'published')" <>
+                   value ReplaceExtPublished
                   )
               <*> many (argument str (metavar "ARG"))
           runJarCmd = RunJar
@@ -75,6 +75,7 @@ commandParser =
               "never" -> Just ReplaceExtNever
               "newer" -> Just ReplaceExtNewer
               "always" -> Just ReplaceExtAlways
+              "published" -> Just ReplaceExtPublished
               _ -> Nothing
 
 runCommand :: Command -> IO ()

--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -187,7 +187,8 @@ runDamlStudio replaceExt remainingArguments = do
                     ["--install-extension", publishedExtensionName]
                 when (exitCode /= ExitSuccess) $ do
                     hPutStr stderr . unlines $
-                        [ "Failed to install DAML Studio extension from marketplace."
+                        [ err
+                        , "Failed to install DAML Studio extension from marketplace."
                         , "Installing bundled DAML Studio extension instead."
                         ]
                     installBundledExtension'

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -12,9 +12,15 @@ HEAD — ongoing
 - [Scala bindings] Contract keys are exposed on CreatedEvent. See `#1681 <https://github.com/digital-asset/daml/issues/1681>`__.
 - [Navigator] Contract keys are show in the contract details page. See `#1681 <https://github.com/digital-asset/daml/issues/1681>`__.
 - [DAML Standard Library] **BREAKING CHANGE**: Remove the deprecated modules ``DA.Map``, ``DA.Set``, ``DA.Experimental.Map`` and ``DA.Experimental.Set``. Please use ``DA.Next.Map`` and ``DA.Next.Set`` instead.
-- [Sandbox] Fixed an issue when CompletionService returns offsets having inclusive semantics when used for re-subscription. 
+- [Sandbox] Fixed an issue when CompletionService returns offsets having inclusive semantics when used for re-subscription.
   See `#1932 <https://github.com/digital-asset/daml/pull/1932>`__.
-  
+
 - [DAML Compiler] The default output path for all artifacts is now in the ``.daml`` directory.
   In particular, the default output path for .dar files in ``daml build`` is now
   ``.daml/dist/<projectname>.dar``.
+
+- [DAML Studio] DAML Studio is now published as an extension in the Visual Studio Code
+  marketplace. The ``daml studio`` command will now install the published extension by
+  default, but will revert to the extension bundled with the DAML SDK if installation
+  fails. You can get the old default behavior of always using the bundled extension
+  by running ``daml studio --replace=newer`` or ``daml studio --replace=always`` instead.


### PR DESCRIPTION
Part of #414.

Instead of installing the extension that is bundled with the SDK by default, install the extension from the VSCode marketplace. We use vscode's command-line API to manage that installation. To this end I added a `--replace=published` option which will uninstall any other version of the extension, ensure the published version of the extension is installed, and I made it the default option.

`--replace=newer` and `--replace=always` still use the bundled extension, as before, and they uninstall the published extension in the process. That way a *power user* (or a user in a pinch) can ensure that they get a specific extension version they want, but the typical user will get the extension we publish in the marketplace automatically, and there's no chance of interference.