### PR TITLE
Buildifier: Exclude ./node_modules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -180,6 +180,7 @@ buildifier_excluded_patterns = [
     "./3rdparty/jvm/*",
     "./3rdparty/workspace.bzl",
     "./hazel/packages.bzl",
+    "./node_modules/*",
 ]
 
 # Run this to check if BUILD files are well-formatted.


### PR DESCRIPTION
This directory contains generated files by rules_nodejs which can throw off buildifier.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
