### PR TITLE
Fix race condition in termination of scenario service

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -29,6 +29,7 @@ module DA.Daml.LF.ScenarioServiceClient.LowLevel
 
 import Conduit (runConduit, (.|), MonadUnliftIO(..))
 import Data.Maybe
+import Data.IORef
 import GHC.Generics
 import Text.Read
 import Control.Concurrent.Async
@@ -173,12 +174,23 @@ withCheckedProcessCleanup' cp f = withRunInIO $ \run -> bracket
             then return res
             else throwIO $ ProcessExitedUnsuccessfully cp ec
 
-handleCrashingScenarioService :: StreamingProcessHandle -> IO a -> IO a
-handleCrashingScenarioService h act = do
-    res <- race (waitForStreamingProcess h) act
-    case res of
-        Left _ -> fail "Scenario service exited unexpectedly"
-        Right r -> pure r
+handleCrashingScenarioService :: IORef Bool -> StreamingProcessHandle -> IO a -> IO a
+handleCrashingScenarioService exitExpected h act =
+    -- `race` doesn’t quite work here since we might end up
+    -- declaring an expected exit at the very end as a failure.
+    -- In particular, once we close stdin of the scenario service
+    -- `waitForStreamingProcess` can return before `act` returns.
+    -- See https://github.com/digital-asset/daml/pull/1974.
+    withAsync (waitForStreamingProcess h) $ \scenarioProcess ->
+    withAsync act $ \act' -> do
+        r <- waitEither scenarioProcess act'
+        case r of
+            Right a -> pure a
+            Left _ -> do
+                expected <- readIORef exitExpected
+                if expected
+                   then wait act'
+                   else fail "Scenario service exited unexpectedly"
 
 withScenarioService :: Options -> (Handle -> IO a) -> IO a
 withScenarioService opts@Options{..} f = do
@@ -188,8 +200,12 @@ withScenarioService opts@Options{..} f = do
       throwIO (ScenarioServiceException (optServerJar <> " does not exist."))
   validateJava opts
   cp <- javaProc (["-jar" , optServerJar] <> maybeToList (show <$> optGrpcMaxMessageSize))
+  exitExpected <- newIORef False
+  let closeStdin hdl = do
+          atomicWriteIORef exitExpected True
+          System.IO.hClose hdl
   withCheckedProcessCleanup' cp $ \processHdl (stdinHdl :: System.IO.Handle) stdoutSrc stderrSrc ->
-          flip finally (System.IO.hClose stdinHdl) $ handleCrashingScenarioService processHdl $ do
+          flip finally (closeStdin stdinHdl) $ handleCrashingScenarioService exitExpected processHdl $ do
     let splitOutput = C.T.decode C.T.utf8 .| C.T.lines
     let printStderr line
             -- The last line should not be treated as an error.
@@ -218,7 +234,7 @@ withScenarioService opts@Options{..} f = do
         -- the callback. Note that on Windows, killThread will not be able to kill the conduits
         -- if they are blocked in hGetNonBlocking so it is crucial that we close stdin in the
         -- callback or withAsync will block forever.
-        flip finally (System.IO.hClose stdinHdl) $ do
+        flip finally (closeStdin stdinHdl) $ do
             System.IO.hFlush System.IO.stdout
             port <- either fail pure =<< takeMVar portMVar
             liftIO $ optLogInfo $ "Scenario service backend running on port " <> show port


### PR DESCRIPTION
Previously we sometimes ended up declaring the expected exit of the
scenario service as an unexpected exit. This PR addresses this by
adding a new variable that we set to True before we ask the scenario
service to exit by closing stdin.

I am sure that this was an issue but I’m not sure it was the only one since I’m still trying to resurrect my Windows build environment which seems to be broken atm.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
