### PR TITLE
Add a page on deploying options

### DIFF
--- a/docs/configs/pdf/index.rst
+++ b/docs/configs/pdf/index.rst
@@ -64,6 +64,15 @@ Background concepts
    concepts/glossary
    concepts/ledger-model/index
 
+Deploying
+---------
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+
+   deploy/index
+
 Examples
 --------
 

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -35,61 +35,7 @@ implementing the DAML Ledger API. For example uses of the integration kit see
 
 .. _daml_ledgers_built_or_in_development:
 
-DAML Ledgers built or in development
-************************************
-
-The following table lists the ledgers that support DAML, or are implementing
-support for running DAML.
-
-.. note: the table renderer fails *silently* if you don't have the right
-   number of columns!
-
-.. list-table::
-   :widths: 25 25 25 25
-   :header-rows: 1
-
-   * - Ledger
-     - Status
-     - Developer (Managed Offering)
-     - More Information
-   * - `VMware Blockchain <https://blogs.vmware.com/blockchain>`__
-     - In Development
-     - `VMware <https://www.vmware.com/>`__
-     - `press release :: April 2019
-       <http://hub.digitalasset.com/press-release/digital-asset-daml-smart-contract-language-now-extended-to-vmware-blockchain>`__
-   * - `Hyperledger Sawtooth <https://sawtooth.hyperledger.org/>`__
-     - In Development
-     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
-       (`Sextant <https://blockchaintp.com/sextant/>`__)
-     - `press release :: April 2019
-       <https://www.hyperledger.org/blog/2019/04/16/daml-smart-contracts-coming-to-hyperledger-sawtooth>`__
-   * - `Hyperledger Fabric <https://www.hyperledger.org/projects/fabric>`__
-     - In Development
-     - `Hacera <https://hacera.com>`__
-       (`Hacera Unbounded Network <https://unbounded.network/>`__)
-     - `press release :: June 2019
-       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
-   * - `R3 Corda <https://www.corda.net>`__
-     - In Development
-     - `Digital Asset <https://digitalasset.com/>`__
-     - `press release :: June 2019
-       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
-   * - `Amazon Aurora <https://aws.amazon.com/rds/aurora/>`__
-     - In Development
-     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
-       (`Sextant <https://blockchaintp.com/sextant/>`__)
-     - `press release :: June 2019
-       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
-   * - :doc:`/tools/sandbox`
-     - Stable
-     - `Digital Asset <https://digitalasset.com/>`__
-     - supports `PostgreSQL <https://www.postgresql.org/>`__,
-       see section on persistence in :doc:`/tools/sandbox` docs
-   * - `Canton <https://www.canton.io>`__
-     - In Development
-     - `Digital Asset <https://digitalasset.com/>`__
-     - `www.canton.io <https://www.canton.io>`__ :: native support for :doc:`DAML's fine-grained privacy model
-       </concepts/ledger-model/ledger-privacy>`.
+TODO include other page
 
 .. _status_and_roadmap:
 

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -29,10 +29,8 @@ We provide the resources in the kit, which include guides to
 
 Using these guides, you can focus on your own distributed-ledger or database
 and reuse our DAML Ledger server and DAML interpreter code for
-implementing the DAML Ledger API. For example uses of the integration kit see
-:ref:`daml_ledgers_built_or_in_development`.
-
-.. _daml_ledgers_built_or_in_development:
+implementing the DAML Ledger API. For example uses of the integration kit, see
+below.
 
 .. include:: ../deploy/index.rst
 

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -32,10 +32,9 @@ and reuse our DAML Ledger server and DAML interpreter code for
 implementing the DAML Ledger API. For example uses of the integration kit see
 :ref:`daml_ledgers_built_or_in_development`.
 
-
 .. _daml_ledgers_built_or_in_development:
 
-TODO include other page
+.. include:: ../deploy/index.rst
 
 .. _status_and_roadmap:
 

--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -1,0 +1,58 @@
+.. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+DAML Ledgers built or in development
+************************************
+
+To run a DAML application, you'll need to deploy it to a DAML ledger. The following table lists the ledgers that support DAML, or are implementing
+support for running DAML.
+
+.. note: the table renderer fails *silently* if you don't have the right
+   number of columns!
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Ledger
+     - Status
+     - Developer (Managed Offering)
+     - More information
+   * - `VMware Blockchain <https://blogs.vmware.com/blockchain>`__
+     - In development
+     - `VMware <https://www.vmware.com/>`__
+     - `press release : April 2019
+       <http://hub.digitalasset.com/press-release/digital-asset-daml-smart-contract-language-now-extended-to-vmware-blockchain>`__
+   * - `Hyperledger Sawtooth <https://sawtooth.hyperledger.org/>`__
+     - In development
+     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
+       (`Sextant <https://blockchaintp.com/sextant/>`__)
+     - `press release : April 2019
+       <https://www.hyperledger.org/blog/2019/04/16/daml-smart-contracts-coming-to-hyperledger-sawtooth>`__
+   * - `Hyperledger Fabric <https://www.hyperledger.org/projects/fabric>`__
+     - In development
+     - `Hacera <https://hacera.com>`__
+       (`Hacera Unbounded Network <https://unbounded.network/>`__)
+     - `press release : June 2019
+       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
+   * - `R3 Corda <https://www.corda.net>`__
+     - In development
+     - `Digital Asset <https://digitalasset.com/>`__
+     - `press release : June 2019
+       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
+   * - `Amazon Aurora <https://aws.amazon.com/rds/aurora/>`__
+     - In development
+     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
+       (`Sextant <https://blockchaintp.com/sextant/>`__)
+     - `press release : June 2019
+       <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
+   * - :doc:`/tools/sandbox`
+     - Stable
+     - `Digital Asset <https://digitalasset.com/>`__
+     - supports `PostgreSQL <https://www.postgresql.org/>`__,
+       see section on persistence in :doc:`/tools/sandbox` docs
+   * - `Canton <https://www.canton.io>`__
+     - In development
+     - `Digital Asset <https://digitalasset.com/>`__
+     - `www.canton.io <https://www.canton.io>`__ : native support for :doc:`DAML's fine-grained privacy model
+       </concepts/ledger-model/ledger-privacy>`.

--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -21,30 +21,30 @@ support for running DAML.
    * - `VMware Blockchain <https://blogs.vmware.com/blockchain>`__
      - In development
      - `VMware <https://www.vmware.com/>`__
-     - `press release : April 2019
+     - `press release, April 2019
        <http://hub.digitalasset.com/press-release/digital-asset-daml-smart-contract-language-now-extended-to-vmware-blockchain>`__
    * - `Hyperledger Sawtooth <https://sawtooth.hyperledger.org/>`__
      - In development
      - `Blockchain Technology Partners <https://blockchaintp.com/>`__
        (`Sextant <https://blockchaintp.com/sextant/>`__)
-     - `press release : April 2019
+     - `press release, April 2019
        <https://www.hyperledger.org/blog/2019/04/16/daml-smart-contracts-coming-to-hyperledger-sawtooth>`__
    * - `Hyperledger Fabric <https://www.hyperledger.org/projects/fabric>`__
      - In development
      - `Hacera <https://hacera.com>`__
        (`Hacera Unbounded Network <https://unbounded.network/>`__)
-     - `press release : June 2019
+     - `press release, June 2019
        <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
    * - `R3 Corda <https://www.corda.net>`__
      - In development
      - `Digital Asset <https://digitalasset.com/>`__
-     - `press release : June 2019
+     - `press release, June 2019
        <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
    * - `Amazon Aurora <https://aws.amazon.com/rds/aurora/>`__
      - In development
      - `Blockchain Technology Partners <https://blockchaintp.com/>`__
        (`Sextant <https://blockchaintp.com/sextant/>`__)
-     - `press release : June 2019
+     - `press release, June 2019
        <https://hub.digitalasset.com/press-release/digital-asset-announces-daml-partner-integrations-with-hyperledger-fabric-r3-corda-and-amazon-aurora>`__
    * - :doc:`/tools/sandbox`
      - Stable
@@ -54,5 +54,5 @@ support for running DAML.
    * - `Canton <https://www.canton.io>`__
      - In development
      - `Digital Asset <https://digitalasset.com/>`__
-     - `www.canton.io <https://www.canton.io>`__ : native support for :doc:`DAML's fine-grained privacy model
+     - `www.canton.io <https://www.canton.io>`__, has native support for :doc:`DAML's fine-grained privacy model
        </concepts/ledger-model/ledger-privacy>`.

--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -1,10 +1,23 @@
 .. Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-DAML Ledgers built or in development
-************************************
+Deploying to DAML ledgers
+*************************
 
-To run a DAML application, you'll need to deploy it to a DAML ledger. The following table lists the ledgers that support DAML, or are implementing
+To run a DAML application, you'll need to deploy it to a DAML ledger.
+
+How to deploy
+-------------
+
+You can deploy to:
+
+- The Sandbox with persistence. For information on how to do this, see the section on persistence in :doc:`/tools/sandbox` docs
+- Further deployment options which are in development. For information on these options and their stage of development, see the table below.
+
+DAML ledgers built or in development
+------------------------------------
+
+The following table lists the ledgers that support DAML, or are implementing
 support for running DAML.
 
 .. note: the table renderer fails *silently* if you don't have the right

--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -7,7 +7,7 @@ Deploying to DAML ledgers
 To run a DAML application, you'll need to deploy it to a DAML ledger.
 
 How to deploy
--------------
+=============
 
 You can deploy to:
 
@@ -15,7 +15,7 @@ You can deploy to:
 - Further deployment options which are in development. For information on these options and their stage of development, see the table below.
 
 DAML ledgers built or in development
-------------------------------------
+====================================
 
 The following table lists the ledgers that support DAML, or are implementing
 support for running DAML.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,14 @@ DAML SDK documentation
    :titlesonly:
    :maxdepth: 2
    :hidden:
+   :caption: Deploying
+
+   deploy/index
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+   :hidden:
    :caption: Examples
 
    examples/examples


### PR DESCRIPTION
I feel there should be a high-level TOC item on deploying, though I don't know if this is the correct time to do it: as we don't tell you _how_ to deploy with any of these options yet, this might be premature.

Anyway, this is what I think it should look like when we're ready to start having a deployment section. I'm happy to merge it now, or to wait: @meiersi-da, I think that's basically your call.