### PR TITLE
Ledger API Test Tool: skip semantic tests on unsupported Ledger API.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -75,6 +75,7 @@ object Cli {
           |use numbers lower than 1.0 to make test timeouts more strict.""".stripMargin)
 
     opt[Unit]("verbose")
+      .abbr("v")
       .action((_, c) => c.copy(verbose = true))
       .text("Prints full stacktraces on failures.")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/ToolReporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/ToolReporter.scala
@@ -82,7 +82,7 @@ class ToolReporter(verbose: Boolean) extends Reporter {
           threadName,
           timeStamp) =>
         testsSucceeded += 1
-        println(ansiGreen + "✓")
+        println(ansiGreen + "✓" + ansiReset)
 
       case e.TestCanceled(
           ordinal,
@@ -102,7 +102,19 @@ class ToolReporter(verbose: Boolean) extends Reporter {
           threadName,
           timeStamp) =>
         testsCancelled += 1
-        println(ansiRed + "cancelled.")
+        println(ansiYellow + "cancelled." + ansiReset)
+        throwable match {
+          case None =>
+            println(indented(ansiRed + s"Cancel details missing!", 1, ' '))
+          case Some(e) =>
+            println(indented(s"Cancel details:", 1, ' '))
+            val st = if (verbose) {
+              ExceptionUtils.getStackTrace(e)
+            } else {
+              e.getMessage
+            }
+            println(indented(st, 2, '|'))
+        }
 
       case e.TestFailed(
           ordinal,
@@ -188,8 +200,11 @@ class ToolReporter(verbose: Boolean) extends Reporter {
         println(ansiYellow + "No tests were run" + ansiReset)
       case Statistics(a, s, 0, 0) =>
         println(ansiGreen + s"All ${s}/${a} tests were successful!" + ansiReset)
+      case Statistics(a, 0, c, 0) =>
+        println(ansiYellow + s"All ${a}/${a} tests were cancelled." + ansiReset)
       case Statistics(a, s, c, 0) =>
-        println(ansiYellow + s"${s}/${a} tests were successful, but ${c} were skipped." + ansiReset)
+        println(
+          ansiYellow + s"${s}/${a} tests were successful, but ${c} were cancelled." + ansiReset)
       case Statistics(a, s, 0, f) =>
         println(ansiRed + s"${s} were successful and ${f} failed out of ${a} tests." + ansiReset)
       case _ =>


### PR DESCRIPTION
Semantic tests will be skipped if the specified Ledger API endpoint does not
implement TimeService.

This teaches MultiLedgerFixture to deal with cancelled tests.

This improves Ledger API Test Tool reporter to deal with cancellations better.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
