### PR TITLE
windows dev-env printing the root cause in case of failure after clean install

### DIFF
--- a/dev-env/windows/libexec/core.ps1
+++ b/dev-env/windows/libexec/core.ps1
@@ -125,7 +125,7 @@ function da_install_all([String] $Directory) {
             } Else {
                 $msg = "$app installation failed after clean install."
                 da_error "<< $msg"
-                da_error "<< Check Windows 'Control Panel \ Programs \ Programs and Features' and uninstall manually if installed."
+                da_error $out
                 throw $msg
             }
         } ElseIf ($alreadyInstalled) {


### PR DESCRIPTION
It happened at least 2 times recently on CI and it wasn't clear why it failed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
