### PR TITLE
Standalone pieces for hie-core

### DIFF
--- a/compiler/hie-core/.ghci
+++ b/compiler/hie-core/.ghci
@@ -1,0 +1,18 @@
+:set -Wunused-binds -Wunused-imports -Worphans -Wunused-matches -Wincomplete-patterns
+
+:set -XBangPatterns
+:set -XDeriveGeneric
+:set -XGeneralizedNewtypeDeriving
+:set -XLambdaCase
+:set -XNamedFieldPuns
+:set -XRecordWildCards
+:set -XScopedTypeVariables
+:set -XStandaloneDeriving
+:set -XTupleSections
+:set -XTypeApplications
+:set -XViewPatterns
+
+:set -package=ghc
+:set -DGHC_STABLE
+:set -isrc -iexe
+:load Main

--- a/compiler/hie-core/.gitignore
+++ b/compiler/hie-core/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.stack-work/

--- a/compiler/hie-core/.gitignore
+++ b/compiler/hie-core/.gitignore
@@ -1,2 +1,4 @@
 dist/
 .stack-work/
+dist-newstyle/
+cabal.project.local

--- a/compiler/hie-core/hie.yaml
+++ b/compiler/hie-core/hie.yaml
@@ -1,0 +1,23 @@
+cradle:
+  direct:
+    arguments:
+      - -Wunused-binds
+      - -Wunused-imports
+      - -Worphans
+      - -Wunused-matches
+      - -Wincomplete-patterns
+      - -XBangPatterns
+      - -XDeriveGeneric
+      - -XGeneralizedNewtypeDeriving
+      - -XLambdaCase
+      - -XNamedFieldPuns
+      - -XRecordWildCards
+      - -XScopedTypeVariables
+      - -XStandaloneDeriving
+      - -XTupleSections
+      - -XTypeApplications
+      - -XViewPatterns
+      - -package=ghc
+      - -DGHC_STABLE
+      - -isrc
+      - -iexe

--- a/compiler/hie-core/install.bat
+++ b/compiler/hie-core/install.bat
@@ -1,3 +1,6 @@
+:: Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+:: SPDX-License-Identifier: Apache-2.0
+
 @REM Install hie-core where cabal install would put it on Windows
 @REM but avoid checking configure or installing local libraries (faster)
 ghc Main -o dist\obj\hie-core.exe -XBangPatterns -XDeriveGeneric -XGeneralizedNewtypeDeriving -XLambdaCase -XNamedFieldPuns -XRecordWildCards -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XViewPatterns -package=ghc -DGHC_STABLE -isrc -iexe -outputdir dist\obj && copy dist\obj\hie-core.exe %AppData%\cabal\bin\hie-core.exe

--- a/compiler/hie-core/install.bat
+++ b/compiler/hie-core/install.bat
@@ -1,0 +1,3 @@
+@REM Install hie-core where cabal install would put it on Windows
+@REM but avoid checking configure or installing local libraries (faster)
+ghc Main -o dist\obj\hie-core.exe -XBangPatterns -XDeriveGeneric -XGeneralizedNewtypeDeriving -XLambdaCase -XNamedFieldPuns -XRecordWildCards -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XViewPatterns -package=ghc -DGHC_STABLE -isrc -iexe -outputdir dist\obj && copy dist\obj\hie-core.exe %AppData%\cabal\bin\hie-core.exe


### PR DESCRIPTION
These pieces make it easy to develop hie-core as an independent piece (aside from the rest of daml) with a global Cabal install on Windows. Only the install.bat is Windows specific, so the other pieces should be generally useful.