### PR TITLE
Restart on nix compression errors

### DIFF
--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -44,7 +44,9 @@ for i in `seq 10`; do
     nix-build nix -A tools -A cached 2>&1 | tee nix_log || NIX_FAILED=1
     # It should be in the last line but let’s use the last 3 and wildcards
     # to be robust against slight changes.
-    if [[ $NIX_FAILED -ne 0 ]] && [[ $(tail -n 3 nix_log) == *"unexpected end-of-file"* ]]; then
+    if [[ $NIX_FAILED -ne 0 ]] &&
+       ([[ $(tail -n 3 nix_log) == *"unexpected end-of-file"* ]] ||
+        [[ $(tail -n 3 nix_log) == *"decompressing xz file"* ]]); then
         echo "Restarting nix-build due to failed cache download"
         continue
     fi


### PR DESCRIPTION
We have seen this error on CI at least 2 times so lets restart
automatically when we encounter it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
