### PR TITLE
Hlb optional offset in command completion

### DIFF
--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -119,10 +119,10 @@ tSubmitBad withSandbox = testCase "submit/bad" $ run withSandbox $ \_pid -> do
     liftIO $ assertTextContains err "Couldn't find package"
 
 tSubmitComplete :: SandboxTest
-tSubmitComplete withSandbox = testCase "submit/complete" $ run withSandbox $ \pid -> do
+tSubmitComplete withSandbox = testCase "tSubmitComplete" $ run withSandbox $ \pid -> do
     lid <- getLedgerIdentity
     let command = createIOU pid alice "A-coin" 100
-    completions <- completionStream (lid,myAid,[alice],LedgerBegin)
+    completions <- completionStream (lid,myAid,[alice],Nothing)
     off0 <- completionEnd lid
     Right cidA1 <- submitCommand lid alice command
     Right (Just Checkpoint{offset=cp1},[Completion{cid=cidB1}]) <- liftIO $ takeStream completions
@@ -140,8 +140,8 @@ tSubmitComplete withSandbox = testCase "submit/complete" $ run withSandbox $ \pi
         assertEqual "cp1" off1 cp1
         assertEqual "cp2" off2 cp2
 
-    completionsX <- completionStream (lid,myAid,[alice],LedgerAbsOffset off0)
-    completionsY <- completionStream (lid,myAid,[alice],LedgerAbsOffset off1)
+    completionsX <- completionStream (lid,myAid,[alice],Just (LedgerAbsOffset off0))
+    completionsY <- completionStream (lid,myAid,[alice],Just (LedgerAbsOffset off1))
 
     Right (Just Checkpoint{offset=cpX},[Completion{cid=cidX}]) <- liftIO $ takeStream completionsX
     Right (Just Checkpoint{offset=cpY},[Completion{cid=cidY}]) <- liftIO $ takeStream completionsY


### PR DESCRIPTION

- Adapt `CommandCompletionService,completionStream` to support the underlying functionality offered by the API, which is to allow the offset field to be missing (it should default to the behaviour of LedgerEnd)

- Adapt tests to the new interface, and make a call with offset=Nothing

- Fix code to stop dropping error info returned from streaming grpc calls, and transmit this as an Abnormal stream close instead of simple EOS.

(The bug where the error info was dropped was initially discovered when making the call with offset=Nothing.. because there was a bug in the ledger which required the offset field, contrary to the specified behaviour in the .proto file. This bug has since been fixed - thanks  Stefano!)


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
