### PR TITLE
Implement debouncing of diagnostics

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Core/Debouncer.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Debouncer.hs
@@ -1,0 +1,45 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Development.IDE.Core.Debouncer
+    ( Debouncer
+    , newDebouncer
+    , registerEvent
+    ) where
+
+import Control.Concurrent.Extra
+import Control.Concurrent.Async
+import Control.Exception
+import Control.Monad.Extra
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import System.Time.Extra
+
+-- | A debouncer can be used to avoid triggering many events
+-- (e.g. diagnostics) for the same key (e.g. the same file)
+-- within a short timeframe. This is accomplished
+-- by delaying each event for a given time. If another event
+-- is registered for the same key within that timeframe,
+-- only the new event will fire.
+newtype Debouncer k = Debouncer (Var (Map k (Async ())))
+
+-- | Create a new empty debouncer.
+newDebouncer :: IO (Debouncer k)
+newDebouncer = do
+    m <- newVar Map.empty
+    pure $ Debouncer m
+
+-- | Register an event that will fire after the given delay if no other event
+-- for the same key gets registered until then.
+--
+-- If there is a pending event for the same key, the pending event will be killed.
+-- Events are run unmasked so it is up to the user of `registerEvent`
+-- to mask if required.
+registerEvent :: Ord k => Debouncer k -> Seconds -> k -> IO () -> IO ()
+registerEvent (Debouncer d) delay k fire = modifyVar_ d $ \m -> mask_ $ do
+    whenJust (Map.lookup k m) cancel
+    a <- asyncWithUnmask $ \unmask -> unmask $ do
+        sleep delay
+        fire
+        modifyVar_ d (pure . Map.delete k)
+    pure $ Map.insert k a m

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 module Main (main) where
 
+import Control.Concurrent
 import Control.Lens hiding (List)
 import Control.Monad (forM, forM_, void)
 import Control.Monad.IO.Class
@@ -397,9 +398,12 @@ stressTests run _runScenarios = testGroup "Stress tests"
         foo <- openDoc' "Foo.daml" damlId $ fooContent 0
         forM_ [1 .. 999] $ \i ->
             replaceDoc foo $ fooContent i
+        -- We delay to account for debouncing
+        liftIO $ threadDelay (10 ^ (6 :: Int))
         expectDiagnostics [("Foo.daml", [(DsError, (3, 6), "Couldn't match expected type")])]
         forM_ [1000 .. 2000] $ \i ->
             replaceDoc foo $ fooContent i
+        liftIO $ threadDelay (10 ^ (6 :: Int))
         expectDiagnostics [("Foo.daml", [])]
         closeDoc foo
   , testCase "Set 10 files of interest" $ run $ do


### PR DESCRIPTION
Previously, we emitted diagnostics notifications as soon as we got
them. This resulted in a lot of flickering due to diagnostics getting
cleared briefly when typing only to immediately reappear.

Now, we buffer them for 0.1s so that a new event restoring the
same diagnostics for a slightly modified file will overwrite the
initial clear of diagnostics for the new document version.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
