### PR TITLE
Add Development.IDE.Core.Debouncer to library other-modules

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -88,6 +88,7 @@ library
         Development.IDE.Types.Logger
         Development.IDE.Types.Options
     other-modules:
+        Development.IDE.Core.Debouncer
         Development.IDE.Core.Compile
         Development.IDE.GHC.Compat
         Development.IDE.GHC.CPP


### PR DESCRIPTION
Missing module leading to link errors.