### PR TITLE
Make the gRPC timeout used for the scenario service configurable

### DIFF
--- a/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/GHC.hs
@@ -81,7 +81,7 @@ mainAll :: IO ()
 mainAll = mainWithVersions (delete versionDev supportedInputVersions)
 
 mainWithVersions :: [Version] -> IO ()
-mainWithVersions versions = SS.withScenarioService Logger.makeNopHandle $ \scenarioService -> do
+mainWithVersions versions = SS.withScenarioService Logger.makeNopHandle SS.defaultScenarioServiceConfig $ \scenarioService -> do
   hSetEncoding stdout utf8
   setEnv "TASTY_NUM_THREADS" "1" True
   todoRef <- newIORef DList.empty

--- a/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
+++ b/daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs
@@ -29,7 +29,7 @@ import Development.IDE.Core.API.Testing
 import Development.IDE.Core.Service.Daml(VirtualResource(..))
 
 main :: IO ()
-main = SS.withScenarioService Logger.makeNopHandle $ \scenarioService -> do
+main = SS.withScenarioService Logger.makeNopHandle SS.defaultScenarioServiceConfig $ \scenarioService -> do
   -- The scenario service is a shared resource so running tests in parallel doesn’t work properly.
   setEnv "TASTY_NUM_THREADS" "1" True
   -- The startup of the scenario service is fairly expensive so instead of launching a separate

--- a/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc.hs
@@ -264,8 +264,9 @@ execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
         , optScenarioValidation = ScenarioValidationLight
         , optThreads = 0
         }
+    scenarioServiceConfig <- readScenarioServiceConfig
     withLogger $ \loggerH ->
-        withScenarioService' enableScenarioService loggerH $ \mbScenarioService -> do
+        withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
             -- TODO we should allow different LF versions in the IDE.
             execInit LF.versionDefault (ProjectOpts Nothing (ProjectCheck "" False)) (InitPkgDb True)
             sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")

--- a/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc/IdeState.hs
+++ b/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc/IdeState.hs
@@ -41,10 +41,11 @@ withDamlIdeState
     -> (LSP.FromServerMessage -> IO ())
     -> (IdeState -> IO a)
     -> IO a
-withDamlIdeState compilerOpts loggerH eventHandler f =
-    Scenario.withScenarioService' (optScenarioService compilerOpts) loggerH $ \mbScenarioService -> do
+withDamlIdeState opts@Options{..} loggerH eventHandler f = do
+    scenarioServiceConfig <- Scenario.readScenarioServiceConfig
+    Scenario.withScenarioService' optScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
         vfs <- makeVFSHandle
-        ideState <- getDamlIdeState compilerOpts mbScenarioService loggerH eventHandler vfs
+        ideState <- getDamlIdeState opts mbScenarioService loggerH eventHandler vfs
         f ideState
 
 -- | Adapter to the IDE logger module.

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -95,6 +95,7 @@ The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory
       - daml-stdlib
     scenario-service:
       grpc-max-message-size: 134217728
+      grpc-timeout: 60
 
 
 Here is what each field means:
@@ -114,9 +115,12 @@ Here is what each field means:
 - ``dependencies``: the dependencies of this project.
 - ``scenario-service``: settings for the scenario service
 
-  - ``grpc-max-message-size``: This controls the maximum size of gRPC messages.
+  - ``grpc-max-message-size``: This option controls the maximum size of gRPC messages.
     If unspecified this defaults to 128MB (134217728 bytes). Unless you get
-    errors there should be no reason to modify this.
+    errors, there should be no reason to modify this.
+  - ``grpc-timeout``: This option controls the timeout used for communicating
+    with the scenario service. If unspecified this defaults to 60s. Unless you get
+    errors, there should be no reason to modify this.
 
 ..  TODO (@robin-da) document the dependency syntax
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -35,3 +35,7 @@ HEAD — ongoing
   allowing users to resume a Postgres sandbox ledger without having to again
   specify all packages through the CLI.
   See `#1929 <https://github.com/digital-asset/daml/issues/1929>`__.
+- [DAML Studio] You can now configure the gRPC timeout
+  ``daml.yaml`` via ``scenario-service: {"grpc-timeout": 42}``.
+  This option will set the timeout to 42 seconds. You should
+  only need to set this option for very large projects.


### PR DESCRIPTION
Given that we already made the max message size configurable it only
seems reasonable to also make the timeout configurable and on very
large projects, we do sometimes hit this.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
