### PR TITLE
loading Dars from ZipInputStreams

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -99,6 +99,7 @@ da_scala_library(
     deps = [
         ":daml_lf_java_proto",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+        "//3rdparty/jvm/commons_io",
         "//3rdparty/jvm/org/scalaz:scalaz_core",
         "//daml-lf/data",
         "//daml-lf/language",

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
@@ -64,7 +64,7 @@ class DarReader[A](
     sequence(names.map(parseOne(getInputStreamFor)))
 
   private def parseOne(getInputStreamFor: String => Try[(Long, InputStream)])(s: String): Try[A] =
-    bracket(getInputStreamFor(s))({ case (_, is) => close(is) }).flatMap({
+    bracket(getInputStreamFor(s))({ case (_, is) => Try(is.close())}).flatMap({
       case (size, is) =>
         parseDalf(size, is)
     })
@@ -116,7 +116,7 @@ object DarReader {
 
     private def parseDalfNamesFromManifest(
         readDalfNamesFromManifest: InputStream => Try[Dar[String]]): Try[Dar[String]] =
-      bracket(getInputStreamFor(ManifestName)) { case (_, is) => close(is) }
+      bracket(getInputStreamFor(ManifestName)) { case (_, is) => Try(is.close()) }
         .flatMap { case (_, is) => readDalfNamesFromManifest(is) }
 
     // There are three cases:
@@ -138,8 +138,6 @@ object DarReader {
 
     private def isPrimDalf(s: String): Boolean = s.toLowerCase.contains("-prim") && isDalf(s)
   }
-
-  private[archive] def close(is: InputStream): Try[Unit] = Try(is.close())
 
   def apply(): DarReader[(Ref.PackageId, DamlLf.ArchivePayload)] =
     new DarReader(DarManifestReader.dalfNames, {

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
@@ -97,12 +97,9 @@ private[lf] object SupportedFileType {
   sealed abstract class SupportedFileType(fileExtension: String) extends Serializable with Product {
     def matchesFileExtension(f: File): Boolean = f.getName.endsWith(fileExtension)
   }
-
   final case object DarFile extends SupportedFileType(".dar")
-
   final case object DalfFile extends SupportedFileType(".dalf")
 
   case class UnsupportedFileExtension(file: File)
       extends RuntimeException(s"Unsupported file extension: ${file.getAbsolutePath}")
-
 }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
@@ -48,6 +48,7 @@ class UniversalArchiveReader[A](
   private def zipInputStream(inputStream: InputStream): ZipInputStream =
     new ZipInputStream(inputStream)
 
+  //TODO: use bracket here?
   private def fileToInputStream(f: File): Try[InputStream] =
     Try(new BufferedInputStream(new FileInputStream(f)))
 

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
@@ -3,8 +3,7 @@
 
 package com.digitalasset.daml.lf.archive
 
-import java.io.{File, FileInputStream}
-import java.util.zip.ZipInputStream
+import java.io.File
 
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.data.Ref
@@ -28,9 +27,7 @@ class DarReaderTest extends WordSpec with Matchers with Inside with BazelRunfile
 
   s"should read dar file: $darFile, main archive: DarReaderTest returned first" in {
     val archives: Try[Dar[((Ref.PackageId, DamlLf.ArchivePayload), LanguageMajorVersion)]] =
-      DarReaderWithVersion.readArchive(
-        darFile.getName,
-        new ZipInputStream(new FileInputStream(darFile)))
+      DarReaderWithVersion.readArchiveFromFile(darFile)
 
     inside(archives) {
       case Success(

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
@@ -3,8 +3,8 @@
 
 package com.digitalasset.daml.lf.archive
 
-import java.io.File
-import java.util.zip.ZipFile
+import java.io.{File, FileInputStream}
+import java.util.zip.ZipInputStream
 
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.data.Ref
@@ -28,7 +28,9 @@ class DarReaderTest extends WordSpec with Matchers with Inside with BazelRunfile
 
   s"should read dar file: $darFile, main archive: DarReaderTest returned first" in {
     val archives: Try[Dar[((Ref.PackageId, DamlLf.ArchivePayload), LanguageMajorVersion)]] =
-      DarReaderWithVersion.readArchive(new ZipFile(darFile))
+      DarReaderWithVersion.readArchive(
+        darFile.getName,
+        new ZipInputStream(new FileInputStream(darFile)))
 
     inside(archives) {
       case Success(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -24,9 +24,6 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
 
-import java.io.FileInputStream
-import java.util.zip.ZipInputStream
-
 private[codegen] object CodeGenRunner extends StrictLogging {
 
   def run(conf: Conf): Unit = {
@@ -74,7 +71,7 @@ private[codegen] object CodeGenRunner extends StrictLogging {
         val file = path.toFile
         // Explicitly calling `get` to bubble up any exception when reading the dar
         val dar = ArchiveReader
-          .readArchive(file.getName, new ZipInputStream(new FileInputStream(file)))
+          .readArchiveFromFile(file)
           .get
         dar.all.map { archive =>
           val (_, interface) = InterfaceReader.readInterface(archive)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -6,7 +6,6 @@ package com.digitalasset.daml.lf.codegen
 import java.nio.file.{Files, Path, StandardOpenOption}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
-import java.util.zip.ZipFile
 
 import com.digitalasset.daml.lf.archive.DarManifestReader
 import com.digitalasset.daml.lf.archive.DarReader
@@ -24,6 +23,9 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
+
+import java.io.FileInputStream
+import java.util.zip.ZipInputStream
 
 private[codegen] object CodeGenRunner extends StrictLogging {
 
@@ -69,8 +71,11 @@ private[codegen] object CodeGenRunner extends StrictLogging {
       conf: Conf): (Seq[Interface], Map[PackageId, String]) = {
     val interfacesAndPrefixes = conf.darFiles.toList.flatMap {
       case (path, pkgPrefix) =>
+        val file = path.toFile
         // Explicitly calling `get` to bubble up any exception when reading the dar
-        val dar = ArchiveReader.readArchive(new ZipFile(path.toFile)).get
+        val dar = ArchiveReader
+          .readArchive(file.getName, new ZipInputStream(new FileInputStream(file)))
+          .get
         dar.all.map { archive =>
           val (_, interface) = InterfaceReader.readInterface(archive)
           logger.trace(s"DAML-LF Archive decoded, packageId '${interface.packageId}'")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -70,9 +70,7 @@ private[codegen] object CodeGenRunner extends StrictLogging {
       case (path, pkgPrefix) =>
         val file = path.toFile
         // Explicitly calling `get` to bubble up any exception when reading the dar
-        val dar = ArchiveReader
-          .readArchiveFromFile(file)
-          .get
+        val dar = ArchiveReader.readArchiveFromFile(file).get
         dar.all.map { archive =>
           val (_, interface) = InterfaceReader.readInterface(archive)
           logger.trace(s"DAML-LF Archive decoded, packageId '${interface.packageId}'")

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -16,9 +16,6 @@ import com.digitalasset.platform.index.cli.Cli
 import com.digitalasset.platform.index.{StandaloneIndexServer, StandaloneIndexerServer}
 import org.slf4j.LoggerFactory
 
-import java.util.zip.ZipInputStream
-import java.io.FileInputStream
-
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -47,9 +44,8 @@ object ReferenceServer extends App {
 
   config.archiveFiles.foreach { file =>
     val archivesTry = for {
-      zipInputStream <- Try(new ZipInputStream(new FileInputStream(file)))
       dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
-        .readArchive(file.getName, zipInputStream)
+        .readArchiveFromFile(file)
     } yield ledger.uploadPackages(dar.all, None)
   }
 

--- a/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.api.server.damlonx.reference
 
-import java.io.{File, FileWriter}
-import java.util.zip.ZipFile
+import java.io.{File, FileInputStream, FileWriter}
+import java.util.zip.ZipInputStream
 
 import akka.NotUsed
 import akka.actor.ActorSystem
@@ -51,7 +51,7 @@ object ReferenceServer extends App {
   //val ledger = new Ledger(timeModel, tsb)
   def archivesFromDar(file: File): List[Archive] = {
     DarReader[Archive] { case (_, x) => Try(Archive.parseFrom(x)) }
-      .readArchive(new ZipFile(file))
+      .readArchive(file.getName, new ZipInputStream(new FileInputStream(file)))
       .fold(t => throw new RuntimeException(s"Failed to parse DAR from $file", t), dar => dar.all)
   }
 

--- a/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
@@ -3,8 +3,7 @@
 
 package com.daml.ledger.api.server.damlonx.reference
 
-import java.io.{File, FileInputStream, FileWriter}
-import java.util.zip.ZipInputStream
+import java.io.{File, FileWriter}
 
 import akka.NotUsed
 import akka.actor.ActorSystem
@@ -51,7 +50,7 @@ object ReferenceServer extends App {
   //val ledger = new Ledger(timeModel, tsb)
   def archivesFromDar(file: File): List[Archive] = {
     DarReader[Archive] { case (_, x) => Try(Archive.parseFrom(x)) }
-      .readArchive(file.getName, new ZipInputStream(new FileInputStream(file)))
+      .readArchiveFromFile(file)
       .fold(t => throw new RuntimeException(s"Failed to parse DAR from $file", t), dar => dar.all)
   }
 

--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/PackageManagementServiceIT.scala
@@ -3,9 +3,8 @@
 
 package com.digitalasset.platform.tests.integration.ledger.api
 
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.nio.file.Files
-import java.util.zip.ZipInputStream
 
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.archive.{DarReader, Decode}
@@ -68,7 +67,7 @@ class PackageManagementServiceIT
 
     val testPackages = DarReader {
       case (archiveSize, x) => Try(Archive.parseFrom(x)).map(ar => (archiveSize, ar))
-    }.readArchive(file.getName, new ZipInputStream(new FileInputStream(file)))
+    }.readArchiveFromFile(file)
       .fold(t => Left(s"Failed to parse DAR from $file: $t"), dar => Right(dar.all))
       .flatMap {
         _ traverseU {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
@@ -3,9 +3,8 @@
 
 package com.digitalasset.platform.sandbox.stores
 
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.time.Instant
-import java.util.zip.ZipInputStream
 
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, PackageDetails}
 import com.daml.ledger.participant.state.v2.UploadPackagesResult
@@ -114,9 +113,8 @@ class InMemoryPackageStore() extends IndexPackagesService {
       sourceDescription: Option[String],
       file: File): Either[String, Map[PackageId, PackageDetails]] = this.synchronized {
     val archivesTry = for {
-      zipStream <- Try(new ZipInputStream(new FileInputStream(file)))
       dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
-        .readArchive(file.getName, zipStream)
+        .readArchiveFromFile(file)
     } yield dar.all
 
     for {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
@@ -3,9 +3,9 @@
 
 package com.digitalasset.platform.sandbox.stores
 
-import java.io.File
+import java.io.{File, FileInputStream}
 import java.time.Instant
-import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, PackageDetails}
 import com.daml.ledger.participant.state.v2.UploadPackagesResult
@@ -114,8 +114,9 @@ class InMemoryPackageStore() extends IndexPackagesService {
       sourceDescription: Option[String],
       file: File): Either[String, Map[PackageId, PackageDetails]] = this.synchronized {
     val archivesTry = for {
-      zipFile <- Try(new ZipFile(file))
-      dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }.readArchive(zipFile)
+      zipStream <- Try(new ZipInputStream(new FileInputStream(file)))
+      dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
+        .readArchive(file.getName, zipStream)
     } yield dar.all
 
     for {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryPackageStore.scala
@@ -113,8 +113,7 @@ class InMemoryPackageStore() extends IndexPackagesService {
       sourceDescription: Option[String],
       file: File): Either[String, Map[PackageId, PackageDetails]] = this.synchronized {
     val archivesTry = for {
-      dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
-        .readArchiveFromFile(file)
+      dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }.readArchiveFromFile(file)
     } yield dar.all
 
     for {

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -3,9 +3,9 @@
 
 package com.digitalasset.platform.sandbox
 
-import java.io.File
+import java.io.{File, FileInputStream}
 import java.time.Instant
-import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.v2.ParticipantId
@@ -16,12 +16,12 @@ import com.digitalasset.daml.lf.engine.Engine
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.services.ApiSubmissionService
+import com.digitalasset.platform.sandbox.stores.ledger.CommandExecutorImpl
 import com.digitalasset.platform.sandbox.stores.{
   InMemoryActiveContracts,
   InMemoryPackageStore,
   SandboxIndexAndWriteService
 }
-import com.digitalasset.platform.sandbox.stores.ledger.CommandExecutorImpl
 import com.digitalasset.platform.server.api.validation.IdentifierResolver
 import com.digitalasset.platform.services.time.TimeModel
 
@@ -29,7 +29,11 @@ import scala.concurrent.ExecutionContext
 
 object TestDar {
   val darFile: File = new File("ledger/sandbox/Test.dar")
-  lazy val parsedPackageId = DarReader().readArchive(new ZipFile(darFile)).get.main._1
+  lazy val parsedPackageId = DarReader()
+    .readArchive(darFile.getName, new ZipInputStream(new FileInputStream(darFile)))
+    .get
+    .main
+    ._1
 }
 
 trait TestHelpers {

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -3,9 +3,8 @@
 
 package com.digitalasset.platform.sandbox
 
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.time.Instant
-import java.util.zip.ZipInputStream
 
 import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.v2.ParticipantId
@@ -30,7 +29,7 @@ import scala.concurrent.ExecutionContext
 object TestDar {
   val darFile: File = new File("ledger/sandbox/Test.dar")
   lazy val parsedPackageId = DarReader()
-    .readArchive(darFile.getName, new ZipInputStream(new FileInputStream(darFile)))
+    .readArchiveFromFile(darFile)
     .get
     .main
     ._1

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
@@ -3,10 +3,9 @@
 
 package com.digitalasset.platform.sandbox.services
 
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.time.Instant
 import java.util
-import java.util.zip.ZipInputStream
 
 import com.digitalasset.api.util.TimestampConversion
 import com.digitalasset.daml.lf.archive.DarReader
@@ -38,7 +37,7 @@ trait TestCommands {
   protected def templateIds = {
     new TestTemplateIdentifiers(
       DarReader()
-        .readArchive(darFile.getName, new ZipInputStream(new FileInputStream(darFile)))
+        .readArchiveFromFile(darFile)
         .get
         .main
         ._1)

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
@@ -3,10 +3,10 @@
 
 package com.digitalasset.platform.sandbox.services
 
-import java.io.File
+import java.io.{File, FileInputStream}
 import java.time.Instant
 import java.util
-import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 import com.digitalasset.api.util.TimestampConversion
 import com.digitalasset.daml.lf.archive.DarReader
@@ -36,7 +36,12 @@ trait TestCommands {
 
   @transient
   protected def templateIds = {
-    new TestTemplateIdentifiers(DarReader().readArchive(new ZipFile(darFile)).get.main._1)
+    new TestTemplateIdentifiers(
+      DarReader()
+        .readArchive(darFile.getName, new ZipInputStream(new FileInputStream(darFile)))
+        .get
+        .main
+        ._1)
   }
 
   protected def buildRequest(
@@ -96,7 +101,9 @@ trait TestCommands {
         )))
 
   import com.digitalasset.platform.participant.util.ValueConversions._
+
   private def integerListRecordLabel = "integerList"
+
   protected def paramShowcaseArgs: Record = {
     val variant = Value(Value.Sum.Variant(Variant(None, "SomeInteger", 1.asInt64)))
     val nestedVariant = Vector("value" -> variant).asRecordValue
@@ -116,6 +123,7 @@ trait TestCommands {
       )
     )
   }
+
   protected def paramShowcase = Commands(
     "ledgerId",
     "workflowId",

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
@@ -35,12 +35,7 @@ trait TestCommands {
 
   @transient
   protected def templateIds = {
-    new TestTemplateIdentifiers(
-      DarReader()
-        .readArchiveFromFile(darFile)
-        .get
-        .main
-        ._1)
+    new TestTemplateIdentifiers(DarReader().readArchiveFromFile(darFile).get.main._1)
   }
 
   protected def buildRequest(
@@ -100,9 +95,7 @@ trait TestCommands {
         )))
 
   import com.digitalasset.platform.participant.util.ValueConversions._
-
   private def integerListRecordLabel = "integerList"
-
   protected def paramShowcaseArgs: Record = {
     val variant = Value(Value.Sum.Variant(Variant(None, "SomeInteger", 1.asInt64)))
     val nestedVariant = Vector("value" -> variant).asRecordValue
@@ -122,7 +115,6 @@ trait TestCommands {
       )
     )
   }
-
   protected def paramShowcase = Commands(
     "ledgerId",
     "workflowId",

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -3,11 +3,10 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql
 
-import java.io.FileInputStream
+import java.io.File
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
-import java.util.zip.ZipInputStream
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.index.v2
@@ -528,9 +527,7 @@ object PostgresDaoSpec {
       Try(DamlLf.Archive.parseFrom(stream))
     }
     private val Success(Dar(testPackage, _)) =
-      reader.readArchive(
-        "Test.dar",
-        new ZipInputStream(new FileInputStream(rlocation("ledger/sandbox/Test.dar"))))
+      reader.readArchiveFromFile(new File(rlocation("ledger/sandbox/Test.dar")))
     private val archiveSize = testPackage.getSerializedSize.toLong
     private val now = Instant.now()
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -3,10 +3,11 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql
 
+import java.io.FileInputStream
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
-import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.index.v2
@@ -527,7 +528,9 @@ object PostgresDaoSpec {
       Try(DamlLf.Archive.parseFrom(stream))
     }
     private val Success(Dar(testPackage, _)) =
-      reader.readArchive(new ZipFile(rlocation("ledger/sandbox/Test.dar")))
+      reader.readArchive(
+        "Test.dar",
+        new ZipInputStream(new FileInputStream(rlocation("ledger/sandbox/Test.dar"))))
     private val archiveSize = testPackage.getSerializedSize.toLong
     private val now = Instant.now()
 


### PR DESCRIPTION
Changes DAR loading to accept an `InputStream` instead of `ZipFile`. This is to avoid having to create temporary files when uploading DARs via the ledger api, or when loading them from a Jar file as a resource.

Note, that this change will make all the Zip entries from a DAR file loaded temporarily in memory, which should be acceptable.

fixes #547 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
