### PR TITLE
Fix some expected failures in damlc-shake-tests

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Spans/AtPoint.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/AtPoint.hs
@@ -124,12 +124,14 @@ locationsAtPoint getHieFile IdeOptions{..} pkgState pos =
 
 spansAtPoint :: Position -> [SpanInfo] -> [SpanInfo]
 spansAtPoint pos = filter atp where
-  line = _line pos + 1
-  cha = _character pos + 1
+  line = _line pos
+  cha = _character pos
   atp SpanInfo{..} =    spaninfoStartLine <= line
                      && spaninfoEndLine >= line
                      && spaninfoStartCol <= cha
-                     && spaninfoEndCol >= cha
+                     -- The end col points to the column after the
+                     -- last character so we use > instead of >=
+                     && spaninfoEndCol > cha
 
 showName :: Outputable a => a -> T.Text
 showName = T.pack . prettyprint

--- a/compiler/hie-core/src/Development/IDE/Spans/Calculate.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/Calculate.hs
@@ -167,9 +167,11 @@ toSpanInfo :: (SpanSource, SrcSpan, Maybe Type) -> Maybe SpanInfo
 toSpanInfo (name,mspan,typ) =
   case mspan of
     RealSrcSpan spn ->
-      Just (SpanInfo (srcSpanStartLine spn)
+      -- GHC’s line and column numbers are 1-based while LSP’s line and column
+      -- numbers are 0-based.
+      Just (SpanInfo (srcSpanStartLine spn - 1)
                      (srcSpanStartCol spn - 1)
-                     (srcSpanEndLine spn)
+                     (srcSpanEndLine spn - 1)
                      (srcSpanEndCol spn - 1)
                      typ
                      name)

--- a/compiler/hie-core/src/Development/IDE/Spans/Type.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/Type.hs
@@ -21,13 +21,13 @@ import OccName
 -- unboxed but Haddock doesn't show that.
 data SpanInfo =
   SpanInfo {spaninfoStartLine :: {-# UNPACK #-} !Int
-            -- ^ Start line of the span.
+            -- ^ Start line of the span, zero-based.
            ,spaninfoStartCol :: {-# UNPACK #-} !Int
-            -- ^ Start column of the span.
+            -- ^ Start column of the span, zero-based.
            ,spaninfoEndLine :: {-# UNPACK #-} !Int
-            -- ^ End line of the span (absolute).
+            -- ^ End line of the span (absolute), zero-based.
            ,spaninfoEndCol :: {-# UNPACK #-} !Int
-            -- ^ End column of the span (absolute).
+            -- ^ End column of the span (absolute), zero-based.
            ,spaninfoType :: !(Maybe Type)
             -- ^ A pretty-printed representation fo the type.
            ,spaninfoSource :: !SpanSource

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -270,7 +270,7 @@ requestTests run _runScenarios = testGroup "requests"
                     , "*\t*\t*"
                     , "**Defined at " <> T.pack fp <> ":4:1**"
                     ]
-              , _range = Just $ Range (Position 10 17) (Position 10 20)
+              , _range = Just $ Range (Position 9 17) (Position 9 20)
               }
           closeDoc main'
 
@@ -283,7 +283,7 @@ requestTests run _runScenarios = testGroup "requests"
           r <- getHover main' (Position 2 27)
           liftIO $ r @?= Just Hover
               { _contents = HoverContents $ MarkupContent MkMarkdown "```daml\n: Decimal\n```\n"
-              , _range = Just $ Range (Position 3 27) (Position 3 30)
+              , _range = Just $ Range (Position 2 27) (Position 2 30)
               }
           closeDoc main'
     , testCase "definition" $ run $ do

--- a/daml-foundations/daml-ghc/BUILD.bazel
+++ b/daml-foundations/daml-ghc/BUILD.bazel
@@ -41,7 +41,7 @@ da_haskell_test(
 )
 
 da_haskell_test(
-    name = "daml-ghc-shake-test-ci",
+    name = "damlc-shake-tests",
     size = "large",
     # this test takes a while and often time out -- tell that to bazel
     timeout = "long",

--- a/daml-foundations/daml-ghc/README.md
+++ b/daml-foundations/daml-ghc/README.md
@@ -19,7 +19,7 @@ find runfiles such as the scenario service and the package database
 when we’re running inside GHCi.
 
 ```
-bazel build //daml-foundations/daml-ghc:daml-ghc-shake-test-ci
+bazel build //daml-foundations/daml-ghc:damlc-shake-tests
 ```
 
 When working on the compiler:
@@ -33,7 +33,7 @@ bazel run damlc -- compile $PWD/MyDaml12File.daml
 When working on the IDE via the test suite:
 
 ```
-bazel run //daml-foundations/daml-ghc:daml-ghc-shake-test-ci -- --pattern=
+bazel run //daml-foundations/daml-ghc:damlc-shake-tests -- --pattern=
 da-ghcid daml-foundations/daml-ghc/test-src/DA/Test/ShakeIdeClient.hs --test=":main --pattern="
 ```
 


### PR DESCRIPTION
Most of them were caused by off-by-one errors in goto definition.

There was also one test that was marked as an expected failure but the
actual bug has been fixed for some time and the only reason it was
failing is that the error message was different than the test
expected.

I’ve also renamed daml-ghc-shake-test-ci to damlc-shake-tests which is
something that I might actually be able to remember :)

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
