### PR TITLE
damldoc: Move towards extracting information from TypecheckedModule in HaddockParse.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -169,27 +169,50 @@ filegroup(
 )
 
 genrule(
+    name = "daml-prim-json-docs",
+    srcs = ["//compiler/damlc/daml-prim-src"],
+    outs = ["daml-prim.json"],
+    cmd = """
+        $(location //compiler/damlc) -- docs \
+            --output=$(OUTS) \
+            --package-name=daml-prim \
+            --format=Json \
+            $(locations //compiler/damlc/daml-prim-src)
+    """,
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "daml-stdlib-json-docs",
+    srcs = ["//compiler/damlc/daml-stdlib-src"],
+    outs = ["daml-stdlib.json"],
+    cmd = """
+        $(location //compiler/damlc) -- docs \
+            --output=$(OUTS) \
+            --package-name=daml-stdlib \
+            --format=Json \
+            $(locations //compiler/damlc/daml-stdlib-src)
+    """,
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "daml-base-hoogle-docs",
     srcs = [
-        "//compiler/damlc/daml-prim-src",
-        "//compiler/damlc/daml-stdlib-src",
+        ":daml-prim.json",
+        ":daml-stdlib.json",
         ":daml-base-hoogle-prefix",
     ],
     outs = ["daml-base-hoogle.txt"],
     cmd = """
-        TMP_DOC=`mktemp`
-        $(location //compiler/damlc) -- docs \
-            --output=$$TMP_DOC \
-            --package-name=daml-stlib \
-            --format=Hoogle \
-            $(locations //compiler/damlc/daml-stdlib-src) \
-            --prefix=$(location :daml-base-hoogle-prefix)
         $(location //compiler/damlc) -- docs \
             --output=$(OUTS) \
-            --package-name=daml-prim \
+            --input-format=json \
             --format=Hoogle \
-            $(locations //compiler/damlc/daml-prim-src) \
-            --prefix=$$TMP_DOC
+            --prefix=$(location :daml-base-hoogle-prefix) \
+            $(location :daml-stdlib.json) $(location :daml-prim.json)
     """,
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
@@ -198,25 +221,18 @@ genrule(
 genrule(
     name = "daml-base-rst-docs",
     srcs = [
-        "//compiler/damlc/daml-prim-src",
-        "//compiler/damlc/daml-stdlib-src",
+        ":daml-prim.json",
+        ":daml-stdlib.json",
         ":daml-base-rst-prefix",
     ],
     outs = ["daml-base.rst"],
     cmd = """
-        TMP_DOC=`mktemp`
-        $(location //compiler/damlc) -- docs \
-            --output=$$TMP_DOC \
-            --package-name=daml-stlib \
-            --format=Rst \
-            $(locations //compiler/damlc/daml-stdlib-src) \
-            --prefix=$(location :daml-base-rst-prefix)
         $(location //compiler/damlc) -- docs \
             --output=$(OUTS) \
-            --package-name=daml-prim \
+            --input-format=json \
             --format=Rst \
-            $(locations //compiler/damlc/daml-prim-src) \
-            --prefix=$$TMP_DOC
+            --prefix=$(location :daml-base-rst-prefix) \
+            $(location :daml-stdlib.json) $(location :daml-prim.json)
     """,
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -171,11 +171,26 @@ filegroup(
 genrule(
     name = "daml-base-hoogle-docs",
     srcs = [
-        ":daml-base-files",
+        "//compiler/damlc/daml-prim-src",
+        "//compiler/damlc/daml-stdlib-src",
         ":daml-base-hoogle-prefix",
     ],
     outs = ["daml-base-hoogle.txt"],
-    cmd = "$(location //compiler/damlc) -- docs --output=$(OUTS) --format=Hoogle $(locations :daml-base-files) --prefix=$(location :daml-base-hoogle-prefix)",
+    cmd = """
+        TMP_DOC=`mktemp`
+        $(location //compiler/damlc) -- docs \
+            --output=$$TMP_DOC \
+            --package-name=daml-stlib \
+            --format=Hoogle \
+            $(locations //compiler/damlc/daml-stdlib-src) \
+            --prefix=$(location :daml-base-hoogle-prefix)
+        $(location //compiler/damlc) -- docs \
+            --output=$(OUTS) \
+            --package-name=daml-prim \
+            --format=Hoogle \
+            $(locations //compiler/damlc/daml-prim-src) \
+            --prefix=$$TMP_DOC
+    """,
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
 )
@@ -183,11 +198,26 @@ genrule(
 genrule(
     name = "daml-base-rst-docs",
     srcs = [
-        ":daml-base-files",
+        "//compiler/damlc/daml-prim-src",
+        "//compiler/damlc/daml-stdlib-src",
         ":daml-base-rst-prefix",
     ],
     outs = ["daml-base.rst"],
-    cmd = "$(location //compiler/damlc) -- docs --output=$(OUTS) --format=Rst $(locations :daml-base-files) --prefix=$(location :daml-base-rst-prefix)",
+    cmd = """
+        TMP_DOC=`mktemp`
+        $(location //compiler/damlc) -- docs \
+            --output=$$TMP_DOC \
+            --package-name=daml-stlib \
+            --format=Rst \
+            $(locations //compiler/damlc/daml-stdlib-src) \
+            --prefix=$(location :daml-base-rst-prefix)
+        $(location //compiler/damlc) -- docs \
+            --output=$(OUTS) \
+            --package-name=daml-prim \
+            --format=Rst \
+            $(locations //compiler/damlc/daml-prim-src) \
+            --prefix=$$TMP_DOC
+    """,
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
 )

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
@@ -8,7 +8,7 @@
 -- satisfy the regex /[a-z0-9]+(-[a-z0-9]+)*/). It's also nice for them to be readable.
 -- So we generate a human readable tag, and append a hash to guarantee uniqueness.
 
-module DA.Daml.Doc.Render.Anchor
+module DA.Daml.Doc.Anchor
     ( Anchor
     , moduleAnchor
     , classAnchor
@@ -24,11 +24,9 @@ import Data.Hashable
 import qualified Data.Text as T
 import qualified Data.Char as C
 
-type Anchor = T.Text
-
 moduleAnchor :: Modulename -> Anchor
 -- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
-moduleAnchor m = T.intercalate "-" ["module", convertModulename m, hashText . T.unpack . unModulename $ m]
+moduleAnchor m = Anchor $ T.intercalate "-" ["module", convertModulename m, hashText . T.unpack . unModulename $ m]
 
 convertModulename :: Modulename -> T.Text
 convertModulename = T.toLower . T.replace "." "-" . T.replace "_" "" . unModulename
@@ -47,10 +45,9 @@ dataAnchor     m n = anchor "data"     m (unTypename n) ()
 constrAnchor   m n = anchor "constr"   m (unTypename n) ()
 functionAnchor m n = anchor "function" m (unFieldname n)
 
-
 anchor :: Hashable v => T.Text -> Modulename -> T.Text -> v -> Anchor
 -- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes
-anchor k m n v = T.intercalate "-" [k, convertModulename m, expandOps n, hashText (T.unpack k, T.unpack (unModulename m), T.unpack n, v)]
+anchor k m n v = Anchor $ T.intercalate "-" [k, convertModulename m, expandOps n, hashText (T.unpack k, T.unpack (unModulename m), T.unpack n, v)]
   where
     expandOps :: T.Text -> T.Text
     expandOps = T.pack . replaceEmpty . concatMap expandOp . T.unpack

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -5,7 +5,7 @@
 
 module DA.Daml.Doc.HaddockParse(mkDocs) where
 
-import           DA.Daml.Doc.Types                 as DDoc
+import DA.Daml.Doc.Types as DDoc
 import Development.IDE.Types.Options (IdeOptions(..))
 import Development.IDE.Core.FileStore
 import qualified Development.IDE.Core.Service     as Service

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -15,8 +15,6 @@ import qualified Development.IDE.Core.OfInterest as Service
 import           Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Logger
 import Development.IDE.Types.Location
-import Development.IDE.Core.Compile
-
 
 import           "ghc-lib" GHC
 import qualified "ghc-lib-parser" Outputable                      as Out

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -47,9 +47,9 @@ mkDocs opts fp = do
         . hsmodHaddockModHeader . unLoc
         . pm_parsed_source . tm_parsed_module
 
-    mkModuleDocs :: TcModuleResult -> ModuleDoc
+    mkModuleDocs :: Service.TcModuleResult -> ModuleDoc
     mkModuleDocs tmr =
-        let ctx@DocCtx{..} = buildDocCtx (tmrModule tmr)
+        let ctx@DocCtx{..} = buildDocCtx (Service.tmrModule tmr)
             typeMap = MS.fromList $ mapMaybe (getTypeDocs ctx) dc_decls
             fctDocs = mapMaybe (getFctDocs ctx) dc_decls
             clsDocs = mapMaybe (getClsDocs ctx) dc_decls
@@ -155,7 +155,7 @@ buildDocCtx dc_tcmod  =
 --   invoked by a CLI tool.
 haddockParse :: IdeOptions ->
                 [NormalizedFilePath] ->
-                Ex.ExceptT [FileDiagnostic] IO [TcModuleResult]
+                Ex.ExceptT [FileDiagnostic] IO [Service.TcModuleResult]
 haddockParse opts f = ExceptT $ do
   vfs <- makeVFSHandle
   service <- Service.initialise Service.mainRule (const $ pure ()) noLogging opts vfs

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -424,13 +424,13 @@ hsTypeToType_ t = case t of
   HsTupleTy _ _con tys -> TypeTuple $ map hsTypeToType tys
 
   -- GHC specials. FIXME deal with them specially
-  HsRecTy _ _flds -> TypeApp (Typename $ toText t) [] -- FIXME pprConDeclFields flds
+  HsRecTy _ _flds -> TypeApp Nothing (Typename $ toText t) [] -- FIXME pprConDeclFields flds
 
   HsSumTy _ _tys -> undefined -- FIXME tupleParens UnboxedTuple (pprWithBars ppr tys)
 
 
   -- straightforward base case
-  HsTyVar _ _ (L _ name) -> TypeApp (Typename $ idpToText name) []
+  HsTyVar _ _ (L _ name) -> TypeApp Nothing (Typename $ idpToText name) []
 
   HsFunTy _ ty1 ty2 -> case hsTypeToType ty2 of
     TypeFun as -> TypeFun $ hsTypeToType ty1 : as
@@ -446,14 +446,14 @@ hsTypeToType_ t = case t of
   HsExplicitListTy _ _ _tys ->  unexpected "explicit list"
   HsExplicitTupleTy _ _tys  -> unexpected "explicit tuple"
 
-  HsTyLit _ ty      -> TypeApp (Typename $ toText ty) []
+  HsTyLit _ ty      -> TypeApp Nothing (Typename $ toText ty) []
   -- kind things. Can be printed, not sure why we would
-  HsWildCardTy {}   -> TypeApp (Typename "_") []
-  HsStarTy _ _      -> TypeApp (Typename "*") []
+  HsWildCardTy {}   -> TypeApp Nothing (Typename "_") []
+  HsStarTy _ _      -> TypeApp Nothing (Typename "*") []
 
   HsAppTy _ fun_ty arg_ty ->
     case hsTypeToType fun_ty of
-      TypeApp f as -> TypeApp f $ as <> [hsTypeToType arg_ty]  -- flattens app chains
+      TypeApp m f as -> TypeApp m f $ as <> [hsTypeToType arg_ty]  -- flattens app chains
       TypeFun _ -> unexpected "function type in a type app"
       TypeList _   -> unexpected "list type in a type app"
       TypeTuple _   -> unexpected "tuple type in a type app"
@@ -461,7 +461,7 @@ hsTypeToType_ t = case t of
   HsAppKindTy _ _ _ -> unexpected "kind application"
 
   HsOpTy _ ty1 (L _ op) ty2 ->
-    TypeApp (Typename $ toText op) [ hsTypeToType ty1, hsTypeToType ty2 ]
+    TypeApp Nothing (Typename $ toText op) [ hsTypeToType ty1, hsTypeToType ty2 ]
 
   HsParTy _ ty  -> hsTypeToType ty
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -64,7 +64,7 @@ adtConstr2hoogle md_name typename PrefixC{..} = concat
       , T.unwords
             [ wrapOp (unTypename ac_name)
             , "::"
-            , type2hoogle $ TypeFun (ac_args ++ [TypeApp (Just md_name) typename []])
+            , type2hoogle $ TypeFun (ac_args ++ [TypeApp Nothing typename []])
             ]
       , "" ]
     ]
@@ -75,7 +75,7 @@ adtConstr2hoogle md_name typename RecordC{..} = concat
             [ wrapOp (unTypename ac_name)
             , "::"
             , type2hoogle $ TypeFun
-                (map fd_type ac_fields ++ [TypeApp (Just md_name) typename []])
+                (map fd_type ac_fields ++ [TypeApp Nothing typename []])
             ]
       , "" ]
     , concatMap (fieldDoc2hoogle typename) ac_fields
@@ -116,7 +116,7 @@ cls2hoogle md_name ClassDoc{..} = concat
         Just ctx -> Just (TypeTuple [contextTy, ctx])
 
     contextTy :: Type
-    contextTy = TypeApp (Just md_name) cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
+    contextTy = TypeApp Nothing cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
 
 fct2hoogle :: Modulename -> FunctionDoc -> [T.Text]
 fct2hoogle md_name FunctionDoc{..} = concat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -8,7 +8,7 @@ module DA.Daml.Doc.Render.Hoogle
   ) where
 
 import DA.Daml.Doc.Types
-import DA.Daml.Doc.Render.Anchor
+import DA.Daml.Doc.Anchor
 import DA.Daml.Doc.Render.Util
 
 import           Data.Maybe
@@ -24,7 +24,7 @@ hooglify (Just md) =
             : map ("--   " <>) xs
 
 urlTag :: Anchor -> T.Text
-urlTag = ("@url https://docs.daml.com/daml/reference/base.html#" <>)
+urlTag = ("@url https://docs.daml.com/daml/reference/base.html#" <>) . unAnchor
 
 renderSimpleHoogle :: ModuleDoc -> T.Text
 renderSimpleHoogle ModuleDoc{..}

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -64,7 +64,7 @@ adtConstr2hoogle md_name typename PrefixC{..} = concat
       , T.unwords
             [ wrapOp (unTypename ac_name)
             , "::"
-            , type2hoogle $ TypeFun (ac_args ++ [TypeApp Nothing typename []])
+            , type2hoogle $ TypeFun (ac_args ++ [TypeApp (Just md_name) typename []])
             ]
       , "" ]
     ]
@@ -75,7 +75,7 @@ adtConstr2hoogle md_name typename RecordC{..} = concat
             [ wrapOp (unTypename ac_name)
             , "::"
             , type2hoogle $ TypeFun
-                (map fd_type ac_fields ++ [TypeApp Nothing typename []])
+                (map fd_type ac_fields ++ [TypeApp (Just md_name) typename []])
             ]
       , "" ]
     , concatMap (fieldDoc2hoogle typename) ac_fields
@@ -116,7 +116,7 @@ cls2hoogle md_name ClassDoc{..} = concat
         Just ctx -> Just (TypeTuple [contextTy, ctx])
 
     contextTy :: Type
-    contextTy = TypeApp Nothing cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
+    contextTy = TypeApp (Just md_name) cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
 
 fct2hoogle :: Modulename -> FunctionDoc -> [T.Text]
 fct2hoogle md_name FunctionDoc{..} = concat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -64,7 +64,7 @@ adtConstr2hoogle md_name typename PrefixC{..} = concat
       , T.unwords
             [ wrapOp (unTypename ac_name)
             , "::"
-            , type2hoogle $ TypeFun (ac_args ++ [TypeApp typename []])
+            , type2hoogle $ TypeFun (ac_args ++ [TypeApp Nothing typename []])
             ]
       , "" ]
     ]
@@ -75,7 +75,7 @@ adtConstr2hoogle md_name typename RecordC{..} = concat
             [ wrapOp (unTypename ac_name)
             , "::"
             , type2hoogle $ TypeFun
-                (map fd_type ac_fields ++ [TypeApp typename []])
+                (map fd_type ac_fields ++ [TypeApp Nothing typename []])
             ]
       , "" ]
     , concatMap (fieldDoc2hoogle typename) ac_fields
@@ -116,7 +116,7 @@ cls2hoogle md_name ClassDoc{..} = concat
         Just ctx -> Just (TypeTuple [contextTy, ctx])
 
     contextTy :: Type
-    contextTy = TypeApp cl_name [TypeApp (Typename arg) [] | arg <- cl_args]
+    contextTy = TypeApp Nothing cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
 
 fct2hoogle :: Modulename -> FunctionDoc -> [T.Text]
 fct2hoogle md_name FunctionDoc{..} = concat
@@ -142,6 +142,6 @@ t2hg _ _ (TypeList t1) =
     "[" <> t2hg id id t1 <> "]"
 t2hg _ _ (TypeTuple ts) =
     "(" <> T.intercalate ", " (map (t2hg id id) ts) <> ")"
-t2hg _ _ (TypeApp n []) = unTypename n
-t2hg _ f (TypeApp name args) = f $
+t2hg _ _ (TypeApp _ n []) = unTypename n
+t2hg _ f (TypeApp _ name args) = f $
     T.unwords (wrapOp (unTypename name) : map (t2hg inParens inParens) args)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -143,8 +143,8 @@ type2md t = t2md id t
         t2md _ (TypeTuple ts) = "`(` " <>
                             T.concat (intersperse ", " $ map (t2md id) ts) <>
                             " `)`"
-        t2md _ (TypeApp n []) = asCode (unTypename n)
-        t2md f (TypeApp name args) =
+        t2md _ (TypeApp _ n []) = asCode (unTypename n)
+        t2md f (TypeApp _ name args) =
           f $ T.unwords ( asCode (unTypename name) : map (t2md codeParens) args)
         codeParens s = "`(` " <> s <> " `)`"
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -9,7 +9,7 @@ module DA.Daml.Doc.Render.Rst
 
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Render.Util
-import DA.Daml.Doc.Render.Anchor
+import DA.Daml.Doc.Anchor
 
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import           Data.Text.Prettyprint.Doc (Doc, defaultLayoutOptions, layoutPretty, pretty, (<+>))
@@ -22,7 +22,7 @@ import qualified Data.Text as T
 import CMarkGFM
 
 renderAnchor :: Anchor -> T.Text
-renderAnchor anchor = "\n.. _" <> anchor <> ":\n"
+renderAnchor anchor = "\n.. _" <> unAnchor anchor <> ":\n"
 
 renderSimpleRst :: ModuleDoc -> T.Text
 renderSimpleRst ModuleDoc{..}

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -167,8 +167,8 @@ type2rst = f (0 :: Int)
     -- 0 = no brackets
     -- 1 = brackets around function
     -- 2 = brackets around function AND application
-    f _ (TypeApp n []) = unTypename n
-    f i (TypeApp n as) = (if i >= 2 then inParens else id) $ T.unwords (unTypename n : map (f 2) as)
+    f _ (TypeApp _ n []) = unTypename n
+    f i (TypeApp _ n as) = (if i >= 2 then inParens else id) $ T.unwords (unTypename n : map (f 2) as)
     f i (TypeFun ts) = (if i >= 1 then inParens else id) $ T.intercalate " -> " $ map (f 1) ts
     f _ (TypeList t1) = "[" <> f 0 t1 <> "]"
     f _ (TypeTuple ts) = "(" <> T.intercalate ", " (map (f 0) ts) <>  ")"

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -39,6 +39,10 @@ data Type = TypeApp !(Maybe Modulename) !Typename [Type] -- ^ Type application
 instance Hashable Type where
   hashWithSalt salt = hashWithSalt salt . show
 
+-- | Anchors are URL-safe ids into the docs.
+newtype Anchor = Anchor { unAnchor :: Text }
+    deriving (Eq, Ord, Show)
+
 ------------------------------------------------------------
 -- | Documentation data for a module
 data ModuleDoc = ModuleDoc

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -30,7 +30,7 @@ newtype Modulename = Modulename { unModulename :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type expression, possibly a (nested) type application
-data Type = TypeApp (Maybe Modulename) Typename [Type] -- ^ Type application
+data Type = TypeApp !(Maybe Modulename) !Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -30,7 +30,7 @@ newtype Modulename = Modulename { unModulename :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type expression, possibly a (nested) type application
-data Type = TypeApp !(Maybe Modulename) !Typename [Type] -- ^ Type application
+data Type = TypeApp !(Maybe Anchor) !Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax
@@ -41,7 +41,7 @@ instance Hashable Type where
 
 -- | Anchors are URL-safe ids into the docs.
 newtype Anchor = Anchor { unAnchor :: Text }
-    deriving (Eq, Ord, Show)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON)
 
 ------------------------------------------------------------
 -- | Documentation data for a module

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -30,7 +30,7 @@ newtype Modulename = Modulename { unModulename :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 -- | Type expression, possibly a (nested) type application
-data Type = TypeApp Typename [Type] -- ^ Type application
+data Type = TypeApp (Maybe Modulename) Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -33,19 +33,19 @@ cases = [ ("Empty module",
            ModuleDoc "Empty" Nothing [] [] [] [])
         , ("Type def with argument",
            ModuleDoc "Typedef" Nothing []
-            [TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp "TT" [TypeApp "TTT" []])]
+            [TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
             [] []
           )
         , ("Two types",
            ModuleDoc "TwoTypes" Nothing []
-            [ TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp "TT" [])
-            , ADTDoc "D" Nothing ["d"] [PrefixC "D" (Just "D descr") [TypeApp "a" []]]
+            [ TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
+            , ADTDoc "D" Nothing ["d"] [PrefixC "D" (Just "D descr") [TypeApp Nothing "a" []]]
             ]
             [] []
           )
         , ("Documented function with type",
            ModuleDoc "Function1" Nothing [] []
-            [FunctionDoc "f" Nothing (Just $ TypeApp "TheType" []) (Just "the doc")] []
+            [FunctionDoc "f" Nothing (Just $ TypeApp Nothing "TheType" []) (Just "the doc")] []
           )
         , ("Documented function without type",
            ModuleDoc "Function2" Nothing [] []
@@ -53,12 +53,12 @@ cases = [ ("Empty module",
           )
         , ("Undocumented function with type",
            ModuleDoc "Function3" Nothing [] []
-            [FunctionDoc "f" Nothing (Just $ TypeApp "TheType" []) Nothing] []
+            [FunctionDoc "f" Nothing (Just $ TypeApp Nothing "TheType" []) Nothing] []
           )
         -- The doc extraction won't generate functions without type nor description
         , ("Module with only a type class",
            ModuleDoc "OnlyClass" Nothing [] [] []
-            [ClassDoc "C" Nothing Nothing ["a"] [FunctionDoc "member" Nothing (Just (TypeApp "a" [])) Nothing]])
+            [ClassDoc "C" Nothing Nothing ["a"] [FunctionDoc "member" Nothing (Just (TypeApp Nothing "a" [])) Nothing]])
         , ("Multiline field description",
            ModuleDoc
              "MultiLineField"
@@ -68,7 +68,7 @@ cases = [ ("Empty module",
                 "D"
                 Nothing
                 []
-                [RecordC "D" Nothing [FieldDoc "f" (TypeApp "T" []) (Just "This is a multiline\nfield description")]]]
+                [RecordC "D" Nothing [FieldDoc "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]]
              []
              []
           )

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -84,13 +84,13 @@ expectRst =
             ["\n.. _type-twotypes-t-17090:\n\ntype **T a**\n    = TT\n\n  T descr"
             , "\n.. _data-twotypes-d-66754:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d-45919:\n  \n  **D** a\n  \n  D descr"]
             []
-        , mkExpectRst "module-function1-29590" "Function1" "" [] [] [] [ "\n.. _function-function1-f-2320:\n\n**f**\n  : TheType\n\n  the doc\n"]
+        , mkExpectRst "module-function1-29590" "Function1" "" [] [] [] [ "\n.. _function-function1-f-45407:\n\n**f**\n  : TheType\n\n  the doc\n"]
         , mkExpectRst "module-function2-7227" "Function2" "" [] [] [] [ "\n.. _function-function2-f-87524:\n\n**f**\n  :   the doc\n"]
-        , mkExpectRst "module-function3-84844" "Function3" "" [] [] [] [ "\n.. _function-function3-f-53414:\n\n**f**\n  : TheType\n\n"]
+        , mkExpectRst "module-function3-84844" "Function3" "" [] [] [] [ "\n.. _function-function3-f-32653:\n\n**f**\n  : TheType\n\n"]
         , mkExpectRst "module-onlyclass-88463" "OnlyClass" ""
             []
             [ "\n.. _class-onlyclass-c-63566:"
-            , "**class C a where**\n  \n  .. _function-onlyclass-member-29050:\n  \n  **member**\n    : a"
+            , "**class C a where**\n  \n  .. _function-onlyclass-member-45125:\n  \n  **member**\n    : a"
             ]
             []
             []

--- a/compiler/damlc/daml-prim-src/GHC/Base.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Base.daml
@@ -5,7 +5,7 @@
 {-# LANGUAGE MagicHash #-}
 
 daml 1.2
--- | MOVE Prelude
+-- | Included in Prelude
 module GHC.Base
   ( otherwise
   , getTag

--- a/compiler/damlc/daml-prim-src/GHC/Enum.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Enum.daml
@@ -5,7 +5,8 @@
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 daml 1.2
 
--- | MOVE Prelude
+-- | Included in Prelude.
+--
 -- A weird module - based on base.GHC.Enum, but not realy in the GHC namespace.
 -- Has to live here so GHC can find it for deriving instances.
 module GHC.Enum

--- a/compiler/damlc/daml-prim-src/GHC/Err.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Err.daml
@@ -4,7 +4,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 daml 1.2
 
--- | MOVE Prelude
+-- | Included in Prelude
+--
 -- A weird module - based on base.GHC.Err, but not realy in the GHC namespace.
 -- Has to live here so GHC can find it for deriving instances.
 module GHC.Err

--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -4,8 +4,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 daml 1.2
 
--- | MOVE Prelude
---   Has to live here so GHC can find it for deriving instances.
+-- | Included in Prelude
+--
+-- Has to live here so GHC can find it for deriving instances.
 module GHC.Num
   ( Additive (..)
   , Multiplicative (..)

--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -5,7 +5,7 @@
 {-# LANGUAGE MagicHash #-}
 
 daml 1.2
--- | MOVE Prelude
+-- | Included in Prelude
 module GHC.Show
   ( Show(..)
   , ShowS

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -8,7 +8,7 @@
 {-# OPTIONS -Wno-unused-binds #-} -- the opaque constructors are not exported
 daml 1.2
 
--- | MOVE Prelude
+-- | Included in Prelude
 module GHC.Types (
         -- Data types that are built-in syntax
         -- They are defined here, but not explicitly exported

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -34,6 +34,7 @@ documentation :: InputFormat -> Parser CmdArgs
 documentation x = Damldoc x <$>
                 optOutput
                 <*> optJsonOrFormat
+                <*> optMbPackageName
                 <*> optPrefix
                 <*> optOmitEmpty
                 <*> optDataOnly
@@ -47,6 +48,13 @@ documentation x = Damldoc x <$>
                 <> help "Output name of generated files (required)"
                 <> long "output"
                 <> short 'o'
+
+    optMbPackageName :: Parser (Maybe String)
+    optMbPackageName =
+        option (Just <$> str) $ metavar "NAME"
+            <> help "Name of package to generate."
+            <> long "package-name"
+            <> value Nothing
 
     optPrefix :: Parser (Maybe FilePath)
     optPrefix = option (Just <$> str) $ metavar "FILE"
@@ -114,6 +122,7 @@ documentation x = Damldoc x <$>
 data CmdArgs = Damldoc { cInputFormat :: InputFormat
                        , cOutput   :: FilePath
                        , cFormat   :: DocFormat
+                       , cPkgName :: Maybe String
                        , cPrefix   :: Maybe FilePath
                        , cOmitEmpty :: Bool
                        , cDataOnly  :: Bool
@@ -127,7 +136,7 @@ data CmdArgs = Damldoc { cInputFormat :: InputFormat
 exec :: CmdArgs -> IO ()
 exec Damldoc{..} = do
     opts <- defaultOptionsIO Nothing
-    damlDocDriver cInputFormat (toCompileOpts opts) cOutput cFormat cPrefix options (map toNormalizedFilePath cMainFiles)
+    damlDocDriver cInputFormat (toCompileOpts opts { optMbPackageName = cPkgName })  cOutput cFormat cPrefix options (map toNormalizedFilePath cMainFiles)
   where options =
           [ IncludeModules cIncludeMods | not $ null cIncludeMods] <>
           [ ExcludeModules cExcludeMods | not $ null cExcludeMods] <>

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -51,17 +51,18 @@ documentation x = Damldoc x <$>
 
     optMbPackageName :: Parser (Maybe String)
     optMbPackageName =
-        option (Just <$> str) $ metavar "NAME"
+        optional . option str
+            $ metavar "NAME"
             <> help "Name of package to generate."
             <> long "package-name"
-            <> value Nothing
 
     optPrefix :: Parser (Maybe FilePath)
-    optPrefix = option (Just <$> str) $ metavar "FILE"
-                <> help "File to prepend to all generated files"
-                <> long "prefix"
-                <> short 'p'
-                <> value Nothing
+    optPrefix =
+        optional . option str
+            $ metavar "FILE"
+            <> help "File to prepend to all generated files"
+            <> long "prefix"
+            <> short 'p'
 
     argMainFiles :: Parser [FilePath]
     argMainFiles = some $ argument str $ metavar "FILE..."

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,3 +13,6 @@ HEAD — ongoing
 - [DAML-LF] Fixed regression that produced an invalid daml-lf-archive artefact. See `#2058 <https://github.com/digital-asset/daml/issues/2058>`__.
 - [daml assistant] Kill child processes on ``SIGTERM``. This means that killing
   ``daml sandbox`` will also kill the sandbox process.
+
+- [DAML Docs] **BREAKING CHANGE** ``damlc docs`` now typechecks the source files before doc generation, to be able to use type information during doc generation. This may break existing doc builds.
+- [DAML Docs] Added a ``--package-name`` flag to ``damlc docs``.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -15,4 +15,4 @@ HEAD — ongoing
   ``daml sandbox`` will also kill the sandbox process.
 
 - [DAML Docs] **BREAKING CHANGE** ``damlc docs`` now typechecks the source files before doc generation, to be able to use type information during doc generation. This may break existing doc builds.
-- [DAML Docs] Added a ``--package-name`` flag to ``damlc docs``.
+- [DAML Docs] Added ``--package-name`` and ``--input-format`` flags to ``damlc docs``.


### PR DESCRIPTION
Wiring things up to be able to get type checked information in the generated docs. Nothing should have changed *yet*, but we're nearly there. Lots of refactoring going on. (Committing now to prevent an even bigger PR down the road, and because I'm satisfied with this direction after several false starts.)