### PR TITLE
Produce package db for single DAML-LF version in daml_package_db rule

### DIFF
--- a/daml-foundations/daml-ghc/package-database/BUILD.bazel
+++ b/daml-foundations/daml-ghc/package-database/BUILD.bazel
@@ -18,21 +18,36 @@ DAML_LF_VERSIONS = [
     "1.dev",
 ]
 
-daml_package_db(
-    name = "package_db_for_daml-prim",
-    daml_lf_versions = DAML_LF_VERSIONS,
-    pkgs = [],
-    visibility = ["//visibility:public"],
-)
+[
+    daml_package_db(
+        name = "package_db_for_daml-prim-{}".format(ver),
+        daml_lf_version = ver,
+        db_name = "package_db_for_daml-prim",
+        pkgs = [],
+        visibility = ["//visibility:public"],
+    )
+    for ver in DAML_LF_VERSIONS
+]
 
 [
     daml_package_rule(
         name = "daml-prim-{}".format(ver),
         srcs = "//daml-foundations/daml-ghc/daml-prim-src",
         daml_lf_version = ver,
-        package_db = ":package_db_for_daml-prim",
+        package_db = ":package_db_for_daml-prim-{}".format(ver),
         pkg_name = "daml-prim",
         pkg_root = "daml-foundations/daml-ghc/daml-prim-src",
+        visibility = ["//visibility:public"],
+    )
+    for ver in DAML_LF_VERSIONS
+]
+
+[
+    daml_package_db(
+        name = "package_db_for_daml-stdlib-{}".format(ver),
+        daml_lf_version = ver,
+        db_name = "package_db_for_daml-stdlib",
+        pkgs = [":daml-prim-{}".format(ver)],
         visibility = ["//visibility:public"],
     )
     for ver in DAML_LF_VERSIONS
@@ -44,7 +59,7 @@ daml_package_db(
         srcs = "//daml-foundations/daml-ghc/daml-stdlib-src",
         daml_lf_version = ver,
         dependencies = [":daml-prim-{}".format(ver)],
-        package_db = ":package_db_for_daml-stdlib",
+        package_db = ":package_db_for_daml-stdlib-{}".format(ver),
         pkg_name = "daml-stdlib",
         pkg_root = "daml-foundations/daml-ghc/daml-stdlib-src",
         visibility = ["//visibility:public"],
@@ -52,18 +67,22 @@ daml_package_db(
     for ver in DAML_LF_VERSIONS
 ]
 
-daml_package_db(
-    name = "package_db_for_daml-stdlib",
-    daml_lf_versions = DAML_LF_VERSIONS,
-    pkgs = [":daml-prim-{}".format(ver) for ver in DAML_LF_VERSIONS],
-    visibility = ["//visibility:public"],
-)
+[
+    daml_package_db(
+        name = "package-db-{}".format(ver),
+        daml_lf_version = ver,
+        db_name = "package-db",
+        pkgs = [
+            ":daml-prim-{}".format(ver),
+            ":daml-stdlib-{}".format(ver),
+        ],
+        visibility = ["//visibility:public"],
+    )
+    for ver in DAML_LF_VERSIONS
+]
 
-daml_package_db(
+filegroup(
     name = "package-db",
-    daml_lf_versions = DAML_LF_VERSIONS,
-    pkgs =
-        [":daml-prim-{}".format(ver) for ver in DAML_LF_VERSIONS] +
-        [":daml-stdlib-{}".format(ver) for ver in DAML_LF_VERSIONS],
+    srcs = [":package-db-{}".format(ver) for ver in DAML_LF_VERSIONS],
     visibility = ["//visibility:public"],
 )

--- a/daml-foundations/daml-ghc/package-database/util.bzl
+++ b/daml-foundations/daml-ghc/package-database/util.bzl
@@ -95,7 +95,7 @@ def _daml_package_rule_impl(ctx):
     """.format(
             main = modules[ctx.attr.main],
             name = name,
-            package_db_dir = package_db_dir.path,
+            package_db_dir = package_db_dir.path.rpartition("/")[0],
             damlc_bootstrap = ctx.executable.damlc_bootstrap.path,
             dalf_file = dalf.path,
             daml_lf_version = ctx.attr.daml_lf_version,
@@ -146,7 +146,7 @@ PackageDb = provider(fields = ["db_dir", "pkgs"])
 
 def _daml_package_db_impl(ctx):
     toolchain = ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"]
-    db_dir = ctx.actions.declare_directory(ctx.attr.name + "_dir")
+    db_dir = ctx.actions.declare_directory(ctx.attr.db_name + "_dir/{}".format(ctx.attr.daml_lf_version))
     ctx.actions.run_shell(
         inputs = [inp for pkg in ctx.attr.pkgs for inp in [pkg[DamlPackage].pkg_conf, pkg[DamlPackage].iface_dir, pkg[DamlPackage].dalf]],
         tools = [toolchain.tools.ghc_pkg],
@@ -155,20 +155,16 @@ def _daml_package_db_impl(ctx):
             """
         set -eou pipefail
         shopt -s nullglob
-        mkdir -p {db_dir}
-        for ver in {daml_lf_versions}; do
-            mkdir -p "{db_dir}/$ver/package.conf.d"
-        done
-        """.format(db_dir = db_dir.path, daml_lf_versions = " ".join(ctx.attr.daml_lf_versions)) +
+        mkdir -p "{db_dir}/package.conf.d"
+        """.format(db_dir = db_dir.path, daml_lf_version = ctx.attr.daml_lf_version) +
             "".join(
                 [
                     """
-        mkdir -p "{db_dir}/{daml_lf_version}/{pkg_name}"
-        cp {pkg_conf} "{db_dir}/{daml_lf_version}/package.conf.d/{pkg_name}.conf"
-        cp -aL {iface_dir}/* "{db_dir}/{daml_lf_version}/{pkg_name}/"
-        cp {dalf} "{db_dir}/{daml_lf_version}/{pkg_name}.dalf"
+        mkdir -p "{db_dir}/{pkg_name}"
+        cp {pkg_conf} "{db_dir}/package.conf.d/{pkg_name}.conf"
+        cp -aL {iface_dir}/* "{db_dir}/{pkg_name}/"
+        cp {dalf} "{db_dir}/{pkg_name}.dalf"
         """.format(
-                        daml_lf_version = pkg[DamlPackage].daml_lf_version,
                         pkg_name = pkg[DamlPackage].pkg_name,
                         pkg_conf = pkg[DamlPackage].pkg_conf.path,
                         iface_dir = pkg[DamlPackage].iface_dir.path,
@@ -179,9 +175,7 @@ def _daml_package_db_impl(ctx):
                 ],
             ) +
             """
-        for lf_version in "{db_dir}"/*; do
-          {ghc_pkg} recache --package-db=$lf_version/package.conf.d --no-expand-pkgroot
-        done
+        {ghc_pkg} recache --package-db={db_dir}/package.conf.d --no-expand-pkgroot
         """.format(
                 db_dir = db_dir.path,
                 ghc_pkg = toolchain.tools.ghc_pkg.path,
@@ -196,10 +190,11 @@ daml_package_db = rule(
     implementation = _daml_package_db_impl,
     toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
     attrs = {
+        "db_name": attr.string(mandatory = True),
         "pkgs": attr.label_list(
             allow_files = False,
             providers = [DamlPackage],
         ),
-        "daml_lf_versions": attr.string_list(mandatory = True),
+        "daml_lf_version": attr.string(mandatory = True),
     },
 )


### PR DESCRIPTION
Currently, the daml_package_db rule produces package databases for all
supported DAML-LF versions in one go. This is rather inconvient when you
want to put further files into the database that are generated using
bazel's string interpolation. However, that is exactly what I need to do
in the context of making the daml-stdlib aware of the DAML-LF version
we're compiling to via CPP.

Thus, this PR changes the daml_pacakge_db rule such that we only produce
the package database for a single DAML-LF version.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2015)
<!-- Reviewable:end -->
