### PR TITLE
build pr commit on pr build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,7 @@ jobs:
       name: 'linux-pool'
     steps:
       - checkout: self
+      - template: ci/reset-if-pr.yml
       - bash: ci/dev-env-install.sh
         displayName: 'Build/Install the Developer Environment'
       - bash: ci/configure-bazel.sh
@@ -91,6 +92,7 @@ jobs:
     steps:
       - checkout: self
         persistCredentials: true
+      - template: ci/reset-if-pr.yml
       - task: DownloadPipelineArtifact@0
         inputs:
           artifactName: $(unsigned-installer)
@@ -128,6 +130,7 @@ jobs:
     steps:
       - checkout: self
         persistCredentials: true
+      - template: ci/reset-if-pr.yml
       - bash: |
           set -euxo pipefail
           git tag v$(cat VERSION)

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -3,6 +3,7 @@ parameters:
 
 steps:
   - checkout: self
+  - template: reset-if-pr.yml
 
   - bash: ci/dev-env-install.sh
     displayName: 'Build/Install the Developer Environment'

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -1,5 +1,6 @@
 steps:
   - checkout: self
+  - template: reset-if-pr.yml
 
   - bash: ci/configure-bazel.sh
     displayName: 'Configure Bazel'

--- a/ci/reset-if-pr.yml
+++ b/ci/reset-if-pr.yml
@@ -1,0 +1,6 @@
+steps:
+  - bash: |
+      set -euo pipefail
+      if [[ "$(Build.Reason)" == "PullRequest" ]]; then
+        git reset --hard HEAD^2
+      fi


### PR DESCRIPTION
# Open for debate

> This PR is the answer to "how would we do it", please read further for _what_ "it" is, why we'd want it, and why we wouldn't want it.

I am obviously biased towards making this change (otherwise I would not have made this PR), so there may be more arguments against than I am representing here.

## What does this do?

By default, when Azure Pipelines builds a pull request, what it runs is the result of merging the PR branch into master. By taking the second parent of the current commit (`HEAD^2`), this resets the current working directory to be just the unadulterated pull request as it can be seen on GitHub.

## Why would we *not* want this?

Though I would deplore the fact that this Azure Pipelines behaviour is undocumented and does not expose any kind of control over it, I have to agree that, in many cases, running CI builds on the result of merging the PR into master _is_ the right thing to do. Running the PR branch alone (as this change would do) is not quite enough to be confident about the final status of merging it into master.

## Why, then, _would_ we want this?

The problem is, this breaks down somewhat in our case, because master just moves too fast. Or because Azure does not go far enough along its own line of reasoning, depending on your point of view.

In a world where master moves sufficiently slowly, it is a good thing that looking at a PR's build result gives you confidence merging it will result in a working master _because the PR build result is already testing the result of the merge_. However, in a world, like ours, where, for the vast majority of PRs, between the time the Azure build starts and the time the PR would get merged, _master has changed_, this behaviour results in two undesirable consequences:
1. If we know about this Azure behaviour, the PR build result is misleading because master has changed since the build has run; therefore, a successful build gives us a false sense of security.
2. If we do not know about this Azure behaviour, the build result is misleading because it simply has not run what we believe it has run.

In my opinion, the default behaviour of Azure would really only make sense if it followed its own logic all the way through and restarted all the PR builds whenever master changes. Note that we already have a way to approximate that behaviour (with much smarter resource utilization) in the `automerge-after-rebase` tag.