### PR TITLE
remove cmd echo from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-set -euxo pipefail
+set -euo pipefail
 
 eval "$($(dirname "$0")/dev-env/bin/dade-assist)"
 


### PR DESCRIPTION
I assume it was there for debugging purposes at some point, but right now it seems like it's just adding unnecessary noise.