### PR TITLE
Add Sandbox binary that starts an ephemeral postgres instance

### DIFF
--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -97,6 +97,17 @@ da_scala_binary(
     ],
 )
 
+da_scala_binary(
+    name = "sandbox-ephemeral-postgres",
+    main_class = "com.digitalasset.platform.sandbox.persistence.EphemeralPostgresSandboxMain",
+    resources = ["src/main/resources/logback.xml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":sandbox",
+        ":sandbox-scala-tests-lib",
+    ],
+)
+
 genrule(
     name = "sandbox-tarball",
     srcs = [
@@ -174,53 +185,57 @@ da_scala_test_suite(
         ":sandbox-scala-tests-lib",
     ] + testDependencies,
 )
-### GS: disabling conformance tests until we figure out how to
-###     run sandbox on postgres with ledger-api-test-tool
-#client_server_test(
-#    name = "conformance-test-static-time",
-#    timeout = "short",
-#    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
-#    client_args = [
-#        "--all-tests",
-#    ],
-#    data = [
-#        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
-#        "//ledger/sandbox:Test.dar",
-#    ],
-#    server = "//ledger/sandbox:sandbox-binary",
-#    server_args = [
-#        "-s",
-#        "ledger/ledger-api-integration-tests/SemanticTests.dar",
-#        "ledger/sandbox/Test.dar",
-#    ],
-#    tags = [
-#        "dont-run-on-darwin",
-#        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
-#        "exclusive",
-#    ],
-#) if not is_windows else None
-#
-#client_server_test(
-#    name = "conformance-test-wall-clock",
-#    timeout = "short",
-#    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
-#    client_args = [
-#        "--all-tests",
-#        "--exclude SemanticTests",
-#    ],
-#    data = [
-#        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
-#        "//ledger/sandbox:Test.dar",
-#    ],
-#    server = "//ledger/sandbox:sandbox-binary",
-#    server_args = [
-#        "-w",
-#        "ledger/ledger-api-integration-tests/SemanticTests.dar",
-#        "ledger/sandbox/Test.dar",
-#    ],
-#    tags = [
-#        "dont-run-on-darwin",
-#        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
-#        "exclusive",
-#    ],
-#) if not is_windows else None
+
+client_server_test(
+    name = "conformance-test-wall-clock-inmemory",
+    timeout = "short",
+    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
+    client_args = [
+        "--all-tests",
+        "--exclude SemanticTests",
+    ],
+    data = [
+        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
+        "//ledger/sandbox:Test.dar",
+    ],
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "-w",
+        "ledger/ledger-api-integration-tests/SemanticTests.dar",
+        "ledger/sandbox/Test.dar",
+    ],
+    tags = [
+        "dont-run-on-darwin",
+        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
+        "exclusive",
+    ],
+) if not is_windows else None
+
+client_server_test(
+    name = "conformance-test-wall-clock-postgres",
+    timeout = "short",
+    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
+    client_args = [
+        "--all-tests",
+        "--exclude SemanticTests",
+    ],
+    data = [
+        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
+        "//ledger/sandbox:Test.dar",
+        "@postgresql_dev_env//:all",
+        "@postgresql_dev_env//:createdb",
+        "@postgresql_dev_env//:initdb",
+        "@postgresql_dev_env//:pg_ctl",
+    ],
+    server = "//ledger/sandbox:sandbox-ephemeral-postgres",
+    server_args = [
+        "-w",
+        "ledger/ledger-api-integration-tests/SemanticTests.dar",
+        "ledger/sandbox/Test.dar",
+    ],
+    tags = [
+        "dont-run-on-darwin",
+        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
+        "exclusive",
+    ],
+) if not is_windows else None

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/EphemeralPostgresSandboxMain.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/EphemeralPostgresSandboxMain.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.persistence
+
+import com.digitalasset.platform.sandbox.SandboxMain
+
+object EphemeralPostgresSandboxMain extends App with PostgresAround {
+  val fixture = startEphemeralPg()
+  sys.addShutdownHook(stopAndCleanUp(fixture.tempDir, fixture.dataDir, fixture.logFile))
+  SandboxMain.main(args ++ List("--sql-backend-jdbcurl", fixture.jdbcUrl))
+}


### PR DESCRIPTION
This allows us to use the client_server_test bazel macro to run against
the sandbox backed by postgres.

## This is only for our own internal testing in CI.

Fixes #1543

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
