### PR TITLE
Refactor generatePackageMap

### DIFF
--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -17,10 +17,13 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import Data.List.Extra
 import Data.Maybe
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as S
 import qualified Data.Text as T
 import System.Directory
 import System.FilePath
+
+import Module (unitIdString)
 
 import Development.IDE.Core.Rules.Daml
 import Development.IDE.Core.RuleTypes.Daml
@@ -102,10 +105,10 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
               show (S.toList missingExposed)
       let dalf = encodeArchiveLazy pkg
       -- get all dalf dependencies.
-      deps <- getDalfDependencies file
-      dalfDependencies<- forM deps $ \(DalfDependency depName fp) -> do
-        pkgDalf <- liftIO $ BS.readFile fp
-        return (depName, pkgDalf)
+      dalfDependencies <-
+          fmap
+              (map (\(unitId, pkg) -> (T.pack $ unitIdString unitId, dalfPackageBytes pkg)) . Map.toList)
+              (getDalfDependencies file)
       -- get all file dependencies
       fileDependencies <- MaybeT $ getDependencies file
       liftIO $

--- a/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Dar.hs
+++ b/daml-foundations/daml-ghc/daml-compiler/src/DA/Service/Daml/Compiler/Impl/Dar.hs
@@ -105,10 +105,9 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
               show (S.toList missingExposed)
       let dalf = encodeArchiveLazy pkg
       -- get all dalf dependencies.
-      dalfDependencies <-
-          fmap
-              (map (\(unitId, pkg) -> (T.pack $ unitIdString unitId, dalfPackageBytes pkg)) . Map.toList)
-              (getDalfDependencies file)
+      dalfDependencies0 <- getDalfDependencies file
+      let dalfDependencies =
+              [ (T.pack $ unitIdString unitId, dalfPackageBytes pkg) | (unitId, pkg) <- Map.toList dalfDependencies0 ]
       -- get all file dependencies
       fileDependencies <- MaybeT $ getDependencies file
       liftIO $

--- a/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Upgrade.hs
+++ b/daml-foundations/daml-ghc/ghc-compiler/src/DA/Daml/GHC/Compiler/Upgrade.hs
@@ -104,7 +104,7 @@ upgradeTemplate n =
 
 -- | Extract all data defintions from a daml-lf module and generate a haskell source file from it.
 generateSrcFromLf ::
-       LF.PackageId -> MS.Map GHC.UnitId T.Text -> LF.Module -> ParsedSource
+       LF.PackageId -> MS.Map GHC.UnitId LF.PackageId -> LF.Module -> ParsedSource
 generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
   where
     thisModuleName =
@@ -115,8 +115,8 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
     getUnitId pkgRef =
         fromJust (error $ "Unknown package: " <> show pkgRef) $
         case pkgRef of
-            LF.PRSelf -> MS.lookup (LF.unPackageId thisPkgId) pkgMapInv
-            LF.PRImport (LF.PackageId pkgId) -> MS.lookup pkgId pkgMapInv
+            LF.PRSelf -> MS.lookup thisPkgId pkgMapInv
+            LF.PRImport pkgId -> MS.lookup pkgId pkgMapInv
     mod =
         HsModule
             { hsmodImports = imports

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -35,7 +35,16 @@ type instance RuleResult GenerateRawDalf = LF.Module
 type instance RuleResult GeneratePackage = LF.Package
 type instance RuleResult GenerateRawPackage = LF.Package
 type instance RuleResult GeneratePackageDeps = LF.Package
-type instance RuleResult GeneratePackageMap = (Map UnitId (LF.PackageId, LF.Package, BS.ByteString, FilePath))
+
+data DalfPackage = DalfPackage
+    { dalfPackageId :: LF.PackageId
+    , dalfPackagePkg :: LF.Package
+    , dalfPackageBytes :: BS.ByteString
+    } deriving (Show, Eq, Generic)
+
+instance NFData DalfPackage
+
+type instance RuleResult GeneratePackageMap = (Map UnitId DalfPackage)
 
 -- | Runs all scenarios in the given file (but not scenarios in imports).
 type instance RuleResult RunScenarios = [(VirtualResource, Either SS.Error SS.ScenarioResult)]

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -44,7 +44,7 @@ data DalfPackage = DalfPackage
 
 instance NFData DalfPackage
 
-type instance RuleResult GeneratePackageMap = (Map UnitId DalfPackage)
+type instance RuleResult GeneratePackageMap = Map UnitId DalfPackage
 
 -- | Runs all scenarios in the given file (but not scenarios in imports).
 type instance RuleResult RunScenarios = [(VirtualResource, Either SS.Error SS.ScenarioResult)]

--- a/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc.hs
+++ b/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc.hs
@@ -48,6 +48,7 @@ import qualified Data.Text.Encoding as TE
 import Development.IDE.Core.API
 import Development.IDE.Core.Service (runAction)
 import Development.IDE.Core.Rules.Daml (getDalf)
+import Development.IDE.Core.RuleTypes.Daml (DalfPackage(..))
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import GHC.Conc
@@ -676,7 +677,7 @@ execMigrate opts inFile1 inFile2 mbDir = do
             extractFilesFromArchive [OptDestination tmpDir] dar
             (diags, pkgMap) <- generatePackageMap [tmpDir]
             unless (null diags) $ Logger.logWarning logH $ showDiagnostics diags
-            pure $ MS.map (\(LF.PackageId pkgId, _, _, _) -> pkgId) pkgMap
+            pure $ MS.map dalfPackageId pkgMap
 
 --------------------------------------------------------------------------------
 -- main

--- a/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc/IdeState.hs
+++ b/daml-foundations/daml-tools/daml-cli/DA/Cli/Damlc/IdeState.hs
@@ -13,7 +13,6 @@ import DA.Daml.GHC.Compiler.Options
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Daml.Compiler.Impl.Scenario as Scenario
 import Development.IDE.Core.Rules.Daml
-import qualified Development.IDE.Core.Shake as Shake
 import Development.IDE.Core.API
 import qualified Development.IDE.Types.Logger as IdeLogger
 
@@ -25,12 +24,7 @@ getDamlIdeState
     -> VFSHandle
     -> IO IdeState
 getDamlIdeState compilerOpts mbScenarioService loggerH eventHandler vfs = do
-    -- Load the packages from the package database for the scenario service. We swallow errors here
-    -- but shake will report them when typechecking anything.
-    (_diags, pkgMap) <- generatePackageMap (optPackageDbs compilerOpts)
-    let rule = do
-            mainRule compilerOpts
-            Shake.addIdeGlobal $ GlobalPkgMap pkgMap
+    let rule = mainRule compilerOpts
     initialise rule eventHandler (toIdeLogger loggerH) compilerOpts vfs mbScenarioService
 
 -- Wrapper for the common case where the scenario service will be started automatically (if enabled)


### PR DESCRIPTION
1. I’m too stupid for 4-tuples  so I replaced it by a record.
2. GlobalPkgMap was simply unnecessary given that we have a rule for
getting the package map.
3. getDalfDependencies threw away the bytestring that we store in the
package db only to then read the file again.

This also brings a measurable performance improvement:

On the skeleton project, the runtime of `daml build` drops from 1.4s
to 0.9s and total memory use drops from 67MB to 44MB.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
