### PR TITLE
Add a reference server main class that starts an ephemeral postgres server

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -45,27 +45,49 @@ da_scala_binary(
     ],
 )
 
-#client_server_test(
-#    name = "conformance-test",
-#    timeout = "short",
-#    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
-#    client_args = [
-#        "--all-tests",
-#        "--exclude SemanticTests",
-#    ],
-#    data = [
-#        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
-#        "//ledger/sandbox:Test.dar",
-#    ],
-#    server = ":reference-v2",
-#    server_args = [
-#        "--jdbc-url",
-#        "jdbc:postgresql://localhost/aio?user=aio&password=aio",
-#        "ledger/ledger-api-integration-tests/SemanticTests.dar",
-#        "ledger/sandbox/Test.dar",
-#    ],
-#    tags = [
-#        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
-#        "exclusive",
-#    ],
-#) if not is_windows else None
+########################################
+### Testing the index server
+########################################
+
+da_scala_binary(
+    name = "ephemeral-postgres-reference-server",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    main_class = "com.daml.ledger.api.server.damlonx.reference.v2.EphemeralPostgresReferenceServerMain",
+    resources = ["src/main/resources/logback.xml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":reference-v2",
+        "//3rdparty/jvm/org/slf4j:slf4j_api",
+        "//ledger/sandbox:sandbox-scala-tests-lib",
+    ],
+)
+
+client_server_test(
+    name = "conformance-test",
+    timeout = "short",
+    client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
+    client_args = [
+        # disabling all tests for now, so that at least we have the infrastructure
+        # to slowly add and fix tests one after the other.
+        # "--all-tests",
+        "--exclude SemanticTests",
+    ],
+    data = [
+        "//ledger/ledger-api-integration-tests:SemanticTests.dar",
+        "//ledger/sandbox:Test.dar",
+        "@postgresql_dev_env//:all",
+        "@postgresql_dev_env//:createdb",
+        "@postgresql_dev_env//:initdb",
+        "@postgresql_dev_env//:pg_ctl",
+    ],
+    server = ":ephemeral-postgres-reference-server",
+    server_args = [
+        "ledger/ledger-api-integration-tests/SemanticTests.dar",
+        "ledger/sandbox/Test.dar",
+    ],
+    tags = [
+        "dont-run-on-darwin",
+        # NOTE(JM): As this test is somewhat heavy and has timeouts, run it without competition to avoid flakyness.
+        "exclusive",
+    ],
+) if not is_windows else None

--- a/ledger/api-server-damlonx/reference-v2/src/test/scala/com/daml/ledger/api/server/damlonx/reference/v2/EphemeralPostgresReferenceServerMain.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/test/scala/com/daml/ledger/api/server/damlonx/reference/v2/EphemeralPostgresReferenceServerMain.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.server.damlonx.reference.v2
+
+import com.digitalasset.platform.sandbox.persistence.PostgresAround
+
+object EphemeralPostgresReferenceServerMain extends App with PostgresAround {
+  val fixture = startEphemeralPg()
+  sys.addShutdownHook(stopAndCleanUp(fixture.tempDir, fixture.dataDir, fixture.logFile))
+  ReferenceServer.main(args ++ List("--jdbc-url", fixture.jdbcUrl))
+}


### PR DESCRIPTION
This way we can run the test suite of the ledger api test tool against the
postgres index and postgres indexer.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
