### PR TITLE
Cache rewrites of PRSelf references

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -9,6 +9,8 @@ module DA.Daml.LF.Ast.World(
     initWorld,
     initWorldSelf,
     extendWorldSelf,
+    ExternalPackage,
+    rewriteSelfReferences,
     LookupError,
     lookupTemplate,
     lookupDataType,
@@ -19,9 +21,12 @@ module DA.Daml.LF.Ast.World(
 
 import DA.Pretty
 
-import           Control.Lens
+import Control.DeepSeq
+import Control.Lens
 import qualified Data.HashMap.Strict as HMS
+import Data.List
 import qualified Data.NameMap as NM
+import GHC.Generics
 
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.Optics (moduleModuleRef)
@@ -38,24 +43,35 @@ data World = World
 
 makeLensesFor [("_worldSelf","worldSelf")] ''World
 
+-- | A package where all references to `PRSelf` have been rewritten
+-- to `PRImport`.
+data ExternalPackage = ExternalPackage PackageId Package
+    deriving (Show, Eq, Generic)
+
+instance NFData ExternalPackage
+
+-- | Rewrite all `PRSelf` references to `PRImport` references.
+rewriteSelfReferences :: PackageId -> Package -> ExternalPackage
+rewriteSelfReferences pkgId = ExternalPackage pkgId . rewrite
+    where
+        rewrite = over (_packageModules . NM.traverse . moduleModuleRef . _1) $ \case
+            PRSelf -> PRImport pkgId
+            ref@PRImport{} -> ref
+
 -- | Construct the 'World' from only the imported packages.
-initWorld :: [(PackageId, Package)] -> Version -> World
+initWorld :: [ExternalPackage] -> Version -> World
 initWorld importedPkgs version =
   World
-    (HMS.mapWithKey rewritePRSelf (foldl insertPkg HMS.empty importedPkgs))
+    (foldl' insertPkg HMS.empty importedPkgs)
     (Package version NM.empty)
   where
-    insertPkg hms (pkgId, pkg)
+    insertPkg hms (ExternalPackage pkgId pkg)
       | pkgId `HMS.member` hms =
           error $  "World.initWorld: duplicate package id " ++ show pkgId
       | otherwise = HMS.insert pkgId pkg hms
-    rewritePRSelf :: PackageId -> Package -> Package
-    rewritePRSelf pkgId = over (_packageModules . NM.traverse . moduleModuleRef . _1) $ \case
-      PRSelf -> PRImport pkgId
-      ref@PRImport{} -> ref
 
 -- | Create a World with an initial self package
-initWorldSelf :: [(PackageId, Package)] -> Package -> World
+initWorldSelf :: [ExternalPackage] -> Package -> World
 initWorldSelf importedPkgs pkg = (initWorld importedPkgs $ packageLfVersion pkg){_worldSelf = pkg}
 
 -- | Extend the 'World' by a module in the current package.

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/InferSerializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/InferSerializability.hs
@@ -3,11 +3,9 @@
 
 module DA.Daml.LF.InferSerializability
   ( inferModule
-  , inferPackage
   ) where
 
 import           Control.Monad.Error.Class
-import           Data.Foldable (foldlM)
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.HashSet as HS
 import qualified Data.NameMap as NM
@@ -35,13 +33,3 @@ inferModule world0 version mod0 = do
       let updateDataType dataType =
             dataType{dataSerializable = IsSerializable (HMS.lookupDefault False (dataTypeCon dataType) serializabilities)}
       pure mod0{moduleDataTypes = NM.map updateDataType dataTypes}
-
--- | Infer the serializability information for a package. Assumes the modules
--- have been sorted topologically. Does not change the order of the modules.
--- See 'DA.Daml.LF.Ast.Util.topoSortPackage'.
-inferPackage :: [(PackageId, Package)] -> Package -> Either String Package
-inferPackage pkgDeps (Package version mods0) = do
-      let infer1 (mods1, world0) mod0 = do
-            mod1 <- inferModule world0 version mod0
-            pure (NM.insert mod1 mods1, extendWorldSelf mod1 world0)
-      Package version . fst <$> foldlM infer1 (NM.empty, initWorld pkgDeps version) mods0

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
@@ -4,13 +4,8 @@
 module DA.Daml.LF.TypeChecker
   ( Error (..)
   , checkModule
-  , checkPackage
   , errorLocation
   ) where
-
-import Data.Functor
-import           Data.Either.Combinators           (mapLeft)
-import           Data.Foldable
 
 import           DA.Daml.LF.Ast
 import qualified DA.Daml.LF.TypeChecker.Check      as Check
@@ -31,14 +26,3 @@ checkModule world0 version m = do
       Recursion.checkModule m
       Serializability.checkModule m
       PartyLits.checkModule m
-
--- | Type checks a whole DAML-LF package. Assumes the modules in the package are
--- sorted topologically, i.e., module @A@ appears before module @B@ whenever @B@
--- depends on @A@.
-checkPackage :: [(PackageId, Package)] -> Package -> Either Error ()
-checkPackage pkgDeps pkg = do
-    Package version mods <- mapLeft EImportCycle (topoSortPackage pkg)
-    let check1 world0 mod0 = do
-          checkModule world0 version mod0
-          pure (extendWorldSelf mod0 world0)
-    void (foldlM check1 (initWorld pkgDeps version) mods)

--- a/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/daml-foundations/daml-ghc/ide/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -38,7 +38,7 @@ type instance RuleResult GeneratePackageDeps = LF.Package
 
 data DalfPackage = DalfPackage
     { dalfPackageId :: LF.PackageId
-    , dalfPackagePkg :: LF.Package
+    , dalfPackagePkg :: LF.ExternalPackage
     , dalfPackageBytes :: BS.ByteString
     } deriving (Show, Eq, Generic)
 

--- a/daml-foundations/daml-tools/daml-cli/DA/Cli/Visual.hs
+++ b/daml-foundations/daml-tools/daml-cli/DA/Cli/Visual.hs
@@ -68,9 +68,9 @@ templatePossibleUpdates world tpl = map (\c -> ChoiceAndAction tpl c (startFromC
 moduleAndTemplates :: LF.World -> LF.Module -> [TemplateChoiceAction]
 moduleAndTemplates world mod = map (\t -> TemplateChoiceAction t (templatePossibleUpdates world t)) $ NM.toList $ LF.moduleTemplates mod
 
-dalfBytesToPakage :: BSL.ByteString -> (LF.PackageId, LF.Package)
+dalfBytesToPakage :: BSL.ByteString -> ExternalPackage
 dalfBytesToPakage bytes = case Archive.decodeArchive $ BSL.toStrict bytes of
-    Right a -> a
+    Right (pkgId, pkg) -> rewriteSelfReferences pkgId pkg
     Left err -> error (show err)
 
 darToWorld :: ManifestData -> LF.Package -> LF.World


### PR DESCRIPTION
Previously we rewrote references to `PRSelf` to `PRImport` references
every time we call `initWorld`. However, we call `initWorld` quite
often (e.g. every time we run a scenario) while the packages that need
to be rewritten stay constant. Since rewriting the package references
requires traversing the whole package, this can be quite expensive.

This PR moves the rewriting of package references out of `initWorld`
and caches it as part of `GeneratePackageMap`.

On a large project where I tested this, this caused a drop in the
runtime of `daml test` from 250s to 200s. In the IDE this can also
make a pretty big difference since we call this everytime we run a
scenario which we do on every file change.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
