### PR TITLE
Generate a list of single package updates for an upload message containing multiple packages

### DIFF
--- a/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/IndexState.scala
+++ b/ledger/participant-state-index/reference/src/main/scala/com/daml/ledger/participant/state/index/v1/impl/reference/IndexState.scala
@@ -80,21 +80,16 @@ final case class IndexState(
                 Some(u.displayName),
                 u.participantId == state.participantId)))
 
-        case Update.PublicPackagesUploaded(
-            archives,
-            sourceDescription,
-            participantId,
-            uploadRecordTime) =>
+        case Update.PublicPackageUploaded(archive, sourceDescription, _, uploadRecordTime) =>
           val newPackages =
-            state.packages ++ archives.map(a => PackageId.assertFromString(a.getHash) -> a)
+            state.packages + (PackageId.assertFromString(archive.getHash) -> archive)
 
           val newPackageDetails =
-            state.packageDetails ++ archives.map(
-              a =>
-                PackageId.assertFromString(a.getHash) -> PackageDetails(
-                  a.getPayload.size.toLong,
-                  uploadRecordTime,
-                  sourceDescription))
+            state.packageDetails +
+              (PackageId.assertFromString(archive.getHash) -> PackageDetails(
+                archive.getPayload.size.toLong,
+                uploadRecordTime,
+                sourceDescription))
 
           //val decodedPackages = newPackages.mapValues(archive => Decode.decodeArchive(archive)._2)
           Right(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
@@ -363,7 +363,7 @@ class InMemoryKVParticipantState(
     dispatcher
       .startingAt(
         beginAfter
-          .map(_.components.head.toInt + 1) // startingAt is inclusive, so jump over one element.
+          .map(_.components.head.toInt)
           .getOrElse(beginning)
       )
       .collect {
@@ -373,6 +373,12 @@ class InMemoryKVParticipantState(
           }
       }
       .mapConcat(identity)
+      .filter {
+        case (offset, _) =>
+          if (beginAfter.isDefined)
+            offset > beginAfter.get
+          else true
+      }
 
   /** Submit a transaction to the ledger.
     *

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -13,6 +13,7 @@ import com.digitalasset.ledger.api.domain.PartyDetails
 import com.google.common.io.BaseEncoding
 import com.google.protobuf.ByteString
 
+import scala.collection.breakOut
 import scala.collection.JavaConverters._
 
 /** Utilities for producing [[Update]] events from [[DamlLogEntry]]'s committed to a
@@ -43,7 +44,7 @@ object KeyValueConsumption {
 
     entry.getPayloadCase match {
       case DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
-        entry.getPackageUploadEntry.getArchivesList.asScala.toList.map { archive =>
+        entry.getPackageUploadEntry.getArchivesList.asScala.map { archive =>
           Update.PublicPackageUploaded(
             archive,
             if (entry.getPackageUploadEntry.getSourceDescription.nonEmpty)
@@ -52,7 +53,7 @@ object KeyValueConsumption {
             Ref.LedgerString.assertFromString(entry.getPackageUploadEntry.getParticipantId),
             recordTime
           )
-        }
+        }(breakOut)
 
       case DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_REJECTION_ENTRY =>
         List.empty

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/v2/ParticipantStateConversion.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/v2/ParticipantStateConversion.scala
@@ -107,12 +107,12 @@ object ParticipantStateConversion {
               case v1.Update.ConfigurationChanged(newConfiguration) =>
                 v2.Update.ConfigurationChanged(configurationToV2(newConfiguration))
 
-              case v1.Update.PublicPackagesUploaded(
+              case v1.Update.PublicPackageUploaded(
                   archives,
                   sourceDescription,
                   participantId,
                   recordTime) =>
-                v2.Update.PublicPackagesUploaded(
+                v2.Update.PublicPackageUploaded(
                   archives,
                   sourceDescription.getOrElse(""),
                   participantId,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantStateIT.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantStateIT.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils
 
 import akka.stream.scaladsl.Sink
-import com.daml.ledger.participant.state.v1.Update.{PartyAddedToParticipant, PublicPackagesUploaded}
+import com.daml.ledger.participant.state.v1.Update.{PartyAddedToParticipant, PublicPackageUploaded}
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Time.Timestamp
@@ -73,10 +73,10 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
             fail("unexpected response to party allocation")
         }
         updateTuple match {
-          case (offset: Offset, update: PublicPackagesUploaded) =>
+          case (offset: Offset, update: PublicPackageUploaded) =>
             ps.close()
-            assert(offset == Offset(Array(0L)))
-            assert(update.archives == List(archive))
+            assert(offset == Offset(Array(0L, 0L)))
+            assert(update.archive == archive)
             assert(update.sourceDescription == sourceDescription)
             assert(update.participantId == ps.participantId)
             assert(update.recordTime >= rt)
@@ -85,7 +85,7 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
       }
     }
 
-    "duplicate package removed from update after uploadPackages" in {
+    "provide two updates after uploadPackages with two archives" in {
       val ps = new InMemoryKVParticipantState(participantId)
       val rt = ps.getNewRecordTime()
 
@@ -94,13 +94,14 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
         .setHash("asdf")
         .setPayload(ByteString.copyFromUtf8("AAAAAAAHHHHHH"))
         .build
+      val otherArchive = DamlLf.Archive.newBuilder
+        .setHash("zxcv")
+        .setPayload(ByteString.copyFromUtf8("ZZZZZZZZZZZZZ"))
+        .build
 
       for {
-        _ <- ps
-          .uploadPackages(List(archive), sourceDescription)
-          .toScala
         result <- ps
-          .uploadPackages(List(archive), sourceDescription)
+          .uploadPackages(List(archive, otherArchive), sourceDescription)
           .toScala
         updateTuples <- ps.stateUpdates(beginAfter = None).take(2).runWith(Sink.seq)
       } yield {
@@ -111,11 +112,80 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
           case _ =>
             fail("unexpected response to party allocation")
         }
-        updateTuples(1) match {
-          case (offset: Offset, update: PublicPackagesUploaded) =>
+        updateTuples.head match {
+          case (offset: Offset, update: PublicPackageUploaded) =>
             ps.close()
-            assert(offset == Offset(Array(1L)))
-            assert(update.archives == List.empty)
+            assert(offset == Offset(Array(0L, 0L)))
+            assert(update.archive == archive)
+            assert(update.sourceDescription == sourceDescription)
+            assert(update.participantId == ps.participantId)
+            assert(update.recordTime >= rt)
+          case _ => fail("unexpected update message after a package upload")
+        }
+        updateTuples(1) match {
+          case (offset: Offset, update: PublicPackageUploaded) =>
+            ps.close()
+            assert(offset == Offset(Array(0L, 1L)))
+            assert(update.archive == otherArchive)
+            assert(update.sourceDescription == sourceDescription)
+            assert(update.participantId == ps.participantId)
+            assert(update.recordTime >= rt)
+          case _ => fail("unexpected update message after a package upload")
+        }
+      }
+    }
+
+    "remove duplicate package from update after uploadPackages" in {
+      val ps = new InMemoryKVParticipantState(participantId)
+      val rt = ps.getNewRecordTime()
+
+      val sourceDescription = Some("provided by test")
+      val archive = DamlLf.Archive.newBuilder
+        .setHash("asdf")
+        .setPayload(ByteString.copyFromUtf8("AAAAAAAHHHHHH"))
+        .build
+      val otherArchive = DamlLf.Archive.newBuilder
+        .setHash("zxcv")
+        .setPayload(ByteString.copyFromUtf8("ZZZZZZZZZZZZZ"))
+        .build
+
+      for {
+        _ <- ps
+          .uploadPackages(List(archive), sourceDescription)
+          .toScala
+        result <- ps
+          .uploadPackages(List(archive), sourceDescription)
+          .toScala
+        _ <- ps
+          .uploadPackages(List(otherArchive), sourceDescription)
+          .toScala
+        updateTuples <- ps.stateUpdates(beginAfter = None).take(2).runWith(Sink.seq)
+      } yield {
+        ps.close()
+        result match {
+          case UploadPackagesResult.Ok =>
+            succeed
+          case _ =>
+            fail("unexpected response to party allocation")
+        }
+        // first upload arrives as head update:
+        updateTuples.head match {
+          case (offset: Offset, update: PublicPackageUploaded) =>
+            ps.close()
+            assert(offset == Offset(Array(0L, 0L)))
+            assert(update.archive == archive)
+            assert(update.sourceDescription == sourceDescription)
+            assert(update.participantId == ps.participantId)
+            assert(update.recordTime >= rt)
+          case _ => fail("unexpected update message after a package upload")
+        }
+        // second upload results in no update because it was a duplicate
+        // third upload arrives as a second update:
+        updateTuples(1) match {
+          case (offset: Offset, update: PublicPackageUploaded) =>
+            ps.close()
+            assert(offset == Offset(Array(2L, 0L)))
+            assert(update.archive == otherArchive)
             assert(update.sourceDescription == sourceDescription)
             assert(update.participantId == ps.participantId)
             assert(update.recordTime >= rt)
@@ -172,7 +242,7 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
         }
         updateTuple match {
           case (offset: Offset, update: PartyAddedToParticipant) =>
-            assert(offset == Offset(Array(0L)))
+            assert(offset == Offset(Array(0L, 0L)))
             assert(update.party == hint.get)
             assert(update.displayName == displayName.get)
             assert(update.participantId == ps.participantId)
@@ -267,7 +337,7 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
         ps.stateUpdates(beginAfter = None).runWith(Sink.head).map {
           case (offset, update) =>
             ps.close()
-            assert(offset == Offset(Array(0L)))
+            assert(offset == Offset(Array(0L, 0L)))
         }
 
       ps.submitTransaction(submitterInfo(rt), transactionMeta(rt), emptyTransaction)
@@ -285,10 +355,10 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
 
           val (offset1, update1) = updates.head
           val (offset2, update2) = updates(1)
-          assert(offset1 == Offset(Array(0L)))
+          assert(offset1 == Offset(Array(0L, 0L)))
           assert(update1.isInstanceOf[Update.TransactionAccepted])
 
-          assert(offset2 == Offset(Array(1L)))
+          assert(offset2 == Offset(Array(1L, 0L)))
           assert(update2.isInstanceOf[Update.CommandRejected])
           assert(
             update2
@@ -307,10 +377,10 @@ class InMemoryKVParticipantStateIT extends AsyncWordSpec with AkkaBeforeAndAfter
       val rt = ps.getNewRecordTime()
 
       val waitForUpdateFuture =
-        ps.stateUpdates(beginAfter = Some(Offset(Array(0L)))).runWith(Sink.head).map {
+        ps.stateUpdates(beginAfter = Some(Offset(Array(0L, 0L)))).runWith(Sink.head).map {
           case (offset, update) =>
             ps.close()
-            assert(offset == Offset(Array(1L)))
+            assert(offset == Offset(Array(1L, 0L)))
             assert(update.isInstanceOf[Update.CommandRejected])
         }
       ps.submitTransaction(submitterInfo(rt), transactionMeta(rt), emptyTransaction)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
@@ -52,7 +52,7 @@ trait ReadService {
     *
     * - *initialize before transaction acceptance*: before any
     *   [[Update.TransactionAccepted]], there is a [[Update.ConfigurationChanged]] update
-    *   and [[Update.PublicPackagesUploaded]] updates for all packages referenced by
+    *   and [[Update.PublicPackageUploaded]] updates for all packages referenced by
     *   the [[Update.TransactionAccepted]].
     *
     * - *monotonic record time*: for any update `u1` with an associated record

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
@@ -71,20 +71,20 @@ object Update {
     * https://github.com/digital-asset/daml/issues/311.
     *
     *
-    * @param archives
-    *   The list of DAML-LF packages that were uploaded.
+    * @param archive
+    *   The DAML-LF package that was uploaded.
     *
     * @param sourceDescription
-    *   A description of the packages, provided by the administrator as part of
+    *   A description of the package, provided by the administrator as part of
     *   the upload.
     *
     * @param participantId
-    *   The participant through which the packages were uploaded. This field
+    *   The participant through which the package was uploaded. This field
     *   is informative, and can be used by applications to display information
-    *   about the origin of the packages.
+    *   about the origin of the package.
     *
     * @param recordTime
-    *   The ledger-provided timestamp at which the packages were uploaded.
+    *   The ledger-provided timestamp at which the package was uploaded.
     *
     */
   final case class PublicPackageUploaded(
@@ -94,7 +94,7 @@ object Update {
       recordTime: Timestamp)
       extends Update {
     override def description: String =
-      s"""Public packages uploaded: ${archive.getHash}"""
+      s"""Public package uploaded: ${archive.getHash}"""
   }
 
   /** Signal the acceptance of a transaction.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
@@ -87,14 +87,14 @@ object Update {
     *   The ledger-provided timestamp at which the packages were uploaded.
     *
     */
-  final case class PublicPackagesUploaded(
-      archives: List[DamlLf.Archive],
+  final case class PublicPackageUploaded(
+      archive: DamlLf.Archive,
       sourceDescription: Option[String],
       participantId: ParticipantId,
       recordTime: Timestamp)
       extends Update {
     override def description: String =
-      s"""Public packages uploaded: ${archives.map(_.getHash).mkString(",")}"""
+      s"""Public packages uploaded: ${archive.getHash}"""
   }
 
   /** Signal the acceptance of a transaction.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
@@ -20,7 +20,7 @@ trait WritePackagesService {
     * manner as it is done for transaction submission. It is possible that
     * in some implementations, upload will fail due to authorization etc.
     *
-    * Successful archives upload will result in a [[Update.PublicPackagesUploaded]]
+    * Successful archives upload will result in a [[Update.PublicPackageUploaded]]
     * message. See the comments on [[ReadService.stateUpdates]] and [[Update]] for
     * further details.
     *

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ReadService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ReadService.scala
@@ -52,7 +52,7 @@ trait ReadService {
     *
     * - *initialize before transaction acceptance*: before any
     *   [[Update.TransactionAccepted]], there is a [[Update.ConfigurationChanged]] update
-    *   and [[Update.PublicPackagesUploaded]] updates for all packages referenced by
+    *   and [[Update.PublicPackageUploaded]] updates for all packages referenced by
     *   the [[Update.TransactionAccepted]].
     *
     * - *monotonic record time*: for any update `u1` with an associated record

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
@@ -89,14 +89,14 @@ object Update {
     *   The ledger-provided timestamp at which the packages were uploaded.
     *
     */
-  final case class PublicPackagesUploaded(
-      archives: List[DamlLf.Archive],
+  final case class PublicPackageUploaded(
+      archive: DamlLf.Archive,
       sourceDescription: String,
       participantId: String,
       recordTime: Timestamp)
       extends Update {
     override def description: String =
-      s"""Public packages uploaded: ${archives.map(_.getHash).mkString(",")}"""
+      s"""Public packages uploaded: ${archive.getHash}"""
   }
 
   /** Signal the acceptance of a transaction.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
@@ -73,20 +73,20 @@ object Update {
     * https://github.com/digital-asset/daml/issues/311.
     *
     *
-    * @param archives
-    *   The list of DAML-LF packages that were uploaded.
+    * @param archive
+    *   The DAML-LF package that was uploaded.
     *
     * @param sourceDescription
-    *   A description of the packages, provided by the administrator as part of
+    *   A description of the package, provided by the administrator as part of
     *   the upload.
     *
     * @param participantId
-    *   The participant through which the packages were uploaded. This field
+    *   The participant through which the package was uploaded. This field
     *   is informative, and can be used by applications to display information
-    *   about the origin of the packages.
+    *   about the origin of the package.
     *
     * @param recordTime
-    *   The ledger-provided timestamp at which the packages were uploaded.
+    *   The ledger-provided timestamp at which the package was uploaded.
     *
     */
   final case class PublicPackageUploaded(
@@ -96,7 +96,7 @@ object Update {
       recordTime: Timestamp)
       extends Update {
     override def description: String =
-      s"""Public packages uploaded: ${archive.getHash}"""
+      s"""Public package uploaded: ${archive.getHash}"""
   }
 
   /** Signal the acceptance of a transaction.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
@@ -20,7 +20,7 @@ trait WritePackagesService {
     * manner as it is done for transaction submission. It is possible that
     * in some implementations, upload will fail due to authorization etc.
     *
-    * Successful archives upload will result in a [[Update.PublicPackagesUploaded]]
+    * Successful archives upload will result in a [[Update.PublicPackageUploaded]]
     * message. See the comments on [[ReadService.stateUpdates]] and [[Update]] for
     * further details.
     *


### PR DESCRIPTION
Make every PublicPackageUploaded update in the ReadService contain one package. It means that 

- KV-Utils level message that contains a list of archives needs to be split up into series of updates with a single package each

- ReadService update subscriptions must correctly map between client requests, where offsets have 2 components and KV-Utils where offsets only have one