### PR TITLE
clean up versions v1 and v2 of participant-state

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -36,6 +36,7 @@ da_scala_binary(
         "//ledger/api-server-damlonx",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//ledger/ledger-api-domain",
         "//ledger/participant-state",
         "//ledger/participant-state:participant-state-v1",
         "//ledger/participant-state-index",

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ParticipantStateConversion.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ParticipantStateConversion.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.v2
+package com.daml.ledger.api.server.damlonx.reference.v2
 
 import java.time.Duration
 import java.util.concurrent.CompletionStage
@@ -51,7 +51,7 @@ object ParticipantStateConversion {
             case v1.UploadPackagesResult.ParticipantNotAuthorized =>
               v2.UploadPackagesResult.ParticipantNotAuthorized
             case v1.UploadPackagesResult.NotSupported =>
-              v2.UploadPackagesResult.InvalidPackage("Not supported")
+              v2.UploadPackagesResult.NotSupported
         })
     }
 
@@ -68,7 +68,7 @@ object ParticipantStateConversion {
             case v1.PartyAllocationResult.InvalidName(name) =>
               v2.PartyAllocationResult.InvalidName(name)
             case v1.PartyAllocationResult.NotSupported =>
-              v2.PartyAllocationResult.InvalidName("Not supported")
+              v2.PartyAllocationResult.NotSupported
         })
     }
   }
@@ -112,11 +112,8 @@ object ParticipantStateConversion {
                   sourceDescription,
                   participantId,
                   recordTime) =>
-                v2.Update.PublicPackageUploaded(
-                  archives,
-                  sourceDescription.getOrElse(""),
-                  participantId,
-                  recordTime)
+                v2.Update
+                  .PublicPackageUploaded(archives, sourceDescription, participantId, recordTime)
 
               case v1.Update.TransactionAccepted(
                   optSubmitterInfo,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -9,7 +9,6 @@ import java.util.zip.ZipFile
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import com.daml.ledger.participant.state.kvutils.InMemoryKVParticipantState
-import com.daml.ledger.participant.state.kvutils.v2.ParticipantStateConversion
 import com.daml.ledger.participant.state.v2.ParticipantId
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.Ref

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
@@ -33,7 +33,7 @@ trait ReadService {
   def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed]
 
   /** Get the stream of state [[Update]]s starting from the beginning or right
-    * after the given [[Option[[Offset]]]]
+    * after the given [[Offset]]
     *
     * This is where the meat of the implementation effort lies. Please take your time
     * to read carefully through the properties required from correct implementations.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -14,7 +14,7 @@ object UploadPackagesResult {
     override def description: String = "Packages successfully uploaded"
   }
 
-  /** Synchronous party allocation is not supported */
+  /** Synchronous package upload is not supported */
   final case object NotSupported extends UploadPackagesResult {
     override def description: String = "Packages upload not supported"
   }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/PartyAllocationResult.scala
@@ -16,6 +16,11 @@ object PartyAllocationResult {
     override def description: String = "Party successfully allocated"
   }
 
+  /** Synchronous party allocation is not supported */
+  final case object NotSupported extends PartyAllocationResult {
+    override def description: String = "Party allocation not supported"
+  }
+
   /** The requested party name already exists */
   final case object AlreadyExists extends PartyAllocationResult {
     override def description: String = "Party already exists"
@@ -30,5 +35,4 @@ object PartyAllocationResult {
   final case object ParticipantNotAuthorized extends PartyAllocationResult {
     override def description: String = "Participant is not authorized to allocate a party"
   }
-
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
@@ -56,7 +56,7 @@ object Update {
   final case class PartyAddedToParticipant(
       party: Party,
       displayName: String,
-      participantId: String,
+      participantId: ParticipantId,
       recordTime: Timestamp)
       extends Update {
     override def description: String =
@@ -91,8 +91,8 @@ object Update {
     */
   final case class PublicPackageUploaded(
       archive: DamlLf.Archive,
-      sourceDescription: String,
-      participantId: String,
+      sourceDescription: Option[String],
+      participantId: ParticipantId,
       recordTime: Timestamp)
       extends Update {
     override def description: String =

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/UploadPackagesResult.scala
@@ -14,6 +14,11 @@ object UploadPackagesResult {
     override def description: String = "Packages successfully uploaded"
   }
 
+  /** Synchronous package upload is not supported */
+  final case object NotSupported extends UploadPackagesResult {
+    override def description: String = "Packages upload not supported"
+  }
+
   /** One of the uploaded packages is not valid */
   final case class InvalidPackage(reason: String) extends UploadPackagesResult {
     override def description: String = "Uploaded packages were invalid: " + reason

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/PostgresIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/PostgresIndexer.scala
@@ -180,7 +180,7 @@ class PostgresIndexer private (
           archive -> v2.PackageDetails(
             size = archive.getPayload.size.toLong,
             knownSince = uploadInstant,
-            sourceDescription = Some(sourceDescription)
+            sourceDescription = sourceDescription
           )
         )
         ledgerDao.uploadLfPackages(uploadId, packages).map(_ => ())(DEC)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -76,6 +76,8 @@ class ApiPackageManagementService(
               Future.failed(ErrorFactories.invalidArgument(r.description))
             case r @ UploadPackagesResult.ParticipantNotAuthorized =>
               Future.failed(ErrorFactories.permissionDenied(r.description))
+            case r @ UploadPackagesResult.NotSupported =>
+              Future.failed(ErrorFactories.unimplemented(r.description))
           }(DE)
     )
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -64,6 +64,8 @@ class ApiPartyManagementService private (
           Future.failed(ErrorFactories.invalidArgument(r.description))
         case r @ PartyAllocationResult.ParticipantNotAuthorized =>
           Future.failed(ErrorFactories.permissionDenied(r.description))
+        case r @ PartyAllocationResult.NotSupported =>
+          Future.failed(ErrorFactories.unimplemented(r.description))
       }(DE)
   }
 


### PR DESCRIPTION
- Clean up unnecessary differences between versions v1 and v2 of the participant-state interface
- Move ParticipantStateConversion to ReferenceServer where it is needed, so that the lower level libraries aren't unnecessarily polluted.