### PR TITLE
Get hlint into the build system

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -526,6 +526,7 @@ hazel_repositories(
             # We'll be using it via the library, not the binary.
             hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
             hazel_github_external("ndmitchell", "hlint", "efb49fe567b0c45eee1aaa5fab01d1fe59251fe4", "7c4765920741a41dedb7d0e95b9effa2fc56e0cbefa8033bb2714985ba9b9d45") +
+            hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +
             hazel_hackage("bytestring-nums", "0.3.6", "bdca97600d91f00bb3c0f654784e3fbd2d62fcf4671820578105487cdf39e7cd") +

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -526,7 +526,6 @@ hazel_repositories(
             # We'll be using it via the library, not the binary.
             hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
             hazel_github_external("ndmitchell", "hlint", "efb49fe567b0c45eee1aaa5fab01d1fe59251fe4", "7c4765920741a41dedb7d0e95b9effa2fc56e0cbefa8033bb2714985ba9b9d45") +
-
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +
             hazel_hackage("bytestring-nums", "0.3.6", "bdca97600d91f00bb3c0f654784e3fbd2d62fcf4671820578105487cdf39e7cd") +

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -518,7 +518,15 @@ hazel_repositories(
             # Read [Working on ghc-lib] for ghc-lib update instructions at
             # https://github.com/DACH-NY/daml/blob/master/ghc-lib/working-on-ghc-lib.md
             hazel_ghclibs(GHC_LIB_VERSION, "4a427e093f1711b28b6cf9dd6123e94c9e45589992d67274af626ecfa720308e", "0e4eda986fd3af0e18a2c89719e584d21dce136bcfdad3d0a9effcc6b654c842") +
-            hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
+
+            # Support for Hlint:
+            #   - Requires haskell-src-exts 1.21.0 so override hazel/packages.bzl.
+            #   - To build the binary : `bazel build @haskell_hlint//:bin`
+            #   - To build the library : `bazel build @haskell_hlint//:lib`
+            # We'll be using it via the library, not the binary.
+            hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
+            hazel_github_external("ndmitchell", "hlint", "efb49fe567b0c45eee1aaa5fab01d1fe59251fe4", "7c4765920741a41dedb7d0e95b9effa2fc56e0cbefa8033bb2714985ba9b9d45") +
+
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +
             hazel_hackage("bytestring-nums", "0.3.6", "bdca97600d91f00bb3c0f654784e3fbd2d62fcf4671820578105487cdf39e7cd") +


### PR DESCRIPTION
This PR makes `hlint` available in bazel build rules.