### PR TITLE
hlint - Fix runfiles reference

### DIFF
--- a/bazel_tools/haskell-runfiles.patch
+++ b/bazel_tools/haskell-runfiles.patch
@@ -1,0 +1,312 @@
+diff --git a/tools/runfiles/BUILD.bazel b/tools/runfiles/BUILD.bazel
+index b49a805..9b94279 100644
+--- a/tools/runfiles/BUILD.bazel
++++ b/tools/runfiles/BUILD.bazel
+@@ -2,17 +2,25 @@ load(
+     "@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_library",
+     "haskell_test",
++    "haskell_toolchain_library",
+ )
+ 
++haskell_toolchain_library(name = "base")
++haskell_toolchain_library(name = "directory")
++haskell_toolchain_library(name = "filepath")
++haskell_toolchain_library(name = "process")
++haskell_toolchain_library(name = "transformers")
++
+ haskell_library(
+     name = "runfiles",
+     srcs = ["src/Bazel/Runfiles.hs"],
+     src_strip_prefix = "src",
+     visibility = ["//visibility:public"],
+     deps = [
+-        "@stackage//:base",
+-        "@stackage//:directory",
+-        "@stackage//:filepath",
++        ":base",
++        ":directory",
++        ":filepath",
++        ":transformers",
+     ],
+ )
+ 
+@@ -24,8 +32,8 @@ haskell_test(
+     src_strip_prefix = "bin",
+     deps = [
+         ":runfiles",
+-        "@stackage//:base",
+-        "@stackage//:filepath",
++        ":base",
++        ":filepath",
+     ],
+ )
+ 
+@@ -39,8 +47,8 @@ haskell_test(
+     src_strip_prefix = "test",
+     deps = [
+         ":runfiles",
+-        "@stackage//:base",
+-        "@stackage//:filepath",
+-        "@stackage//:process",
++        ":base",
++        ":filepath",
++        ":process",
+     ],
+ )
+diff --git a/tools/runfiles/bazel-runfiles.cabal b/tools/runfiles/bazel-runfiles.cabal
+index edfc7b6..99ec363 100644
+--- a/tools/runfiles/bazel-runfiles.cabal
++++ b/tools/runfiles/bazel-runfiles.cabal
+@@ -37,6 +37,7 @@ library
+       base >=4.7 && <5
+     , directory
+     , filepath
++    , transformers
+   default-language: Haskell2010
+ 
+ executable bazel-runfiles-exe
+diff --git a/tools/runfiles/src/Bazel/Runfiles.hs b/tools/runfiles/src/Bazel/Runfiles.hs
+index 8dfb980..96b3aeb 100644
+--- a/tools/runfiles/src/Bazel/Runfiles.hs
++++ b/tools/runfiles/src/Bazel/Runfiles.hs
+@@ -1,13 +1,9 @@
++{-# LANGUAGE TupleSections #-}
++
+ -- | This module enables finding data dependencies ("runfiles") of Haskell
+ -- binaries at runtime.
+ --
+ -- For more information, see: https://github.com/bazelbuild/bazel/issues/4460
+---
+--- Note: this does not currently support the RUNFILES_MANIFEST environmental
+--- variable.  However, that's only necessary on Windows, which rules_haskell
+--- doesn't support yet.
+---
+--- Additionally, this is not yet supported by the REPL.
+ module Bazel.Runfiles
+     ( Runfiles
+     , create
+@@ -15,19 +11,69 @@ module Bazel.Runfiles
+     , env
+     ) where
+ 
+-import System.Directory (doesDirectoryExist)
++import Control.Monad (guard)
++import Control.Monad.Trans.Maybe (MaybeT (..))
++import Control.Monad.IO.Class (liftIO)
++import Data.Char (toLower)
++import Data.Foldable (asum)
++import Data.List (find, isPrefixOf, isSuffixOf)
++import Data.Maybe (fromMaybe)
++import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+ import System.Environment (getExecutablePath, lookupEnv)
+-import System.FilePath (FilePath, (</>), (<.>))
++import qualified System.FilePath
++import System.FilePath (FilePath, (</>), (<.>), addTrailingPathSeparator)
++import System.Info (os)
++
++-- | Reference to Bazel runfiles, runfiles root or manifest file.
++data Runfiles
++  = RunfilesRoot !FilePath
++    -- ^ The runfiles root directory.
++  | RunfilesManifest !FilePath ![(FilePath, FilePath)]
++    -- ^ The runfiles manifest file and its content.
++  deriving Show
+ 
+--- | A path to a directory tree containing runfiles for the given
+-newtype Runfiles = Runfiles FilePath
+-    deriving Show
+ 
+ -- | Construct a path to a data dependency within the given runfiles.
+ --
+--- For example: @rlocation \"myworkspace/mypackage/myfile.txt\"@
++-- For example: @rlocation \"myworkspace\/mypackage\/myfile.txt\"@
+ rlocation :: Runfiles -> FilePath -> FilePath
+-rlocation (Runfiles f) g = f </> g
++rlocation (RunfilesRoot f) g = f </> normalize g
++rlocation (RunfilesManifest _ m) g = fromMaybe g' $ asum [lookup g' m, lookupDir g' m]
++  where
++    g' = normalize g
++
++-- | Lookup a directory in the manifest file.
++--
++-- Bazel's manifest file only lists files. However, the @RunfilesRoot@ method
++-- supports looking up directories, and this is an important feature for Cabal
++-- path modules in Hazel. This function allows to lookup a directory in a
++-- manifest file, by looking for the first entry with a matching prefix and
++-- then stripping the superfluous suffix.
++lookupDir :: FilePath -> [(FilePath, FilePath)] -> Maybe FilePath
++lookupDir p = fmap stripSuffix . find match
++  where
++    p' = normalize $ addTrailingPathSeparator p
++    match (key, value) = p' `isPrefixOf` key && drop (length p') key `isSuffixOf` value
++    stripSuffix (key, value) = take (length value - (length key - length p')) value
++
++-- | Normalize a path according to the Bazel specification.
++--
++-- See https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
++--
++-- "[...] returns the absolute path of the file, which is normalized (and
++-- lowercase on Windows) and uses "/" as directory separator on every platform
++-- (including Windows)"
++normalize :: FilePath -> FilePath
++normalize | os == "mingw32" = normalizeWindows
++          | otherwise       = System.FilePath.normalise
++
++-- | Normalize a path on Windows according to the Bazel specification.
++normalizeWindows :: FilePath -> FilePath
++normalizeWindows = map (toLower . normalizeSlash) . System.FilePath.normalise
++  where
++    normalizeSlash '\\' = '/'
++    normalizeSlash c    = c
++
+ 
+ -- | Set environmental variables for locating the given runfiles directory.
+ --
+@@ -36,27 +82,111 @@ rlocation (Runfiles f) g = f </> g
+ -- during "bazel run"; thus, non-test binaries should set the
+ -- environment manually for processes that they call.
+ env :: Runfiles -> [(String, String)]
+-env (Runfiles f) = [(runfilesDirEnv, f)]
++env (RunfilesRoot f) = [(runfilesDirEnv, f)]
++env (RunfilesManifest f _) = [(manifestFileEnv, f), (manifestOnlyEnv, "1")]
+ 
+ runfilesDirEnv :: String
+ runfilesDirEnv = "RUNFILES_DIR"
+ 
+--- | Locate the runfiles directory for the current binary.
++manifestFileEnv :: String
++manifestFileEnv = "RUNFILES_MANIFEST_FILE"
++
++manifestOnlyEnv :: String
++manifestOnlyEnv = "RUNFILES_MANIFEST_ONLY"
++
++
++-- | Locate the runfiles directory or manifest for the current binary.
+ --
+ -- This behaves according to the specification in:
+ -- https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
+---
+--- Note: it does not currently support the @RUNFILES_MANIFEST@ environmental
+--- variable.  However, that's only necessary on Windows, which rules_haskell
+--- doesn't support yet anyway.
+ create :: IO Runfiles
+ create = do
+-    exeRunfilesPath <- fmap (<.> "runfiles") getExecutablePath
+-    exeRunfilesExists <- doesDirectoryExist exeRunfilesPath
+-    if exeRunfilesExists
+-      then return $ Runfiles exeRunfilesPath
+-      else do
+-        envDir <- lookupEnv runfilesDirEnv
+-        case envDir of
+-            Just f -> return $ Runfiles f
+-            Nothing -> error "Unable to locate runfiles directory"
++    exePath <- getExecutablePath
++
++    mbRunfiles <- runMaybeT $ asum
++      [ do
++        -- Bazel sets RUNFILES_MANIFEST_ONLY=1 if the manifest file should be
++        -- used instead of the runfiles root.
++        manifestOnly <- liftIO $ lookupEnv manifestOnlyEnv
++        guard (manifestOnly /= Just "1")
++        -- Locate runfiles directory relative to executable or by environment.
++        runfilesRoot <- asum
++          [ do
++            let dir = exePath <.> "runfiles"
++            exists <- liftIO $ doesDirectoryExist dir
++            guard exists
++            pure dir
++          , do
++            dir <- MaybeT $ lookupEnv runfilesDirEnv
++            exists <- liftIO $ doesDirectoryExist dir
++            guard exists
++            pure dir
++          ]
++        -- Existence alone is not sufficient, on Windows Bazel creates a
++        -- runfiles directory containing only MANIFEST. We need to check that
++        -- more entries exist, before we commit to using the runfiles
++        -- directory.
++        containsData <- liftIO $ containsOneDataFile runfilesRoot
++        guard containsData
++        pure $! RunfilesRoot runfilesRoot
++      , do
++        -- Locate manifest file relative to executable or by environment.
++        manifestPath <- asum
++          [ do
++            let file = exePath <.> "runfiles_manifest"
++            exists <- liftIO $ doesFileExist file
++            guard exists
++            pure file
++          , do
++            file <- MaybeT $ lookupEnv manifestFileEnv
++            exists <- liftIO $ doesFileExist file
++            guard exists
++            pure file
++          ]
++        content <- liftIO $ readFile manifestPath
++        let mapping = parseManifest content
++        pure $! RunfilesManifest manifestPath mapping
++      ]
++
++    case mbRunfiles of
++        Just runfiles -> pure runfiles
++        Nothing -> error "Unable to locate runfiles directory or manifest"
++
++-- | Check if the given directory contains at least one data file.
++--
++-- Traverses the given directory tree until a data file is found. A file named
++-- @MANIFEST@ does not count, as it corresponds to @runfiles_manifest@.
++--
++-- Assumes that the given filepath exists and is a directory.
++containsOneDataFile :: FilePath -> IO Bool
++containsOneDataFile = loop
++  where
++    loop fp = do
++        isDir <- doesDirectoryExist fp
++        if isDir
++            then anyM loop =<< listDirectory fp
++            else pure $! fp /= "MANIFEST"
++
++-- | Check if the given predicate holds on any of the given values.
++--
++-- Short-circuting:
++-- Stops iteration on the first element for which the predicate holds.
++anyM :: Monad m => (a -> m Bool) -> [a] -> m Bool
++anyM predicate = loop
++  where
++    loop [] = pure False
++    loop (x:xs) = do
++        b <- predicate x
++        if b
++            then pure True
++            else loop xs
++
++-- | Parse Bazel's manifest file content.
++--
++-- The manifest file holds lines of keys and values separted by a space.
++parseManifest :: String -> [(FilePath, FilePath)]
++parseManifest = map parseLine . lines
++  where
++    parseLine l =
++        let (key, value) = span (/= ' ') l in
++        (key, dropWhile (== ' ') value)
+diff --git a/tools/runfiles/test/Test.hs b/tools/runfiles/test/Test.hs
+index 3ef3b28..8d09d6a 100644
+--- a/tools/runfiles/test/Test.hs
++++ b/tools/runfiles/test/Test.hs
+@@ -2,6 +2,7 @@ module Main (main) where
+ 
+ import qualified Bazel.Runfiles as Runfiles
+ import Control.Monad (when)
++import System.Info (os)
+ import System.Process (callProcess)
+ 
+ main :: IO ()
+@@ -10,4 +11,6 @@ main = do
+     foo <- readFile (Runfiles.rlocation r "io_tweag_rules_haskell/tools/runfiles/test-data.txt")
+     when (lines foo /= ["foo"]) -- ignore trailing newline
+         $ error $ "Incorrect contents: got: " ++ show foo
+-    callProcess (Runfiles.rlocation r "io_tweag_rules_haskell/tools/runfiles/bin") []
++    let bin | os == "mingw32" =  "io_tweag_rules_haskell/tools/runfiles/bin.exe"
++            | otherwise       =  "io_tweag_rules_haskell/tools/runfiles/bin"
++    callProcess (Runfiles.rlocation r bin) []

--- a/bazel_tools/hazel-runfiles.patch
+++ b/bazel_tools/hazel-runfiles.patch
@@ -1,0 +1,50 @@
+diff --git a/hazel/paths-template.hs b/hazel/paths-template.hs
+index b439d74..6f9cb16 100644
+--- a/hazel/paths-template.hs
++++ b/hazel/paths-template.hs
+@@ -5,6 +5,7 @@ module %{module} (
+     getDataFileName,
+     ) where
+ 
++import qualified Bazel.Runfiles as Runfiles
+ import Data.Version (Version, makeVersion)
+ import Prelude
+ import System.FilePath ((</>), takeDirectory)
+@@ -13,8 +14,8 @@ import System.Environment (getExecutablePath)
+ -- TODO: automatically locate root directory
+ getDataDir :: IO FilePath
+ getDataDir = do
+-    exePath <- getExecutablePath
+-    return $ takeDirectory exePath </> "%{base_dir}"
++    r <- Runfiles.create
++    pure $! Runfiles.rlocation r "%{data_dir}"
+ 
+ getDataFileName :: FilePath -> IO FilePath
+ getDataFileName name = do
+diff --git a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+index 90fe60a..2deb10c 100644
+--- a/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
++++ b/hazel/third_party/cabal2bazel/bzl/cabal_paths.bzl
+@@ -40,12 +40,8 @@ def _impl_path_module_gen(ctx):
+         output = paths_file,
+         substitutions = {
+             "%{module}": ctx.attr.module,
+-            "%{base_dir}": paths.join(
+-                # TODO: this probably won't work for packages not in external
+-                # repositories.  See:
+-                # https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure
+-                "..",
+-                paths.relativize(ctx.label.workspace_root, "external"),
++            "%{data_dir}": paths.join(
++                ctx.label.workspace_name,
+                 base_dir,
+             ),
+             "%{version}": str(ctx.attr.version),
+@@ -123,6 +119,7 @@ def cabal_paths(name = None, package = None, data_dir = "", data = [], version =
+         deps = [
+             hazel_library("base"),
+             hazel_library("filepath"),
++            "@io_tweag_rules_haskell//tools/runfiles",
+         ],
+         # TODO: run directory resolution.
+         **kwargs

--- a/deps.bzl
+++ b/deps.bzl
@@ -55,6 +55,7 @@ def daml_deps():
                 # Bazel 0.27. https://github.com/tweag/rules_haskell/pull/970
                 "@haskell_static_ghc_patch//file:downloaded",
                 "@com_github_digital_asset_daml//bazel_tools:haskell-windows-library-dirs.patch",
+                "@com_github_digital_asset_daml//bazel_tools:haskell-runfiles.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,
@@ -74,6 +75,10 @@ def daml_deps():
             strip_prefix = "rules_haskell-{}/hazel".format(rules_haskell_version),
             urls = ["https://github.com/tweag/rules_haskell/archive/%s.tar.gz" % rules_haskell_version],
             sha256 = rules_haskell_sha256,
+            patches = [
+                "@com_github_digital_asset_daml//bazel_tools:hazel-runfiles.patch",
+            ],
+            patch_args = ["-p2"],
         )
 
     if "com_github_madler_zlib" not in native.existing_rules():


### PR DESCRIPTION
- Patches Hazel's `Paths` module generation to use the `bazel-runfiles` library.

This fixes the Hazel built `hlint` which before failed to locate its builtin `hlint.yaml` file.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
