### PR TITLE
Fix VSCode path for mac in daml assistant

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -107,7 +107,7 @@ addVsCodeToPath :: [(String, String)] -> [(String,String)]
 addVsCodeToPath env | isMac =
     let pathM = lookup "PATH" env
         newSearchPath = maybe "" (<> [searchPathSeparator]) pathM <>
-            "/Applications/Visual\\ Studio\\ Code.app/Contents/Resources/app/bin"
+            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
     in ("PATH", newSearchPath) : filter ((/= "PATH") . fst) env
 addVsCodeToPath env = env
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,4 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [daml assistant] Fix VSCode path for use if not already in PATH on mac


### PR DESCRIPTION
Apparently the backslashes are not needed for escaping the spaces when in the value for the PATH. (Confusing as you need them when typing into a terminal.)

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
