### PR TITLE
Adapt type of getTransactions rpc-wrappers

### DIFF
--- a/language-support/hs/bindings/examples/chat/src/ChatLedger.hs
+++ b/language-support/hs/bindings/examples/chat/src/ChatLedger.hs
@@ -46,7 +46,7 @@ sendCommand asParty h@Handle{pid} cc = do
 getTrans :: Party -> Handle -> IO (PastAndFuture ChatContract)
 getTrans party Handle{log,lid} = do
     pf <- run 6000 $ getTransactionsPF lid party
-    mapListPF (fmap maybeToList . extractTransaction log) pf
+    mapListPF (fmap concat . mapM (fmap maybeToList . extractTransaction log)) pf
 
 submitCommand :: Handle -> Party -> Command -> IO (Either String ())
 submitCommand Handle{lid} party com = do

--- a/language-support/hs/bindings/examples/nim-console/src/NimLedger.hs
+++ b/language-support/hs/bindings/examples/nim-console/src/NimLedger.hs
@@ -48,7 +48,7 @@ getTrans :: Player -> Handle -> IO (PastAndFuture NimTrans)
 getTrans player Handle{log,lid} = do
     let party = partyOfPlayer player
     pf <- run 6000 $ getTransactionsPF lid party
-    mapListPF (extractTransaction log) pf
+    mapListPF (fmap concat . mapM (extractTransaction log)) pf
 
 submitCommand :: Handle -> Party -> Command -> IO (Either String ())
 submitCommand Handle{lid} party com = do

--- a/language-support/hs/bindings/src/DA/Ledger.hs
+++ b/language-support/hs/bindings/src/DA/Ledger.hs
@@ -38,19 +38,19 @@ configOfPort port =
 -- Non-primitive, but useful way to get Transactions
 -- TODO: move to separate Utils module?
 
-getAllTransactions :: LedgerId -> Party -> Verbosity -> LedgerService (Stream Transaction)
+getAllTransactions :: LedgerId -> Party -> Verbosity -> LedgerService (Stream [Transaction])
 getAllTransactions lid party verbose = do
     let filter = filterEverthingForParty party
     let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
     getTransactions req
 
-getAllTransactionTrees :: LedgerId -> Party -> Verbosity -> LedgerService (Stream TransactionTree)
+getAllTransactionTrees :: LedgerId -> Party -> Verbosity -> LedgerService (Stream [TransactionTree])
 getAllTransactionTrees lid party verbose = do
     let filter = filterEverthingForParty party
     let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
     getTransactionTrees req
 
-getTransactionsPF :: LedgerId -> Party -> LedgerService (PastAndFuture Transaction)
+getTransactionsPF :: LedgerId -> Party -> LedgerService (PastAndFuture [Transaction])
 getTransactionsPF lid party = do
     now <- fmap LedgerAbsOffset (ledgerEnd lid)
     let filter = filterEverthingForParty party

--- a/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
@@ -26,7 +26,7 @@ import qualified Com.Digitalasset.Ledger.Api.V1.TransactionService as LL
 import qualified Data.Map as Map
 import qualified Data.Vector as Vector
 
-getTransactions :: GetTransactionsRequest -> LedgerService (Stream Transaction)
+getTransactions :: GetTransactionsRequest -> LedgerService (Stream [Transaction])
 getTransactions req =
     makeLedgerService $ \timeout config -> do
     stream <- newStream
@@ -34,11 +34,11 @@ getTransactions req =
         withGRPCClient config $ \client -> do
             service <- LL.transactionServiceClient client
             let LL.TransactionService {transactionServiceGetTransactions=rpc} = service
-            sendToStreamFlat timeout (lowerRequest req) f stream rpc
+            sendToStream timeout (lowerRequest req) f stream rpc
     return stream
     where f = raiseList raiseTransaction . LL.getTransactionsResponseTransactions
 
-getTransactionTrees :: GetTransactionsRequest -> LedgerService (Stream TransactionTree)
+getTransactionTrees :: GetTransactionsRequest -> LedgerService (Stream [TransactionTree])
 getTransactionTrees req =
     makeLedgerService $ \timeout config -> do
     stream <- newStream
@@ -46,7 +46,7 @@ getTransactionTrees req =
         withGRPCClient config $ \client -> do
             service <- LL.transactionServiceClient client
             let LL.TransactionService {transactionServiceGetTransactionTrees=rpc} = service
-            sendToStreamFlat timeout (lowerRequest req) f stream rpc
+            sendToStream timeout (lowerRequest req) f stream rpc
     return stream
     where f = raiseList raiseTransactionTree . LL.getTransactionTreesResponseTransactions
 

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -165,7 +165,7 @@ tCreateWithKey withSandbox = testCase "createWithKey" $ run withSandbox $ \pid -
     let command = createWithKey pid alice 100
     Right _ <- submitCommand lid alice command
     liftIO $ do
-        Just (Right Transaction{events=[CreatedEvent{key}]}) <- timeout 1 (takeStream txs)
+        Just (Right [Transaction{events=[CreatedEvent{key}]}]) <- timeout 1 (takeStream txs)
         assertEqual "contract has right key" key (Just (VRecord (Record Nothing [ RecordField "" (VParty alice), RecordField "" (VInt 100) ])))
         closeStream txs gone
     where gone = Abnormal "client gone"
@@ -177,7 +177,7 @@ tCreateWithoutKey withSandbox = testCase "createWithoutKey" $ run withSandbox $ 
     let command = createWithoutKey pid alice 100
     Right _ <- submitCommand lid alice command
     liftIO $ do
-        Just (Right Transaction{events=[CreatedEvent{key}]}) <- timeout 1 (takeStream txs)
+        Just (Right [Transaction{events=[CreatedEvent{key}]}]) <- timeout 1 (takeStream txs)
         assertEqual "contract has no key" key Nothing
         closeStream txs gone
     where gone = Abnormal "client gone"
@@ -189,7 +189,7 @@ tStakeholders withSandbox = testCase "stakeholders are exposed correctly" $ run 
     let command = createIOU pid alice "alice-in-chains" 100
     _ <- submitCommand lid alice command
     liftIO $ do
-        Just (Right Transaction{events=[CreatedEvent{signatories,observers}]}) <- timeout 1 (takeStream txs)
+        Just (Right [Transaction{events=[CreatedEvent{signatories,observers}]}]) <- timeout 1 (takeStream txs)
         assertEqual "the only signatory" signatories [ alice ]
         assertEqual "observers are empty" observers []
         closeStream txs gone
@@ -219,7 +219,7 @@ tGetFlatTransactionByEventId withSandbox = testCase "tGetFlatTransactionByEventI
     lid <- getLedgerIdentity
     txs <- getAllTransactions lid alice (Verbosity True)
     Right _ <- submitCommand lid alice $ createIOU pid alice "A-coin" 100
-    Just (Right txOnStream) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [txOnStream]) <- liftIO $ timeout 1 (takeStream txs)
     Transaction{events=[CreatedEvent{eid}]} <- return txOnStream
     Just txByEventId <- getFlatTransactionByEventId lid eid [alice]
     liftIO $ assertEqual "tx" txOnStream txByEventId
@@ -231,7 +231,7 @@ tGetFlatTransactionById withSandbox = testCase "tGetFlatTransactionById" $ run w
     lid <- getLedgerIdentity
     txs <- getAllTransactions lid alice (Verbosity True)
     Right _ <- submitCommand lid alice $ createIOU pid alice "A-coin" 100
-    Just (Right txOnStream) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [txOnStream]) <- liftIO $ timeout 1 (takeStream txs)
     Transaction{trid} <- return txOnStream
     Just txById <- getFlatTransactionById lid trid [alice]
     liftIO $ assertEqual "tx" txOnStream txById
@@ -243,7 +243,7 @@ tGetTransactions withSandbox = testCase "tGetTransactions" $ run withSandbox $ \
     lid <- getLedgerIdentity
     txs <- getAllTransactions lid alice (Verbosity True)
     Right cidA <- submitCommand lid alice (createIOU pid alice "A-coin" 100)
-    Just (Right Transaction{cid=Just cidB}) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [Transaction{cid=Just cidB}]) <- liftIO $ timeout 1 (takeStream txs)
     liftIO $ do assertEqual "cid" cidA cidB
 
 tGetTransactionTrees :: SandboxTest
@@ -251,7 +251,7 @@ tGetTransactionTrees withSandbox = testCase "tGetTransactionTrees" $ run withSan
     lid <- getLedgerIdentity
     txs <- getAllTransactionTrees lid alice (Verbosity True)
     Right cidA <- submitCommand lid alice (createIOU pid alice "A-coin" 100)
-    Just (Right TransactionTree{cid=Just cidB}) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [TransactionTree{cid=Just cidB}]) <- liftIO $ timeout 1 (takeStream txs)
     liftIO $ do assertEqual "cid" cidA cidB
 
 tGetTransactionByEventId :: SandboxTest
@@ -259,7 +259,7 @@ tGetTransactionByEventId withSandbox = testCase "tGetTransactionByEventId" $ run
     lid <- getLedgerIdentity
     txs <- getAllTransactionTrees lid alice (Verbosity True)
     Right _ <- submitCommand lid alice $ createIOU pid alice "A-coin" 100
-    Just (Right txOnStream) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [txOnStream]) <- liftIO $ timeout 1 (takeStream txs)
     TransactionTree{roots=[eid]} <- return txOnStream
     Just txByEventId <- getTransactionByEventId lid eid [alice]
     liftIO $ assertEqual "tx" txOnStream txByEventId
@@ -271,7 +271,7 @@ tGetTransactionById withSandbox = testCase "tGetTransactionById" $ run withSandb
     lid <- getLedgerIdentity
     txs <- getAllTransactionTrees lid alice (Verbosity True)
     Right _ <- submitCommand lid alice $ createIOU pid alice "A-coin" 100
-    Just (Right txOnStream) <- liftIO $ timeout 1 (takeStream txs)
+    Just (Right [txOnStream]) <- liftIO $ timeout 1 (takeStream txs)
     TransactionTree{trid} <- return txOnStream
     Just txById <- getTransactionById lid trid [alice]
     liftIO $ assertEqual "tx" txOnStream txById


### PR DESCRIPTION

- Adapt type of stream element in getTransactions rpc-wrappers, from `Transaction` to `[Transaction]`, matching more closely the type from the underlying .proto definition

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
