### PR TITLE
Fix conversion of getTag and tagToEnum#

### DIFF
--- a/compiler/damlc/test-files/EnumLF.daml
+++ b/compiler/damlc/test-files/EnumLF.daml
@@ -6,6 +6,7 @@
 -- @QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Color"]) | has("enum")
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$ctor$u003aRed"]) | .expr | has("enum_con")
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["isRed"]) | .expr.abs.body.case.alts | .[0] | has("enum")
+-- @QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Tag"]) | (has("enum") | not)
 daml 1.2
 module EnumLF where
 
@@ -19,3 +20,20 @@ isRed : Color -> Bool
 isRed = \case
     Red -> True
     _ -> False
+
+-- Note that it is important to use so many constructors
+-- to get GHC to implement the Eq instance using getTag/tagToEnum#.
+data Tag
+  = A
+  | B
+  | C
+  | D
+  | E
+  | F
+  | G
+  | H
+  | I
+  | J
+  | K
+  | L Text
+  deriving Eq


### PR DESCRIPTION
Previously, we unconditionally assumed that GHC will only use those on
Enum-like types, i.e., types with only nullary constructors. This
assumption turns out to be incorrect so this PR introduces additional
checks.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
