### PR TITLE
nodejs_dev_env: Use Bazel's repository_ctx.symlink

### DIFF
--- a/bazel_tools/dev_env_package/dev_env_package.bzl
+++ b/bazel_tools/dev_env_package/dev_env_package.bzl
@@ -30,10 +30,14 @@ def _dev_env_package_impl(ctx):
         python = ctx.which("python")
     if python == None:
         fail("Cannot find python3 executable")
-    mklinks = ctx.path(Label("//bazel_tools/dev_env_package:dev_env_package.py"))
-    res = ctx.execute([python, mklinks, tool_home, ctx.attr.symlink_path])
+    list_contents = ctx.path(Label("//bazel_tools/dev_env_package:dev_env_package.py"))
+    res = ctx.execute([python, list_contents, tool_home])
     if res.return_code != 0:
-        fail("Failed to create symlinks\nstdout:{}\nstderr:{}\n".format(res.stdout, res.stderr))
+        fail("Failed to list contents\nstdout:{}\nstderr:{}\n".format(res.stdout, res.stderr))
+    for item in res.stdout.splitlines():
+        src = tool_home + "/" + item
+        dst = ctx.path(ctx.attr.symlink_path + "/" + item)
+        ctx.symlink(src, dst)
 
     build_path = ctx.path("BUILD")
     build_content = _dev_env_package_build_template.format(

--- a/bazel_tools/dev_env_package/dev_env_package.py
+++ b/bazel_tools/dev_env_package/dev_env_package.py
@@ -10,22 +10,17 @@ import os
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("source", type=str)
-    parser.add_argument("destination", type=str)
     args = parser.parse_args()
 
-    create_symlinks(args.source, args.destination)
+    list_contents(args.source)
 
 
-def create_symlinks(source_dir, dest_dir):
-    print(os.getcwd(), source_dir, dest_dir)
-    os.makedirs(dest_dir, exist_ok=True)
+def list_contents(source_dir):
     for item in os.listdir(source_dir):
         if item in ["BUILD", "BUILD.bazel", "WORKSPACE"]:
             # Skip nested BUILD files as they confuse Bazel.
             continue
-        relpath = os.path.relpath(os.path.join(source_dir, item), dest_dir)
-        print("ln -s {} {}".format(relpath, os.path.join(dest_dir, item)))
-        os.symlink(relpath, os.path.join(dest_dir, item))
+        print(item)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python's `os.symlink` may fail on Windows if the user has insufficient
permissions to create symbolic links. This was not noticed on CI, since
builds there are executed with administrator privileges.

This changes `dev_env_package` to only outsource the listing of
directory contents to Python, but then fall back to Bazel's own
`repository_ctx.symlink` for the creation of symbolic links (or copies
if necessary).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
