### PR TITLE
Improve logic for building daml-lf-archive-java

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -195,7 +195,7 @@ genrule(
     ],
     outs = ["daml_lf_archive_java.jar"],
     cmd = """
-    INPUT=$$(echo "$(locations :daml_lf_proto_lib_java)" | cut -d ' ' -f 1)
+    INPUT=$$(echo "$(locations :daml_lf_proto_lib_java)" | tr ' ' '\n' | grep -v '\-src.jar')
     cp -L $$INPUT $@
     chmod u+w $@
     $(location @zip_dev_env//:zip) -g $@ $(locations :proto_srcs)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,3 +10,4 @@ HEAD — ongoing
 --------------
 
 - [daml assistant] Fix VSCode path for use if not already in PATH on mac
+- [DAML-LF] Fixed regression that produced an invalid daml-lf-archive artefact. See `#2058 <https://github.com/digital-asset/daml/issues/2058>`__.


### PR DESCRIPTION
daml-lf-archive-java is put together from the proto sources with the
compiled java classes. However, the logic that picks the java classes
was dependent on the output of $(locations :daml_lf_proto_lib_java),
because it always would pick the first item.

The new logic filters by name rather than position.

Fixes #2058.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
