### PR TITLE
remove bazel_skylib from nix

### DIFF
--- a/nix/overrides/bazel/default.nix
+++ b/nix/overrides/bazel/default.nix
@@ -41,7 +41,6 @@ let
         in builtins.listToAttrs (map toFetchurl [
       srcs.desugar_jdk_libs
       srcs.io_bazel_skydoc
-      srcs.bazel_skylib
       srcs.io_bazel_rules_sass
       (if stdenv.hostPlatform.isDarwin
        then srcs.${"java_tools_javac11_darwin-v2.0.zip"}
@@ -439,9 +438,6 @@ stdenv.mkDerivation rec {
     tar xf ${srcDepsSet.io_bazel_skydoc} -C $TEST_TMPDIR
     mv $(ls | grep skydoc-) io_bazel_skydoc
 
-    tar xf ${srcDepsSet.bazel_skylib} -C $TEST_TMPDIR
-    mv $(ls | grep bazel-skylib-) bazel_skylib
-
     tar xf ${srcDepsSet.io_bazel_rules_sass} -C $TEST_TMPDIR
     mv $(ls | grep rules_sass-) rules_sass
 
@@ -451,7 +447,6 @@ stdenv.mkDerivation rec {
     hello_test () {
       $out/bin/bazel test \
         --override_repository=io_bazel_skydoc=$TEST_TMPDIR/io_bazel_skydoc \
-        --override_repository=bazel_skylib=$TEST_TMPDIR/bazel_skylib \
         --override_repository=io_bazel_rules_sass=$TEST_TMPDIR/rules_sass \
         --override_repository=build_bazel_rules_nodejs=$TEST_TMPDIR/build_bazel_rules_nodejs \
         --test_output=errors \

--- a/nix/overrides/bazel/src-deps.json
+++ b/nix/overrides/bazel/src-deps.json
@@ -48,15 +48,6 @@
             "https://github.com/buchgr/bazel_rbe_toolchains/archive/f50471a57cd05a313a953fa54756db6e8fd93673.tar.gz"
         ]
     },
-    "bazel_skylib": {
-        "name": "bazel_skylib",
-        "sha256": "ba5d15ca230efca96320085d8e4d58da826d1f81b444ef8afccd8b23e0799b52",
-        "strip_prefix": "bazel-skylib-f83cb8dd6f5658bc574ccd873e25197055265d1c",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz"
-        ]
-    },
     "bazel_toolchains": {
         "name": "bazel_toolchains",
         "sha256": "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
@@ -106,14 +97,6 @@
         "urls": [
             "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
             "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip"
-        ]
-    },
-    "f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz": {
-        "name": "f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
-        "sha256": "ba5d15ca230efca96320085d8e4d58da826d1f81b444ef8afccd8b23e0799b52",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz"
         ]
     },
     "io_bazel_rules_sass": {


### PR DESCRIPTION
I was trying to get rid of the
```
DEBUG: /private/var/tmp/_bazel_garyverhaegen/4b497307028b2b2afb5dc552b427a4b7/external/bazel_skylib/lib.bzl:30:1: WARNING: lib.bzl is deprecated and will go 
away in the future, please directly load the bzl file(s) of the module(s) needed as it is more efficient.
```
warning in our builds. I naïvely thought if I removed the library entirely we would not be loading it anymore, but unfortunately the warning is still there.

On the bright side, I've run a full nix + bazel rebuild (& test) with remote cache disabled and everything still seems to work, so I decided to push this anyway under the assumption than one fewer dependency we didn't really depend on is a good (if small) thing.