### PR TITLE
shortcut to ImmArray#map from ImmArraySeq#map

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -395,6 +395,7 @@ object ImmArray {
       with GenericTraversableTemplate[A, ImmArraySeq]
       with IndexedSeqLike[A, ImmArraySeq[A]]
       with IndexedSeqOptimized[A, ImmArraySeq[A]] {
+    import ImmArraySeq.IASCanBuildFrom
 
     // TODO make this faster by implementing as many methods as possible.
     override def iterator: Iterator[A] = array.iterator
@@ -409,6 +410,12 @@ object ImmArray {
       new ImmArraySeq(array.relaxedSlice(from, to))
     override def copyToArray[B >: A](xs: Array[B], dstStart: Int, dstLen: Int): Unit =
       array.copyToArray(xs, dstStart, dstLen)
+
+    override def map[B, That](f: A => B)(implicit bf: CanBuildFrom[ImmArraySeq[A], B, That]): That =
+      bf match {
+        case _: IASCanBuildFrom[B] => array.map(f).toSeq
+        case _ => super.map(f)(bf)
+      }
 
     override def companion: GenericCompanion[ImmArraySeq] = ImmArraySeq
 
@@ -434,8 +441,10 @@ object ImmArray {
     implicit def `immArraySeq Equal instance`[A: Equal]: Equal[ImmArraySeq[A]] =
       if (Equal[A].equalIsNatural) Equal.equalA else Equal[ImmArray[A]].contramap(_.toImmArray)
 
+    private final class IASCanBuildFrom[A] extends GenericCanBuildFrom[A]
+
     implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ImmArraySeq[A]] =
-      new GenericCanBuildFrom
+      new IASCanBuildFrom
 
     override def newBuilder[A]: mutable.Builder[A, ImmArraySeq[A]] =
       ImmArray.newBuilder.mapResult(_.toSeq)

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/ImmArrayTest.scala
@@ -152,6 +152,8 @@ class ImmArrayTest extends FlatSpec with Matchers with Checkers {
     val seq = ImmArray.ImmArraySeq("hello")
     val stillSeq: ImmArray.ImmArraySeq[String] = seq.map(_ => "hello")
     seq shouldBe stillSeq
+    val stillSeqAgain: ImmArray.ImmArraySeq[String] = seq.flatMap(_ => Seq("hello"))
+    seq shouldBe stillSeqAgain
   }
 
   it should "drop correctly" in {


### PR DESCRIPTION
With GADTs, `That` isn't so mysterious. Extend `GenericCanBuildFrom` so the tag is strong enough for patmat to actually believe, then just use the `That >: target` proof in the consequent. 100% sound, unlike how some of 2.12 collections approach the same problem.

@bitonic You can do [more complicated things](https://bitbucket.org/S11001001/record-map/src/default/#markdown-header-using-gadts-to-find-fast-paths-safely), but this kind of shortcut override is relatively simple.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
