### PR TITLE
Add package for bazel_tools client_server_test and scala-protoc-plugins to avoid bazel warnings

### DIFF
--- a/bazel_tools/client_server_test/tests/BUILD.bazel
+++ b/bazel_tools/client_server_test/tests/BUILD.bazel
@@ -21,7 +21,7 @@ exports_files(["client_input_file"])
 da_scala_binary(
     name = "server",
     srcs = ["server.scala"],
-    main_class = "Main",
+    main_class = "bazeltools.clientservertest.tests.Main",
     deps = [
         "//3rdparty/jvm/com/github/scopt",
     ],

--- a/bazel_tools/client_server_test/tests/server.scala
+++ b/bazel_tools/client_server_test/tests/server.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package bazeltools.clientservertest.tests
+
 import java.net._
 import java.io._
 import scala.io._

--- a/scala-protoc-plugins/scala-akka/AkkaGrpcServicePrinter.scala
+++ b/scala-protoc-plugins/scala-akka/AkkaGrpcServicePrinter.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package protoc.plugins.akka
+
 import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
 import scalapb.compiler._

--- a/scala-protoc-plugins/scala-akka/AkkaStreamGenerator.scala
+++ b/scala-protoc-plugins/scala-akka/AkkaStreamGenerator.scala
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+package protoc.plugins.akka
 
 import com.google.protobuf.Descriptors._
 import com.google.protobuf.ExtensionRegistry

--- a/scala-protoc-plugins/scala-akka/BUILD.bazel
+++ b/scala-protoc-plugins/scala-akka/BUILD.bazel
@@ -6,7 +6,7 @@ load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library")
 da_scala_binary(
     name = "compiler_plugin",
     srcs = glob(["*.scala"]),
-    main_class = "AkkaStreamCompilerPlugin",
+    main_class = "protoc.plugins.akka.AkkaStreamCompilerPlugin",
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@com_github_scalapb_scalapb//:scala-library",

--- a/scala-protoc-plugins/scala-logging/BUILD.bazel
+++ b/scala-protoc-plugins/scala-logging/BUILD.bazel
@@ -6,7 +6,7 @@ load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library")
 da_scala_binary(
     name = "compiler_plugin",
     srcs = ["LoggingCompilerPlugin.scala"],
-    main_class = "LoggingCompilerPlugin",
+    main_class = "protoc.plugins.logging.LoggingCompilerPlugin",
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@com_github_scalapb_scalapb//:scala-library",

--- a/scala-protoc-plugins/scala-logging/LoggingCompilerPlugin.scala
+++ b/scala-protoc-plugins/scala-logging/LoggingCompilerPlugin.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package protoc.plugins.logging
+
 import com.google.protobuf.Descriptors.{FileDescriptor, MethodDescriptor, ServiceDescriptor}
 import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}

--- a/scala-protoc-plugins/scalapb/BUILD.bazel
+++ b/scala-protoc-plugins/scalapb/BUILD.bazel
@@ -6,7 +6,7 @@ load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library")
 da_scala_binary(
     name = "compiler_plugin",
     srcs = glob(["*.scala"]),
-    main_class = "ScalaPbCompilerPlugin",
+    main_class = "protoc.plugins.scalapb.ScalaPbCompilerPlugin",
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@com_github_scalapb_scalapb//:scala-library",

--- a/scala-protoc-plugins/scalapb/ScalaPbCompilerPlugin.scala
+++ b/scala-protoc-plugins/scalapb/ScalaPbCompilerPlugin.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package protoc.plugins.scalapb
+
 import scala.reflect.io.Streamable
 
 // This file is mostly copied over from ScalaPbCodeGenerator and ProtobufGenerator


### PR DESCRIPTION
Address #2064 by defining package for scala files that are package-less in `bazel_tools` and `scala-protoc-plugin` today.
Ensure that main_class definition in bazel build files reflects new package naming