### PR TITLE
Set 'Opt_KeepRawTokenStream'

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -167,6 +167,7 @@ xFlagsSet :: [ GeneralFlag ]
 xFlagsSet = [
    Opt_Haddock
  , Opt_Ticky
+ , Opt_KeepRawTokenStream -- Harvest comments when lexing.
  ]
 
 -- | Warning options set for DAML compilation. Note that these can be modified

--- a/compiler/damlc/daml-prim-src/GHC/Classes.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Classes.daml
@@ -72,45 +72,44 @@ default ()              -- Double isn't available yet
 class IP (x : Symbol) a | x -> a where
   ip : a
 
-{- $matching_overloaded_methods_in_rules
-
-Matching on class methods (e.g. `(==)`) in rewrite rules tends to be a bit
-fragile. For instance, consider this motivating example from the `bytestring`
-library,
-
-> break :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
-> breakByte :: Word8 -> ByteString -> (ByteString, ByteString)
-> {-# RULES "break -> breakByte" forall a. break (== x) = breakByte x #-}
-
-Here we have two functions, with `breakByte` providing an optimized
-implementation of `break` where the predicate is merely testing for equality
-with a known `Word8`. As written, however, this rule will be quite fragile as
-the `(==)` class operation rule may rewrite the predicate before our `break`
-rule has a chance to fire.
-
-For this reason, most of the primitive types in `base` have 'Eq' and 'Ord'
-instances defined in terms of helper functions with inlinings delayed to phase
-1. For instance, `Word8`\'s `Eq` instance looks like,
-
-> instance Eq Word8 where
->     (==) = eqWord8
->     (/=) = neWord8
->
-> eqWord8, neWord8 :: Word8 -> Word8 -> Bool
-> eqWord8 (W8# x) (W8# y) = ...
-> neWord8 (W8# x) (W8# y) = ...
-> {-# INLINE [1] eqWord8 #-}
-> {-# INLINE [1] neWord8 #-}
-
-This allows us to save our `break` rule above by rewriting it to instead match
-against `eqWord8`,
-
-> {-# RULES "break -> breakByte" forall a. break (`eqWord8` x) = breakByte x #-}
-
-Currently this is only done for '(==)', '(/=)', '(<)', '(<=)', '(>)', and '(>=)'
-for the types in "GHC.Word" and "GHC.Int".
--}
-
+-- $matching_overloaded_methods_in_rules
+--
+-- Matching on class methods (e.g. `(==)`) in rewrite rules tends to be a bit
+-- fragile. For instance, consider this motivating example from the `bytestring`
+-- library,
+--
+-- > break :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
+-- > breakByte :: Word8 -> ByteString -> (ByteString, ByteString)
+-- > {-# RULES "break -> breakByte" forall a. break (== x) = breakByte x #-}
+--
+-- Here we have two functions, with `breakByte` providing an optimized
+-- implementation of `break` where the predicate is merely testing for equality
+-- with a known `Word8`. As written, however, this rule will be quite fragile as
+-- the `(==)` class operation rule may rewrite the predicate before our `break`
+-- rule has a chance to fire.
+--
+-- For this reason, most of the primitive types in `base` have 'Eq' and 'Ord'
+-- instances defined in terms of helper functions with inlinings delayed to phase
+-- 1. For instance, `Word8`\'s `Eq` instance looks like,
+--
+-- > instance Eq Word8 where
+-- >     (==) = eqWord8
+-- >     (/=) = neWord8
+-- >
+-- > eqWord8, neWord8 :: Word8 -> Word8 -> Bool
+-- > eqWord8 (W8# x) (W8# y) = ...
+-- > neWord8 (W8# x) (W8# y) = ...
+-- > {-# INLINE [1] eqWord8 #-}
+-- > {-# INLINE [1] neWord8 #-}
+--
+-- This allows us to save our `break` rule above by rewriting it to instead match
+-- against `eqWord8`,
+--
+-- > {-# RULES "break -> breakByte" forall a. break (`eqWord8` x) = breakByte x #-}
+--
+-- Currently this is only done for '(==)', '(/=)', '(<)', '(<=)', '(>)', and '(>=)'
+-- for the types in "GHC.Word" and "GHC.Int".
+--
 -- | The `Eq` class defines equality (`==`) and inequality (`/=`).
 -- All the basic datatypes exported by the "Prelude" are instances of `Eq`,
 -- and `Eq` may be derived for any datatype whose constituents are also


### PR DESCRIPTION
In the current state, the second field of the `ApiAnns` value computed by `parseFileContents` (`//compiler/hie-core/src/Development/IDE/Core/Compile.hs`) is never non-empty. The general flag `Opt_KeepRawTokenStream` tells the lexer to harvest comments during parsing.  This PR turns it on.