### PR TITLE
damldoc: Apply annotations to JSON input.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -9,10 +9,12 @@ module DA.Daml.Doc.Driver(
     , DocOption(..)
     ) where
 
-import           DA.Daml.Doc.Types
-import           DA.Daml.Doc.Render
-import           DA.Daml.Doc.HaddockParse
-import           DA.Daml.Doc.Transform
+import DA.Daml.Doc.Types
+import DA.Daml.Doc.Render
+import DA.Daml.Doc.HaddockParse
+import DA.Daml.Doc.Transform
+import DA.Daml.Doc.Annotate
+
 import Development.IDE.Types.Location
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Options
@@ -54,7 +56,7 @@ damlDocDriver cInputFormat ideOpts output cFormat prefixFile options files = do
             InputJson -> do
                 input <- mapM (BS.readFile . fromNormalizedFilePath) files
                 let mbData = map AE.eitherDecode input :: [Either String [ModuleDoc]]
-                concatMapM (either printAndExit pure) mbData
+                applyAnnotations <$> concatMapM (either printAndExit pure) mbData
 
             InputDaml ->
                 onErrorExit $ runExceptT

--- a/compiler/damlc/daml-prim-src/GHC/Base.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Base.daml
@@ -5,7 +5,7 @@
 {-# LANGUAGE MagicHash #-}
 
 daml 1.2
--- | Included in Prelude
+-- | MOVE Prelude
 module GHC.Base
   ( otherwise
   , getTag

--- a/compiler/damlc/daml-prim-src/GHC/Enum.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Enum.daml
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 daml 1.2
 
--- | Included in Prelude.
+-- | MOVE Prelude.
 --
 -- A weird module - based on base.GHC.Enum, but not realy in the GHC namespace.
 -- Has to live here so GHC can find it for deriving instances.

--- a/compiler/damlc/daml-prim-src/GHC/Err.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Err.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 daml 1.2
 
--- | Included in Prelude
+-- | MOVE Prelude
 --
 -- A weird module - based on base.GHC.Err, but not realy in the GHC namespace.
 -- Has to live here so GHC can find it for deriving instances.

--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 daml 1.2
 
--- | Included in Prelude
+-- | MOVE Prelude
 --
 -- Has to live here so GHC can find it for deriving instances.
 module GHC.Num

--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -5,7 +5,7 @@
 {-# LANGUAGE MagicHash #-}
 
 daml 1.2
--- | Included in Prelude
+-- | MOVE Prelude
 module GHC.Show
   ( Show(..)
   , ShowS

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -8,7 +8,7 @@
 {-# OPTIONS -Wno-unused-binds #-} -- the opaque constructors are not exported
 daml 1.2
 
--- | Included in Prelude
+-- | MOVE Prelude
 module GHC.Types (
         -- Data types that are built-in syntax
         -- They are defined here, but not explicitly exported


### PR DESCRIPTION
Apply annotations like `HIDE` and `MOVE` to JSON input. This lets you specify annotations when inputting JSON docs. But more importantly, it also recombines modules correctly so you don't end up with two `Prelude` modules, for example.

As part of this I reintroduced the `MOVE Prelude` annotations in `daml-prim`, so the standard library docs should be back to normal.

Fixes #2060. 
