### PR TITLE
haskell ledger bindings: improve thread handling

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -8,6 +8,7 @@ da_haskell_library(
     name = "hs-ledger",
     srcs = glob(["src/**/*.hs"]),
     hazel_deps = [
+        "async",
         "base",
         "bytestring",
         "containers",
@@ -72,7 +73,6 @@ da_haskell_test(
         ":quickstart.dar",
         "//ledger/sandbox:sandbox-binary",
     ],
-    flaky = True,  # FIXME Remove this once #1927 is solved
     hazel_deps = [
         "async",
         "base",

--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -19,6 +19,7 @@ da_haskell_library(
         "text",
         "time",
         "transformers",
+        "unliftio",
         "vector",
     ],
     visibility = ["//visibility:public"],

--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -73,6 +73,7 @@ da_haskell_test(
         ":quickstart.dar",
         "//ledger/sandbox:sandbox-binary",
     ],
+    flaky = True,  # FIXME Remove this once #1927 is solved
     hazel_deps = [
         "async",
         "base",

--- a/language-support/hs/bindings/src/DA/Ledger.hs
+++ b/language-support/hs/bindings/src/DA/Ledger.hs
@@ -13,8 +13,16 @@ module DA.Ledger ( -- High level interface to the Ledger API
     module DA.Ledger.Stream,
     module DA.Ledger.Types,
 
-    configOfPort, getAllTransactions, getTransactionsPF,
-    getAllTransactionTrees,
+    configOfPort,
+
+    getTransactionsPF,
+
+    withGetTransactions,
+    withGetTransactionTrees,
+
+    withGetAllTransactions,
+    withGetTransactionsPF,
+    withGetAllTransactionTrees,
 
     ) where
 
@@ -25,6 +33,7 @@ import DA.Ledger.Services
 import DA.Ledger.Stream
 import DA.Ledger.Types
 
+import Control.Exception (try,SomeException,throwIO)
 import Control.Monad.IO.Class(liftIO)
 
 configOfPort :: Port -> ClientConfig
@@ -35,20 +44,6 @@ configOfPort port =
                  , clientSSLConfig = Nothing
                  }
 
--- Non-primitive, but useful way to get Transactions
--- TODO: move to separate Utils module?
-
-getAllTransactions :: LedgerId -> Party -> Verbosity -> LedgerService (Stream [Transaction])
-getAllTransactions lid party verbose = do
-    let filter = filterEverthingForParty party
-    let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
-    getTransactions req
-
-getAllTransactionTrees :: LedgerId -> Party -> Verbosity -> LedgerService (Stream [TransactionTree])
-getAllTransactionTrees lid party verbose = do
-    let filter = filterEverthingForParty party
-    let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
-    getTransactionTrees req
 
 getTransactionsPF :: LedgerId -> Party -> LedgerService (PastAndFuture [Transaction])
 getTransactionsPF lid party = do
@@ -59,5 +54,67 @@ getTransactionsPF lid party = do
     let req2 = GetTransactionsRequest lid now         Nothing    filter verbose
     stream <- getTransactions req1
     future <- getTransactions req2
-    past <- liftIO $ streamToList stream
+    past <- withTimeout $ liftIO $ streamToList stream
     return PastAndFuture { past, future }
+
+
+withGetTransactions
+    :: GetTransactionsRequest
+    -> (Stream [Transaction] -> LedgerService a)
+    -> LedgerService a
+withGetTransactions req act = do
+    stream <- getTransactions req
+    res <- mapIOLedgerService try (act stream)
+    liftIO $ closeStream stream EOS
+    case res of
+        Left e -> liftIO $ throwIO (e::SomeException)
+        Right x -> return x
+
+
+withGetTransactionTrees
+    :: GetTransactionsRequest
+    -> (Stream [TransactionTree] -> LedgerService a)
+    -> LedgerService a
+withGetTransactionTrees req act = do
+    stream <- getTransactionTrees req
+    res <- mapIOLedgerService try (act stream)
+    liftIO $ closeStream stream EOS
+    case res of
+        Left e -> liftIO $ throwIO (e::SomeException)
+        Right x -> return x
+
+
+withGetAllTransactions
+    :: LedgerId -> Party -> Verbosity
+    -> (Stream [Transaction] -> LedgerService a)
+    -> LedgerService a
+withGetAllTransactions lid party verbose act = do
+    let filter = filterEverthingForParty party
+    let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
+    withGetTransactions req act
+
+
+withGetTransactionsPF
+    :: LedgerId -> Party
+    -> (PastAndFuture [Transaction] -> LedgerService a)
+    -> LedgerService a
+withGetTransactionsPF lid party act = do
+    now <- fmap LedgerAbsOffset (ledgerEnd lid)
+    let filter = filterEverthingForParty party
+    let verbose = Verbosity False
+    let req1 = GetTransactionsRequest lid LedgerBegin (Just now) filter verbose
+    let req2 = GetTransactionsRequest lid now         Nothing    filter verbose
+    withGetTransactions req1 $ \stream -> do
+    withGetTransactions req2 $ \future -> do
+    past <- withTimeout $ liftIO $ streamToList stream
+    act $ PastAndFuture { past, future }
+
+
+withGetAllTransactionTrees
+    :: LedgerId -> Party -> Verbosity
+    -> (Stream [TransactionTree] -> LedgerService a)
+    -> LedgerService a
+withGetAllTransactionTrees lid party verbose act = do
+    let filter = filterEverthingForParty party
+    let req = GetTransactionsRequest lid LedgerBegin Nothing filter verbose
+    withGetTransactionTrees req act

--- a/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
@@ -4,14 +4,16 @@
 -- Abstraction for LedgerService, which can be composed monadically.
 module DA.Ledger.LedgerService (
     LedgerService, runLedgerService, makeLedgerService, TimeoutSeconds,
+    withTimeout, mapIOLedgerService,
     ) where
 
 import Control.Monad.Fail (MonadFail)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Reader (ReaderT(..),runReaderT)
+import Control.Monad.IO.Class (MonadIO,liftIO)
+import Control.Monad.Trans.Reader (ReaderT(..),runReaderT,ask)
 import DA.Ledger.Retry (ledgerRetry)
-import Network.GRPC.HighLevel.Generated(ClientConfig)
 import Network.GRPC.HighLevel.Client(TimeoutSeconds)
+import Network.GRPC.HighLevel.Generated(ClientConfig)
+import System.Time.Extra (timeout)
 
 type Context = (TimeoutSeconds,ClientConfig)
 
@@ -23,3 +25,13 @@ runLedgerService (LedgerService r) ts cc = runReaderT r (ts,cc)
 
 makeLedgerService :: (TimeoutSeconds -> ClientConfig -> IO a) -> LedgerService a
 makeLedgerService f = LedgerService $ ReaderT $ \(ts,cc) -> ledgerRetry $ f ts cc
+
+withTimeout :: LedgerService a -> LedgerService a
+withTimeout service = do
+    (ts,cc) <- LedgerService ask
+    Just x <- liftIO $ timeout (fromIntegral ts) (runLedgerService service ts cc)
+    return x
+
+mapIOLedgerService :: (IO a -> IO b) -> LedgerService a -> LedgerService b
+mapIOLedgerService f (LedgerService r) =
+    LedgerService $ ReaderT $ \c -> f $ runReaderT r c

--- a/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
@@ -4,21 +4,21 @@
 -- Abstraction for LedgerService, which can be composed monadically.
 module DA.Ledger.LedgerService (
     LedgerService, runLedgerService, makeLedgerService, TimeoutSeconds,
-    withTimeout, mapIOLedgerService,
+    askTimeout,
     ) where
 
 import Control.Monad.Fail (MonadFail)
-import Control.Monad.IO.Class (MonadIO,liftIO)
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT(..),runReaderT,ask)
 import DA.Ledger.Retry (ledgerRetry)
 import Network.GRPC.HighLevel.Client(TimeoutSeconds)
 import Network.GRPC.HighLevel.Generated(ClientConfig)
-import System.Time.Extra (timeout)
+import UnliftIO(MonadUnliftIO)
 
 type Context = (TimeoutSeconds,ClientConfig)
 
 newtype LedgerService a = LedgerService (ReaderT Context IO a)
-    deriving (Functor,Applicative,Monad,MonadFail,MonadIO)
+    deriving (Functor,Applicative,Monad,MonadFail,MonadIO,MonadUnliftIO)
 
 runLedgerService :: LedgerService a -> TimeoutSeconds -> ClientConfig -> IO a
 runLedgerService (LedgerService r) ts cc = runReaderT r (ts,cc)
@@ -26,12 +26,5 @@ runLedgerService (LedgerService r) ts cc = runReaderT r (ts,cc)
 makeLedgerService :: (TimeoutSeconds -> ClientConfig -> IO a) -> LedgerService a
 makeLedgerService f = LedgerService $ ReaderT $ \(ts,cc) -> ledgerRetry $ f ts cc
 
-withTimeout :: LedgerService a -> LedgerService a
-withTimeout service = do
-    (ts,cc) <- LedgerService ask
-    Just x <- liftIO $ timeout (fromIntegral ts) (runLedgerService service ts cc)
-    return x
-
-mapIOLedgerService :: (IO a -> IO b) -> LedgerService a -> LedgerService b
-mapIOLedgerService f (LedgerService r) =
-    LedgerService $ ReaderT $ \c -> f $ runReaderT r c
+askTimeout :: LedgerService TimeoutSeconds
+askTimeout = LedgerService $ fmap fst $ ask

--- a/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/LedgerService.hs
@@ -27,4 +27,4 @@ makeLedgerService :: (TimeoutSeconds -> ClientConfig -> IO a) -> LedgerService a
 makeLedgerService f = LedgerService $ ReaderT $ \(ts,cc) -> ledgerRetry $ f ts cc
 
 askTimeout :: LedgerService TimeoutSeconds
-askTimeout = LedgerService $ fmap fst $ ask
+askTimeout = LedgerService $ fmap fst ask

--- a/language-support/hs/bindings/src/DA/Ledger/Stream.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Stream.hs
@@ -20,7 +20,7 @@ module DA.Ledger.Stream(
     ) where
 
 import Control.Concurrent
-import Control.Exception (SomeException,catch)
+import Control.Exception (SomeException,catch,mask_)
 import Control.Concurrent.Async(async,cancel)
 
 newtype Stream a = Stream {status :: MVar (Either Closed (Open a))}
@@ -126,7 +126,7 @@ streamToList stream = do
 
 -- Generate a stream in an asyncronous thread
 asyncStreamGen :: (Stream a -> IO ()) -> IO (Stream a)
-asyncStreamGen act = do
+asyncStreamGen act = mask_ $ do
     stream <- newStream
     gen <- async $ act stream
         `catch` \(e::SomeException) -> closeStream stream (Abnormal (show e))

--- a/language-support/hs/bindings/src/DA/Ledger/Stream.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Stream.hs
@@ -16,9 +16,12 @@ module DA.Ledger.Stream(
     whenClosed, isClosed,
     mapListStream,
     streamToList,
+    asyncStreamGen,
     ) where
 
 import Control.Concurrent
+import Control.Exception (SomeException,catch)
+import Control.Concurrent.Async(async,cancel)
 
 newtype Stream a = Stream {status :: MVar (Either Closed (Open a))}
 
@@ -110,7 +113,7 @@ mapListStream f source = do
                     ys <- f x
                     mapM_ (\y -> writeStream target (Right y)) ys
                     loop
-    _ <- forkIO loop
+    _ <- async loop
     return target
 
 -- Force a Stream, which we expect to reach EOS, to a list
@@ -120,3 +123,12 @@ streamToList stream = do
         Left (Abnormal s) -> fail s
         Left EOS -> return []
         Right x -> fmap (x:) $ streamToList stream
+
+-- Generate a stream in an asyncronous thread
+asyncStreamGen :: (Stream a -> IO ()) -> IO (Stream a)
+asyncStreamGen act = do
+    stream <- newStream
+    gen <- async $ act stream
+        `catch` \(e::SomeException) -> closeStream stream (Abnormal (show e))
+    onClose stream $ \_ -> cancel gen
+    return stream


### PR DESCRIPTION
- Introduce `asyncStreamGen`
    - uses `async` not `forkIO`
    - generator is `cancel`ed when `stream` is closed
    - used by streaming RPC services

-  Add timeOut when calling `streamToList` in `getTransactionsPF`.

- Introduce `with..`-style resource acquisition for streaming RPCs.

- Use `withGetAllTransactions` and friends in `Test.hs`, replacing explicit calls to `closeStream`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
