### PR TITLE
daml-lf-repl: drop ad-hoc parser

### DIFF
--- a/daml-lf/README.md
+++ b/daml-lf/README.md
@@ -145,13 +145,10 @@ The REPL can be compiled with `bazel build //:daml-lf-repl` and run with
 `bazel run //:daml-lf-repl -- repl`. The `//:` prefix is not needed when
 at repository root.
 
-Note that the REPL currently only supports loading from .dalf files,
-not from .dar files.
-
 Example use:
 
 $ bazel run //:daml-lf-repl -- repl
-daml> :load project.dalf
+daml> :load project.dar
 daml> Project.double 4
 8
 daml> :scenario Project.tests

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -42,6 +42,8 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       id ^^ EVar |
       `(` ~> expr <~ `)`
 
+  lazy val exprs: Parser[List[Expr]] = rep(expr0)
+
   private lazy val literal: Parsers.Parser[PrimLit] =
     acceptMatch[PrimLit]("Number", { case Number(l) => PLInt64(l) }) |
       acceptMatch("Decimal", { case Decimal(d) => PLDecimal(d) }) |

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/package.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/package.scala
@@ -29,7 +29,7 @@ package object parser {
       implicit parserParameters: ParserParameters[P]): Either[String, Expr] =
     safeParse(new ExprParser[P](parserParameters).expr, s)
   def parseExprs[P](s: String)(
-    implicit parserParameters: ParserParameters[P]): Either[String, List[Expr]] =
+      implicit parserParameters: ParserParameters[P]): Either[String, List[Expr]] =
     safeParse(new ExprParser[P](parserParameters).exprs, s)
   def parseModules[P](s: String)(
       implicit parserParameters: ParserParameters[P]): Either[String, List[Module]] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/package.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/package.scala
@@ -28,6 +28,9 @@ package object parser {
   def parseExpr[P](s: String)(
       implicit parserParameters: ParserParameters[P]): Either[String, Expr] =
     safeParse(new ExprParser[P](parserParameters).expr, s)
+  def parseExprs[P](s: String)(
+    implicit parserParameters: ParserParameters[P]): Either[String, List[Expr]] =
+    safeParse(new ExprParser[P](parserParameters).exprs, s)
   def parseModules[P](s: String)(
       implicit parserParameters: ParserParameters[P]): Either[String, List[Module]] =
     safeParse(Parsers.rep(new ModParser[P](parserParameters).mod), s)

--- a/daml-lf/repl/BUILD.bazel
+++ b/daml-lf/repl/BUILD.bazel
@@ -9,7 +9,7 @@ load(
 da_scala_binary(
     name = "repl",
     srcs = glob(["src/main/**/*.scala"]),
-    main_class = "com.digitalasset.daml.lf.speedy.Main",
+    main_class = "com.digitalasset.daml.lf.speedy.testing.Main",
     tags = ["maven_coordinates=com.digitalasset:daml-lf-repl:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
@@ -26,5 +26,6 @@ da_scala_binary(
         "//daml-lf/scenario-interpreter",
         "//daml-lf/transaction",
         "//daml-lf/validation",
+        "//daml-lf/parser"
     ],
 )

--- a/daml-lf/repl/BUILD.bazel
+++ b/daml-lf/repl/BUILD.bazel
@@ -23,9 +23,9 @@ da_scala_binary(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
+        "//daml-lf/parser",
         "//daml-lf/scenario-interpreter",
         "//daml-lf/transaction",
         "//daml-lf/validation",
-        "//daml-lf/parser"
     ],
 )

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -378,7 +378,6 @@ object Repl {
         println(s"Error: cannot parser arguments '${args.mkString(" ")}'")
 
       case Right(argExprs) =>
-
         lookup(state, id) match {
           case None =>
             println("Error: definition '" + id + "' not found. Try :list.")
@@ -575,7 +574,7 @@ object Repl {
 
   case class ParseError(error: String) extends RuntimeException(error)
 
-  private def assertRight[X](e: Either[String, X]):X =
+  private def assertRight[X](e: Either[String, X]): X =
     e.fold(
       err => throw ParseError(err),
       identity

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -396,7 +396,6 @@ object Repl {
             val startTime = System.nanoTime()
             var errored = false
             while (!machine.isFinal && !errored) {
-//              machine.print(count)
               machine.step match {
                 case SResultError(err) =>
                   println(prettyError(err, machine.ptx).render(128))

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -2,28 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.speedy
+package testing
 
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.archive.Decode
+import com.digitalasset.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.speedy.Pretty._
 import com.digitalasset.daml.lf.speedy.SError._
 import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.types.Ledger
-import com.digitalasset.daml.lf.value.Value
-import Value._
+import com.digitalasset.daml.lf.speedy.SExpr.LfDefRef
+import com.digitalasset.daml.lf.PureCompiledPackages
+import com.digitalasset.daml.lf.validation.Validation
+import com.digitalasset.daml.lf.testing.parser
+import com.digitalasset.daml.lf.language.LanguageVersion
+import com.digitalasset.daml.lf.transaction.VersionTimeline
 import java.io.{File, PrintWriter, StringWriter}
 import java.nio.file.{Path, Paths}
 import java.io.PrintStream
-import com.digitalasset.daml.lf.language.LanguageVersion
-import com.digitalasset.daml.lf.transaction.VersionTimeline
 
-import com.digitalasset.daml.lf.speedy.SExpr.LfDefRef
-import com.digitalasset.daml.lf.PureCompiledPackages
-import com.digitalasset.daml.lf.archive.UniversalArchiveReader
-import com.digitalasset.daml.lf.validation.Validation
 import org.jline.builtins.Completers
 import org.jline.reader.{History, LineReader, LineReaderBuilder}
 import org.jline.reader.impl.completer.{AggregateCompleter, ArgumentCompleter, StringsCompleter}
@@ -31,7 +30,6 @@ import org.jline.reader.impl.history.DefaultHistory
 
 import scala.collection.immutable.ListMap
 import scala.collection.JavaConverters._
-import scala.util.parsing.combinator._
 
 object Main extends App {
   // idempotent; force stdout to output in UTF-8 -- in theory it should pick it up from
@@ -236,7 +234,7 @@ object Repl {
     )
 
   def dispatch(state: State, line: String): State = {
-    line.split(" ").toList match {
+    line.trim.split(" ").toList match {
       case Nil => state
       case "" :: _ => state
       case cmdS :: args =>
@@ -253,7 +251,6 @@ object Repl {
         println(pkgId)
         pkg.modules.foreach {
           case (mname, mod) =>
-            println("  " + mname.toString + ":")
             val maxLen =
               if (mod.definitions.nonEmpty) mod.definitions.map(_._1.toString.length).max
               else 0
@@ -261,7 +258,7 @@ object Repl {
               case (name, defn) =>
                 val paddedName = name.toString.padTo(maxLen, ' ')
                 val typ = prettyDefinitionType(defn, pkgId, mod.name)
-                println(s"    $paddedName ∷ $typ")
+                println(s"    ${mname.toString}:$paddedName ∷ $typ")
             }
         }
     }
@@ -363,58 +360,72 @@ object Repl {
     }
   }
 
+  implicit val parserParameters: parser.ParserParameters[Repl.this.type] =
+    parser.ParserParameters(
+      defaultPackageId = Ref.PackageId.assertFromString("-dummy-"),
+      languageVersion = LanguageVersion.defaultV1,
+    )
+
   // Invoke the given top-level function with given arguments.
   // The identifier can be fully-qualified (Foo.Bar@<package id>). If package is not
   // specified, the last used package is used.
   // If the resulting type is a scenario it is automatically executed.
   def invokePure(state: State, id: String, args: Seq[String]): Unit = {
-    //try {
-    val argExprs = ValueParser.parseArgs(args).map(valueToExpr)
-    lookup(state, id) match {
-      case None =>
-        println("Error: definition '" + id + "' not found. Try :list."); usage
-      case Some((lfVer, DValue(_, _, body, _))) =>
-        val expr = argExprs.foldLeft(body)((e, arg) => EApp(e, arg))
 
-        val machine =
-          Speedy.Machine.fromExpr(
-            expr = expr,
-            checkSubmitterInMaintainers = VersionTimeline.checkSubmitterInMaintainers(lfVer),
-            compiledPackages = PureCompiledPackages(state.packages).right.get,
-            scenario = false
-          )
-        var count = 0
-        val startTime = System.nanoTime()
-        var errored = false
-        while (!machine.isFinal && !errored) {
-          machine.print(count)
-          machine.step match {
-            case SResultError(err) =>
-              println(prettyError(err, machine.ptx).render(128))
-              errored = true
-            case SResultContinue =>
-              ()
-            case other =>
-              sys.error("unimplemented callback: " + other.toString)
-          }
-          count += 1
+    parser.parseExprs[this.type](args.mkString(" ")) match {
+
+      case Left(error) =>
+        println(s"Error: cannot parser arguments '${args.mkString(" ")}'")
+
+      case Right(argExprs) =>
+
+        lookup(state, id) match {
+          case None =>
+            println("Error: definition '" + id + "' not found. Try :list.")
+            usage
+          case Some((lfVer, DValue(_, _, body, _))) =>
+            val expr = argExprs.foldLeft(body)((e, arg) => EApp(e, arg))
+
+            val machine =
+              Speedy.Machine.fromExpr(
+                expr = expr,
+                checkSubmitterInMaintainers = VersionTimeline.checkSubmitterInMaintainers(lfVer),
+                compiledPackages = PureCompiledPackages(state.packages).right.get,
+                scenario = false
+              )
+            var count = 0
+            val startTime = System.nanoTime()
+            var errored = false
+            while (!machine.isFinal && !errored) {
+//              machine.print(count)
+              machine.step match {
+                case SResultError(err) =>
+                  println(prettyError(err, machine.ptx).render(128))
+                  errored = true
+                case SResultContinue =>
+                  ()
+                case other =>
+                  sys.error("unimplemented callback: " + other.toString)
+              }
+              count += 1
+            }
+            val endTime = System.nanoTime()
+            val diff = (endTime - startTime) / 1000 / 1000
+            machine.print(count)
+            println(s"steps: $count")
+            println(s"time: ${diff}ms")
+            if (!errored) {
+              val result = machine.ctrl match {
+                case Speedy.CtrlValue(sv) =>
+                  prettyValue(true)(sv.toValue).render(128)
+                case x => x.toString
+              }
+              println("result:")
+              println(result)
+            }
+          case Some(_) =>
+            println("Error: " + id + " not a value.")
         }
-        val endTime = System.nanoTime()
-        val diff = (endTime - startTime) / 1000 / 1000
-        machine.print(count)
-        println(s"steps: $count")
-        println(s"time: ${diff}ms")
-        if (!errored) {
-          val result = machine.ctrl match {
-            case Speedy.CtrlValue(sv) =>
-              prettyValue(true)(sv.toValue).render(128)
-            case x => x.toString
-          }
-          println("result:")
-          println(result)
-        }
-      case Some(_) =>
-        println("Error: " + id + " not a value.")
     }
   }
 
@@ -426,7 +437,7 @@ object Repl {
             println("Error: " + id + " not found.")
             None
           case Some((lfVer, DValue(_, _, body, _))) =>
-            val argExprs = args.map(ValueParser.parse).map(valueToExpr)
+            val argExprs = args.map(s => assertRight(parser.parseExpr(s)))
             Some((lfVer, argExprs.foldLeft(body)((e, arg) => EApp(e, arg))))
           case Some(_) =>
             println("Error: " + id + " is not a value.")
@@ -562,116 +573,11 @@ object Repl {
     """.stripMargin)
   }
 
-  object ValueParser extends RegexParsers {
-    // FIXME(JM): Parse types as well to allow creation of nominal records?
-    val dummyId =
-      Ref.Identifier(
-        PackageId.assertFromString("-dummy package-"),
-        QualifiedName.assertFromString("Dummy:Dummy"))
+  case class ParseError(error: String) extends RuntimeException(error)
 
-    def pDecimal: Parser[Value[Nothing]] = """\d+\.\d+""".r ^^ { s =>
-      ValueDecimal(Decimal.assertFromString(s))
-    }
-    def pInt64: Parser[Value[Nothing]] = """\d+""".r ^^ { s =>
-      ValueInt64(s.toLong)
-    }
-    def pText: Parser[Value[Nothing]] = """\"(\w*)\"""".r ^^ { s =>
-      ValueText(s.stripPrefix("\"").stripSuffix("\""))
-    }
-    def pTrue: Parser[Value[Nothing]] = "true" ^^ { _ =>
-      ValueBool(true)
-    }
-    def pFalse: Parser[Value[Nothing]] = "false" ^^ { _ =>
-      ValueBool(false)
-    }
-    def pVariant: Parser[Value[Nothing]] =
-      """[A-Z][a-z]*""".r ~ ("(" ~> pValue <~ ")").? ^^ {
-        case variant ~ optValue =>
-          ValueVariant(Some(dummyId), Name.assertFromString(variant), optValue.getOrElse(ValueUnit))
-      }
-    def pList: Parser[Value[Nothing]] =
-      """\[\s*""".r ~> (pValue <~ """\s*,\s*""".r).* ~ pValue.? <~ """\s*\]""".r ^^ {
-        case front ~ Some(last) => ValueList(FrontStack(ImmArray(front :+ last)))
-        case _ => ValueList(FrontStack.empty)
-      }
-
-    def pField: Parser[(Name, Value[Nothing])] =
-      ("""(\w+)""".r ~ """\s*=\s*""".r ~ pValue) ^^ {
-        case field ~ _ ~ value => Name.assertFromString(field) -> value
-      }
-    def pFields: Parser[List[(Name, Value[Nothing])]] =
-      ("""\s*""".r ~> pField <~ """\ *,\ *""".r).* ~ pField.? ^^ {
-        case fs ~ Some(last) => fs :+ last
-        case _ => List()
-      }
-    def pRecord: Parser[Value[Nothing]] = "{" ~> pFields <~ "}" ^^ { fs =>
-      ValueRecord(Some(dummyId), ImmArray(fs.map {
-        case (lbl, v) => (Some(lbl), v)
-      }))
-    }
-
-    def pValue: Parser[Value[Nothing]] =
-      pDecimal | pInt64 | pVariant | pRecord | pList | pText
-
-    def pValues: Parser[Seq[Value[Nothing]]] = (pValue <~ """\s*""".r).*
-
-    case class ParseError(error: String) extends RuntimeException(error)
-
-    def parse(s: String): Value[Nothing] =
-      parseAll(pValue, s) match {
-        case Success(v, _) => v
-        case err => throw ParseError(err.toString)
-      }
-
-    def parseArgs(s: Seq[String]): Seq[Value[Nothing]] =
-      parseAll(pValues, s.mkString(" ")) match {
-        case Success(v, _) => v
-        case err => throw ParseError(err.toString)
-      }
-  }
-
-  def debugParse(args: Seq[String]): Unit =
-    try {
-      println(
-        ValueParser
-          .parseArgs(args)
-          .map(x => prettyValue(true)(x).render(128))
-          .mkString("\n"))
-    } catch {
-      case ValueParser.ParseError(err) => println("parse error: " + err)
-    }
-
-  def valueToExpr(v: Value[AbsoluteContractId]): Expr = {
-    // FIXME(JM): Fix the handling of types.
-    val dummyTyCon =
-      TypeConName(
-        PackageId.assertFromString("-dummy-"),
-        QualifiedName.assertFromString("Dummy:Dummy"))
-    val dummyTyApp = TypeConApp(dummyTyCon, ImmArray.empty)
-    v match {
-      case ValueText(s) => EPrimLit(PLText(s))
-      case ValueInt64(i) => EPrimLit(PLInt64(i))
-      case ValueDecimal(d) => EPrimLit(PLDecimal(d))
-      case ValueVariant(_, variant, value) =>
-        EVariantCon(dummyTyApp, variant, valueToExpr(value))
-      case ValueEnum(_, constructor) =>
-        EVariantCon(dummyTyApp, constructor, EUnit)
-      case ValueRecord(_, fs) =>
-        ETupleCon(fs.map(kv => (kv._1.get, valueToExpr(kv._2))))
-      case ValueTuple(fs) =>
-        ETupleCon(fs.map(kv => (kv._1, valueToExpr(kv._2))))
-      case ValueUnit => EUnit
-      case ValueBool(b) => EPrimCon(if (b) PCTrue else PCFalse)
-      case ValueList(xs) =>
-        ECons(TTyCon(dummyTyCon), xs.map(valueToExpr).toImmArray, ENil(TTyCon(dummyTyCon)))
-      case ValueParty(p) => EPrimLit(PLParty(p))
-      case ValueTimestamp(t) => EPrimLit(PLTimestamp(t))
-      case ValueDate(t) => EPrimLit(PLDate(t))
-      case ValueContractId(acoid) => EContractId(acoid.coid, dummyTyCon)
-      case ValueOptional(Some(e)) => ESome(TTyCon(dummyTyCon), valueToExpr(e))
-      case ValueOptional(None) => ENone(TTyCon(dummyTyCon))
-      case ValueMap(_) =>
-        sys.error(s"Cannot represent Map in expressions")
-    }
-  }
+  private def assertRight[X](e: Either[String, X]):X =
+    e.fold(
+      err => throw ParseError(err),
+      identity
+    )
 }


### PR DESCRIPTION
In this PR we drop  the internal value parser of repl and replace it by the daml-lf parser. 
In the same time, we drop the (now useless) internal value to expression converter.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
