### PR TITLE
damldocs: Generate doc anchors at doc extraction.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
@@ -36,14 +36,14 @@ templateAnchor :: Modulename -> Typename  -> Anchor
 typeAnchor     :: Modulename -> Typename  -> Anchor
 dataAnchor     :: Modulename -> Typename  -> Anchor
 constrAnchor   :: Modulename -> Typename  -> Anchor
-functionAnchor :: Modulename -> Fieldname -> Maybe Type -> Anchor
+functionAnchor :: Modulename -> Fieldname -> Anchor
 
 classAnchor    m n = anchor "class"    m (unTypename n) ()
 templateAnchor m n = anchor "template" m (unTypename n) ()
 typeAnchor     m n = anchor "type"     m (unTypename n) ()
 dataAnchor     m n = anchor "data"     m (unTypename n) ()
 constrAnchor   m n = anchor "constr"   m (unTypename n) ()
-functionAnchor m n = anchor "function" m (unFieldname n)
+functionAnchor m n = anchor "function" m (unFieldname n) ()
 
 anchor :: Hashable v => T.Text -> Modulename -> T.Text -> v -> Anchor
 -- calculating a hash on String instead of Data.Text as hash output of the later is different on Windows than other OSes

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -198,7 +198,7 @@ getFctDocs DocCtx{..} (DeclData decl docs) = do
   let fct_name = Fieldname (idpToText name)
       fct_context = hsTypeToContext =<< mbType
       fct_type = fmap hsTypeToType mbType
-      fct_anchor = Just $ functionAnchor dc_mod fct_name fct_type
+      fct_anchor = Just $ functionAnchor dc_mod fct_name
       fct_descr = docs
   Just FunctionDoc {..}
 
@@ -274,10 +274,7 @@ getTypeDocs DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
     fieldDoc ConDeclField{..} = do
         let fd_name = Fieldname . T.concat . map (toText . unLoc) $ cd_fld_names
             fd_type = hsTypeToType cd_fld_type
-            fd_anchor = Just $ functionAnchor dc_mod fd_name Nothing
-                -- FIXME (FM): add the right type, or (better yet) get rid of the
-                -- type argument for function anchors while maintaining anchor
-                -- uniqueness.
+            fd_anchor = Just $ functionAnchor dc_mod fd_name
             fd_descr = fmap (docToText . unLoc) cd_fld_doc
         Just FieldDoc{..}
     fieldDoc XConDeclField{}  = Nothing

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -46,7 +46,8 @@ newtype Anchor = Anchor { unAnchor :: Text }
 ------------------------------------------------------------
 -- | Documentation data for a module
 data ModuleDoc = ModuleDoc
-  { md_name      :: Modulename
+  { md_anchor    :: Maybe Anchor
+  , md_name      :: Modulename
   , md_descr     :: Maybe DocText
   , md_templates :: [TemplateDoc]
   , md_adts      :: [ADTDoc]
@@ -61,7 +62,8 @@ data ModuleDoc = ModuleDoc
 
 -- | Documentation data for a template
 data TemplateDoc = TemplateDoc
-  { td_name    :: Typename
+  { td_anchor  :: Maybe Anchor
+  , td_name    :: Typename
   , td_descr   :: Maybe DocText
   , td_payload :: [FieldDoc]
   , td_choices :: [ChoiceDoc]
@@ -69,7 +71,8 @@ data TemplateDoc = TemplateDoc
   deriving (Eq, Show, Generic)
 
 data ClassDoc = ClassDoc
-  { cl_name :: Typename
+  { cl_anchor :: Maybe Anchor
+  , cl_name :: Typename
   , cl_descr :: Maybe DocText
   , cl_super :: Maybe Type
   , cl_args :: [Text]
@@ -79,13 +82,15 @@ data ClassDoc = ClassDoc
 
 -- | Documentation data for an ADT or type synonym
 data ADTDoc = ADTDoc
-  { ad_name   :: Typename
+  { ad_anchor :: Maybe Anchor
+  , ad_name   :: Typename
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_constrs :: [ADTConstr]  -- allowed to be empty
   }
   | TypeSynDoc
-  { ad_name   :: Typename
+  { ad_anchor :: Maybe Anchor
+  , ad_name   :: Typename
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_rhs    :: Type
@@ -95,11 +100,13 @@ data ADTDoc = ADTDoc
 
 -- | Constructors (Record or Prefix)
 data ADTConstr =
-    PrefixC { ac_name :: Typename
+    PrefixC { ac_anchor :: Maybe Anchor
+            , ac_name :: Typename
             , ac_descr :: Maybe DocText
             , ac_args :: [Type]   -- use retained var.names
             }
-  | RecordC { ac_name :: Typename
+  | RecordC { ac_anchor :: Maybe Anchor
+            , ac_name :: Typename
             , ac_descr :: Maybe DocText
             , ac_fields :: [FieldDoc]
             }
@@ -119,7 +126,8 @@ data ChoiceDoc = ChoiceDoc
 
 -- | Documentation data for a field in a record
 data FieldDoc = FieldDoc
-  { fd_name  :: Fieldname
+  { fd_anchor :: Maybe Anchor
+  , fd_name  :: Fieldname
   , fd_type  :: Type
     -- TODO align with GHC data structure. The type representation must use FQ
     -- names in components to enable links, and it Can use bound type var.s.
@@ -130,7 +138,8 @@ data FieldDoc = FieldDoc
 
 -- | Documentation data for functions (top level only, type optional)
 data FunctionDoc = FunctionDoc
-  { fct_name  :: Fieldname
+  { fct_anchor :: Maybe Anchor
+  , fct_name  :: Fieldname
   , fct_context :: Maybe Type
   , fct_type  :: Maybe Type
   , fct_descr :: Maybe DocText

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -41,7 +41,7 @@ instance Hashable Type where
 
 -- | Anchors are URL-safe ids into the docs.
 newtype Anchor = Anchor { unAnchor :: Text }
-    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON)
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
 ------------------------------------------------------------
 -- | Documentation data for a module

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -30,45 +30,47 @@ mkTestTree = do
 
 cases :: [(String, ModuleDoc)]
 cases = [ ("Empty module",
-           ModuleDoc "Empty" Nothing [] [] [] [])
+           ModuleDoc Nothing "Empty" Nothing [] [] [] [])
         , ("Type def with argument",
-           ModuleDoc "Typedef" Nothing []
-            [TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
+           ModuleDoc (Just "module-typedef") "Typedef" Nothing []
+            [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
             [] []
           )
         , ("Two types",
-           ModuleDoc "TwoTypes" Nothing []
-            [ TypeSynDoc "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
-            , ADTDoc "D" Nothing ["d"] [PrefixC "D" (Just "D descr") [TypeApp Nothing "a" []]]
+           ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing []
+            [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
+            , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]]
             ]
             [] []
           )
         , ("Documented function with type",
-           ModuleDoc "Function1" Nothing [] []
-            [FunctionDoc "f" Nothing (Just $ TypeApp Nothing "TheType" []) (Just "the doc")] []
+           ModuleDoc (Just "module-function1") "Function1" Nothing [] []
+            [FunctionDoc (Just "function-function1-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) (Just "the doc")] []
           )
         , ("Documented function without type",
-           ModuleDoc "Function2" Nothing [] []
-            [FunctionDoc "f" Nothing Nothing (Just "the doc")] []
+           ModuleDoc (Just "module-function2") "Function2" Nothing [] []
+            [FunctionDoc (Just "function-function2-f") "f" Nothing Nothing (Just "the doc")] []
           )
         , ("Undocumented function with type",
-           ModuleDoc "Function3" Nothing [] []
-            [FunctionDoc "f" Nothing (Just $ TypeApp Nothing "TheType" []) Nothing] []
+           ModuleDoc (Just "module-function3") "Function3" Nothing [] []
+            [FunctionDoc (Just "function-function3-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) Nothing] []
           )
         -- The doc extraction won't generate functions without type nor description
         , ("Module with only a type class",
-           ModuleDoc "OnlyClass" Nothing [] [] []
-            [ClassDoc "C" Nothing Nothing ["a"] [FunctionDoc "member" Nothing (Just (TypeApp Nothing "a" [])) Nothing]])
+           ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] []
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (Just (TypeApp Nothing "a" [])) Nothing]])
         , ("Multiline field description",
            ModuleDoc
+             (Just "module-multilinefield")
              "MultiLineField"
              Nothing
              []
              [ADTDoc
+                (Just "data-multilinefield-d")
                 "D"
                 Nothing
                 []
-                [RecordC "D" Nothing [FieldDoc "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]]
+                [RecordC (Just "constr-multilinefield-d") "D" Nothing [FieldDoc (Just "function-multilinefield-f") "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]]
              []
              []
           )
@@ -77,31 +79,31 @@ cases = [ ("Empty module",
 expectRst :: [T.Text]
 expectRst =
         [ T.empty
-        , mkExpectRst "module-typedef-50108" "Typedef" "" [] []
-            ["\n.. _type-typedef-t-88479:\n\ntype **T a**\n    = TT TTT\n\n  T descr"] []
-        , mkExpectRst "module-twotypes-33303" "TwoTypes" "" []
+        , mkExpectRst "module-typedef" "Typedef" "" [] []
+            ["\n.. _type-typedef-t:\n\ntype **T a**\n    = TT TTT\n\n  T descr"] []
+        , mkExpectRst "module-twotypes" "TwoTypes" "" []
             []
-            ["\n.. _type-twotypes-t-17090:\n\ntype **T a**\n    = TT\n\n  T descr"
-            , "\n.. _data-twotypes-d-66754:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d-45919:\n  \n  **D** a\n  \n  D descr"]
+            ["\n.. _type-twotypes-t:\n\ntype **T a**\n    = TT\n\n  T descr"
+            , "\n.. _data-twotypes-d:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d:\n  \n  **D** a\n  \n  D descr"]
             []
-        , mkExpectRst "module-function1-29590" "Function1" "" [] [] [] [ "\n.. _function-function1-f-45407:\n\n**f**\n  : TheType\n\n  the doc\n"]
-        , mkExpectRst "module-function2-7227" "Function2" "" [] [] [] [ "\n.. _function-function2-f-87524:\n\n**f**\n  :   the doc\n"]
-        , mkExpectRst "module-function3-84844" "Function3" "" [] [] [] [ "\n.. _function-function3-f-32653:\n\n**f**\n  : TheType\n\n"]
-        , mkExpectRst "module-onlyclass-88463" "OnlyClass" ""
+        , mkExpectRst "module-function1" "Function1" "" [] [] [] [ "\n.. _function-function1-f:\n\n**f**\n  : TheType\n\n  the doc\n"]
+        , mkExpectRst "module-function2" "Function2" "" [] [] [] [ "\n.. _function-function2-f:\n\n**f**\n  :   the doc\n"]
+        , mkExpectRst "module-function3" "Function3" "" [] [] [] [ "\n.. _function-function3-f:\n\n**f**\n  : TheType\n\n"]
+        , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
-            [ "\n.. _class-onlyclass-c-63566:"
-            , "**class C a where**\n  \n  .. _function-onlyclass-member-45125:\n  \n  **member**\n    : a"
+            [ "\n.. _class-onlyclass-c:"
+            , "**class C a where**\n  \n  .. _function-onlyclass-member:\n  \n  **member**\n    : a"
             ]
             []
             []
-        , mkExpectRst "module-multilinefield-24755" "MultiLineField" ""
+        , mkExpectRst "module-multilinefield" "MultiLineField" ""
             []
             []
-            [ "\n.. _data-multilinefield-d-47142:"
+            [ "\n.. _data-multilinefield-d:"
             , "data **D**"
             , T.concat
                   [ "  \n  \n"
-                  , "  .. _constr-multilinefield-d-61939:\n  \n"
+                  , "  .. _constr-multilinefield-d:\n  \n"
                   , "  **D**\n  \n  \n"
                   , "  .. list-table::\n"
                   , "     :widths: 15 10 30\n"

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -9,9 +9,12 @@ module DA.Daml.Doc.Tests(mkTestTree)
 import           DA.Bazel.Runfiles
 import           DA.Daml.Options
 import           DA.Daml.Options.Types
-import           DA.Daml.Doc.HaddockParse
-import           DA.Daml.Doc.Render
-import           DA.Daml.Doc.Types
+
+import DA.Daml.Doc.HaddockParse
+import DA.Daml.Doc.Render
+import DA.Daml.Doc.Types
+import DA.Daml.Doc.Anchor
+
 import           DA.Test.Util
 import Development.IDE.Types.Location
 
@@ -206,15 +209,15 @@ testModHdr = T.pack $ "daml 1.2 module\n  " <> testModule <> " where\n"
 
 
 emptyDocs :: String -> ModuleDoc
-emptyDocs name = ModuleDoc { md_anchor = Nothing
-                           , md_name = Modulename (T.pack name)
-                           , md_descr = Nothing
-                           , md_templates = []
-                           , md_adts = []
-                           , md_functions = []
-                           , md_classes = []
-                           }
-
+emptyDocs name =
+    let md_name = Modulename (T.pack name)
+        md_anchor = Just (moduleAnchor md_name)
+        md_descr = Nothing
+        md_templates = []
+        md_adts = []
+        md_functions = []
+        md_classes = []
+    in ModuleDoc {..}
 
 -- | Compiles the given input string (in a tmp file) and checks generated doc.s
 -- using the predicate provided.

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -206,7 +206,8 @@ testModHdr = T.pack $ "daml 1.2 module\n  " <> testModule <> " where\n"
 
 
 emptyDocs :: String -> ModuleDoc
-emptyDocs name = ModuleDoc { md_name = Modulename (T.pack name)
+emptyDocs name = ModuleDoc { md_anchor = Nothing
+                           , md_name = Modulename (T.pack name)
                            , md_descr = Nothing
                            , md_templates = []
                            , md_adts = []

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
@@ -1,5 +1,4 @@
 
-
 .. _module-ioutemplate-98694:
 
 Module Iou_template


### PR DESCRIPTION
Fixing an old mistake. By generating anchors in HaddockParse we ensure they are consistent between the Rst and Hoogle docs, instead of computing them separately for both. This also means the anchors don't depend on the interpretation of MOVE annotations, so anchors are more closely matched with ghc names (*I want to generate anchors from ghc-lib names soon*). This simplifies the arguments needed to generate function anchors (they don't need a `Maybe Type` parameter any more). 