### PR TITLE
language: additional (hidden) compiler options needed for migrate

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -13,6 +13,7 @@ module DA.Daml.Options.Types
     , projectPackageDatabase
     , ifaceDir
     , distDir
+    , genDir
     , basePackages
     ) where
 
@@ -34,7 +35,9 @@ data Options = Options
   , optMbPackageName :: Maybe String
     -- ^ compile in the context of the given package name and create interface files
   , optWriteInterface :: Bool
-    -- ^ Directory to write interface files to. Default is current working directory.
+    -- ^ whether to write interface files or not.
+  , optIfaceDir :: Maybe FilePath
+    -- ^ alternative directory to write interface files to. Default is <current working dir>.daml/interfaces.
   , optHideAllPkgs :: Bool
     -- ^ hide all imported packages
   , optPackageImports :: [(String, [(String, String)])]
@@ -55,6 +58,8 @@ data Options = Options
     -- ^ Controls whether the scenario service server runs all checks
     -- or only a subset of them. This is mostly used to run additional
     -- checks on CI while keeping the IDE fast.
+  , optIsGenerated :: Bool
+    -- Whether we're compiling generated code. Then we allow internal imports.
   } deriving Show
 
 data ScenarioValidation
@@ -74,6 +79,9 @@ projectPackageDatabase = damlArtifactDir </> "package-database"
 
 ifaceDir :: FilePath
 ifaceDir = damlArtifactDir </> "interfaces"
+
+genDir :: FilePath
+genDir = damlArtifactDir </> "generated"
 
 distDir :: FilePath
 distDir = damlArtifactDir </> "dist"
@@ -110,6 +118,7 @@ defaultOptions mbVersion =
         , optPackageDbs = []
         , optMbPackageName = Nothing
         , optWriteInterface = False
+        , optIfaceDir = Nothing
         , optHideAllPkgs = False
         , optPackageImports = []
         , optShakeProfiling = Nothing
@@ -119,6 +128,7 @@ defaultOptions mbVersion =
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
         , optScenarioValidation = ScenarioValidationFull
+        , optIsGenerated = False
         }
 
 getBaseDir :: IO FilePath

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -12,6 +12,7 @@ module DA.Daml.Options(toCompileOpts) where
 import Control.Monad
 import qualified CmdLineParser as Cmd (warnMsg)
 import Data.Bifunctor
+import Data.Maybe
 import Data.IORef
 import Data.List
 import DynFlags (parseDynamicFilePragma)
@@ -34,7 +35,7 @@ import qualified Development.IDE.Types.Options as HieCore
 toCompileOpts :: Options -> HieCore.IdeOptions
 toCompileOpts Options{..} =
     HieCore.IdeOptions
-      { optPreprocessor = damlPreprocessor optMbPackageName
+      { optPreprocessor = if optIsGenerated then noPreprocessor else damlPreprocessor optMbPackageName
       , optGhcSession = do
             env <- liftIO $ runGhcFast $ do
                 setupDamlGHC optImportPath optMbPackageName optGhcCustomOpts
@@ -45,7 +46,7 @@ toCompileOpts Options{..} =
           { optLocateHieFile = locateInPkgDb "hie"
           , optLocateSrcFile = locateInPkgDb "daml"
           }
-      , optIfaceDir = HieCore.InterfaceDirectory (ifaceDir <$ guard optWriteInterface)
+      , optIfaceDir = HieCore.InterfaceDirectory (fromMaybe ifaceDir optIfaceDir <$ guard optWriteInterface)
       , optExtensions = ["daml"]
       , optThreads = optThreads
       , optShakeProfiling = optShakeProfiling

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -4,6 +4,7 @@
 
 module DA.Daml.Preprocessor
   ( damlPreprocessor
+  , noPreprocessor
   ) where
 
 import           DA.Daml.Preprocessor.Records
@@ -40,6 +41,10 @@ damlPreprocessor mbPkgName x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = ([], x)
     | otherwise = (checkImports x ++ checkDataTypes x ++ checkModuleDefinition x, recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName x)
     where name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
+
+-- | No preprocessing. Used for generated code.
+noPreprocessor :: GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
+noPreprocessor x = ([], x)
 
 
 -- With RebindableSyntax any missing DAML import results in pretty much nothing

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -703,6 +703,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> optPackageDir
     <*> parsePkgName
     <*> optWriteIface
+    <*> pure Nothing
     <*> optHideAllPackages
     <*> many optPackage
     <*> optShakeProfiling
@@ -712,6 +713,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> (concat <$> many optGhcCustomOptions)
     <*> pure enableScenarioService
     <*> pure (optScenarioValidation $ defaultOptions Nothing)
+    <*> pure False
   where
     optImportPath :: Parser [FilePath]
     optImportPath =


### PR DESCRIPTION
This adds two compiler options (that are not user facing), ifaceDir and isGenerated to the compiler
options. These will be needed to write generated interface files to the
right directory and treat generated source files special when generating
interface files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
