### PR TITLE
Ensure that dev-env is loaded when running dev-env tools from outside

### DIFF
--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -127,6 +127,8 @@ execTool() {
   local outputName=$2
   local binary=$3
   shift 3
+  [[ $PATH =~ (^|.*:)$DADE_DEVENV_DIR/bin($|:.*) ]] || \
+    eval "$(${DADE_DEVENV_DIR}/bin/dade assist)"
   buildTool $attr $outputName 0
   exec "$(readlink "$DADE_BUILD_RESULT")/bin/$binary" "$@"
 }


### PR DESCRIPTION
This is relevant for users of the IntelliJ bazel plugin. It is common to start IntelliJ via the GUI such that the dev-env is not loaded for IntelliJ. The bazel plugin is then configured to execute the dev-env bazel by entering the path into the corresponding configuration option. However, this bazel is then executed without the dev-env tools in PATH. Some of the repository rules expect certain dev-env tools in PATH, e.g. python3. Those will then fail.

This patch fixes that by ensuring that the dev-env is loaded when executing a dev-env tool from outside.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
