### PR TITLE
damldoc: Derive missing type signatures and add links in type signatures.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -72,7 +72,7 @@ damlDocDriver cInputFormat ideOpts output cFormat prefixFile options files = do
 
     case cFormat of
             Json -> write output $ T.decodeUtf8 . BS.toStrict $ AP.encodePretty' jsonConf docData
-            Rst  -> write output $ T.concat $ map renderSimpleRst docData
+            Rst  -> write output $ renderFinish $ mconcat $ map renderSimpleRst docData
             Hoogle   -> write output $ T.concat $ map renderSimpleHoogle docData
             Markdown -> write output $ T.concat $ map renderSimpleMD docData
             Html -> sequence_

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -157,19 +157,19 @@ buildDocCtx dc_tcmod  =
 
       tythings = modInfoTyThings . tm_checked_module_info $ dc_tcmod
 
-      dc_tycons = MS.fromList . catMaybes . flip map tythings $ \case
+      dc_tycons = MS.fromList . flip mapMaybe tythings $ \case
           ATyCon tycon ->
               let typename = Typename . packName . tyConName $ tycon
               in Just (typename, tycon)
           _ -> Nothing
 
-      dc_datacons = MS.fromList . catMaybes . flip map tythings $ \case
+      dc_datacons = MS.fromList . flip mapMaybe tythings $ \case
           AConLike (RealDataCon datacon) ->
               let conname = Typename . packName . dataConName $ datacon
               in Just (conname, datacon)
           _ -> Nothing
 
-      dc_ids = MS.fromList . catMaybes . flip map tythings $ \case
+      dc_ids = MS.fromList . flip mapMaybe tythings $ \case
           AnId id ->
               let fieldname = Fieldname . packId $ id
               in Just (fieldname, id)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -24,7 +24,6 @@ import           "ghc-lib-parser" ConLike
 import           "ghc-lib-parser" DataCon
 import           "ghc-lib-parser" Id
 import           "ghc-lib-parser" Name
---import           "ghc-lib-parser" OccName
 import           "ghc-lib-parser" RdrName
 import qualified "ghc-lib-parser" Outputable                      as Out
 import qualified "ghc-lib-parser" DynFlags                        as DF

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -157,23 +157,23 @@ buildDocCtx dc_tcmod  =
 
       tythings = modInfoTyThings . tm_checked_module_info $ dc_tcmod
 
-      dc_tycons = MS.fromList . flip mapMaybe tythings $ \case
-          ATyCon tycon ->
-              let typename = Typename . packName . tyConName $ tycon
-              in Just (typename, tycon)
-          _ -> Nothing
+      dc_tycons = MS.fromList
+          [ (typename, tycon)
+          | ATyCon tycon <- tythings
+          , let typename = Typename . packName . tyConName $ tycon
+          ]
 
-      dc_datacons = MS.fromList . flip mapMaybe tythings $ \case
-          AConLike (RealDataCon datacon) ->
-              let conname = Typename . packName . dataConName $ datacon
-              in Just (conname, datacon)
-          _ -> Nothing
+      dc_datacons = MS.fromList
+          [ (conname, datacon)
+          | AConLike (RealDataCon datacon) <- tythings
+          , let conname = Typename . packName . dataConName $ datacon
+          ]
 
-      dc_ids = MS.fromList . flip mapMaybe tythings $ \case
-          AnId id ->
-              let fieldname = Fieldname . packId $ id
-              in Just (fieldname, id)
-          _ -> Nothing
+      dc_ids = MS.fromList
+          [ (fieldname, id)
+          | AnId id <- tythings
+          , let fieldname = Fieldname . packId $ id
+          ]
 
   in DocCtx {..}
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -149,9 +149,7 @@ data DeclData = DeclData
 
 buildDocCtx :: TypecheckedModule -> DocCtx
 buildDocCtx dc_tcmod  =
-  let dc_mod
-          = Modulename . T.pack . moduleNameString . moduleName
-          . ms_mod . pm_mod_summary . tm_parsed_module $ dc_tcmod
+  let dc_mod = packModule . ms_mod . pm_mod_summary . tm_parsed_module $ dc_tcmod
       dc_decls
           = map (uncurry DeclData) . collectDocs . hsmodDecls . unLoc
           . pm_parsed_source . tm_parsed_module $ dc_tcmod
@@ -487,7 +485,7 @@ tyConAnchor :: DocCtx -> TyCon -> Maybe Anchor
 tyConAnchor DocCtx{..} tycon = do
     let ghcName = tyConName tycon
         name = Typename . packName $ ghcName
-        mod = maybe dc_mod packModule (nameModule_maybe $ ghcName)
+        mod = maybe dc_mod packModule (nameModule_maybe ghcName)
         anchorFn
             | isClassTyCon tycon = classAnchor
             | isDataTyCon tycon = dataAnchor

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -5,6 +5,7 @@
 
 module DA.Daml.Doc.Render
   ( DocFormat(..)
+  , renderFinish
   , renderSimpleRst
   , renderSimpleMD
   , renderSimpleHtml

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -24,7 +24,8 @@ import CMarkGFM
 
 -- | Renderer output. This is the set of anchors that were generated, and a
 -- list of output functions that depend on that set. The goal is to prevent
--- the creation of spurious anchors links.
+-- the creation of spurious anchors links (i.e. links to anchors that don't
+-- exist).
 --
 -- (In theory this could be done in two steps, but that seems more error prone
 -- than building up both steps at the same time, and combining them at the
@@ -38,6 +39,12 @@ newtype RenderOut = RenderOut (RenderEnv, [RenderEnv -> [T.Text]])
 newtype RenderEnv = RenderEnv (Set.Set Anchor)
     deriving newtype (Semigroup, Monoid)
 
+-- | Is the anchor available in the render environment? Renderers should avoid
+-- generating links to anchors that don't actually exist.
+--
+-- One reason an anchor may be unavailable is because of a @-- | HIDE@ directive.
+-- Another possibly reason is that the anchor refers to a definition in another
+-- package (and at the moment it's not possible to link accross packages).
 renderAnchorAvailable :: RenderEnv -> Anchor -> Bool
 renderAnchorAvailable (RenderEnv anchors) anchor = Set.member anchor anchors
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -167,7 +167,7 @@ adt2rst ADTDoc{..} = mconcat $
 
 
 constr2rst ::  ADTConstr -> RenderOut
-constr2rst PrefixC{..} = mconcat $
+constr2rst PrefixC{..} = mconcat
     [ renderAnchor ac_anchor
     , renderLineDep $ \env ->
         T.unwords (enclosedIn "**" (unTypename ac_name) : map (type2rst env) ac_args)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -183,7 +183,7 @@ type2rst = f 0
             else T.concat ["`", unTypename n, " <", unAnchor anchor, "_>`_"]
 
 -- | A list of anchors to exclude because they don't appear in the stdlib docs.
--- This is a temporary approach -- missing anchors should be derived automatically
+-- This is a temporary approach -- available anchors should be derived automatically
 -- before rendering everything.
 excludedAnchors :: [Anchor]
 excludedAnchors =

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -219,7 +219,7 @@ renderTest format (name, input) expected =
   let
     renderer = case format of
                  Json -> error "Json encoder testing not done here"
-                 Rst -> renderSimpleRst
+                 Rst -> renderFinish . renderSimpleRst
                  Markdown -> renderSimpleMD
                  Html -> error "HTML testing not supported (use Markdown)"
                  Hoogle -> error "Hoogle doc testing not yet supported."

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -267,7 +267,7 @@ fileTest damlFile = do
                 let extension = takeExtension expectation
                 ref <- T.readFileUtf8 expectation
                 case extension of
-                  ".rst"  -> expectEqual extension ref $ renderSimpleRst docs
+                  ".rst"  -> expectEqual extension ref $ renderFinish $ renderSimpleRst docs
                   ".md"   -> expectEqual extension ref $ renderSimpleMD docs
                   ".json" -> expectEqual extension ref
                              (T.decodeUtf8 . BS.toStrict $

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -51,7 +51,7 @@
 
 ## Functions
 
-* `main`  
+* `main` : `Scenario` `()`  
   A single test scenario covering all functionality that `Iou` implements.
   This description contains [a link](http://example.com), some bogus <inline html>,
   and words_ with_ underscore, to test damldoc capabilities.

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -51,7 +51,7 @@
 
 ## Functions
 
-* `main` : `Scenario` `()`  
+* `main` : `Scenario` `(`  `)`  
   A single test scenario covering all functionality that `Iou` implements.
   This description contains [a link](http://example.com), some bogus <inline html>,
   and words_ with_ underscore, to test damldoc capabilities.

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
@@ -21,19 +21,19 @@ template **Iou**
        - Type
        - Description
      * - issuer
-       - Party
+       - `Party <data-da-internal-lf-party-49559_>`_
        -
      * - owner
-       - Party
+       - `Party <data-da-internal-lf-party-49559_>`_
        -
      * - currency
-       - Text
+       - `Text <data-ghc-types-text-90519_>`_
        - only 3-letter symbols are allowed
      * - amount
-       - Decimal
+       - `Decimal <data-ghc-types-decimal-21402_>`_
        - must be positive
      * - regulators
-       - [Party]
+       - [`Party <data-da-internal-lf-party-49559_>`_]
        - ``regulators`` may observe any use of the ``Iou``
 
   + **Choice Merge**
@@ -47,7 +47,7 @@ template **Iou**
          - Type
          - Description
        * - otherCid
-         - ContractId Iou
+         - `ContractId <data-da-internal-lf-contractid-51443_>`_ `Iou <data-ioutemplate-iou-71654_>`_
          - Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original ``Iou``.
   + **Choice Split**
     splits into two ``Iou``s with
@@ -61,7 +61,7 @@ template **Iou**
          - Type
          - Description
        * - splitAmount
-         - Decimal
+         - `Decimal <data-ghc-types-decimal-21402_>`_
          - must be between zero and original amount
   + **Choice Transfer**
     changes the owner
@@ -74,7 +74,7 @@ template **Iou**
          - Type
          - Description
        * - owner\_
-         - Party
+         - `Party <data-da-internal-lf-party-49559_>`_
          -
 
 
@@ -85,7 +85,9 @@ Functions
 .. _function-ioutemplate-main-13221:
 
 **main**
-  :   A single test scenario covering all functionality that ``Iou`` implements.
+  : `Scenario <data-da-internal-lf-scenario-34170_>`_ ()
+
+  A single test scenario covering all functionality that ``Iou`` implements.
   This description contains a link(http://example.com), some bogus <inline html>,
   and words\_ with\_ underscore, to test damldoc capabilities.
 

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
@@ -12,7 +12,6 @@ Templates
 
 template **Iou**
 
-
   .. list-table::
      :widths: 15 10 30
      :header-rows: 1
@@ -21,24 +20,24 @@ template **Iou**
        - Type
        - Description
      * - issuer
-       - `Party <data-da-internal-lf-party-49559_>`_
+       - Party
        -
      * - owner
-       - `Party <data-da-internal-lf-party-49559_>`_
+       - Party
        -
      * - currency
-       - `Text <data-ghc-types-text-90519_>`_
+       - Text
        - only 3-letter symbols are allowed
      * - amount
-       - `Decimal <data-ghc-types-decimal-21402_>`_
+       - Decimal
        - must be positive
      * - regulators
-       - [`Party <data-da-internal-lf-party-49559_>`_]
+       - [Party]
        - ``regulators`` may observe any use of the ``Iou``
 
   + **Choice Merge**
-    merges two "compatible" ``Iou``s
   
+    merges two "compatible" ``Iou``s
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -47,12 +46,12 @@ template **Iou**
          - Type
          - Description
        * - otherCid
-         - `ContractId <data-da-internal-lf-contractid-51443_>`_ `Iou <data-ioutemplate-iou-71654_>`_
+         - ContractId Iou
          - Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original ``Iou``.
   + **Choice Split**
+  
     splits into two ``Iou``s with
     smaller amounts
-  
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -61,11 +60,11 @@ template **Iou**
          - Type
          - Description
        * - splitAmount
-         - `Decimal <data-ghc-types-decimal-21402_>`_
+         - Decimal
          - must be between zero and original amount
   + **Choice Transfer**
-    changes the owner
   
+    changes the owner
     .. list-table::
        :widths: 15 10 30
        :header-rows: 1
@@ -74,10 +73,8 @@ template **Iou**
          - Type
          - Description
        * - owner\_
-         - `Party <data-da-internal-lf-party-49559_>`_
+         - Party
          -
-
-
 
 Functions
 ^^^^^^^^^
@@ -85,10 +82,8 @@ Functions
 .. _function-ioutemplate-main-13221:
 
 **main**
-  : `Scenario <data-da-internal-lf-scenario-34170_>`_ ()
+  : Scenario ()
 
   A single test scenario covering all functionality that ``Iou`` implements.
   This description contains a link(http://example.com), some bogus <inline html>,
   and words\_ with\_ underscore, to test damldoc capabilities.
-
-

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -1,0 +1,26 @@
+# Module Newtype
+
+
+
+## Data types
+
+### `data` `Nat`
+
+* `Nat`
+
+  | Field   | Type/Description |
+  | :------ | :----------------
+  | `unNat` | `Int` |
+
+
+
+## Functions
+
+* `mkNat` : `Int` `->` `Nat`
+* `unsafeMkNat` : `Int` `->` `Nat`
+* `zero0` : `Nat`
+* `one1` : `Nat`
+* `unNat1` : `Nat` `->` `Int`
+* `unNat2` : `Nat` `->` `Int`
+* `unNat3` : `Nat` `->` `Int`
+

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -1,0 +1,83 @@
+
+.. _module-newtype-36781:
+
+Module Newtype
+--------------
+
+
+Data types
+^^^^^^^^^^
+
+.. _type-newtype-nat-61947:
+
+data **Nat**
+
+  
+  
+  .. _constr-newtype-nat-99832:
+  
+  **Nat**
+  
+  
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - unNat
+       - Int
+       -
+
+Functions
+^^^^^^^^^
+
+.. _function-newtype-mknat-8513:
+
+**mkNat**
+  : Int -> `Nat <type-newtype-nat-61947_>`_
+
+
+
+.. _function-newtype-unsafemknat-96593:
+
+**unsafeMkNat**
+  : Int -> `Nat <type-newtype-nat-61947_>`_
+
+
+
+.. _function-newtype-zero0-10450:
+
+**zero0**
+  : `Nat <type-newtype-nat-61947_>`_
+
+
+
+.. _function-newtype-one1-53872:
+
+**one1**
+  : `Nat <type-newtype-nat-61947_>`_
+
+
+
+.. _function-newtype-unnat1-26452:
+
+**unNat1**
+  : `Nat <type-newtype-nat-61947_>`_ -> Int
+
+
+
+.. _function-newtype-unnat2-96339:
+
+**unNat2**
+  : `Nat <type-newtype-nat-61947_>`_ -> Int
+
+
+
+.. _function-newtype-unnat3-97654:
+
+**unNat3**
+  : `Nat <type-newtype-nat-61947_>`_ -> Int
+
+

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -80,3 +80,6 @@ HEAD — ongoing
   `restriction about contract key lookup
   <https://github.com/digital-asset/daml/issues/1866>`__ described in the
   DAML-LF section
+
+- [DAML Docs]: Added links to type signatures in generated docs. Check out the updated
+`the standard library docs <https://docs.daml.com/daml/reference/base.html>`__.


### PR DESCRIPTION
Finished up wiring type information in damldocs HaddockParse.

Good:

- Missing type signatures are now derived automatically.
- Anchors are available in type signatures, so I added links in the Rst renderer. See attached image:

![image](https://user-images.githubusercontent.com/231829/61142709-54861a80-a4c8-11e9-834e-9ad10f560555.png)

~~Evil:~~

- ~~Hardcoded `excludedAnchors` list in the Rst renderer, to avoid generating anchors that are missing,  otherwise Sphinx complains and stdlib doc generation fails. The list of existing anchors should be derived automatically. I have an idea of how to do this properly, and improve the renderer in the process, but it's a bit of work.~~

To avoid generating links for anchors that don't exist, I introduced a new monoid `RenderOut` in the Rst renderer, which captures the two passes necessary to do this properly. In the first pass it collects a set of generated anchors, in the second pass it generates the output.