### PR TITLE
Remove filegroup now there's only hlint.yaml

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -17,7 +17,7 @@ da_haskell_binary(
         "-optl-pthread",
     ] if is_windows else [],
     data = [
-        "//compiler/damlc/daml-ide-core:hlint-yaml",
+        "//compiler/damlc/daml-ide-core:hlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],
@@ -58,7 +58,7 @@ package_app(
     binary = ":damlc",
     resources = [
         ":ghc-pkg-dist",
-        "//compiler/damlc/daml-ide-core:hlint-yaml",
+        "//compiler/damlc/daml-ide-core:hlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -6,16 +6,12 @@ load(
     "da_haskell_library",
 )
 
-filegroup(
-    name = "hlint-yaml",
-    srcs = ["hlint.yaml"],
-    visibility = ["//visibility:public"],
-)
+exports_files(["hlint.yaml"])
 
 da_haskell_library(
     name = "daml-ide-core",
     srcs = glob(["src/**/*.hs"]),
-    data = [":hlint-yaml"],
+    data = [":hlint.yaml"],
     hazel_deps = [
         "aeson",
         "base",


### PR DESCRIPTION
Tiny PR that simplifies the packaging of `hlint.yaml`.