### PR TITLE
Improve diagnostics of hlint ideas

### DIFF
--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -27,6 +27,7 @@ da_haskell_library(
         "hashable",
         "haskell-lsp",
         "haskell-lsp-types",
+        "haskell-src-exts",
         "hlint",
         "http-types",
         "mtl",

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -549,11 +549,11 @@ getHlintDiagnosticsRule =
       srcSpanToRange :: HSE.SrcSpan -> LSP.Range
       srcSpanToRange span = Range {
           _start = LSP.Position {
-                _line = HSE.srcSpanStartLine span
-              , _character  = HSE.srcSpanStartColumn span }
+                _line = HSE.srcSpanStartLine span - 1
+              , _character  = HSE.srcSpanStartColumn span - 1}
         , _end   = LSP.Position {
-                _line = HSE.srcSpanEndLine span
-             , _character = HSE.srcSpanEndColumn span }
+                _line = HSE.srcSpanEndLine span - 1
+             , _character = HSE.srcSpanEndColumn span - 1}
         }
       diagnostic :: NormalizedFilePath -> Idea -> FileDiagnostic
       diagnostic file i =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -61,6 +61,7 @@ import qualified DA.Daml.LF.Simplifier as LF
 import qualified DA.Daml.LF.TypeChecker as LF
 import qualified DA.Pretty as Pretty
 
+import qualified Language.Haskell.Exts.SrcLoc as HSE
 import Language.Haskell.HLint4
 
 -- | Get thr URI that corresponds to a virtual resource. The VS Code has a
@@ -543,17 +544,26 @@ getHlintDiagnosticsRule =
         let modu = pm_parsed_source pm
         (classify, hint) <- useNoFile_ GetHlintSettings
         let ideas = applyHints classify hint [createModuleEx anns modu]
-        return ([toDiagnostic file i | i <- ideas, ideaSeverity i /= Ignore], Just ())
+        return ([diagnostic file i | i <- ideas, ideaSeverity i /= Ignore], Just ())
     where
-      -- To-do : Improve this.
-      toDiagnostic file i = ideHintText file (T.pack $ show i)
-      ideHintText fp msg = (fp, LSP.Diagnostic {
-         _range = noRange,
-         _severity = Just LSP.DsInfo,
-         _code = Nothing,
-         _source = Just "linter",
-         _message = msg,
-         _relatedInformation = Nothing
+      srcSpanToRange :: HSE.SrcSpan -> LSP.Range
+      srcSpanToRange span = Range {
+          _start = LSP.Position {
+                _line = HSE.srcSpanStartLine span
+              , _character  = HSE.srcSpanStartColumn span }
+        , _end   = LSP.Position {
+                _line = HSE.srcSpanEndLine span
+             , _character = HSE.srcSpanEndColumn span }
+        }
+      diagnostic :: NormalizedFilePath -> Idea -> FileDiagnostic
+      diagnostic file i =
+        (file, LSP.Diagnostic {
+              _range = srcSpanToRange $ ideaSpan i
+            , _severity = Just LSP.DsInfo
+            , _code = Nothing
+            , _source = Just "linter"
+            , _message = T.pack $ show i
+            , _relatedInformation = Nothing
       })
 
 --

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -460,7 +460,7 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
                 ]
             setFilesOfInterest [foo]
             expectNoErrors
-            expectOnlyDiagnostics [(DsInfo, (foo, 0, 0), "Suggestion: Use newtype")] -- hlint!
+            expectOnlyDiagnostics [(DsInfo, (foo, 5, 1), "Suggestion: Use newtype")] -- hlint!
             -- foo
             expectGoToDefinition (foo,1,[13..14]) (At (foo,3,0))
             -- A

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -460,7 +460,7 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
                 ]
             setFilesOfInterest [foo]
             expectNoErrors
-            expectOnlyDiagnostics [(DsInfo, (foo, 5, 1), "Suggestion: Use newtype")] -- hlint!
+            expectOnlyDiagnostics [(DsInfo, (foo, 4, 0), "Suggestion: Use newtype")] -- hlint!
             -- foo
             expectGoToDefinition (foo,1,[13..14]) (At (foo,3,0))
             -- A


### PR DESCRIPTION
This PR improves conversion of hlint ideas to file diagnostics. Particularly, the src span of the idea is now recorded.
