### PR TITLE
Eliminate the maybe in the hlint option

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -101,7 +101,6 @@ da_haskell_library(
         "haskell-lsp",
         "lens-aeson",
         "lens",
-        "listsafe",
         "memory",
         "mtl",
         "network",

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -101,6 +101,7 @@ da_haskell_library(
         "haskell-lsp",
         "lens-aeson",
         "lens",
+        "listsafe",
         "memory",
         "mtl",
         "network",

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -441,7 +441,7 @@ ofInterestRule opts = do
         -- We don’t always have a scenario service (e.g., damlc compile)
         -- so only run scenarios if we have one.
         let shouldRunScenarios = isJust envScenarioService
-        let hlintEnabled = case optHlintUsage opts of Just (HlintEnabled _) -> True ; _ -> False
+        let hlintEnabled = case optHlintUsage opts of HlintEnabled _ -> True ; HlintDisabled -> False
         let files = Set.toList scenarioFiles
         let dalfActions = [(void . getDalf) f | f <- files]
         let hlintActions = [use_ GetHlintDiagnostics f | hlintEnabled, f <- files]
@@ -529,12 +529,12 @@ hlintSettings hlintDataDir = do
     findSettings (unmask . readSettingsFile (Just hlintDataDir)) Nothing
   return (classify, hints)
 
-getHlintSettingsRule :: Maybe HlintUsage -> Rules ()
+getHlintSettingsRule :: HlintUsage -> Rules ()
 getHlintSettingsRule usage =
     defineNoFile $ \GetHlintSettings ->
       liftIO $ case usage of
-          Just (HlintEnabled dir) -> hlintSettings dir
-          _ -> fail "linter configuration unspecified"
+          HlintEnabled dir -> hlintSettings dir
+          HlintDisabled -> fail "linter configuration unspecified"
 
 getHlintDiagnosticsRule :: Rules ()
 getHlintDiagnosticsRule =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -441,7 +441,9 @@ ofInterestRule opts = do
         -- We don’t always have a scenario service (e.g., damlc compile)
         -- so only run scenarios if we have one.
         let shouldRunScenarios = isJust envScenarioService
-        let hlintEnabled = case optHlintUsage opts of HlintEnabled _ -> True ; HlintDisabled -> False
+        let hlintEnabled = case optHlintUsage opts of
+              HlintEnabled _ -> True
+              HlintDisabled -> False
         let files = Set.toList scenarioFiles
         let dalfActions = [(void . getDalf) f | f <- files]
         let hlintActions = [use_ GetHlintDiagnostics f | hlintEnabled, f <- files]

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -120,7 +120,7 @@ pattern EventVirtualResourceChanged vr doc <-
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
     hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-    options <- mkOptions $ (defaultOptions Nothing){optHlintUsage=Just(HlintEnabled hlintDataDir)}
+    options <- mkOptions $ (defaultOptions Nothing){optHlintUsage=HlintEnabled hlintDataDir}
     virtualResources <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = modifyTVar' virtualResources(Map.insert vr doc)
         eventLogger _ = pure ()

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -59,7 +59,7 @@ data Options = Options
     -- ^ Controls whether the scenario service server runs all checks
     -- or only a subset of them. This is mostly used to run additional
     -- checks on CI while keeping the IDE fast.
-  , optHlintUsage :: Maybe HlintUsage
+  , optHlintUsage :: HlintUsage
   -- ^ Information about hlint usage.
   , optIsGenerated :: Bool
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
@@ -107,8 +107,8 @@ mkOptions opts@Options {..} = do
     let mbDefaultPkgDbDir = fmap (</> "pkg-db_dir") mbDefaultPkgDb
     pkgDbs <- filterM Dir.doesDirectoryExist (toList mbDefaultPkgDbDir ++ [projectPackageDatabase])
     case optHlintUsage of
-      Just (HlintEnabled dir) -> checkDirExists dir
-      _ -> return ()
+      HlintEnabled dir -> checkDirExists dir
+      HlintDisabled -> return ()
     pure opts {optPackageDbs = map (</> versionSuffix) $ pkgDbs ++ optPackageDbs}
   where checkDirExists f =
           Dir.doesDirectoryExist f >>= \ok ->
@@ -138,7 +138,7 @@ defaultOptions mbVersion =
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
         , optScenarioValidation = ScenarioValidationFull
-        , optHlintUsage = Nothing
+        , optHlintUsage = HlintDisabled
         , optIsGenerated = False
         }
 

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -7,6 +7,7 @@ module DA.Cli.Options
 
 import qualified Data.Text           as T
 import           Data.List.Extra     (trim, splitOn)
+import qualified Data.List.Safe      (last)
 import Options.Applicative.Extended
 import Data.List
 import Data.Maybe
@@ -349,5 +350,5 @@ hlintDisabledOpt = flag' HlintDisabled
   )
 
 hlintUsageOpt :: Parser HlintUsage
-hlintUsageOpt = fmap (fromMaybe HlintDisabled) $
-  optional (hlintEnabledOpt <|> hlintDisabledOpt)
+hlintUsageOpt = fmap (fromMaybe HlintDisabled . Data.List.Safe.last) $
+  many (hlintEnabledOpt <|> hlintDisabledOpt)

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -9,6 +9,7 @@ import qualified Data.Text           as T
 import           Data.List.Extra     (trim, splitOn)
 import Options.Applicative.Extended
 import Data.List
+import Data.Maybe
 import Text.Read
 import qualified DA.Pretty           as Pretty
 import DA.Daml.Options.Types
@@ -347,5 +348,6 @@ hlintDisabledOpt = flag' HlintDisabled
     <> help "Disable hlint"
   )
 
-hlintUsageOpt :: Parser (Maybe HlintUsage)
-hlintUsageOpt = optional (hlintEnabledOpt <|> hlintDisabledOpt)
+hlintUsageOpt :: Parser HlintUsage
+hlintUsageOpt = fmap (fromMaybe HlintDisabled) $
+  optional (hlintEnabledOpt <|> hlintDisabledOpt)

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -7,8 +7,8 @@ module DA.Cli.Options
 
 import qualified Data.Text           as T
 import           Data.List.Extra     (trim, splitOn)
-import qualified Data.List.Safe      (last)
 import Options.Applicative.Extended
+import Safe (lastMay)
 import Data.List
 import Data.Maybe
 import Text.Read
@@ -350,5 +350,5 @@ hlintDisabledOpt = flag' HlintDisabled
   )
 
 hlintUsageOpt :: Parser HlintUsage
-hlintUsageOpt = fmap (fromMaybe HlintDisabled . Data.List.Safe.last) $
+hlintUsageOpt = fmap (fromMaybe HlintDisabled . lastMay) $
   many (hlintEnabledOpt <|> hlintDisabledOpt)


### PR DESCRIPTION
Eliminate the `Maybe` from the `hlintUsageOpt` parser.