### PR TITLE
Base DA.Bazel.Runfiles on bazel-runfiles

### DIFF
--- a/bazel_tools/haskell-runfiles-normalize.patch
+++ b/bazel_tools/haskell-runfiles-normalize.patch
@@ -1,0 +1,10 @@
+diff --git a/tools/runfiles/src/Bazel/Runfiles.hs b/tools/runfiles/src/Bazel/Runfiles.hs
+index 96b3aeb..665e0ee 100644
+--- a/tools/runfiles/src/Bazel/Runfiles.hs
++++ b/tools/runfiles/src/Bazel/Runfiles.hs
+@@ -189,4 +189,4 @@ parseManifest = map parseLine . lines
+   where
+     parseLine l =
+         let (key, value) = span (/= ' ') l in
+-        (key, dropWhile (== ' ') value)
++        (normalize key, normalize $ dropWhile (== ' ') value)

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -22,7 +22,6 @@ import Control.Monad.Reader
 import DA.Bazel.Runfiles
 import qualified DA.Daml.LF.Ast as LF
 import DA.Pretty (renderPretty)
-import Data.Foldable (toList)
 import Data.Maybe
 import qualified System.Directory as Dir
 import System.FilePath
@@ -103,9 +102,9 @@ basePackages = ["daml-prim", "daml-stdlib"]
 mkOptions :: Options -> IO Options
 mkOptions opts@Options {..} = do
     mapM_ checkDirExists $ optImportPath <> optPackageDbs
-    mbDefaultPkgDb <- locateRunfilesMb (mainWorkspace </> "compiler" </> "damlc" </> "pkg-db")
-    let mbDefaultPkgDbDir = fmap (</> "pkg-db_dir") mbDefaultPkgDb
-    pkgDbs <- filterM Dir.doesDirectoryExist (toList mbDefaultPkgDbDir ++ [projectPackageDatabase])
+    defaultPkgDb <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "pkg-db")
+    let defaultPkgDbDir = defaultPkgDb </> "pkg-db_dir"
+    pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDbDir, projectPackageDatabase]
     case optHlintUsage of
       HlintEnabled dir -> checkDirExists dir
       HlintDisabled -> return ()

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -381,7 +381,7 @@ createProjectPackageDb lfVersion fps = do
     ghcPkgPath <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghc-pkg")
     callCommand $
         unwords
-            [ ghcPkgPath </> "ghc-pkg"
+            [ ghcPkgPath </> exe "ghc-pkg"
             , "recache"
             -- ghc-pkg insists on using a global package db and will trie
             -- to find one automatically if we don’t specify it here.

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -31,7 +31,7 @@ main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
     damlcPath <- locateRunfiles $
-        mainWorkspace </> "compiler" </> "damlc" </> "damlc"
+        mainWorkspace </> "compiler" </> "damlc" </> exe "damlc"
     let run s = withTempDir $ \dir -> runSessionWithConfig conf (damlcPath <> " ide --scenarios=no") fullCaps dir s
         runScenarios s
             -- We are currently seeing issues with GRPC FFI calls which make everything

--- a/deps.bzl
+++ b/deps.bzl
@@ -47,6 +47,7 @@ def daml_deps():
                 "@com_github_digital_asset_daml//bazel_tools:haskell-ghci-grpc.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell_public_ghci_repl_wrapper.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell-windows-library-dirs.patch",
+                "@com_github_digital_asset_daml//bazel_tools:haskell-runfiles-normalize.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,

--- a/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
@@ -13,7 +13,7 @@ module DA.Ledger.Sandbox ( -- Run a sandbox for testing on a dynamically selecte
 
 import Control.Exception (bracket, evaluate, onException)
 import Control.Monad(when)
-import DA.Bazel.Runfiles(locateRunfiles,mainWorkspace)
+import DA.Bazel.Runfiles(exe,locateRunfiles,mainWorkspace)
 import DA.Ledger (Port (..), unPort)
 import Data.List (isInfixOf)
 import Data.List.Extra(splitOn)
@@ -33,7 +33,7 @@ selectedPort = 0 --dynamic port selection
 
 sandboxProcess :: SandboxSpec -> IO CreateProcess
 sandboxProcess SandboxSpec{dar} = do
-    binary <- locateRunfiles (mainWorkspace </> "ledger/sandbox/sandbox-binary")
+    binary <- locateRunfiles (mainWorkspace </> exe "ledger/sandbox/sandbox-binary")
     pure $ proc binary [ dar, "--port", show selectedPort]
 
 startSandboxProcess :: SandboxSpec -> IO (ProcessHandle,Maybe Handle)

--- a/libs-haskell/bazel-runfiles/BUILD.bazel
+++ b/libs-haskell/bazel-runfiles/BUILD.bazel
@@ -15,7 +15,9 @@ da_haskell_library(
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+        "@io_tweag_rules_haskell//tools/runfiles",
+    ],
 )
 
 da_haskell_test(

--- a/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
+++ b/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
@@ -23,6 +23,12 @@ exe :: FilePath -> FilePath
 exe | os == "mingw32" = (<.> "exe")
     | otherwise       = id
 
+-- | Return the resources directory for the given runfiles dependency.
+--
+-- In packaged application, using @bazel_tools/packaging/packaging.bzl@
+-- this corresponds to the top-level @resources@ directory. In a @bazel run@ or
+-- @bazel test@ target this corresponds to the @runfiles@ path of the given
+-- @data@ dependency.
 locateRunfiles :: FilePath -> IO FilePath
 locateRunfiles fp = do
   -- If the current executable was packaged using @package_app@, then

--- a/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
+++ b/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
@@ -7,15 +7,21 @@
 module DA.Bazel.Runfiles
   ( locateRunfiles
   , mainWorkspace
+  , exe
   ) where
 
 import qualified Bazel.Runfiles
 import System.Directory
 import System.Environment
 import System.FilePath
+import System.Info (os)
 
 mainWorkspace :: String
 mainWorkspace = "com_github_digital_asset_daml"
+
+exe :: FilePath -> FilePath
+exe | os == "mingw32" = (<.> "exe")
+    | otherwise       = id
 
 locateRunfiles :: FilePath -> IO FilePath
 locateRunfiles fp = do

--- a/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
+++ b/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
@@ -6,14 +6,10 @@
 -- it is simpler to have all code located here.
 module DA.Bazel.Runfiles
   ( locateRunfiles
-  , locateRunfilesMb
   , mainWorkspace
   ) where
 
-import Control.Monad.Trans.Maybe
-import Data.Foldable
-import Data.List
-import Data.List.Split (splitOn)
+import qualified Bazel.Runfiles
 import System.Directory
 import System.Environment
 import System.FilePath
@@ -22,54 +18,17 @@ mainWorkspace :: String
 mainWorkspace = "com_github_digital_asset_daml"
 
 locateRunfiles :: FilePath -> IO FilePath
-locateRunfiles target = do
-    dirOrError <- locateRunfilesMb target
-    case dirOrError of
-        Left e -> error e
-        Right d -> pure d
-
-locateRunfilesMb :: FilePath -> IO (Either String FilePath)
-locateRunfilesMb target = do
-    execPath <- getExecutablePath
-    mbDir <- runMaybeT . asum . map MaybeT $
-        [ do let jarResources = takeDirectory execPath </> "resources"
-             hasJarResources <- doesDirectoryExist jarResources
-             pure $ if hasJarResources
-                 then Just jarResources
-                 else Nothing
-        , do let runfilesDir = execPath <> ".runfiles"
-             hasTarget <- doesPathExist (runfilesDir </> target)
-             hasManifest <- doesFileExist (runfilesDir </> "MANIFEST")
-             if hasTarget
-                then pure $ Just(runfilesDir </> target)
-             else if hasManifest
-                then lookupTargetInManifestFile (runfilesDir </> "MANIFEST") target
-             else pure Nothing
-        , do mbDir <- lookupEnv "RUNFILES_DIR"
-             pure (fmap (</> target) mbDir)
-        ]
-    pure $ maybe (Left $ "Could not locate runfiles for target: " <> target) Right mbDir
-
-lookupTargetInManifestFile :: FilePath -> FilePath -> IO (Maybe FilePath)
-lookupTargetInManifestFile manifestPath target = do
-    manifestFile <- readFile manifestPath
-    let manifest = map lineToTuple (lines manifestFile)
-    let targetNormalised = intercalate "/" (splitOn "\\" (normalise target))
-    pure $ asum [findExact targetNormalised manifest, findDir targetNormalised manifest]
-
-lineToTuple :: FilePath -> (FilePath, FilePath)
-lineToTuple line = case splitOn " " line of
-    [a, b] -> (a, b)
-    _ -> error $ "Expected a line with two entries separated by space but got " <> show line
-
--- | Given a list of entries in the `MANIFEST` file, try to find an exact match for the given path.
-findExact :: FilePath -> [(FilePath, FilePath)] -> Maybe FilePath
-findExact path entries = fmap snd (find (\(k,_) -> k == path) entries)
-
--- | The `MANIFEST` file only contains file paths not directories so use this to lookup a directory.
-findDir :: FilePath -> [(FilePath, FilePath)] -> Maybe FilePath
-findDir path entries = do
-    (k, v) <- find (\(k, v) -> path `isPrefixOf` k && drop (length path) k `isSuffixOf` v) entries
-    -- The length of the file suffix after the directory
-    let fileLength = length k - length path
-    pure $ take (length v - fileLength) v
+locateRunfiles fp = do
+  -- If the current executable was packaged using @package_app@, then
+  -- data files are stored underneath the resources directory.
+  -- See @bazel_tools/packaging/packaging.bzl@.
+  -- This is based on Buck's runfiles behavior and users of locateRunfiles
+  -- expect the resources directory itself.
+  execPath <- getExecutablePath
+  let jarResources = takeDirectory execPath </> "resources"
+  hasJarResources <- doesDirectoryExist jarResources
+  if hasJarResources
+      then pure jarResources
+      else do
+          runfiles <- Bazel.Runfiles.create
+          pure $! Bazel.Runfiles.rlocation runfiles fp


### PR DESCRIPTION
Most of the functionality of `DA.Bazel.Runfiles` is now available in rules_haskell's `bazel-runfiles`. The only exception is the `resources` directory of `package_app`. With this PR `Da.Bazel.Runfiles` exposes an API similar to `bazel-runfiles` and falls back to using `bazel-runfiles` outside the `package_app` case.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
