### PR TITLE
Generate interface files from dalf

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -9,7 +9,7 @@ module DA.Daml.LF.Ast.World(
     initWorld,
     initWorldSelf,
     extendWorldSelf,
-    ExternalPackage,
+    ExternalPackage(..),
     rewriteSelfReferences,
     LookupError,
     lookupTemplate,

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -116,7 +116,7 @@ generateSrcPkgFromLf thisPkgId pkgMap pkg = do
     mod <- NM.toList $ LF.packageModules pkg
     let fp =
             toNormalizedFilePath $
-            (T.unpack $ T.intercalate "/" $ LF.unModuleName $ LF.moduleName mod) <.>
+            (joinPath $ map T.unpack $ LF.unModuleName $ LF.moduleName mod) <.>
             ".daml"
     pure ( fp
          , unlines header ++

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -90,21 +90,21 @@ generateUpgradeModule templateNames modName pkgA pkgB =
 
 upgradeTemplate :: String -> [String]
 upgradeTemplate n =
-  [ "template " <> n <> "Upgrade"
-  , "    with"
-  , "        op : Party"
-  , "    where"
-  , "        signatory op"
-  , "        nonconsuming choice Upgrade: ContractId B." <> n
-  , "            with"
-  , "                inC : ContractId A." <> n
-  , "                sigs : [Party]"
-  , "            controller sigs"
-  , "                do"
-  , "                    d <- fetch inC"
-  , "                    assert $ fromList sigs == fromList (signatory d)"
-  , "                    create $ conv d"
-  ]
+    [ "template " <> n <> "Upgrade"
+    , "    with"
+    , "        op : Party"
+    , "    where"
+    , "        signatory op"
+    , "        nonconsuming choice Upgrade: ContractId B." <> n
+    , "            with"
+    , "                inC : ContractId A." <> n
+    , "                sigs : [Party]"
+    , "            controller sigs"
+    , "                do"
+    , "                    d <- fetch inC"
+    , "                    assert $ fromList sigs == fromList (signatory d)"
+    , "                    create $ conv d"
+    ]
 
 -- | Generate the full source for a daml-lf package.
 generateSrcPkgFromLf ::
@@ -131,7 +131,7 @@ generateSrcFromLf ::
     -> MS.Map GHC.UnitId LF.PackageId
     -> LF.Module
     -> ParsedSource
-generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
+generateSrcFromLf thisPkgId pkgMap m = noLoc mod
   where
     pkgMapInv = MS.fromList $ map swap $ MS.toList pkgMap
     getUnitId :: LF.PackageRef -> UnitId
@@ -147,7 +147,7 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
             { hsmodImports = imports
             , hsmodName =
                   Just
-                      (mkNoLoc $
+                      (noLoc $
                        mkModuleName $
                        T.unpack $ LF.moduleNameString $ LF.moduleName m)
             , hsmodDecls = decls
@@ -156,12 +156,12 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
             , hsmodExports = Nothing
             }
     templateTy =
-        mkNoLoc $
+        noLoc $
         HsTyVar NoExt NotPromoted $
-        mkNoLoc $
+        noLoc $
         mkRdrQual (mkModuleName "DA.Internal.Template") $
         mkOccName varName "Template" :: LHsType GhcPs
-    sigRdrName = mkNoLoc $ mkRdrUnqual $ mkOccName varName "signatory"
+    sigRdrName = noLoc $ mkRdrUnqual $ mkOccName varName "signatory"
     decls =
         concat $ do
             LF.DefDataType {..} <- NM.toList $ LF.moduleDataTypes m
@@ -175,11 +175,11 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                     T.unpack $
                     sanitize $ T.intercalate "." $ LF.unTypeConName dataTypeCon
             let dataDecl =
-                    mkNoLoc $
+                    noLoc $
                     TyClD NoExt $
                     DataDecl
                         { tcdDExt = NoExt
-                        , tcdLName = mkNoLoc $ mkRdrUnqual $ occName
+                        , tcdLName = noLoc $ mkRdrUnqual occName
                         , tcdTyVars =
                               HsQTvs
                                   { hsq_ext = NoExt
@@ -193,17 +193,17 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                               HsDataDefn
                                   { dd_ext = NoExt
                                   , dd_ND = DataType
-                                  , dd_ctxt = mkNoLoc []
+                                  , dd_ctxt = noLoc []
                                   , dd_cType = Nothing
                                   , dd_kindSig = Nothing
                                   , dd_cons = convDataCons dataTypeCon dataCons
-                                  , dd_derivs = mkNoLoc []
+                                  , dd_derivs = noLoc []
                                   }
                         }
             -- dummy template instance to make sure we get a template instance in the interface
             -- file
             let templInstDecl =
-                    mkNoLoc $
+                    noLoc $
                     InstD NoExt $
                     ClsInstD
                         NoExt
@@ -213,13 +213,13 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                                   HsIB
                                       { hsib_ext = noExt
                                       , hsib_body =
-                                            mkNoLoc $
+                                            noLoc $
                                             HsAppTy noExt templateTy $
                                             noLoc $ convType templType
                                       }
                             , cid_binds =
                                   listToBag
-                                      [ mkNoLoc $
+                                      [ noLoc $
                                         FunBind
                                             { fun_ext = noExt
                                             , fun_id = sigRdrName
@@ -227,8 +227,8 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                                                   MG
                                                       { mg_ext = noExt
                                                       , mg_alts =
-                                                            mkNoLoc
-                                                                [ mkNoLoc $
+                                                            noLoc
+                                                                [ noLoc $
                                                                   Match
                                                                       { m_ext =
                                                                             noExt
@@ -249,12 +249,12 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                                                                                 { grhssExt =
                                                                                       noExt
                                                                                 , grhssGRHSs =
-                                                                                      [ mkNoLoc $
+                                                                                      [ noLoc $
                                                                                         GRHS
                                                                                             noExt
                                                                                             [
                                                                                             ]
-                                                                                            (mkNoLoc $
+                                                                                            (noLoc $
                                                                                              HsApp
                                                                                                  noExt
                                                                                                  (noLoc $
@@ -271,7 +271,7 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                                                                                                       "undefined template class method in generated code"))
                                                                                       ]
                                                                                 , grhssLocalBinds =
-                                                                                      noLoc $
+                                                                                      noLoc
                                                                                       emptyLocalBinds
                                                                                 }
                                                                       }
@@ -293,29 +293,29 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
     convDataCons dataTypeCon =
         \case
             LF.DataRecord fields ->
-                [ mkNoLoc $
+                [ noLoc $
                   ConDeclH98
                       { con_ext = NoExt
                       , con_name =
-                            mkNoLoc $
+                            noLoc $
                             mkRdrUnqual $
                             mkOccName dataName $
                             T.unpack $
                             sanitize $
                             T.intercalate "." $ LF.unTypeConName dataTypeCon
-                      , con_forall = mkNoLoc False
+                      , con_forall = noLoc False
                       , con_ex_tvs = []
                       , con_mb_cxt = Nothing
                       , con_doc = Nothing
                       , con_args =
                             RecCon $
-                            mkNoLoc
-                                [ mkNoLoc $
+                            noLoc
+                                [ noLoc $
                                 ConDeclField
                                     { cd_fld_ext = NoExt
                                     , cd_fld_doc = Nothing
                                     , cd_fld_names =
-                                          [ mkNoLoc $
+                                          [ noLoc $
                                             FieldOcc
                                                 { extFieldOcc = NoExt
                                                 , rdrNameFieldOcc =
@@ -323,22 +323,22 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                                                       LF.unFieldName fieldName
                                                 }
                                           ]
-                                    , cd_fld_type = mkNoLoc $ convType ty
+                                    , cd_fld_type = noLoc $ convType ty
                                     }
                                 | (fieldName, ty) <- fields
                                 ]
                       }
                 ]
             LF.DataVariant cons ->
-                [ mkNoLoc $
+                [ noLoc $
                 ConDeclH98
                     { con_ext = NoExt
                     , con_name =
-                          mkNoLoc $
+                          noLoc $
                           mkRdrUnqual $
                           mkOccName varName $
                           T.unpack $ sanitize $ LF.unVariantConName conName
-                    , con_forall = mkNoLoc False
+                    , con_forall = noLoc False
                     , con_ex_tvs = []
                     , con_mb_cxt = Nothing
                     , con_doc = Nothing
@@ -347,24 +347,24 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                               LF.TBuiltin LF.BTUnit -> PrefixCon []
                               otherTy ->
                                   PrefixCon
-                                      [ mkNoLoc $
+                                      [ noLoc $
                                         HsParTy
                                             NoExt
-                                            (mkNoLoc $ convType otherTy)
+                                            (noLoc $ convType otherTy)
                                       ]
                     }
                 | (conName, ty) <- cons
                 ]
             LF.DataEnum cons ->
-                [ mkNoLoc $
+                [ noLoc $
                 ConDeclH98
                     { con_ext = NoExt
                     , con_name =
-                          mkNoLoc $
+                          noLoc $
                           mkRdrUnqual $
                           mkOccName varName $
                           T.unpack $ sanitize $ LF.unVariantConName conName
-                    , con_forall = mkNoLoc False
+                    , con_forall = noLoc False
                     , con_ex_tvs = []
                     , con_mb_cxt = Nothing
                     , con_doc = Nothing
@@ -372,11 +372,11 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                     }
                 | conName <- cons
                 ]
-    mkRdrName = mkNoLoc . mkRdrUnqual . mkOccName varName . T.unpack
+    mkRdrName = noLoc . mkRdrUnqual . mkOccName varName . T.unpack
     mkUserTyVar :: T.Text -> LHsTyVarBndr GhcPs
     mkUserTyVar =
-        mkNoLoc .
-        UserTyVar NoExt . mkNoLoc . mkRdrUnqual . mkOccName tvName . T.unpack
+        noLoc .
+        UserTyVar NoExt . noLoc . mkRdrUnqual . mkOccName tvName . T.unpack
     convType :: LF.Type -> HsType GhcPs
     convType =
         \case
@@ -385,7 +385,7 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                 mkRdrName $ LF.unTypeVarName tyVarName
             LF.TCon LF.Qualified {..} ->
                 HsTyVar NoExt NotPromoted $
-                mkNoLoc $
+                noLoc $
                 mkOrig
                     (mkModule
                          (getUnitId qualPackage)
@@ -394,19 +394,19 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
                     (mkOccName varName $
                      T.unpack $ T.intercalate "." $ LF.unTypeConName qualObject)
             LF.TApp ty1 ty2 ->
-                HsAppTy NoExt (mkNoLoc $ convType ty1) (mkNoLoc $ convType ty2)
+                HsAppTy NoExt (noLoc $ convType ty1) (noLoc $ convType ty2)
             LF.TBuiltin builtinTy -> convBuiltInTy builtinTy
             LF.TForall {..} ->
                 HsForAllTy
                     NoExt
                     [mkUserTyVar $ LF.unTypeVarName $ fst forallBinder]
-                    (mkNoLoc $ convType forallBody)
+                    (noLoc $ convType forallBody)
             -- TODO (drsk): Is this the correct tuple type? What about the field names?
             LF.TTuple fls ->
                 HsTupleTy
                     NoExt
                     HsBoxedTuple
-                    [mkNoLoc $ convType ty | (_fldName, ty) <- fls]
+                    [noLoc $ convType ty | (_fldName, ty) <- fls]
     convBuiltInTy :: LF.BuiltinType -> HsType GhcPs
     convBuiltInTy =
         \case
@@ -427,29 +427,29 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
             LF.BTArrow -> mkTyConType funTyCon
     mkGhcType =
         HsTyVar NoExt NotPromoted .
-        mkNoLoc . mkOrig gHC_TYPES . mkOccName varName
+        noLoc . mkOrig gHC_TYPES . mkOccName varName
     damlStdlibUnitId = stringToUnitId "daml-stdlib"
     mkLfInternalType =
         HsTyVar NoExt NotPromoted .
-        mkNoLoc .
+        noLoc .
         mkOrig (mkModule damlStdlibUnitId $ mkModuleName "DA.Internal.LF") .
         mkOccName varName
     mkLfInternalPrelude =
         HsTyVar NoExt NotPromoted .
-        mkNoLoc .
+        noLoc .
         mkOrig (mkModule damlStdlibUnitId $ mkModuleName "DA.Internal.Prelude") .
         mkOccName varName
     mkTyConType :: TyCon -> HsType GhcPs
     mkTyConType tyCon =
         let name = getName tyCon
-         in HsTyVar NoExt NotPromoted . mkNoLoc $
+         in HsTyVar NoExt NotPromoted . noLoc $
             mkOrig (nameModule name) (occName name)
     mkGhcPrimImport :: Bool -> String -> LImportDecl GhcPs
-    mkGhcPrimImport qualified  modName =  mkNoLoc $
+    mkGhcPrimImport qualified  modName =  noLoc $
            ImportDecl
                { ideclExt = NoExt
                , ideclSourceSrc = NoSourceText
-               , ideclName = mkNoLoc $ mkModuleName modName
+               , ideclName = noLoc $ mkModuleName modName
                , ideclPkgQual =
                      Just $ StringLiteral NoSourceText $ mkFastString "daml-prim"
                , ideclSource = False
@@ -465,12 +465,12 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
         -- qualified imports from daml-prim
         map (mkGhcPrimImport False) ["Data.String"] ++
         -- unqualified importts from daml-prim
-        [ mkNoLoc $
+        [ noLoc $
         ImportDecl
             { ideclExt = NoExt
             , ideclSourceSrc = NoSourceText
             , ideclName =
-                  mkNoLoc $ mkModuleName $ T.unpack $ LF.moduleNameString modRef
+                  noLoc $ mkModuleName $ T.unpack $ LF.moduleNameString modRef
             , ideclPkgQual =
                   Just $ StringLiteral NoSourceText $ unitIdFS $ getUnitId pkgRef
             , ideclSource = False
@@ -485,4 +485,3 @@ generateSrcFromLf thisPkgId pkgMap m = mkNoLoc mod
         , pkgId /= thisPkgId
         ]
         -- imports needed by the module declarations
-    mkNoLoc = L noSrcSpan

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -7,7 +7,11 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Set up the GHC monad in a way that works for us
-module DA.Daml.Options(toCompileOpts) where
+module DA.Daml.Options
+    ( toCompileOpts
+    , generatePackageState
+    , PackageDynFlags(..)
+    ) where
 
 import Control.Monad
 import qualified CmdLineParser as Cmd (warnMsg)

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -700,22 +700,15 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                 let dar = toArchive $ BSL.fromStrict bytes
                 -- get the main pkg
                 manifest <- getEntry "META-INF/MANIFEST.MF" dar
-                mainDalfPath <-
-                    maybe
-                        (ioError $
-                         userError
-                             "Missing Main-Dalf entry in META-INF/MANIFEST.MF")
-                        pure $
-                    headMay
-                        [ main
-                        | l <-
-                              lines $
-                              BSC.unpack $ BSL.toStrict $ fromEntry manifest
-                        , Just main <- [stripPrefix "Main-Dalf: " l]
-                        ]
+                let mainDalfPath =
+                        headNote
+                            "Missing Main-Dalf entry in META-INF/MANIFEST.MF"
+                            [ main
+                            | l <- lines $ BSC.unpack $ BSL.toStrict $ fromEntry manifest
+                            , Just main <- [stripPrefix "Main-Dalf: " l]
+                            ]
                 mainDalfEntry <- getEntry mainDalfPath dar
-                (mainPkgId, mainLfPkg) <-
-                    decode $ BSL.toStrict $ fromEntry mainDalfEntry
+                (mainPkgId, mainLfPkg) <- decode $ BSL.toStrict $ fromEntry mainDalfEntry
                 pure (pkgName, mainPkgId, mainLfPkg)
         -- generate upgrade modules and instances modules
         let eqModNames =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -639,7 +639,7 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                 | (unitId, dalfPkg) <- MS.toList pkgMap
                 , LF.ExternalPackage _ dalf <- [dalfPackagePkg dalfPkg]
                 ]
-      -- order the packages in topological order
+        -- order the packages in topological order
         packageState <-
             generatePackageState (dbPath : optPackageDbs opts) False []
         let (depGraph, vertexToNode, _keyToVertex) =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -698,7 +698,7 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                 bytes <- B.readFile inFile
                 let pkgName = takeBaseName inFile
                 let dar = toArchive $ BSL.fromStrict bytes
-              -- get the main pkg
+                -- get the main pkg
                 manifest <- getEntry "META-INF/MANIFEST.MF" dar
                 mainDalfPath <-
                     maybe

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -717,7 +717,7 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                 (mainPkgId, mainLfPkg) <-
                     decode $ BSL.toStrict $ fromEntry mainDalfEntry
                 pure (pkgName, mainPkgId, mainLfPkg)
-      -- generate upgrade modules and instances modules
+        -- generate upgrade modules and instances modules
         let eqModNames =
                 (NM.names $ LF.packageModules lfPkg1) `intersect`
                 (NM.names $ LF.packageModules lfPkg2)

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -26,6 +26,7 @@ import qualified DA.Pretty
 import DA.Daml.Compiler.Dar
 import DA.Daml.Compiler.Scenario
 import DA.Daml.Compiler.Upgrade
+import DA.Daml.Options
 import DA.Daml.Options.Types
 import DA.Daml.LanguageServer
 import qualified DA.Daml.LF.Ast as LF
@@ -72,6 +73,12 @@ import DA.Cli.Visual
 import Data.List
 import qualified Data.NameMap as NM
 import qualified Data.Map.Strict as MS
+import "ghc-lib-parser" DynFlags
+import "ghc-lib-parser" Module
+import Data.Graph
+import Development.IDE.GHC.Util
+import Development.IDE.Core.Rules
+import "ghc-lib-parser" Packages
 
 --------------------------------------------------------------------------------
 -- Commands
@@ -218,7 +225,8 @@ cmdMigrate numProcessors =
   where
     cmd =
         execMigrate
-        <$> optionsParser
+        <$> projectOpts "daml damlc migrate"
+        <*> optionsParser
             numProcessors
             (EnableScenarioService False)
             (Just <$> packageNameOpt)
@@ -603,68 +611,156 @@ execInspectDar inFile = do
             show (LF.unPackageId pkgId)
 
 execMigrate ::
-       Options -> FilePath -> FilePath -> Maybe FilePath -> Command
-execMigrate opts inFile1 inFile2 mbDir = do
+       ProjectOpts
+    -> Options
+    -> FilePath
+    -> FilePath
+    -> Maybe FilePath
+    -> Command
+execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
+    opts <- mkOptions opts0
+    inFile1 <- makeAbsolute inFile1_
+    inFile2 <- makeAbsolute inFile2_
     loggerH <- getLogger opts "migrate"
-    [(pkgName1, pkgId1, lfPkg1, pkgMap1), (pkgName2, pkgId2, lfPkg2, pkgMap2)] <-
-        forM [inFile1, inFile2] $ \inFile -> do
-            let pkg = takeBaseName inFile
-            bytes <- B.readFile inFile
-            let dar = toArchive $ BSL.fromStrict bytes
-            manifest <- getEntry "META-INF/MANIFEST.MF" dar
-            mainDalfPath <-
-                maybe (ioError $ userError "Missing Main-Dalf entry in META-INF/MANIFEST.MF") pure $
-                headMay
-                    [ main
-                    | l <-
-                          lines $ BSC.unpack $ BSL.toStrict $ fromEntry manifest
-                    , Just main <- [stripPrefix "Main-Dalf: " l]
-                    ]
-            mainDalf <- BSL.toStrict . fromEntry <$> getEntry mainDalfPath dar
-            (pkgId, lfPkg) <-
-                errorOnLeft
-                    ("Cannot decode package " <> mainDalfPath)
-                    (Archive.decodeArchive mainDalf)
-            pkgMap <- generatePkgMap loggerH dar
-            pure (pkg, pkgId, lfPkg, pkgMap)
-    let eqModNames =
-            (NM.names $ LF.packageModules lfPkg1) `intersect`
-            (NM.names $ LF.packageModules lfPkg2)
-    forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
-        [genSrc1, genSrc2] <-
-            forM [(pkgId1, lfPkg1, pkgMap1), (pkgId2, lfPkg2, pkgMap2)] $ \(pkgId, pkg, pkgMap) -> do
-                generateSrcFromLf pkgId pkgMap <$> getModule m pkg
-        let upgradeModPath =
-                (joinPath $ fromMaybe "" mbDir : map T.unpack modName) <>
-                ".daml"
-        let instancesModPath1 =
-                replaceBaseName upgradeModPath $
-                takeBaseName upgradeModPath <> "InstancesA"
-        let instancesModPath2 =
-                replaceBaseName upgradeModPath $
-                takeBaseName upgradeModPath <> "InstancesB"
-        templateNames <-
-            map (T.unpack . T.intercalate "." . LF.unTypeConName) .
-            NM.names . LF.moduleTemplates <$>
-            getModule m lfPkg1
-        let generatedUpgradeMod =
-                generateUpgradeModule
-                    templateNames
-                    (T.unpack $ LF.moduleNameString m)
-                    pkgName1
-                    pkgName2
-        let generatedInstancesMod1 =
-                generateGenInstancesModule "A" (pkgName1, genSrc1)
-        let generatedInstancesMod2 =
-                generateGenInstancesModule "B" (pkgName2, genSrc2)
-        forM_
-            [ (upgradeModPath, generatedUpgradeMod)
-            , (instancesModPath1, generatedInstancesMod1)
-            , (instancesModPath2, generatedInstancesMod2)
-            ] $ \(path, mod) -> do
-            createDirectoryIfMissing True $ takeDirectory path
-            writeFile path mod
+    -- initialise the package database
+    execInit (optDamlLfVersion opts) projectOpts (InitPkgDb True)
+    withProjectRoot' projectOpts $ \_relativize
+     -> do
+        -- for all contained dalfs, generate source, typecheck and generate interface files and
+        -- overwrite the existing ones.
+        dbPath <- makeAbsolute $
+                projectPackageDatabase </>
+                lfVersionString (optDamlLfVersion opts)
+        (diags, pkgMap) <- generatePackageMap [dbPath]
+        unless (null diags) $ Logger.logWarning loggerH $ showDiagnostics diags
+        let pkgMap0 = MS.map dalfPackageId pkgMap
+        let genSrcs =
+                [ ( unitId
+                  , generateSrcPkgFromLf (dalfPackageId dalfPkg) pkgMap0 dalf)
+                | (unitId, dalfPkg) <- MS.toList pkgMap
+                , LF.ExternalPackage _ dalf <- [dalfPackagePkg dalfPkg]
+                ]
+      -- order the packages in topological order
+        packageState <-
+            generatePackageState (dbPath : optPackageDbs opts) False []
+        let (depGraph, vertexToNode, _keyToVertex) =
+                graphFromEdges $ do
+                    (uid, src) <- genSrcs
+                    let iuid = toInstalledUnitId uid
+                    Just pkgInfo <-
+                        [ lookupInstalledPackage
+                              (fakeDynFlags
+                                   {pkgState = pdfPkgState packageState})
+                              iuid
+                        ]
+                    pure (src, iuid, depends pkgInfo)
+        let unitIdsTopoSorted = reverse $ topSort depGraph
+        createDirectoryIfMissing True genDir
+        projectPkgDb <- makeAbsolute projectPackageDatabase
+        forM_ unitIdsTopoSorted $ \vertex -> withCurrentDirectory genDir $ do
+            let (src, iuid, _) = vertexToNode vertex
+            unless
+                -- TODO (drsk) remove this filter
+                (iuid `elem`
+                 map stringToInstalledUnitId ["daml-prim", "daml-stdlib"]) $ do
+                  -- typecheck and generate interface files
+                  forM_ src $ \(fp, content) -> do
+                      let path = fromNormalizedFilePath fp
+                      createDirectoryIfMissing True $ takeDirectory path
+                      writeFile path content
+                  opts' <-
+                      mkOptions $
+                      opts
+                          { optWriteInterface = True
+                          , optPackageDbs = [projectPkgDb]
+                          , optIfaceDir =
+                                Just
+                                    (dbPath </> installedUnitIdString iuid)
+                          , optIsGenerated = True
+                          , optMbPackageName =
+                                Just $ installedUnitIdString iuid
+                          }
+                  withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
+                      forM_ src $ \(fp, _content) -> do
+                          mbCore <-
+                              runAction ide $
+                              getGhcCore fp
+                          case mbCore of
+                              Nothing ->
+                                  ioError $
+                                  userError $
+                                  "Compilation of generated source for " <>
+                                  (installedUnitIdString iuid) <>
+                                  " failed."
+                              Just _core -> pure ()
+        -- get the package name and the lf-package
+        [(pkgName1, pkgId1, lfPkg1), (pkgName2, pkgId2, lfPkg2)] <-
+            forM [inFile1, inFile2] $ \inFile -> do
+                bytes <- B.readFile inFile
+                let pkgName = takeBaseName inFile
+                let dar = toArchive $ BSL.fromStrict bytes
+              -- get the main pkg
+                manifest <- getEntry "META-INF/MANIFEST.MF" dar
+                mainDalfPath <-
+                    maybe
+                        (ioError $
+                         userError
+                             "Missing Main-Dalf entry in META-INF/MANIFEST.MF")
+                        pure $
+                    headMay
+                        [ main
+                        | l <-
+                              lines $
+                              BSC.unpack $ BSL.toStrict $ fromEntry manifest
+                        , Just main <- [stripPrefix "Main-Dalf: " l]
+                        ]
+                mainDalfEntry <- getEntry mainDalfPath dar
+                (mainPkgId, mainLfPkg) <-
+                    decode $ BSL.toStrict $ fromEntry mainDalfEntry
+                pure (pkgName, mainPkgId, mainLfPkg)
+      -- generate upgrade modules and instances modules
+        let eqModNames =
+                (NM.names $ LF.packageModules lfPkg1) `intersect`
+                (NM.names $ LF.packageModules lfPkg2)
+        forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
+            [genSrc1, genSrc2] <-
+                forM [(pkgId1, lfPkg1), (pkgId2, lfPkg2)] $ \(pkgId, pkg) -> do
+                    generateSrcFromLf pkgId pkgMap0 <$> getModule m pkg
+            let upgradeModPath =
+                    (joinPath $ fromMaybe "" mbDir : map T.unpack modName) <>
+                    ".daml"
+            let instancesModPath1 =
+                    replaceBaseName upgradeModPath $
+                    takeBaseName upgradeModPath <> "InstancesA"
+            let instancesModPath2 =
+                    replaceBaseName upgradeModPath $
+                    takeBaseName upgradeModPath <> "InstancesB"
+            templateNames <-
+                map (T.unpack . T.intercalate "." . LF.unTypeConName) .
+                NM.names . LF.moduleTemplates <$>
+                getModule m lfPkg1
+            let generatedUpgradeMod =
+                    generateUpgradeModule
+                        templateNames
+                        (T.unpack $ LF.moduleNameString m)
+                        pkgName1
+                        pkgName2
+            let generatedInstancesMod1 =
+                    generateGenInstancesModule "A" (pkgName1, genSrc1)
+            let generatedInstancesMod2 =
+                    generateGenInstancesModule "B" (pkgName2, genSrc2)
+            forM_
+                [ (upgradeModPath, generatedUpgradeMod)
+                , (instancesModPath1, generatedInstancesMod1)
+                , (instancesModPath2, generatedInstancesMod2)
+                ] $ \(path, mod) -> do
+                createDirectoryIfMissing True $ takeDirectory path
+                writeFile path mod
   where
+    decode dalf =
+        errorOnLeft
+            ("Cannot decode daml-lf archive")
+            (Archive.decodeArchive dalf)
     getEntry fp dar =
         maybe (ioError $ userError $ "Package does not contain " <> fp) pure $
         findEntryByPath fp dar
@@ -675,12 +771,6 @@ execMigrate opts inFile1 inFile2 mbDir = do
              T.unpack $ "Can't find module" <> LF.moduleNameString modName)
             pure $
         NM.lookup modName $ LF.packageModules pkg
-    generatePkgMap logH dar =
-        withTempDir $ \tmpDir -> do
-            extractFilesFromArchive [OptDestination tmpDir] dar
-            (diags, pkgMap) <- generatePackageMap [tmpDir]
-            unless (null diags) $ Logger.logWarning logH $ showDiagnostics diags
-            pure $ MS.map dalfPackageId pkgMap
 
 --------------------------------------------------------------------------------
 -- main

--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -553,7 +553,9 @@ runMigrate targetFolder pkgPath1 pkgPath2
          [ "damlc"
          , "migrate"
          , "--srcdir"
-         , targetFolder </> "daml"
+         , "daml"
+         , "--project-root"
+         , targetFolder
          , "upgrade-pkg"
          , pkgPath1
          , pkgPath2


### PR DESCRIPTION
We switch upgrade module generation from reading the source in a dar archive to generating interface files from the contained dalf files to become independent of compiler versions. We do so by generating source from dalf files and typecheck those. There are still some problems with source generation, this is why we're excluding daml-stdlib and daml-prim from source generation for now. This will be addressed in the next PR. 

There's a bit of re-formatting going that I tried to put mainly in the last commit.

###Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
