### PR TITLE
damldocs: Anchors and type signature links for markdown output.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -170,6 +170,12 @@ filegroup(
     visibility = ["__pkg__"],
 )
 
+filegroup(
+    name = "daml-base-md-prefix",
+    srcs = ["base-md-prefix.md"],
+    visibility = ["__pkg__"],
+)
+
 genrule(
     name = "daml-prim-json-docs",
     srcs = ["//compiler/damlc/daml-prim-src"],
@@ -234,6 +240,26 @@ genrule(
             --input-format=json \
             --format=Rst \
             --prefix=$(location :daml-base-rst-prefix) \
+            $(location :daml-stdlib.json) $(location :daml-prim.json)
+    """,
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "daml-base-md-docs",
+    srcs = [
+        ":daml-prim.json",
+        ":daml-stdlib.json",
+        ":daml-base-md-prefix",
+    ],
+    outs = ["daml-base.md"],
+    cmd = """
+        $(location //compiler/damlc) -- docs \
+            --output=$(OUTS) \
+            --input-format=json \
+            --format=Markdown \
+            --prefix=$(location :daml-base-md-prefix) \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
     """,
     tools = ["//compiler/damlc"],

--- a/compiler/damlc/base-md-prefix.md
+++ b/compiler/damlc/base-md-prefix.md
@@ -1,0 +1,14 @@
+
+# The standard library
+
+The DAML standard library is a collection of DAML modules that can be used to implement concrete applications.
+
+## Usage
+
+The standard library is included in the DAML compiler so it can
+be used straight out of the box. You can import modules from the standard library just like your own, for example:
+
+```
+import DA.Optional
+import DA.Time
+```

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -72,9 +72,9 @@ damlDocDriver cInputFormat ideOpts output cFormat prefixFile options files = do
 
     case cFormat of
             Json -> write output $ T.decodeUtf8 . BS.toStrict $ AP.encodePretty' jsonConf docData
-            Rst  -> write output $ renderFinish $ mconcat $ map renderSimpleRst docData
-            Hoogle   -> write output $ T.concat $ map renderSimpleHoogle docData
-            Markdown -> write output $ T.concat $ map renderSimpleMD docData
+            Rst  -> write output . renderFinish . mconcat $ map renderSimpleRst docData
+            Hoogle   -> write output . T.concat $ map renderSimpleHoogle docData
+            Markdown -> write output . renderFinish . mconcat $ map renderSimpleMD docData
             Html -> sequence_
                 [ write (output </> hyphenated (unModulename md_name) <> ".html") $ renderSimpleHtml m
                 | m@ModuleDoc{..} <- docData ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -13,6 +13,7 @@ module DA.Daml.Doc.Render
   , jsonConf
   ) where
 
+import DA.Daml.Doc.Render.Monoid
 import DA.Daml.Doc.Render.Rst
 import DA.Daml.Doc.Render.Markdown
 import DA.Daml.Doc.Render.Hoogle

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -42,7 +42,7 @@ data DocFormat = Json | Rst | Markdown | Html | Hoogle
 -- | Html renderer, using cmark-gfm
 renderSimpleHtml :: ModuleDoc -> T.Text
 renderSimpleHtml m@ModuleDoc{..} =
-  wrapHtml t $ GFM.commonmarkToHtml [] [GFM.extTable] $ renderSimpleMD m
+  wrapHtml t $ GFM.commonmarkToHtml [] [GFM.extTable] $ renderFinish $ renderSimpleMD m
   where t = "Module " <> unModulename md_name
 
 wrapHtml :: T.Text -> T.Text -> T.Text

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -94,7 +94,7 @@ cls2md ClassDoc{..} = mconcat
         , " where**"
         ]
     , renderDocText cl_descr
-    , mconcatMap fct2md cl_functions
+    , renderPrefix "> " $ mconcatMap fct2md cl_functions
     ]
 
 adt2md :: ADTDoc -> RenderOut
@@ -104,15 +104,6 @@ adt2md TypeSynDoc{..} = mconcat
     , renderLineDep $ \env -> T.concat ["  =  ", type2md env ad_rhs]
     , renderDocText ad_descr
     ]
-      -- renderLineDep $ \env -> T.concat
-      --   [ "**type "
-      --   , tag
-      --   , T.unwords (unTypename ad_name : ad_args)
-      --   , " = "
-      --   , type2md env ad_rhs
-      --   , "**"
-      --   ]
-
 
 adt2md ADTDoc{..} = mconcat
     [ renderAnchorInfix "**data " ad_anchor $
@@ -200,7 +191,7 @@ fct2md FunctionDoc{..} = mconcat
     [ renderAnchorInfix "" fct_anchor $ T.concat
         [ "**", escapeMd $ unFieldname fct_name, "**  " ]
     , renderLinesDep $ \env ->
-        maybe [""] (\t -> ["  : " <> type2md env t, ""]) fct_type
+        maybe [] (\t -> ["\\ \\ : " <> type2md env t]) fct_type
     , renderDocText fct_descr
     ]
 ------------------------------------------------------------
@@ -213,4 +204,4 @@ escapeMd = T.pack . concatMap escapeChar . T.unpack
         | shouldEscape c = ['\\', c]
         | otherwise = [c]
 
-    shouldEscape = (`elem` ("[]*_~`<>\\" :: String))
+    shouldEscape = (`elem` ("[]*_~`<>\\&" :: String))

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -101,7 +101,7 @@ adt2md :: ADTDoc -> RenderOut
 adt2md TypeSynDoc{..} = mconcat
     [ renderAnchorInfix "**type " ad_anchor $
         escapeMd (T.unwords (unTypename ad_name : ad_args)) <> "**  "
-    , renderLineDep $ \env -> T.concat ["  =  ", type2md env ad_rhs]
+    , renderLineDep $ \env -> T.concat ["&nbsp; = ", type2md env ad_rhs]
     , renderDocText ad_descr
     ]
 
@@ -191,7 +191,7 @@ fct2md FunctionDoc{..} = mconcat
     [ renderAnchorInfix "" fct_anchor $ T.concat
         [ "**", escapeMd $ unFieldname fct_name, "**  " ]
     , renderLinesDep $ \env ->
-        maybe [] (\t -> ["\\ \\ : " <> type2md env t]) fct_type
+        maybe [] (\t -> ["&nbsp; : " <> type2md env t]) fct_type
     , renderDocText fct_descr
     ]
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -9,98 +9,133 @@ module DA.Daml.Doc.Render.Markdown
 
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Render.Util
+import DA.Daml.Doc.Render.Monoid
 
 import           Data.Maybe
 import qualified Data.Text as T
-import           Data.List (intersperse)
+import Data.List.Extra
 
-renderSimpleMD :: ModuleDoc -> T.Text
+
+-- | Declare anchor and generate HTML tag to insert in renderer output.
+withAnchorTag :: Maybe Anchor -> (T.Text -> RenderOut) -> RenderOut
+withAnchorTag Nothing fn = fn ""
+withAnchorTag (Just anchor) fn = mconcat
+    [ renderDeclareAnchor anchor
+    , fn $ T.concat ["<a name=\"", unAnchor anchor, "\"></a>"]
+    ]
+
+-- | Declare anchor and output HTML tag between two pieces of text.
+renderAnchorInfix :: T.Text -> Maybe Anchor ->  T.Text -> RenderOut
+renderAnchorInfix pre anchor post =
+    withAnchorTag anchor (\tag -> renderLine $ T.concat [ pre, tag, post ])
+
+-- | Render doc text. If Nothing, renders an empty line. If Just, renders
+-- doc text block between two empty lines.
+renderDocText :: Maybe DocText -> RenderOut
+renderDocText Nothing = renderLine ""
+renderDocText (Just (DocText d)) = renderLines ("" : T.lines d ++ [""])
+
+renderSimpleMD :: ModuleDoc -> RenderOut
 renderSimpleMD ModuleDoc{..}
   | null md_templates && null md_classes &&
     null md_adts && null md_functions &&
-    isNothing md_descr = T.empty
-renderSimpleMD ModuleDoc{..} = T.unlines $
-  [ "# " <> "Module " <> unModulename md_name
-  , ""
-  , maybe "" unDocText md_descr
-  , "" ]
-  <> concat
-  [ if null md_templates then []
-    else [ "## Templates"
-         , ""
-         , T.unlines $ map tmpl2md md_templates
-         , "" ]
-  , if null md_classes
-    then []
-    else [ "## Typeclasses"
-         , ""
-         , T.unlines $ map cls2md md_classes
-         , ""
-         ]
-  , if null md_adts then []
-    else [ "## Data types"
-         , ""
-         , T.unlines $ map adt2md md_adts
-         , "" ]
-  , if null md_functions then []
-    else [ "## Functions"
-         , ""
-         , T.unlines $ map fct2md md_functions
-         ]
-  ]
-
-
-tmpl2md :: TemplateDoc -> T.Text
-tmpl2md TemplateDoc{..} = T.unlines $
-    [ "### Template " <> asCode (unTypename td_name)
-    , maybe "" (T.cons '\n' . unDocText) td_descr
-    , ""
-    , fieldTable td_payload
-    , ""
-    , "  #### Choices"
-    , ""
-    ] ++ map choiceBullet td_choices -- ends by "\n" because of unlines above
-
+    isNothing md_descr = mempty
+renderSimpleMD ModuleDoc{..} = mconcat
+    [ renderAnchorInfix "# " md_anchor ("Module " <> escapeMd (unModulename md_name))
+    , renderDocText md_descr
+    , section "Templates" tmpl2md md_templates
+    , section "Typeclasses" cls2md md_classes
+    , section "Data types" adt2md md_adts
+    , section "Functions" fct2md md_functions
+    ]
   where
-    choiceBullet :: ChoiceDoc -> T.Text
-    choiceBullet ChoiceDoc{..} = T.unlines
-        [ prefix "* " $ asCode (unTypename cd_name)
-        , maybe "  " (flip T.snoc '\n' . indent 2 . unDocText) cd_descr
-        , indent 2 (fieldTable cd_fields)
+    section :: T.Text -> (a -> RenderOut) -> [a] -> RenderOut
+    section _ _ [] = mempty
+    section sectionTitle f xs = mconcat
+        [ renderLines
+            [ "## " <> sectionTitle
+            , ""
+            ]
+        , mconcatMap f xs
+        , renderLine ""
         ]
 
-cls2md :: ClassDoc -> T.Text
-cls2md ClassDoc{..} = T.unlines $
-    [ "### `class` "
-        <> maybe "" (\x -> type2md x <> " => ") cl_super
-        <> T.unwords (unTypename cl_name : cl_args)
-        <> " where"
-    , maybe "" (T.cons '\n' . indent 2 . unDocText) cl_descr
-    ] ++ map (indent 2 . fct2md) cl_functions
 
-adt2md :: ADTDoc -> T.Text
-adt2md TypeSynDoc{..} = T.unlines $
-    [ "### `type` "
-        <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
-    , "    = " <> type2md ad_rhs
-    ] ++ maybe [] ((:[]) . T.cons '\n' . indent 2 . unDocText) ad_descr
+tmpl2md :: TemplateDoc -> RenderOut
+tmpl2md TemplateDoc{..} = mconcat
+    [ renderAnchorInfix "### " td_anchor ("Template " <> escapeMd (unTypename td_name))
+    , renderDocText td_descr
+    , fieldTable td_payload
+    , if null td_choices
+        then mempty
+        else mconcat
+            [ renderLines ["", "Choices:", ""]
+            , mconcatMap choiceBullet td_choices
+            ]
+    ]
+  where
+    choiceBullet :: ChoiceDoc -> RenderOut
+    choiceBullet ChoiceDoc{..} = mconcat
+        [ renderLine ("* " <> escapeMd (unTypename cd_name))
+        , renderIndent 2 $ mconcat
+            [ renderDocText cd_descr
+            , fieldTable cd_fields
+            ]
+        ]
 
-adt2md ADTDoc{..} = T.unlines $
-    [ "### `data` "
-        <> asCode (unTypename ad_name <> (T.concat $ map (T.cons ' ') ad_args))
-    , maybe T.empty (T.cons '\n' . indent 2 . unDocText) ad_descr
-    ] ++ map constrMdItem ad_constrs
+cls2md :: ClassDoc -> RenderOut
+cls2md ClassDoc{..} = mconcat
+    [ renderAnchorInfix "### " cl_anchor ("Class " <> escapeMd (unTypename cl_name))
+    , renderLine ""
+    , renderLineDep $ \env -> T.concat
+        [ "**class "
+        , maybe "" (\x -> type2md env x <> " => ") cl_super
+        , escapeMd $ T.unwords (unTypename cl_name : cl_args)
+        , " where**"
+        ]
+    , renderDocText cl_descr
+    , mconcatMap fct2md cl_functions
+    ]
 
-constrMdItem :: ADTConstr -> T.Text
-constrMdItem PrefixC{..} =
-  ("* " <> T.unwords (asCode (unTypename ac_name) : map type2md ac_args))
-  <> maybe T.empty (T.cons '\n' . indent 2 . unDocText) ac_descr
-constrMdItem RecordC{..} =
-  ("* " <> asCode (unTypename ac_name))
-  <> maybe T.empty (T.cons '\n' . indent 2 . unDocText) ac_descr
-  <> "\n\n"
-  <> indent 2 (fieldTable ac_fields)
+adt2md :: ADTDoc -> RenderOut
+adt2md TypeSynDoc{..} = mconcat
+    [ renderAnchorInfix "**type " ad_anchor $
+        escapeMd (T.unwords (unTypename ad_name : ad_args)) <> "**  "
+    , renderLineDep $ \env -> T.concat ["  =  ", type2md env ad_rhs]
+    , renderDocText ad_descr
+    ]
+      -- renderLineDep $ \env -> T.concat
+      --   [ "**type "
+      --   , tag
+      --   , T.unwords (unTypename ad_name : ad_args)
+      --   , " = "
+      --   , type2md env ad_rhs
+      --   , "**"
+      --   ]
 
+
+adt2md ADTDoc{..} = mconcat
+    [ renderAnchorInfix "**data " ad_anchor $
+        escapeMd (T.unwords (unTypename ad_name : ad_args)) <> "**"
+    , renderDocText ad_descr
+    , mconcatMap constrMdItem ad_constrs
+    ]
+
+constrMdItem :: ADTConstr -> RenderOut
+constrMdItem PrefixC{..} = withAnchorTag ac_anchor $ \tag -> mconcat
+    [ renderLineDep $ \env -> T.unwords
+        ("*" : (tag <> escapeMd (unTypename ac_name)) : map (type2md env) ac_args)
+    , renderIndent 2 $ renderDocText ac_descr
+    , renderLine ""
+    ]
+constrMdItem RecordC{..} = mconcat
+    [ renderAnchorInfix "* " ac_anchor . escapeMd $ unTypename ac_name
+    , renderIndent 2 $ mconcat
+        [ renderDocText ac_descr
+        , fieldTable ac_fields
+        ]
+    , renderLine ""
+    ]
 
 -- | Render fields as a pipe-table, like this:
 -- >  | Field    | Type/Description |
@@ -111,50 +146,71 @@ constrMdItem RecordC{..} =
 -- >  |`andText` | `Text`
 -- >  |          | and text
 -- >
-fieldTable :: [FieldDoc] -> T.Text
-fieldTable []  = "(no fields)"
-fieldTable fds = header <> fieldRows <> "\n"
+fieldTable :: [FieldDoc] -> RenderOut
+fieldTable []  = renderLine "(no fields)"
+fieldTable fds = header <> fieldRows <> renderLine ""
   where
-    header = T.unlines
+    header = renderLines
       [ "| " <> adjust fLen "Field"   <> " | Type/Description |"
       , "| :" <> T.replicate (fLen - 1) "-" <> " | :----------------"
       ]
 
-    fieldRows = T.unlines
-      [ "| " <> adjust fLen (asCode (unFieldname fd_name))
-        <> " | " <> type2md fd_type <> " |"
-        <> maybe "" (\desc -> "\n" <> col1Empty <> removeLineBreaks (unDocText desc) <> " |") fd_descr
+    fieldRows = renderLinesDep $ \env -> concat
+      [ ("| " <> adjust fLen (escapeMd $ unFieldname fd_name)
+              <> " | " <> type2md env fd_type <> " |")
+        : maybe []
+              (\descr -> [col1Empty <> removeLineBreaks (unDocText descr) <> " |"])
+              fd_descr
       | FieldDoc{..} <- fds ]
 
     -- Markdown does not support multi-row cells so we have to remove
     -- line breaks.
     removeLineBreaks = T.unwords . T.lines
 
-    fLen = maximum $ 5 : map (T.length . asCode . unFieldname . fd_name) fds
+    fLen = maximum $ 5 : map (T.length . escapeMd . unFieldname . fd_name) fds
       -- 5 = length of "Field" header
 
     col1Empty = "| " <> T.replicate fLen " " <> " | "
 
 -- | Render a type. Nested type applications are put in parentheses.
-type2md :: Type -> T.Text
-type2md t = t2md id t
-  where t2md f (TypeFun ts) = f $ T.intercalate " `->` " $ map (t2md id) ts
-        t2md _ (TypeList t1) = "`[` " <> t2md id t1 <> " `]`"
-        t2md _ (TypeTuple ts) = "`(` " <>
-                            T.concat (intersperse ", " $ map (t2md id) ts) <>
-                            " `)`"
-        t2md _ (TypeApp _ n []) = asCode (unTypename n)
-        t2md f (TypeApp _ name args) =
-          f $ T.unwords ( asCode (unTypename name) : map (t2md codeParens) args)
-        codeParens s = "`(` " <> s <> " `)`"
+type2md :: RenderEnv -> Type -> T.Text
+type2md env = f 0
+  where
+    -- 0 = no brackets
+    -- 1 = brackets around function
+    -- 2 = brackets around function AND application
+    f :: Int -> Type -> T.Text
+    f _ (TypeApp a n []) = link a n
+    f i (TypeApp a n as) = (if i >= 2 then inParens else id) $
+        T.unwords (link a n : map (f 2) as)
+    f i (TypeFun ts) = (if i >= 1 then inParens else id) $
+        T.intercalate " -> " $ map (f 1) ts
+    f _ (TypeList t1) = "\\[" <> f 0 t1 <> "\\]"
+    f _ (TypeTuple ts) = "(" <> T.intercalate ", " (map (f 0) ts) <>  ")"
 
-fct2md :: FunctionDoc -> T.Text
-fct2md FunctionDoc{..} =
-  "* " <> asCode (unFieldname fct_name) <> maybe "" ((" : " <>) . type2md) fct_type
-  <> maybe "" (("  \n" <>) . indent 2 . unDocText) fct_descr
-  --             ^^ NB trailing whitespace to cause a line break
+    link :: Maybe Anchor -> Typename -> T.Text
+    link Nothing n = escapeMd $ unTypename n
+    link (Just anchor) n =
+        if renderAnchorAvailable env anchor
+            then T.concat ["[", escapeMd $ unTypename n, "](#", unAnchor anchor, ")"]
+            else escapeMd $ unTypename n
 
+fct2md :: FunctionDoc -> RenderOut
+fct2md FunctionDoc{..} = mconcat
+    [ renderAnchorInfix "" fct_anchor $ T.concat
+        [ "**", escapeMd $ unFieldname fct_name, "**  " ]
+    , renderLinesDep $ \env ->
+        maybe [""] (\t -> ["  : " <> type2md env t, ""]) fct_type
+    , renderDocText fct_descr
+    ]
 ------------------------------------------------------------
 
-asCode :: T.Text -> T.Text
-asCode = enclosedIn "`"
+-- | Escape characters to prevent markdown interpretation.
+escapeMd :: T.Text -> T.Text
+escapeMd = T.pack . concatMap escapeChar . T.unpack
+  where
+    escapeChar c
+        | shouldEscape c = ['\\', c]
+        | otherwise = [c]
+
+    shouldEscape = (`elem` ("[]*_~`<>\\" :: String))

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -58,6 +58,11 @@ renderLineDep f = renderLinesDep (pure . f)
 renderLinesDep :: (RenderEnv -> [T.Text]) -> RenderOut
 renderLinesDep f = RenderOut (mempty, [f])
 
+-- | Prefix every output line by a particular text.
+renderPrefix :: T.Text -> RenderOut -> RenderOut
+renderPrefix p (RenderOut (env, fs)) =
+    RenderOut (env, map (map (p <>) .) fs)
+
+-- | Indent every output line by a particular amount.
 renderIndent :: Int -> RenderOut -> RenderOut
-renderIndent n (RenderOut (env, fs)) =
-    RenderOut (env, map (map (T.replicate n " " <>) .) fs)
+renderIndent n = renderPrefix (T.replicate n " ")

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -1,0 +1,63 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings, DerivingStrategies #-}
+
+-- | Monoid with which to render documentation.
+module DA.Daml.Doc.Render.Monoid
+  ( module DA.Daml.Doc.Render.Monoid
+  ) where
+
+import DA.Daml.Doc.Types
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+-- | Environment in which to generate final documentation.
+newtype RenderEnv = RenderEnv (Set.Set Anchor)
+    deriving newtype (Semigroup, Monoid)
+
+-- | Is the anchor available in the rendering environment? Renderers should avoid
+-- generating links to anchors that don't actually exist.
+--
+-- One reason an anchor may be unavailable is because of a @-- | HIDE@ directive.
+-- Another possibly reason is that the anchor refers to a definition in another
+-- package (and at the moment it's not possible to link accross packages).
+renderAnchorAvailable :: RenderEnv -> Anchor -> Bool
+renderAnchorAvailable (RenderEnv anchors) anchor = Set.member anchor anchors
+
+-- | Renderer output. This is the set of anchors that were generated, and a
+-- list of output functions that depend on that set. The goal is to prevent
+-- the creation of spurious anchors links (i.e. links to anchors that don't
+-- exist).
+--
+-- (In theory this could be done in two steps, but that seems more error prone
+-- than building up both steps at the same time, and combining them at the
+-- end, as is done here.)
+--
+-- Using a newtype here so we can derive the semigroup / monoid instances we
+-- want automatically. :-)
+newtype RenderOut = RenderOut (RenderEnv, [RenderEnv -> [T.Text]])
+    deriving newtype (Semigroup, Monoid)
+
+renderFinish :: RenderOut -> T.Text
+renderFinish (RenderOut (xs, fs)) = T.unlines (concatMap ($ xs) fs)
+
+-- | Declare an anchor for the purposes of rendering output.
+renderDeclareAnchor :: Anchor -> RenderOut
+renderDeclareAnchor anchor = RenderOut (RenderEnv $ Set.singleton anchor, [])
+
+renderLine :: T.Text -> RenderOut
+renderLine l = renderLines [l]
+
+renderLines :: [T.Text] -> RenderOut
+renderLines ls = renderLinesDep (const ls)
+
+renderLineDep :: (RenderEnv -> T.Text) -> RenderOut
+renderLineDep f = renderLinesDep (pure . f)
+
+renderLinesDep :: (RenderEnv -> [T.Text]) -> RenderOut
+renderLinesDep f = RenderOut (mempty, [f])
+
+renderIndent :: Int -> RenderOut -> RenderOut
+renderIndent n (RenderOut (env, fs)) =
+    RenderOut (env, map (map (T.replicate n " " <>) .) fs)

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -220,7 +220,7 @@ renderTest format (name, input) expected =
     renderer = case format of
                  Json -> error "Json encoder testing not done here"
                  Rst -> renderFinish . renderSimpleRst
-                 Markdown -> renderSimpleMD
+                 Markdown -> renderFinish . renderSimpleMD
                  Html -> error "HTML testing not supported (use Markdown)"
                  Hoogle -> error "Hoogle doc testing not yet supported."
     output = T.strip $ renderer input

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -156,46 +156,84 @@ mkExpectRst anchor name descr templates classes adts fcts = T.unlines $
 expectMarkdown :: [T.Text]
 expectMarkdown =
         [ T.empty
-        , mkExpectMD "Typedef" "" [] [] ["### `type` `T a`\n    = `TT` `TTT`\n\n  T descr\n"] []
-        , mkExpectMD "TwoTypes" "" [] []
-            ["### `type` `T a`\n    = `TT`\n\n  T descr\n"
-            , "### `data` `D d`\n\n* `D` `a`\n  D descr\n"]
-            []
-        , mkExpectMD "Function1" "" [] [] [] [ "* `f` : `TheType`  \n  the doc\n"]
-        , mkExpectMD "Function2" "" [] [] [] [ "* `f`  \n  the doc\n"]
-        , mkExpectMD "Function3" "" [] [] [] [ "* `f` : `TheType`\n"]
-        , mkExpectMD "OnlyClass" ""
-            []
-            [ "### `class` C a where"
+        , mkExpectMD "module-typedef" "Typedef" "" [] []
+            [ "**type <a name=\"type-typedef-t\"></a>T a**  "
+            , "&nbsp; = TT TTT"
             , ""
-            , "  * `member` : `a`"
+            , "T descr"
+            , ""]
+            []
+        , mkExpectMD "module-twotypes" "TwoTypes" "" [] []
+            [ "**type <a name=\"type-twotypes-t\"></a>T a**  "
+            , "&nbsp; = TT"
+            , ""
+            , "T descr"
+            , ""
+            , "**data <a name=\"data-twotypes-d\"></a>D d**"
+            , ""
+            , "* <a name=\"constr-twotypes-d\"></a>D a"
+            , "  "
+            , "  D descr"
+            , "  "
+            , ""
+            ]
+            []
+        , mkExpectMD "module-function1" "Function1" "" [] [] []
+            [ "<a name=\"function-function1-f\"></a>**f**  "
+            , "&nbsp; : TheType"
+            , ""
+            , "the doc"
+            , ""
+            ]
+        , mkExpectMD "module-function2" "Function2" "" [] [] []
+            [ "<a name=\"function-function2-f\"></a>**f**  "
+            , ""
+            , "the doc"
+            , ""
+            ]
+        , mkExpectMD "module-function3" "Function3" "" [] [] []
+            [ "<a name=\"function-function3-f\"></a>**f**  "
+            , "&nbsp; : TheType"
+            , ""
+            ]
+        , mkExpectMD "module-onlyclass" "OnlyClass" ""
+            []
+            [ "### <a name=\"class-onlyclass-c\"></a>Class C"
+            , ""
+            , "**class C a where**"
+            , ""
+            , "> <a name=\"function-onlyclass-member\"></a>**member**  "
+            , "> &nbsp; : a"
+            , "> "
             ]
             []
             []
-        , mkExpectMD "MultiLineField" ""
+        , mkExpectMD "module-multilinefield" "MultiLineField" ""
             []
             []
-            [ "### `data` `D`"
+            [ "**data <a name=\"data-multilinefield-d\"></a>D**"
             , ""
-            , "* `D`"
-            , ""
+            , "* <a name=\"constr-multilinefield-d\"></a>D"
+            , "  "
             , "  | Field | Type/Description |"
             , "  | :---- | :----------------"
-            , "  | `f`   | `T` |"
-            , "  |       | This is a multiline field description |" ]
+            , "  | f     | T |"
+            , "  |       | This is a multiline field description |"
+            ]
             []
         ]
         <> repeat (error "Missing expectation (Markdown)")
 
-mkExpectMD :: T.Text -> T.Text -> [T.Text] -> [T.Text] -> [T.Text] -> [T.Text] -> T.Text
-mkExpectMD name descr templates classes adts fcts
+mkExpectMD :: T.Text -> T.Text -> T.Text -> [T.Text] -> [T.Text] -> [T.Text] -> [T.Text] -> T.Text
+mkExpectMD anchor name descr templates classes adts fcts
   | null templates && null classes && null adts && null fcts && T.null descr = T.empty
   | otherwise = T.unlines $
-  [ "# Module " <> name
-  , "", descr, ""
-  ]
+  ["# <a name=\"" <> anchor <> "\"></a>Module " <> name]
   <> concat
-  [ if null templates then [] else
+  [ if T.null descr
+        then [""]
+        else ["", descr, ""]
+  , if null templates then [] else
       [ "## Templates"
       , "", T.unlines templates
       , ""]

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -268,7 +268,7 @@ fileTest damlFile = do
                 ref <- T.readFileUtf8 expectation
                 case extension of
                   ".rst"  -> expectEqual extension ref $ renderFinish $ renderSimpleRst docs
-                  ".md"   -> expectEqual extension ref $ renderSimpleMD docs
+                  ".md"   -> expectEqual extension ref $ renderFinish $ renderSimpleMD docs
                   ".json" -> expectEqual extension ref
                              (T.decodeUtf8 . BS.toStrict $
                                AP.encodePretty' jsonConf docs)

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -1,58 +1,58 @@
-# Module Iou_template
-
-
+# <a name="module-ioutemplate-98694"></a>Module Iou\_template
 
 ## Templates
 
-### Template `Iou`
+### <a name="template-ioutemplate-iou-32396"></a>Template Iou
+
+| Field      | Type/Description |
+| :--------- | :----------------
+| issuer     | Party |
+| owner      | Party |
+| currency   | Text |
+|            | only 3-letter symbols are allowed |
+| amount     | Decimal |
+|            | must be positive |
+| regulators | \[Party\] |
+|            | `regulators` may observe any use of the `Iou` |
 
 
-| Field        | Type/Description |
-| :----------- | :----------------
-| `issuer`     | `Party` |
-| `owner`      | `Party` |
-| `currency`   | `Text` |
-|              | only 3-letter symbols are allowed |
-| `amount`     | `Decimal` |
-|              | must be positive |
-| `regulators` | `[` `Party` `]` |
-|              | `regulators` may observe any use of the `Iou` |
+Choices:
 
-
-
-  #### Choices
-
-* `Merge`
+* Merge
+  
   merges two "compatible" `Iou`s
-
-  | Field      | Type/Description |
-  | :--------- | :----------------
-  | `otherCid` | `ContractId` `Iou` |
-  |            | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
-
-* `Split`
-  splits into two `Iou`s with
-  smaller amounts
-
-  | Field         | Type/Description |
-  | :------------ | :----------------
-  | `splitAmount` | `Decimal` |
-  |               | must be between zero and original amount |
-
-* `Transfer`
-  changes the owner
-
+  
   | Field    | Type/Description |
   | :------- | :----------------
-  | `owner_` | `Party` |
-
-
-
+  | otherCid | ContractId Iou |
+  |          | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
+  
+* Split
+  
+  splits into two `Iou`s with
+  smaller amounts
+  
+  | Field       | Type/Description |
+  | :---------- | :----------------
+  | splitAmount | Decimal |
+  |             | must be between zero and original amount |
+  
+* Transfer
+  
+  changes the owner
+  
+  | Field   | Type/Description |
+  | :------ | :----------------
+  | owner\_ | Party |
+  
 
 ## Functions
 
-* `main` : `Scenario` `(`  `)`  
-  A single test scenario covering all functionality that `Iou` implements.
-  This description contains [a link](http://example.com), some bogus <inline html>,
-  and words_ with_ underscore, to test damldoc capabilities.
+<a name="function-ioutemplate-main-13221"></a>**main**  
+&nbsp; : Scenario ()
+
+A single test scenario covering all functionality that `Iou` implements.
+This description contains [a link](http://example.com), some bogus <inline html>,
+and words_ with_ underscore, to test damldoc capabilities.
+
 

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -1,26 +1,38 @@
-# Module Newtype
-
-
+# <a name="module-newtype-36781"></a>Module Newtype
 
 ## Data types
 
-### `data` `Nat`
+**data <a name="type-newtype-nat-61947"></a>Nat**
 
-* `Nat`
-
-  | Field   | Type/Description |
-  | :------ | :----------------
-  | `unNat` | `Int` |
-
+* <a name="constr-newtype-nat-99832"></a>Nat
+  
+  | Field | Type/Description |
+  | :---- | :----------------
+  | unNat | Int |
+  
 
 
 ## Functions
 
-* `mkNat` : `Int` `->` `Nat`
-* `unsafeMkNat` : `Int` `->` `Nat`
-* `zero0` : `Nat`
-* `one1` : `Nat`
-* `unNat1` : `Nat` `->` `Int`
-* `unNat2` : `Nat` `->` `Int`
-* `unNat3` : `Nat` `->` `Int`
+<a name="function-newtype-mknat-8513"></a>**mkNat**  
+&nbsp; : Int -> [Nat](#type-newtype-nat-61947)
+
+<a name="function-newtype-unsafemknat-96593"></a>**unsafeMkNat**  
+&nbsp; : Int -> [Nat](#type-newtype-nat-61947)
+
+<a name="function-newtype-zero0-10450"></a>**zero0**  
+&nbsp; : [Nat](#type-newtype-nat-61947)
+
+<a name="function-newtype-one1-53872"></a>**one1**  
+&nbsp; : [Nat](#type-newtype-nat-61947)
+
+<a name="function-newtype-unnat1-26452"></a>**unNat1**  
+&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
+
+<a name="function-newtype-unnat2-96339"></a>**unNat2**  
+&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
+
+<a name="function-newtype-unnat3-97654"></a>**unNat3**  
+&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
+
 


### PR DESCRIPTION
Ports over the Rst rendering with anchors and type signature links to Markdown. I redid the Markdown output format to make it a little closer to the Rst output, but it's still not mature. I also added a Bazel rule to render stdlib docs in Markdown, in case we choose to switch the docs sight.