### PR TITLE
Support reading of DAML-LF 1.5 in damlc again

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -20,6 +20,10 @@ data Version
 data MinorVersion = PointStable Int | PointDev
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
+-- | DAML-LF version 1.5
+version1_5 :: Version
+version1_5 = V1 $ PointStable 5
+
 -- | DAML-LF version 1.6
 version1_6 :: Version
 version1_6 = V1 $ PointStable 6
@@ -32,11 +36,11 @@ versionDefault = version1_6
 versionDev :: Version
 versionDev = V1 PointDev
 
-supportedInputVersions :: [Version]
-supportedInputVersions = [version1_6, versionDev]
-
 supportedOutputVersions :: [Version]
-supportedOutputVersions = supportedInputVersions
+supportedOutputVersions = [version1_6, versionDev]
+
+supportedInputVersions :: [Version]
+supportedInputVersions = version1_5 : supportedOutputVersions
 
 
 data Feature = Feature

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -79,7 +79,7 @@ main :: IO ()
 main = mainWithVersions [versionDev]
 
 mainAll :: IO ()
-mainAll = mainWithVersions (delete versionDev supportedInputVersions)
+mainAll = mainWithVersions (delete versionDev supportedOutputVersions)
 
 mainWithVersions :: [Version] -> IO ()
 mainWithVersions versions = SS.withScenarioService Logger.makeNopHandle SS.defaultScenarioServiceConfig $ \scenarioService -> do

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,4 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [DAML Compiler] Support reading of DAML-LF 1.5 again.


### PR DESCRIPTION
We dropped support for this for no good reason when we dropped support for
writing DAML-LF 1.5. Being able to _read_ older versions of DAML-LF is
important for the upgrading story.

We don't support reading older versions of DAML-LF since there seems to
be no need for this.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2180)
<!-- Reviewable:end -->
