### PR TITLE
damldocs: Show generic template args and context.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -336,7 +336,7 @@ getTemplateDocs DocCtx{..} typeMap templateInstanceMap =
     -- defined internally, and not expected to fail on consistent arguments.
     mkTemplateDoc :: Typename -> TemplateDoc
     mkTemplateDoc name = TemplateDoc
-      { td_anchor = ad_anchor tmplADT
+      { td_anchor = Just $ templateAnchor dc_modname name
       , td_name = ad_name tmplADT
       , td_args = ad_args tmplADT
       , td_super = cl_super =<< MS.lookup name templateInstanceMap

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -258,8 +258,6 @@ getClsDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ c@ClassDecl{..})) docs) = do
             let theta = classSCTheta cls
             guard (notNull theta)
             Just (TypeTuple $ map (typeToType ctx) theta)
-    guard (isNothing (stripInstanceSuffix cl_name))
-       -- don't generate docs for template instance classes
     Just ClassDoc {..}
   where
     f :: LSig GhcPs -> [FunctionDoc]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -62,8 +62,14 @@ renderSimpleMD ModuleDoc{..} = mconcat
 
 
 tmpl2md :: TemplateDoc -> RenderOut
-tmpl2md TemplateDoc{..} = mconcat
-    [ renderAnchorInfix "### " td_anchor ("Template " <> escapeMd (unTypename td_name))
+tmpl2md TemplateDoc{..} = withAnchorTag td_anchor $ \tag -> mconcat
+    [ renderLineDep $ \env -> T.concat
+        [ "### "
+        , tag
+        , "template "
+        , maybe "" ((<> " => ") . type2md env) td_super
+        , escapeMd . T.unwords $ unTypename td_name : td_args
+        ]
     , renderDocText td_descr
     , fieldTable td_payload
     , if null td_choices

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -88,7 +88,11 @@ renderSimpleRst ModuleDoc{..} = mconcat $
 tmpl2rst :: TemplateDoc -> RenderOut
 tmpl2rst TemplateDoc{..} = mconcat $
   [ renderAnchor td_anchor
-  , renderLine $ "template " <> enclosedIn "**" (unTypename td_name)
+  , renderLineDep $ \env -> T.concat
+      [ "template "
+      , maybe "" ((<> " => ") . type2rst env) td_super
+      , T.unwords (enclosedIn "**" (unTypename td_name) : td_args)
+      ]
   , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) td_descr
   , renderLine ""
   , renderIndent 2 (fieldTable td_payload)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -64,6 +64,8 @@ data ModuleDoc = ModuleDoc
 data TemplateDoc = TemplateDoc
   { td_anchor  :: Maybe Anchor
   , td_name    :: Typename
+  , td_super   :: Maybe Type
+  , td_args    :: [Text]
   , td_descr   :: Maybe DocText
   , td_payload :: [FieldDoc]
   , td_choices :: [ChoiceDoc]

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -2,7 +2,7 @@
 
 ## Templates
 
-### <a name="template-ioutemplate-iou-32396"></a>Template Iou
+### <a name="template-ioutemplate-iou-32396"></a>template Iou
 
 | Field      | Type/Description |
 | :--------- | :----------------

--- a/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.md
@@ -1,0 +1,22 @@
+# <a name="module-proposaldsl-55246"></a>Module ProposalDSL
+
+## Templates
+
+### <a name="template-proposaldsl-proposal-62786"></a>template (Template t) => Proposal t
+
+| Field     | Type/Description |
+| :-------- | :----------------
+| asset     | t |
+| receivers | \[Party\] |
+| name      | Text |
+
+
+Choices:
+
+* Accept
+  
+  (no fields)
+* External:Archive
+  
+  (no fields)
+

--- a/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
@@ -10,7 +10,7 @@ Templates
 
 .. _template-proposaldsl-proposal-62786:
 
-template **Proposal**
+template (Template t) => **Proposal** t
 
   .. list-table::
      :widths: 15 10 30


### PR DESCRIPTION
This PR collects the generic template args and context and displays it in the Rst and Markdown docs. The only thing left to finish generic template support in damldocs (for now) is collecting and displaying template instances.