### PR TITLE
Rephrase lint exit actions

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -338,8 +338,10 @@ execLint inputFile opts =
         setFilesOfInterest ide (Set.singleton inputFile)
         runAction ide $ getHlintIdeas inputFile
         diags <- getDiagnostics ide
-        when (null diags) $ hPutStrLn stderr "No hints."
-        unless (null diags) exitFailure
+        if null diags then
+          hPutStrLn stderr "No hints."
+        else
+          exitFailure
   where
      setHlintDataDir :: Options -> IO Options
      setHlintDataDir opts = do


### PR DESCRIPTION
Rephrase funny `when, unless` with a regular `if`.