### PR TITLE
Haskell ledger bindings - multiple reset test

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -86,6 +86,7 @@ da_haskell_test(
         "async",
         "base",
         "bytestring",
+        "containers",
         "filepath",
         "directory",
         "extra",


### PR DESCRIPTION
Adding a test for multiple ledger resets as this is what fails on current GRPC upgrade attempt on Windows (and is caught implicitly by presence of many separate tests performing a reset).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
