### PR TITLE
set initial version in templates to 0.1.0

### DIFF
--- a/templates/migrate/daml.yaml.template
+++ b/templates/migrate/daml.yaml.template
@@ -4,7 +4,7 @@ source: daml/Main.daml
 parties:
   - Alice
   - Bob
-version: 1.0.0
+version: 0.0.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/templates/quickstart-java/daml.yaml.template
+++ b/templates/quickstart-java/daml.yaml.template
@@ -7,7 +7,7 @@ parties:
   - Bob
   - USD_Bank
   - EUR_Bank
-version: 1.0.0
+version: 0.0.1
 exposed-modules:
   - Main
 dependencies:

--- a/templates/quickstart-scala/daml.yaml.template
+++ b/templates/quickstart-scala/daml.yaml.template
@@ -7,7 +7,7 @@ parties:
   - Bob
   - USD_Bank
   - EUR_Bank
-version: 1.0.0
+version: 0.0.1
 exposed-modules:
   - Main
 dependencies:

--- a/templates/skeleton/daml.yaml.template
+++ b/templates/skeleton/daml.yaml.template
@@ -5,7 +5,7 @@ scenario: Main:setup
 parties:
   - Alice
   - Bob
-version: 1.0.0
+version: 0.0.1
 dependencies:
   - daml-prim
   - daml-stdlib


### PR DESCRIPTION
`1.0.0` has a lot of cultural baggage, I think we shouldn't put that much pressure on every single new DAML project.