### PR TITLE
Wait for index before completing package upload

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -6,6 +6,8 @@ package com.digitalasset.platform.sandbox.services.admin
 import java.io.ByteArrayInputStream
 import java.util.zip.ZipInputStream
 
+import akka.actor.Scheduler
+import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.index.v2.IndexPackagesService
 import com.daml.ledger.participant.state.v2.{UploadPackagesResult, WritePackagesService}
 import com.digitalasset.daml.lf.archive.DarReader
@@ -21,11 +23,13 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Try
 
 class ApiPackageManagementService(
     packagesIndex: IndexPackagesService,
-    packagesWrite: WritePackagesService)
+    packagesWrite: WritePackagesService,
+    scheduler: Scheduler)
     extends PackageManagementService
     with GrpcApiService {
 
@@ -59,13 +63,13 @@ class ApiPackageManagementService(
           "package-upload",
           new ZipInputStream(new ByteArrayInputStream(request.darFile.toByteArray)))
     } yield {
-      packagesWrite.uploadPackages(dar.all, None)
+      (packagesWrite.uploadPackages(dar.all, None), dar.all.map(_.getHash))
     }
     resultT.fold(
       err => Future.failed(ErrorFactories.invalidArgument(err.getMessage)),
       res =>
         FutureConverters
-          .toScala(res)
+          .toScala(res._1)
           .flatMap {
             case UploadPackagesResult.Ok =>
               Future.successful(UploadDarFileResponse())
@@ -76,13 +80,51 @@ class ApiPackageManagementService(
             case r @ UploadPackagesResult.NotSupported =>
               Future.failed(ErrorFactories.unimplemented(r.description))
           }(DE)
+          .flatMap(
+            pollUntilPersisted(
+              res._2,
+              _,
+              50.milliseconds,
+              500.milliseconds,
+              (d: FiniteDuration) => d * 2))(DE)
     )
+  }
+
+  /**
+    * Wraps a call [[PollingUtils.pollUntilPersisted]] so that it can be chained on the package upload with a `flatMap`.
+    *
+    * Checks invariants and forwards the original result after all packages are found to be persisted.
+    *
+    * @param ids The IDs of the uploaded packages
+    * @return The result of the party allocation received originally, wrapped in a [[Future]]
+    */
+  private def pollUntilPersisted(
+      ids: List[String],
+      result: UploadDarFileResponse,
+      minWait: FiniteDuration,
+      maxWait: FiniteDuration,
+      iteration: FiniteDuration => FiniteDuration): Future[UploadDarFileResponse] = {
+    val newPackages = ids.toSet
+    val description = s"packages ${ids.mkString(", ")}"
+    PollingUtils
+      .pollUntilPersisted(() => packagesIndex.listLfPackages())(
+        x => newPackages.subsetOf(x.keySet.toSet),
+        description,
+        minWait,
+        maxWait,
+        iteration,
+        scheduler)
+      .map { numberOfAttempts =>
+        logger.debug(
+          s"All ${ids.length} packages available, read after $numberOfAttempts attempt(s)")
+        result
+      }(DE)
   }
 }
 
 object ApiPackageManagementService {
-  def createApiService(
-      readBackend: IndexPackagesService,
-      writeBackend: WritePackagesService): GrpcApiService =
-    new ApiPackageManagementService(readBackend, writeBackend) with PackageManagementServiceLogging
+  def createApiService(readBackend: IndexPackagesService, writeBackend: WritePackagesService)(
+      implicit mat: ActorMaterializer): GrpcApiService =
+    new ApiPackageManagementService(readBackend, writeBackend, mat.system.scheduler)
+    with PackageManagementServiceLogging
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -107,7 +107,7 @@ class ApiPackageManagementService(
     val newPackages = ids.toSet
     val description = s"packages ${ids.mkString(", ")}"
     PollingUtils
-      .pollUntilPersisted(() => packagesIndex.listLfPackages())(
+      .pollUntilPersisted(packagesIndex.listLfPackages _)(
         x => newPackages.subsetOf(x.keySet.toSet),
         description,
         minWait,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -66,7 +66,7 @@ class ApiPartyManagementService private (
     require(result.partyDetails.isDefined, "Party allocation response must have the party details")
     val newParty = result.partyDetails.get.party
     PollingUtils
-      .pollUntilPersisted(() => partyManagementService.listParties())(
+      .pollUntilPersisted(partyManagementService.listParties _)(
         _.exists(_.party == newParty),
         s"party $newParty",
         minWait,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
@@ -52,6 +52,11 @@ object PollingUtils {
             after(waitTime, scheduler)(
               go(attempt + 1, backoffProgression(waitTime).min(maxWait).max(50.milliseconds)))(DE)
         }(DE)
+        .recoverWith {
+          case _ =>
+            after(waitTime, scheduler)(
+              go(attempt + 1, backoffProgression(waitTime).min(maxWait).max(50.milliseconds)))(DE)
+        }(DE)
     }
 
     go(1, minWait.min(maxWait).max(50.milliseconds))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.services.admin
+
+import akka.actor.Scheduler
+import akka.pattern.after
+import com.digitalasset.platform.common.util.{DirectExecutionContext => DE}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+case object PollingUtils {
+
+  private val logger: Logger = LoggerFactory.getLogger(PollingUtils.getClass)
+
+  /**
+    * Continuously polls the given service to check if the given item has been persisted.
+    *
+    * Despite the `go` inner function not being stack-safe per se, only one stack frame will be on
+    * the stack at any given time since the "recursive" invocation happens on a different thread.
+    *
+    * The backoff waiting time are applied after the first poll returns without a result (i.e. the first call is not delayed).
+    *
+    * @param poll               The service, returning a collection of items
+    * @param check              Returns true iff the service returned all items that are being waited for
+    * @param description        A human readable description of the item that is being waited for, for logging purposes
+    * @param minWait            The minimum waiting time - will not be enforced if less than `maxWait`
+    *                           Does not make sense to set this lower than the OS scheduler threshold
+    *                           Anyway always padded to 50 milliseconds
+    * @param maxWait            The maximum waiting time - takes precedence over `minWait` and `backoffProgression`
+    *                           Does not make sense to set this lower than the OS scheduler threshold
+    *                           Anyway always padded to 50 milliseconds
+    * @param backoffProgression How the following backoff time is computed as a function of the current one - `maxWait` takes precedence though
+    * @return The number of attempts before the item was found wrapped in a [[Future]]
+    */
+  def pollUntilPersisted[T](poll: () => Future[T])(
+      check: T => Boolean,
+      description: String,
+      minWait: FiniteDuration,
+      maxWait: FiniteDuration,
+      backoffProgression: FiniteDuration => FiniteDuration,
+      scheduler: Scheduler): Future[Int] = {
+    def go(attempt: Int, waitTime: FiniteDuration): Future[Int] = {
+      logger.debug(s"Polling for '$description' being persisted (attempt #$attempt)...")
+      poll()
+        .flatMap {
+          case persisted if check(persisted) => Future.successful(attempt)
+          case _ =>
+            logger.debug(
+              s"'${description.capitalize}' not yet persisted, backing off for $waitTime...")
+            after(waitTime, scheduler)(
+              go(attempt + 1, backoffProgression(waitTime).min(maxWait).max(50.milliseconds)))(DE)
+        }(DE)
+    }
+
+    go(1, minWait.min(maxWait).max(50.milliseconds))
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
@@ -11,7 +11,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-case object PollingUtils {
+object PollingUtils {
 
   private val logger: Logger = LoggerFactory.getLogger(PollingUtils.getClass)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
@@ -48,8 +48,7 @@ object PollingUtils {
         .flatMap {
           case persisted if check(persisted) => Future.successful(attempt)
           case _ =>
-            logger.debug(
-              s"'$description' not yet persisted, backing off for $waitTime...")
+            logger.debug(s"'$description' not yet persisted, backing off for $waitTime...")
             after(waitTime, scheduler)(
               go(attempt + 1, backoffProgression(waitTime).min(maxWait).max(50.milliseconds)))(DE)
         }(DE)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtils.scala
@@ -49,7 +49,7 @@ object PollingUtils {
           case persisted if check(persisted) => Future.successful(attempt)
           case _ =>
             logger.debug(
-              s"'${description.capitalize}' not yet persisted, backing off for $waitTime...")
+              s"'$description' not yet persisted, backing off for $waitTime...")
             after(waitTime, scheduler)(
               go(attempt + 1, backoffProgression(waitTime).min(maxWait).max(50.milliseconds)))(DE)
         }(DE)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtilsSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/admin/PollingUtilsSpec.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.services.admin
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+final class PollingUtilsSpec extends AsyncFlatSpec with Matchers {
+
+  private[this] val actorSystem = ActorSystem("PollingUtilsSpec")
+  private[this] val materializer = ActorMaterializer()(actorSystem)
+  private[this] val scheduler = materializer.system.scheduler
+
+  behavior of "pollUntilPersisted"
+
+  it should "succeed with 1 attempt if there are no failures" in {
+    PollingUtils.pollUntilPersisted(() => Future.successful(42))(
+      _ == 42,
+      "",
+      0.millis,
+      0.millis,
+      identity,
+      scheduler) map { attempts =>
+      assert(attempts == 1)
+    }
+  }
+
+  it should "succeed with 4 attempts after 3 failures" in {
+    val process = failNTimesAndThenReturn(3, 42)
+    PollingUtils.pollUntilPersisted(() => process.next()())(
+      _ == 42,
+      "",
+      0.millis,
+      0.millis,
+      identity,
+      scheduler) map { attempts =>
+      assert(attempts == 4)
+    }
+  }
+
+  it should "succeed with 4 attempts after 3 misses" in {
+    val process = returnNTimesAndThenReturn(3, 41, 42)
+    PollingUtils.pollUntilPersisted(() => process.next()())(
+      _ == 42,
+      "",
+      0.millis,
+      0.millis,
+      identity,
+      scheduler) map { attempts =>
+      assert(attempts == 4)
+    }
+  }
+
+  it should "respect minimal wait time" in {
+    // There should be at least 100ms between attempts
+    val process = returnUntil(950L, 41, 42)
+    PollingUtils.pollUntilPersisted(process)(
+      _ == 42,
+      "",
+      100.millis,
+      100.millis,
+      identity,
+      scheduler) map { attempts =>
+      assert(attempts < 11)
+    }
+  }
+
+  it should "respect exponential backoff" in {
+    // Exponential backoff
+    // Delays are: 100ms, 200ms, 400ms, 800ms
+    // Attempts are at: 0ms, 100ms, 300ms, 700ms, 1500ms
+    val process = returnUntil(750L, 41, 42)
+    PollingUtils.pollUntilPersisted(process)(
+      _ == 42,
+      "",
+      100.millis,
+      1000.millis,
+      d => d * 2,
+      scheduler) map { attempts =>
+      assert(attempts < 6)
+    }
+  }
+
+  /** An iterator that returns n failed futures, and then a successful future */
+  private def failNTimesAndThenReturn[A](n: Int, a: A): Iterator[() => Future[A]] =
+    Iterator.tabulate(n)(c => () => Future.failed(new RuntimeException(s"failure #${c + 1}"))) ++ Iterator
+      .single(() => Future.successful(a))
+
+  /** An iterator that returns n failed futures, and then a successful future */
+  private def returnNTimesAndThenReturn[A](n: Int, a1: A, a2: A): Iterator[() => Future[A]] =
+    Iterator.tabulate(n)(_ => () => Future.successful(a1)) ++ Iterator.single(() =>
+      Future.successful(a2))
+
+  /** An iterator that continuously emits a1 until the given delay (from calling this function) has passed, then emits a2 */
+  private def returnUntil[A](millis: Long, a1: A, a2: A): () => Future[A] = {
+    val start = System.nanoTime()
+    () =>
+      {
+        val millisPassed = (System.nanoTime() - start) / 1000000L
+        Future.successful(if (millisPassed < millis) a1 else a2)
+      }
+  }
+
+}


### PR DESCRIPTION
This PR factors out the main polling function of `ApiPartyManagementService` into a separate helper, and uses it from both `ApiPartyManagementService` and `ApiPackageManagementService`.

This makes sure users can immediately query new packages after the upload completed.

Fixes #2066