### PR TITLE
damldocs: Fix Rst typeclass headers, simplify type anchors, make type decls robust.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
@@ -12,9 +12,7 @@ module DA.Daml.Doc.Anchor
     ( Anchor
     , moduleAnchor
     , classAnchor
-    , templateAnchor
     , typeAnchor
-    , dataAnchor
     , constrAnchor
     , functionAnchor
     ) where
@@ -32,16 +30,12 @@ convertModulename :: Modulename -> T.Text
 convertModulename = T.toLower . T.replace "." "-" . T.replace "_" "" . unModulename
 
 classAnchor    :: Modulename -> Typename  -> Anchor
-templateAnchor :: Modulename -> Typename  -> Anchor
 typeAnchor     :: Modulename -> Typename  -> Anchor
-dataAnchor     :: Modulename -> Typename  -> Anchor
 constrAnchor   :: Modulename -> Typename  -> Anchor
 functionAnchor :: Modulename -> Fieldname -> Anchor
 
 classAnchor    m n = anchor "class"    m (unTypename n) ()
-templateAnchor m n = anchor "template" m (unTypename n) ()
 typeAnchor     m n = anchor "type"     m (unTypename n) ()
-dataAnchor     m n = anchor "data"     m (unTypename n) ()
 constrAnchor   m n = anchor "constr"   m (unTypename n) ()
 functionAnchor m n = anchor "function" m (unFieldname n) ()
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -110,7 +110,7 @@ cls2rst ::  ClassDoc -> RenderOut
 cls2rst ClassDoc{..} = mconcat
     [ renderAnchor cl_anchor
     , renderLineDep $ \env ->
-        "**class " <> maybe "" (\x -> type2rst env x <> " => ") cl_super <> T.unwords (unTypename cl_name : cl_args) <> " where**"
+        "class " <> maybe "" (\x -> type2rst env x <> " => ") cl_super <> "**" <> T.unwords (unTypename cl_name : cl_args) <> "** where"
     , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) cl_descr
     , mconcat $ map (renderIndent 2 . fct2rst) cl_functions
     ]

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -92,7 +92,7 @@ expectRst =
         , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
             [ "\n.. _class-onlyclass-c:"
-            , "**class C a where**\n  \n  .. _function-onlyclass-member:\n  \n  **member**\n    : a"
+            , "class **C a** where\n  \n  .. _function-onlyclass-member:\n  \n  **member**\n    : a"
             ]
             []
             []

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -2,7 +2,7 @@
 
 ## Templates
 
-### <a name="template-ioutemplate-iou-32396"></a>template Iou
+### <a name="type-ioutemplate-iou-55222"></a>template Iou
 
 | Field      | Type/Description |
 | :--------- | :----------------
@@ -24,7 +24,7 @@ Choices:
   
   | Field    | Type/Description |
   | :------- | :----------------
-  | otherCid | ContractId Iou |
+  | otherCid | ContractId [Iou](#type-ioutemplate-iou-55222) |
   |          | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
   
 * Split

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
@@ -8,7 +8,7 @@ Module Iou_template
 Templates
 ^^^^^^^^^
 
-.. _template-ioutemplate-iou-32396:
+.. _type-ioutemplate-iou-55222:
 
 template **Iou**
 
@@ -46,7 +46,7 @@ template **Iou**
          - Type
          - Description
        * - otherCid
-         - ContractId Iou
+         - ContractId `Iou <type-ioutemplate-iou-55222_>`_
          - Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original ``Iou``.
   + **Choice Split**
   

--- a/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.md
@@ -2,7 +2,7 @@
 
 ## Templates
 
-### <a name="template-proposaldsl-proposal-62786"></a>template (Template t) => Proposal t
+### <a name="type-proposaldsl-proposal-65892"></a>template (Template t) => Proposal t
 
 | Field     | Type/Description |
 | :-------- | :----------------

--- a/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
@@ -8,7 +8,7 @@ Module ProposalDSL
 Templates
 ^^^^^^^^^
 
-.. _template-proposaldsl-proposal-62786:
+.. _type-proposaldsl-proposal-65892:
 
 template (Template t) => **Proposal** t
 


### PR DESCRIPTION
Small but important fixes:

* Rst typeclass headers were broken because you can't have links inside bold text (!!). So I adjusted the boldness to only be on the typeclass name and its arguments.

*  Template anchors were not being properly linked to because they are just types to GHC's eyes. I fixed this by simplifying the type anchors to all be the same, so template anchors are just type anchors, so everything gets linked properly.

* `data Bool` was missing, and there were no links to it. My guess is that we are handling `data Bool` in `GHC.Types` in a special way, which results in damldocs not finding the corresponding tycon. I reinstated data Bool by making all type declarations more robust to missing type information -- they may show an `_` if type information is missing for whatever reason, but at least the type isn't *gone*. (And for Bool, it shows everything, and Bool links work again.)