### PR TITLE
Fix MOVE in GHC.Enum

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Enum.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Enum.daml
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 daml 1.2
 
--- | MOVE Prelude.
+-- | MOVE Prelude
 --
 -- A weird module - based on base.GHC.Enum, but not realy in the GHC namespace.
 -- Has to live here so GHC can find it for deriving instances.


### PR DESCRIPTION
It was being MOVEd to `Prelude.` which was unintentional.