### PR TITLE
Make module import aliases slightly less useless

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -27,8 +27,8 @@ import qualified DA.Daml.LF.ScenarioServiceClient as SSC
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Development.Shake as Shake
-import qualified Development.IDE.Core.API as CompilerService
-import qualified Development.IDE.Core.Rules.Daml as CompilerService
+import qualified Development.IDE.Core.API as IDE
+import qualified Development.IDE.Core.Rules.Daml as DamlRules
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import qualified ScenarioService as SS
@@ -51,8 +51,8 @@ execTest inFiles color mbJUnitOutput cliOptions = do
         -- Run synchronously at the end to make sure that all gRPC requests
         -- finish properly. We have seen segfaults on CI sometimes
         -- which are probably caused by not doing this.
-        CompilerService.runActionSync h (pure ())
-        diags <- CompilerService.getDiagnostics h
+        IDE.runActionSync h (pure ())
+        diags <- IDE.getDiagnostics h
         when (any ((Just DsError ==) . _severity . snd) diags) exitFailure
 
 
@@ -63,12 +63,12 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
 
     -- take the transitive closure of all imports and run on all of them
     -- If some dependencies can't be resolved we'll get a Diagnostic out anyway, so don't worry
-    deps <- CompilerService.runAction h $ mapM CompilerService.getDependencies inFiles
+    deps <- IDE.runAction h $ mapM IDE.getDependencies inFiles
     let files = nubOrd $ concat $ inFiles : catMaybes deps
 
-    results <- CompilerService.runAction h $
+    results <- IDE.runAction h $
         Shake.forP files $ \file -> do
-            mbScenarioResults <- CompilerService.runScenarios file
+            mbScenarioResults <- DamlRules.runScenarios file
             results <- case mbScenarioResults of
                 Nothing -> failedTestOutput h file
                 Just scenarioResults -> do
@@ -84,10 +84,10 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
 
 
 -- We didn't get scenario results, so we use the diagnostics as the error message for each scenario.
-failedTestOutput :: IdeState -> NormalizedFilePath -> CompilerService.Action [(VirtualResource, Maybe T.Text)]
+failedTestOutput :: IdeState -> NormalizedFilePath -> IDE.Action [(VirtualResource, Maybe T.Text)]
 failedTestOutput h file = do
-    mbScenarioNames <- CompilerService.getScenarioNames file
-    diagnostics <- liftIO $ CompilerService.getDiagnostics h
+    mbScenarioNames <- DamlRules.getScenarioNames file
+    diagnostics <- liftIO $ IDE.getDiagnostics h
     let errMsg = showDiagnostics diagnostics
     pure $ map (, Just errMsg) $ fromMaybe [VRScenario file "Unknown"] mbScenarioNames
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -57,8 +57,8 @@ import           Text.Read
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import           System.Time.Extra
-import qualified Development.IDE.Core.API as Compile
-import qualified Development.IDE.Core.Rules.Daml as Compile
+import qualified Development.IDE.Core.API as IDE
+import qualified Development.IDE.Core.Rules.Daml as DamlRules
 import qualified Development.IDE.Types.Diagnostics as D
 import Development.IDE.GHC.Util
 import           Data.Tagged                  (Tagged (..))
@@ -131,12 +131,12 @@ getIntegrationTests registerTODO scenarioService version = do
         }
 
     -- initialise the compiler service
-    vfs <- Compile.makeVFSHandle
-    damlEnv <- Compile.mkDamlEnv opts (Just scenarioService)
+    vfs <- IDE.makeVFSHandle
+    damlEnv <- IDE.mkDamlEnv opts (Just scenarioService)
     pure $
       withResource
-      (Compile.initialise (Compile.mainRule opts) (const $ pure ()) IdeLogger.noLogging damlEnv (toCompileOpts opts) vfs)
-      Compile.shutdown $ \service ->
+      (IDE.initialise (DamlRules.mainRule opts) (const $ pure ()) IdeLogger.noLogging damlEnv (toCompileOpts opts) vfs)
+      IDE.shutdown $ \service ->
       withTestArguments $ \args -> testGroup ("Tests for DAML-LF " ++ renderPretty version) $
         map (testCase args version service outdir registerTODO) allTestFiles
 
@@ -154,7 +154,7 @@ instance IsTest TestCase where
     pure $ res { resultDescription = desc }
   testOptions = Tagged []
 
-testCase :: TestArguments -> LF.Version -> IO Compile.IdeState -> FilePath -> (TODO -> IO ()) -> FilePath -> TestTree
+testCase :: TestArguments -> LF.Version -> IO DamlRules.IdeState -> FilePath -> (TODO -> IO ()) -> FilePath -> TestTree
 testCase args version getService outdir registerTODO file = singleTest file . TestCase $ \log -> do
   service <- getService
   anns <- readFileAnns file
@@ -167,9 +167,9 @@ testCase args version getService outdir registerTODO file = singleTest file . Te
       }
     else do
       -- FIXME: Use of unsafeClearDiagnostics is only because we don't naturally lose them when we change setFilesOfInterest
-      Compile.unsafeClearDiagnostics service
+      IDE.unsafeClearDiagnostics service
       ex <- try $ mainProj args service outdir log (toNormalizedFilePath file) :: IO (Either SomeException Package)
-      diags <- Compile.getDiagnostics service
+      diags <- IDE.getDiagnostics service
       for_ [file ++ ", " ++ x | Todo x <- anns] (registerTODO . TODO)
       resDiag <- checkDiagnostics log [fields | DiagnosticFields fields <- anns] $
         [ideErrorText "" $ T.pack $ show e | Left e <- [ex], not $ "_IGNORE_" `isInfixOf` show e] ++ diags
@@ -307,7 +307,7 @@ parseRange s =
             (Position (rowEnd - 1) (colEnd - 1))
     _ -> error $ "Failed to parse range, got " ++ s
 
-mainProj :: TestArguments -> Compile.IdeState -> FilePath -> (String -> IO ()) -> NormalizedFilePath -> IO LF.Package
+mainProj :: TestArguments -> DamlRules.IdeState -> FilePath -> (String -> IO ()) -> NormalizedFilePath -> IO LF.Package
 mainProj TestArguments{..} service outdir log file = do
     writeFile <- return $ \a b -> length b `seq` writeFile a b
     let proj = takeBaseName (fromNormalizedFilePath file)
@@ -316,8 +316,8 @@ mainProj TestArguments{..} service outdir log file = do
     let lfSave = timed log "LF saving" . liftIO . writeFileLf (outdir </> proj <.> "dalf")
     let lfPrettyPrint = timed log "LF pretty-printing" . liftIO . writeFile (outdir </> proj <.> "pdalf") . renderPretty
 
-    Compile.setFilesOfInterest service (Set.singleton file)
-    Compile.runActionSync service $ do
+    IDE.setFilesOfInterest service (Set.singleton file)
+    IDE.runActionSync service $ do
             cores <- ghcCompile log file
             corePrettyPrint cores
             lf <- lfConvert log file
@@ -335,16 +335,16 @@ unjust act = do
       Just v -> return v
 
 ghcCompile :: (String -> IO ()) -> NormalizedFilePath -> Action [GHC.CoreModule]
-ghcCompile log file = timed log "GHC compile" $ unjust $ Compile.getGhcCore file
+ghcCompile log file = timed log "GHC compile" $ unjust $ DamlRules.getGhcCore file
 
 lfConvert :: (String -> IO ()) -> NormalizedFilePath -> Action LF.Package
-lfConvert log file = timed log "LF convert" $ unjust $ Compile.getRawDalf file
+lfConvert log file = timed log "LF convert" $ unjust $ DamlRules.getRawDalf file
 
 lfTypeCheck :: (String -> IO ()) -> NormalizedFilePath -> Action LF.Package
-lfTypeCheck log file = timed log "LF type check" $ unjust $ Compile.getDalf file
+lfTypeCheck log file = timed log "LF type check" $ unjust $ DamlRules.getDalf file
 
 lfRunScenarios :: (String -> IO ()) -> NormalizedFilePath -> Action ()
-lfRunScenarios log file = timed log "LF execution" $ void $ unjust $ Compile.runScenarios file
+lfRunScenarios log file = timed log "LF execution" $ void $ unjust $ DamlRules.runScenarios file
 
 timed :: MonadIO m => (String -> IO ()) -> String -> m a -> m a
 timed log msg act = do

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -29,8 +29,8 @@ module Development.IDE.Core.Rules(
 import           Control.Monad.Except
 import Control.Monad.Trans.Maybe
 import qualified Development.IDE.Core.Compile             as Compile
-import qualified Development.IDE.Types.Options as Compile
-import qualified Development.IDE.Spans.Calculate as Compile
+import qualified Development.IDE.Types.Options as Options
+import qualified Development.IDE.Spans.Calculate as Spans
 import Development.IDE.Import.DependencyInformation
 import Development.IDE.Import.FindImports
 import           Development.IDE.Core.FileStore
@@ -152,7 +152,7 @@ getLocatedImportsRule =
         let dflags = Compile.addRelativeImport pm $ hsc_dflags env
         opt <- getIdeOptions
         xs <- forM imports $ \(mbPkgName, modName) ->
-            (modName, ) <$> locateModule dflags (Compile.optExtensions opt) getFileExists modName mbPkgName
+            (modName, ) <$> locateModule dflags (Options.optExtensions opt) getFileExists modName mbPkgName
         return (concat $ lefts $ map snd xs, Just $ map (second eitherToMaybe) xs)
 
 
@@ -237,7 +237,7 @@ getSpanInfoRule =
         tc <- use_ TypeCheck file
         imports <- use_ GetLocatedImports file
         packageState <- useNoFile_ GhcSession
-        x <- liftIO $ Compile.getSrcSpanInfos packageState (fileImports imports) tc
+        x <- liftIO $ Spans.getSrcSpanInfos packageState (fileImports imports) tc
         return ([], Just x)
 
 -- Typechecks a module.
@@ -266,7 +266,7 @@ loadGhcSession :: Rules ()
 loadGhcSession =
     defineNoFile $ \GhcSession -> do
         opts <- getIdeOptions
-        Compile.optGhcSession opts
+        Options.optGhcSession opts
 
 
 getHieFileRule :: Rules ()


### PR DESCRIPTION
Importing a module that doesn't have `Compile` in its name `as Compile`
seems odd. Similar for `CompilerService`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2217)
<!-- Reviewable:end -->
