### PR TITLE
minimal quick fix for quickstart template, and test!

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -76,7 +76,7 @@ tests damlDir tmpDir = testGroup "Integration tests"
     , quickstartTests quickstartDir mvnDir
     , cleanTests cleanDir
     ]
-    where quickstartDir = tmpDir </> "quickstart"
+    where quickstartDir = tmpDir </> "q-u-i-c-k-s-t-a-r-t"
           cleanDir = tmpDir </> "clean"
           mvnDir = tmpDir </> "m2"
           tarballDir = tmpDir </> "tarball"

--- a/templates/quickstart-java/daml.yaml.template
+++ b/templates/quickstart-java/daml.yaml.template
@@ -1,5 +1,5 @@
 sdk-version: __VERSION__
-name: __PROJECT_NAME__
+name: quickstart
 source: daml/Main.daml
 scenario: Main:setup
 parties:

--- a/templates/quickstart-scala/daml.yaml.template
+++ b/templates/quickstart-scala/daml.yaml.template
@@ -1,5 +1,5 @@
 sdk-version: __VERSION__
-name: __PROJECT_NAME__
+name: quickstart
 source: daml/Main.daml
 scenario: Main:setup
 parties:


### PR DESCRIPTION

Minimal fix as discussed with Fran, Moritz and Gary:

- Fix for the quickstart templates to hardcode project name as `quickstart`
- matching what is expected by the `pom.xml` file
- so the following now works properly: `daml new xxx quickstart-java`
- and the integration test proves the fix.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
