### PR TITLE
language: add a 'main' option to the migration command

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper/Main.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Main.hs
@@ -33,7 +33,7 @@ data Command
     = DamlStudio { replaceExtension :: ReplaceExtension, remainingArguments :: [String] }
     | RunJar { jarPath :: FilePath, remainingArguments :: [String] }
     | New { targetFolder :: FilePath, templateNameM :: Maybe String }
-    | Migrate { targetFolder :: FilePath, pkgPathFrom :: FilePath, pkgPathTo :: FilePath }
+    | Migrate { targetFolder :: FilePath, mainPath :: FilePath, pkgPathFrom :: FilePath, pkgPathTo :: FilePath }
     | Init { targetFolderM :: Maybe FilePath }
     | Deploy { optSandboxPort :: Maybe SandboxPort }
     | ListTemplates
@@ -68,6 +68,7 @@ commandParser =
               ]
           migrateCmd =  Migrate
                   <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
+                  <*> argument str (metavar "MAIN" <> help "Path to the main daml file within the project")
                   <*> argument str (metavar "FROM_PATH" <> help "Path to the dar-package from which to migrate from")
                   <*> argument str (metavar "TO_PATH" <> help "Path to the dar-package to which to migrate to")
           initCmd = Init <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
@@ -91,8 +92,8 @@ commandParser =
 runCommand :: Command -> IO ()
 runCommand DamlStudio {..} = runDamlStudio replaceExtension remainingArguments
 runCommand RunJar {..} = runJar jarPath remainingArguments
-runCommand New {..} = runNew targetFolder templateNameM []
-runCommand Migrate {..} = runMigrate targetFolder pkgPathFrom pkgPathTo
+runCommand New {..} = runNew targetFolder templateNameM Nothing []
+runCommand Migrate {..} = runMigrate targetFolder mainPath pkgPathFrom pkgPathTo
 runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
 runCommand Start {..} = runStart (optSandboxPort `orElse` defaultSandboxPort) startNavigator openBrowser onStartM waitForSignal

--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -449,8 +449,8 @@ runInit targetFolderM = do
 -- * Creation of a project in existing folder (suggest daml init instead).
 -- * Creation of a project inside another project.
 --
-runNew :: FilePath -> Maybe String -> [String] -> IO ()
-runNew targetFolder templateNameM pkgDeps = do
+runNew :: FilePath -> Maybe String -> Maybe FilePath -> [String] -> IO ()
+runNew targetFolder templateNameM mbMain pkgDeps = do
     templatesFolder <- getTemplatesFolder
     let templateName = fromMaybe defaultProjectTemplate templateNameM
         templateFolder = templatesFolder </> templateName
@@ -530,6 +530,7 @@ runNew targetFolder templateNameM pkgDeps = do
         let config = replace "__VERSION__"  sdkVersion
                    . replace "__PROJECT_NAME__" projectName
                    . replace "__DEPENDENCIES__" (unlines ["  - " <> dep | dep <- pkgDeps])
+                   . maybe id (replace "__MAIN__") mbMain
                    $ configTemplate
         writeFileUTF8 configPath config
         removeFile configTemplatePath
@@ -540,13 +541,13 @@ runNew targetFolder templateNameM pkgDeps = do
         "\" based on the template \"" <> templateName <> "\"."
 
 -- | Create a project containing code to migrate a running system between two given packages.
-runMigrate :: FilePath -> FilePath -> FilePath -> IO ()
-runMigrate targetFolder pkgPath1 pkgPath2
+runMigrate :: FilePath -> FilePath -> FilePath -> FilePath -> IO ()
+runMigrate targetFolder main pkgPath1 pkgPath2
  = do
     pkgPath1Abs <- makeAbsolute pkgPath1
     pkgPath2Abs <- makeAbsolute pkgPath2
     -- Create a new project
-    runNew targetFolder (Just "migrate") [pkgPath1Abs, pkgPath2Abs]
+    runNew targetFolder (Just "migrate") (Just main) [pkgPath1Abs, pkgPath2Abs]
 
     -- Call damlc to create the upgrade source files.
     assistant <- getDamlAssistant

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -258,7 +258,7 @@ packagingTests tmpDir = testGroup "packaging"
         withCurrentDirectory projectB $ callCommandQuiet "daml build"
         assertBool "a.dar was not created." =<< doesFileExist bDar
         step "Creating migration project"
-        callCommandQuiet $ unwords ["daml", "migrate", projectMigrate, aDar, bDar]
+        callCommandQuiet $ unwords ["daml", "migrate", projectMigrate, "daml/Main.daml", aDar, bDar]
         step "Build migration project"
         withCurrentDirectory projectMigrate $ callCommandQuiet "daml build"
     ]

--- a/templates/migrate/daml.yaml.template
+++ b/templates/migrate/daml.yaml.template
@@ -1,6 +1,6 @@
 sdk-version: __VERSION__
 name: __PROJECT_NAME__
-source: daml/Main.daml
+source: __MAIN__
 parties:
   - Alice
   - Bob


### PR DESCRIPTION
We add an additional argument "main" to the migrate command to put the
right main filepath into the project config.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
