### PR TITLE
Fix gRPC issues in damlc

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -48,10 +48,6 @@ execTest inFiles color mbJUnitOutput cliOptions = do
     withDamlIdeState opts loggerH diagnosticsLogger $ \h -> do
         let lfVersion = optDamlLfVersion cliOptions
         testRun h inFiles lfVersion color mbJUnitOutput
-        -- Run synchronously at the end to make sure that all gRPC requests
-        -- finish properly. We have seen segfaults on CI sometimes
-        -- which are probably caused by not doing this.
-        runActionSync h (pure ())
         diags <- getDiagnostics h
         when (any ((Just DsError ==) . _severity . snd) diags) exitFailure
 

--- a/nix/third-party/gRPC-haskell/core/chs/Network/GRPC/Unsafe.hs
+++ b/nix/third-party/gRPC-haskell/core/chs/Network/GRPC/Unsafe.hs
@@ -320,6 +320,11 @@ grpcShutdown =
   grpcShutdown'_ >>
   return ()
 
+grpcShutdownBlocking :: IO ()
+grpcShutdownBlocking =
+  grpcShutdownBlocking'_ >>
+  return ()
+
 {-# LINE 143 "nix/third-party/gRPC-haskell/core/src/Network/GRPC/Unsafe.chs" #-}
 
 
@@ -788,6 +793,9 @@ foreign import ccall safe "bazel-out/k8-fastbuild/bin/nix/third-party/gRPC-haske
 
 foreign import ccall safe "bazel-out/k8-fastbuild/bin/nix/third-party/gRPC-haskell/core/chs-src_Network_GRPC_Unsafe.chs/Network/GRPC/Unsafe.chs.h grpc_shutdown"
   grpcShutdown'_ :: (IO ())
+
+foreign import ccall safe "bazel-out/k8-fastbuild/bin/nix/third-party/gRPC-haskell/core/chs-src_Network_GRPC_Unsafe.chs/Network/GRPC/Unsafe.chs.h grpc_shutdown_blocking"
+  grpcShutdownBlocking'_ :: (IO ())
 
 foreign import ccall safe "bazel-out/k8-fastbuild/bin/nix/third-party/gRPC-haskell/core/chs-src_Network_GRPC_Unsafe.chs/Network/GRPC/Unsafe.chs.h grpc_version_string"
   grpcVersionString'_ :: (IO (C2HSImp.Ptr C2HSImp.CChar))

--- a/nix/third-party/gRPC-haskell/core/src/Network/GRPC/Unsafe.chs
+++ b/nix/third-party/gRPC-haskell/core/src/Network/GRPC/Unsafe.chs
@@ -142,6 +142,8 @@ castPeek p = do
 
 {#fun grpc_shutdown as ^ {} -> `()'#}
 
+{#fun grpc_shutdown_blocking as ^ {} -> `()'#}
+
 {#fun grpc_version_string as ^ {} -> `String' #}
 
 -- | Create a new 'CompletionQueue' for GRPC_CQ_NEXT. See the docs for

--- a/nix/third-party/gRPC-haskell/core/tests/UnsafeTests.hs
+++ b/nix/third-party/gRPC-haskell/core/tests/UnsafeTests.hs
@@ -197,7 +197,7 @@ assertCqEventComplete e = do
   eventSuccess e HU.@?= True
 
 grpc :: IO a -> IO ()
-grpc = bracket_ grpcInit grpcShutdown . void
+grpc = bracket_ grpcInit grpcShutdownBlocking . void
 
 _nowarnUnused :: a
 _nowarnUnused = assertCqEventComplete `undefined` threadDelaySecs

--- a/nix/third-party/gRPC-haskell/src/Network/GRPC/HighLevel/Client.hs
+++ b/nix/third-party/gRPC-haskell/src/Network/GRPC/HighLevel/Client.hs
@@ -23,6 +23,7 @@ module Network.GRPC.HighLevel.Client
 
 where
 
+import Control.Exception
 import qualified Network.GRPC.LowLevel.Client as LL
 import qualified Network.GRPC.LowLevel.Call as LL
 import Network.GRPC.LowLevel.CompletionQueue (TimeoutSeconds)
@@ -93,7 +94,13 @@ clientRequest :: (Message request, Message response) =>
                  LL.Client -> RegisteredMethod streamType request response
               -> ClientRequest streamType request response -> IO (ClientResult streamType response)
 clientRequest client (RegisteredMethod method) (ClientNormalRequest req timeout meta) =
-    mkResponse <$> LL.clientRequest client method timeout (BL.toStrict (toLazyByteString req)) meta
+    -- The internals of clientRequest are not able to handle asynchronous exceptions so we mask them.
+    -- This is probably also an issue for the other methods below but until we have a good
+    -- test case for those, I’ll leave it as is.
+    -- In particular for streaming requests, masking everything is not reasonable
+    -- so we probably need to fix the internals to handle asynchronous exceptions properly
+    -- at a finer granularity.
+    mkResponse <$> mask_ (LL.clientRequest client method timeout (BL.toStrict (toLazyByteString req)) meta)
   where
     mkResponse (Left ioError_) = ClientErrorResponse (ClientIOError ioError_)
     mkResponse (Right rsp) =


### PR DESCRIPTION
The gRPC library does not handle asynchronous exceptions properly and
ends up leaking things which causes various issues (segfaults,
assertion failures, weird backup poller timer messages, …) when
shutting down gRPC.

The switch to grpcShutdownBlocking is somewhat unrelated (the issues
happen with and without that and the fix seems to work both times) but
that function seems to be the right way to shut down gRPC in newer
versions and is what all the official language bindings switched to,
so I also made the switch.

I haven’t yet looked into the issues in the HS ledger bindings so not
sure if this helps with those as well.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
