### PR TITLE
language: added a merge command to damlc

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -6,6 +6,7 @@
 module DA.Daml.Compiler.Dar
   ( buildDar
   , FromDalf(..)
+  , breakAt72Chars
   ) where
 
 import qualified Codec.Archive.Zip as Zip
@@ -179,10 +180,10 @@ createArchive dalf modRoot dalfDependencies fileDependencies dataFiles name sdkV
           , "Encryption: non-encrypted"
           ]
 
-        breakAt72Chars :: String -> String
-        breakAt72Chars s = case splitAt 72 s of
-          (s0, []) -> s0
-          (s0, rest) -> s0 ++ "\n" ++ breakAt72Chars (" " ++ rest)
+breakAt72Chars :: String -> String
+breakAt72Chars s = case splitAt 72 s of
+  (s0, []) -> s0
+  (s0, rest) -> s0 ++ "\n" ++ breakAt72Chars (" " ++ rest)
 
 -- | Like `makeRelative` but also takes care of normalising filepaths so
 --

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -824,6 +824,7 @@ execMergeDars darFp1 darFp2 mbOutFp = do
     let merged =
             Archive
                 (nubSortOn eRelativePath $ mf : zEntries dar1 ++ zEntries dar2)
+                -- nubSortOn keeps the first occurence
                 Nothing
                 BSL.empty
     BSL.writeFile outFp $ fromArchive merged


### PR DESCRIPTION
This adds a 'merge-dars' command to damlc to merge two dars into one.
This is useful when you created an upgrade dar and want to ship it as
part of the latest version of a package.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
