### PR TITLE
Remove dependency on ghc from daml-helper

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -42,7 +42,6 @@ da_haskell_binary(
     srcs = ["src/DamlHelper/Main.hs"],
     hazel_deps = [
         "base",
-        "ghc",
     ],
     main_function = "DamlHelper.Main.main",
     visibility = ["//visibility:public"],

--- a/daml-assistant/daml-helper/src/DamlHelper/Main.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Main.hs
@@ -4,7 +4,7 @@ module DamlHelper.Main (main) where
 
 import Control.Exception
 import Data.Foldable
-import Maybes (orElse)
+import Data.Maybe
 import Options.Applicative.Extended
 import System.Environment
 import System.Exit
@@ -96,5 +96,5 @@ runCommand New {..} = runNew targetFolder templateNameM Nothing []
 runCommand Migrate {..} = runMigrate targetFolder mainPath pkgPathFrom pkgPathTo
 runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
-runCommand Start {..} = runStart (optSandboxPort `orElse` defaultSandboxPort) startNavigator openBrowser onStartM waitForSignal
-runCommand Deploy {..} = runDeploy (optSandboxPort `orElse` defaultSandboxPort)
+runCommand Start {..} = runStart (fromMaybe defaultSandboxPort optSandboxPort) startNavigator openBrowser onStartM waitForSignal
+runCommand Deploy {..} = runDeploy (fromMaybe defaultSandboxPort optSandboxPort)


### PR DESCRIPTION
GHCi gets confused if both ghc and ghc-lib are exposed and there is no
reason why we should depend on ghc here anyway.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
