### PR TITLE
clean before ci build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,6 +120,7 @@ jobs:
     steps:
       - template: ci/report-start.yml
       - checkout: self
+      - bash: git clean -xffd
       - bash: ci/dev-env-install.sh
         displayName: 'Build/Install the Developer Environment'
       - bash: ci/configure-bazel.sh
@@ -131,6 +132,7 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
+          bazel clean --expunge
           bazel run -- //ledger/sandbox-perf -foe true -i1 -f1 -wi 1 -bm avgt -rf csv -rff "$(Build.StagingDirectory)/sandbox-perf.csv"
       - task: PublishBuildArtifacts@1
         condition: succeededOrFailed()

--- a/build.ps1
+++ b/build.ps1
@@ -57,6 +57,8 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+bazel clean `-`-expunge
+
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -2,6 +2,9 @@ parameters:
   name: ''
 
 steps:
+  - bash: |
+      git clean -xffd
+
   - bash: ci/dev-env-install.sh
     displayName: 'Build/Install the Developer Environment'
 
@@ -25,6 +28,10 @@ steps:
       IS_FORK: $(System.PullRequest.IsFork)
       # to upload to the bazel cache
       GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+
+  - bash: |
+      eval "$(./dev-env/bin/dade-assist)"
+      bazel clean --expunge
 
   - bash: ./build.sh "_$(uname)"
     displayName: 'Build'

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -1,5 +1,6 @@
 steps:
   - checkout: self
+  - bash: git clean -xffd
 
   - bash: ci/configure-bazel.sh
     displayName: 'Configure Bazel'


### PR DESCRIPTION
We suspect interactions between builds. This should prevent that.