### PR TITLE
Upgrade hlint

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -526,7 +526,7 @@ hazel_repositories(
             #   - To build the library : `bazel build @haskell_hlint//:lib`
             # We'll be using it via the library, not the binary.
             hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
-            hazel_github_external("ndmitchell", "hlint", "9589299bf9a6273fe7c2915da3f9b7c35f82d527", "49386869b32cf1ccf8241ce9fe927d14475bd693e769ad65670715d3401a959f") +
+            hazel_github_external("shayne-fletcher-da", "hlint", "699adc7c7be5f876433a49661311093c42259cf1", "1fe563fa724ce589b85d67349d98ce254e01cfe28bda8bcf46958d944987e2cb") +
             hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +


### PR DESCRIPTION
This PR brings DAML level with hlint head. It pulls in naming and import rules. There is one slight problem : as the GHC and DAML parse trees are divergent, hlint upstream is incompatible in `Naming.hs` with the DAML version of `ghc-lib`. This requires patching hlint (the `Match` constructor has 5 arguments rather than 4 in our version to account for optional function return type signatures). I've done this on the `da-master` branch of my fork and updated `WORKSPACE` to fetch hlint from there for the time being.