### PR TITLE
Cache nix store

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -3,6 +3,28 @@ parameters:
 
 steps:
   - checkout: self
+  - bash: |
+       set -euo pipefail
+       if [[ ! -e /nix ]]; then
+         echo "Installing Nix"
+         sudo mkdir -m 0755 /nix
+         sudo chown "$(id -u):$(id -g)" /nix
+         # 2.2.2 seems to segfault on MacOS in CI so for now we use 2.2.1.
+         curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
+       fi
+       source dev-env/lib/ensure-nix
+
+       export NIX_CONF_DIR=$PWD/dev-env/etc
+       CACHE_KEY="$(nix-instantiate --quiet nix -A tools -A cached)"
+       # Strip newlines and spaces to avoid Azure interpreting it as files.
+       CACHE_KEY="$(echo $CACHE_KEY | sed 's/\s//g')"
+       echo "##vso[task.setvariable variable=CACHE_KEY]$CACHE_KEY"
+
+  - task: CacheBeta@0
+    inputs:
+      key: $(CACHE_KEY)
+      path: /nix/store
+    displayName: Cache nix store
 
   - bash: ci/dev-env-install.sh
     displayName: 'Build/Install the Developer Environment'

--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -17,16 +17,6 @@ step() {
 
 cd "$(dirname "$0")/.."
 
-if [[ ! -e /nix ]]; then
-  step "Installing Nix"
-
-  sudo mkdir -m 0755 /nix
-  sudo chown "$(id -u):$(id -g)" /nix
-
-  # 2.2.2 seems to segfault on MacOS in CI so for now we use 2.2.1.
-  curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
-fi
-
 # shellcheck source=../dev-env/lib/ensure-nix
 source dev-env/lib/ensure-nix
 


### PR DESCRIPTION
At least in theory, Azure pipelines should have caching now that we should be able to use to cache the Nix store.
This is mostly helpful on MacOS builders where we currently spend about 7 minutes just fetching the store.

I’m sure I’ve screwed up the syntax in various ways so mostly opening this to get some CI feedback.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
