### PR TITLE
damldocs: Document template instances.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -402,6 +402,9 @@ getTemplateDocs DocCtx{..} typeMap templateInstanceMap =
 --
 -- So the goal of this function is to extract the template instance doc
 -- from the newtype doc if it exists.
+--
+-- The TEMPLATE_INSTANCE doc marker used here does not exist yet.
+-- (See issue #2239 in the daml repo for an up to date status.)
 getTemplateInstanceDoc :: ADTDoc -> Maybe TemplateInstanceDoc
 getTemplateInstanceDoc adt
     | ADTDoc{..} <- adt

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -73,6 +73,7 @@ mkDocs opts fp = do
             md_anchor = Just (moduleAnchor md_name)
             md_descr = modDoc dc_tcmod
             md_templates = getTemplateDocs ctx typeMap templateInstanceMap
+            md_templateInstances = []
             md_functions = mapMaybe (getFctDocs ctx) dc_decls
             md_adts
                 = MS.elems . MS.withoutKeys typeMap . Set.unions

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -44,6 +44,7 @@ renderSimpleMD ModuleDoc{..} = mconcat
     [ renderAnchorInfix "# " md_anchor ("Module " <> escapeMd (unModulename md_name))
     , renderDocText md_descr
     , section "Templates" tmpl2md md_templates
+    , section "Template Instances" renderTemplateInstanceDocAsMarkdown md_templateInstances
     , section "Typeclasses" cls2md md_classes
     , section "Data types" adt2md md_adts
     , section "Functions" fct2md md_functions
@@ -88,6 +89,14 @@ tmpl2md TemplateDoc{..} = withAnchorTag td_anchor $ \tag -> mconcat
             , fieldTable cd_fields
             ]
         ]
+
+renderTemplateInstanceDocAsMarkdown :: TemplateInstanceDoc -> RenderOut
+renderTemplateInstanceDocAsMarkdown TemplateInstanceDoc{..} = mconcat
+    [ renderAnchorInfix "**template instance " ti_anchor $
+        escapeMd (unTypename ti_name) <> "**  "
+    , renderLineDep $ \env -> T.concat ["&nbsp; = ", type2md env ti_rhs]
+    , renderDocText ti_descr
+    ]
 
 cls2md :: ClassDoc -> RenderOut
 cls2md ClassDoc{..} = mconcat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -75,7 +75,7 @@ tmpl2rst TemplateDoc{..} = mconcat $
   , renderLineDep $ \env -> T.concat
       [ "template "
       , maybe "" ((<> " => ") . type2rst env) td_super
-      , T.unwords (enclosedIn "**" (unTypename td_name) : td_args)
+      , T.unwords (bold (unTypename td_name) : td_args)
       ]
   , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) td_descr
   , renderLine ""
@@ -87,7 +87,7 @@ renderTemplateInstanceDocAsRst :: TemplateInstanceDoc -> RenderOut
 renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat
     [ renderAnchor ti_anchor
     , renderLinesDep $ \env ->
-        [ "template instance " <> enclosedIn "**" (unTypename ti_name)
+        [ "template instance " <> bold (unTypename ti_name)
         , "    = " <> type2rst env ti_rhs
         , ""
         ]
@@ -96,7 +96,7 @@ renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat
 
 choiceBullet :: ChoiceDoc -> RenderOut
 choiceBullet ChoiceDoc{..} = mconcat
-  [ renderLine $ prefix "+ " $ enclosedIn "**" $ "Choice " <> unTypename cd_name
+  [ renderLine $ prefix "+ " $ bold $ "Choice " <> unTypename cd_name
   , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) cd_descr
   , renderIndent 2 (fieldTable cd_fields)
   ]
@@ -105,7 +105,8 @@ cls2rst ::  ClassDoc -> RenderOut
 cls2rst ClassDoc{..} = mconcat
     [ renderAnchor cl_anchor
     , renderLineDep $ \env ->
-        "class " <> maybe "" (\x -> type2rst env x <> " => ") cl_super <> "**" <> T.unwords (unTypename cl_name : cl_args) <> "** where"
+        "class " <> maybe "" (\x -> type2rst env x <> " => ") cl_super <>
+        bold (T.unwords (unTypename cl_name : cl_args)) <> " where"
     , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) cl_descr
     , mconcat $ map (renderIndent 2 . fct2rst) cl_functions
     ]
@@ -114,7 +115,7 @@ adt2rst :: ADTDoc -> RenderOut
 adt2rst TypeSynDoc{..} = mconcat
     [ renderAnchor ad_anchor
     , renderLinesDep $ \env ->
-        [ "type " <> enclosedIn "**"
+        [ "type " <> bold
             (T.unwords (unTypename ad_name : ad_args))
         , "    = " <> type2rst env ad_rhs
         , ""
@@ -124,7 +125,7 @@ adt2rst TypeSynDoc{..} = mconcat
 adt2rst ADTDoc{..} = mconcat $
     [ renderAnchor ad_anchor
     , renderLines
-        [ "data " <> enclosedIn "**" (T.unwords (unTypename ad_name : ad_args))
+        [ "data " <> bold (T.unwords (unTypename ad_name : ad_args))
         , "" ]
     , maybe mempty ((<> renderLine "") . renderIndent 2 . renderDocText) ad_descr
     ] ++ map (renderIndent 2 . (renderLine "" <>) . constr2rst) ad_constrs
@@ -134,7 +135,7 @@ constr2rst ::  ADTConstr -> RenderOut
 constr2rst PrefixC{..} = mconcat
     [ renderAnchor ac_anchor
     , renderLineDep $ \env ->
-        T.unwords (enclosedIn "**" (unTypename ac_name) : map (type2rst env) ac_args)
+        T.unwords (bold (unTypename ac_name) : map (type2rst env) ac_args)
             -- FIXME: Parentheses around args seems necessary here
             -- if they are type application or function (see type2rst).
     , maybe mempty ((renderLine "" <>) . renderDocText) ac_descr
@@ -142,7 +143,7 @@ constr2rst PrefixC{..} = mconcat
 
 constr2rst RecordC{..} = mconcat
     [ renderAnchor ac_anchor
-    , renderLine $ enclosedIn "**" (unTypename ac_name)
+    , renderLine $ bold (unTypename ac_name)
     , renderLine ""
     , maybe mempty renderDocText ac_descr
     , renderLine ""
@@ -216,7 +217,7 @@ fct2rst :: FunctionDoc -> RenderOut
 fct2rst FunctionDoc{..} = mconcat
     [ renderAnchor fct_anchor
     , renderLinesDep $ \ env ->
-        [ enclosedIn "**" (wrapOp (unFieldname fct_name))
+        [ bold (wrapOp (unFieldname fct_name))
         , T.concat
             [ "  : "
             , maybe "" ((<> " => ") . type2rst env) fct_context

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -53,7 +53,6 @@ renderSimpleRst ModuleDoc{..} = mconcat $
     , section "Typeclasses" cls2rst md_classes
     , section "Data types" adt2rst md_adts
     , section "Functions" fct2rst md_functions
-    , renderLine ""
     ]
 
   where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -57,6 +57,14 @@ renderSimpleRst ModuleDoc{..} = mconcat $
               , "^^^^^^^^^" ]
          , mconcat $ map tmpl2rst md_templates
          ]
+  , if null md_templateInstances
+    then []
+    else [ renderLines
+              [ ""
+              , "Template Instances"
+              , "^^^^^^^^^^^^^^^^^^" ]
+         , mconcat $ map renderTemplateInstanceDocAsRst md_templateInstances
+         ]
   , if null md_classes
     then []
     else [ renderLines
@@ -98,6 +106,17 @@ tmpl2rst TemplateDoc{..} = mconcat $
   , renderIndent 2 (fieldTable td_payload)
   , renderLine ""
   ] ++ map (renderIndent 2 . choiceBullet) td_choices
+
+renderTemplateInstanceDocAsRst :: TemplateInstanceDoc -> RenderOut
+renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat $
+    [ renderAnchor ti_anchor
+    , renderLinesDep $ \env ->
+        [ "template instance " <> enclosedIn "**" (unTypename ti_name)
+        , "    = " <> type2rst env ti_rhs
+        , ""
+        ]
+    , maybe mempty ((<> renderLine "") . renderIndent 2 . renderDocText) ti_descr
+    ]
 
 choiceBullet :: ChoiceDoc -> RenderOut
 choiceBullet ChoiceDoc{..} = mconcat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -41,7 +41,7 @@ renderSimpleRst ModuleDoc{..}
   | null md_templates && null md_classes &&
     null md_adts && null md_functions &&
     isNothing md_descr = mempty
-renderSimpleRst ModuleDoc{..} = mconcat $
+renderSimpleRst ModuleDoc{..} = mconcat
     [ renderAnchor md_anchor
     , renderLines
         [ title
@@ -84,7 +84,7 @@ tmpl2rst TemplateDoc{..} = mconcat $
   ] ++ map (renderIndent 2 . choiceBullet) td_choices
 
 renderTemplateInstanceDocAsRst :: TemplateInstanceDoc -> RenderOut
-renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat $
+renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat
     [ renderAnchor ti_anchor
     , renderLinesDep $ \env ->
         [ "template instance " <> enclosedIn "**" (unTypename ti_name)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
@@ -8,6 +8,7 @@ module DA.Daml.Doc.Render.Util
   , prefix
   , indent
   , enclosedIn
+  , bold
   , inParens
   , wrapOp
   ) where
@@ -21,6 +22,10 @@ inParens t = "(" <> t <> ")"
 -- | Surrounds text in 2nd argument by text in the 1st
 enclosedIn :: T.Text -> T.Text -> T.Text
 enclosedIn c t = T.concat [c, t, c]
+
+-- | A bold function that works for both Rst and Markdown.
+bold :: T.Text -> T.Text
+bold = enclosedIn "**"
 
 -- | Indents all lines in Text by n spaces
 indent :: Int -> T.Text -> T.Text

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -76,6 +76,7 @@ data TemplateDoc = TemplateDoc
 data TemplateInstanceDoc = TemplateInstanceDoc
     { ti_anchor :: Maybe Anchor
     , ti_name :: Typename
+    , ti_descr :: Maybe DocText
     , ti_rhs :: Type
     } deriving (Eq, Show, Generic)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -50,6 +50,7 @@ data ModuleDoc = ModuleDoc
   , md_name      :: Modulename
   , md_descr     :: Maybe DocText
   , md_templates :: [TemplateDoc]
+  , md_templateInstances :: [TemplateInstanceDoc]
   , md_adts      :: [ADTDoc]
   , md_functions :: [FunctionDoc]
   , md_classes   :: [ClassDoc]
@@ -71,6 +72,12 @@ data TemplateDoc = TemplateDoc
   , td_choices :: [ChoiceDoc]
   }
   deriving (Eq, Show, Generic)
+
+data TemplateInstanceDoc = TemplateInstanceDoc
+    { ti_anchor :: Maybe Anchor
+    , ti_name :: Typename
+    , ti_rhs :: Type
+    } deriving (Eq, Show, Generic)
 
 data ClassDoc = ClassDoc
   { cl_anchor :: Maybe Anchor
@@ -197,6 +204,12 @@ instance ToJSON TemplateDoc where
     toJSON = genericToJSON aesonOptions
 
 instance FromJSON TemplateDoc where
+    parseJSON = genericParseJSON aesonOptions
+
+instance ToJSON TemplateInstanceDoc where
+    toJSON = genericToJSON aesonOptions
+
+instance FromJSON TemplateInstanceDoc where
     parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON ModuleDoc where

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -30,40 +30,41 @@ mkTestTree = do
 
 cases :: [(String, ModuleDoc)]
 cases = [ ("Empty module",
-           ModuleDoc Nothing "Empty" Nothing [] [] [] [])
+           ModuleDoc Nothing "Empty" Nothing [] [] [] [] [])
         , ("Type def with argument",
-           ModuleDoc (Just "module-typedef") "Typedef" Nothing []
+           ModuleDoc (Just "module-typedef") "Typedef" Nothing [] []
             [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
             [] []
           )
         , ("Two types",
-           ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing []
+           ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing [] []
             [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
             , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]]
             ]
             [] []
           )
         , ("Documented function with type",
-           ModuleDoc (Just "module-function1") "Function1" Nothing [] []
+           ModuleDoc (Just "module-function1") "Function1" Nothing [] [] []
             [FunctionDoc (Just "function-function1-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) (Just "the doc")] []
           )
         , ("Documented function without type",
-           ModuleDoc (Just "module-function2") "Function2" Nothing [] []
+           ModuleDoc (Just "module-function2") "Function2" Nothing [] [] []
             [FunctionDoc (Just "function-function2-f") "f" Nothing Nothing (Just "the doc")] []
           )
         , ("Undocumented function with type",
-           ModuleDoc (Just "module-function3") "Function3" Nothing [] []
+           ModuleDoc (Just "module-function3") "Function3" Nothing [] [] []
             [FunctionDoc (Just "function-function3-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) Nothing] []
           )
         -- The doc extraction won't generate functions without type nor description
         , ("Module with only a type class",
-           ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] []
+           ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
             [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (Just (TypeApp Nothing "a" [])) Nothing]])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")
              "MultiLineField"
              Nothing
+             []
              []
              [ADTDoc
                 (Just "data-multilinefield-d")

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -224,6 +224,7 @@ emptyDocs name =
         md_anchor = Just (moduleAnchor md_name)
         md_descr = Nothing
         md_templates = []
+        md_templateInstances = []
         md_adts = []
         md_functions = []
         md_classes = []

--- a/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.md
@@ -1,0 +1,28 @@
+# <a name="module-ioudsl-47944"></a>Module IouDSL
+
+## Templates
+
+### <a name="type-ioudsl-iou-73876"></a>template Iou
+
+| Field  | Type/Description |
+| :----- | :----------------
+| issuer | Party |
+| owner  | Party |
+| amount | Decimal |
+
+
+Choices:
+
+* External:Archive
+  
+  (no fields)
+* Burn
+  
+  (no fields)
+
+## Template Instances
+
+**template instance <a name="type-ioudsl-proposaliou-92778"></a>ProposalIou**  
+&nbsp; = Proposal [Iou](#type-ioudsl-iou-73876)
+
+

--- a/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.rst
@@ -1,0 +1,42 @@
+
+.. _module-ioudsl-47944:
+
+Module IouDSL
+-------------
+
+
+Templates
+^^^^^^^^^
+
+.. _type-ioudsl-iou-73876:
+
+template **Iou**
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - issuer
+       - Party
+       -
+     * - owner
+       - Party
+       -
+     * - amount
+       - Decimal
+       -
+
+  + **Choice External:Archive**
+  + **Choice Burn**
+
+Template Instances
+^^^^^^^^^^^^^^^^^^
+
+.. _type-ioudsl-proposaliou-92778:
+
+template instance **ProposalIou**
+    = Proposal `Iou <type-ioudsl-iou-73876_>`_
+

--- a/compiler/damlc/tests/daml-test-files/IouDSL.daml
+++ b/compiler/damlc/tests/daml-test-files/IouDSL.daml
@@ -77,7 +77,7 @@ instance IouInstance where
 
 
 -- The instantiation of the generic proposal workflow for `Iou`.
-newtype ProposalIou = MkProposalIou with unProposalIou : Proposal Iou
+newtype ProposalIou = MkProposalIou with unProposalIou : Proposal Iou -- ^ TEMPLATE_INSTANCE
 
 instance ProposalInstance Iou where
 


### PR DESCRIPTION
I was most of the way to adding template instance docs to damldoc, when I realized my approach to detecting template instances did not work, and in fact *there is no way to detect that a newtype comes from a template instance* under the current generic templates desugaring proposal.

I created the issue #2239 to add a marker in the generated newtype's field docs that will let us detect generation during template instance desugaring. So the template instance support in this PR is somewhat speculative, but it should be easy to change again should template instances be desugared in a different way from the linked issue.

Nevertheless I added a test that uses the proposed marker.

This PR rounds out all the damldocs support needed for generic templates (#1387).