### PR TITLE
hie-core/test: Dedicated test suite for hie-core

### DIFF
--- a/compiler/hie-core/BUILD.bazel
+++ b/compiler/hie-core/BUILD.bazel
@@ -114,4 +114,4 @@ da_haskell_binary(
     deps = [
         "hie-core-public",
     ],
-) if not is_windows else None  # Disable on Windows until ghc-paths is fixed upstream
+)

--- a/compiler/hie-core/BUILD.bazel
+++ b/compiler/hie-core/BUILD.bazel
@@ -1,7 +1,12 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library")
+load(
+    "//bazel_tools:haskell.bzl",
+    "da_haskell_binary",
+    "da_haskell_library",
+    "da_haskell_test",
+)
 load("@os_info//:os_info.bzl", "is_windows")
 
 depends = [

--- a/compiler/hie-core/test/BUILD.bazel
+++ b/compiler/hie-core/test/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 da_haskell_library(
     name = "hie-core-testing",
     srcs = glob(["src/**/*.hs"]),
-    src_strip_prefix = "src",
     hazel_deps = [
         "base",
         "containers",
@@ -21,16 +20,16 @@ da_haskell_library(
         "tasty-hunit",
         "text",
     ],
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
     deps = [
         "//compiler/hie-core",
     ],
-    visibility = ["//visibility:public"],
 )
 
 da_haskell_test(
     name = "hie-core-tests",
     srcs = glob(["exe/**/*.hs"]),
-    src_strip_prefix = "exe",
     data = ["//compiler/hie-core:hie-core-exe"],
     hazel_deps = [
         "base",
@@ -42,10 +41,10 @@ da_haskell_test(
         "tasty-hunit",
         "text",
     ],
+    src_strip_prefix = "exe",
     deps = [
         "//compiler/hie-core",
         "//compiler/hie-core/test:hie-core-testing",
         "//libs-haskell/bazel-runfiles",
     ],
 )
-

--- a/compiler/hie-core/test/BUILD.bazel
+++ b/compiler/hie-core/test/BUILD.bazel
@@ -1,0 +1,51 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:haskell.bzl",
+    "da_haskell_library",
+    "da_haskell_test",
+)
+
+da_haskell_library(
+    name = "hie-core-testing",
+    srcs = glob(["src/**/*.hs"]),
+    src_strip_prefix = "src",
+    hazel_deps = [
+        "base",
+        "containers",
+        "haskell-lsp-types",
+        "lens",
+        "lsp-test",
+        "parser-combinators",
+        "tasty-hunit",
+        "text",
+    ],
+    deps = [
+        "//compiler/hie-core",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+da_haskell_test(
+    name = "hie-core-tests",
+    srcs = glob(["exe/**/*.hs"]),
+    src_strip_prefix = "exe",
+    data = ["//compiler/hie-core:hie-core-exe"],
+    hazel_deps = [
+        "base",
+        "extra",
+        "filepath",
+        "haskell-lsp-types",
+        "lsp-test",
+        "tasty",
+        "tasty-hunit",
+        "text",
+    ],
+    deps = [
+        "//compiler/hie-core",
+        "//compiler/hie-core/test:hie-core-testing",
+        "//libs-haskell/bazel-runfiles",
+    ],
+)
+

--- a/compiler/hie-core/test/exe/Main.hs
+++ b/compiler/hie-core/test/exe/Main.hs
@@ -5,13 +5,12 @@
 
 module Main (main) where
 
-import Control.Monad (void, when)
-import Data.Maybe (isNothing)
+import Control.Monad (void)
 import qualified Data.Text as T
 import Development.IDE.Test
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
-import System.Environment (lookupEnv, setEnv)
+import System.Environment.Blank (setEnv)
 import System.FilePath
 import System.IO.Extra
 import Test.Tasty
@@ -65,10 +64,9 @@ run s = withTempDir $ \dir -> do
   let hieCoreExePath = mainWorkspace </> exe "compiler/hie-core/hie-core-exe"
   hieCoreExe <- locateRunfiles hieCoreExePath
   let cmd = unwords [hieCoreExe, "--lsp", "--cwd", dir]
-  home <- lookupEnv "HOME"
-  when (isNothing home) $
-    -- HIE calls getXgdDirectory which assumes that HOME is set.
-    setEnv "HOME" "/homeless-shelter"
+  -- HIE calls getXgdDirectory which assumes that HOME is set.
+  -- Only sets HOME if it wasn't already set.
+  setEnv "HOME" "/homeless-shelter" False
   runSessionWithConfig conf cmd fullCaps dir s
   where
     conf = defaultConfig

--- a/compiler/hie-core/test/src/Development/IDE/Test.hs
+++ b/compiler/hie-core/test/src/Development/IDE/Test.hs
@@ -1,0 +1,74 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Development.IDE.Test
+  ( Cursor
+  , cursorPosition
+  , requireDiagnostic
+  , expectDiagnostics
+  ) where
+
+import Control.Applicative.Combinators
+import Control.Lens hiding (List)
+import Control.Monad
+import Control.Monad.IO.Class
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import Language.Haskell.LSP.Test hiding (message, openDoc')
+import qualified Language.Haskell.LSP.Test as LspTest
+import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens as Lsp
+import Test.Tasty.HUnit
+
+
+-- | (0-based line number, 0-based column number)
+type Cursor = (Int, Int)
+
+cursorPosition :: Cursor -> Position
+cursorPosition (line,  col) = Position line col
+
+requireDiagnostic :: List Diagnostic -> (DiagnosticSeverity, Cursor, T.Text) -> Assertion
+requireDiagnostic actuals expected@(severity, cursor, expectedMsg) = do
+    unless (any match actuals) $
+        assertFailure $
+            "Could not find " <> show expected <>
+            " in " <> show actuals
+  where
+    match :: Diagnostic -> Bool
+    match d =
+        Just severity == _severity d
+        && cursorPosition cursor == d ^. range . start
+        && standardizeQuotes (T.toLower expectedMsg) `T.isInfixOf`
+           standardizeQuotes (T.toLower $ d ^. message)
+
+expectDiagnostics :: [(FilePath, [(DiagnosticSeverity, Cursor, T.Text)])] -> Session ()
+expectDiagnostics expected = do
+    expected' <- Map.fromListWith (<>) <$> traverseOf (traverse . _1) (fmap toNormalizedUri . getDocUri) expected
+    go expected'
+    where
+        go m
+            | Map.null m = pure ()
+            | otherwise = do
+                  diagsNot <- skipManyTill anyMessage LspTest.message :: Session PublishDiagnosticsNotification
+                  let fileUri = diagsNot ^. params . uri
+                  case Map.lookup (diagsNot ^. params . uri . to toNormalizedUri) m of
+                      Nothing -> liftIO $ assertFailure $
+                          "Got diagnostics for " <> show fileUri <>
+                          " but only expected diagnostics for " <> show (Map.keys m)
+                      Just expected -> do
+                          let actual = diagsNot ^. params . diagnostics
+                          liftIO $ mapM_ (requireDiagnostic actual) expected
+                          liftIO $ unless (length expected == length actual) $
+                              assertFailure $
+                              "Incorrect number of diagnostics for " <> show fileUri <>
+                              ", expected " <> show expected <>
+                              " but got " <> show actual
+                          go $ Map.delete (diagsNot ^. params . uri . to toNormalizedUri) m
+
+standardizeQuotes :: T.Text -> T.Text
+standardizeQuotes msg = let
+        repl '‘' = '\''
+        repl '’' = '\''
+        repl '`' = '\''
+        repl  c   = c
+    in  T.map repl msg

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -36,6 +36,7 @@ da_haskell_test(
     deps = [
         "//compiler/damlc/daml-ide-core",
         "//compiler/hie-core",
+        "//compiler/hie-core/test:hie-core-testing",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",
     ],

--- a/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
+++ b/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
@@ -23,7 +23,6 @@ import Control.Lens hiding (List)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Aeson (Result(..), fromJSON)
-import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Language.Haskell.LSP.Test hiding (message, openDoc')
 import qualified Language.Haskell.LSP.Test as LspTest
@@ -33,52 +32,9 @@ import Network.URI
 import System.IO.Extra
 import Test.Tasty.HUnit
 
-import DA.Test.Util
+import Development.IDE.Test
 import Development.IDE.Core.Rules.Daml (VirtualResourceChangedParams(..))
 
--- | (0-based line number, 0-based column number)
-type Cursor = (Int, Int)
-
-cursorPosition :: Cursor -> Position
-cursorPosition (line,  col) = Position line col
-
-requireDiagnostic :: List Diagnostic -> (DiagnosticSeverity, Cursor, T.Text) -> Assertion
-requireDiagnostic actuals expected@(severity, cursor, expectedMsg) = do
-    unless (any match actuals) $
-        assertFailure $
-            "Could not find " <> show expected <>
-            " in " <> show actuals
-  where
-    match :: Diagnostic -> Bool
-    match d =
-        Just severity == _severity d
-        && cursorPosition cursor == d ^. range . start
-        && standardizeQuotes (T.toLower expectedMsg) `T.isInfixOf`
-           standardizeQuotes (T.toLower $ d ^. message)
-
-expectDiagnostics :: [(FilePath, [(DiagnosticSeverity, Cursor, T.Text)])] -> Session ()
-expectDiagnostics expected = do
-    expected' <- Map.fromListWith (<>) <$> traverseOf (traverse . _1) (fmap toNormalizedUri . getDocUri) expected
-    go expected'
-    where
-        go m
-            | Map.null m = pure ()
-            | otherwise = do
-                  diagsNot <- skipManyTill anyMessage LspTest.message :: Session PublishDiagnosticsNotification
-                  let fileUri = diagsNot ^. params . uri
-                  case Map.lookup (diagsNot ^. params . uri . to toNormalizedUri) m of
-                      Nothing -> liftIO $ assertFailure $
-                          "Got diagnostics for " <> show fileUri <>
-                          " but only expected diagnostics for " <> show (Map.keys m)
-                      Just expected -> do
-                          let actual = diagsNot ^. params . diagnostics
-                          liftIO $ mapM_ (requireDiagnostic actual) expected
-                          liftIO $ unless (length expected == length actual) $
-                              assertFailure $
-                              "Incorrect number of diagnostics for " <> show fileUri <>
-                              ", expected " <> show expected <>
-                              " but got " <> show actual
-                          go $ Map.delete (diagsNot ^. params . uri . to toNormalizedUri) m
 
 damlId :: String
 damlId = "daml"


### PR DESCRIPTION
- Add a dedicated test-suite for `hie-core`.
    For now only a small number of tests. This can be extended as we go forward.
- Factor out hie-core testing functionality to share between hie-core tests and lsp-tests
- The hie-core test is defined as a Bazel test case.
    Not yet as a Cabal test, because we have a dependency to daml's bazel-runfiles.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
