### PR TITLE
Generic templates: erase default implementations of magic methods

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -607,6 +607,17 @@ convertBind2 env (NonRec name x)
     | Just internals <- MS.lookup (envGHCModuleName env) (internalFunctions $ envLfVersion env)
     , is name `elem` internals
     = pure []
+    -- NOTE(MH): Desugaring `template X` will result in a type class
+    -- `XInstance` which has methods `createX`, `fetchX` and `exerciseXY`
+    -- (among others). The implementations of these methods are replaced
+    -- with DAML-LF primitives in `convertGenericChoice` below. As part of
+    -- this rewriting we also need to erase the default implementations of
+    -- these methods.
+    --
+    -- TODO(MH): The check is an approximation which will fail when users
+    -- start the name of their own methods with, say, `_exercise`.
+    | any (`isPrefixOf` is name) [ "$"++prefix++"_"++method | prefix <- ["dm", "c"], method <- ["create", "fetch", "exercise"] ]
+    = pure []
     -- NOTE(MH): Our inline return type syntax produces a local letrec for
     -- recursive functions. We currently don't support local letrecs.
     -- However, we can work around this issue by rewriting


### PR DESCRIPTION
`template X` generates type class `XInstance` which contains a few methods
which are implemented in terms of `magic` and then rewritten during the
conversion to DAML-LF. The default implementations of these methods need to
be erase during the conversion to DAML-LF since `magic` is erased as well.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2249)
<!-- Reviewable:end -->
