### PR TITLE
Fix the source field in daml.yaml produced by daml init

### DIFF
--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -393,8 +393,10 @@ runInit targetFolderM = do
     currentSdkVersion <- getSdkVersion
 
     projectFiles <- listFilesRecursive targetFolder
+    let targetFolderSep = addTrailingPathSeparator targetFolder
+    let projectFilesRel = mapMaybe (stripPrefix targetFolderSep) projectFiles
     let isMainDotDaml = (== "Main.daml") . takeFileName
-        sourceM = listToMaybe (filter isMainDotDaml projectFiles)
+        sourceM = find isMainDotDaml projectFilesRel
         source = fromMaybe "daml/Main.daml" sourceM
         name = takeFileName (dropTrailingPathSeparator targetFolderAbs)
 


### PR DESCRIPTION
Currently, if you do `daml init foo` and there's a file `foo/Main.daml`,
you'd end up with a file `foo/daml.yaml` whose `source` entry is
`foo/Main.daml`when it should actually just be `Main.daml`.

This PR fixes this problem.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2250)
<!-- Reviewable:end -->
