### PR TITLE
Erase key lookup methods implemented using magic as well

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -609,7 +609,7 @@ convertBind2 env (NonRec name x)
     = pure []
     -- NOTE(MH): Desugaring `template X` will result in a type class
     -- `XInstance` which has methods `_createX`, `_fetchX`, `_exerciseXY`,
-    -- `fetchByKeyX` and `lokkupByKeyX`
+    -- `_fetchByKeyX` and `_lookupByKeyX`
     -- (among others). The implementations of these methods are replaced
     -- with DAML-LF primitives in `convertGenericChoice` below. As part of
     -- this rewriting we also need to erase the default implementations of

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -608,7 +608,8 @@ convertBind2 env (NonRec name x)
     , is name `elem` internals
     = pure []
     -- NOTE(MH): Desugaring `template X` will result in a type class
-    -- `XInstance` which has methods `createX`, `fetchX` and `exerciseXY`
+    -- `XInstance` which has methods `_createX`, `_fetchX`, `_exerciseXY`,
+    -- `fetchByKeyX` and `lokkupByKeyX`
     -- (among others). The implementations of these methods are replaced
     -- with DAML-LF primitives in `convertGenericChoice` below. As part of
     -- this rewriting we also need to erase the default implementations of
@@ -616,7 +617,7 @@ convertBind2 env (NonRec name x)
     --
     -- TODO(MH): The check is an approximation which will fail when users
     -- start the name of their own methods with, say, `_exercise`.
-    | any (`isPrefixOf` is name) [ "$"++prefix++"_"++method | prefix <- ["dm", "c"], method <- ["create", "fetch", "exercise"] ]
+    | any (`isPrefixOf` is name) [ "$"++prefix++"_"++method | prefix <- ["dm", "c"], method <- ["create", "fetch", "exercise", "fetchByKey", "lookupByKey"] ]
     = pure []
     -- NOTE(MH): Our inline return type syntax produces a local letrec for
     -- recursive functions. We currently don't support local letrecs.


### PR DESCRIPTION
We're already erasing `create`, `fetch` and `exercise` methods. I've
missed the ones related to key lookups when I did that. This PR fixes
my mishap.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2252)
<!-- Reviewable:end -->
