### PR TITLE
Hide the --target flag of damlc

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -129,6 +129,7 @@ lfVersionOpt = option (str >>= select) $
     <> help ("DAML-LF version to output: " ++ versionsStr)
     <> long "target"
     <> value LF.versionDefault
+    <> internal
   where
     renderVersion v =
       let def = if v == LF.versionDefault then " (default)" else ""


### PR DESCRIPTION
We want to discourage users to pin down a target DAML-LF version but rather
want them to always use the default version, which is typically the newest
version. Thus, we turn this into an expert flag that is mostly used for
testing by us.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2253)
<!-- Reviewable:end -->
