### PR TITLE
Switch to the digital asset hlint fork

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -516,8 +516,10 @@ hazel_repositories(
     },
     packages = add_extra_packages(
         extra =
-            # Read [Working on ghc-lib] for ghc-lib update instructions at
-            # https://github.com/DACH-NY/daml/blob/master/ghc-lib/working-on-ghc-lib.md
+
+            # Read [Working on ghc-lib] for ghc-lib update
+            # instructions at
+            # https://github.com/DACH-NY/daml/blob/master/ghc-lib/working-on-ghc-lib.md.
             hazel_ghclibs(GHC_LIB_VERSION, "4a427e093f1711b28b6cf9dd6123e94c9e45589992d67274af626ecfa720308e", "0e4eda986fd3af0e18a2c89719e584d21dce136bcfdad3d0a9effcc6b654c842") +
 
             # Support for Hlint:
@@ -526,7 +528,7 @@ hazel_repositories(
             #   - To build the library : `bazel build @haskell_hlint//:lib`
             # We'll be using it via the library, not the binary.
             hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
-            hazel_github_external("shayne-fletcher-da", "hlint", "699adc7c7be5f876433a49661311093c42259cf1", "1fe563fa724ce589b85d67349d98ce254e01cfe28bda8bcf46958d944987e2cb") +
+            hazel_github_external("digital-asset", "hlint", "af5633e777d870819a58a1b1b53be678c0d9fa1a", "b8d91b9770ca6307705bb8449fd980579bb57d8abe84a9472c1431a2a277b87d") +
             hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +


### PR DESCRIPTION
This PR updates bazel to get hlint from the newly created Digital Asset fork. 