### PR TITLE
Support depending on potentially stale values in damlc

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -164,6 +164,23 @@ da_haskell_test(
     ],
 )
 
+da_haskell_test(
+    name = "position-mapping",
+    srcs = ["src/DA/Test/PositionMapping.hs"],
+    hazel_deps = [
+        "base",
+        "haskell-lsp-types",
+        "tasty",
+        "tasty-hunit",
+        "text",
+        "QuickCheck",
+    ],
+    main_function = "DA.Test.PositionMapping.main",
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = ["//compiler/hie-core"],
+)
+
 # Memory tests
 
 da_haskell_binary(

--- a/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
+++ b/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
@@ -50,6 +50,11 @@ main = defaultMain $
                     (Range (Position 0 1) (Position 0 3))
                     "abc\nd"
                     (Position 0 4) @?= Just (Position 1 2)
+              , testCase "after, same line, newline + newline at end" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\nd\n"
+                    (Position 0 4) @?= Just (Position 2 1)
               ]
         , testGroup "fromCurrent"
               [ testCase "before" $
@@ -87,6 +92,11 @@ main = defaultMain $
                     (Range (Position 0 1) (Position 0 3))
                     "abc\nd"
                     (Position 1 2) @?= Just (Position 0 4)
+              , testCase "after, same line, newline + newline at end" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\nd\n"
+                    (Position 2 1) @?= Just (Position 0 4)
               ]
         ]
 

--- a/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
+++ b/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
@@ -1,0 +1,92 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+module DA.Test.PositionMapping (main) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Development.IDE.Core.PositionMapping
+import Language.Haskell.LSP.Types
+
+
+main :: IO ()
+main = defaultMain $
+    testGroup "position mapping"
+        [ testGroup "toCurrent"
+              [ testCase "before" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "ab"
+                    (Position 0 0) @?= Just (Position 0 0)
+              , testCase "after, same line, same length" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "ab"
+                    (Position 0 3) @?= Just (Position 0 3)
+              , testCase "after, same line, increased length" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc"
+                    (Position 0 3) @?= Just (Position 0 4)
+              , testCase "after, same line, decreased length" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "a"
+                    (Position 0 3) @?= Just (Position 0 2)
+              , testCase "after, next line, no newline" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc"
+                    (Position 1 3) @?= Just (Position 1 3)
+              , testCase "after, next line, newline" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\ndef"
+                    (Position 1 0) @?= Just (Position 2 0)
+              , testCase "after, same line, newline" $
+                toCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\nd"
+                    (Position 0 4) @?= Just (Position 1 2)
+              ]
+        , testGroup "fromCurrent"
+              [ testCase "before" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "ab"
+                    (Position 0 0) @?= Just (Position 0 0)
+              , testCase "after, same line, same length" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "ab"
+                    (Position 0 3) @?= Just (Position 0 3)
+              , testCase "after, same line, increased length" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc"
+                    (Position 0 4) @?= Just (Position 0 3)
+              , testCase "after, same line, decreased length" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "a"
+                    (Position 0 2) @?= Just (Position 0 3)
+              , testCase "after, next line, no newline" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc"
+                    (Position 1 3) @?= Just (Position 1 3)
+              , testCase "after, next line, newline" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\ndef"
+                    (Position 2 0) @?= Just (Position 1 0)
+              , testCase "after, same line, newline" $
+                fromCurrent
+                    (Range (Position 0 1) (Position 0 3))
+                    "abc\nd"
+                    (Position 1 2) @?= Just (Position 0 4)
+              ]
+        ]
+

--- a/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
@@ -1,0 +1,85 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
+module Development.IDE.Core.PositionMapping
+  ( PositionMapping(..)
+  , toCurrentRange
+  , fromCurrentRange
+  , applyChange
+  , idMapping
+  -- toCurrent and fromCurrent are mainly exposed for testing
+  , toCurrent
+  , fromCurrent
+  ) where
+
+import Control.Monad
+import qualified Data.Text as T
+import Language.Haskell.LSP.Types
+
+data PositionMapping = PositionMapping
+  { toCurrentPosition :: !(Position -> Maybe Position)
+  , fromCurrentPosition :: !(Position -> Maybe Position)
+  }
+
+toCurrentRange :: PositionMapping -> Range -> Maybe Range
+toCurrentRange mapping (Range a b) =
+    Range <$> toCurrentPosition mapping a <*> toCurrentPosition mapping b
+
+fromCurrentRange :: PositionMapping -> Range -> Maybe Range
+fromCurrentRange mapping (Range a b) =
+    Range <$> fromCurrentPosition mapping a <*> fromCurrentPosition mapping b
+
+idMapping :: PositionMapping
+idMapping = PositionMapping Just Just
+
+applyChange :: PositionMapping -> TextDocumentContentChangeEvent -> PositionMapping
+applyChange posMapping (TextDocumentContentChangeEvent (Just r) _ t) = PositionMapping
+    { toCurrentPosition = toCurrent r t <=< toCurrentPosition posMapping
+    , fromCurrentPosition = fromCurrentPosition posMapping <=< fromCurrent r t
+    }
+applyChange posMapping _ = posMapping
+
+toCurrent :: Range -> T.Text -> Position -> Maybe Position
+toCurrent (Range (Position startLine startColumn) (Position endLine endColumn)) t (Position line column)
+    | line < startLine || line == startLine && column <= startColumn =
+      -- Position is before the change and thereby unchanged
+      Just $ Position line column
+    | line > endLine || line == endLine && column >= endColumn =
+      -- Position is after the change so increase line and column number
+      -- as necessary.
+      Just $ Position (line + lineDiff) newColumn
+    | otherwise = Nothing
+    -- Position is in the region that was changed.
+    where
+        lineDiff = linesNew - linesOld
+        linesNew = T.count "\n" t
+        linesOld = endLine - startLine
+        newEndColumn
+          | linesNew == 0 = startColumn + T.length t
+          | otherwise = T.length $ last $ T.lines t
+        newColumn
+          | line == endLine = column + newEndColumn - endColumn
+          | otherwise = column
+
+fromCurrent :: Range -> T.Text -> Position -> Maybe Position
+fromCurrent (Range (Position startLine startColumn) (Position endLine endColumn)) t (Position line column)
+    | line < startLine || line == startLine && column <= startColumn =
+      -- Position is before the change and thereby unchanged
+      Just $ Position line column
+    | line > newEndLine || line == newEndLine && column >= newEndColumn =
+      -- Position is after the change so increase line and column number
+      -- as necessary.
+      Just $ Position (line - lineDiff) newColumn
+    | otherwise = Nothing
+    -- Position is in the region that was changed.
+    where
+        lineDiff = linesNew - linesOld
+        linesNew = T.count "\n" t
+        linesOld = endLine - startLine
+        newEndLine = endLine + lineDiff
+        newEndColumn
+          | linesNew == 0 = startColumn + T.length t
+          | otherwise = T.length $ last $ T.lines t
+        newColumn
+          | line == newEndLine = column - (newEndColumn - endColumn)
+          | otherwise = column

--- a/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
@@ -56,7 +56,7 @@ toCurrent (Range (Position startLine startColumn) (Position endLine endColumn)) 
         linesOld = endLine - startLine
         newEndColumn
           | linesNew == 0 = startColumn + T.length t
-          | otherwise = T.length $ last $ T.lines t
+          | otherwise = T.length $ T.takeWhileEnd (/= '\n') t
         newColumn
           | line == endLine = column + newEndColumn - endColumn
           | otherwise = column
@@ -79,7 +79,7 @@ fromCurrent (Range (Position startLine startColumn) (Position endLine endColumn)
         newEndLine = endLine + lineDiff
         newEndColumn
           | linesNew == 0 = startColumn + T.length t
-          | otherwise = T.length $ last $ T.lines t
+          | otherwise = T.length $ T.takeWhileEnd (/= '\n') t
         newColumn
           | line == newEndLine = column - (newEndColumn - endColumn)
           | otherwise = column

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -15,7 +15,8 @@ module Development.IDE.Core.Service(
     runActionSync,
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
-    ideLogger
+    ideLogger,
+    updatePositionMapping
     ) where
 
 import           Control.Concurrent.Extra

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -16,7 +16,7 @@ module Development.IDE.Core.Service(
     writeProfile,
     getDiagnostics, unsafeClearDiagnostics,
     ideLogger,
-    updatePositionMapping
+    updatePositionMapping,
     ) where
 
 import           Control.Concurrent.Extra

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -25,7 +25,7 @@ module Development.IDE.Core.Shake(
     shakeOpen, shakeShut,
     shakeRun,
     shakeProfile,
-    use, useNoFile, uses,
+    use, useWithStale, useNoFile, uses, usesWithStale,
     use_, useNoFile_, uses_,
     define, defineEarlyCutoff,
     getDiagnostics, unsafeClearDiagnostics,
@@ -36,24 +36,29 @@ module Development.IDE.Core.Shake(
     ideLogger,
     actionLogger,
     FileVersion(..),
-    Priority(..)
+    Priority(..),
+    updatePositionMapping
     ) where
 
-import           Development.Shake
+import           Development.Shake hiding (ShakeValue)
 import           Development.Shake.Database
 import           Development.Shake.Classes
 import           Development.Shake.Rule
 import qualified Data.HashMap.Strict as HMap
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
+import qualified Data.Map.Merge.Strict as Map
 import qualified Data.ByteString.Char8 as BS
 import           Data.Dynamic
 import           Data.Maybe
 import Data.Map.Strict (Map)
 import           Data.Either.Extra
 import           Data.List.Extra
+import qualified Data.Set as Set
 import qualified Data.Text as T
+import Data.Tuple.Extra
 import Data.Unique
 import Development.IDE.Core.Debouncer
+import Development.IDE.Core.PositionMapping
 import Development.IDE.Types.Logger hiding (Priority)
 import Language.Haskell.LSP.Diagnostics
 import qualified Data.SortedList as SL
@@ -87,6 +92,9 @@ data ShakeExtras = ShakeExtras
     ,publishedDiagnostics :: Var (Map NormalizedUri [Diagnostic])
     -- ^ This represents the set of diagnostics that we have published.
     -- Due to debouncing not every change might get published.
+    ,positionMapping :: Var (Map NormalizedUri (Map TextDocumentVersion PositionMapping))
+    -- ^ Map from a text document version to a PositionMapping that describes how to map
+    -- positions in a version of that document to positions in the latest version
     }
 
 getShakeExtras :: Action ShakeExtras
@@ -152,7 +160,8 @@ instance Hashable Key where
 type IdeResult v = ([FileDiagnostic], Maybe v)
 
 data Value v
-    = Succeeded v
+    = Succeeded TextDocumentVersion v
+    | Stale TextDocumentVersion v
     | Failed
     deriving (Functor, Generic, Show)
 
@@ -160,15 +169,37 @@ instance NFData v => NFData (Value v)
 
 -- | Convert a Value to a Maybe. This will only return `Just` for
 -- up2date results not for stale values.
-valueToMaybe :: Value v -> Maybe v
-valueToMaybe (Succeeded v) = Just v
-valueToMaybe Failed = Nothing
+currentValue :: Value v -> Maybe v
+currentValue (Succeeded _ v) = Just v
+currentValue (Stale _ _) = Nothing
+currentValue Failed = Nothing
 
--- | Convert a Value to a Maybe. A `Just` will be treated as a
--- succesful run rather than a stale result
-maybeToValue :: Maybe v -> Value v
-maybeToValue (Just v) = Succeeded v
-maybeToValue Nothing = Failed
+-- | Return the most recent, potentially stale, value and a PositionMapping
+-- for the version of that value.
+lastValue :: NormalizedFilePath -> Value v -> Action (Maybe (v, PositionMapping))
+lastValue file v = do
+    ShakeExtras{positionMapping} <- getShakeExtras
+    allMappings <- liftIO $ readVar positionMapping
+    pure $ case v of
+        Succeeded ver v -> Just (v, mappingForVersion allMappings file ver)
+        Stale ver v -> Just (v, mappingForVersion allMappings file ver)
+        Failed -> Nothing
+
+valueVersion :: Value v -> Maybe TextDocumentVersion
+valueVersion = \case
+    Succeeded ver _ -> Just ver
+    Stale ver _ -> Just ver
+    Failed -> Nothing
+
+mappingForVersion
+    :: Map NormalizedUri (Map TextDocumentVersion PositionMapping)
+    -> NormalizedFilePath
+    -> TextDocumentVersion
+    -> PositionMapping
+mappingForVersion allMappings file ver =
+    fromMaybe idMapping $
+    Map.lookup ver =<<
+    Map.lookup (filePathToUri' file) allMappings
 
 type IdeRule k v =
   ( Shake.RuleResult k ~ v
@@ -245,6 +276,7 @@ shakeOpen eventer logger opts rules = do
         diagnostics <- newVar mempty
         publishedDiagnostics <- newVar mempty
         debouncer <- newDebouncer
+        positionMapping <- newVar mempty
         pure ShakeExtras{..}
     (shakeDb, shakeClose) <-
         shakeOpenDatabase
@@ -327,11 +359,16 @@ unsafeClearDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
 -- | Clear the results for all files that do not match the given predicate.
 garbageCollect :: (NormalizedFilePath -> Bool) -> Action ()
 garbageCollect keep = do
-    ShakeExtras{state, diagnostics} <- getShakeExtras
+    ShakeExtras{state, diagnostics,publishedDiagnostics,positionMapping} <- getShakeExtras
     liftIO $
-        do modifyVar_ state $ return . HMap.filterWithKey (\(file, _) _ -> keep file)
+        do newState <- modifyVar state $ return . dupe .  HMap.filterWithKey (\(file, _) _ -> keep file)
            modifyVar_ diagnostics $ return . filterDiagnostics keep
-
+           modifyVar_ publishedDiagnostics $ return . Map.filterWithKey (\uri _ -> keep (fromUri uri))
+           let versionsForFile =
+                   Map.fromListWith Set.union $
+                   mapMaybe (\((file, _key), v) -> (filePathToUri' file,) . Set.singleton <$> valueVersion v) $
+                   HMap.toList newState
+           modifyVar_ positionMapping $ return . filterVersionMap versionsForFile
 define
     :: IdeRule k v
     => (k -> NormalizedFilePath -> Action (IdeResult v)) -> Rules ()
@@ -340,6 +377,10 @@ define op = defineEarlyCutoff $ \k v -> (Nothing,) <$> op k v
 use :: IdeRule k v
     => k -> NormalizedFilePath -> Action (Maybe v)
 use key file = head <$> uses key [file]
+
+useWithStale :: IdeRule k v
+    => k -> NormalizedFilePath -> Action (Maybe (v, PositionMapping))
+useWithStale key file = head <$> usesWithStale key [file]
 
 useNoFile :: IdeRule k v => k -> Action (Maybe v)
 useNoFile key = use key ""
@@ -382,7 +423,9 @@ instance Show k => Show (Q k) where
 
 -- | Invariant: the 'v' must be in normal form (fully evaluated).
 --   Otherwise we keep repeatedly 'rnf'ing values taken from the Shake database
-data A v = A (Value v) (Maybe BS.ByteString)
+-- Note (MK) I am not sure why we need the ShakeValue here, maybe we
+-- can just remove it?
+data A v = A (Value v) ShakeValue
     deriving Show
 
 instance NFData (A v) where rnf (A v x) = v `seq` rnf x
@@ -392,22 +435,31 @@ instance NFData (A v) where rnf (A v x) = v `seq` rnf x
 type instance RuleResult (Q k) = A (RuleResult k)
 
 
--- | Compute the value
+-- | Return up2date results. Stale results will be ignored.
 uses :: IdeRule k v
     => k -> [NormalizedFilePath] -> Action [Maybe v]
-uses key files = map (\(A value _) -> valueToMaybe value) <$> apply (map (Q . (key,)) files)
+uses key files = map (\(A value _) -> currentValue value) <$> apply (map (Q . (key,)) files)
+
+-- | Return the last computed result which might be stale.
+usesWithStale :: IdeRule k v
+    => k -> [NormalizedFilePath] -> Action [Maybe (v, PositionMapping)]
+usesWithStale key files = do
+    values <- map (\(A value _) -> value) <$> apply (map (Q . (key,)) files)
+    mapM (uncurry lastValue) (zip files values)
 
 defineEarlyCutoff
     :: IdeRule k v
     => (k -> NormalizedFilePath -> Action (Maybe BS.ByteString, IdeResult v))
     -> Rules ()
-defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) old mode -> do
+defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> do
     extras@ShakeExtras{state} <- getShakeExtras
     val <- case old of
         Just old | mode == RunDependenciesSame -> do
             v <- liftIO $ getValues state key file
             case v of
-                Just v -> return $ Just $ RunResult ChangedNothing old $ A v (unwrap old)
+                -- No changes in the dependencies and we have
+                -- an existing result.
+                Just v -> return $ Just $ RunResult ChangedNothing old $ A v (decodeShakeValue old)
                 _ -> return Nothing
         _ -> return Nothing
     case val of
@@ -416,20 +468,59 @@ defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) old m
             (bs, (diags, res)) <- actionCatch
                 (do v <- op key file; liftIO $ evaluate $ force $ v) $
                 \(e :: SomeException) -> pure (Nothing, ([ideErrorText file $ T.pack $ show e | not $ isBadDependency e],Nothing))
-            res <- pure $ maybeToValue res
-
+            modTime <- liftIO $ join . fmap currentValue <$> getValues state GetModificationTime file
+            (bs, res) <- case res of
+                Nothing -> do
+                    staleV <- liftIO $ getValues state key file
+                    pure $ case staleV of
+                        Nothing -> (toShakeValue ShakeResult bs, Failed)
+                        Just v -> case v of
+                            Succeeded ver v -> (toShakeValue ShakeStale bs, Stale ver v)
+                            Stale ver v -> (toShakeValue ShakeStale bs, Stale ver v)
+                            Failed -> (toShakeValue ShakeResult bs, Failed)
+                Just v -> pure $ (maybe ShakeNoCutoff ShakeResult bs, Succeeded (vfsVersion =<< modTime) v)
             liftIO $ setValues state key file res
             updateFileDiagnostics file (Key key) extras $ map snd diags
-            let eq = case (bs, fmap unwrap old) of
-                    (Just a, Just (Just b)) -> a == b
+            let eq = case (bs, fmap decodeShakeValue old) of
+                    (ShakeResult a, Just (ShakeResult b)) -> a == b
+                    (ShakeStale a, Just (ShakeStale b)) -> a == b
+                    -- If we do not have a previous result
+                    -- or we got ShakeNoCutoff we always return False.
                     _ -> False
             return $ RunResult
                 (if eq then ChangedRecomputeSame else ChangedRecomputeDiff)
-                (wrap bs)
-                $ A res bs
-    where
-        wrap = maybe BS.empty (BS.cons '_')
-        unwrap x = if BS.null x then Nothing else Just $ BS.tail x
+                (encodeShakeValue bs) $
+                A res bs
+
+toShakeValue :: (BS.ByteString -> ShakeValue) -> Maybe BS.ByteString -> ShakeValue
+toShakeValue = maybe ShakeNoCutoff
+
+data ShakeValue
+    = ShakeNoCutoff
+    -- ^ This is what we use when we get Nothing from
+    -- a rule.
+    | ShakeResult !BS.ByteString
+    -- ^ This is used both for `Failed`
+    -- as well as `Succeeded`.
+    | ShakeStale !BS.ByteString
+    deriving (Generic, Show)
+
+instance NFData ShakeValue
+
+encodeShakeValue :: ShakeValue -> BS.ByteString
+encodeShakeValue = \case
+    ShakeNoCutoff -> BS.empty
+    ShakeResult r -> BS.cons 'r' r
+    ShakeStale r -> BS.cons 's' r
+
+decodeShakeValue :: BS.ByteString -> ShakeValue
+decodeShakeValue bs = case BS.uncons bs of
+    Nothing -> ShakeNoCutoff
+    Just (x, xs)
+      | x == 'r' -> ShakeResult xs
+      | x == 's' -> ShakeStale xs
+      | otherwise -> error $ "Failed to parse shake value " <> show bs
+
 
 updateFileDiagnostics ::
      NormalizedFilePath
@@ -438,7 +529,7 @@ updateFileDiagnostics ::
   -> [Diagnostic] -- ^ current results
   -> Action ()
 updateFileDiagnostics fp k ShakeExtras{diagnostics, publishedDiagnostics, state, debouncer, eventer} current = liftIO $ do
-    modTime <- join . fmap valueToMaybe <$> getValues state GetModificationTime fp
+    modTime <- join . fmap currentValue <$> getValues state GetModificationTime fp
     mask_ $ do
         -- Mask async exceptions to ensure that updated diagnostics are always
         -- published. Otherwise, we might never publish certain diagnostics if
@@ -540,3 +631,21 @@ filterDiagnostics ::
     DiagnosticStore
 filterDiagnostics keep =
     Map.filterWithKey (\uri _ -> maybe True (keep . toNormalizedFilePath) $ uriToFilePath' $ fromNormalizedUri uri)
+
+filterVersionMap
+    :: Map NormalizedUri (Set.Set TextDocumentVersion)
+    -> Map NormalizedUri (Map TextDocumentVersion a)
+    -> Map NormalizedUri (Map TextDocumentVersion a)
+filterVersionMap =
+    Map.merge Map.dropMissing Map.dropMissing $
+    Map.zipWithMatched $ \_ versionsToKeep versionMap -> Map.restrictKeys versionMap versionsToKeep
+
+updatePositionMapping :: IdeState -> VersionedTextDocumentIdentifier -> List TextDocumentContentChangeEvent -> IO ()
+updatePositionMapping IdeState{shakeExtras = ShakeExtras{positionMapping}} VersionedTextDocumentIdentifier{..} changes = do
+    modifyVar_ positionMapping $ \allMappings -> do
+        let uri = toNormalizedUri _uri
+        let mappingForUri = Map.findWithDefault Map.empty uri allMappings
+        let updatedMapping =
+                Map.insert _version idMapping $
+                Map.map (\oldMapping -> foldl' applyChange oldMapping changes) mappingForUri
+        pure $ Map.insert uri updatedMapping allMappings

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -276,7 +276,7 @@ shakeOpen eventer logger opts rules = do
         diagnostics <- newVar mempty
         publishedDiagnostics <- newVar mempty
         debouncer <- newDebouncer
-        positionMapping <- newVar mempty
+        positionMapping <- newVar Map.empty
         pure ShakeExtras{..}
     (shakeDb, shakeClose) <-
         shakeOpenDatabase

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -8,3 +8,7 @@ This page contains release notes for the SDK.
 
 HEAD — ongoing
 --------------
+
+- [DAML Studio] Scenario links no longer disappear if the
+  current file does not compile. The location is adjusted but this is done
+  one a best effort basis and can fail if the scenario itself is modified.


### PR DESCRIPTION
For now, this is opt-in and only enabled for the scenario service.
Locations should be properly mapped so if lines are inserted above a
scenario, the scenario link will move down.

Eventually, we will probably want to enable this for most rules.

It is also a precursor for completion since you usually want that on a file that does not compile at the moment.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
