### PR TITLE
Use the build-helper-maven-plugin to add generated sources

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -519,21 +519,21 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :language: java
-      :lines: 50-54
+      :lines: 46-50
       :dedent: 8
 
 #. An in-memory contract-store is initialized. This is intended to provide a live view of all active contracts, with mappings between ledger and external Ids.
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :language: java
-      :lines: 62-64
+      :lines: 58-60
       :dedent: 8
 
 #. The Active Contracts Service (ACS) is used to quickly build up the contract-store to a recent state.
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :language: java
-      :lines: 67-78
+      :lines: 63-74
       :dedent: 8
 
    Note the use of ``blockingForEach`` to ensure that the contract store is fully built and the ledger-offset up to which the ACS provides data is known before moving on.
@@ -543,14 +543,14 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :language: java
-      :lines: 80-96
+      :lines: 76-92
       :dedent: 8
 
 #. Commands are submitted via the Command Submission Service.
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :language: java
-      :lines: 131-141
+      :lines: 127-137
       :dedent: 4
 
    You can find examples of ``ExerciseCommand`` and ``CreateCommand`` instantiation in the bodies of the ``transfer`` and ``iou`` endpoints, respectively.
@@ -558,13 +558,13 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :caption: ExerciseCommand
       :language: java
-      :lines: 112-113
+      :lines: 108-109
       :dedent: 12
 
    .. literalinclude:: quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
       :caption: CreateCommand
       :language: java
-      :lines: 105-106
+      :lines: 101-102
       :dedent: 12
 
 The rest of the application sets up the REST services using `Spark Java <http://sparkjava.com/>`_, and does dynamic package Id detection using the Package Service. The latter is useful during development when package Ids change frequently.

--- a/docs/source/getting-started/quickstart/template-root/pom.xml
+++ b/docs/source/getting-started/quickstart/template-root/pom.xml
@@ -74,7 +74,6 @@
                                 <argument>com.digitalasset.quickstart.iou.TemplateDecoder</argument>
                                 <argument>${project.basedir}/.daml/dist/quickstart.dar=com.digitalasset.quickstart.model</argument>
                             </arguments>
-                            <sourceRoot>${daml-codegen-java.output}</sourceRoot>
                         </configuration>
                     </execution>
                     <execution>
@@ -90,6 +89,25 @@
                                 <argument>${party}</argument>
                                 <argument>${restport}</argument>
                             </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${daml-codegen-java.output}</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/docs/source/getting-started/quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
+++ b/docs/source/getting-started/quickstart/template-root/src/main/java/com/digitalasset/quickstart/iou/IouMain.java
@@ -5,18 +5,14 @@ package com.digitalasset.quickstart.iou;
 
 import com.daml.ledger.rxjava.DamlLedgerClient;
 import com.daml.ledger.rxjava.LedgerClient;
-import com.daml.ledger.rxjava.PackageClient;
 import com.daml.ledger.javaapi.data.*;
 import com.digitalasset.quickstart.model.iou.Iou;
-import com.digitalasset.quickstart.model.iou.Iou_Transfer;
 import com.google.common.collect.BiMap;
 
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.protobuf.Empty;
-import com.google.protobuf.InvalidProtocolBufferException;
-import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,3 +20,5 @@ HEAD — ongoing
 - [Ledger API] **BREAKING CHANGE** Drop support for legacy identifier. The
   previously deprecated field ``name`` in ``Identifier`` message is not
   supported anymore. Use ``module_name`` and ``entity_name`` instead.
+- [Documentation] Improved the Maven pom.xml file for ``quickstart-java`` to better integrate with VS Code.
+  See `#887 <https://github.com/digital-asset/daml/issues/887>`__.


### PR DESCRIPTION
The sourceRoot tag of the maven exec plugin isn't supported by the maven
integration in VS Code (which really is the eclipse stack).

Using the much more verbose build-helper-maven-plugin to make the
generated sources folder known to maven now makes the project properly
loadable by VS Code.

Fixes #887.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
