### PR TITLE
language: put hash in package directories

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Archive.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Archive.hs
@@ -7,6 +7,8 @@ module DA.Daml.LF.Proto3.Archive
   ( decodeArchive
   , encodeArchive
   , encodeArchiveLazy
+  , encodePackageHash
+  , encodeHash
   , ArchiveError(..)
   ) where
 
@@ -67,6 +69,11 @@ encodeArchiveLazy package =
           , ProtoLF.archiveHashFunction = Proto.Enumerated (Right ProtoLF.HashFunctionSHA256)
           }
     in Proto.toLazyByteString archive
+
+encodePackageHash :: LF.Package -> T.Text
+encodePackageHash pkg = encodeHash (BA.convert (Crypto.hash @_ @Crypto.SHA256 payload) :: BS.ByteString)
+  where
+    payload = BSL.toStrict $ Proto.toLazyByteString $ Encode.encodePayload pkg
 
 encodeArchive :: LF.Package -> BS.ByteString
 encodeArchive = BSL.toStrict . encodeArchiveLazy

--- a/compiler/daml-lf-reader/BUILD.bazel
+++ b/compiler/daml-lf-reader/BUILD.bazel
@@ -11,6 +11,7 @@ da_haskell_library(
         "bytestring",
         "extra",
         "filepath",
+        "safe",
         "unordered-containers",
         "utf8-string",
         "zip-archive",

--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -5,6 +5,7 @@ module DA.Daml.LF.Reader
     ( Manifest(..)
     , ManifestData(..)
     , manifestFromDar
+    , multiLineContent
     ) where
 
 import Codec.Archive.Zip
@@ -29,6 +30,9 @@ lineToKeyValue line = case splitOn ":" line of
     [l, r] -> (trim l , trim r)
     _ -> error $ "Expected two fields in line " <> line
 
+multiLineContent :: String -> [String]
+multiLineContent = filter (not . null) . lines . replace "\n " ""
+
 manifestMapToManifest :: Map.HashMap String String -> Manifest
 manifestMapToManifest hash = Manifest mainDalf dependDalfs
     where
@@ -45,6 +49,6 @@ manifestFromDar :: Archive -> ManifestData
 manifestFromDar dar = manifestDataFromDar dar manifest
     where
         manifestEntry = head [fromEntry e | e <- zEntries dar, ".MF" `isExtensionOf` eRelativePath e]
-        manifestLines = filter (not . null) $ lines $ replace "\n " "" $ UTF8.toString manifestEntry
+        manifestLines = multiLineContent $ UTF8.toString manifestEntry
         manifest = manifestMapToManifest $ Map.fromList $ map lineToKeyValue manifestLines
 

--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -43,13 +43,13 @@ manifestMapToManifest hash = Manifest mainDalf dependDalfs
 manifestDataFromDar :: Archive -> Manifest -> ManifestData
 manifestDataFromDar archive manifest = ManifestData manifestDalfByte dependencyDalfBytes
     where
-        manifestDalfByte = headNote ("manifestDalfByte: " ++ "main-dalf:" ++ mainDalf manifest ++ show [eRelativePath e | e <- zEntries archive]) [fromEntry e | e <- zEntries archive, ".dalf" `isExtensionOf` eRelativePath e  && eRelativePath e  == mainDalf manifest]
+        manifestDalfByte = headNote "manifestDalfByte" [fromEntry e | e <- zEntries archive, ".dalf" `isExtensionOf` eRelativePath e  && eRelativePath e  == mainDalf manifest]
         dependencyDalfBytes = [fromEntry e | e <- zEntries archive, ".dalf" `isExtensionOf` eRelativePath e  && elem (trim (eRelativePath e))  (dalfs manifest)]
 
 manifestFromDar :: Archive -> ManifestData
 manifestFromDar dar = manifestDataFromDar dar manifest
     where
-        manifestEntry = headNote "manifestEntry" $ [fromEntry e | e <- zEntries dar, ".MF" `isExtensionOf` eRelativePath e]
+        manifestEntry = headNote "manifestEntry" [fromEntry e | e <- zEntries dar, ".MF" `isExtensionOf` eRelativePath e]
         manifestLines = multiLineContent $ UTF8.toString manifestEntry
         manifest = manifestMapToManifest $ Map.fromList $ map lineToKeyValue manifestLines
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -194,11 +194,15 @@ createArchive dalf hash modRoot dalfDependencies fileDependencies dataFiles name
             [ "Manifest-Version: 1.0"
             , "Created-By: Digital Asset packager (DAML-GHC)"
             , "Sdk-Version: " <> sdkVersion
-            , breakAt72Chars $ "Main-Dalf: " <> location
-            , breakAt72Chars $ "Dalfs: " <> intercalate ", " dalfs
+            , breakAt72Chars $ "Main-Dalf: " <> toPosixFilePath location
+            , breakAt72Chars $ "Dalfs: " <> intercalate ", " (map toPosixFilePath dalfs)
             , "Format: daml-lf"
             , "Encryption: non-encrypted"
             ]
+    -- zip entries do have posix filepaths. hence the entries in the manifest also need to be posix
+    -- files paths regardless of the operatin system.
+    toPosixFilePath :: FilePath -> FilePath
+    toPosixFilePath = replace "\\" "/"
 
 breakAt72Chars :: String -> String
 breakAt72Chars s = case splitAt 72 s of

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -32,7 +32,7 @@ import Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger as IdeLogger
 import DA.Daml.Options.Types
 import qualified DA.Daml.LF.Ast as LF
-import DA.Daml.LF.Proto3.Archive (encodeArchiveLazy)
+import DA.Daml.LF.Proto3.Archive (encodeArchiveLazy, encodeHash, encodePackageHash)
 
 ------------------------------------------------------------------------------
 {- | Builds a dar file.
@@ -70,7 +70,7 @@ buildDar
   -> Maybe [String] -- ^ exposed modules
   -> String -- ^ package name
   -> String -- ^ sdk version
-  -> (LF.Package -> [(String, BS.ByteString)])
+  -> ((String, LF.Package) -> [(String, BS.ByteString)])
   -- We allow datafiles to depend on the package being produces to
   -- allow inference of things like exposedModules.
   -- Once we kill the old "package" command we could instead just
@@ -88,6 +88,7 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
       bytes <- BSL.readFile file'
       createArchive
         bytes
+        (T.unpack $ encodeHash $ BSL.toStrict bytes)
         (toNormalizedFilePath $ takeDirectory file')
         []
         []
@@ -104,80 +105,100 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               show (S.toList missingExposed)
       let dalf = encodeArchiveLazy pkg
+      let hash = T.unpack $ encodePackageHash pkg
       -- get all dalf dependencies.
       dalfDependencies0 <- getDalfDependencies file
       let dalfDependencies =
               [ (T.pack $ unitIdString unitId, dalfPackageBytes pkg) | (unitId, pkg) <- Map.toList dalfDependencies0 ]
       -- get all file dependencies
       fileDependencies <- MaybeT $ getDependencies file
+      let dataFiles = buildDataFiles (hash, pkg)
       liftIO $
         createArchive
           dalf
+          hash
           (toNormalizedFilePath $ takeDirectory file')
           dalfDependencies
           (file:fileDependencies)
-          (buildDataFiles pkg)
+          dataFiles
           pkgName
           sdkVersion
 
 -- | Helper to bundle up all files into a DAR.
-createArchive
-  :: BSL.ByteString -- ^ DALF
-  -> NormalizedFilePath -- ^ Module root used to locate interface and source files
-  -> [(T.Text, BS.ByteString)] -- ^ DALF dependencies
-  -> [NormalizedFilePath] -- ^ Module dependencies
-  -> [(String, BS.ByteString)] -- ^ Data files
-  -> String -- ^ Name of the main DALF
-  -> String -- ^ SDK version
-  -> IO BS.ByteString
-createArchive dalf modRoot dalfDependencies fileDependencies dataFiles name sdkVersion = do
+createArchive ::
+       BSL.ByteString -- ^ DALF
+    -> String -- ^ Package id
+    -> NormalizedFilePath -- ^ Module root used to locate interface and source files
+    -> [(T.Text, BS.ByteString)] -- ^ DALF dependencies
+    -> [NormalizedFilePath] -- ^ Module dependencies
+    -> [(String, BS.ByteString)] -- ^ Data files
+    -> String -- ^ Name of the main DALF
+    -> String -- ^ SDK version
+    -> IO BS.ByteString
+createArchive dalf hash modRoot dalfDependencies fileDependencies dataFiles name sdkVersion
     -- Take all source file dependencies and produced interface files. Only the new package command
     -- produces interface files per default, hence we filter for existent files.
+ = do
+    let nameWithHash = name ++ "-" ++ hash
     ifaces <-
         fmap (map toNormalizedFilePath) $
         filterM doesFileExist $
-        concat [[ifaceDir </> dep -<.> "hi", ifaceDir </> dep -<.> "hie"] | dep <- map fromNormalizedFilePath fileDependencies]
-
+        concat
+            [ [ifaceDir </> dep -<.> "hi", ifaceDir </> dep -<.> "hie"]
+            | dep <- map fromNormalizedFilePath fileDependencies
+            ]
     -- Reads all module source files, and pairs paths (with changed prefix)
     -- with contents as BS. The path must be within the module root path, and
-    -- is modified to have prefix <name> instead of the original root path.
-    srcFiles <- forM fileDependencies $ \mPath -> do
-      contents <- BSL.readFile $ fromNormalizedFilePath mPath
-      return (name </> fromNormalizedFilePath (makeRelative' modRoot mPath), contents)
-
-    ifaceFaceFiles <- forM ifaces $ \mPath -> do
-      contents <- BSL.readFile $ fromNormalizedFilePath mPath
-      let ifaceRoot = toNormalizedFilePath (ifaceDir </> fromNormalizedFilePath modRoot)
-      return (name </> fromNormalizedFilePath (makeRelative' ifaceRoot mPath), contents)
-
-    let dalfName = name <> ".dalf"
-    let dependencies = [(T.unpack pkgName <> ".dalf", BSC.fromStrict bs)
-                          | (pkgName, bs) <- dalfDependencies]
-    let dataFiles' = [("data" </> n, BSC.fromStrict bs) | (n, bs) <- dataFiles]
-
+    -- is modified to have prefix <name-hash> instead of the original root path.
+    srcFiles <-
+        forM fileDependencies $ \mPath -> do
+            contents <- BSL.readFile $ fromNormalizedFilePath mPath
+            return
+                ( nameWithHash </>
+                  fromNormalizedFilePath (makeRelative' modRoot mPath)
+                , contents)
+    ifaceFaceFiles <-
+        forM ifaces $ \mPath -> do
+            contents <- BSL.readFile $ fromNormalizedFilePath mPath
+            let ifaceRoot =
+                    toNormalizedFilePath
+                        (ifaceDir </> fromNormalizedFilePath modRoot)
+            return
+                ( nameWithHash </>
+                  fromNormalizedFilePath (makeRelative' ifaceRoot mPath)
+                , contents)
+    let dalfName = nameWithHash </> name <> ".dalf"
+    let dependencies =
+            [ (nameWithHash </> T.unpack pkgName <> ".dalf", BSC.fromStrict bs)
+            | (pkgName, bs) <- dalfDependencies
+            ]
+    let dataFiles' =
+            [ (nameWithHash </> "data" </> n, BSC.fromStrict bs)
+            | (n, bs) <- dataFiles
+            ]
     -- construct a zip file from all required files
-    let allFiles = ("META-INF/MANIFEST.MF", manifestHeader dalfName $ dalfName:map fst dependencies)
-                    : (dalfName, dalf)
-                    : srcFiles
-                    ++ ifaceFaceFiles
-                    ++ dependencies
-                    ++ dataFiles'
-
+    let allFiles =
+            ( "META-INF/MANIFEST.MF"
+            , manifestHeader dalfName (dalfName : map fst dependencies)) :
+            (dalfName, dalf) :
+            srcFiles ++ ifaceFaceFiles ++ dependencies ++ dataFiles'
         mkEntry (filePath, content) = Zip.toEntry filePath 0 content
-        zipArchive = foldr (Zip.addEntryToArchive . mkEntry) Zip.emptyArchive allFiles
-
+        zipArchive =
+            foldr (Zip.addEntryToArchive . mkEntry) Zip.emptyArchive allFiles
     pure $ BSL.toStrict $ Zip.fromArchive zipArchive
-      where
-        manifestHeader :: FilePath -> [String] -> BSL.ByteString
-        manifestHeader location dalfs = BSC.pack $ unlines
-          [ "Manifest-Version: 1.0"
-          , "Created-By: Digital Asset packager (DAML-GHC)"
-          , "Sdk-Version: " <> sdkVersion
-          , breakAt72Chars $ "Main-Dalf: " <> location
-          , breakAt72Chars $ "Dalfs: " <> intercalate ", " dalfs
-          , "Format: daml-lf"
-          , "Encryption: non-encrypted"
-          ]
+  where
+    manifestHeader :: FilePath -> [String] -> BSL.ByteString
+    manifestHeader location dalfs =
+        BSC.pack $
+        unlines
+            [ "Manifest-Version: 1.0"
+            , "Created-By: Digital Asset packager (DAML-GHC)"
+            , "Sdk-Version: " <> sdkVersion
+            , breakAt72Chars $ "Main-Dalf: " <> location
+            , breakAt72Chars $ "Dalfs: " <> intercalate ", " dalfs
+            , "Format: daml-lf"
+            , "Encryption: non-encrypted"
+            ]
 
 breakAt72Chars :: String -> String
 breakAt72Chars s = case splitAt 72 s of

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -32,7 +32,7 @@ import Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger as IdeLogger
 import DA.Daml.Options.Types
 import qualified DA.Daml.LF.Ast as LF
-import DA.Daml.LF.Proto3.Archive (encodeArchiveLazy, encodeHash, encodePackageHash)
+import DA.Daml.LF.Proto3.Archive (encodeHash, encodeArchiveAndHash)
 
 ------------------------------------------------------------------------------
 {- | Builds a dar file.
@@ -70,7 +70,7 @@ buildDar
   -> Maybe [String] -- ^ exposed modules
   -> String -- ^ package name
   -> String -- ^ sdk version
-  -> ((String, LF.Package) -> [(String, BS.ByteString)])
+  -> ((String, LF.Package) -> [(FilePath, BS.ByteString)])
   -- We allow datafiles to depend on the package being produces to
   -- allow inference of things like exposedModules.
   -- Once we kill the old "package" command we could instead just
@@ -104,8 +104,8 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
           error $
               "The following modules are declared in exposed-modules but are not part of the DALF: " <>
               show (S.toList missingExposed)
-      let dalf = encodeArchiveLazy pkg
-      let hash = T.unpack $ encodePackageHash pkg
+      let (dalf, hash0) = encodeArchiveAndHash pkg
+      let hash = T.unpack hash0
       -- get all dalf dependencies.
       dalfDependencies0 <- getDalfDependencies file
       let dalfDependencies =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -791,7 +791,9 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                         headNote
                             "Missing Main-Dalf entry in META-INF/MANIFEST.MF"
                             [ main
-                            | l <- lines $ BSC.unpack $ BSL.toStrict $ fromEntry manifest
+                            | l <-
+                                  lines $
+                                  replace "\n " "" $ BSC.unpack $ BSL.toStrict $ fromEntry manifest
                             , Just main <- [stripPrefix "Main-Dalf: " l]
                             ]
                 mainDalfEntry <- getEntry mainDalfPath dar

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -433,19 +433,21 @@ createProjectPackageDb lfVersion fps = do
         let srcs =
                 [ e
                 | e <- zEntries archive
-                , takeExtension (eRelativePath e) `elem` [".daml", ".hie", ".hi"]
+                , takeExtension (eRelativePath e) `elem`
+                      [".daml", ".hie", ".hi"]
                 ]
-        forM_ dalfs $ \dalf ->
-            BSL.writeFile (dbPath </> eRelativePath dalf) (fromEntry dalf)
-        forM_ confFiles $ \conf ->
-            BSL.writeFile
-                (dbPath </> "package.conf.d" </> (takeFileName $ eRelativePath conf))
+        forM_ dalfs $ \dalf -> do
+            write (dbPath </> eRelativePath dalf) (fromEntry dalf)
+        forM_ confFiles $ \conf -> do
+            write
+                (dbPath </> "package.conf.d" </>
+                 (takeFileName $ eRelativePath conf))
                 (fromEntry conf)
         forM_ srcs $ \src -> do
             let path = dbPath </> eRelativePath src
-            createDirectoryIfMissing True $ takeDirectory path
-            BSL.writeFile path (fromEntry src)
-    ghcPkgPath <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghc-pkg")
+            write path (fromEntry src)
+    ghcPkgPath <-
+        locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghc-pkg")
     callCommand $
         unwords
             [ ghcPkgPath </> exe "ghc-pkg"
@@ -455,6 +457,8 @@ createProjectPackageDb lfVersion fps = do
             , "--global-package-db=" ++ (dbPath </> "package.conf.d")
             , "--expand-pkgroot"
             ]
+  where
+    write fp bs = createDirectoryIfMissing True (takeDirectory fp) >> BSL.writeFile fp bs
 
 -- | Write interface files and hie files to the location specified by the given options.
 writeIfacesAndHie :: Options -> NormalizedFilePath -> IdeState -> IO ()
@@ -536,9 +540,9 @@ execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts
             -> String
             -> Maybe [String]
             -> [FilePath]
-            -> LF.Package
+            -> (String, LF.Package)
             -> (String, B.ByteString)
-        mkConfFile name version exposedMods deps pkg = (confName, bs)
+        mkConfFile name version exposedMods deps (pkgId, pkg) = (confName, bs)
           where
             confName = name ++ ".conf"
             bs =
@@ -550,9 +554,9 @@ execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts
                     , "version: " ++ version
                     , "exposed: True"
                     , "exposed-modules: " ++ unwords (fromMaybe (map T.unpack $ LF.packageModuleNames pkg) exposedMods)
-                    , "import-dirs: ${pkgroot}" </> name
-                    , "library-dirs: ${pkgroot}" </> name
-                    , "data-dir: ${pkgroot}" </> name
+                    , "import-dirs: ${pkgroot}" </> intercalate "-" [name, pkgId]
+                    , "library-dirs: ${pkgroot}" </> intercalate "-" [name, pkgId]
+                    , "data-dir: ${pkgroot}" </> intercalate "-" [name, pkgId]
                     , "depends: " ++
                       unwords [dropExtension $ takeFileName dep | dep <- deps]
                     ]

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString as B
 import Data.Generics.Uniplate.Data
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
+import Safe
 
 type IsConsuming = Bool
 type InternalChcName = LF.ChoiceName
@@ -120,7 +121,7 @@ darToWorld manifest pkg = AST.initWorldSelf pkgs pkg
         pkgs = map dalfBytesToPakage (dalfsContent manifest)
 
 tplNameUnqual :: LF.Template -> T.Text
-tplNameUnqual LF.Template {..} = head (LF.unTypeConName tplTypeCon)
+tplNameUnqual LF.Template {..} = headNote "tplNameUnqual" $ (LF.unTypeConName tplTypeCon)
 
 choiceNameWithId :: [TemplateChoices] -> Map.Map InternalChcName ChoiceDetails
 choiceNameWithId tplChcActions = Map.fromList choiceWithIds
@@ -140,7 +141,7 @@ nodeIdForChoice nodeLookUp chc = case Map.lookup chc nodeLookUp of
 
 addCreateChoice :: TemplateChoices -> Map.Map LF.ChoiceName ChoiceDetails -> ChoiceDetails
 addCreateChoice TemplateChoices {..} lookupData = nodeIdForChoice lookupData tplNameCreateChoice
-    where tplNameCreateChoice = LF.ChoiceName $ T.pack $ DAP.renderPretty (head (LF.unTypeConName (LF.tplTypeCon template))) ++ "_Create"
+    where tplNameCreateChoice = LF.ChoiceName $ T.pack $ DAP.renderPretty (headNote "addCreateChoice" (LF.unTypeConName (LF.tplTypeCon template))) ++ "_Create"
 
 constructSubgraphsWithLables :: Map.Map LF.ChoiceName ChoiceDetails -> TemplateChoices -> SubGraph
 constructSubgraphsWithLables lookupData tpla@TemplateChoices {..} = SubGraph nodesWithCreate template
@@ -149,7 +150,7 @@ constructSubgraphsWithLables lookupData tpla@TemplateChoices {..} = SubGraph nod
         nodesWithCreate = addCreateChoice tpla lookupData : nodes
 
 tplNamet :: LF.TypeConName -> T.Text
-tplNamet tplConName = head (LF.unTypeConName tplConName)
+tplNamet tplConName = headNote "tplNamet" (LF.unTypeConName tplConName)
 
 actionToChoice :: Action -> LF.ChoiceName
 actionToChoice (ACreate LF.Qualified {..}) = LF.ChoiceName $ tplNamet qualObject <> "_Create"

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -121,7 +121,7 @@ darToWorld manifest pkg = AST.initWorldSelf pkgs pkg
         pkgs = map dalfBytesToPakage (dalfsContent manifest)
 
 tplNameUnqual :: LF.Template -> T.Text
-tplNameUnqual LF.Template {..} = headNote "tplNameUnqual" $ (LF.unTypeConName tplTypeCon)
+tplNameUnqual LF.Template {..} = headNote "tplNameUnqual" (LF.unTypeConName tplTypeCon)
 
 choiceNameWithId :: [TemplateChoices] -> Map.Map InternalChcName ChoiceDetails
 choiceNameWithId tplChcActions = Map.fromList choiceWithIds

--- a/compiler/damlc/tests/src/DamlcVisual.hs
+++ b/compiler/damlc/tests/src/DamlcVisual.hs
@@ -31,9 +31,14 @@ unitTests = do
             , testCase "multiline manifest file test" $
                 assertEqual "content over multiple lines"
                     ["Dalfs: stdlib.dalf, prim.dalf", "Main-Dalf: testing.dalf"]
-                    (multiLineContent ["Dalfs: stdlib.da", " lf, prim.dalf" , "Main-Dalf: testing.dalf"])
+                    (multiLineContent $ unlines [ "Dalfs: stdlib.da"
+                                                , " lf, prim.dalf"
+                                                , "Main-Dalf: testing.dalf"
+                                                ])
             , testCase "multiline manifest file test" $
                 assertEqual "all content in the same line"
                     ["Dalfs: stdlib.dalf", "Main-Dalf:solution.dalf"]
-                    (multiLineContent ["Dalfs: stdlib.dalf" , "Main-Dalf:solution.dalf"])
+                    (multiLineContent $ unlines [ "Dalfs: stdlib.dalf"
+                                                , "Main-Dalf:solution.dalf"
+                                                ])
             ]

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -181,9 +181,7 @@ packagingTests tmpDir = testGroup "packaging"
         let dar = projDir </> ".daml" </> "dist" </> "proj.dar"
         assertBool "proj.dar was not created." =<< doesFileExist dar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile dar
-        -- Note that we really want a forward slash here instead of </> since filepaths in
-        -- zip files use forward slashes.
-        assertBool "A.daml is missing" ("proj/A.daml" `elem` darFiles)
+        assertBool "A.daml is missing" (any (\f -> takeFileName f == "A.daml") darFiles)
     , testCase "Project without exposed modules" $ withTempDir $ \projDir -> do
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "daml 1.2"

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
@@ -99,18 +99,10 @@ object DarReader {
 
   private val ManifestName = "META-INF/MANIFEST.MF"
 
-  private def normalize(entryName: String): String =
-    entryName.replace('\\', '/')
-
-  private[archive] object ZipEntries {
-    def apply(name: String, entries: Map[String, (Long, InputStream)]): ZipEntries =
-      new ZipEntries(name, entries.map { case (k, v) => normalize(k) -> v })
-  }
-
   private[archive] case class ZipEntries(name: String, entries: Map[String, (Long, InputStream)]) {
 
     def getInputStreamFor(entryName: String): Try[(Long, InputStream)] = {
-      entries.get(normalize(entryName)) match {
+      entries.get(entryName) match {
         case Some((size, is)) => Success(size -> is)
         case None => Failure(InvalidZipEntry(entryName, this))
       }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DarReader.scala
@@ -99,10 +99,18 @@ object DarReader {
 
   private val ManifestName = "META-INF/MANIFEST.MF"
 
+  private def normalize(entryName: String): String =
+    entryName.replace('\\', '/')
+
+  private[archive] object ZipEntries {
+    def apply(name: String, entries: Map[String, (Long, InputStream)]): ZipEntries =
+      new ZipEntries(name, entries.map { case (k, v) => normalize(k) -> v })
+  }
+
   private[archive] case class ZipEntries(name: String, entries: Map[String, (Long, InputStream)]) {
 
     def getInputStreamFor(entryName: String): Try[(Long, InputStream)] = {
-      entries.get(entryName) match {
+      entries.get(normalize(entryName)) match {
         case Some((size, is)) => Success(size -> is)
         case None => Failure(InvalidZipEntry(entryName, this))
       }


### PR DESCRIPTION
We put the package id of the main dalf of a package into the directory
names, where we store the files of that package in the package database.
This way we make sure that two equally named packages don't overwrite
their dependencies and files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
