### PR TITLE
damldocs: Reinstate contexts in markdown function docs.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -211,16 +211,11 @@ fct2md :: FunctionDoc -> RenderOut
 fct2md FunctionDoc{..} = mconcat
     [ renderAnchorInfix "" fct_anchor $ T.concat
         [ "**", escapeMd $ unFieldname fct_name, "**  " ]
-    , renderLinesDep $ \env ->
-        case (fct_context, fct_type) of
-            (Nothing, Nothing) -> []
-            (_, _) ->
-                [ T.concat
-                    [ "&nbsp; : "
-                    , maybe "" ((<> " => ") . type2md env) fct_context
-                    , maybe "\\_"  (type2md env) fct_type
-                    ]
-                ]
+    , renderLineDep $ \env -> T.concat
+        [ "&nbsp; : "
+        , maybe "" ((<> " => ") . type2md env) fct_context
+        , maybe "\\_"  (type2md env) fct_type
+        ]
     , renderDocText fct_descr
     ]
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -212,7 +212,15 @@ fct2md FunctionDoc{..} = mconcat
     [ renderAnchorInfix "" fct_anchor $ T.concat
         [ "**", escapeMd $ unFieldname fct_name, "**  " ]
     , renderLinesDep $ \env ->
-        maybe [] (\t -> ["&nbsp; : " <> type2md env t]) fct_type
+        case (fct_context, fct_type) of
+            (Nothing, Nothing) -> []
+            (_, _) ->
+                [ T.concat
+                    [ "&nbsp; : "
+                    , maybe "" ((<> " => ") . type2md env) fct_context
+                    , maybe "\\_"  (type2md env) fct_type
+                    ]
+                ]
     , renderDocText fct_descr
     ]
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -223,19 +223,16 @@ type2rst env = f 0
 fct2rst :: FunctionDoc -> RenderOut
 fct2rst FunctionDoc{..} = mconcat
     [ renderAnchor fct_anchor
-    , renderLine $ bold (wrapOp (unFieldname fct_name))
     , renderLinesDep $ \ env ->
-        case (fct_context, fct_type) of
-            (Nothing, Nothing) -> []
-            (_, _) ->
-                [ T.concat
-                    [ "  : "
-                    , maybe "" ((<> " => ") . type2rst env) fct_context
-                    , maybe "_" (type2rst env) fct_type
-                    ]
-                , ""
-                ]
-    , renderLine $ maybe "" (indent 2 . docTextToRst) fct_descr
+        [ bold (wrapOp (unFieldname fct_name))
+        , T.concat
+            [ "  : "
+            , maybe "" ((<> " => ") . type2rst env) fct_context
+            , maybe "_" (type2rst env) fct_type
+            ]
+        , ""
+        , maybe "" (indent 2 . docTextToRst) fct_descr
+        ]
     ]
 
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -223,16 +223,19 @@ type2rst env = f 0
 fct2rst :: FunctionDoc -> RenderOut
 fct2rst FunctionDoc{..} = mconcat
     [ renderAnchor fct_anchor
+    , renderLine $ bold (wrapOp (unFieldname fct_name))
     , renderLinesDep $ \ env ->
-        [ bold (wrapOp (unFieldname fct_name))
-        , T.concat
-            [ "  : "
-            , maybe "" ((<> " => ") . type2rst env) fct_context
-            , maybe "" ((<> "\n\n") . type2rst env) fct_type
-                -- FIXME: when would a function not have a type?
-            , maybe "" (indent 2 . docTextToRst) fct_descr
-            ]
-        ]
+        case (fct_context, fct_type) of
+            (Nothing, Nothing) -> []
+            (_, _) ->
+                [ T.concat
+                    [ "  : "
+                    , maybe "" ((<> " => ") . type2rst env) fct_context
+                    , maybe "_" (type2rst env) fct_type
+                    ]
+                , ""
+                ]
+    , renderLine $ maybe "" (indent 2 . docTextToRst) fct_descr
     ]
 
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -231,8 +231,8 @@ fct2rst FunctionDoc{..} = mconcat
             , maybe "_" (type2rst env) fct_type
             ]
         , ""
-        , maybe "" (indent 2 . docTextToRst) fct_descr
         ]
+    , maybe (renderLine "") (renderIndent 2 . renderDocText) fct_descr
     ]
 
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -102,7 +102,7 @@ expectRst =
             , "\n.. _data-twotypes-d:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d:\n  \n  **D** a\n  \n  D descr"]
             []
         , mkExpectRst "module-function1" "Function1" "" [] [] [] [ ".. _function-function1-f:\n\n**f**\n  : TheType\n\n  the doc\n"]
-        , mkExpectRst "module-function2" "Function2" "" [] [] [] [ ".. _function-function2-f:\n\n**f**\n  the doc\n"]
+        , mkExpectRst "module-function2" "Function2" "" [] [] [] [ ".. _function-function2-f:\n\n**f**\n  : _\n\n  the doc\n"]
         , mkExpectRst "module-function3" "Function3" "" [] [] [] [ ".. _function-function3-f:\n\n**f**\n  : TheType\n\n"]
         , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
@@ -216,6 +216,7 @@ expectMarkdown =
             ]
         , mkExpectMD "module-function2" "Function2" "" [] [] []
             [ "<a name=\"function-function2-f\"></a>**f**  "
+            , "&nbsp; : \\_"
             , ""
             , "the doc"
             , ""


### PR DESCRIPTION
Function contexts were missing from function docs in Markdown. This wasn't caught by our test suite because there were no tests where functions had contexts. So I fixed it and added a test.

I also simplified some of the logic around missing types in the function docs.

(There was some weird rendering here.)