### PR TITLE
{-# LANGUAGE OverloadedStrings #-} is now on by default

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -69,6 +69,7 @@
   - {name: GeneralizedNewtypeDeriving, within: []}
   - {name: LambdaCase, within: []}
   - {name: NamedFieldPuns, within: []}
+  - {name: OverloadedStrings, within: []}
   - {name: PackageImports, within: []}
   - {name: RecordWildCards, within: []}
   - {name: ScopedTypeVariables, within: []}

--- a/bazel_tools/client_server_test/runner/Main.hs
+++ b/bazel_tools/client_server_test/runner/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Main(main) where
 
 import Control.Concurrent (threadDelay)

--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -41,6 +41,7 @@ common_haskell_exts = [
     "LambdaCase",
     "NamedFieldPuns",
     "NumericUnderscores",
+    "OverloadedStrings",
     "PackageImports",
     "RecordWildCards",
     "ScopedTypeVariables",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies #-}
 -- | Types and pretty-printer for the AST of the DAML Ledger Fragment.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -3,7 +3,6 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternSynonyms #-}
 module DA.Daml.LF.Ast.Pretty(
     (<:>)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.LF.Ast.Util(module DA.Daml.LF.Ast.Util) where
 
 import Data.Maybe

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.LF.Ast.Version(module DA.Daml.LF.Ast.Version) where
 
 import           Data.Data

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module DA.Daml.LF.Ast.World(

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Archive.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Archive.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Utilities for working with DAML-LF protobuf archives
 module DA.Daml.LF.Proto3.Archive

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiWayIf #-}
 
 module DA.Daml.LF.Proto3.DecodeV1

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Encoding of the LF package into LF version 1 format.
 module DA.Daml.LF.Proto3.EncodeV1

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- | This module contains the DAML-LF type checker.
 --
 -- Some notes:

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.LF.TypeChecker.Error(
     Context(..),
     Error(..),

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 
 module DA.Daml.Compiler.Dar
   ( buildDar

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DocTest.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DocTest.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.Compiler.DocTest (docTest) where
 
 import Control.Monad

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Scenario.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Scenario.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 
 -- | Compiles, generates and creates scenarios for DAML-LF

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 --
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Compiler.Upgrade
     ( generateUpgradeModule

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Anchor.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Generate anchor names to link between Hoogle and Rst docs. These need to be
 -- unique, and conform to the Rst's restrictions on anchor names (AFAICT they have to

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Annotate(applyAnnotations) where
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Driver(
     damlDocDriver,

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/HaddockParse.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.HaddockParse(mkDocs) where
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Render
   ( DocFormat(..)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Render.Hoogle
   ( renderSimpleHoogle

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Render.Markdown
   ( renderSimpleMD

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings, DerivingStrategies #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 -- | Monoid with which to render documentation.
 module DA.Daml.Doc.Render.Monoid

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings, DerivingStrategies #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module DA.Daml.Doc.Render.Rst
   ( renderSimpleRst

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Render.Util
   ( adjust

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Render.Tests(mkTestTree)
   where

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Daml.Doc.Tests(mkTestTree)
   where

--- a/compiler/damlc/daml-doctest/src/DA/Daml/DocTest.hs
+++ b/compiler/damlc/daml-doctest/src/DA/Daml/DocTest.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.DocTest
     ( getDocTestModule
     , docTestModuleName

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module Development.IDE.Core.Rules.Daml
     ( module Development.IDE.Core.Rules
     , module Development.IDE.Core.Rules.Daml

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 
 module Development.IDE.Core.Service.Daml(
     VirtualResource(..),

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DuplicateRecordFields #-}

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes #-}
 
 module DA.Daml.LanguageServer

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Gather code lenses like scenario execution for a DAML file.
 module DA.Daml.LanguageServer.CodeLens

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-} -- Because the pattern match checker is garbage

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-} -- Because the pattern match checker is garbage
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | DAML-LF utility functions, may move to the LF utility if they are generally useful
 module DA.Daml.LFConversion.UtilLF(

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE ApplicativeDo       #-}
 

--- a/compiler/damlc/lib/DA/Cli/Damlc/BuildInfo.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/BuildInfo.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Cli.Damlc.BuildInfo
   ( buildInfo

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 
 module DA.Cli.Damlc.Command.Damldoc(cmdDamlDoc) where
 

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Main entry-point of the DAML compiler
 module DA.Cli.Damlc.Test (

--- a/compiler/damlc/lib/DA/Cli/Output.hs
+++ b/compiler/damlc/lib/DA/Cli/Output.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Cli.Output
   ( writeOutput
   , writeOutputBSL

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings   #-}
 -- | Main entry-point of the DAML compiler
 module DA.Cli.Visual
   ( execVisual

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Test.DamlDoc (main) where
 

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Test.DamlDocTest (main) where
 
 import qualified Data.Text.Extended as T

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Test driver for DAML-GHC CompilerService.
 -- For each file, compile it with GHC, convert it,

--- a/compiler/damlc/tests/src/DA/Test/GenerateModuleTree.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateModuleTree.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Generate a module tree consisting of modules FatTree0 to
 -- FatTree<N> where FatTree<M> imports FatTree0-FatTree<M-1>. The

--- a/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
+++ b/compiler/damlc/tests/src/DA/Test/PositionMapping.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Test.PositionMapping (main) where
 
 import Test.QuickCheck

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Shake IDE API test suite. Run these manually with:
 --

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module DamlcTest
    ( main
    ) where

--- a/compiler/damlc/tests/src/DamlcVisual.hs
+++ b/compiler/damlc/tests/src/DamlcVisual.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module VisualTest
    ( main
    ) where

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE CPP #-}
 

--- a/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/OfInterest.hs
@@ -3,7 +3,6 @@
 
 
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 -- | A Shake implementation of the compiler service, built

--- a/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/PositionMapping.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module Development.IDE.Core.PositionMapping
   ( PositionMapping(..)
   , toCurrentRange

--- a/compiler/hie-core/src/Development/IDE/Core/Rules.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Rules.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 -- | A Shake implementation of the compiler service, built

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE OverloadedStrings          #-}
 
 -- | A Shake implementation of the compiler service.
 --

--- a/compiler/hie-core/src/Development/IDE/GHC/Error.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Error.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module Development.IDE.GHC.Error
   (
     -- * Producing Diagnostic values

--- a/compiler/hie-core/src/Development/IDE/Import/FindImports.hs
+++ b/compiler/hie-core/src/Development/IDE/Import/FindImports.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module Development.IDE.Import.FindImports
   ( locateModule

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
 -- | Go to the definition of a variable.

--- a/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Definition.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Go to the definition of a variable.
 module Development.IDE.LSP.Definition

--- a/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Hover.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Display information on hover.
 module Development.IDE.LSP.Hover

--- a/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/LanguageServer.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ExistentialQuantification  #-}
 
 -- WARNING: A copy of DA.Daml.LanguageServer, try to keep them in sync

--- a/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/Notifications.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Development.IDE.LSP.Notifications

--- a/compiler/hie-core/src/Development/IDE/Spans/AtPoint.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/AtPoint.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings   #-}
 -- | Gives information about symbols at a given point in DAML files.
 -- These are all pure functions that should execute quickly.
 module Development.IDE.Spans.AtPoint (

--- a/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module Development.IDE.Types.Diagnostics (
   LSP.Diagnostic(..),

--- a/compiler/hie-core/src/Development/IDE/Types/Location.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Location.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings  #-}
 
 -- | Types and functions for working with source code locations.
 module Development.IDE.Types.Location

--- a/compiler/hie-core/test/exe/Main.hs
+++ b/compiler/hie-core/test/exe/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 

--- a/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
+++ b/compiler/lsp-tests/src/Daml/Lsp/Test/Util.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Daml.Lsp.Test.Util
     ( Cursor
     , cursorPosition

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 module Main (main) where
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Pretty-printing of scenario results
 module DA.Daml.LF.PrettyScenario

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.LF.ScenarioServiceClient
   ( Options(..)
   , ScenarioServiceConfig

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE OverloadedStrings #-}
 module DA.Daml.LF.ScenarioServiceClient.LowLevel
   ( Options(..)
   , TimeoutSeconds

--- a/daml-assistant/daml-helper/src/DamlHelper/Run.hs
+++ b/daml-assistant/daml-helper/src/DamlHelper/Run.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module DamlHelper.Run
     ( runDamlStudio
     , runInit

--- a/daml-assistant/daml-project-config/DAML/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Config.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Project.Config
     ( DamlConfig

--- a/daml-assistant/daml-project-config/DAML/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DAML/Project/Types.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Project.Types
     ( module DAML.Project.Types

--- a/daml-assistant/exe/DAML/Assistant.hs
+++ b/daml-assistant/exe/DAML/Assistant.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant
     ( main

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
 import qualified Codec.Archive.Zip as Zip

--- a/daml-assistant/src/DAML/Assistant/Cache.hs
+++ b/daml-assistant/src/DAML/Assistant/Cache.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Cache
     ( cacheAvailableSdkVersions

--- a/daml-assistant/src/DAML/Assistant/Command.hs
+++ b/daml-assistant/src/DAML/Assistant/Command.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Command
     ( Command(..)

--- a/daml-assistant/src/DAML/Assistant/Env.hs
+++ b/daml-assistant/src/DAML/Assistant/Env.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Env
     ( Env (..)

--- a/daml-assistant/src/DAML/Assistant/Install.hs
+++ b/daml-assistant/src/DAML/Assistant/Install.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module DAML.Assistant.Install
     ( InstallOptions (..)
     , InstallURL (..)

--- a/daml-assistant/src/DAML/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DAML/Assistant/Install/Github.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Discover releases from the digital-asset/daml github.
 module DAML.Assistant.Install.Github

--- a/daml-assistant/src/DAML/Assistant/Types.hs
+++ b/daml-assistant/src/DAML/Assistant/Types.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Types
     ( module DAML.Assistant.Types

--- a/daml-assistant/src/DAML/Assistant/Version.hs
+++ b/daml-assistant/src/DAML/Assistant/Version.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Version
     ( getInstalledSdkVersions

--- a/daml-assistant/test/DAML/Assistant/Tests.hs
+++ b/daml-assistant/test/DAML/Assistant/Tests.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DAML.Assistant.Tests
     ( main

--- a/language-support/hs/bindings/examples/chat/src/DA/Chat/ChatLedger.hs
+++ b/language-support/hs/bindings/examples/chat/src/DA/Chat/ChatLedger.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- Abstraction for a Ledger which is hosting the Chat domain model.
 -- This is basically unchanged from the Nim example

--- a/language-support/hs/bindings/examples/chat/src/DA/Chat/Contracts.hs
+++ b/language-support/hs/bindings/examples/chat/src/DA/Chat/Contracts.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Chat Contracts, both sent-to, and coming-from the external ledger.
 module DA.Chat.Contracts (
     ChatContract(..),

--- a/language-support/hs/bindings/examples/chat/src/DA/Chat/Main.hs
+++ b/language-support/hs/bindings/examples/chat/src/DA/Chat/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Chat.Main (main) where
 

--- a/language-support/hs/bindings/examples/nim/src/DA/Nim/Domain.hs
+++ b/language-support/hs/bindings/examples/nim/src/DA/Nim/Domain.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Nim domain types. These should be derived automatically from the Daml model.
 
 module DA.Nim.Domain(

--- a/language-support/hs/bindings/examples/nim/src/DA/Nim/NimCommand.hs
+++ b/language-support/hs/bindings/examples/nim/src/DA/Nim/NimCommand.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Nim commands, to be sent to the external ledger.
 module DA.Nim.NimCommand(NimCommand(..), makeLedgerCommands,) where
 

--- a/language-support/hs/bindings/examples/nim/src/DA/Nim/NimLedger.hs
+++ b/language-support/hs/bindings/examples/nim/src/DA/Nim/NimLedger.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Abstraction for a Ledger which is hosting the Nim domain model.
 module DA.Nim.NimLedger(Handle, connect, sendCommand, getTrans) where
 

--- a/language-support/hs/bindings/examples/nim/src/DA/Nim/NimTrans.hs
+++ b/language-support/hs/bindings/examples/nim/src/DA/Nim/NimTrans.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Nim transitions, coming from the external ledger.
 module DA.Nim.NimTrans(NimTrans(..), extractTransaction,) where
 

--- a/language-support/hs/bindings/src/DA/Ledger.hs
+++ b/language-support/hs/bindings/src/DA/Ledger.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 module DA.Ledger ( -- High level interface to the Ledger API
 
     Port(..), Host(..), ClientConfig(..),

--- a/language-support/hs/bindings/src/DA/Ledger/Convert.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Convert.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 -- Convert between HL Ledger.Types and the LL types generated from .proto files
 module DA.Ledger.Convert (

--- a/language-support/hs/bindings/src/DA/Ledger/IsLedgerValue.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/IsLedgerValue.hs
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
-
 module DA.Ledger.IsLedgerValue (
     IsLedgerValue(..), -- types which can be converted to/from a Ledger API Value
     ) where

--- a/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Ledger.Sandbox ( -- Run a sandbox for testing on a dynamically selected port
     SandboxSpec(..),

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module DA.Ledger.Tests (main) where

--- a/libs-haskell/da-hs-base/src/DA/Pretty.hs
+++ b/libs-haskell/da-hs-base/src/DA/Pretty.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | This library provides the basis for all our pretty-printing. It extends
 -- "Text.PrettyPrint.Annotated.Extended" from 'da-base' with support for

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE BlockArguments #-}

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/IO.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 
 module DA.Service.Logger.Impl.IO
     ( newStderrLogger

--- a/libs-haskell/da-hs-base/src/Data/Conduit/Tar/Extra.hs
+++ b/libs-haskell/da-hs-base/src/Data/Conduit/Tar/Extra.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Data.Conduit.Tar.Extra
     ( module Data.Conduit.Tar
     , restoreFile

--- a/notices-gen/src/notices.hs
+++ b/notices-gen/src/notices.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
 import System.Environment

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Main (main) where
 

--- a/release/src/Types.hs
+++ b/release/src/Types.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE ConstraintKinds  #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Types (
     AllArtifacts(..),
     ArtifactId,

--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DuplicateRecordFields #-}

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/release/windows-installer/src/WindowsInstaller.hs
+++ b/release/windows-installer/src/WindowsInstaller.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
 import Data.String


### PR DESCRIPTION

- modified:   bazel_tools/haskell.bzl -- switch on `OverloadedStrings` by default
- modified:   .hlint.yaml -- extend hlint to dissallow per file switch on
- remove per file switch on in 100+ haskell files
- no other changes required to any haskell file



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
