### PR TITLE
damldocs: Use blockquotes for layout in markdown rendering.

### DIFF
--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -186,54 +186,52 @@ expectMarkdown =
         [ T.empty
         , mkExpectMD "module-typedef" "Typedef" "" [] []
             [ "**type <a name=\"type-typedef-t\"></a>T a**  "
-            , "&nbsp; = TT TTT"
-            , ""
-            , "T descr"
-            , ""]
+            , "> = TT TTT"
+            , "> "
+            , "> T descr"
+            , "> "]
             []
         , mkExpectMD "module-twotypes" "TwoTypes" "" [] []
             [ "**type <a name=\"type-twotypes-t\"></a>T a**  "
-            , "&nbsp; = TT"
-            , ""
-            , "T descr"
-            , ""
+            , "> = TT"
+            , "> "
+            , "> T descr"
+            , "> "
             , "**data <a name=\"data-twotypes-d\"></a>D d**"
-            , ""
-            , "* <a name=\"constr-twotypes-d\"></a>D a"
-            , "  "
-            , "  D descr"
-            , "  "
-            , ""
+            , "> "
+            , "> * <a name=\"constr-twotypes-d\"></a>**D** a"
+            , ">   "
+            , ">   D descr"
+            , ">   "
+            , "> "
             ]
             []
         , mkExpectMD "module-function1" "Function1" "" [] [] []
             [ "<a name=\"function-function1-f\"></a>**f**  "
-            , "&nbsp; : TheType"
-            , ""
-            , "the doc"
-            , ""
+            , "> : TheType"
+            , "> "
+            , "> the doc"
+            , "> "
             ]
         , mkExpectMD "module-function2" "Function2" "" [] [] []
             [ "<a name=\"function-function2-f\"></a>**f**  "
-            , "&nbsp; : \\_"
-            , ""
-            , "the doc"
-            , ""
+            , "> : \\_"
+            , "> "
+            , "> the doc"
+            , "> "
             ]
         , mkExpectMD "module-function3" "Function3" "" [] [] []
             [ "<a name=\"function-function3-f\"></a>**f**  "
-            , "&nbsp; : TheType"
-            , ""
+            , "> : TheType"
+            , "> "
             ]
         , mkExpectMD "module-onlyclass" "OnlyClass" ""
             []
-            [ "### <a name=\"class-onlyclass-c\"></a>Class C"
-            , ""
-            , "**class C a where**"
-            , ""
-            , "> <a name=\"function-onlyclass-member\"></a>**member**  "
-            , "> &nbsp; : a"
+            [ "<a name=\"class-onlyclass-c\"></a>**class C a where**"
             , "> "
+            , "> <a name=\"function-onlyclass-member\"></a>**member**  "
+            , "> > : a"
+            , "> > "
             ]
             []
             []
@@ -241,25 +239,28 @@ expectMarkdown =
             []
             []
             [ "**data <a name=\"data-multilinefield-d\"></a>D**"
-            , ""
-            , "* <a name=\"constr-multilinefield-d\"></a>D"
-            , "  "
-            , "  | Field | Type/Description |"
-            , "  | :---- | :----------------"
-            , "  | f     | T |"
-            , "  |       | This is a multiline field description |"
+            , "> "
+            , "> * <a name=\"constr-multilinefield-d\"></a>**D**"
+            , ">   "
+            , ">   | Field | Type/Description |"
+            , ">   | :---- | :----------------"
+            , ">   | f     | T |"
+            , ">   |       | This is a multiline field description |"
+            , ">   "
+            , "> "
             ]
             []
         , mkExpectMD "module-functionctx" "FunctionCtx" "" [] [] []
             [ "<a name=\"function-f\"></a>**f**  "
-            , "&nbsp; : (Eq t) => \\_"
-            , ""
-            , "function with context but no type"
-            , ""
+            , "> : (Eq t) => \\_"
+            , "> "
+            , "> function with context but no type"
+            , "> "
             , "<a name=\"function-g\"></a>**g**  "
-            , "&nbsp; : (Eq t) => t -> Bool"
-            , ""
-            , "function with context and type"
+            , "> : (Eq t) => t -> Bool"
+            , "> "
+            , "> function with context and type"
+            , "> "
             ]
         ]
         <> repeat (error "Missing expectation (Markdown)")

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.md
@@ -49,10 +49,10 @@ Choices:
 ## Functions
 
 <a name="function-ioutemplate-main-13221"></a>**main**  
-&nbsp; : Scenario ()
-
-A single test scenario covering all functionality that `Iou` implements.
-This description contains [a link](http://example.com), some bogus <inline html>,
-and words_ with_ underscore, to test damldoc capabilities.
-
+> : Scenario ()
+> 
+> A single test scenario covering all functionality that `Iou` implements.
+> This description contains [a link](http://example.com), some bogus <inline html>,
+> and words_ with_ underscore, to test damldoc capabilities.
+> 
 

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -3,36 +3,36 @@
 ## Data types
 
 **data <a name="type-newtype-nat-61947"></a>Nat**
-
-* <a name="constr-newtype-nat-99832"></a>Nat
-  
-  | Field | Type/Description |
-  | :---- | :----------------
-  | unNat | Int |
-  
-
+> 
+> * <a name="constr-newtype-nat-99832"></a>**Nat**
+>   
+>   | Field | Type/Description |
+>   | :---- | :----------------
+>   | unNat | Int |
+>   
+> 
 
 ## Functions
 
 <a name="function-newtype-mknat-8513"></a>**mkNat**  
-&nbsp; : Int -> [Nat](#type-newtype-nat-61947)
-
+> : Int -> [Nat](#type-newtype-nat-61947)
+> 
 <a name="function-newtype-unsafemknat-96593"></a>**unsafeMkNat**  
-&nbsp; : Int -> [Nat](#type-newtype-nat-61947)
-
+> : Int -> [Nat](#type-newtype-nat-61947)
+> 
 <a name="function-newtype-zero0-10450"></a>**zero0**  
-&nbsp; : [Nat](#type-newtype-nat-61947)
-
+> : [Nat](#type-newtype-nat-61947)
+> 
 <a name="function-newtype-one1-53872"></a>**one1**  
-&nbsp; : [Nat](#type-newtype-nat-61947)
-
+> : [Nat](#type-newtype-nat-61947)
+> 
 <a name="function-newtype-unnat1-26452"></a>**unNat1**  
-&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
-
+> : [Nat](#type-newtype-nat-61947) -> Int
+> 
 <a name="function-newtype-unnat2-96339"></a>**unNat2**  
-&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
-
+> : [Nat](#type-newtype-nat-61947) -> Int
+> 
 <a name="function-newtype-unnat3-97654"></a>**unNat3**  
-&nbsp; : [Nat](#type-newtype-nat-61947) -> Int
-
+> : [Nat](#type-newtype-nat-61947) -> Int
+> 
 


### PR DESCRIPTION
This PR uses blockquotes to arrange the Markdown docs more hierarchically. They are much easier to read absent any real theme (you can preview this by running the bazel rule `//compiler/damlc:daml-base-html-docs` and opening the generated docs in a browser -- this should probably be easier to do though).

This PR also gets rid of `### Class X` headers that were just visual clutter.