### PR TITLE
damldocs: Make function types mandatory in FunctionDoc, and hide non-exported functions.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -120,9 +120,11 @@ fct2hoogle :: FunctionDoc -> [T.Text]
 fct2hoogle FunctionDoc{..} = concat
     [ hooglify fct_descr
     , [ urlTag fct_anchor
-      , T.unwords $ [wrapOp (unFieldname fct_name), "::"]
-                 ++ maybe [] ((:["=>"]) . type2hoogle) fct_context
-                 ++ maybe ["_"] ((:[]) . type2hoogle) fct_type -- FIXME(FM): what to do when missing type?
+      , T.unwords . concat $
+          [ [wrapOp (unFieldname fct_name), "::"]
+          , maybe [] ((:["=>"]) . type2hoogle) fct_context
+          , [type2hoogle fct_type]
+          ]
       , "" ]
     ]
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -221,7 +221,7 @@ fct2md FunctionDoc{..} = mconcat
         [ renderLineDep $ \env -> T.concat
             [ ": "
             , maybe "" ((<> " => ") . type2md env) fct_context
-            , maybe "\\_"  (type2md env) fct_type
+            , type2md env fct_type
             ]
         , renderDocText fct_descr
         ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -228,7 +228,7 @@ fct2rst FunctionDoc{..} = mconcat
         , T.concat
             [ "  : "
             , maybe "" ((<> " => ") . type2rst env) fct_context
-            , maybe "_" (type2rst env) fct_type
+            , type2rst env fct_type
             ]
         , ""
         ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -151,7 +151,7 @@ data FunctionDoc = FunctionDoc
   { fct_anchor :: Maybe Anchor
   , fct_name  :: Fieldname
   , fct_context :: Maybe Type
-  , fct_type  :: Maybe Type
+  , fct_type  :: Type
   , fct_descr :: Maybe DocText
   }
   deriving (Eq, Show, Generic)

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -44,20 +44,16 @@ cases = [ ("Empty module",
           )
         , ("Documented function with type",
            ModuleDoc (Just "module-function1") "Function1" Nothing [] [] []
-            [FunctionDoc (Just "function-function1-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) (Just "the doc")] []
-          )
-        , ("Documented function without type",
-           ModuleDoc (Just "module-function2") "Function2" Nothing [] [] []
-            [FunctionDoc (Just "function-function2-f") "f" Nothing Nothing (Just "the doc")] []
+            [FunctionDoc (Just "function-function1-f") "f" Nothing (TypeApp Nothing "TheType" []) (Just "the doc")] []
           )
         , ("Undocumented function with type",
            ModuleDoc (Just "module-function3") "Function3" Nothing [] [] []
-            [FunctionDoc (Just "function-function3-f") "f" Nothing (Just $ TypeApp Nothing "TheType" []) Nothing] []
+            [FunctionDoc (Just "function-function3-f") "f" Nothing (TypeApp Nothing "TheType" []) Nothing] []
           )
         -- The doc extraction won't generate functions without type nor description
         , ("Module with only a type class",
            ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
-            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (Just (TypeApp Nothing "a" [])) Nothing]])
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing]])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")
@@ -78,14 +74,10 @@ cases = [ ("Empty module",
            ModuleDoc
             (Just "module-functionctx") "FunctionCtx"
             Nothing [] [] []
-            [ FunctionDoc (Just "function-f") "f"
+            [ FunctionDoc (Just "function-g") "g"
                 (Just $ TypeTuple [TypeApp Nothing "Eq" [TypeApp Nothing "t" []]])
-                Nothing
-                (Just "function with context but no type")
-            , FunctionDoc (Just "function-g") "g"
-                (Just $ TypeTuple [TypeApp Nothing "Eq" [TypeApp Nothing "t" []]])
-                (Just $ TypeFun [TypeApp Nothing "t" [], TypeApp Nothing "Bool" []])
-                (Just "function with context and type")
+                (TypeFun [TypeApp Nothing "t" [], TypeApp Nothing "Bool" []])
+                (Just "function with context")
             ] []
           )
         ]
@@ -101,7 +93,6 @@ expectRst =
             , "\n.. _data-twotypes-d:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d:\n  \n  **D** a\n  \n  D descr"]
             []
         , mkExpectRst "module-function1" "Function1" "" [] [] [] [ ".. _function-function1-f:\n\n**f**\n  : TheType\n\n  the doc\n"]
-        , mkExpectRst "module-function2" "Function2" "" [] [] [] [ ".. _function-function2-f:\n\n**f**\n  : _\n\n  the doc\n"]
         , mkExpectRst "module-function3" "Function3" "" [] [] [] [ ".. _function-function3-f:\n\n**f**\n  : TheType\n\n"]
         , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
@@ -135,19 +126,12 @@ expectRst =
             ]
             []
         , mkExpectRst "module-functionctx" "FunctionCtx" "" [] [] []
-            [ ".. _function-f:"
-            , ""
-            , "**f**"
-            , "  : (Eq t) => _"
-            , ""
-            , "  function with context but no type"
-            , ""
-            , ".. _function-g:"
+            [ ".. _function-g:"
             , ""
             , "**g**"
             , "  : (Eq t) => t -> Bool"
             , ""
-            , "  function with context and type"
+            , "  function with context"
             ]
         ]
         <> repeat (error "Missing expectation (Rst)")
@@ -213,13 +197,6 @@ expectMarkdown =
             , "> the doc"
             , "> "
             ]
-        , mkExpectMD "module-function2" "Function2" "" [] [] []
-            [ "<a name=\"function-function2-f\"></a>**f**  "
-            , "> : \\_"
-            , "> "
-            , "> the doc"
-            , "> "
-            ]
         , mkExpectMD "module-function3" "Function3" "" [] [] []
             [ "<a name=\"function-function3-f\"></a>**f**  "
             , "> : TheType"
@@ -251,15 +228,10 @@ expectMarkdown =
             ]
             []
         , mkExpectMD "module-functionctx" "FunctionCtx" "" [] [] []
-            [ "<a name=\"function-f\"></a>**f**  "
-            , "> : (Eq t) => \\_"
-            , "> "
-            , "> function with context but no type"
-            , "> "
-            , "<a name=\"function-g\"></a>**g**  "
+            [ "<a name=\"function-g\"></a>**g**  "
             , "> : (Eq t) => t -> Bool"
             , "> "
-            , "> function with context and type"
+            , "> function with context"
             , "> "
             ]
         ]


### PR DESCRIPTION
Makes function types mandatory in the `FunctionDoc` type, meaning that if we can't find a function's type info, we don't generate documentation for the function. (The only time this apparently happens is when the function is not exported. There is some GHC magic here.)

As such, we also hide all non-exported functions. This is part of issue #38.