### PR TITLE
damlc visual: detect ledger actions at surface level

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -55,7 +55,7 @@ startFromUpdate seen world update = case update of
     LF.UBind (LF.Binding _ e1) e2 -> startFromExpr seen world e1 `Set.union` startFromExpr seen world e2
     LF.UGetTime -> Set.empty
     LF.UEmbedExpr _ upEx -> startFromExpr seen world upEx
-    -- NOTE(MH): The above cases are impossible because they only appear
+    -- NOTE(MH): The cases below are impossible because they only appear
     -- in dictionaries for the `Template` and `Choice` classes, which we
     -- ignore below.
     LF.UCreate{}-> error "IMPOSSIBLE"

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -1,5 +1,6 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE PatternSynonyms #-}
 -- | Main entry-point of the DAML compiler
 module DA.Cli.Visual
   ( execVisual
@@ -52,25 +53,43 @@ startFromUpdate :: Set.Set (LF.Qualified LF.ExprValName) -> LF.World -> LF.Updat
 startFromUpdate seen world update = case update of
     LF.UPure _ e -> startFromExpr seen world e
     LF.UBind (LF.Binding _ e1) e2 -> startFromExpr seen world e1 `Set.union` startFromExpr seen world e2
-    LF.UCreate tpl e -> Set.singleton (ACreate tpl) `Set.union` startFromExpr seen world e
-    LF.UExercise tpl chc e1 e2 e3 -> Set.singleton (AExercise tpl chc) `Set.union` startFromExpr seen world e1 `Set.union` maybe Set.empty (startFromExpr seen world) e2 `Set.union` startFromExpr seen world e3
-    LF.UFetch _ ctIdEx -> startFromExpr seen world ctIdEx
     LF.UGetTime -> Set.empty
     LF.UEmbedExpr _ upEx -> startFromExpr seen world upEx
-    LF.ULookupByKey _ -> Set.empty
-    LF.UFetchByKey _ -> Set.empty
+    -- NOTE(MH): The above cases are impossible because they only appear
+    -- in dictionaries for the `Template` and `Choice` classes, which we
+    -- ignore below.
+    LF.UCreate{}-> error "IMPOSSIBLE"
+    LF.UExercise{} -> error "IMPOSSIBLE"
+    LF.UFetch{} -> error "IMPOSSIBLE"
+    LF.ULookupByKey{} -> error "IMPOSSIBLE"
+    LF.UFetchByKey{} -> error "IMPOSSIBLE"
 
 startFromExpr :: Set.Set (LF.Qualified LF.ExprValName) -> LF.World  -> LF.Expr -> Set.Set Action
 startFromExpr seen world e = case e of
     LF.EVar _ -> Set.empty
+    -- NOTE(MH): We ignore the dictionaries for the `Template` and `Choice`
+    -- classes because they contain too many ledger actions. We detect the
+    -- `create`, `archive` and `exercise` functions which take these
+    -- dictionaries as arguments instead.
+    LF.EVal (LF.Qualified _ _ (LF.ExprValName ref))
+        | "$fTemplate" `T.isPrefixOf` ref || "$fChoice" `T.isPrefixOf` ref -> Set.empty
     LF.EVal ref ->  case LF.lookupValue ref world of
         Right LF.DefValue{..}
             | ref `Set.member` seen  -> Set.empty
             | otherwise -> startFromExpr (Set.insert ref seen)  world dvalBody
         Left _ -> error "This should not happen"
     LF.EUpdate upd -> startFromUpdate seen world upd
-    LF.ETmApp (LF.ETyApp (LF.EVal (LF.Qualified _ (LF.ModuleName ["DA","Internal","Template"]) (LF.ExprValName "fetch"))) _) _ -> Set.empty
+    EInternalTemplateVal "create" `LF.ETyApp` LF.TCon tpl `LF.ETmApp` _dict
+        -> Set.singleton (ACreate tpl)
+    EInternalTemplateVal "exercise" `LF.ETyApp` LF.TCon tpl `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
+        Set.singleton (AExercise tpl (LF.ChoiceName chc))
+    EInternalTemplateVal "archive" `LF.ETyApp` LF.TCon tpl `LF.ETmApp` _dict ->
+        Set.singleton (AExercise tpl (LF.ChoiceName "Archive"))
     expr -> Set.unions $ map (startFromExpr seen world) $ children expr
+
+pattern EInternalTemplateVal :: T.Text -> LF.Expr
+pattern EInternalTemplateVal val <-
+    LF.EVal (LF.Qualified _pkg (LF.ModuleName ["DA", "Internal", "Template"]) (LF.ExprValName val))
 
 startFromChoice :: LF.World -> LF.TemplateChoice -> Set.Set Action
 startFromChoice world chc = startFromExpr Set.empty world (LF.chcUpdate chc)

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -83,6 +83,9 @@ startFromExpr seen world e = case e of
         -> Set.singleton (ACreate tpl)
     EInternalTemplateVal "exercise" `LF.ETyApp` LF.TCon tpl `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
         Set.singleton (AExercise tpl (LF.ChoiceName chc))
+    -- TODO(MH): We need to add a special case for `archive` because it
+    -- currently defined as `archive c = exercise c Archive` and we can't
+    -- handle polymorphic calls to `exercise` like this one.
     EInternalTemplateVal "archive" `LF.ETyApp` LF.TCon tpl `LF.ETmApp` _dict ->
         Set.singleton (AExercise tpl (LF.ChoiceName "Archive"))
     expr -> Set.unions $ map (startFromExpr seen world) $ children expr

--- a/compiler/damlc/tests/visual/Basic.daml
+++ b/compiler/damlc/tests/visual/Basic.daml
@@ -61,6 +61,11 @@ template Membership
                 assert (sender `elem` members)
                 create Message with sender, recipients = members, gid, body
 
+        nonconsuming choice Membership_Shutdown_Indirect : ()
+            controller owner
+            do
+                exercise self Membership_Shutdown
+
         choice Membership_Shutdown : ()
             controller owner
             do

--- a/compiler/damlc/tests/visual/Basic.dot
+++ b/compiler/damlc/tests/visual/Basic.dot
@@ -16,18 +16,16 @@ label=Message;color=blue
 }subgraph cluster_Membership{
 n6[label=Create][color=green]; 
 n7[label=Archive][color=red]; 
-n8[label=Membership_Shutdown][color=red]; 
-n9[label=Membership_SendMessage][color=green]; 
-n10[label=Membership_Leave][color=red]; 
-n11[label=Membership_Join][color=red]; 
+n8[label=Membership_Shutdown_Indirect][color=green]; 
+n9[label=Membership_Shutdown][color=red]; 
+n10[label=Membership_SendMessage][color=green]; 
+n11[label=Membership_Leave][color=red]; 
+n12[label=Membership_Join][color=red]; 
 label=Membership;color=blue
-}n8->n0
-n8->n1
-n9->n4
-n9->n5
-n10->n6
-n10->n7
+}n8->n9
+n9->n1
+n10->n4
 n11->n6
-n11->n7
+n12->n6
 
 }


### PR DESCRIPTION
Instead of detecting the DAML-LF primitives for `create` and `exercise`,
we detect the corresponding surface DAML functions and ignore the
dictionaries for the `Template` and `Choice` classes. This will be
necessary for swiching to the new template desugaring.

This is the quickest way to get this working but might turn into a brittle
maintenance nightmare one day. If that happens, we should switch to doing
proper symbolic evaluation, which will we be a bit more code though.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2278)
<!-- Reviewable:end -->
