### PR TITLE
Improve debugging output

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -340,7 +340,7 @@ shakeRun IdeState{shakeExtras=ShakeExtras{..}, ..} acts = modifyVar shakeAbort $
         signalBarrier bar res
         runTime <- start
         let res' = case res of
-                Left e -> "exception: " <> show e
+                Left e -> "exception: " <> displayException e
                 Right _ -> "completed"
         logDebug logger $ T.pack $
             "Finishing shakeRun (took " ++ showDuration runTime ++ ", " ++ res' ++ ")"

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -50,7 +50,6 @@ import qualified Data.ByteString.Char8 as BS
 import           Data.Dynamic
 import           Data.Maybe
 import Data.Map.Strict (Map)
-import           Data.Either.Extra
 import           Data.List.Extra
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -340,8 +339,11 @@ shakeRun IdeState{shakeExtras=ShakeExtras{..}, ..} acts = modifyVar shakeAbort $
     thread <- forkFinally (shakeRunDatabaseProfile shakeDb acts) $ \res -> do
         signalBarrier bar res
         runTime <- start
+        let res' = case res of
+                Left e -> "exception: " <> show e
+                Right _ -> "completed"
         logDebug logger $ T.pack $
-            "Finishing shakeRun (took " ++ showDuration runTime ++ ", " ++ (if isLeft res then "exception" else "completed") ++ ")"
+            "Finishing shakeRun (took " ++ showDuration runTime ++ ", " ++ res' ++ ")"
     -- important: we send an async exception to the thread, then wait for it to die, before continuing
     return (do killThread thread; void $ waitBarrier bar, either throwIO return =<< waitBarrier bar)
 

--- a/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
+++ b/libs-haskell/bazel-runfiles/src/DA/Bazel/Runfiles.hs
@@ -11,6 +11,7 @@ module DA.Bazel.Runfiles
   ) where
 
 import qualified Bazel.Runfiles
+import GHC.Stack
 import System.Directory
 import System.Environment
 import System.FilePath
@@ -29,7 +30,7 @@ exe | os == "mingw32" = (<.> "exe")
 -- this corresponds to the top-level @resources@ directory. In a @bazel run@ or
 -- @bazel test@ target this corresponds to the @runfiles@ path of the given
 -- @data@ dependency.
-locateRunfiles :: FilePath -> IO FilePath
+locateRunfiles :: HasCallStack => FilePath -> IO FilePath
 locateRunfiles fp = do
   -- If the current executable was packaged using @package_app@, then
   -- data files are stored underneath the resources directory.


### PR DESCRIPTION
Displaying the exception makes it easier to figure out what is going
wrong.

I’ve also added a HasCallStack constraint to `locateRunfiles` since it
looked like that was failing. Turned out to be a call to `create` that
didn’t go via `locateRunfiles` but I think it’s useful either way.
Should be more useful with https://github.com/tweag/rules_haskell/pull/1007

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
