### PR TITLE
fix shebang line in daml-sdk-head

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # Make sure they are in the right repo


### PR DESCRIPTION
bash is not necessarily installed at `/bin/bash`, and even when one is there it may not be the one we want to use (e.g. maybe we want to use the one from dev-env).
