### PR TITLE
language: a shake rule to get interface/hie files

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -16,7 +16,6 @@ module DA.Daml.Options
 import Control.Monad
 import qualified CmdLineParser as Cmd (warnMsg)
 import Data.Bifunctor
-import Data.Maybe
 import Data.IORef
 import Data.List
 import DynFlags (parseDynamicFilePragma)
@@ -50,7 +49,6 @@ toCompileOpts options@Options{..} =
           { optLocateHieFile = locateInPkgDb "hie"
           , optLocateSrcFile = locateInPkgDb "daml"
           }
-      , optIfaceDir = HieCore.InterfaceDirectory (fromMaybe ifaceDir optIfaceDir <$ guard optWriteInterface)
       , optExtensions = ["daml"]
       , optThreads = optThreads
       , optShakeProfiling = optShakeProfiling

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -141,17 +141,10 @@ mkTcModuleResult
 mkTcModuleResult tcm = do
     session <- getSession
     (iface, _) <- liftIO $ mkIfaceTc session Nothing Sf_None details tcGblEnv
-    hieFile <-
-        liftIO $
-        runHsc session $
-        mkHieFile (tcModSummary tcm) tcGblEnv (fromJust $ renamedSource tcm)
     let mod_info = HomeModInfo iface details Nothing
-    return $ TcModuleResult tcm mod_info hieFile
+    return $ TcModuleResult tcm mod_info
   where
     (tcGblEnv, details) = tm_internals_ tcm
-
-tcModSummary :: TypecheckedModule -> ModSummary
-tcModSummary = pm_mod_summary . tm_parsed_module
 
 -- | Setup the environment that GHC needs according to our
 -- best understanding (!)

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -52,7 +52,6 @@ import           Data.Maybe
 import           Data.Tuple.Extra
 import qualified Data.Map.Strict                          as Map
 import           System.FilePath
-import           System.Directory
 import System.IO.Extra
 import Data.Char
 
@@ -84,19 +83,18 @@ computePackageDeps env pkg = do
 
 -- | Typecheck a single module using the supplied dependencies and packages.
 typecheckModule
-    :: IdeOptions
-    -> HscEnv
+    :: HscEnv
     -> [TcModuleResult]
     -> ParsedModule
     -> IO ([FileDiagnostic], Maybe TcModuleResult)
-typecheckModule opt packageState deps pm =
+typecheckModule packageState deps pm =
     fmap (either (, Nothing) (second Just)) $
     runGhcEnv packageState $
         catchSrcErrors $ do
             setupEnv deps
             (warnings, tcm) <- withWarnings $ \tweak ->
                 GHC.typecheckModule pm{pm_mod_summary = tweak $ pm_mod_summary pm}
-            tcm2 <- mkTcModuleResult (optIfaceDir opt) tcm
+            tcm2 <- mkTcModuleResult tcm
             return (warnings, tcm2)
 
 -- | Compile a single type-checked module to a 'CoreModule' value, or
@@ -138,25 +136,18 @@ addRelativeImport modu dflags = dflags
 
 mkTcModuleResult
     :: GhcMonad m
-    => InterfaceDirectory
-    -> TypecheckedModule
+    => TypecheckedModule
     -> m TcModuleResult
-mkTcModuleResult (InterfaceDirectory mbIfaceDir) tcm = do
-    session   <- getSession
-    (iface,_) <- liftIO $ mkIfaceTc session Nothing Sf_None details tcGblEnv
-    liftIO $ whenJust mbIfaceDir $ \ifaceDir -> do
-        let path = ifaceDir </> file tcm
-        createDirectoryIfMissing True (takeDirectory path)
-        writeIfaceFile (hsc_dflags session) (replaceExtension path ".hi") iface
-        -- For now, we write .hie files whenever we write .hi files which roughly corresponds to
-        -- when we are building a package. It should be easily decoupable if that turns out to be
-        -- useful.
-        hieFile <- runHsc session $ mkHieFile (tcModSummary tcm) tcGblEnv (fromJust $ renamedSource tcm)
-        writeHieFile (replaceExtension path ".hie") hieFile
+mkTcModuleResult tcm = do
+    session <- getSession
+    (iface, _) <- liftIO $ mkIfaceTc session Nothing Sf_None details tcGblEnv
+    hieFile <-
+        liftIO $
+        runHsc session $
+        mkHieFile (tcModSummary tcm) tcGblEnv (fromJust $ renamedSource tcm)
     let mod_info = HomeModInfo iface details Nothing
-    return $ TcModuleResult tcm mod_info
+    return $ TcModuleResult tcm mod_info hieFile
   where
-    file = ms_hspp_file . tcModSummary
     (tcGblEnv, details) = tm_internals_ tcm
 
 tcModSummary :: TypecheckedModule -> ModSummary

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -47,6 +47,7 @@ type instance RuleResult GetDependencies = TransitiveDependencies
 data TcModuleResult = TcModuleResult
     { tmrModule     :: TypecheckedModule
     , tmrModInfo    :: HomeModInfo
+    , tmrHieFile    :: HieFile
     }
 instance Show TcModuleResult where
     show = show . pm_mod_summary . tm_parsed_module . tmrModule

--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -47,7 +47,6 @@ type instance RuleResult GetDependencies = TransitiveDependencies
 data TcModuleResult = TcModuleResult
     { tmrModule     :: TypecheckedModule
     , tmrModInfo    :: HomeModInfo
-    , tmrHieFile    :: HieFile
     }
 instance Show TcModuleResult where
     show = show . pm_mod_summary . tm_parsed_module . tmrModule

--- a/compiler/hie-core/src/Development/IDE/Types/Options.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Options.hs
@@ -7,7 +7,6 @@
 module Development.IDE.Types.Options
   ( IdeOptions(..)
   , IdePkgLocationOptions(..)
-  , InterfaceDirectory(..)
   , defaultIdeOptions
   ) where
 
@@ -16,16 +15,12 @@ import           GHC hiding (parseModule, typecheckModule)
 import           GhcPlugins                     as GHC hiding (fst3, (<>))
 
 
--- | If `Nothing` we do not write .hi files.
-newtype InterfaceDirectory = InterfaceDirectory (Maybe FilePath)
-
 data IdeOptions = IdeOptions
   { optPreprocessor :: GHC.ParsedSource -> ([(GHC.SrcSpan, String)], GHC.ParsedSource)
   , optGhcSession :: Action HscEnv
   -- ^ Setup a GHC session using a given package state. If a `ParsedModule` is supplied,
   -- the import path should be setup for that module.
   , optPkgLocationOpts :: IdePkgLocationOptions
-  , optIfaceDir :: InterfaceDirectory
   , optExtensions :: [String]
 
   , optThreads :: Int
@@ -37,7 +32,6 @@ data IdeOptions = IdeOptions
 defaultIdeOptions :: Action HscEnv -> IdeOptions
 defaultIdeOptions session = IdeOptions
     {optPreprocessor = (,) []
-    ,optIfaceDir = InterfaceDirectory Nothing
     ,optGhcSession = session
     ,optExtensions = ["hs"]
     ,optPkgLocationOpts = defaultIdePkgLocationOptions


### PR DESCRIPTION
This adds a shake rule to get module interfaces and hie files. This
gives more control on when to build them and also an opportunity to
change the package name after typechecking. This is used in the next
PR to add package hashes to the package name in the interface files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
