### PR TITLE
Fix hanging hie-core tests with stack

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -111,6 +111,7 @@ library
 executable hie-core
     default-language:   Haskell2010
     hs-source-dirs:     exe
+    ghc-options: -threaded
     main-is: Main.hs
     build-depends:
         base == 4.*,
@@ -153,7 +154,10 @@ test-suite hie-core-tests
         tasty-hunit,
         text
     hs-source-dirs: test/cabal test/exe test/src
+    ghc-options: -threaded
     main-is: Main.hs
     other-modules:
         Development.IDE.Test
         Development.IDE.Test.Runfiles
+    default-extensions:
+        OverloadedStrings


### PR DESCRIPTION
`hie-core` tests where hanging when executed with `stack test` instead of `bazel test`. The issue was that the `hie-core` executable was not built with the threaded runtime.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
