### PR TITLE
fix retry handling for issue #2260

### DIFF
--- a/language-support/hs/bindings/src/DA/Ledger/GrpcWrapUtils.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/GrpcWrapUtils.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE GADTs             #-}
 
 module DA.Ledger.GrpcWrapUtils (
-    noTrace, emptyMdm, unwrap, sendToStream,
+    noTrace, emptyMdm,
+    unwrap, unwrapWithNotFound, unwrapWithInvalidArgument,
+    sendToStream,
     ) where
 
 import Prelude hiding (fail)
@@ -29,6 +31,20 @@ emptyMdm = MetadataMap Map.empty
 unwrap :: ClientResult 'Normal a -> IO a
 unwrap = \case
     ClientNormalResponse x _m1 _m2 _status _details -> return x
+    ClientErrorResponse (ClientIOError e) -> throwIO e
+    ClientErrorResponse ce -> fail (show ce)
+
+unwrapWithNotFound :: ClientResult 'Normal a -> IO (Maybe a)
+unwrapWithNotFound = \case
+    ClientNormalResponse x _m1 _m2 _status _details -> return $ Just x
+    ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusNotFound _)) -> return Nothing
+    ClientErrorResponse (ClientIOError e) -> throwIO e
+    ClientErrorResponse ce -> fail (show ce)
+
+unwrapWithInvalidArgument :: ClientResult 'Normal a -> IO (Either StatusDetails a)
+unwrapWithInvalidArgument = \case
+    ClientNormalResponse x _m1 _m2 _status _details -> return $ Right x
+    ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) -> return $ Left details
     ClientErrorResponse (ClientIOError e) -> throwIO e
     ClientErrorResponse ce -> fail (show ce)
 

--- a/language-support/hs/bindings/src/DA/Ledger/Services/CommandCompletionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/CommandCompletionService.hs
@@ -51,8 +51,9 @@ completionEnd lid =
         service <- commandCompletionServiceClient client
         let CommandCompletionService {commandCompletionServiceCompletionEnd=rpc} = service
         let request = CompletionEndRequest (unLedgerId lid) noTrace
-        response <- rpc (ClientNormalRequest request timeout emptyMdm)
-        unwrap response >>= \case
+        rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrap
+            >>= \case
             CompletionEndResponse (Just offset) ->
                 case raiseAbsLedgerOffset offset of
                     Left reason -> fail (show reason)

--- a/language-support/hs/bindings/src/DA/Ledger/Services/CommandService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/CommandService.hs
@@ -25,13 +25,10 @@ submitAndWait commands =
         let LL.CommandService{commandServiceSubmitAndWaitForTransactionId=rpc} = service
         let request = LL.SubmitAndWaitRequest (Just (lowerCommands commands)) noTrace
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse LL.SubmitAndWaitForTransactionIdResponse{} _m1 _m2 _status _details -> do
-                return $ Right ()
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
-                return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)
+            Right LL.SubmitAndWaitForTransactionIdResponse{} -> return $ Right ()
+            Left details -> return $ Left $ show $ unStatusDetails details
 
 submitAndWaitForTransactionId :: Commands -> LedgerService (Either String TransactionId)
 submitAndWaitForTransactionId commands =
@@ -41,14 +38,13 @@ submitAndWaitForTransactionId commands =
         let LL.CommandService{commandServiceSubmitAndWaitForTransactionId=rpc} = service
         let request = LL.SubmitAndWaitRequest (Just (lowerCommands commands)) noTrace
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse response _m1 _m2 _status _details -> do
+            Right response -> do
                 let LL.SubmitAndWaitForTransactionIdResponse{..} = response
                 return $ Right $ TransactionId submitAndWaitForTransactionIdResponseTransactionId
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
+            Left details ->
                 return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)
 
 submitAndWaitForTransaction :: Commands -> LedgerService (Either String Transaction)
 submitAndWaitForTransaction commands =
@@ -58,13 +54,12 @@ submitAndWaitForTransaction commands =
         let LL.CommandService{commandServiceSubmitAndWaitForTransaction=rpc} = service
         let request = LL.SubmitAndWaitRequest (Just (lowerCommands commands)) noTrace
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse response _m1 _m2 _status _details -> do
+            Right response ->
                 either (fail . show) (return . Right) $ raiseResponse response
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
+            Left details ->
                 return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)
   where
       raiseResponse = \case
           LL.SubmitAndWaitForTransactionResponse{..} -> do
@@ -79,13 +74,12 @@ submitAndWaitForTransactionTree commands =
         let LL.CommandService{commandServiceSubmitAndWaitForTransactionTree=rpc} = service
         let request = LL.SubmitAndWaitRequest (Just (lowerCommands commands)) noTrace
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse response _m1 _m2 _status _details -> do
+            Right response ->
                 either (fail . show) (return . Right) $ raiseResponse response
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
+            Left details ->
                 return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)
   where
       raiseResponse = \case
           LL.SubmitAndWaitForTransactionTreeResponse{..} -> do

--- a/language-support/hs/bindings/src/DA/Ledger/Services/CommandSubmissionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/CommandSubmissionService.hs
@@ -21,10 +21,9 @@ submit commands =
         let CommandSubmissionService rpc = service
         let request = SubmitRequest (Just (lowerCommands commands)) noTrace
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse Empty{} _m1 _m2 _status _details ->
+            Right Empty{} ->
                 return $ Right ()
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
+            Left details ->
                 return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)

--- a/language-support/hs/bindings/src/DA/Ledger/Services/TimeService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/TimeService.hs
@@ -33,10 +33,9 @@ setTime lid currentTime newTime  =
         let LL.TimeService {timeServiceSetTime=rpc} = service
         let request = LL.SetTimeRequest (unLedgerId lid) (Just (lowerTimestamp currentTime)) (Just (lowerTimestamp newTime))
         rpc (ClientNormalRequest request timeout emptyMdm)
+            >>= unwrapWithInvalidArgument
             >>= \case
-            ClientNormalResponse Empty{} _m1 _m2 _status _details -> do
+            Right Empty{} ->
                 return $ Right ()
-            ClientErrorResponse (ClientIOError (GRPCIOBadStatusCode StatusInvalidArgument details)) ->
+            Left details ->
                 return $ Left $ show $ unStatusDetails details
-            ClientErrorResponse e ->
-                fail (show e)

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -353,7 +353,6 @@ tUploadDarFile withSandbox = testCase "tUploadDarFileGood" $ run withSandbox $ \
 
 tListKnownPackages :: SandboxTest
 tListKnownPackages withSandbox = testCase "tListKnownPackages" $ run withSandbox $ \_pid -> do
-    _ <- getLedgerIdentity -- without this, the first call to listKnownPackages times-out
     known0 <- listKnownPackages
     let pids0 = map (\PackageDetails{pid} -> pid) known0
     liftIO $ do assertEqual "#known0" 3 (length known0)


### PR DESCRIPTION

Fix for retry handling in HLB service wrapper code
- was reported as sandbox issue: https://github.com/digital-asset/daml/issues/2260
- but was actually a bug in HLB
- problem came when service wrapper code did not use the `unwrap` helper (because they couldn't), but forgot the following important line which allows the retry handling to work:
```
    ClientErrorResponse (ClientIOError e) -> throwIO e
```

The solution in this PR is to be much more DRY, and introduce to new variants of `unwrap`:
- `unwrapWithNotFound`
- `unwrapWithInvalidArgument`


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
