### PR TITLE
Avoid evaluating modules unnecessarily to NF

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -95,7 +95,7 @@ buildDar service file mbExposedModules pkgName sdkVersion buildDataFiles dalfInp
         pkgName
         sdkVersion
     else runAction service $ runMaybeT $ do
-      pkg <- useE GeneratePackage file
+      WhnfPackage pkg <- useE GeneratePackage file
       let pkgModuleNames = S.fromList $ map T.unpack $ LF.packageModuleNames pkg
       let missingExposed = S.fromList (fromMaybe [] mbExposedModules) S.\\ pkgModuleNames
       unless (S.null missingExposed) $


### PR DESCRIPTION
Currently, we call `force` on every result of a rule. This was
problematic for the rules that produce LF packages:

Even if only the top-level module changes, the package for that module
contains all its dependencies. This means that we end up RNFing every
module that the current module depends on. On a project with ~900
dependencies this added up to over 1s for both GeneratePackageDeps and
GeneratePackage which corresponded to more than half of the overall
runtime.

This PR introduces a newtype for packages that does not evaluate the
modules in a package to NF. With this PR both rules are below 0.02s so
his is quite a significant improvement. We do not introduce any
potential space leaks here since the modules are produced by rules
that already force them to NF.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
