### PR TITLE
DAML-LF: Prepare archive proto for Numeric

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -193,11 +193,11 @@ instance Pretty BuiltinExpr where
     BEGreater t   -> maybeParens (prec > precEApp) ("GREATER"    <-> prettyBTyArg t)
     BEGreaterEq t -> maybeParens (prec > precEApp) ("GREATER_EQ" <-> prettyBTyArg t)
     BEToText t    -> maybeParens (prec > precEApp) ("TO_TEXT"    <-> prettyBTyArg t)
-    BEAddDecimal -> "ADD_DECIMAL"
-    BESubDecimal -> "SUB_DECIMAL"
-    BEMulDecimal -> "MUL_DECIMAL"
-    BEDivDecimal -> "DIV_DECIMAL"
-    BERoundDecimal -> "ROUND_DECIMAL"
+    BEAddDecimal -> "ADD_NUMERIC"
+    BESubDecimal -> "SUB_NUMERIC"
+    BEMulDecimal -> "MUL_NUMERIC"
+    BEDivDecimal -> "DIV_NUMERIC"
+    BERoundDecimal -> "ROUND_NUMERIC"
     BEAddInt64 -> "ADD_INT64"
     BESubInt64 -> "SUB_INT64"
     BEMulInt64 -> "MUL_INT64"
@@ -216,8 +216,8 @@ instance Pretty BuiltinExpr where
     BEAppendText -> "APPEND_TEXT"
     BETimestamp ts -> pretty (timestampToText ts)
     BEDate date -> pretty (dateToText date)
-    BEInt64ToDecimal -> "INT64_TO_DECIMAL"
-    BEDecimalToInt64 -> "DECIMAL_TO_INT64"
+    BEInt64ToDecimal -> "INT64_TO_NUMERIC"
+    BEDecimalToInt64 -> "NUMERIC_TO_INT64"
     BETimestampToUnixMicroseconds -> "TIMESTAMP_TO_UNIX_MICROSECONDS"
     BEUnixMicrosecondsToTimestamp -> "UNIX_MICROSECONDS_TO_TIMESTAMP"
     BEDateToUnixDays -> "DATE_TO_UNIX_DAYS"
@@ -229,7 +229,7 @@ instance Pretty BuiltinExpr where
     BEEqualContractId -> "EQUAL_CONTRACT_ID"
     BEPartyFromText -> "FROM_TEXT_PARTY"
     BEInt64FromText -> "FROM_TEXT_INT64"
-    BEDecimalFromText -> "FROM_TEXT_DECIMAL"
+    BEDecimalFromText -> "FROM_TEXT_NUMERIC"
     BEPartyToQuotedText -> "PARTY_TO_QUOTED_TEXT"
     BETextToCodePoints -> "TEXT_TO_CODE_POINTS"
     BETextFromCodePoints -> "TEXT_FROM_CODE_POINTS"

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -165,97 +165,103 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
-decodeBuiltinFunction = pure . \case
-  LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
-  LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
-  LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
-  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
-  LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
-  LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
-  LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
+decodeBuiltinFunction x = case x of
+  LF1.BuiltinFunctionEQUAL_INT64 -> pure $ BEEqual BTInt64
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> pure $ BEEqual BTDecimal
+  LF1.BuiltinFunctionEQUAL_TEXT -> pure $ BEEqual BTText
+  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> pure $ BEEqual BTTimestamp
+  LF1.BuiltinFunctionEQUAL_DATE -> pure $ BEEqual BTDate
+  LF1.BuiltinFunctionEQUAL_PARTY -> pure $ BEEqual BTParty
+  LF1.BuiltinFunctionEQUAL_BOOL -> pure $ BEEqual BTBool
 
-  LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
-  LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_TEXT    -> BELessEq BTText
-  LF1.BuiltinFunctionLEQ_TIMESTAMP    -> BELessEq BTTimestamp
-  LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
-  LF1.BuiltinFunctionLEQ_PARTY -> BELessEq BTParty
+  LF1.BuiltinFunctionLEQ_INT64 -> pure $ BELessEq BTInt64
+  LF1.BuiltinFunctionLEQ_NUMERIC -> pure $ BELessEq BTDecimal
+  LF1.BuiltinFunctionLEQ_TEXT    -> pure $ BELessEq BTText
+  LF1.BuiltinFunctionLEQ_TIMESTAMP    -> pure $ BELessEq BTTimestamp
+  LF1.BuiltinFunctionLEQ_DATE -> pure $ BELessEq BTDate
+  LF1.BuiltinFunctionLEQ_PARTY -> pure $ BELessEq BTParty
 
-  LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
-  LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
-  LF1.BuiltinFunctionLESS_TEXT    -> BELess BTText
-  LF1.BuiltinFunctionLESS_TIMESTAMP    -> BELess BTTimestamp
-  LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
-  LF1.BuiltinFunctionLESS_PARTY -> BELess BTParty
+  LF1.BuiltinFunctionLESS_INT64 -> pure $ BELess BTInt64
+  LF1.BuiltinFunctionLESS_NUMERIC -> pure $ BELess BTDecimal
+  LF1.BuiltinFunctionLESS_TEXT    -> pure $ BELess BTText
+  LF1.BuiltinFunctionLESS_TIMESTAMP    -> pure $ BELess BTTimestamp
+  LF1.BuiltinFunctionLESS_DATE -> pure $ BELess BTDate
+  LF1.BuiltinFunctionLESS_PARTY -> pure $ BELess BTParty
 
-  LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
-  LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_TEXT    -> BEGreaterEq BTText
-  LF1.BuiltinFunctionGEQ_TIMESTAMP    -> BEGreaterEq BTTimestamp
-  LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
-  LF1.BuiltinFunctionGEQ_PARTY -> BEGreaterEq BTParty
+  LF1.BuiltinFunctionGEQ_INT64 -> pure $ BEGreaterEq BTInt64
+  LF1.BuiltinFunctionGEQ_NUMERIC -> pure $ BEGreaterEq BTDecimal
+  LF1.BuiltinFunctionGEQ_TEXT    -> pure $ BEGreaterEq BTText
+  LF1.BuiltinFunctionGEQ_TIMESTAMP    -> pure $ BEGreaterEq BTTimestamp
+  LF1.BuiltinFunctionGEQ_DATE -> pure $ BEGreaterEq BTDate
+  LF1.BuiltinFunctionGEQ_PARTY -> pure $ BEGreaterEq BTParty
 
-  LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
-  LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_TEXT    -> BEGreater BTText
-  LF1.BuiltinFunctionGREATER_TIMESTAMP    -> BEGreater BTTimestamp
-  LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
-  LF1.BuiltinFunctionGREATER_PARTY -> BEGreater BTParty
+  LF1.BuiltinFunctionGREATER_INT64 -> pure $ BEGreater BTInt64
+  LF1.BuiltinFunctionGREATER_NUMERIC -> pure $ BEGreater BTDecimal
+  LF1.BuiltinFunctionGREATER_TEXT    -> pure $ BEGreater BTText
+  LF1.BuiltinFunctionGREATER_TIMESTAMP    -> pure $ BEGreater BTTimestamp
+  LF1.BuiltinFunctionGREATER_DATE -> pure $ BEGreater BTDate
+  LF1.BuiltinFunctionGREATER_PARTY -> pure $ BEGreater BTParty
 
-  LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
-  LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_TEXT    -> BEToText BTText
-  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> BEToText BTTimestamp
-  LF1.BuiltinFunctionTO_TEXT_PARTY   -> BEToText BTParty
-  LF1.BuiltinFunctionTO_TEXT_DATE -> BEToText BTDate
-  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
-  LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
-  LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
-  LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
-  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
-  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
+  LF1.BuiltinFunctionTO_TEXT_INT64 -> pure $ BEToText BTInt64
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> pure $ BEToText BTDecimal
+  LF1.BuiltinFunctionTO_TEXT_TEXT    -> pure $ BEToText BTText
+  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> pure $ BEToText BTTimestamp
+  LF1.BuiltinFunctionTO_TEXT_PARTY   -> pure $ BEToText BTParty
+  LF1.BuiltinFunctionTO_TEXT_DATE -> pure $ BEToText BTDate
+  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> pure BETextFromCodePoints
+  LF1.BuiltinFunctionFROM_TEXT_PARTY -> pure BEPartyFromText
+  LF1.BuiltinFunctionFROM_TEXT_INT64 -> pure BEInt64FromText
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> pure BEDecimalFromText
+  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> pure BETextToCodePoints
+  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> pure BEPartyToQuotedText
 
-  LF1.BuiltinFunctionADD_DECIMAL   -> BEAddDecimal
-  LF1.BuiltinFunctionSUB_DECIMAL   -> BESubDecimal
-  LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
-  LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
-  LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
+  LF1.BuiltinFunctionADD_NUMERIC   -> pure BEAddDecimal
+  LF1.BuiltinFunctionSUB_NUMERIC   -> pure BESubDecimal
+  LF1.BuiltinFunctionMUL_NUMERIC   -> pure BEMulDecimal
+  LF1.BuiltinFunctionDIV_NUMERIC   -> pure BEDivDecimal
+  LF1.BuiltinFunctionROUND_NUMERIC -> pure BERoundDecimal
+  LF1.BuiltinFunctionCAST_NUMERIC  ->
+    -- FixMe https://github.com/digital-asset/daml/issues/2289
+    throwError $ ParseError "builtin CAST_NUMERIC not supported"
+  LF1.BuiltinFunctionSHIFT_NUMERIC ->
+    -- FixMe https://github.com/digital-asset/daml/issues/2289
+    throwError $ ParseError "builtin SHIFT_NUMERIC not supported"
 
-  LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
-  LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
-  LF1.BuiltinFunctionMUL_INT64 -> BEMulInt64
-  LF1.BuiltinFunctionDIV_INT64 -> BEDivInt64
-  LF1.BuiltinFunctionMOD_INT64 -> BEModInt64
-  LF1.BuiltinFunctionEXP_INT64 -> BEExpInt64
+  LF1.BuiltinFunctionADD_INT64 -> pure BEAddInt64
+  LF1.BuiltinFunctionSUB_INT64 -> pure BESubInt64
+  LF1.BuiltinFunctionMUL_INT64 -> pure BEMulInt64
+  LF1.BuiltinFunctionDIV_INT64 -> pure BEDivInt64
+  LF1.BuiltinFunctionMOD_INT64 -> pure BEModInt64
+  LF1.BuiltinFunctionEXP_INT64 -> pure BEExpInt64
 
-  LF1.BuiltinFunctionFOLDL          -> BEFoldl
-  LF1.BuiltinFunctionFOLDR          -> BEFoldr
-  LF1.BuiltinFunctionEQUAL_LIST     -> BEEqualList
-  LF1.BuiltinFunctionAPPEND_TEXT    -> BEAppendText
-  LF1.BuiltinFunctionERROR          -> BEError
+  LF1.BuiltinFunctionFOLDL          -> pure BEFoldl
+  LF1.BuiltinFunctionFOLDR          -> pure BEFoldr
+  LF1.BuiltinFunctionEQUAL_LIST     -> pure BEEqualList
+  LF1.BuiltinFunctionAPPEND_TEXT    -> pure BEAppendText
+  LF1.BuiltinFunctionERROR          -> pure BEError
 
-  LF1.BuiltinFunctionMAP_EMPTY      -> BEMapEmpty
-  LF1.BuiltinFunctionMAP_INSERT     -> BEMapInsert
-  LF1.BuiltinFunctionMAP_LOOKUP     -> BEMapLookup
-  LF1.BuiltinFunctionMAP_DELETE     -> BEMapDelete
-  LF1.BuiltinFunctionMAP_TO_LIST    -> BEMapToList
-  LF1.BuiltinFunctionMAP_SIZE       -> BEMapSize
+  LF1.BuiltinFunctionMAP_EMPTY      -> pure BEMapEmpty
+  LF1.BuiltinFunctionMAP_INSERT     -> pure BEMapInsert
+  LF1.BuiltinFunctionMAP_LOOKUP     -> pure BEMapLookup
+  LF1.BuiltinFunctionMAP_DELETE     -> pure BEMapDelete
+  LF1.BuiltinFunctionMAP_TO_LIST    -> pure BEMapToList
+  LF1.BuiltinFunctionMAP_SIZE       -> pure BEMapSize
 
-  LF1.BuiltinFunctionEXPLODE_TEXT -> BEExplodeText
-  LF1.BuiltinFunctionIMPLODE_TEXT -> BEImplodeText
-  LF1.BuiltinFunctionSHA256_TEXT  -> BESha256Text
+  LF1.BuiltinFunctionEXPLODE_TEXT -> pure BEExplodeText
+  LF1.BuiltinFunctionIMPLODE_TEXT -> pure BEImplodeText
+  LF1.BuiltinFunctionSHA256_TEXT  -> pure BESha256Text
 
-  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> BEDateToUnixDays
-  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> BEUnixDaysToDate
-  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> BETimestampToUnixMicroseconds
-  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> BEUnixMicrosecondsToTimestamp
+  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> pure BEDateToUnixDays
+  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> pure BEUnixDaysToDate
+  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> pure BETimestampToUnixMicroseconds
+  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> pure BEUnixMicrosecondsToTimestamp
 
-  LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
-  LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> pure BEInt64ToDecimal
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> pure BEDecimalToInt64
 
-  LF1.BuiltinFunctionTRACE -> BETrace
-  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
-  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> BECoerceContractId
+  LF1.BuiltinFunctionTRACE -> pure BETrace
+  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> pure BEEqualContractId
+  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> pure BECoerceContractId
 
 decodeLocation :: LF1.Location -> DecodeImpl SourceLoc
 decodeLocation (LF1.Location mbModRef mbRange) = do
@@ -477,7 +483,7 @@ decodeVarWithType LF1.VarWithType{..} =
 decodePrimLit :: MonadDecode m => LF1.PrimLit -> m BuiltinExpr
 decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumInt64 sInt -> pure $ BEInt64 sInt
-  LF1.PrimLitSumDecimal sDec -> case readMaybe (TL.unpack sDec) of
+  LF1.PrimLitSumNumeric sDec -> case readMaybe (TL.unpack sDec) of
     Nothing -> throwError $ ParseError ("bad fixed while decoding Decimal: '" <> TL.unpack sDec <> "'")
     Just dec -> return (BEDecimal dec)
   LF1.PrimLitSumTimestamp sTime -> pure $ BETimestamp sTime
@@ -491,11 +497,14 @@ decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumArrow (LF1.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
+  LF1.KindSumNat LF1.Unit ->
+    -- FixMe https://github.com/digital-asset/daml/issues/2289
+    throwError $ ParseError "nat kind not supported"
 
 decodePrim :: LF1.PrimType -> Decode BuiltinType
 decodePrim = pure . \case
   LF1.PrimTypeINT64 -> BTInt64
-  LF1.PrimTypeDECIMAL -> BTDecimal
+  LF1.PrimTypeNUMERIC -> BTDecimal
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
@@ -529,6 +538,9 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
     decodeImpl $ foldr TForall body <$> traverse decodeTypeVarWithKind (V.toList binders)
   LF1.TypeSumTuple (LF1.Type_Tuple flds) ->
     TTuple <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
+  LF1.TypeSumNat _ ->
+    -- FixMe https://github.com/digital-asset/daml/issues/2289
+    throwError $ ParseError "nat type not supported"
   where
     decodeWithArgs :: V.Vector LF1.Type -> DecodeImpl Type -> DecodeImpl Type
     decodeWithArgs args fun = foldl TApp <$> fun <*> traverse decodeType args

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -165,103 +165,97 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
-decodeBuiltinFunction x = case x of
-  LF1.BuiltinFunctionEQUAL_INT64 -> pure $ BEEqual BTInt64
-  LF1.BuiltinFunctionEQUAL_NUMERIC -> pure $ BEEqual BTDecimal
-  LF1.BuiltinFunctionEQUAL_TEXT -> pure $ BEEqual BTText
-  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> pure $ BEEqual BTTimestamp
-  LF1.BuiltinFunctionEQUAL_DATE -> pure $ BEEqual BTDate
-  LF1.BuiltinFunctionEQUAL_PARTY -> pure $ BEEqual BTParty
-  LF1.BuiltinFunctionEQUAL_BOOL -> pure $ BEEqual BTBool
+decodeBuiltinFunction = pure . \case
+  LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqual BTDecimal
+  LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
+  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
+  LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
+  LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
+  LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
 
-  LF1.BuiltinFunctionLEQ_INT64 -> pure $ BELessEq BTInt64
-  LF1.BuiltinFunctionLEQ_NUMERIC -> pure $ BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_TEXT    -> pure $ BELessEq BTText
-  LF1.BuiltinFunctionLEQ_TIMESTAMP    -> pure $ BELessEq BTTimestamp
-  LF1.BuiltinFunctionLEQ_DATE -> pure $ BELessEq BTDate
-  LF1.BuiltinFunctionLEQ_PARTY -> pure $ BELessEq BTParty
+  LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
+  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEq BTDecimal
+  LF1.BuiltinFunctionLEQ_TEXT    -> BELessEq BTText
+  LF1.BuiltinFunctionLEQ_TIMESTAMP    -> BELessEq BTTimestamp
+  LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
+  LF1.BuiltinFunctionLEQ_PARTY -> BELessEq BTParty
 
-  LF1.BuiltinFunctionLESS_INT64 -> pure $ BELess BTInt64
-  LF1.BuiltinFunctionLESS_NUMERIC -> pure $ BELess BTDecimal
-  LF1.BuiltinFunctionLESS_TEXT    -> pure $ BELess BTText
-  LF1.BuiltinFunctionLESS_TIMESTAMP    -> pure $ BELess BTTimestamp
-  LF1.BuiltinFunctionLESS_DATE -> pure $ BELess BTDate
-  LF1.BuiltinFunctionLESS_PARTY -> pure $ BELess BTParty
+  LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
+  LF1.BuiltinFunctionLESS_NUMERIC -> BELess BTDecimal
+  LF1.BuiltinFunctionLESS_TEXT    -> BELess BTText
+  LF1.BuiltinFunctionLESS_TIMESTAMP    -> BELess BTTimestamp
+  LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
+  LF1.BuiltinFunctionLESS_PARTY -> BELess BTParty
 
-  LF1.BuiltinFunctionGEQ_INT64 -> pure $ BEGreaterEq BTInt64
-  LF1.BuiltinFunctionGEQ_NUMERIC -> pure $ BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_TEXT    -> pure $ BEGreaterEq BTText
-  LF1.BuiltinFunctionGEQ_TIMESTAMP    -> pure $ BEGreaterEq BTTimestamp
-  LF1.BuiltinFunctionGEQ_DATE -> pure $ BEGreaterEq BTDate
-  LF1.BuiltinFunctionGEQ_PARTY -> pure $ BEGreaterEq BTParty
+  LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
+  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEq BTDecimal
+  LF1.BuiltinFunctionGEQ_TEXT    -> BEGreaterEq BTText
+  LF1.BuiltinFunctionGEQ_TIMESTAMP    -> BEGreaterEq BTTimestamp
+  LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
+  LF1.BuiltinFunctionGEQ_PARTY -> BEGreaterEq BTParty
 
-  LF1.BuiltinFunctionGREATER_INT64 -> pure $ BEGreater BTInt64
-  LF1.BuiltinFunctionGREATER_NUMERIC -> pure $ BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_TEXT    -> pure $ BEGreater BTText
-  LF1.BuiltinFunctionGREATER_TIMESTAMP    -> pure $ BEGreater BTTimestamp
-  LF1.BuiltinFunctionGREATER_DATE -> pure $ BEGreater BTDate
-  LF1.BuiltinFunctionGREATER_PARTY -> pure $ BEGreater BTParty
+  LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
+  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreater BTDecimal
+  LF1.BuiltinFunctionGREATER_TEXT    -> BEGreater BTText
+  LF1.BuiltinFunctionGREATER_TIMESTAMP    -> BEGreater BTTimestamp
+  LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
+  LF1.BuiltinFunctionGREATER_PARTY -> BEGreater BTParty
 
-  LF1.BuiltinFunctionTO_TEXT_INT64 -> pure $ BEToText BTInt64
-  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> pure $ BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_TEXT    -> pure $ BEToText BTText
-  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> pure $ BEToText BTTimestamp
-  LF1.BuiltinFunctionTO_TEXT_PARTY   -> pure $ BEToText BTParty
-  LF1.BuiltinFunctionTO_TEXT_DATE -> pure $ BEToText BTDate
-  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> pure BETextFromCodePoints
-  LF1.BuiltinFunctionFROM_TEXT_PARTY -> pure BEPartyFromText
-  LF1.BuiltinFunctionFROM_TEXT_INT64 -> pure BEInt64FromText
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> pure BEDecimalFromText
-  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> pure BETextToCodePoints
-  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> pure BEPartyToQuotedText
+  LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToText BTDecimal
+  LF1.BuiltinFunctionTO_TEXT_TEXT    -> BEToText BTText
+  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> BEToText BTTimestamp
+  LF1.BuiltinFunctionTO_TEXT_PARTY   -> BEToText BTParty
+  LF1.BuiltinFunctionTO_TEXT_DATE -> BEToText BTDate
+  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
+  LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
+  LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BEDecimalFromText
+  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
+  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
 
-  LF1.BuiltinFunctionADD_NUMERIC   -> pure BEAddDecimal
-  LF1.BuiltinFunctionSUB_NUMERIC   -> pure BESubDecimal
-  LF1.BuiltinFunctionMUL_NUMERIC   -> pure BEMulDecimal
-  LF1.BuiltinFunctionDIV_NUMERIC   -> pure BEDivDecimal
-  LF1.BuiltinFunctionROUND_NUMERIC -> pure BERoundDecimal
-  LF1.BuiltinFunctionCAST_NUMERIC  ->
-    -- FixMe https://github.com/digital-asset/daml/issues/2289
-    throwError $ ParseError "builtin CAST_NUMERIC not supported"
-  LF1.BuiltinFunctionSHIFT_NUMERIC ->
-    -- FixMe https://github.com/digital-asset/daml/issues/2289
-    throwError $ ParseError "builtin SHIFT_NUMERIC not supported"
+  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddDecimal
+  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubDecimal
+  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulDecimal
+  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivDecimal
+  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundDecimal
 
-  LF1.BuiltinFunctionADD_INT64 -> pure BEAddInt64
-  LF1.BuiltinFunctionSUB_INT64 -> pure BESubInt64
-  LF1.BuiltinFunctionMUL_INT64 -> pure BEMulInt64
-  LF1.BuiltinFunctionDIV_INT64 -> pure BEDivInt64
-  LF1.BuiltinFunctionMOD_INT64 -> pure BEModInt64
-  LF1.BuiltinFunctionEXP_INT64 -> pure BEExpInt64
+  LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
+  LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
+  LF1.BuiltinFunctionMUL_INT64 -> BEMulInt64
+  LF1.BuiltinFunctionDIV_INT64 -> BEDivInt64
+  LF1.BuiltinFunctionMOD_INT64 -> BEModInt64
+  LF1.BuiltinFunctionEXP_INT64 -> BEExpInt64
 
-  LF1.BuiltinFunctionFOLDL          -> pure BEFoldl
-  LF1.BuiltinFunctionFOLDR          -> pure BEFoldr
-  LF1.BuiltinFunctionEQUAL_LIST     -> pure BEEqualList
-  LF1.BuiltinFunctionAPPEND_TEXT    -> pure BEAppendText
-  LF1.BuiltinFunctionERROR          -> pure BEError
+  LF1.BuiltinFunctionFOLDL          -> BEFoldl
+  LF1.BuiltinFunctionFOLDR          -> BEFoldr
+  LF1.BuiltinFunctionEQUAL_LIST     -> BEEqualList
+  LF1.BuiltinFunctionAPPEND_TEXT    -> BEAppendText
+  LF1.BuiltinFunctionERROR          -> BEError
 
-  LF1.BuiltinFunctionMAP_EMPTY      -> pure BEMapEmpty
-  LF1.BuiltinFunctionMAP_INSERT     -> pure BEMapInsert
-  LF1.BuiltinFunctionMAP_LOOKUP     -> pure BEMapLookup
-  LF1.BuiltinFunctionMAP_DELETE     -> pure BEMapDelete
-  LF1.BuiltinFunctionMAP_TO_LIST    -> pure BEMapToList
-  LF1.BuiltinFunctionMAP_SIZE       -> pure BEMapSize
+  LF1.BuiltinFunctionMAP_EMPTY      -> BEMapEmpty
+  LF1.BuiltinFunctionMAP_INSERT     -> BEMapInsert
+  LF1.BuiltinFunctionMAP_LOOKUP     -> BEMapLookup
+  LF1.BuiltinFunctionMAP_DELETE     -> BEMapDelete
+  LF1.BuiltinFunctionMAP_TO_LIST    -> BEMapToList
+  LF1.BuiltinFunctionMAP_SIZE       -> BEMapSize
 
-  LF1.BuiltinFunctionEXPLODE_TEXT -> pure BEExplodeText
-  LF1.BuiltinFunctionIMPLODE_TEXT -> pure BEImplodeText
-  LF1.BuiltinFunctionSHA256_TEXT  -> pure BESha256Text
+  LF1.BuiltinFunctionEXPLODE_TEXT -> BEExplodeText
+  LF1.BuiltinFunctionIMPLODE_TEXT -> BEImplodeText
+  LF1.BuiltinFunctionSHA256_TEXT  -> BESha256Text
 
-  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> pure BEDateToUnixDays
-  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> pure BEUnixDaysToDate
-  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> pure BETimestampToUnixMicroseconds
-  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> pure BEUnixMicrosecondsToTimestamp
+  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> BEDateToUnixDays
+  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> BEUnixDaysToDate
+  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> BETimestampToUnixMicroseconds
+  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> BEUnixMicrosecondsToTimestamp
 
-  LF1.BuiltinFunctionINT64_TO_NUMERIC -> pure BEInt64ToDecimal
-  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> pure BEDecimalToInt64
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToDecimal
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BEDecimalToInt64
 
-  LF1.BuiltinFunctionTRACE -> pure BETrace
-  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> pure BEEqualContractId
-  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> pure BECoerceContractId
+  LF1.BuiltinFunctionTRACE -> BETrace
+  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
+  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> BECoerceContractId
 
 decodeLocation :: LF1.Location -> DecodeImpl SourceLoc
 decodeLocation (LF1.Location mbModRef mbRange) = do

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -137,7 +137,7 @@ encodeKind version = P.Kind . Just . \case
 encodeBuiltinType :: Version -> BuiltinType -> P.Enumerated P.PrimType
 encodeBuiltinType _version = P.Enumerated . Right . \case
     BTInt64 -> P.PrimTypeINT64
-    BTDecimal -> P.PrimTypeDECIMAL
+    BTDecimal -> P.PrimTypeNUMERIC
     BTText -> P.PrimTypeTEXT
     BTTimestamp -> P.PrimTypeTIMESTAMP
     BTParty -> P.PrimTypePARTY
@@ -189,7 +189,7 @@ encodeTypeConApp encctx@EncodeCtx{..} (TypeConApp tycon args) = Just $ P.Type_Co
 encodeBuiltinExpr :: BuiltinExpr -> P.ExprSum
 encodeBuiltinExpr = \case
     BEInt64 x -> lit $ P.PrimLitSumInt64 x
-    BEDecimal dec -> lit $ P.PrimLitSumDecimal (TL.pack (show dec))
+    BEDecimal dec -> lit $ P.PrimLitSumNumeric (TL.pack (show dec))
     BEText x -> lit $ P.PrimLitSumText (TL.fromStrict x)
     BETimestamp x -> lit $ P.PrimLitSumTimestamp x
     BEParty x -> lit $ P.PrimLitSumParty $ TL.fromStrict $ unPartyLiteral x
@@ -202,7 +202,7 @@ encodeBuiltinExpr = \case
 
     BEEqual typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionEQUAL_INT64
-      BTDecimal -> builtin P.BuiltinFunctionEQUAL_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionEQUAL_NUMERIC
       BTText -> builtin P.BuiltinFunctionEQUAL_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionEQUAL_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionEQUAL_DATE
@@ -212,7 +212,7 @@ encodeBuiltinExpr = \case
 
     BELessEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLEQ_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionLEQ_NUMERIC
       BTText -> builtin P.BuiltinFunctionLEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLEQ_DATE
@@ -221,7 +221,7 @@ encodeBuiltinExpr = \case
 
     BELess typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLESS_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLESS_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionLESS_NUMERIC
       BTText -> builtin P.BuiltinFunctionLESS_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLESS_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLESS_DATE
@@ -230,7 +230,7 @@ encodeBuiltinExpr = \case
 
     BEGreaterEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGEQ_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionGEQ_NUMERIC
       BTText -> builtin P.BuiltinFunctionGEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGEQ_DATE
@@ -239,7 +239,7 @@ encodeBuiltinExpr = \case
 
     BEGreater typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGREATER_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGREATER_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionGREATER_NUMERIC
       BTText -> builtin P.BuiltinFunctionGREATER_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGREATER_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGREATER_DATE
@@ -248,7 +248,7 @@ encodeBuiltinExpr = \case
 
     BEToText typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionTO_TEXT_INT64
-      BTDecimal -> builtin P.BuiltinFunctionTO_TEXT_DECIMAL
+      BTDecimal -> builtin P.BuiltinFunctionTO_TEXT_NUMERIC
       BTText -> builtin P.BuiltinFunctionTO_TEXT_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionTO_TEXT_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionTO_TEXT_DATE
@@ -257,15 +257,15 @@ encodeBuiltinExpr = \case
     BETextFromCodePoints -> builtin P.BuiltinFunctionTEXT_FROM_CODE_POINTS
     BEPartyFromText -> builtin P.BuiltinFunctionFROM_TEXT_PARTY
     BEInt64FromText -> builtin P.BuiltinFunctionFROM_TEXT_INT64
-    BEDecimalFromText-> builtin P.BuiltinFunctionFROM_TEXT_DECIMAL
+    BEDecimalFromText-> builtin P.BuiltinFunctionFROM_TEXT_NUMERIC
     BETextToCodePoints -> builtin P.BuiltinFunctionTEXT_TO_CODE_POINTS
     BEPartyToQuotedText -> builtin P.BuiltinFunctionTO_QUOTED_TEXT_PARTY
 
-    BEAddDecimal -> builtin P.BuiltinFunctionADD_DECIMAL
-    BESubDecimal -> builtin P.BuiltinFunctionSUB_DECIMAL
-    BEMulDecimal -> builtin P.BuiltinFunctionMUL_DECIMAL
-    BEDivDecimal -> builtin P.BuiltinFunctionDIV_DECIMAL
-    BERoundDecimal -> builtin P.BuiltinFunctionROUND_DECIMAL
+    BEAddDecimal -> builtin P.BuiltinFunctionADD_NUMERIC
+    BESubDecimal -> builtin P.BuiltinFunctionSUB_NUMERIC
+    BEMulDecimal -> builtin P.BuiltinFunctionMUL_NUMERIC
+    BEDivDecimal -> builtin P.BuiltinFunctionDIV_NUMERIC
+    BERoundDecimal -> builtin P.BuiltinFunctionROUND_NUMERIC
 
     BEAddInt64 -> builtin P.BuiltinFunctionADD_INT64
     BESubInt64 -> builtin P.BuiltinFunctionSUB_INT64
@@ -274,8 +274,8 @@ encodeBuiltinExpr = \case
     BEModInt64 -> builtin P.BuiltinFunctionMOD_INT64
     BEExpInt64 -> builtin P.BuiltinFunctionEXP_INT64
 
-    BEInt64ToDecimal -> builtin P.BuiltinFunctionINT64_TO_DECIMAL
-    BEDecimalToInt64 -> builtin P.BuiltinFunctionDECIMAL_TO_INT64
+    BEInt64ToDecimal -> builtin P.BuiltinFunctionINT64_TO_NUMERIC
+    BEDecimalToInt64 -> builtin P.BuiltinFunctionNUMERIC_TO_INT64
 
     BEFoldl -> builtin P.BuiltinFunctionFOLDL
     BEFoldr -> builtin P.BuiltinFunctionFOLDR

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -186,6 +186,7 @@ enum PrimType {
   INT64 = 2;
 
   // Builtin type 'Numeric'
+  // was named `DECIMAL` in version 1.6 or earlier
   NUMERIC = 3;
 
   // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
@@ -298,12 +299,12 @@ message Type {
     Forall forall = 5;
     Tuple tuple = 7;
     // *Available since version 1.dev*
-    // *Must be positive*
-    // use signed integer for future use.
+    // *Must be between 0 and 38 (bounds inclusive)*
+    // use standard signed long for future usage.
     sint64 nat = 11;
   }
 
-  reserved 6; // This was list.  Removed in favour of PrimType.LIST
+  reserved 6; // This was list. Removed in favour of PrimType.LIST
   reserved 8; // This was contract_id. Removed in favour of PrimType.CONTRACT_ID
   reserved 9; // This was update. Removed in favour of PrimType.UPDATE
   reserved 10; // This was scenario. Removed in favor of PrimType.SCENARIO
@@ -326,11 +327,11 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_NUMERIC = 0;
-  SUB_NUMERIC = 1;
-  MUL_NUMERIC = 2;
-  DIV_NUMERIC = 3;
-  ROUND_NUMERIC = 6;
+  ADD_NUMERIC = 0;    // Called `ADD_DECIMAL` in version 1.6 or earlier
+  SUB_NUMERIC = 1;    // Called `SUB_DECIMAL` in version 1.6 or earlier
+  MUL_NUMERIC = 2;    // Called `MUL_DECIMAL` in version 1.6 or earlier
+  DIV_NUMERIC = 3;    // Called `DIV_DECIMAL` in version 1.6 or earlier
+  ROUND_NUMERIC = 6;  // Called `DIV_DECIMAL` in version 1.6 or earlier
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -355,35 +356,35 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_NUMERIC = 34;
+  LEQ_NUMERIC = 34;  // Called `LEQ_DECIMAL` in version 1.6 or earlier
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
   LEQ_DATE = 67;
   LEQ_PARTY = 89; // *Available Since version 1.1*
 
   LESS_INT64 = 39;
-  LESS_NUMERIC = 40;
+  LESS_NUMERIC = 40;  // Called `LESS_DECIMAL` in version 1.6 or earlier
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
   LESS_DATE = 68;
   LESS_PARTY = 90; // *Available Since version 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_NUMERIC = 46;
+  GEQ_NUMERIC = 46;  // Called `GEQ_DECIMAL` in version 1.6 or earlier
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
   GEQ_DATE = 69;
   GEQ_PARTY = 91; // *Available Since version 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_NUMERIC = 52;
+  GREATER_NUMERIC = 52;  // Called `GREATED_DECIMAL` in version 1.6 or earlier
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
   GREATER_DATE = 70;
   GREATER_PARTY = 92; // *Available Since version 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_NUMERIC = 58;
+  TO_TEXT_NUMERIC = 58;  // Called `GREATED_DECIMAL` in version 1.6 or earlier
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
   TO_TEXT_DATE = 71;
@@ -391,7 +392,7 @@ enum BuiltinFunction {
   TO_TEXT_PARTY = 94; // *Available Since version 1.2*
   FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
   FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
-  FROM_TEXT_NUMERIC = 104; // *Available Since version 1.5*
+  FROM_TEXT_NUMERIC = 104; // *Available Since version 1.5*, was named `GREATER_DECIMAL` in version 1.5 and 1.6
   SHA256_TEXT = 93; // *Available Since version 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
@@ -400,13 +401,13 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_NUMERIC = 76;
-  NUMERIC_TO_INT64 = 77;
+  INT64_TO_NUMERIC = 76;  // was named `INT64_TO_NUMERIC` in version 1.6 or earlier
+  NUMERIC_TO_INT64 = 77;  // was named `NUMERIC_TO_INT64` in version 1.6 or earlier
 
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_NUMERIC = 80;
+  EQUAL_NUMERIC = 80;  // was named `EQUAL_NUMERIC` in version 1.6 or earlier
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
   EQUAL_DATE = 83;

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -331,8 +331,6 @@ enum BuiltinFunction {
   MUL_NUMERIC = 2;
   DIV_NUMERIC = 3;
   ROUND_NUMERIC = 6;
-  CAST_NUMERIC = 107; // *Available Since version 1.dev*
-  SHIFT_NUMERIC = 108; // *Available Since version 1.dev*
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -423,7 +421,7 @@ enum BuiltinFunction {
 
   TEXT_FROM_CODE_POINTS = 105;  // *Available since version 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available since version 1.6*
-  // Next id is 109. 108 is SHIFT_NUMERIC.
+  // Next id is 107. 106 is TEXT_TO_CODE_POINTS.
 }
 
 // Builtin literals

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -166,8 +166,11 @@ message Kind {
   oneof Sum {
     // Kind of monomorphic type.
     Unit star = 1;
-    // King of polymorphic type.
+    // Kind of polymorphic type.
     Arrow arrow = 2;
+    // kind of TNat type;
+    // *Available since version 1.dev*
+    Unit nat = 3;
   }
 }
 
@@ -182,8 +185,8 @@ enum PrimType {
   // Builtin type 'Int64'
   INT64 = 2;
 
-  // Builtin type 'Int64'
-  DECIMAL = 3;
+  // Builtin type 'Numeric'
+  NUMERIC = 3;
 
   // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
 
@@ -204,7 +207,7 @@ enum PrimType {
   // Builtin type 'Update'
   UPDATE = 10;
 
-  // Builtin type 'Scenatrio'
+  // Builtin type 'Scenario'
   SCENARIO = 11;
 
   // Builtin type 'Date'
@@ -294,6 +297,10 @@ message Type {
     Fun fun = 4;
     Forall forall = 5;
     Tuple tuple = 7;
+    // *Available since version 1.dev*
+    // *Must be positive*
+    // use signed integer for future use.
+    sint64 nat = 11;
   }
 
   reserved 6; // This was list.  Removed in favour of PrimType.LIST
@@ -319,11 +326,13 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_DECIMAL = 0;
-  SUB_DECIMAL = 1;
-  MUL_DECIMAL = 2;
-  DIV_DECIMAL = 3;
-  ROUND_DECIMAL = 6;
+  ADD_NUMERIC = 0;
+  SUB_NUMERIC = 1;
+  MUL_NUMERIC = 2;
+  DIV_NUMERIC = 3;
+  ROUND_NUMERIC = 6;
+  CAST_NUMERIC = 107; // *Available Since version 1.dev*
+  SHIFT_NUMERIC = 108; // *Available Since version 1.dev*
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -348,35 +357,35 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_DECIMAL = 34;
+  LEQ_NUMERIC = 34;
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
   LEQ_DATE = 67;
   LEQ_PARTY = 89; // *Available Since version 1.1*
 
   LESS_INT64 = 39;
-  LESS_DECIMAL = 40;
+  LESS_NUMERIC = 40;
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
   LESS_DATE = 68;
   LESS_PARTY = 90; // *Available Since version 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_DECIMAL = 46;
+  GEQ_NUMERIC = 46;
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
   GEQ_DATE = 69;
   GEQ_PARTY = 91; // *Available Since version 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_DECIMAL = 52;
+  GREATER_NUMERIC = 52;
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
   GREATER_DATE = 70;
   GREATER_PARTY = 92; // *Available Since version 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_DECIMAL = 58;
+  TO_TEXT_NUMERIC = 58;
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
   TO_TEXT_DATE = 71;
@@ -384,7 +393,7 @@ enum BuiltinFunction {
   TO_TEXT_PARTY = 94; // *Available Since version 1.2*
   FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
   FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
-  FROM_TEXT_DECIMAL = 104; // *Available Since version 1.5*
+  FROM_TEXT_NUMERIC = 104; // *Available Since version 1.5*
   SHA256_TEXT = 93; // *Available Since version 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
@@ -393,13 +402,13 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_DECIMAL = 76;
-  DECIMAL_TO_INT64 = 77;
+  INT64_TO_NUMERIC = 76;
+  NUMERIC_TO_INT64 = 77;
 
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_DECIMAL = 80;
+  EQUAL_NUMERIC = 80;
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
   EQUAL_DATE = 83;
@@ -412,9 +421,9 @@ enum BuiltinFunction {
 
   COERCE_CONTRACT_ID = 102;
 
-  TEXT_FROM_CODE_POINTS = 105;  // : List Int64 -> Text   *Available since version 1.6*
-  TEXT_TO_CODE_POINTS = 106; //: Text -> List Int64    *Available since version 1.6*
-  // Next id is 107. 106 is TEXT_TO_CODE_POINTS.
+  TEXT_FROM_CODE_POINTS = 105;  // *Available since version 1.6*
+  TEXT_TO_CODE_POINTS = 106; // *Available since version 1.6*
+  // Next id is 109. 108 is SHIFT_NUMERIC.
 }
 
 // Builtin literals
@@ -436,7 +445,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string decimal = 2;
+    string numeric = 2;
 
     // Unicode string literal ('LitText')
     string text = 4;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -244,6 +244,9 @@ private[archive] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPa
           val params = kArrow.getParamsList.asScala
           assertNonEmpty(params, "params")
           (params :\ decodeKind(kArrow.getResult))((param, kind) => KArrow(decodeKind(param), kind))
+        case PLF.Kind.SumCase.NAT =>
+          // FixMe: https://github.com/digital-asset/daml/issues/2289
+          throw new Error("nat kind not supported")
         case PLF.Kind.SumCase.SUM_NOT_SET =>
           throw ParseError("Kind.SUM_NOT_SET")
       }
@@ -283,6 +286,9 @@ private[archive] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPa
           TTuple(
             ImmArray(fields.map(ft => name(ft.getField) -> decodeType(ft.getType)))
           )
+        case PLF.Type.SumCase.NAT =>
+          // FixMe: https://github.com/digital-asset/daml/issues/2289
+          throw new Error("nat type not supported")
 
         case PLF.Type.SumCase.SUM_NOT_SET =>
           throw ParseError("Type.SUM_NOT_SET")
@@ -664,9 +670,9 @@ private[archive] class DecodeV1(minor: LanguageMinorVersion) extends Decode.OfPa
       lfPrimLit.getSumCase match {
         case PLF.PrimLit.SumCase.INT64 =>
           PLInt64(lfPrimLit.getInt64)
-        case PLF.PrimLit.SumCase.DECIMAL =>
-          checkDecimal(lfPrimLit.getDecimal)
-          val d = Decimal.fromString(lfPrimLit.getDecimal)
+        case PLF.PrimLit.SumCase.NUMERIC =>
+          checkDecimal(lfPrimLit.getNumeric)
+          val d = Decimal.fromString(lfPrimLit.getNumeric)
           d.fold(e => throw ParseError("error parsing decimal: " + e), PLDecimal)
         case PLF.PrimLit.SumCase.TEXT =>
           PLText(lfPrimLit.getText)
@@ -716,7 +722,7 @@ private[lf] object DecodeV1 {
       BOOL -> (BTBool -> "0"),
       TEXT -> (BTText -> "0"),
       INT64 -> (BTInt64 -> "0"),
-      DECIMAL -> (BTDecimal -> "0"),
+      NUMERIC -> (BTDecimal -> "0"),
       TIMESTAMP -> (BTTimestamp -> "0"),
       PARTY -> (BTParty -> "0"),
       LIST -> (BTList -> "0"),
@@ -734,19 +740,19 @@ private[lf] object DecodeV1 {
     import PLF.BuiltinFunction._
 
     Map[PLF.BuiltinFunction, (Ast.BuiltinFunction, LanguageMinorVersion)](
-      ADD_DECIMAL -> (BAddDecimal -> "0"),
-      SUB_DECIMAL -> (BSubDecimal -> "0"),
-      MUL_DECIMAL -> (BMulDecimal -> "0"),
-      DIV_DECIMAL -> (BDivDecimal -> "0"),
-      ROUND_DECIMAL -> (BRoundDecimal -> "0"),
+      ADD_NUMERIC -> (BAddDecimal -> "0"),
+      SUB_NUMERIC -> (BSubDecimal -> "0"),
+      MUL_NUMERIC -> (BMulDecimal -> "0"),
+      DIV_NUMERIC -> (BDivDecimal -> "0"),
+      ROUND_NUMERIC -> (BRoundDecimal -> "0"),
       ADD_INT64 -> (BAddInt64 -> "0"),
       SUB_INT64 -> (BSubInt64 -> "0"),
       MUL_INT64 -> (BMulInt64 -> "0"),
       DIV_INT64 -> (BDivInt64 -> "0"),
       MOD_INT64 -> (BModInt64 -> "0"),
       EXP_INT64 -> (BExpInt64 -> "0"),
-      INT64_TO_DECIMAL -> (BInt64ToDecimal -> "0"),
-      DECIMAL_TO_INT64 -> (BDecimalToInt64 -> "0"),
+      INT64_TO_NUMERIC -> (BInt64ToDecimal -> "0"),
+      NUMERIC_TO_INT64 -> (BDecimalToInt64 -> "0"),
       FOLDL -> (BFoldl -> "0"),
       FOLDR -> (BFoldr -> "0"),
       MAP_EMPTY -> (BMapEmpty -> "3"),
@@ -758,27 +764,27 @@ private[lf] object DecodeV1 {
       APPEND_TEXT -> (BAppendText -> "0"),
       ERROR -> (BError -> "0"),
       LEQ_INT64 -> (BLessEqInt64 -> "0"),
-      LEQ_DECIMAL -> (BLessEqDecimal -> "0"),
+      LEQ_NUMERIC -> (BLessEqDecimal -> "0"),
       LEQ_TEXT -> (BLessEqText -> "0"),
       LEQ_TIMESTAMP -> (BLessEqTimestamp -> "0"),
       LEQ_PARTY -> (BLessEqParty -> "1"),
       GEQ_INT64 -> (BGreaterEqInt64 -> "0"),
-      GEQ_DECIMAL -> (BGreaterEqDecimal -> "0"),
+      GEQ_NUMERIC -> (BGreaterEqDecimal -> "0"),
       GEQ_TEXT -> (BGreaterEqText -> "0"),
       GEQ_TIMESTAMP -> (BGreaterEqTimestamp -> "0"),
       GEQ_PARTY -> (BGreaterEqParty -> "1"),
       LESS_INT64 -> (BLessInt64 -> "0"),
-      LESS_DECIMAL -> (BLessDecimal -> "0"),
+      LESS_NUMERIC -> (BLessDecimal -> "0"),
       LESS_TEXT -> (BLessText -> "0"),
       LESS_TIMESTAMP -> (BLessTimestamp -> "0"),
       LESS_PARTY -> (BLessParty -> "1"),
       GREATER_INT64 -> (BGreaterInt64 -> "0"),
-      GREATER_DECIMAL -> (BGreaterDecimal -> "0"),
+      GREATER_NUMERIC -> (BGreaterDecimal -> "0"),
       GREATER_TEXT -> (BGreaterText -> "0"),
       GREATER_TIMESTAMP -> (BGreaterTimestamp -> "0"),
       GREATER_PARTY -> (BGreaterParty -> "1"),
       TO_TEXT_INT64 -> (BToTextInt64 -> "0"),
-      TO_TEXT_DECIMAL -> (BToTextDecimal -> "0"),
+      TO_TEXT_NUMERIC -> (BToTextDecimal -> "0"),
       TO_TEXT_TIMESTAMP -> (BToTextTimestamp -> "0"),
       TO_TEXT_PARTY -> (BToTextParty -> "2"),
       TO_TEXT_TEXT -> (BToTextText -> "0"),
@@ -786,7 +792,7 @@ private[lf] object DecodeV1 {
       TEXT_FROM_CODE_POINTS -> (BToTextCodePoints -> "6"),
       FROM_TEXT_PARTY -> (BFromTextParty -> "2"),
       FROM_TEXT_INT64 -> (BFromTextInt64 -> "5"),
-      FROM_TEXT_DECIMAL -> (BFromTextDecimal -> "5"),
+      FROM_TEXT_NUMERIC -> (BFromTextDecimal -> "5"),
       TEXT_TO_CODE_POINTS -> (BFromTextCodePoints -> "6"),
       SHA256_TEXT -> (BSHA256Text -> "2"),
       DATE_TO_UNIX_DAYS -> (BDateToUnixDays -> "0"),
@@ -801,7 +807,7 @@ private[lf] object DecodeV1 {
       UNIX_MICROSECONDS_TO_TIMESTAMP -> (BUnixMicrosecondsToTimestamp -> "0"),
       GREATER_DATE -> (BGreaterDate -> "0"),
       EQUAL_INT64 -> (BEqualInt64 -> "0"),
-      EQUAL_DECIMAL -> (BEqualDecimal -> "0"),
+      EQUAL_NUMERIC -> (BEqualDecimal -> "0"),
       EQUAL_TEXT -> (BEqualText -> "0"),
       EQUAL_TIMESTAMP -> (BEqualTimestamp -> "0"),
       EQUAL_DATE -> (BEqualDate -> "0"),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -28,7 +28,9 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
   "The keys of builtinFunctionMap correspond to Protobuf DamlLf1.BuiltinFunction" in {
 
     (DecodeV1.builtinFunctionMap.keySet + DamlLf1.BuiltinFunction.UNRECOGNIZED) shouldBe
-      DamlLf1.BuiltinFunction.values().toSet
+      (DamlLf1.BuiltinFunction.values().toSet
+      // FixMe https://github.com/digital-asset/daml/issues/2289
+        - DamlLf1.BuiltinFunction.CAST_NUMERIC - DamlLf1.BuiltinFunction.SHIFT_NUMERIC)
 
   }
 

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -28,9 +28,7 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
   "The keys of builtinFunctionMap correspond to Protobuf DamlLf1.BuiltinFunction" in {
 
     (DecodeV1.builtinFunctionMap.keySet + DamlLf1.BuiltinFunction.UNRECOGNIZED) shouldBe
-      (DamlLf1.BuiltinFunction.values().toSet
-      // FixMe https://github.com/digital-asset/daml/issues/2289
-        - DamlLf1.BuiltinFunction.CAST_NUMERIC - DamlLf1.BuiltinFunction.SHIFT_NUMERIC)
+      DamlLf1.BuiltinFunction.values().toSet
 
   }
 

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -334,7 +334,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
       val builder = PLF.PrimLit.newBuilder()
       primLit match {
         case PLInt64(value) => builder.setInt64(value)
-        case PLDecimal(value) => builder.setDecimal(Decimal.toString(value))
+        case PLDecimal(value) => builder.setNumeric(Decimal.toString(value))
         case PLText(value) => builder.setText(value)
         case PLTimestamp(value) => builder.setTimestamp(value.micros)
         case PLParty(party) => builder.setParty(party)

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -286,6 +286,9 @@ object InterfaceReader {
       case TSC.STAR => name(a.getVar)
       case TSC.ARROW =>
         -\/(UnserializableDataType(s"non-star-kinded type variable: ${showKind(a.getKind)}"))
+      case TSC.NAT =>
+        // FixMe: https://github.com/digital-asset/daml/issues/2289
+        -\/(InvalidDataTypeDefinition("DamlLf1.Kind.SumCase.NAT"))
       case TSC.SUM_NOT_SET =>
         -\/(InvalidDataTypeDefinition("DamlLf1.Kind.SumCase.SUM_NOT_SET"))
     }
@@ -320,6 +323,9 @@ object InterfaceReader {
       case TSC.PRIM => primitiveType(a.getPrim, ctx)
       case sc @ (TSC.FUN | TSC.FORALL | TSC.TUPLE) =>
         -\/(unserializableDataType(a, s"Unserializable data type: DamlLf1.Type.SumCase.${sc.name}"))
+      case TSC.NAT =>
+        // FixMe: https://github.com/digital-asset/daml/issues/2289
+        -\/(invalidDataTypeDefinition(a, "DamlLf1.Type.SumCase.NAT"))
       case TSC.SUM_NOT_SET =>
         -\/(invalidDataTypeDefinition(a, "DamlLf1.Type.SumCase.SUM_NOT_SET"))
     }
@@ -375,7 +381,7 @@ object InterfaceReader {
       case PT.UNIT => \/-((0, PrimType.Unit))
       case PT.BOOL => \/-((0, PrimType.Bool))
       case PT.INT64 => \/-((0, PrimType.Int64))
-      case PT.DECIMAL => \/-((0, PrimType.Decimal))
+      case PT.NUMERIC => \/-((0, PrimType.Decimal))
       case PT.TEXT => \/-((0, PrimType.Text))
       case PT.DATE => \/-((0, PrimType.Date))
       case PT.TIMESTAMP => \/-((0, PrimType.Timestamp))

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -376,7 +376,7 @@ We can now define all the literals that a program can handle::
         LitInt64  ∈ (-?)\d+                         -- LitInt64:
 
   Numeric literals:
-      LitNumeric  ∈  ([+-]?)\d+.\d*                 -- LitNumeric
+      LitNumeric  ∈  ([+-]?)([1-9]\d+|0).\d*        -- LitNumeric
 
   Date literals:
          LitDate  ∈  \d{4}-\d{4}-\d{4}               -- LitDate
@@ -392,15 +392,16 @@ We can now define all the literals that a program can handle::
 
 The literals represent actual DAML-LF values:
 
-* A ``LitNatType`` represents a natural number between ``0`` and ``38`` inclusive.
+* A ``LitNatType`` represents a natural number between ``0`` and
+  ``38``, bounds inclusive.
 * A ``LitInt64`` represents a standard signed 64-bit integer (integer
   between ``−2⁶³`` to ``2⁶³−1``).
-* A ``LitNumeric`` represents a decimal number that can be represented
-  without loss of precision with at most 38 digits (ignoring possible
-  leading 0 and with a scale (the number of significant digits on the
-  right of the decimal point) between ``0`` and ``38`` (bounds
-  inclusive). In the following, we will use ``scale(LitNumeric)`` to
-  denote the scale of the decimal number.
+* A ``LitNumeric`` represents a signed number that can be represented
+  in base-10 without loss of precision with at most 38 digits
+  (ignoring possible leading 0 and with a scale (the number of
+  significant digits on the right of the decimal point) between ``0``
+  and ``38`` (bounds inclusive). In the following, we will use
+  ``scale(LitNumeric)`` to denote the scale of the decimal number.
 * A ``LitDate`` represents the number of day since
   ``1970-01-01`` with allowed range from ``0001-01-01`` to
   ``9999-12-31`` and using a year-month-day format.
@@ -533,7 +534,7 @@ Then we can define our kinds, types, and expressions::
   Types (mnemonic: tau for type)
     τ, σ
       ::= α                                         -- TyVar: Type variable
-       |  n                                         -- TNat: Type natural
+       |  n                                         -- TNat: Nat Type
        |  τ σ                                       -- TyApp: Type application
        |  ∀ α : k . τ                               -- TyForall: Universal quantification
        |  BuiltinType                               -- TyBuiltin: Builtin type
@@ -730,6 +731,9 @@ First, we formally defined *well-formed types*. ::
     ————————————————————————————————————————————— TyVar
       Γ  ⊢  α  :  k
 
+    ————————————————————————————————————————————— TyVar
+      Γ  ⊢  n  :  'nat'
+      
       Γ  ⊢  τ  :  k₁ → k₂      Γ  ⊢  σ  :  k₂
     ————————————————————————————————————————————— TyApp
       Γ  ⊢  τ σ  :  k₁
@@ -2864,9 +2868,10 @@ Starting from DAML-LF 1.dev those messages are deserialized to ``nat``
 kind and ``nat`` type respectively. The field ``nat`` of ``Type``
 message must be a positive integer.
 
-Note that despite, their is no concrete way to build Nat types in
-DAML-LF 1.6 (or earlier) program, those can be implicitly generated as
-described in the next section.
+Note that despite their is no concrete way to build Nat types in a
+DAML-LF 1.6 (or earlier) program, those are implicitly generated when
+reading as Numeric type and Numeric builtin as described in the next
+section.
 
 Parametric scaled Decimals
 ..........................
@@ -2875,15 +2880,15 @@ Parametric scaled Decimals
 
 DAML-LF 1.dev is the first version that supports parametric scaled
 decimals. Prior versions have decimal number with a fix scale of 10
-called `Decimal`. Backward compatibility with the current
-specification is achieved by
+called Decimal. Backward compatibility with the current specification
+is achieved by
 
 1. Renaming the fields and the emum values containing "``decimal``" in
    the Protocol buffer definition with "``numeric``" instead,
 2. Unconditionally fixing the scale of Numeric literals to ``10`` when
    reading DAML-LF 1.6 (or earlier),
-3. Automatically applying the ``Numeric`` types and the numeric
-   builtin functions to the ``nat`` type ``10`` when reading DAML-LF
+3. Automatically applying the Numeric types and the numeric
+   builtin functions to the Nat type ``10`` when reading DAML-LF
    1.6 (or earlier).
 
    


### PR DESCRIPTION
This PR is the first step toward adding user-defined scale Numeric (See #2289).

1.  We update DAML-LF version specification

2. Here we prepare archive proto for Numeric, that is:
    
  - we replace "DECIMAL" by "NUMERIC" in messages and fields
  -  we add `nat` kind and `nat` type

  See https://github.com/digital-asset/daml/pull/2298/files?file-filters%5B%5D=.proto

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
