### PR TITLE
Add a daml deploy integration test.

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -382,6 +382,7 @@ deployTest deployDir = testCase "daml deploy" $ do
                             callCommandQuiet $ unwords
                                 [ "daml deploy"
                                 , "--port", show port
+                                , "--host localhost"
                                 ]
                         -- waitForProcess' will block on Windows so we explicitly kill the process.
                         terminateProcess ph

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -74,11 +74,13 @@ tests damlDir tmpDir = testGroup "Integration tests"
     , packagingTests tmpDir
     , quickstartTests quickstartDir mvnDir
     , cleanTests cleanDir
+    , deployTest deployDir
     ]
     where quickstartDir = tmpDir </> "q-u-i-c-k-s-t-a-r-t"
           cleanDir = tmpDir </> "clean"
           mvnDir = tmpDir </> "m2"
           tarballDir = tmpDir </> "tarball"
+          deployDir = tmpDir </> "deploy"
 
 throwError :: MonadFail m => T.Text -> T.Text -> m ()
 throwError msg e = fail (T.unpack $ msg <> " " <> e)
@@ -356,6 +358,34 @@ cleanTests baseDir = testGroup "daml clean"
                                 , "    files at end:"
                                 , unlines (map ("       "++) filesAtEnd)
                                 ]
+
+deployTest :: FilePath -> TestTree
+deployTest deployDir = testCase "daml deploy" $ do
+    createDirectoryIfMissing True deployDir
+    withCurrentDirectory deployDir $ do
+        callCommandQuiet $ unwords ["daml new", deployDir </> "proj1"]
+        callCommandQuiet $ unwords ["daml new", deployDir </> "proj2"]
+        withCurrentDirectory (deployDir </> "proj1") $ do
+            callCommandQuiet "daml build"
+            withDevNull $ \devNull -> do
+                port :: Int <- fromIntegral <$> getFreePort
+                let sandboxProc =
+                        (shell $ unwords
+                            ["daml sandbox"
+                            , "--port", show port
+                            , ".daml/dist/proj1.dar"
+                            ]) { std_out = UseHandle devNull }
+                withCreateProcess sandboxProc  $ \_ _ _ ph ->
+                    race_ (waitForProcess' sandboxProc ph) $ do
+                        waitForConnectionOnPort (threadDelay 100000) port
+                        withCurrentDirectory (deployDir </> "proj2") $ do
+                            callCommandQuiet $ unwords
+                                [ "daml deploy"
+                                , "--port", show port
+                                ]
+                        -- waitForProcess' will block on Windows so we explicitly kill the process.
+                        terminateProcess ph
+
 
 damlInstallerName :: String
 damlInstallerName

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -364,7 +364,7 @@ deployTest deployDir = testCase "daml deploy" $ do
     createDirectoryIfMissing True deployDir
     withCurrentDirectory deployDir $ do
         callCommandQuiet $ unwords ["daml new", deployDir </> "proj1"]
-        callCommandQuiet $ unwords ["daml new", deployDir </> "proj2"]
+        callCommandQuiet $ unwords ["daml new", deployDir </> "proj2", "quickstart-java"]
         withCurrentDirectory (deployDir </> "proj1") $ do
             callCommandQuiet "daml build"
             withDevNull $ \devNull -> do


### PR DESCRIPTION
I added a small integration test for daml deploy, that:

- creates two projects `proj1` and `proj2`
- runs `daml sandbox` in `proj1`
- runs `daml deploy` in `proj2`, targeting the sandbox

And that's it. In the future it would be nice to add something more comprehensive that relies on successful deployment.