### PR TITLE
assert the reset service has worked as expected

### DIFF
--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -582,6 +582,9 @@ resetSandbox :: Sandbox-> IO ()
 resetSandbox sandbox = runWithSandbox sandbox $ do
     lid <- getLedgerIdentity
     Ledger.reset lid
+    lid2 <- getLedgerIdentity
+    unless (lid /= lid2) $ fail "resetSandbox: reset did not change the ledger-id"
+    return ()
 
 ----------------------------------------------------------------------
 -- misc expectation combinators

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -584,7 +584,6 @@ resetSandbox sandbox = runWithSandbox sandbox $ do
     Ledger.reset lid
     lid2 <- getLedgerIdentity
     unless (lid /= lid2) $ fail "resetSandbox: reset did not change the ledger-id"
-    return ()
 
 ----------------------------------------------------------------------
 -- misc expectation combinators


### PR DESCRIPTION
Add an assertion to determine if the reset service is buggy

The issue being investigated is the flaky failing of the HLB tests:
```
Exception: GRPCIOBadStatusCode StatusNotFound (StatusDetails {unStatusDetails = "Ledger ID 'sandbox-7b9cb417-a690-4103-9f85-c9fc4666ae47' not found. Actual Ledger ID is 'sandbox-54090ea6-4497-4bb8-ace4-9af0355f0b5a'."})
```

The hunch I am testing is that this happens because sometimes a `getLedgerIdentity` RPC call which follows the `reset` succeeds with the old about-to-be-change id.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
