### PR TITLE
Implement RecoveringPostgresIndexer

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/RecoveringPostgresIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/RecoveringPostgresIndexer.scala
@@ -1,0 +1,264 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.index
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.Done
+import akka.actor.Scheduler
+import akka.pattern.after
+import akka.stream.{Materializer, OverflowStrategy}
+import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import com.daml.ledger.participant.state.v1.ReadService
+import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
+
+object RecoveringPostgresIndexer {
+  def create(
+      factory: IndexerFactory,
+      minWait: FiniteDuration = 1.seconds,
+      maxWait: FiniteDuration = 60.seconds,
+      backoffProgression: FiniteDuration => FiniteDuration = _ * 2
+  )(implicit mat: Materializer, scheduler: Scheduler): Future[RecoveringPostgresIndexer] = {
+    val indexer = new RecoveringPostgresIndexer(factory, minWait, maxWait, backoffProgression)
+    indexer.ready.future.map(_ => indexer)(DEC)
+  }
+
+  /** The wrapped indexer doesn't actually have to be a [[PostgresIndexer]].
+    * The only method used by this class that is not part of the abstract [[Indexer]] interface
+    * is close() from [[AutoCloseable]]. */
+  type WrappedIndexer = Indexer with AutoCloseable
+  type IndexerFactory = () => Future[WrappedIndexer]
+}
+
+sealed abstract class CurrentState
+final case class CurrentStateInitial() extends CurrentState
+final case class CurrentStateCreated(indexer: RecoveringPostgresIndexer.WrappedIndexer)
+    extends CurrentState
+final case class CurrentStateSubscribed(
+    indexer: RecoveringPostgresIndexer.WrappedIndexer,
+    handle: IndexFeedHandle)
+    extends CurrentState
+
+sealed abstract class TargetState
+final case class TargetStateCreated(done: Promise[Done]) extends TargetState
+final case class TargetStateSubscribed(
+    readService: ReadService,
+    onError: Throwable => Unit,
+    onComplete: () => Unit,
+    done: Promise[IndexFeedHandle])
+    extends TargetState
+
+sealed abstract class Action
+final case class ActionStep() extends Action
+final case class ActionIStarted(indexer: RecoveringPostgresIndexer.WrappedIndexer) extends Action
+final case class ActionISubscribed(
+    indexer: RecoveringPostgresIndexer.WrappedIndexer,
+    handle: IndexFeedHandle)
+    extends Action
+final case class ActionIStopped(indexer: RecoveringPostgresIndexer.WrappedIndexer) extends Action
+final case class ActionIError(exception: Throwable) extends Action
+final case class ActionEClose() extends Action
+final case class ActionEStop(done: Promise[Done]) extends Action
+final case class ActionESubscribe(
+    readService: ReadService,
+    onError: Throwable => Unit,
+    onComplete: () => Unit,
+    done: Promise[IndexFeedHandle])
+    extends Action
+
+/**
+  A wrapper around a [[PostgresIndexer]] that automatically recovers from errors.
+
+  This class separately tracks target state (what the indexer should do)
+  and current state (what the indexer does), and tries to always make progress such that
+  the current state follows the target state.
+
+  When an error is encountered, the entire PostgresIndexer is stopped and discarded,
+  and a new one is started.
+  This should be safe, as the PostgresIndexer itself should be resilient against random crashes
+  in the middle of any database operation.
+
+  Errors can happen at any stage, including during initialization, retries, or while waiting for an async result.
+  To avoid concurrency issues, all asynchronous actions are serialized through an Akka queue.
+  The queue is processed using [[processAction]], which is the only method allowed to alter state.
+
+  [[Future]] results of wrapped methods and the underlying PostgresIndexer are linked using [[Promise]]s.
+  */
+class RecoveringPostgresIndexer private (
+    factory: RecoveringPostgresIndexer.IndexerFactory,
+    minWait: FiniteDuration,
+    maxWait: FiniteDuration,
+    backoffProgression: FiniteDuration => FiniteDuration
+)(implicit mat: Materializer, scheduler: Scheduler)
+    extends Indexer
+    with AutoCloseable {
+
+  private[this] val logger = LoggerFactory.getLogger(classOf[RecoveringPostgresIndexer])
+
+  /** A promise that completes when the underlying indexer was successfully created for the first time */
+  private val ready: Promise[Done] = Promise[Done]()
+
+  private[this] val state: AtomicReference[(TargetState, CurrentState, FiniteDuration)] =
+    new AtomicReference[(TargetState, CurrentState, FiniteDuration)](
+      (TargetStateCreated(ready), CurrentStateInitial(), minWait))
+
+  private[this] val queue: SourceQueueWithComplete[Action] =
+    Source
+      .queue[Action](100, OverflowStrategy.fail)
+      // Not using getAndUpdate since the function is not side effect free
+      // This is the only place where [[state]] is written
+      .map(action => state.set(processAction(action, state.get)))
+      .toMat(Sink.ignore)(Keep.left[SourceQueueWithComplete[Action], Future[Done]])
+      .run()
+  queue.offer(ActionStep())
+
+  private[this] object FeedHandle extends IndexFeedHandle {
+    def stop(): Future[Done] = {
+      val promise = Promise[Done]()
+      queue.offer(ActionEStop(promise))
+      promise.future
+    }
+  }
+
+  override def subscribe(
+      readService: ReadService,
+      onError: Throwable => Unit,
+      onComplete: () => Unit): Future[IndexFeedHandle] = {
+
+    val promise = Promise[IndexFeedHandle]()
+    queue.offer(ActionESubscribe(readService, onError, onComplete, promise))
+    promise.future
+  }
+
+  override def close(): Unit = {
+    queue.offer(ActionEClose())
+    ()
+  }
+
+  /** Used as callback in Indexer.subscribe.
+    * This class retries on errors, the original callback is not used.
+    */
+  private[this] def internalOnError(err: Throwable): Unit = {
+    queue.offer(ActionIError(err))
+    ()
+  }
+
+  private[this] def processAction(
+      action: Action,
+      state: (TargetState, CurrentState, FiniteDuration))
+    : (TargetState, CurrentState, FiniteDuration) = this.synchronized {
+    // TODO(RA): Remove debug output
+    Console.println(s"($action, ${state._1}, ${state._2}, ${state._3})")
+    (action, state) match {
+      // --------------------------------------------------------------------------------------------------------------
+      // External actions (generated by calls to public methods)
+      // --------------------------------------------------------------------------------------------------------------
+      case (
+          ActionESubscribe(readService, onError, onComplete, done),
+          (_: TargetStateCreated, _, nextWait)) =>
+        queue.offer(ActionStep())
+        (TargetStateSubscribed(readService, onError, onComplete, done), state._2, nextWait)
+      case (_: ActionESubscribe, (_: TargetStateSubscribed, _, _)) =>
+        sys.error("Can't subscribe, already subscribed")
+
+      case (ActionEStop(done), (_: TargetStateSubscribed, _, nextWait)) =>
+        queue.offer(ActionStep())
+        (TargetStateCreated(done), state._2, nextWait)
+      case (_: ActionEStop, (_: TargetStateCreated, _, _)) =>
+        sys.error("Can't stop, not subscribed")
+
+      case (ActionEClose(), (_, CurrentStateInitial(), _)) =>
+        queue.complete()
+        state
+
+      case (ActionEClose(), (_, CurrentStateCreated(indexer), _)) =>
+        indexer.close()
+        queue.complete()
+        state
+
+      case (ActionEClose(), (_, CurrentStateSubscribed(indexer, _), _)) =>
+        indexer.close()
+        queue.complete()
+        state
+
+      // --------------------------------------------------------------------------------------------------------------
+      // Internal actions (generated by callbacks from the wrapped Indexer)
+      // --------------------------------------------------------------------------------------------------------------
+      case (ActionIStarted(indexer), (_, _, nextWait)) =>
+        queue.offer(ActionStep())
+        (state._1, CurrentStateCreated(indexer), nextWait)
+
+      case (ActionISubscribed(indexer, handle), (_, _, nextWait)) =>
+        queue.offer(ActionStep())
+        (state._1, CurrentStateSubscribed(indexer, handle), nextWait)
+
+      case (ActionIStopped(indexer), (_, _, nextWait)) =>
+        queue.offer(ActionStep())
+        (state._1, CurrentStateCreated(indexer), nextWait)
+
+      case (ActionIError(error), (_, _, nextWait)) =>
+        logger.warn(s"Error in wrapped indexer, retry scheduled after $nextWait", error)
+        after(nextWait, scheduler)(Future.successful(Done))(DEC).map(_ =>
+          queue.offer(ActionStep()))(DEC)
+        (state._1, CurrentStateInitial(), backoffProgression(nextWait))
+
+      // --------------------------------------------------------------------------------------------------------------
+      // Step (making progress towards target state)
+      // --------------------------------------------------------------------------------------------------------------
+      case (ActionStep(), (TargetStateCreated(done), CurrentStateCreated(_), _)) =>
+        done.trySuccess(Done)
+        state.copy(state._1, state._2, minWait)
+
+      case (
+          ActionStep(),
+          (TargetStateSubscribed(_, _, _, done), CurrentStateSubscribed(_, _), _)) =>
+        done.trySuccess(FeedHandle)
+        state.copy(state._1, state._2, minWait)
+
+      case (ActionStep(), (TargetStateCreated(_), CurrentStateInitial(), _)) =>
+        factory()
+          .onComplete {
+            case Success(indexer) => queue.offer(ActionIStarted(indexer))
+            case Failure(err) => queue.offer(ActionIError(err))
+          }(DEC)
+        state
+
+      case (
+          ActionStep(),
+          (
+            TargetStateSubscribed(readService, _, onComplete, _),
+            CurrentStateCreated(indexer),
+            _)) =>
+        indexer
+          .subscribe(readService, internalOnError, onComplete)
+          .onComplete {
+            case Success(handle) => queue.offer(ActionISubscribed(indexer, handle))
+            case Failure(err) => queue.offer(ActionIError(err))
+          }(DEC)
+        state
+
+      case (ActionStep(), (_: TargetStateSubscribed, CurrentStateInitial(), _)) =>
+        factory()
+          .onComplete {
+            case Success(indexer) => queue.offer(ActionIStarted(indexer))
+            case Failure(err) => queue.offer(ActionIError(err))
+          }(DEC)
+        state
+
+      case (ActionStep(), (TargetStateCreated(_), CurrentStateSubscribed(indexer, handle), _)) =>
+        handle
+          .stop()
+          .onComplete {
+            case Success(_) => queue.offer(ActionIStopped(indexer))
+            case Failure(err) => queue.offer(ActionIError(err))
+          }(DEC)
+        state
+    }
+  }
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/index/RecoveringPostgresIndexerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/index/RecoveringPostgresIndexerIT.scala
@@ -1,0 +1,262 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.index
+
+import akka.{Done, NotUsed}
+import akka.actor.{ActorSystem, Scheduler}
+import akka.pattern.after
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import com.daml.ledger.participant.state.v1.{LedgerInitialConditions, Offset, ReadService, Update}
+import org.scalatest.{Matchers, WordSpec}
+import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+sealed abstract class StopResult
+final case class StopFails(delay: FiniteDuration) extends StopResult
+final case class StopSucceeds(delay: FiniteDuration) extends StopResult
+
+sealed abstract class SubscribeResult
+final case class SubscribeFails(delay: FiniteDuration) extends SubscribeResult
+final case class SubscribeSucceeds(
+    delay: FiniteDuration,
+    stopResult: StopResult,
+    failAfter: Option[FiniteDuration])
+    extends SubscribeResult
+
+sealed abstract class CreateResult
+final case class CreateFails(delay: FiniteDuration) extends CreateResult
+final case class CreateSucceeds(delay: FiniteDuration, subscribeResult: SubscribeResult)
+    extends CreateResult
+
+class TestIndexerFactory(creates: Iterator[CreateResult], scheduler: Scheduler) {
+
+  var indexers: List[TestIndexer] = List.empty
+  def activeIndexer: TestIndexer = indexers.head
+
+  class TestIndexer(subscribes: Iterator[SubscribeResult]) extends Indexer with AutoCloseable {
+    var closed = false
+    var subscribed = false
+    var crashed = false
+    var errorHandler: Throwable => Unit = (_ => ())
+
+    class TestIndexerFeedHandle(stops: Iterator[StopResult]) extends IndexFeedHandle {
+      override def stop(): Future[Done] = synchronized {
+        assert(subscribed, "Not subscribed")
+        stops.next() match {
+          case StopFails(delay) =>
+            after(delay, scheduler)({
+              Future.failed(new RuntimeException("Random simulated failure: stop"))
+            })(DEC)
+          case StopSucceeds(delay) =>
+            after(delay, scheduler)({
+              subscribed = false
+              Future.successful(Done)
+            })(DEC)
+        }
+      }
+    }
+
+    override def subscribe(
+        readService: ReadService,
+        onError: Throwable => Unit,
+        onComplete: () => Unit): Future[IndexFeedHandle] = synchronized {
+      assert(!subscribed, "Already subscribed")
+      errorHandler = onError
+      subscribes.next() match {
+        case SubscribeFails(delay) =>
+          after(delay, scheduler)({
+            Future.failed(new RuntimeException("Random simulated failure: subscribe"))
+          })(DEC)
+        case SubscribeSucceeds(delay, stop, failAfterO) =>
+          failAfterO.foreach(failAfter =>
+            scheduler.scheduleOnce(failAfter)({
+              crashed = true
+              onError(new RuntimeException("Random simulated failure: onError"))
+            })(DEC))
+          after(delay, scheduler)({
+            subscribed = true
+            Future.successful(new TestIndexerFeedHandle(Iterator.single(stop)))
+          })(DEC)
+
+      }
+    }
+
+    override def close(): Unit = {
+      assert(!closed, "Already closed")
+      closed = true
+    }
+  }
+
+  def create(): Future[Indexer with AutoCloseable] = synchronized {
+    creates.next() match {
+      case CreateFails(delay) =>
+        after(delay, scheduler)({
+          Future.failed(new RuntimeException("Random simulated failure: create"))
+        })(DEC)
+      case CreateSucceeds(delay, subscribe) =>
+        after(delay, scheduler)({
+          val indexer = new TestIndexer(Iterator.single(subscribe))
+          indexers = indexer :: indexers
+          Future.successful(indexer)
+        })(DEC)
+    }
+  }
+}
+
+object TestReadService extends ReadService {
+  override def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed] = Source.empty
+  override def stateUpdates(beginAfter: Option[Offset]): Source[(Offset, Update), NotUsed] =
+    Source.empty
+}
+
+class RecoveringPostgresIndexerIT extends WordSpec with Matchers {
+
+  private[this] val actorSystem = ActorSystem("PollingUtilsSpec")
+  private[this] implicit val materializer: ActorMaterializer = ActorMaterializer()(actorSystem)
+  private[this] implicit val scheduler: Scheduler = materializer.system.scheduler
+  private[this] implicit val ec: ExecutionContext = DEC
+
+  "RecoveringPostgresIndexer" should {
+
+    /**
+      * Test whether all operations (create, subscribe, stop, close) are forwarded to the implementation.
+      */
+    "support all operation" in {
+      val factory: TestIndexerFactory = new TestIndexerFactory(
+        List[CreateResult](
+          CreateSucceeds(0.millis, SubscribeSucceeds(0.millis, StopSucceeds(0.millis), None))
+        ).iterator,
+        scheduler)
+
+      Await.result(
+        for {
+          indexer <- RecoveringPostgresIndexer.create(() => factory.create(), 1.millis)
+          handle <- indexer.subscribe(TestReadService, _ => (), () => ())
+          _ = assert(factory.activeIndexer.subscribed)
+          done <- handle.stop()
+          _ = indexer.close()
+        } yield done,
+        10.seconds
+      )
+
+      factory.indexers.length shouldBe 1
+      factory.indexers(0).subscribed shouldBe false
+      factory.indexers(0).closed shouldBe true
+    }
+
+    "retry a failed create" in {
+      val factory: TestIndexerFactory = new TestIndexerFactory(
+        List[CreateResult](
+          CreateFails(0.millis),
+          CreateSucceeds(0.millis, SubscribeSucceeds(0.millis, StopSucceeds(0.millis), None))
+        ).iterator,
+        scheduler)
+
+      Await.result(for {
+        indexer <- RecoveringPostgresIndexer.create(() => factory.create(), 1.millis)
+      } yield indexer, 10.seconds)
+
+      factory.indexers.length shouldBe 1
+    }
+
+    "retry a failed subscribe" in {
+      val factory: TestIndexerFactory = new TestIndexerFactory(
+        List[CreateResult](
+          CreateSucceeds(0.millis, SubscribeFails(0.millis)),
+          CreateSucceeds(0.millis, SubscribeSucceeds(0.millis, StopSucceeds(0.millis), None))
+        ).iterator,
+        scheduler
+      )
+
+      Await.result(
+        for {
+          indexer <- RecoveringPostgresIndexer.create(() => factory.create(), 1.millis)
+          handle <- indexer.subscribe(TestReadService, _ => (), () => ())
+        } yield handle,
+        10.seconds
+      )
+
+      factory.indexers.length shouldBe 2
+      factory.indexers(1).subscribed shouldBe false
+      factory.indexers(0).subscribed shouldBe true
+    }
+
+    /**
+      * The wrapper hides internal failures.
+      * Test whether stop() can be called while the underlying indexer is failed.
+      *
+      * 1. 0ms:   Indexer successfully created
+      * 2. 0ms:   subscribe() called
+      * 3. 10ms:  Indexer crashes
+      * 4. 50ms:  stop() called (while no indexer is alive)
+      * 4. 100ms: New indexer successfully created
+      */
+    "support operations in a failed state" in {
+      val factory: TestIndexerFactory = new TestIndexerFactory(
+        List[CreateResult](
+          CreateSucceeds(
+            0.millis,
+            SubscribeSucceeds(0.millis, StopSucceeds(0.millis), Some(10.millis))),
+          CreateSucceeds(100.millis, SubscribeSucceeds(0.millis, StopSucceeds(0.millis), None))
+        ).iterator,
+        scheduler
+      )
+
+      Await.result(
+        for {
+          indexer <- RecoveringPostgresIndexer.create(() => factory.create(), 1.millis)
+          handle <- indexer.subscribe(TestReadService, _ => (), () => ())
+          _ <- akka.pattern.after(50.millis, scheduler)(Future.successful(()))
+          _ = assert(factory.activeIndexer.crashed)
+          done <- handle.stop()
+          _ <- akka.pattern.after(200.millis, scheduler)(Future.successful(()))
+        } yield done,
+        10.seconds
+      )
+
+      factory.indexers.length shouldBe 2
+      factory.indexers(1).crashed shouldBe true
+      factory.indexers(0).subscribed shouldBe false
+    }
+
+    /**
+      * Test whether a subscribed indexer can recover from multiple failures:
+      *
+      * 1. Subscribe succeeds
+      * 2. Random failure occurs
+      * 3. Create fails
+      * 4. Create succeeds, subscribe fails
+      * 5. Everything succeeds
+      */
+    "recover from multiple failures" in {
+      val factory: TestIndexerFactory = new TestIndexerFactory(
+        List[CreateResult](
+          CreateSucceeds(
+            10.millis,
+            SubscribeSucceeds(10.millis, StopSucceeds(10.millis), Some(20.millis))),
+          CreateFails(10.millis),
+          CreateSucceeds(10.millis, SubscribeFails(10.millis)),
+          CreateSucceeds(10.millis, SubscribeSucceeds(10.millis, StopSucceeds(10.millis), None)),
+        ).iterator,
+        scheduler
+      )
+
+      Await.result(
+        for {
+          indexer <- RecoveringPostgresIndexer.create(() => factory.create(), 1.millis)
+          handle <- indexer.subscribe(TestReadService, _ => (), () => ())
+        } yield handle,
+        10.seconds
+      )
+
+      factory.indexers.length shouldBe 3
+      factory.indexers(2).crashed shouldBe true
+      factory.indexers(1).subscribed shouldBe false
+      factory.indexers(0).subscribed shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Implements `RecoveringPostgresIndexer`, which wraps a `PostgresIndexer`, restarting the underlying indexer on errors.

Note: this is entirely untested. Tests need to be added.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
