### PR TITLE
Revert "add old releases to hubspot (#2290)"

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -62,7 +62,9 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           echo "Checking for new version..."
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
+          GH_RESP=$(mktemp)
+          curl https://api.github.com/repos/digital-asset/daml/releases -s > $GH_RESP
+          RELEASES=$(cat $GH_RESP | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
           GH_VERSIONS=$(mktemp)
           DOCS_VERSIONS=$(mktemp)
           curl -s https://docs.daml.com/versions.json | jq -r 'keys | .[]' | sort > $DOCS_VERSIONS
@@ -107,10 +109,33 @@ jobs:
           aws cloudfront create-invalidation \
                          --distribution-id E1U753I56ERH55 \
                          --paths '/*'
+          echo "Publishing $LATEST to Hubspot..."
+          DESCRIPTION_MD="$(cat $GH_RESP | jq -r '. | map(select(.tag_name="'$LATEST'"))[0].body')"
+          DESCRIPTION=$(curl -s -XPOST 'https://api.github.com/markdown/raw' -H 'Content-Type: text/plain' -d"$DESCRIPTION_MD" | jq -sR .)
+          DATE="$(date -d $(cat $GH_RESP | jq -r '. | map(select(.tag_name="'$LATEST'"))[0].published_at') +%s)000"
+          SUMMARY="Release notes for version ${LATEST#v}."
+          # content_group_id and blog_author_id reference existing items in HubSpot
+          ID=$(curl -s \
+                    -XPOST 'https://api.hubapi.com/content/api/v2/blog-posts?hapikey='$HUBSPOT_TOKEN \
+                    -d'{"name": "Release of DAML SDK '$LATEST'",
+                        "post_body": '"$DESCRIPTION"',
+                        "content_group_id": 11411412838,
+                        "publish_date": '$DATE',
+                        "post_summary": "'"$SUMMARY"'",
+                        "slug": "'${LATEST#v}'",
+                        "blog_author_id": 11513309969,
+                        "meta_description": "'"$SUMMARY"'"}}' \
+                    -H "Content-Type: application/json" \
+               | jq '.id')
+          curl -s \
+               -XPOST 'https://api.hubapi.com/content/api/v2/blog-posts/'$ID'/publish-action?hapikey='$HUBSPOT_TOKEN \
+               -d'{"action": "schedule-publish"}' \
+               -H "Content-Type: application/json"
           echo "Done."
         env:
           AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
           AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+          HUBSPOT_TOKEN: $(HUBSPOT_TOKEN)
       - task: PublishPipelineArtifact@0
         condition: always()
         inputs:
@@ -125,56 +150,6 @@ jobs:
                --data "{\"text\":\"<!here> *FAILED* Daily Docs: <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
                $(Slack.URL)
         condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
-
-  - job: hubspot
-    timeoutInMinutes: 50
-    pool:
-      name: linux-pool
-    steps:
-      - checkout: self
-      - bash: |
-          set -euo pipefail
-          eval "$(dev-env/bin/dade-assist)"
-          # Manually created items in HubSpot
-          BLOG_ID=11411412838
-          AUTHOR_ID=11513309969
-          GH_RESP=$(mktemp)
-          curl -s "https://api.github.com/repos/digital-asset/daml/releases" > $GH_RESP
-          HS_RESP=$(mktemp)
-          curl -s "https://api.hubapi.com/content/api/v2/blog-posts?hapikey=${HUBSPOT_TOKEN}&content_group_id=${BLOG_ID}" > $HS_RESP
-          RELEASES=$(cat $GH_RESP | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
-          for version in $(echo $RELEASES | sed -e 's/ /\n/g'); do
-              NAME="Release of DAML SDK $version"
-              if [[ -n "$(cat $HS_RESP | jq '.objects[].name | select(. == "'"$NAME"'")')" ]]; then
-                  echo "$version already present in HubSpot"
-              else
-                  echo "Publishing $version to Hubspot..."
-                  DESCRIPTION_MD="$(cat $GH_RESP | jq -r '. | map(select(.tag_name="'$version'"))[0].body')"
-                  DESCRIPTION=$(curl -s -XPOST 'https://api.github.com/markdown/raw' -H 'Content-Type: text/plain' -d"$DESCRIPTION_MD" | jq -sR .)
-                  # HubSpot wants the date in milliseconds since epoch
-                  DATE="$(date -d $(cat $GH_RESP | jq -r '. | map(select(.tag_name="'$version'"))[0].published_at') +%s)000"
-                  SUMMARY="Release notes for version ${version#v}."
-                  ID=$(curl -s \
-                            -XPOST 'https://api.hubapi.com/content/api/v2/blog-posts?hapikey='$HUBSPOT_TOKEN \
-                            -d'{"name": "Release of DAML SDK '$version'",
-                                "post_body": '"$DESCRIPTION"',
-                                "content_group_id": '$BLOG_ID',
-                                "publish_date": '$DATE',
-                                "post_summary": "'"$SUMMARY"'",
-                                "slug": "'${version#v}'",
-                                "blog_author_id": '$AUTHOR_ID',
-                                "meta_description": "'"$SUMMARY"'"}}' \
-                            -H "Content-Type: application/json" \
-                       | jq '.id')
-                  curl -s \
-                       -XPOST 'https://api.hubapi.com/content/api/v2/blog-posts/'$ID'/publish-action?hapikey='$HUBSPOT_TOKEN \
-                       -d'{"action": "schedule-publish"}' \
-                       -H "Content-Type: application/json"
-              fi
-          done
-          echo "Done."
-        env:
-          HUBSPOT_TOKEN: $(HUBSPOT_TOKEN)
 
   - job: docker_image
     timeoutInMinutes: 60


### PR DESCRIPTION
On Friday evening, we have four runs of the cron job that have produced the following logs (after a change of token, which may or may not be related):

> [26/07/2019, 21:00:23](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12410)

```
v0.13.15 already present in HubSpot
v0.13.14 already present in HubSpot
v0.13.13 already present in HubSpot
v0.13.12 already present in HubSpot
v0.13.10 already present in HubSpot
v0.13.5 already present in HubSpot
v0.13.0 already present in HubSpot
v0.12.25 already present in HubSpot
v0.12.24 already present in HubSpot
v0.12.22 already present in HubSpot
v0.12.21 already present in HubSpot
v0.12.20 already present in HubSpot
v0.12.19 already present in HubSpot
v0.12.18 already present in HubSpot
v0.12.17 already present in HubSpot
v0.12.16 already present in HubSpot
Publishing v0.12.15 to Hubspot...
Publishing v0.12.12 to Hubspot...
Publishing v0.12.11 to Hubspot...
Publishing v0.12.3 to Hubspot...
Done.
```

> [26/07/2019, 22:00:21](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12411)

```
v0.13.15 already present in HubSpot
v0.13.14 already present in HubSpot
v0.13.13 already present in HubSpot
v0.13.12 already present in HubSpot
v0.13.10 already present in HubSpot
v0.13.5 already present in HubSpot
v0.13.0 already present in HubSpot
v0.12.25 already present in HubSpot
v0.12.24 already present in HubSpot
v0.12.22 already present in HubSpot
v0.12.21 already present in HubSpot
v0.12.20 already present in HubSpot
Publishing v0.12.19 to Hubspot...
Publishing v0.12.18 to Hubspot...
Publishing v0.12.17 to Hubspot...
Publishing v0.12.16 to Hubspot...
v0.12.15 already present in HubSpot
v0.12.12 already present in HubSpot
v0.12.11 already present in HubSpot
v0.12.3 already present in HubSpot
Done.
```

> [26/07/2019, 23:00:19](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12414)

```
v0.13.15 already present in HubSpot
v0.13.14 already present in HubSpot
v0.13.13 already present in HubSpot
v0.13.12 already present in HubSpot
v0.13.10 already present in HubSpot
v0.13.5 already present in HubSpot
v0.13.0 already present in HubSpot
v0.12.25 already present in HubSpot
Publishing v0.12.24 to Hubspot...
Publishing v0.12.22 to Hubspot...
Publishing v0.12.21 to Hubspot...
Publishing v0.12.20 to Hubspot...
v0.12.19 already present in HubSpot
v0.12.18 already present in HubSpot
v0.12.17 already present in HubSpot
v0.12.16 already present in HubSpot
v0.12.15 already present in HubSpot
v0.12.12 already present in HubSpot
v0.12.11 already present in HubSpot
v0.12.3 already present in HubSpot
Done.
```

> [27/07/2019, 00:00:19](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12415)

```
v0.13.15 already present in HubSpot
v0.13.14 already present in HubSpot
v0.13.13 already present in HubSpot
v0.13.12 already present in HubSpot
Publishing v0.13.10 to Hubspot...
Publishing v0.13.5 to Hubspot...
Publishing v0.13.0 to Hubspot...
Publishing v0.12.25 to Hubspot...
v0.12.24 already present in HubSpot
v0.12.22 already present in HubSpot
v0.12.21 already present in HubSpot
v0.12.20 already present in HubSpot
v0.12.19 already present in HubSpot
v0.12.18 already present in HubSpot
v0.12.17 already present in HubSpot
v0.12.16 already present in HubSpot
v0.12.15 already present in HubSpot
v0.12.12 already present in HubSpot
v0.12.11 already present in HubSpot
v0.12.3 already present in HubSpot
Done.
```

> [27/07/2019, 01:00:18](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12417)

```
v0.13.15 already present in HubSpot
v0.13.14 already present in HubSpot
Publishing v0.13.13 to Hubspot...
Publishing v0.13.12 to Hubspot...
v0.13.10 already present in HubSpot
v0.13.5 already present in HubSpot
v0.13.0 already present in HubSpot
v0.12.25 already present in HubSpot
v0.12.24 already present in HubSpot
v0.12.22 already present in HubSpot
v0.12.21 already present in HubSpot
v0.12.20 already present in HubSpot
v0.12.19 already present in HubSpot
v0.12.18 already present in HubSpot
v0.12.17 already present in HubSpot
v0.12.16 already present in HubSpot
v0.12.15 already present in HubSpot
v0.12.12 already present in HubSpot
v0.12.11 already present in HubSpot
v0.12.3 already present in HubSpot
Done.
```

> [27/07/2019, 02:00:17](https://dev.azure.com/digitalasset/daml/_build/results?buildId=12418)

```
v0.13.15 already present in HubSpot
Publishing v0.13.14 to Hubspot...
v0.13.13 already present in HubSpot
v0.13.12 already present in HubSpot
v0.13.10 already present in HubSpot
v0.13.5 already present in HubSpot
v0.13.0 already present in HubSpot
v0.12.25 already present in HubSpot
v0.12.24 already present in HubSpot
v0.12.22 already present in HubSpot
v0.12.21 already present in HubSpot
v0.12.20 already present in HubSpot
v0.12.19 already present in HubSpot
v0.12.18 already present in HubSpot
v0.12.17 already present in HubSpot
v0.12.16 already present in HubSpot
v0.12.15 already present in HubSpot
v0.12.12 already present in HubSpot
v0.12.11 already present in HubSpot
v0.12.3 already present in HubSpot
Done.
```

With the net result that:
1. We have almost all of the releases twice in the blog, and
2. Because Dan had set up Twitter integration, we have tweeted about 0.12.3-0.12.15 on Friday evening.

Because old releases are already there and the HubSpot API has proven to be unreliable, I would like to revert to the previous approach, which was only pushing to HubSpot after updating the documentation (and therefore does not rely on the HubSpot API to detect when a new post needs to be made).

Note: this would push a new HubSpot blog post (and therefore tweet) when we pull out a release too (i.e. on each change to versions.json), which I'm not sure how I feel about.