### PR TITLE
damldocs: Drop --json flag, update release notes.

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -27,7 +27,7 @@ documentation :: Parser CmdArgs
 documentation = Damldoc
                 <$> optInputFormat
                 <*> optOutputPath
-                <*> optOutputFormatOrJson
+                <*> optOutputFormat
                 <*> optMbPackageName
                 <*> optTemplate
                 <*> optOmitEmpty
@@ -79,13 +79,6 @@ documentation = Damldoc
     argMainFiles :: Parser [FilePath]
     argMainFiles = some $ argument str $ metavar "FILE..."
                   <> help "Main file(s) (*.daml) whose contents are read"
-
-    optOutputFormatOrJson :: Parser OutputFormat
-    optOutputFormatOrJson = fromMaybe
-        <$> optOutputFormat
-        <*> (flag Nothing (Just OutputJson) $
-            long "json"
-            <> help "alias for `--format json'")
 
     optOutputFormat :: Parser OutputFormat
     optOutputFormat =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -4,14 +4,13 @@
 
 module DA.Cli.Damlc.Command.Damldoc(cmdDamlDoc) where
 
-import           DA.Cli.Options
-import           DA.Daml.Doc.Driver
+import DA.Cli.Options
+import DA.Daml.Doc.Driver
 import DA.Daml.Options
 import DA.Daml.Options.Types
 import Development.IDE.Types.Location
 
-import           Options.Applicative
-import Data.Maybe
+import Options.Applicative
 import Data.List.Extra
 import qualified Data.Text as T
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,6 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [DAML Docs] The ``damlc docs`` command now produces docs to a folder by default. Use the new ``--combine`` flag to output a single file instead.
+- [DAML Docs] The ``damlc docs`` flag ``--prefix`` has been replaced with a ``--template`` flag which allows for a more flexible template.
+- [DAML Docs] The ``damlc docs`` flag ``--json`` has been dropped in favor of ``--format=json``.


### PR DESCRIPTION
Based on @jberthold-da's comments on the last PR.

- Drop the `--json` flag (in favor of `--format=json`)
- Updates the release notes (should have been updated last PR, but better late than never).