### PR TITLE
Eliminate grpc-netty runtime warning after grpc upgrade

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/RemoteServerResource.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/RemoteServerResource.scala
@@ -11,6 +11,7 @@ import io.grpc.ManagedChannel
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import io.netty.channel.EventLoopGroup
 import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.util.concurrent.DefaultThreadFactory
 
 object RemoteServerResource {
@@ -35,6 +36,7 @@ class RemoteServerResource(host: String, port: Int, tlsConfig: Option[TlsConfigu
     val channelBuilder: NettyChannelBuilder = NettyChannelBuilder
       .forAddress(host, port)
       .eventLoopGroup(eventLoopGroup)
+      .channelType(classOf[NioSocketChannel])
       .directExecutor()
 
     tlsConfig


### PR DESCRIPTION
Netty emits a warning if the eventLoopGroup is customize without setting
the corresponding channelType.

This warning is new since we recently upgraded to a newer version of grpc-java (and thus also grpc-netty and netty).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
