### PR TITLE
Anchor links in Rst docs, fixing type rendering, and refactoring.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -72,7 +72,7 @@ renderSimpleRst ModuleDoc{..} = mconcat
 tmpl2rst :: TemplateDoc -> RenderOut
 tmpl2rst TemplateDoc{..} = mconcat $
     [ renderAnchor td_anchor
-    , renderLineDep $ \env -> T.unwords . concat
+    , renderLineDep $ \env -> T.unwords . concat $
         [ [bold "template"]
         , maybe [] (\x -> [type2rst env x, bold "=>"]) td_super
         , [makeAnchorLink env td_anchor (unTypename td_name)]
@@ -106,7 +106,7 @@ choiceBullet ChoiceDoc{..} = mconcat
 cls2rst ::  ClassDoc -> RenderOut
 cls2rst ClassDoc{..} = mconcat
     [ renderAnchor cl_anchor
-    , renderLineDep $ \env -> T.unwords . concat
+    , renderLineDep $ \env -> T.unwords . concat $
         [ [bold "class"]
         , maybe [] (\x -> [type2rst env x, bold "=>"]) cl_super
         , [makeAnchorLink env cl_anchor (unTypename cl_name)]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -130,7 +130,7 @@ renderADTDoc TypeSynDoc{..} = mconcat
         ]
     , maybe mempty ((<> renderLine "") . renderIndent 2 . renderDocText) ad_descr
     ]
-renderADTDoc ADTDoc{..} = mconcat $
+renderADTDoc ADTDoc{..} = mconcat
     [ renderAnchor ad_anchor
     , renderLinesDep $ \env ->
         [ T.unwords

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -72,13 +72,11 @@ renderSimpleRst ModuleDoc{..} = mconcat
 tmpl2rst :: TemplateDoc -> RenderOut
 tmpl2rst TemplateDoc{..} = mconcat $
     [ renderAnchor td_anchor
-    , renderLineDep $ \env -> T.concat
-        [ bold "template"
-        , " "
-        , maybe "" ((<> " **=>** ") . type2rst env) td_super
-        , T.unwords
-            $ makeAnchorLink env td_anchor (unTypename td_name)
-            : td_args
+    , renderLineDep $ \env -> T.unwords . concat
+        [ [bold "template"]
+        , maybe [] (\x -> [type2rst env x, bold "=>"]) td_super
+        , [makeAnchorLink env td_anchor (unTypename td_name)]
+        , td_args
         ]
     , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) td_descr
     , renderLine ""
@@ -90,8 +88,8 @@ renderTemplateInstanceDocAsRst :: TemplateInstanceDoc -> RenderOut
 renderTemplateInstanceDocAsRst TemplateInstanceDoc{..} = mconcat
     [ renderAnchor ti_anchor
     , renderLinesDep $ \env ->
-        [ "template instance "
-        <> makeAnchorLink env ti_anchor (unTypename ti_name)
+        [ "template instance " <>
+            makeAnchorLink env ti_anchor (unTypename ti_name)
         , "    = " <> type2rst env ti_rhs
         , ""
         ]
@@ -108,15 +106,12 @@ choiceBullet ChoiceDoc{..} = mconcat
 cls2rst ::  ClassDoc -> RenderOut
 cls2rst ClassDoc{..} = mconcat
     [ renderAnchor cl_anchor
-    , renderLineDep $ \env -> T.concat
-        [ bold "class"
-        , " "
-        , maybe "" (\x -> type2rst env x <> " **=>** ") cl_super
-        , T.unwords
-            $ makeAnchorLink env cl_anchor (unTypename cl_name)
-            : cl_args
-        , " "
-        , bold "where"
+    , renderLineDep $ \env -> T.unwords . concat
+        [ [bold "class"]
+        , maybe [] (\x -> [type2rst env x, bold "=>"]) cl_super
+        , [makeAnchorLink env cl_anchor (unTypename cl_name)]
+        , cl_args
+        , [bold "where"]
         ]
     , maybe mempty ((renderLine "" <>) . renderIndent 2 . renderDocText) cl_descr
     , mconcat $ map (renderIndent 2 . fct2rst) cl_functions

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -86,19 +86,19 @@ expectRst :: [T.Text]
 expectRst =
         [ T.empty
         , mkExpectRst "module-typedef" "Typedef" "" [] []
-            [".. _type-typedef-t:\n\ntype **T a**\n    = TT TTT\n\n  T descr"] []
+            [".. _type-typedef-t:\n\n**type** `T <type-typedef-t_>`_ a\n  = TT TTT\n\n  T descr"] []
         , mkExpectRst "module-twotypes" "TwoTypes" "" []
             []
-            [".. _type-twotypes-t:\n\ntype **T a**\n    = TT\n\n  T descr\n"
-            , "\n.. _data-twotypes-d:\n\ndata **D d**\n\n  \n  \n  .. _constr-twotypes-d:\n  \n  **D** a\n  \n  D descr"]
+            [".. _type-twotypes-t:\n\n**type** `T <type-twotypes-t_>`_ a\n  = TT\n\n  T descr\n"
+            , "\n.. _data-twotypes-d:\n\n**data** `D <data-twotypes-d_>`_ d\n\n  \n  \n  .. _constr-twotypes-d:\n  \n  `D <constr-twotypes-d_>`_ a\n  \n  D descr"]
             []
-        , mkExpectRst "module-function1" "Function1" "" [] [] [] [ ".. _function-function1-f:\n\n**f**\n  : TheType\n\n  the doc\n"]
-        , mkExpectRst "module-function3" "Function3" "" [] [] [] [ ".. _function-function3-f:\n\n**f**\n  : TheType\n\n"]
+        , mkExpectRst "module-function1" "Function1" "" [] [] [] [ ".. _function-function1-f:\n\n`f <function-function1-f_>`_\n  : TheType\n\n  the doc\n"]
+        , mkExpectRst "module-function3" "Function3" "" [] [] [] [ ".. _function-function3-f:\n\n`f <function-function3-f_>`_\n  : TheType\n\n"]
         , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
             [ ".. _class-onlyclass-c:"
             , ""
-            , "class **C a** where\n  \n  .. _function-onlyclass-member:\n  \n  **member**\n    : a"
+            , "**class** `C <class-onlyclass-c_>`_ a **where**\n  \n  .. _function-onlyclass-member:\n  \n  `member <function-onlyclass-member_>`_\n    : a"
             ]
             []
             []
@@ -107,12 +107,12 @@ expectRst =
             []
             [ ".. _data-multilinefield-d:"
             , ""
-            , "data **D**"
+            , "**data** `D <data-multilinefield-d_>`_"
             , ""
             , T.concat
                   [ "  \n  \n"
                   , "  .. _constr-multilinefield-d:\n  \n"
-                  , "  **D**\n  \n  \n"
+                  , "  `D <constr-multilinefield-d_>`_\n  \n  \n"
                   , "  .. list-table::\n"
                   , "     :widths: 15 10 30\n"
                   , "     :header-rows: 1\n  \n"
@@ -128,8 +128,8 @@ expectRst =
         , mkExpectRst "module-functionctx" "FunctionCtx" "" [] [] []
             [ ".. _function-g:"
             , ""
-            , "**g**"
-            , "  : (Eq t) => t -> Bool"
+            , "`g <function-g_>`_"
+            , "  : Eq t => t -> Bool"
             , ""
             , "  function with context"
             ]

--- a/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/IouDSL.EXPECTED.rst
@@ -10,7 +10,7 @@ Templates
 
 .. _type-ioudsl-iou-73876:
 
-template **Iou**
+**template** `Iou <type-ioudsl-iou-73876_>`_
 
   .. list-table::
      :widths: 15 10 30
@@ -37,6 +37,6 @@ Template Instances
 
 .. _type-ioudsl-proposaliou-92778:
 
-template instance **ProposalIou**
-    = Proposal `Iou <type-ioudsl-iou-73876_>`_
+template instance `ProposalIou <type-ioudsl-proposaliou-92778_>`_
+  = Proposal `Iou <type-ioudsl-iou-73876_>`_
 

--- a/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou_template.EXPECTED.rst
@@ -10,7 +10,7 @@ Templates
 
 .. _type-ioutemplate-iou-55222:
 
-template **Iou**
+**template** `Iou <type-ioutemplate-iou-55222_>`_
 
   .. list-table::
      :widths: 15 10 30
@@ -81,7 +81,7 @@ Functions
 
 .. _function-ioutemplate-main-13221:
 
-**main**
+`main <function-ioutemplate-main-13221_>`_
   : Scenario ()
 
   A single test scenario covering all functionality that ``Iou`` implements.

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -10,13 +10,13 @@ Data types
 
 .. _type-newtype-nat-61947:
 
-data **Nat**
+**data** `Nat <type-newtype-nat-61947_>`_
 
   
   
   .. _constr-newtype-nat-99832:
   
-  **Nat**
+  `Nat <constr-newtype-nat-99832_>`_
   
   
   .. list-table::
@@ -35,49 +35,49 @@ Functions
 
 .. _function-newtype-mknat-8513:
 
-**mkNat**
+`mkNat <function-newtype-mknat-8513_>`_
   : Int -> `Nat <type-newtype-nat-61947_>`_
 
 
 
 .. _function-newtype-unsafemknat-96593:
 
-**unsafeMkNat**
+`unsafeMkNat <function-newtype-unsafemknat-96593_>`_
   : Int -> `Nat <type-newtype-nat-61947_>`_
 
 
 
 .. _function-newtype-zero0-10450:
 
-**zero0**
+`zero0 <function-newtype-zero0-10450_>`_
   : `Nat <type-newtype-nat-61947_>`_
 
 
 
 .. _function-newtype-one1-53872:
 
-**one1**
+`one1 <function-newtype-one1-53872_>`_
   : `Nat <type-newtype-nat-61947_>`_
 
 
 
 .. _function-newtype-unnat1-26452:
 
-**unNat1**
+`unNat1 <function-newtype-unnat1-26452_>`_
   : `Nat <type-newtype-nat-61947_>`_ -> Int
 
 
 
 .. _function-newtype-unnat2-96339:
 
-**unNat2**
+`unNat2 <function-newtype-unnat2-96339_>`_
   : `Nat <type-newtype-nat-61947_>`_ -> Int
 
 
 
 .. _function-newtype-unnat3-97654:
 
-**unNat3**
+`unNat3 <function-newtype-unnat3-97654_>`_
   : `Nat <type-newtype-nat-61947_>`_ -> Int
 
 

--- a/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ProposalDSL.EXPECTED.rst
@@ -10,7 +10,7 @@ Templates
 
 .. _type-proposaldsl-proposal-65892:
 
-template (Template t) => **Proposal** t
+**template** Template t => `Proposal <type-proposaldsl-proposal-65892_>`_ t
 
   .. list-table::
      :widths: 15 10 30


### PR DESCRIPTION
* Fixes #2283 for Rst by making template/class/type/function/etc names link to their own anchor. (IMO it also looks a lot nicer than bolding the names.)
* Refactored the Rst renderer a bit, particularly making function names more uniform and descriptive.
* Fixed type rendering in Rst for constructor arguments and single item contexts.