### PR TITLE
Speed up file modification checks

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -81,6 +81,7 @@
   # Shady extensions
   - name: CPP
     within:
+    - Development.IDE.Core.FileStore
     - DA.Sdk.Cli.System
     - DA.Sdk.Cli.Version
     - DAML.Assistant.Install.Path

--- a/compiler/hie-core/BUILD.bazel
+++ b/compiler/hie-core/BUILD.bazel
@@ -39,7 +39,7 @@ depends = [
     "transformers",
     "unordered-containers",
     "utf8-string",
-]
+] + ([] if is_windows else ["unix"])
 
 hidden = [
     "Development.IDE.Core.Compile",
@@ -69,7 +69,18 @@ da_haskell_library(
     hidden_modules = hidden,
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
+    deps = [] if is_windows else [":getmodtime"],
 )
+
+# Used in getModificationTimeRule in Development.IDE.Core.FileStore
+cc_library(
+    name = "getmodtime",
+    srcs = glob(["cbits/getmodtime.c"]),
+    copts = [
+        "-Wall",
+        "-Werror",
+    ],
+) if not is_windows else None
 
 da_haskell_library(
     name = "hie-core-public",
@@ -89,6 +100,7 @@ da_haskell_library(
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
+    deps = [] if is_windows else [":getmodtime"],
 )
 
 da_haskell_binary(

--- a/compiler/hie-core/cbits/getmodtime.c
+++ b/compiler/hie-core/cbits/getmodtime.c
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/stat.h>
+#include <time.h>
+int getmodtime(const char* pathname, time_t* sec, long* nsec) {
+    struct stat s;
+    int r = stat(pathname, &s);
+    if (r != 0) {
+        return r;
+    }
+    *sec = s.st_mtim.tv_sec;
+    *nsec = s.st_mtim.tv_nsec;
+    return 0;
+}
+

--- a/compiler/hie-core/cbits/getmodtime.c
+++ b/compiler/hie-core/cbits/getmodtime.c
@@ -9,8 +9,13 @@ int getmodtime(const char* pathname, time_t* sec, long* nsec) {
     if (r != 0) {
         return r;
     }
+#ifdef __APPLE__
+    *sec = s.st_mtimespec.tv_sec;
+    *nsec = s.st_mtimespec.tv_nsec;
+#else
     *sec = s.st_mtim.tv_sec;
     *nsec = s.st_mtim.tv_nsec;
+#endif
     return 0;
 }
 

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -582,7 +582,10 @@ instance NFData   GetModificationTime
 -- | Get the modification time of a file.
 type instance RuleResult GetModificationTime = FileVersion
 
-data FileVersion = VFSVersion Int | ModificationTime UTCTime
+-- | We store the modification time as a ByteString since we need
+-- a ByteString anyway for Shake and we do not care about how times
+-- are represented.
+data FileVersion = VFSVersion Int | ModificationTime BS.ByteString
     deriving (Show, Generic)
 
 instance NFData FileVersion


### PR DESCRIPTION
Summary: `getModificationTime` from the `directory` package is really
slow. The `unix` package is faster but still slow. This PR brings the
time spent checking file modifications (which is required on every
change) from ~0.5s to ~0.15s.

I’ve tried speeding up further by writing to the `ByteString` in C instead of going via `show` but that doesn’t seem to matter.

Also if forces @hurryabit to read C code :P

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
