### PR TITLE
Support per-project hlint customization (.dlint.yaml files)

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -20,6 +20,7 @@ import Data.Aeson hiding (Options)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as BS
 import Data.Either.Extra
+import Data.Foldable
 import Data.List
 import qualified Data.Map.Strict as Map
 import Data.Maybe
@@ -573,28 +574,24 @@ encodeModuleRule =
 
 hlintSettings :: FilePath -> IO ([Classify], Hint)
 hlintSettings hlintDataDir = do
-  curdir <- getCurrentDirectory
-  home <- catchIOError ((:[]) <$> getHomeDirectory) (const $ return [])
-  dlintYaml <-
-    findM System.Directory.Extra.doesFileExist $
-      map (</> ".dlint.yaml") (ancestors curdir ++ home)
-  -- `findSettings` calls `readFilesConfig` which in turn calls
-  -- `readFileConfigYaml` which finally calls `decodeFileEither` from
-  -- the `yaml` library.  Annoyingly that function catches async
-  -- exceptions and in particular, it ends up catching
-  -- `ThreadKilled`. So, we have to mask to stop it from doing that.
-  let hlintYaml = hlintDataDir </> "hlint.yaml"
-  (_, cs, hs) <-
-    mask $ \unmask ->
-      findSettings (unmask . const (return (hlintYaml, Nothing))) (Just hlintYaml)
-  (_, cs', hs') <- case dlintYaml of
-    Just dlintYaml' ->
-      mask $ \unmask ->
-        findSettings (unmask . const (return (dlintYaml', Nothing))) (Just dlintYaml')
-    Nothing -> return (mempty, mempty, mempty)
-  return (cs <> cs', hs <> hs')
-  where
-    ancestors = init . map joinPath . reverse . inits . splitPath
+    curdir <- getCurrentDirectory
+    home <- ((:[]) <$> getHomeDirectory) `catchIOError` (const $ return [])
+    dlintYaml <-
+      findM System.Directory.Extra.doesFileExist $
+        map (</> ".dlint.yaml") (ancestors curdir ++ home)
+    (_, cs, hs) <- foldMapM parseSettings $
+      (hlintDataDir </> "hlint.yaml") : maybeToList dlintYaml
+    return (cs, hs)
+    where
+      ancestors = init . map joinPath . reverse . inits . splitPath
+      -- `findSettings` calls `readFilesConfig` which in turn calls
+      -- `readFileConfigYaml` which finally calls `decodeFileEither` from
+      -- the `yaml` library.  Annoyingly that function catches async
+      -- exceptions and in particular, it ends up catching
+      -- `ThreadKilled`. So, we have to mask to stop it from doing that.
+      parseSettings f = mask $ \unmask ->
+           findSettings (unmask . const (return (f, Nothing))) (Just f)
+      foldMapM f = foldlM (\acc a -> do w <- f a; return $! mappend acc w) mempty
 
 getHlintSettingsRule :: HlintUsage -> Rules ()
 getHlintSettingsRule usage =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -32,6 +32,7 @@ import Development.Shake hiding (Diagnostic, Env)
 import "ghc-lib" GHC
 import "ghc-lib-parser" Module (stringToUnitId, UnitId(..), DefUnitId(..))
 import Safe
+import System.IO.Error
 import System.Directory.Extra
 import System.FilePath
 
@@ -572,14 +573,28 @@ encodeModuleRule =
 
 hlintSettings :: FilePath -> IO ([Classify], Hint)
 hlintSettings hlintDataDir = do
-  -- `findSettings` ends up calling `readFilesConfig` which in turn
-  -- calls `readFileConfigYaml` which finally calls `decodeFileEither`
-  -- from the `yaml` library.  Annoyingly that function catches async
-  -- exceptions and in particular, it ends up catching `ThreadKilled`.
-  -- So, we have to mask to stop it from doing that.
-  (_, classify, hints) <- mask $ \unmask ->
-    findSettings (unmask . readSettingsFile (Just hlintDataDir)) Nothing
-  return (classify, hints)
+  curdir <- getCurrentDirectory
+  home <- catchIOError ((:[]) <$> getHomeDirectory) (const $ return [])
+  dlintYaml <-
+    findM System.Directory.Extra.doesFileExist $
+      map (</> ".dlint.yaml") (ancestors curdir ++ home)
+  -- `findSettings` calls `readFilesConfig` which in turn calls
+  -- `readFileConfigYaml` which finally calls `decodeFileEither` from
+  -- the `yaml` library.  Annoyingly that function catches async
+  -- exceptions and in particular, it ends up catching
+  -- `ThreadKilled`. So, we have to mask to stop it from doing that.
+  let hlintYaml = hlintDataDir </> "hlint.yaml"
+  (_, cs, hs) <-
+    mask $ \unmask ->
+      findSettings (unmask . const (return (hlintYaml, Nothing))) (Just hlintYaml)
+  (_, cs', hs') <- case dlintYaml of
+    Just dlintYaml' ->
+      mask $ \unmask ->
+        findSettings (unmask . const (return (dlintYaml', Nothing))) (Just dlintYaml')
+    Nothing -> return (mempty, mempty, mempty)
+  return (cs <> cs', hs <> hs')
+  where
+    ancestors = init . map joinPath . reverse . inits . splitPath
 
 getHlintSettingsRule :: HlintUsage -> Rules ()
 getHlintSettingsRule usage =


### PR DESCRIPTION
This PR adds support for customizing linting via `.dlint.yaml` files (I chose `.dlint.yaml` rather than `.hlint.yaml` to avoid colliding with Haskell developer configs).

The logic for finding a `.dlint.yaml` is the same as hlint's i.e. search the current directory and its ancestors and lastly the user's `$HOME`. This should work out well for the IDE since one presumes the current working directory is wherever `daml studio` has been invoked from. 

You can test it like this, add a `$HOME/.dlint.yaml` with contents
```yaml
- ignore: {name: Use newtype instead of data}
```
then run  `bazel run //compiler/damlc/tests:shake -- --pattern=`. You'll observe the following test failure:
```
      compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs:54:
      Shake test resulted in an error: Left (ExpectedDiagnostics [(DsInfo,(NormalizedFilePath "/private/var/folders/kc/bjk2hzwx6bv07jz_s80wjh7w0000gn/T/shake-api-test-cf2ad069bb5c9b28/Foo.daml",4,0),"Suggestion: Use newtype")] [])
```

When we land this we should be in good shape for enabling linting in the IDE! 🚀 