### PR TITLE
bump default size from 4Mib to 16Mib

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/LedgerApiServer.scala
@@ -114,6 +114,7 @@ private class LedgerApiServer(
     builder.workerEventLoopGroup(workerEventLoopGroup)
     builder.permitKeepAliveTime(10, TimeUnit.SECONDS)
     builder.permitKeepAliveWithoutCalls(true)
+    builder.maxInboundMessageSize(16777216) //4x of default one of 4194304
     val grpcServer = apiServices.services.foldLeft(builder)(_ addService _).build
     try {
       grpcServer.start()


### PR DESCRIPTION
In our internal test grid we found that default size of `4MiB` is not sufficient for most of use cases and I would like to request a bump.