### PR TITLE
Unhide GHC.Classes docs and move them to Prelude.

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Classes.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Classes.daml
@@ -25,7 +25,7 @@
 
 {-# OPTIONS_HADDOCK hide #-}
 daml 1.2
--- | HIDE
+-- | MOVE Prelude
 
 --------------------------------------------------------------------------------
 --
@@ -66,7 +66,7 @@ infixr 2  ||
 
 default ()              -- Double isn't available yet
 
--- | The syntax `?x :: a` is desugared into `IP "x" a`
+-- | HIDE The syntax `?x :: a` is desugared into `IP "x" a`
 -- IP is declared very early, so that libraries can take
 -- advantage of the implicit-call-stack feature
 class IP (x : Symbol) a | x -> a where


### PR DESCRIPTION
* Unhide GHC.Classes docs and move them to Prelude. These were hidden a long time ago for some reason (it was pre-repo move). This makes the docs for `Eq` and `Ord` visible, as well as `not`, `&&` and `||`.
* Hiding `IP` since it doesn't seem like something we want in the DAML stdlib docs.