### PR TITLE
Daml-lf: update release note with changes in Protobuf archive definition

### DIFF
--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -33,7 +33,7 @@
 //        2019-06-12: Add Package.interned_package_ids and PackageRef.interned_id
 //        2019-07-04: Transaction submitters must be in contract key maintainers when looking up. See #1866.
 // * dev (special staging area for the next version to be released)
-//        2019-07-04: no change yet.
+//        2019-07-29: Rename DECIMAL in NUMERIC. Add nat kind and nat types
 
 syntax = "proto3";
 package daml_lf_1;

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -80,6 +80,11 @@ DAML Compiler
 
 - Support reading of DAML-LF 1.5 again.
 
+DAML-LF
+~~~~~~~
+
+- **Breaking** Rename ``DECIMAL`` by ``NUMERIC`` in archive Protobuf definition.
+
 Ledger API
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This PR update the releases note with breaking change in LF archive protobuf definition changes (See #2289).

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
