### PR TITLE
Multiple sandbox resets scala test

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
@@ -13,9 +13,11 @@ import com.digitalasset.ledger.api.testing.utils.{
   SuiteResourceManagementAroundEach,
   MockMessages => M
 }
+import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.event.CreatedEvent
+import com.digitalasset.platform.apitesting.LedgerContext
 import com.digitalasset.platform.apitesting.MultiLedgerFixture
 import com.digitalasset.platform.common.LedgerIdMode
 import com.digitalasset.platform.sandbox.services.TestCommands
@@ -25,6 +27,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{AsyncWordSpec, Matchers, Suite}
+import scala.concurrent.Future
 
 class ResetServiceIT
     extends AsyncWordSpec
@@ -62,6 +65,24 @@ class ResetServiceIT
         } yield {
           lid1 should not equal lid2
           IsStatusException(Status.Code.NOT_FOUND)(throwable)
+        }
+      }
+
+      "return new ledger ID - multiple resets" in allFixtures { initialCtx =>
+        case class Acc(ctx: LedgerContext, lids: List[LedgerId])
+
+        val resets = (1 to 20).foldLeft(Future.successful(Acc(initialCtx, List.empty))) {
+          (eventualAcc, _) =>
+            for {
+              acc <- eventualAcc
+              nCtx <- acc.ctx.reset()
+              lid = nCtx.ledgerId
+              lids = acc.lids :+ lid
+            } yield Acc(nCtx, lids)
+        }
+
+        resets.flatMap { acc =>
+          acc.lids.toSet should have size acc.lids.size.toLong
         }
       }
 


### PR DESCRIPTION
Adds a missing sandbox multiple reset test similar to one present in Haskell Ledger Bindings.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
