### PR TITLE
Sandbox ledger reset test sleep

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
+++ b/ledger/ledger-api-integration-tests/src/test/itsuite/scala/com/digitalasset/platform/tests/integration/ledger/api/ResetServiceIT.scala
@@ -13,9 +13,11 @@ import com.digitalasset.ledger.api.testing.utils.{
   SuiteResourceManagementAroundEach,
   MockMessages => M
 }
+import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.event.CreatedEvent
+import com.digitalasset.platform.apitesting.LedgerContext
 import com.digitalasset.platform.apitesting.MultiLedgerFixture
 import com.digitalasset.platform.common.LedgerIdMode
 import com.digitalasset.platform.sandbox.services.TestCommands
@@ -25,6 +27,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{AsyncWordSpec, Matchers, Suite}
+import scala.concurrent.Future
 
 class ResetServiceIT
     extends AsyncWordSpec
@@ -62,6 +65,24 @@ class ResetServiceIT
         } yield {
           lid1 should not equal lid2
           IsStatusException(Status.Code.NOT_FOUND)(throwable)
+        }
+      }
+
+      "return new ledger ID - multiple resets" in allFixtures { initialCtx =>
+        case class Acc(ctx: LedgerContext, lids: List[LedgerId])
+
+        val resets = (1 to 20).foldLeft(Future.successful(Acc(initialCtx, List.empty))) {
+          (eventualAcc, _) =>
+            for {
+              acc <- eventualAcc
+              nCtx <- acc.ctx.reset()
+              lid = nCtx.ledgerId
+              lids = acc.lids :+ lid
+            } yield Acc(nCtx, lids)
+        }
+
+        resets.flatMap { acc =>
+          acc.lids.toSet should have size acc.lids.size.toLong
         }
       }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -289,6 +289,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
   override def close(): Unit = sandboxState.close()
 
   private def writePortFile(port: Int): Unit = {
+    Thread.sleep(1000)
     config.portFile.foreach { f =>
       val w = new FileWriter(f)
       w.write(s"$port\n")


### PR DESCRIPTION
**Only for CI tests - do not merge.**

Tests https://github.com/digital-asset/daml/pull/2337 with enforced sleep in sandbox server startup.