### PR TITLE
Enable linting in the IDE!

### DIFF
--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -132,7 +132,7 @@ pattern EventVirtualResourceNoteSet vr note <-
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
     hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-    options <- mkOptions $ (defaultOptions Nothing){optHlintUsage=HlintEnabled hlintDataDir}
+    options <- mkOptions $ (defaultOptions Nothing){optHlintUsage=HlintEnabled hlintDataDir False}
     virtualResources <- newTVarIO Map.empty
     virtualResourcesNotes <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = do

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -67,7 +67,7 @@ data Options = Options
   } deriving Show
 
 data HlintUsage
-  = HlintEnabled { hlintUseDataDir::FilePath }
+  = HlintEnabled { hlintUseDataDir::FilePath, hlintAllowOverrides::Bool }
   | HlintDisabled
   deriving Show
 
@@ -108,7 +108,7 @@ mkOptions opts@Options {..} = do
     let defaultPkgDbDir = defaultPkgDb </> "pkg-db_dir"
     pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDbDir, projectPackageDatabase]
     case optHlintUsage of
-      HlintEnabled dir -> checkDirExists dir
+      HlintEnabled dir _ -> checkDirExists dir
       HlintDisabled -> return ()
     pure opts {optPackageDbs = map (</> versionSuffix) $ pkgDbs ++ optPackageDbs}
   where checkDirExists f =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -303,11 +303,13 @@ execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
                 Logger.GCP.logOptOut gcpState
                 f loggerH
             Undecided -> f loggerH
+    hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
     opts <- defaultOptionsIO Nothing
     opts <- pure $ opts
         { optScenarioService = enableScenarioService
         , optScenarioValidation = ScenarioValidationLight
         , optThreads = 0
+        , optHlintUsage = HlintEnabled hlintDataDir True
         }
     scenarioServiceConfig <- readScenarioServiceConfig
     withLogger $ \loggerH ->
@@ -353,7 +355,7 @@ execLint inputFile opts =
         runAction ide $ getHlintIdeas inputFile
         diags <- getDiagnostics ide
         if null diags then
-          hPutStrLn stderr "No hints."
+          hPutStrLn stderr "No hints"
         else
           exitFailure
   where
@@ -362,8 +364,8 @@ execLint inputFile opts =
        defaultDir <-locateRunfiles $
          mainWorkspace </> "compiler/damlc/daml-ide-core"
        return $ case optHlintUsage opts of
-         HlintEnabled _ -> opts
-         HlintDisabled  -> opts{optHlintUsage=HlintEnabled defaultDir}
+         HlintEnabled _ _ -> opts
+         HlintDisabled  -> opts{optHlintUsage=HlintEnabled defaultDir True}
 
 newtype DumpPom = DumpPom{unDumpPom :: Bool}
 

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -338,10 +338,15 @@ enableScenarioOpt = EnableScenarioService <$>
     flagYesNoAuto "scenarios" True "Enable/disable support for running scenarios" idm
 
 hlintEnabledOpt :: Parser HlintUsage
-hlintEnabledOpt = HlintEnabled <$> strOption
+hlintEnabledOpt = HlintEnabled
+  <$> strOption
   ( long "with-hlint"
     <> metavar "DIR"
-    <> help "Enable hlint with hlint.yaml directory"
+    <> help "Enable hlint with 'hlint.yaml' directory"
+  )
+  <*> switch
+  ( long "allow-overrides"
+    <> help "Allow 'dlint.yaml' configuration overrides"
   )
 
 hlintDisabledOpt :: Parser HlintUsage


### PR DESCRIPTION
This PR:
  - adds a new hlint command line switch : `allowOverrides`;
  - the shake IDE tests continue to enable hlint but DOES NOT allow linting to be influenced by `.dlint.yaml` files (currently the only test that enables linting otherwise everywhere disabled);
 - the `damlc lint FILE` command DOES allow linting to be influenced by `dlint.yaml` files;
 - the IDE enables linting and DOES allow lintining to be influenced by `.dlint.yaml` files.

We propose that in the next PR, we add a global ignore for `Use newtype instead of data` to `hlint.yaml` and (try to) enable linting across all tests (but not allowing test outcomes to be influenced by `.dlint.yaml` files).

