### PR TITLE
hlint.yaml => dlint.yaml;  globally disable "use newtype" hint

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -528,7 +528,7 @@ hazel_repositories(
             #   - To build the library : `bazel build @haskell_hlint//:lib`
             # We'll be using it via the library, not the binary.
             hazel_hackage("haskell-src-exts", "1.21.0", "95dac187824edfa23b6a2363880b5e113df8ce4a641e8a0f76e6d45aaa699ff3") +
-            hazel_github_external("digital-asset", "hlint", "ba2fcd7d926ca6d365a4d0b2c6bc001f84d022b6", "c2693600d7b5912c763907d76eb91fc432a74355e5646313ba1097513340d8fe") +
+            hazel_github_external("digital-asset", "hlint", "b007fb1f9acfb1342af57d07c96149235e105b50", "61fdbd214a101653ac21cfdfd7da34e4ad4dacfe74dc841dbd782622213bff57") +
             hazel_github_external("awakesecurity", "proto3-wire", "43d8220dbc64ef7cc7681887741833a47b61070f", "1c3a7fbf4ab3308776675c6202583f9750de496757f3ad4815e81edd122d75e1") +
             hazel_github_external("awakesecurity", "proto3-suite", "dd01df7a3f6d0f1ea36125a67ac3c16936b53da0", "59ea7b876b14991347918eefefe24e7f0e064b5c2cc14574ac4ab5d6af6413ca") +
             hazel_hackage("happy", "1.19.10", "22eb606c97105b396e1c7dc27e120ca02025a87f3e44d2ea52be6a653a52caed") +

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -17,7 +17,7 @@ da_haskell_binary(
         "-optl-pthread",
     ] if is_windows else [],
     data = [
-        "//compiler/damlc/daml-ide-core:hlint.yaml",
+        "//compiler/damlc/daml-ide-core:dlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],
@@ -58,7 +58,7 @@ package_app(
     binary = ":damlc",
     resources = [
         ":ghc-pkg-dist",
-        "//compiler/damlc/daml-ide-core:hlint.yaml",
+        "//compiler/damlc/daml-ide-core:dlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -6,12 +6,12 @@ load(
     "da_haskell_library",
 )
 
-exports_files(["hlint.yaml"])
+exports_files(["dlint.yaml"])
 
 da_haskell_library(
     name = "daml-ide-core",
     srcs = glob(["src/**/*.hs"]),
-    data = [":hlint.yaml"],
+    data = [":dlint.yaml"],
     hazel_deps = [
         "aeson",
         "base",

--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -210,6 +210,15 @@
     - warn: {lhs: zipWith f (repeat x), rhs: map (f x)}
     - warn: {lhs: zipWith f y (repeat z), rhs: map (\x -> f x z) y}
 
+    # MONOIDS
+
+    - warn: {lhs: mempty <> x, rhs: x, name: "Monoid law, left identity"}
+    - warn: {lhs: mempty `mappend` x, rhs: x, name: "Monoid law, left identity"}
+    - warn: {lhs: x <> mempty, rhs: x, name: "Monoid law, right identity"}
+    - warn: {lhs: x `mappend` mempty, rhs: x, name: "Monoid law, right identity"}
+    - warn: {lhs: foldr (<>) mempty, rhs: mconcat}
+    - warn: {lhs: foldr mappend mempty, rhs: mconcat}
+
     # TRAVERSABLES
 
     - warn: {lhs: sequenceA (map f x), rhs: traverse f x}
@@ -441,6 +450,8 @@
     - warn: {lhs: Just <$> a <|> pure Nothing, rhs: optional a}
     - hint: {lhs: m >>= pure . f, rhs: f <$> m}
     - hint: {lhs: pure . f =<< m, rhs: f <$> m}
+    - warn: {lhs: empty <|> x, rhs: x, name: "Alternative law, left identity"}
+    - warn: {lhs: x <|> empty, rhs: x, name: "Alternative law, right identity"}
 
 
     # LIST COMP
@@ -504,7 +515,7 @@
     - warn: {lhs: maybe x f (fmap g y), rhs: maybe x (f . g) y, name: Redundant fmap}
     - warn: {lhs: isJust (fmap f x), rhs: isJust x}
     - warn: {lhs: isNothing (fmap f x), rhs: isNothing x}
-    - warn: {lhs: fromJust (fmap f x), rhs: f (fromJust x)}
+    - warn: {lhs: fromJust (fmap f x), rhs: f (fromJust x), note: IncreasesLaziness}
     - warn: {lhs: mapMaybe f (fmap g x), rhs: mapMaybe (f . g) x, name: Redundant fmap}
 
     # EITHER
@@ -965,3 +976,8 @@
 # foo = typeOf (undefined :: a) -- typeRep (Proxy :: Proxy a)
 # {-# RULES "Id-fmap-id" forall (x :: Id a). fmap id x = x #-}
 # </TEST>
+
+# --
+# DAML specific
+
+- ignore: {name: Use newtype instead of data}

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -583,7 +583,7 @@ hlintSettings hlintDataDir enableOverrides = do
       else
         return Nothing
     (_, cs, hs) <- foldMapM parseSettings $
-      (hlintDataDir </> "hlint.yaml") : maybeToList dlintYaml
+      (hlintDataDir </> "dlint.yaml") : maybeToList dlintYaml
     return (cs, hs)
     where
       ancestors = init . map joinPath . reverse . inits . splitPath

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -26,6 +26,7 @@ module Development.IDE.Core.API.Testing
     , expectOneError
     , expectOnlyErrors
     , expectNoErrors
+    , expectDiagnostic
     , expectOnlyDiagnostics
     , expectNoDiagnostics
     , expectGoToDefinition

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -342,11 +342,11 @@ hlintEnabledOpt = HlintEnabled
   <$> strOption
   ( long "with-hlint"
     <> metavar "DIR"
-    <> help "Enable hlint with 'hlint.yaml' directory"
+    <> help "Enable linting with 'dlint.yaml' directory"
   )
   <*> switch
   ( long "allow-overrides"
-    <> help "Allow 'dlint.yaml' configuration overrides"
+    <> help "Allow '.dlint.yaml' configuration overrides"
   )
 
 hlintDisabledOpt :: Parser HlintUsage

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -449,6 +449,17 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
             -- Bool is from GHC.Types which is wired into the compiler
             expectGoToDefinition (foo,2,[20]) Missing
 
+    ,   testCase' "Suggest imports can be simplified" $ do
+            foo <- makeFile "Foo.daml" $ T.unlines
+                [ "daml 1.2"
+                , "module Foo where"
+                , "import DA.Optional"
+                , "import DA.Optional(fromSome)"
+                ]
+            setFilesOfInterest [foo]
+            expectNoErrors
+            expectDiagnostic DsInfo (foo, 2, 0) "Warning: Use fewer imports"
+
     ,   testCase' "Go to definition takes export list to definition" $ do
             foo <- makeFile "Foo.daml" $ T.unlines
                 [ "daml 1.2"
@@ -459,13 +470,13 @@ goToDefinitionTests mbScenarioService = Tasty.testGroup "Go to definition tests"
                 ]
             setFilesOfInterest [foo]
             expectNoErrors
-            expectOnlyDiagnostics [(DsInfo, (foo, 4, 0), "Suggestion: Use newtype")] -- hlint!
             -- foo
             expectGoToDefinition (foo,1,[13..14]) (At (foo,3,0))
             -- A
             expectGoToDefinition (foo,1,[17..17]) (At (foo,4,0))
             -- B
             expectGoToDefinition (foo,1,[19..19]) (At (foo,4,9))
+
     ,    testCase' "Cross-package goto definition" $ do
             foo <- makeModule "Foo"
                 [ "test = scenario do"


### PR DESCRIPTION
Sync with latest hlint. Rename `hlint.yaml`, `dlint.yaml`. Globally disable the "Use newtype instead of data" hint. Write a new test for linting in the shake IDE and remove the now redundant old one.