### PR TITLE
Enable linting in 'defaultOptionsIO'

### DIFF
--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -40,7 +40,6 @@ module Development.IDE.Core.API.Testing
     ) where
 
 -- * internal dependencies
-import DA.Bazel.Runfiles
 import qualified Development.IDE.Core.API         as API
 import qualified Development.IDE.Types.Diagnostics as D
 import qualified Development.IDE.Types.Location as D
@@ -132,8 +131,7 @@ pattern EventVirtualResourceNoteSet vr note <-
 -- | Run shake test on freshly initialised shake service.
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
-    hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-    options <- mkOptions $ (defaultOptions Nothing){optHlintUsage=HlintEnabled hlintDataDir False}
+    options <- defaultOptionsIO Nothing
     virtualResources <- newTVarIO Map.empty
     virtualResourcesNotes <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = do

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -116,11 +116,14 @@ mkOptions opts@Options {..} = do
           unless ok $ fail $ "Required directory does not exist: " <> f
         versionSuffix = renderPretty optDamlLfVersion
 
--- | Default configuration for the compiler with package database set according to daml-lf version
--- and located runfiles. If the version argument is Nothing it is set to the default daml-lf
--- version.
+-- | Default configuration for the compiler with package database set
+-- according to daml-lf version and located runfiles. If the version
+-- argument is Nothing it is set to the default daml-lf
+-- version. Linting is enabled but not '.dlint.yaml' overrides.
 defaultOptionsIO :: Maybe LF.Version -> IO Options
-defaultOptionsIO mbVersion = mkOptions $ defaultOptions mbVersion
+defaultOptionsIO mbVersion = do
+  hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+  mkOptions $ (defaultOptions mbVersion){optHlintUsage=HlintEnabled hlintDataDir False}
 
 defaultOptions :: Maybe LF.Version -> Options
 defaultOptions mbVersion =

--- a/compiler/damlc/tests/daml-test-files/LogicTest.daml
+++ b/compiler/damlc/tests/daml-test-files/LogicTest.daml
@@ -7,7 +7,7 @@ module LogicTest where
 import DA.Logic
 import DA.Assert
 
-proposition_test = scenario do
+propositionTest = scenario do
   let
     p = Proposition 1
     q = Proposition 2
@@ -31,7 +31,7 @@ proposition_test = scenario do
   Left r === interpret truth (q ||| r)
   interpret truth ( p &&& r) === Left r
 
-dnf_test = scenario do
+dnfTest = scenario do
   Disjunction [Conjunction[Proposition 1]] === (toDNF $ Proposition 1)
   Disjunction [Conjunction[Proposition 1]] === (toDNF $ Conjunction[Proposition 1])
   Disjunction [Conjunction[Negation $ Proposition 1]] === (toDNF $ Negation . Proposition $ 1)


### PR DESCRIPTION
This turns on linting in `defaultOptionsIO` (but does not enable overrides via `.dlint.yaml` files). 
This means compiler tests now include linting (and one flagged test is fixed in this PR accordingly).