### PR TITLE
Add a Stack based pipeline for testing hie-core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,44 @@ jobs:
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 
+  - job: hie_core_stack_86
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - template: ci/report-start.yml
+      - checkout: self
+      - task: CacheBeta@0
+        inputs:
+          key: |
+            "stack-cache-v1"
+            $(Agent.OS)
+            $(Build.SourcesDirectory)/compiler/hie-core/stack.yaml
+            $(Build.SourcesDirectory)/compiler/hie-core/hie-core.cabal
+          path: .azure-cache
+          cacheHitVar: CACHE_RESTORED
+        displayName: "Cache stack artifacts"
+      - bash: |
+          mkdir -p ~/.stack
+          tar xzf .azure-cache/stack-root.tar.gz -C $HOME
+        displayName: "Unpack cache"
+        condition: eq(variables.CACHE_RESTORED, 'true')
+      - bash: |
+          sudo apt-get install -y g++ gcc libc6-dev libffi-dev libgmp-dev make zlib1g-dev
+          curl -sSL https://get.haskellstack.org/ | sh
+        displayName: 'Install Stack'
+      - bash: (cd compiler/hie-core; stack setup)
+        displayName: 'stack setup'
+      - bash: (cd compiler/hie-core; stack build --only-dependencies)
+        displayName: 'stack build --only-dependencies --test'
+      - bash: (cd compiler/hie-core; stack test)
+        displayName: 'stack test'
+      - bash: |
+          mkdir -p .azure-cache
+          tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
+        displayName: "Pack cache"
+      - template: ci/tell-slack-failed.yml
+      - template: ci/report-end.yml
   - job: Windows_signing
     # Signing is a separate job so that we can make sure that we only sign on releases.
     # Since the release check is run on Linux, we do not have access to that information

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -54,6 +54,11 @@ library
         transformers,
         unordered-containers,
         utf8-string
+    if !os(windows)
+      build-depends:
+        unix
+      c-sources:
+        cbits/getmodtime.c
 
     cpp-options: -DGHC_STABLE
     default-extensions:

--- a/compiler/hie-core/stack.yaml
+++ b/compiler/hie-core/stack.yaml
@@ -14,3 +14,4 @@ extra-deps:
   commit: 8427e424a83c2f3d60bdd26c02478c00d2189a73
 nix:
   packages: [zlib]
+allow-newer: true


### PR DESCRIPTION
This is in preparation for #2326 as well as for splitting hie-core
into a separate repo. Given that, it explicitely avoids using our
dev-env.

We do need to install a few system packages, so for now this uses the
hosted builder so we can do this. Another option would be to just add
those to our builders. I don’t really have a preference either
way. The cached builds are < 5 minutes so I don’t expect issues from using
the hosted builders.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
