### PR TITLE
Optimize mangleIdentifier

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiWayIf #-}
 module DA.Daml.LF.Mangling (mangleIdentifier, unmangleIdentifier) where
 
+import Data.Bits
 import Data.Char
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -74,7 +75,8 @@ mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
             let poke !j !minj !x
                   | j < minj = pure ()
                   | otherwise = do
-                        let !(!x', !r) = quotRem x 16
+                        let !x' = x `unsafeShiftR` 4
+                        let !r = x .&. 0xF
                         TA.unsafeWrite a j (fromIntegral $ ord $ intToDigit r)
                         poke (j - 1) minj x'
                 go !i !t = case T.uncons t of

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -7,8 +7,11 @@ module DA.Daml.LF.Mangling (mangleIdentifier, unmangleIdentifier) where
 import Data.Char
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import Text.Printf (printf)
-  
+import qualified Data.Text.Internal as T (text)
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Array as TA
+import Data.Word
+
 -- DAML-LF talks about *identifier* to build up different kind of
 -- names.
 --
@@ -46,29 +49,61 @@ isAllowedStart c = c == '_' || isAsciiLetter c
 isAllowedPart :: Char -> Bool
 isAllowedPart c = c == '_' || isAsciiLetter c || isDigit c
 
-mangleIdentifier :: T.Text -> Either String String
-mangleIdentifier txt = case T.unpack txt of
-    [] -> Left "Empty identifier"
-    ch : chs -> Right $ escapeStart ch ++ concatMap escapePart chs
+data MangledSize = MangledSize
+    { _unmangledChars :: !Int
+    , _mangledWord16s :: !Int
+    }
 
-escapeStart :: Char -> String
-escapeStart ch = if
-  | ch == '$' -> "$$"
-  | isAllowedStart ch -> [ch]
-  | otherwise -> escapeChar ch
+ord' :: Char -> Word16
+ord' = fromIntegral . ord
 
-escapePart :: Char -> String
-escapePart ch = if
-  | ch == '$' -> "$$"
-  | isAllowedPart ch -> [ch]
-  | otherwise -> escapeChar ch
-
-escapeChar :: Char -> String
-escapeChar ch = let 
-  codePoint = fromEnum ch
-  in if codePoint > 0xFFFF
-    then printf "$U%08x" codePoint
-    else printf "$u%04x" codePoint
+-- | We spend a fair amount of time in encodeModule which in turn calls
+-- `mangleIdentifier` all over the place so we use a heavily optimized implementation.
+-- In particular, we optimize for the case where don’t have to do any mangling and
+-- can avoid allocating new `Text`s and we optimize the case where we do have to
+-- mangle by preallocating the array of the right size and writing the characters
+-- directly to that.
+mangleIdentifier :: T.Text -> Either String TL.Text
+mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
+    MangledSize 0 _ -> Left "Empty identifier"
+    MangledSize chars word16s
+      | chars == word16s -> Right $! TL.fromStrict txt
+      | otherwise -> Right $! TL.fromStrict $
+        let !arr = TA.run $ do
+            a <- TA.new word16s
+            let poke !j !minj !x
+                  | j < minj = pure ()
+                  | otherwise = do
+                        let !(!x', !r) = quotRem x 16
+                        TA.unsafeWrite a j (fromIntegral $ ord $ intToDigit r)
+                        poke (j - 1) minj x'
+                go !i !t = case T.uncons t of
+                    Nothing -> pure ()
+                    Just (!c, !t')
+                      | isAllowedStart c || i > 0 && isDigit c -> TA.unsafeWrite a i (fromIntegral $ ord c) >> go (i + 1) t'
+                      | c == '$' -> do
+                            TA.unsafeWrite a i (ord' '$')
+                            TA.unsafeWrite a (i + 1) (ord' '$')
+                            go (i + 2) t'
+                      | ord c <= 0xFFFF -> do
+                            TA.unsafeWrite a i (ord' '$')
+                            TA.unsafeWrite a (i + 1) (ord' 'u')
+                            poke (i + 5) (i + 2) (ord c)
+                            go (i + 6) t'
+                      | otherwise -> do
+                            TA.unsafeWrite a i (ord' '$')
+                            TA.unsafeWrite a (i + 1) (ord' 'U')
+                            poke (i + 9) (i + 2) (ord c)
+                            go (i + 10) t'
+            go 0 txt
+            pure a
+        in T.text arr 0 word16s
+    where f :: MangledSize -> Char -> MangledSize
+          f (MangledSize chars word16s) c
+            | isAllowedStart c || chars > 0 && isDigit c = MangledSize (chars + 1) (word16s + 1)
+            | c == '$' = MangledSize 1 (word16s + 2)
+            | ord c > 0xFFFF = MangledSize 1 (word16s + 10)
+            | otherwise = MangledSize 1 (word16s + 6)
 
 unmangleIdentifier :: T.Text -> Either String T.Text
 unmangleIdentifier txt = do

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -55,7 +55,7 @@ encodePackageId = TL.fromStrict . unPackageId
 encodeName :: (a -> T.Text) -> a -> TL.Text
 encodeName unwrapName (unwrapName -> unmangled) = case mangleIdentifier unmangled of
    Left err -> error $ "IMPOSSIBLE: could not mangle name " ++ show unmangled ++ ": " ++ err
-   Right x -> TL.pack x
+   Right x -> x
 
 -- | For now, value names are always encoded version using a single segment.
 --


### PR DESCRIPTION
I am slightly embarassed by importing Data.Text.Internal and
Data.Text.Array. However, this does make a very measurable difference:
On my testcase it brought down the time encoding modules from 22s to
17s, so it’s a 5s improvement.

I did quickcheck this against the old implementation, so I’m confident
it behaves correctly. I also ran some criterion benchmarks to see the
difference and on its own it’s even more of a difference.

https://gist.github.com/cocreature/822114257227473ecff1638a88f07788

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
