### PR TITLE
Make --shake-profiling use the directory based profiling

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -91,7 +91,7 @@ cmdIde =
         "Start the DAML language server on standard input/output."
     <> fullDesc
   where
-    cmd = execIde <$> telemetryOpt <*> debugOpt <*> enableScenarioOpt
+    cmd = execIde <$> telemetryOpt <*> debugOpt <*> enableScenarioOpt <*> shakeProfilingOpt
 
 cmdLicense :: Mod CommandFields Command
 cmdLicense =
@@ -274,8 +274,9 @@ execLicense = B.putStr licenseData
 execIde :: Telemetry
         -> Debug
         -> EnableScenarioService
+        -> Maybe FilePath
         -> Command
-execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
+execIde telemetry (Debug debug) enableScenarioService mbProfileDir = NS.withSocketsDo $ do
     let threshold =
             if debug
             then Logger.Debug
@@ -302,6 +303,7 @@ execIde telemetry (Debug debug) enableScenarioService = NS.withSocketsDo $ do
     opts <- pure $ opts
         { optScenarioService = enableScenarioService
         , optScenarioValidation = ScenarioValidationLight
+        , optShakeProfiling = mbProfileDir
         , optThreads = 0
         , optHlintUsage = HlintEnabled hlintDataDir True
         }
@@ -862,7 +864,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure Nothing
     <*> optHideAllPackages
     <*> many optPackage
-    <*> optShakeProfiling
+    <*> shakeProfilingOpt
     <*> optShakeThreads
     <*> lfVersionOpt
     <*> optDebugLog
@@ -907,12 +909,6 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
       long "hide-all-packages" <>
       internal
 
-    optShakeProfiling :: Parser (Maybe FilePath)
-    optShakeProfiling = optional $ strOption $
-           metavar "PROFILING-REPORT"
-        <> help "Directory for Shake profiling reports"
-        <> long "shake-profiling"
-
     -- optparse-applicative does not provide a nice way
     -- to make the argument for -j optional, see
     -- https://github.com/pcapriotti/optparse-applicative/issues/243
@@ -941,6 +937,12 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
         long "ghc-option" <>
         metavar "OPTION" <>
         help "Options to pass to the underlying GHC"
+
+shakeProfilingOpt :: Parser (Maybe FilePath)
+shakeProfilingOpt = optional $ strOption $
+       metavar "PROFILING-REPORT"
+    <> help "Directory for Shake profiling reports"
+    <> long "shake-profiling"
 
 options :: Int -> Parser Command
 options numProcessors =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -910,7 +910,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     optShakeProfiling :: Parser (Maybe FilePath)
     optShakeProfiling = optional $ strOption $
            metavar "PROFILING-REPORT"
-        <> help "path to Shake profiling report"
+        <> help "Directory for Shake profiling reports"
         <> long "shake-profiling"
 
     -- optparse-applicative does not provide a nice way

--- a/compiler/hie-core/src/Development/IDE/Core/Service.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Service.hs
@@ -50,8 +50,8 @@ initialise mainRule toDiags logger options vfs =
     shakeOpen
         toDiags
         logger
-        (setProfiling options $
-        shakeOptions { shakeThreads = optThreads options
+        (optShakeProfiling options)
+        (shakeOptions { shakeThreads = optThreads options
                      , shakeFiles   = "/dev/null"
                      }) $ do
             addIdeGlobal $ GlobalIdeOptions options
@@ -61,10 +61,6 @@ initialise mainRule toDiags logger options vfs =
 
 writeProfile :: IdeState -> FilePath -> IO ()
 writeProfile = shakeProfile
-
-setProfiling :: IdeOptions -> ShakeOptions -> ShakeOptions
-setProfiling opts shakeOpts =
-  maybe shakeOpts (\p -> shakeOpts { shakeReport = [p], shakeTimings = True }) (optShakeProfiling opts)
 
 -- | Shutdown the Compiler Service.
 shutdown :: IdeState -> IO ()


### PR DESCRIPTION
The single-file based profiling is rather useless in the IDE and I
always found myself having to modify the source to set `profileDir` so
this PR switches the CLI option to control that instead.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
