### PR TITLE
record build times on macos

### DIFF
--- a/ci/report-end.yml
+++ b/ci/report-end.yml
@@ -1,6 +1,6 @@
 steps:
   - bash: |
       set -euo pipefail
-      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -uIs)"
+      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
     condition: always()
     name: end

--- a/ci/report-start.yml
+++ b/ci/report-start.yml
@@ -1,7 +1,7 @@
 steps:
   - bash: |
       set -euo pipefail
-      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -uIs)"
+      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
       echo "##vso[task.setvariable variable=machine;isOutput=true]$(Agent.MachineName)"
     condition: always()
     name: start


### PR DESCRIPTION
Apparently the version of `date` on macOS build nodes does not have the `-I` option.