### PR TITLE
Speed up dependency chasing

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/RuleTypes.hs
@@ -12,14 +12,16 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
-import           Development.IDE.Import.FindImports         (Import(..))
 import           Development.IDE.Import.DependencyInformation
+import Development.IDE.Types.Location
 import           Data.Hashable
 import           Data.Typeable
+import qualified Data.Set as S
 import           Development.Shake                        hiding (Env, newCache)
 import           GHC.Generics                             (Generic)
 
 import           GHC
+import Module (InstalledUnitId)
 import HscTypes (HomeModInfo)
 import Development.IDE.GHC.Compat
 
@@ -66,9 +68,9 @@ type instance RuleResult GenerateCore = CoreModule
 -- | A GHC session that we reuse.
 type instance RuleResult GhcSession = HscEnv
 
--- | Resolve the imports in a module to the list of either external packages or absolute file paths
--- for modules in the same package.
-type instance RuleResult GetLocatedImports = [(Located ModuleName, Maybe Import)]
+-- | Resolve the imports in a module to the file path of a module
+-- in the same package or the package id of another package.
+type instance RuleResult GetLocatedImports = ([(Located ModuleName, Maybe NormalizedFilePath)], S.Set InstalledUnitId)
 
 -- | This rule is used to report import cycles. It depends on GetDependencyInformation.
 -- We cannot report the cycles directly from GetDependencyInformation since


### PR DESCRIPTION
This PR moves as much work as possible to GetLocatedImports which
contracry to GetDependencyInformation is shared between rules.

It’s still slower than it should be and somewhat messy but at least
it’s slightly faster and imho cleaner than before.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
