### PR TITLE
daml deploy, now with party management

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -1,0 +1,51 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+module DA.Daml.Helper.Ledger (
+    HostAndPort(..),
+    listParties, PartyDetails(..), Party(..),
+    lookupParty,
+    allocateParty,
+    uploadDarFile,
+    ) where
+
+import DA.Ledger(LedgerService,PartyDetails(..),Party(..))
+import Data.List.Extra as List
+import Data.String(fromString)
+import qualified DA.Ledger as L
+import qualified Data.ByteString as BS
+import qualified Data.Text.Lazy as Text(pack)
+
+data HostAndPort = HostAndPort { host :: String, port :: Int }
+
+instance Show HostAndPort where
+    show HostAndPort{host,port} = host <> ":" <> show port
+
+listParties :: HostAndPort -> IO [PartyDetails]
+listParties hp = run hp L.listKnownParties
+
+lookupParty :: HostAndPort -> String -> IO (Maybe Party)
+lookupParty hp name = do
+    xs <- listParties hp
+    let text = Text.pack name
+    let pred PartyDetails{displayName,party} = if text == displayName then Just party else Nothing
+    return $ List.firstJust pred xs
+
+allocateParty :: HostAndPort -> String -> IO Party
+allocateParty hp name = run hp $ do
+    let text = Text.pack name
+    let request = L.AllocatePartyRequest
+            { partyIdHint = "" -- text -- ???
+            , displayName = text }
+    PartyDetails{party} <- L.allocateParty request
+    return party
+
+uploadDarFile :: HostAndPort -> BS.ByteString -> IO ()
+uploadDarFile hp bytes = run hp $ do
+    L.uploadDarFile bytes >>= either fail return
+
+run :: HostAndPort -> LedgerService a -> IO a
+run hp ls = do
+    let HostAndPort{host,port} = hp
+    let timeout = 30 :: L.TimeoutSeconds
+    let ledgerClientConfig = L.configOfHostAndPort (L.Host $ fromString host) (L.Port port)
+    L.runLedgerService ls timeout ledgerClientConfig

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -19,10 +19,22 @@ commands:
   path: damlc/damlc
   args: ["build", "--project-check"]
   desc: "Build the DAML project into a DAR file"
+
 - name: deploy
   path: daml-helper/daml-helper
-#  desc: "Build the DAML project and deploy to sandbox"
+  desc: "Build the DAML project and deploy to the ledger"
   args: ["deploy"]
+
+- name: list-parties
+  path: daml-helper/daml-helper
+  desc: "List parties known to the ledger"
+  args: ["list-parties"]
+
+- name: allocate-party
+  path: daml-helper/daml-helper
+  desc: "Allocate named party on the ledger"
+  args: ["allocate-party"]
+
 - name: test
   path: damlc/damlc
   args: ["test"]


### PR DESCRIPTION

WIP: `daml deploy` now with party management
- looking for feedback from @associahedron and Soren Bleikertz

DONE:
- new commands: `daml list-parties`, `daml allocate-party`
- `daml list-parties` reports the parties already allocated on the ledger
- `daml allocate-party` is idempotent, only allocating a new party when it does not already exist
- `daml deploy` is extended to allocate all parties in the config (idempotent) as well as upload the dar
- All commands take `--host` and `--port` flags
- All commands consult `daml.yaml` for `ledger-host` and `ledger-port` settings

TODO:
- navigator startup should take account of mapping shown by `daml list-parties`


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
