### PR TITLE
Fix daml build for usernames with spaces

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -77,7 +77,7 @@ import System.Environment
 import System.Exit
 import System.FilePath
 import System.IO.Extra
-import System.Process(callCommand)
+import System.Process (callProcess)
 import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 
 --------------------------------------------------------------------------------
@@ -437,15 +437,14 @@ createProjectPackageDb lfVersion fps = do
             write path (fromEntry src)
     ghcPkgPath <-
         locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghc-pkg")
-    callCommand $
-        unwords
-            [ ghcPkgPath </> exe "ghc-pkg"
-            , "recache"
-            -- ghc-pkg insists on using a global package db and will trie
-            -- to find one automatically if we don’t specify it here.
-            , "--global-package-db=" ++ (dbPath </> "package.conf.d")
-            , "--expand-pkgroot"
-            ]
+    callProcess
+        (ghcPkgPath </> exe "ghc-pkg")
+        [ "recache"
+        -- ghc-pkg insists on using a global package db and will trie
+        -- to find one automatically if we don’t specify it here.
+        , "--global-package-db=" ++ (dbPath </> "package.conf.d")
+        , "--expand-pkgroot"
+        ]
   where
     write fp bs = createDirectoryIfMissing True (takeDirectory fp) >> BSL.writeFile fp bs
 

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -440,7 +440,7 @@ createProjectPackageDb lfVersion fps = do
     callProcess
         (ghcPkgPath </> exe "ghc-pkg")
         [ "recache"
-        -- ghc-pkg insists on using a global package db and will trie
+        -- ghc-pkg insists on using a global package db and will try
         -- to find one automatically if we don’t specify it here.
         , "--global-package-db=" ++ (dbPath </> "package.conf.d")
         , "--expand-pkgroot"

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -170,7 +170,7 @@ activateDaml env@InstallEnv{..} targetPath = do
         if isWindows
             then writeFile damlBinaryTargetPath $ unlines
                      [ "@echo off"
-                     , damlBinarySourcePath <> " %*"
+                     , "\"" <> damlBinarySourcePath <> "\" %*"
                      ]
             else createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
 


### PR DESCRIPTION
This PR fixes two issues caused by having spaces in your username:

1. On Windows, we need to quote the path to the daml binary in the
batch wrapper (quotes are not valid in usernames, so no need to worry
about escaping them).

2. Invoking ghc-pkg via callCommand broke since shells are
terrible. Luckily, we can easily get away with just using callProcess
here.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
