### PR TITLE
Damldocs qualified flag

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -13,7 +13,7 @@ module DA.Daml.Doc.Driver
 
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Render
-import DA.Daml.Doc.HaddockParse
+import DA.Daml.Doc.Extract
 import DA.Daml.Doc.Transform
 
 import Development.IDE.Types.Location

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -45,6 +45,7 @@ data DamldocOptions = DamldocOptions
     , do_inputFiles :: [NormalizedFilePath]
     , do_docTitle :: Maybe T.Text
     , do_combine :: Bool
+    , do_extractOptions :: ExtractOptions
     }
 
 data InputFormat = InputJson | InputDaml
@@ -82,7 +83,7 @@ inputDocData DamldocOptions{..} = do
             concatMapM (either printAndExit pure) mbData
 
         InputDaml -> onErrorExit . runExceptT $
-            mkDocs do_ideOptions do_inputFiles
+            extractDocs do_extractOptions do_ideOptions do_inputFiles
 
 -- | Output doc data.
 renderDocData :: DamldocOptions -> [ModuleDoc] -> IO ()

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -169,18 +169,25 @@ collectDocs = go Nothing []
 -- 'TypecheckedModule' by 'buildDocCtx'.
 data DocCtx = DocCtx
     { dc_ghcMod :: GHC.Module
+        -- ^ ghc name for current module
     , dc_modname :: Modulename
+        -- ^ name of the current module
     , dc_tcmod :: TypecheckedModule
+        -- ^ typechecked module
     , dc_decls :: [DeclData]
-
+        -- ^ module declarations
     , dc_tycons :: MS.Map Typename TyCon
+        -- ^ types defined in this module
     , dc_datacons :: MS.Map Typename DataCon
+        -- ^ constructors defined in this module
     , dc_ids :: MS.Map Fieldname Id
-
+        -- ^ values defined in this module
     , dc_templates :: Set.Set Typename
+        -- ^ DAML templates defined in this module
     , dc_choices :: MS.Map Typename (Set.Set Typename)
-        -- ^ choices per template
+        -- ^ choices per DAML template defined in this module
     , dc_extractOptions :: ExtractOptions
+        -- ^ command line options that affect the doc extractor
     }
 
 -- | Parsed declaration with associated docs.

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -1,8 +1,11 @@
 -- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-
-module DA.Daml.Doc.HaddockParse(mkDocs) where
+-- | This module extracts docs from DAML modules. It does so by reading
+-- haddock-style comments from the parsed syntax tree and correlating them
+-- with definitions in the typechecked module in order to obtain accurate
+-- type information.
+module DA.Daml.Doc.Extract (mkDocs) where
 
 import DA.Daml.Doc.Types as DDoc
 import DA.Daml.Doc.Anchor as DDoc

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -9,7 +9,7 @@ import           DA.Bazel.Runfiles
 import           DA.Daml.Options
 import           DA.Daml.Options.Types
 
-import DA.Daml.Doc.HaddockParse
+import DA.Daml.Doc.Extract
 import DA.Daml.Doc.Render
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Anchor

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -252,7 +252,10 @@ damldocExpect importPathM testname input check =
           }
 
     -- run the doc generator on that file
-    mbResult <- runExceptT $ mkDocs (toCompileOpts opts') [toNormalizedFilePath testfile]
+    mbResult <- runExceptT $ extractDocs
+        defaultExtractOptions
+        (toCompileOpts opts')
+        [toNormalizedFilePath testfile]
 
     case mbResult of
       Left err -> assertFailure $ unlines

--- a/compiler/damlc/daml-stdlib-src/DA/Text.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Text.daml
@@ -61,7 +61,7 @@ implode : [Text] -> Text
 implode = primitive @"BEImplodeText"
 
 -- | Test for emptiness.
-isEmpty : Text -> Bool
+isEmpty : P.Text -> Bool
 isEmpty = (=="")
 
 -- | Compute the number of symbols in the text.

--- a/compiler/damlc/daml-stdlib-src/DA/Text.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Text.daml
@@ -61,7 +61,7 @@ implode : [Text] -> Text
 implode = primitive @"BEImplodeText"
 
 -- | Test for emptiness.
-isEmpty : P.Text -> Bool
+isEmpty : Text -> Bool
 isEmpty = (=="")
 
 -- | Compute the number of symbols in the text.

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -6,6 +6,7 @@ module DA.Cli.Damlc.Command.Damldoc(cmdDamlDoc) where
 
 import DA.Cli.Options
 import DA.Daml.Doc.Driver
+import DA.Daml.Doc.Extract
 import DA.Daml.Options
 import DA.Daml.Options.Types
 import Development.IDE.Types.Location
@@ -35,6 +36,7 @@ documentation = Damldoc
                 <*> optInclude
                 <*> optExclude
                 <*> optCombine
+                <*> optQualifyTypes
                 <*> argMainFiles
   where
     optInputFormat :: Parser InputFormat
@@ -136,6 +138,11 @@ documentation = Damldoc
         long "combine"
         <> help "Combine all generated docs into a single output file (always on for json and hoogle output)."
 
+    optQualifyTypes :: Parser Bool
+    optQualifyTypes = switch $
+        long "qualify-types"
+        <> help "Fully qualify any non-local types in generated docs."
+
 ------------------------------------------------------------
 
 -- Command Execution
@@ -151,6 +158,7 @@ data CmdArgs = Damldoc { cInputFormat :: InputFormat
                        , cIncludeMods :: [String]
                        , cExcludeMods :: [String]
                        , cCombine :: Bool
+                       , cQualifyTypes :: Bool
                        , cMainFiles :: [FilePath]
                        }
              deriving (Eq, Show, Read)
@@ -168,6 +176,9 @@ exec Damldoc{..} = do
         , do_transformOptions = transformOptions
         , do_docTitle = T.pack <$> cPkgName
         , do_combine = cCombine
+        , do_extractOptions = ExtractOptions
+            { eo_qualifyTypes = cQualifyTypes
+            }
         }
 
   where

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -147,7 +147,7 @@ documentation = Damldoc
     optQualifyTypes = option readQualifyTypes $
         long "qualify-types"
         <> metavar "MODE"
-        <> help "Qualify any non-local types in generated docs. Can be set to \"always\" (always qualify non-local types), \"never\" (never qualify non-local types), and \"inpackage\" (qualify non-local types defined in the same package)."
+        <> help "Qualify any non-local types in generated docs. Can be set to \"always\" (always qualify non-local types), \"never\" (never qualify non-local types), and \"inpackage\" (qualify non-local types defined in the same package). Defaults to \"never\"."
 
     readQualifyTypes =
         eitherReader $ \arg ->
@@ -155,7 +155,7 @@ documentation = Damldoc
                 "always" -> Right QualifyTypesAlways
                 "inpackage" -> Right QualifyTypesInPackage
                 "never" -> Right QualifyTypesNever
-                _ -> Left "Unknown mode for --qualify-types flag. Expected 'always', 'inpackage', or 'never'."
+                _ -> Left "Unknown mode for --qualify-types. Expected \"always\", \"never\", or \"inpackage\"."
 
     optSimplifyQualifiedTypes :: Parser Bool
     optSimplifyQualifiedTypes = switch $

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -147,7 +147,12 @@ documentation = Damldoc
     optQualifyTypes = option readQualifyTypes $
         long "qualify-types"
         <> metavar "MODE"
-        <> help "Qualify any non-local types in generated docs. Can be set to \"always\" (always qualify non-local types), \"never\" (never qualify non-local types), and \"inpackage\" (qualify non-local types defined in the same package). Defaults to \"never\"."
+        <> help ("Qualify any non-local types in generated docs. " <> 
+            "Can be set to \"always\" (always qualify non-local types), " <>
+            "\"never\" (never qualify non-local types), " <> 
+            "and \"inpackage\" (qualify non-local types defined in the "<> 
+            "same package). Defaults to \"never\".")
+         <> value QualifyTypesNever
 
     readQualifyTypes =
         eitherReader $ \arg ->

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -147,12 +147,14 @@ documentation = Damldoc
     optQualifyTypes = option readQualifyTypes $
         long "qualify-types"
         <> metavar "MODE"
-        <> help ("Qualify any non-local types in generated docs. " <> 
-            "Can be set to \"always\" (always qualify non-local types), " <>
-            "\"never\" (never qualify non-local types), " <> 
-            "and \"inpackage\" (qualify non-local types defined in the "<> 
-            "same package). Defaults to \"never\".")
+        <> help
+            ("Qualify any non-local types in generated docs. "
+            <> "Can be set to \"always\" (always qualify non-local types), "
+            <> "\"never\" (never qualify non-local types), "
+            <> "and \"inpackage\" (qualify non-local types defined in the "
+            <> "same package). Defaults to \"never\".")
          <> value QualifyTypesNever
+         <> internal
 
     readQualifyTypes =
         eitherReader $ \arg ->
@@ -166,6 +168,7 @@ documentation = Damldoc
     optSimplifyQualifiedTypes = switch $
         long "simplify-qualified-types"
         <> help "Simplify qualified types by dropping the common module prefix. See --qualify-types option."
+        <> internal
 
 ------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #2390 to some extent, by providing options to control how damldocs qualifies types:

* adds a `--qualify-types` option to control whether non-local types are qualified:

  * `--qualify-types=always` will qualify every non-local type
  * `--qualify-types=inpackage` will qualify every non-local type defined in the same package
  * `--qualify-types=never` will never qualify types (default)

* adds a `--simplify-qualified-types` flag which will drop the common module prefix when qualifying a type with `--qualify-types`. This  means that `Foo.Bar.Baz.X` will be rendered as `Baz.X` inside the docs for the module `Foo.Bar` or `Foo.Bar.Qux`, instead of being rendered as `Foo.Bar.Baz.X`.

