### PR TITLE
Hide daml deploy interface temporarily.

### DIFF
--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -19,22 +19,18 @@ commands:
   path: damlc/damlc
   args: ["build", "--project-check"]
   desc: "Build the DAML project into a DAR file"
-
 - name: deploy
   path: daml-helper/daml-helper
-  desc: "Build the DAML project and deploy to the ledger"
+#  desc: "Build the DAML project and deploy to the ledger"
   args: ["deploy"]
-
 - name: list-parties
   path: daml-helper/daml-helper
-  desc: "List parties known to the ledger"
+#  desc: "List parties known to the ledger"
   args: ["list-parties"]
-
 - name: allocate-party
   path: daml-helper/daml-helper
-  desc: "Allocate named party on the ledger"
+#  desc: "Allocate named party on the ledger"
   args: ["allocate-party"]
-
 - name: test
   path: damlc/damlc
   args: ["test"]


### PR DESCRIPTION
The command-line interface for `daml deploy` is unstable / a work in progress. It's not a good idea to make it visible to the public before it resembles its final form, so this PR hides the commands associated w/ daml deploy temporarily.