### PR TITLE
hlint => dlint everywhere

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -158,22 +158,22 @@ data GetOpenVirtualResources = GetOpenVirtualResources
 instance Hashable GetOpenVirtualResources
 instance NFData   GetOpenVirtualResources
 
-data GetHlintSettings = GetHlintSettings
+data GetDlintSettings = GetDlintSettings
     deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetHlintSettings
-instance NFData   GetHlintSettings
+instance Hashable GetDlintSettings
+instance NFData   GetDlintSettings
 instance NFData Hint where rnf = rwhnf
 instance NFData Classify where rnf = rwhnf
 instance Show Hint where show = const "<hint>"
 
-type instance RuleResult GetHlintSettings = ([Classify], Hint)
+type instance RuleResult GetDlintSettings = ([Classify], Hint)
 
-data GetHlintDiagnostics = GetHlintDiagnostics
+data GetDlintDiagnostics = GetDlintDiagnostics
     deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetHlintDiagnostics
-instance NFData   GetHlintDiagnostics
+instance Hashable GetDlintDiagnostics
+instance NFData   GetDlintDiagnostics
 
-type instance RuleResult GetHlintDiagnostics = ()
+type instance RuleResult GetDlintDiagnostics = ()
 
 data GenerateDocTestModule = GenerateDocTestModule
     deriving (Eq, Show, Typeable, Generic)

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -5,7 +5,7 @@ module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
     , ScenarioValidation(..)
-    , HlintUsage(..)
+    , DlintUsage(..)
     , defaultOptionsIO
     , defaultOptions
     , mkOptions
@@ -58,17 +58,17 @@ data Options = Options
     -- ^ Controls whether the scenario service server runs all checks
     -- or only a subset of them. This is mostly used to run additional
     -- checks on CI while keeping the IDE fast.
-  , optHlintUsage :: HlintUsage
-  -- ^ Information about hlint usage.
+  , optDlintUsage :: DlintUsage
+  -- ^ Information about dlint usage.
   , optIsGenerated :: Bool
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
   , optCoreLinting :: Bool
     -- ^ Whether to enable linting of the generated GHC Core. (Used in testing.)
   } deriving Show
 
-data HlintUsage
-  = HlintEnabled { hlintUseDataDir::FilePath, hlintAllowOverrides::Bool }
-  | HlintDisabled
+data DlintUsage
+  = DlintEnabled { dlintUseDataDir :: FilePath, dlintAllowOverrides :: Bool }
+  | DlintDisabled
   deriving Show
 
 data ScenarioValidation
@@ -107,9 +107,9 @@ mkOptions opts@Options {..} = do
     defaultPkgDb <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "pkg-db")
     let defaultPkgDbDir = defaultPkgDb </> "pkg-db_dir"
     pkgDbs <- filterM Dir.doesDirectoryExist [defaultPkgDbDir, projectPackageDatabase]
-    case optHlintUsage of
-      HlintEnabled dir _ -> checkDirExists dir
-      HlintDisabled -> return ()
+    case optDlintUsage of
+      DlintEnabled dir _ -> checkDirExists dir
+      DlintDisabled -> return ()
     pure opts {optPackageDbs = map (</> versionSuffix) $ pkgDbs ++ optPackageDbs}
   where checkDirExists f =
           Dir.doesDirectoryExist f >>= \ok ->
@@ -122,8 +122,8 @@ mkOptions opts@Options {..} = do
 -- version. Linting is enabled but not '.dlint.yaml' overrides.
 defaultOptionsIO :: Maybe LF.Version -> IO Options
 defaultOptionsIO mbVersion = do
-  hlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-  mkOptions $ (defaultOptions mbVersion){optHlintUsage=HlintEnabled hlintDataDir False}
+  dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+  mkOptions $ (defaultOptions mbVersion){optDlintUsage=DlintEnabled dlintDataDir False}
 
 defaultOptions :: Maybe LF.Version -> Options
 defaultOptions mbVersion =
@@ -142,7 +142,7 @@ defaultOptions mbVersion =
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
         , optScenarioValidation = ScenarioValidationFull
-        , optHlintUsage = HlintDisabled
+        , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optCoreLinting = False
         }

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -337,10 +337,10 @@ enableScenarioOpt :: Parser EnableScenarioService
 enableScenarioOpt = EnableScenarioService <$>
     flagYesNoAuto "scenarios" True "Enable/disable support for running scenarios" idm
 
-hlintEnabledOpt :: Parser HlintUsage
-hlintEnabledOpt = HlintEnabled
+dlintEnabledOpt :: Parser DlintUsage
+dlintEnabledOpt = DlintEnabled
   <$> strOption
-  ( long "with-hlint"
+  ( long "with-dlint"
     <> metavar "DIR"
     <> help "Enable linting with 'dlint.yaml' directory"
   )
@@ -349,12 +349,12 @@ hlintEnabledOpt = HlintEnabled
     <> help "Allow '.dlint.yaml' configuration overrides"
   )
 
-hlintDisabledOpt :: Parser HlintUsage
-hlintDisabledOpt = flag' HlintDisabled
-  ( long "without-hlint"
-    <> help "Disable hlint"
+dlintDisabledOpt :: Parser DlintUsage
+dlintDisabledOpt = flag' DlintDisabled
+  ( long "without-dlint"
+    <> help "Disable dlint"
   )
 
-hlintUsageOpt :: Parser HlintUsage
-hlintUsageOpt = fmap (fromMaybe HlintDisabled . lastMay) $
-  many (hlintEnabledOpt <|> hlintDisabledOpt)
+dlintUsageOpt :: Parser DlintUsage
+dlintUsageOpt = fmap (fromMaybe DlintDisabled . lastMay) $
+  many (dlintEnabledOpt <|> dlintDisabledOpt)

--- a/compiler/hie-core/src/Development/IDE/GHC/CPP.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/CPP.hs
@@ -2,7 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- Copied from https://github.com/ghc/ghc/blob/master/compiler/main/DriverPipeline.hs on 14 May 2019
--- Requested to be exposed at https://gitlab.haskell.org/ghc/ghc/merge_requests/944
+-- Requested to be exposed at https://gitlab.haskell.org/ghc/ghc/merge_requests/944.
+-- Update the above MR got merged to master on 31 May 2019. When it becomes avialable to ghc-lib, this file can be removed.
+
 {- HLINT ignore -} -- since copied from upstream
 
 {-# LANGUAGE CPP, NamedFieldPuns, NondecreasingIndentation, BangPatterns, MultiWayIf #-}


### PR DESCRIPTION
In this PR, the lint command line option is changed to `--with-dlint` and in the code, "hlint" is replaced with "dlint" in all occurrences.