### PR TITLE
fix fetch repo in bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,8 @@ build --remote_upload_local_results=false
 # Enable the disk cache in addition to the http cache.
 build:linux --disk_cache=.bazel-cache/disk
 build:darwin --disk_cache=.bazel-cache/disk
-build:linux --repository_cache=.bazel-cache/repo
-build:darwin --repository_cache=.bazel-cache/repo
+fetch:linux --repository_cache=.bazel-cache/repo
+fetch:darwin --repository_cache=.bazel-cache/repo
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.


### PR DESCRIPTION
turns out caching whatever "repository_cache" caches happens during the fetch phase of the Bazel lifecycle. Or something like that. With these entries the `.bazel-cache/repo` dolfer actually gets created on my machine (it doesn't on current master).