### PR TITLE
set sandbox head version to 100.0.0

### DIFF
--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -115,14 +115,14 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-# The sole purpose of this rule is to get the sandbox.jar with version 0.0.0.
+# The sole purpose of this rule is to get the sandbox.jar with version 100.0.0.
 genrule(
     name = "sandbox-head-tarball",
     srcs = [":sandbox-binary_deploy.jar"],
     outs = ["sandbox-head-tarball.tar.gz"],
     cmd = """
         mkdir -p sandbox-head-tarball/sandbox
-        cp -L $(location :sandbox-binary_deploy.jar) sandbox-head-tarball/sandbox/sandbox-0.0.0.jar
+        cp -L $(location :sandbox-binary_deploy.jar) sandbox-head-tarball/sandbox/sandbox-100.0.0.jar
         out=$$(realpath $@)
         cd sandbox-head-tarball
         tar zcf $$out sandbox


### PR DESCRIPTION
If `sandbox` has version `:component-version` as can be seen in the rule just above, then to be consistent `sandbox-head` should be `100.0.0`, not `0.0.0`.