### PR TITLE
Organizing SDK ledger commands, adding ledger upload-dar and ledger navigator commands.

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -42,6 +42,7 @@ da_haskell_binary(
     srcs = ["src/DA/Daml/Helper/Main.hs"],
     hazel_deps = [
         "base",
+        "extra",
     ],
     main_function = "DA.Daml.Helper.Main.main",
     visibility = ["//visibility:public"],

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -4,6 +4,7 @@ module DA.Daml.Helper.Main (main) where
 
 import Control.Exception
 import Data.Foldable
+import Data.List.Extra
 import Options.Applicative.Extended
 import System.Environment
 import System.Exit
@@ -32,10 +33,11 @@ data Command
     | Init { targetFolderM :: Maybe FilePath }
     | ListTemplates
     | Start { sandboxPortM :: Maybe SandboxPort, openBrowser :: OpenBrowser, startNavigator :: StartNavigator, onStartM :: Maybe String, waitForSignal :: WaitForSignal }
-    | Deploy        { flags :: HostAndPortFlags }
-    | ListParties   { flags :: HostAndPortFlags }
-    | AllocateParty { flags :: HostAndPortFlags , party :: String }
-    | DeployNavigator { flags :: HostAndPortFlags, remainingArguments :: [String] }
+    | Deploy { flags :: HostAndPortFlags }
+    | LedgerListParties { flags :: HostAndPortFlags }
+    | LedgerAllocateParty { flags :: HostAndPortFlags , party :: String }
+    | LedgerUploadDar { flags :: HostAndPortFlags, darPathM :: Maybe FilePath }
+    | LedgerNavigator { flags :: HostAndPortFlags, remainingArguments :: [String] }
 
 commandParser :: Parser Command
 commandParser = subparser $ fold
@@ -44,10 +46,8 @@ commandParser = subparser $ fold
     , command "migrate" (info (migrateCmd <**> helper) idm)
     , command "init" (info (initCmd <**> helper) idm)
     , command "start" (info (startCmd <**> helper) idm)
-    , command "deploy" (info (deployCmd <**> helper) idm)
-    , command "list-parties" (info (listPartiesCmd <**> helper) idm)
-    , command "allocate-party" (info (allocatePartyCmd <**> helper) idm)
-    , command "deploy-navigator" (info (deployNavigatorCmd <**> helper) forwardOptions)
+    , command "deploy" (info (deployCmd <**> helper) deployCmdInfo)
+    , command "ledger" (info (ledgerCmd <**> helper) ledgerCmdInfo)
     , command "run-jar" (info runJarCmd forwardOptions)
     ]
   where
@@ -59,6 +59,13 @@ commandParser = subparser $ fold
                 value ReplaceExtPublished
                 )
         <*> many (argument str (metavar "ARG"))
+
+    readReplacement = maybeReader $ \arg ->
+        case lower arg of
+            "never" -> Just ReplaceExtNever
+            "always" -> Just ReplaceExtAlways
+            "published" -> Just ReplaceExtPublished
+            _ -> Nothing
 
     runJarCmd = RunJar
         <$> argument str (metavar "JAR" <> help "Path to JAR relative to SDK path")
@@ -87,29 +94,71 @@ commandParser = subparser $ fold
         <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
         <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
 
-    deployCmd = Deploy <$> hostAndPortFlags
-    listPartiesCmd = ListParties <$> hostAndPortFlags
-    allocatePartyCmd = AllocateParty <$> hostAndPortFlags
+    deployCmdInfo = progDesc . concat $
+        [ "Deploy the current DAML project to a remote DAML ledger. "
+        , "This will allocate the project's parties on the ledger "
+        , "(if missing) and upload the project's built DAR file. You "
+        , "can specify the ledger in daml.yaml with the ledger.host and "
+        , "ledger.port options, or you can pass the --host and --port "
+        , "flags to this command instead."
+        ]
+
+    deployCmd = Deploy
+        <$> hostAndPortFlags
+
+    ledgerCmdInfo = forwardOptions <>
+        (progDesc . concat $
+            [ "Interact with a remote DAML ledger. You can specify "
+            , "the ledger in daml.yaml with the ledger.host and "
+            , "ledger.port options, or you can pass the --host "
+            , "and --port flags to each command below."
+            ])
+
+    ledgerCmd = subparser $ fold
+        [ command "list-parties" $ info
+            (ledgerListPartiesCmd <**> helper)
+            (progDesc "List parties known to ledger")
+        , command "allocate-party" $ info
+            (ledgerAllocatePartyCmd <**> helper)
+            (progDesc "Allocate a party on ledger")
+        , command "upload-dar" $ info
+            (ledgerUploadDarCmd <**> helper)
+            (progDesc "Upload DAR file to ledger")
+        , command "navigator" $ info
+            (ledgerNavigatorCmd <**> helper)
+            (forwardOptions <> progDesc "Launch Navigator on ledger")
+        ]
+
+    ledgerListPartiesCmd = LedgerListParties
+        <$> hostAndPortFlags
+
+    ledgerAllocatePartyCmd = LedgerAllocateParty
+        <$> hostAndPortFlags
         <*> argument str (metavar "PARTY" <> help "Party to be allocated on the ledger")
 
-    deployNavigatorCmd = DeployNavigator
+    ledgerUploadDarCmd = LedgerUploadDar
+        <$> hostAndPortFlags
+        <*> optional (argument str (metavar "PATH" <> help "DAR file to upload (defaults to project DAR)"))
+
+    ledgerNavigatorCmd = LedgerNavigator
         <$> hostAndPortFlags
         <*> many (argument str (metavar "ARG" <> help "Extra arguments to navigator."))
 
-    hostAndPortFlags = HostAndPortFlags <$> hostFlag <*> portFlag
+    hostAndPortFlags = HostAndPortFlags
+        <$> hostFlag
+        <*> portFlag
 
     hostFlag :: Parser (Maybe String)
-    hostFlag = optional (option str (long "host" <> metavar "HOST_NAME" <> help "Hostname for the ledger"))
+    hostFlag = optional . option str $
+        long "host"
+        <> metavar "HOST_NAME"
+        <> help "Hostname for the ledger"
 
     portFlag :: Parser (Maybe Int)
-    portFlag = optional (option auto (long "port" <> metavar "PORT_NUM" <> help "Port number for the ledger"))
-
-    readReplacement :: ReadM ReplaceExtension
-    readReplacement = maybeReader $ \case
-        "never" -> Just ReplaceExtNever
-        "always" -> Just ReplaceExtAlways
-        "published" -> Just ReplaceExtPublished
-        _ -> Nothing
+    portFlag = optional . option auto $
+        long "port"
+        <> metavar "PORT_NUM"
+        <> help "Port number for the ledger"
 
 runCommand :: Command -> IO ()
 runCommand DamlStudio {..} = runDamlStudio replaceExtension remainingArguments
@@ -120,6 +169,7 @@ runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
 runCommand Start {..} = runStart sandboxPortM startNavigator openBrowser onStartM waitForSignal
 runCommand Deploy {..} = runDeploy flags
-runCommand ListParties {..} = runListParties flags
-runCommand AllocateParty {..} = runAllocateParty flags party
-runCommand DeployNavigator {..} = runDeployNavigator flags remainingArguments
+runCommand LedgerListParties {..} = runLedgerListParties flags
+runCommand LedgerAllocateParty {..} = runLedgerAllocateParty flags party
+runCommand LedgerUploadDar {..} = runLedgerUploadDar flags darPathM
+runCommand LedgerNavigator {..} = runLedgerNavigator flags remainingArguments

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -35,68 +35,81 @@ data Command
     | Deploy        { flags :: HostAndPortFlags }
     | ListParties   { flags :: HostAndPortFlags }
     | AllocateParty { flags :: HostAndPortFlags , party :: String }
+    | DeployNavigator { flags :: HostAndPortFlags, remainingArguments :: [String] }
 
 commandParser :: Parser Command
-commandParser =
-    subparser $ fold
-         [ command "studio" (info (damlStudioCmd <**> helper) forwardOptions)
-         , command "new" (info (newCmd <**> helper) idm)
-         , command "migrate" (info (migrateCmd <**> helper) idm)
-         , command "init" (info (initCmd <**> helper) idm)
-         , command "start" (info (startCmd <**> helper) idm)
-         , command "deploy" (info (deployCmd <**> helper) idm)
-         , command "list-parties" (info (listPartiesCmd <**> helper) idm)
-         , command "allocate-party" (info (allocatePartyCmd <**> helper) idm)
-         , command "run-jar" (info runJarCmd forwardOptions)
-         ]
-    where damlStudioCmd = DamlStudio
-              <$> option readReplacement
-                  (long "replace" <>
-                   help "Whether an existing extension should be overwritten. ('never' or 'always' for bundled extension version, 'published' for official published version of extension, defaults to 'published')" <>
-                   value ReplaceExtPublished
-                  )
-              <*> many (argument str (metavar "ARG"))
-          runJarCmd = RunJar
-              <$> argument str (metavar "JAR" <> help "Path to JAR relative to SDK path")
-              <*> many (argument str (metavar "ARG"))
-          newCmd = asum
-              [ ListTemplates <$ flag' () (long "list" <> help "List the available project templates.")
-              , New
-                  <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
-                  <*> optional (argument str (metavar "TEMPLATE" <> help ("Name of the template used to create the project (default: " <> defaultProjectTemplate <> ")")))
-              ]
-          migrateCmd =  Migrate
-                  <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
-                  <*> argument str (metavar "SOURCE" <> help "Path to the main source file ('source' entry of the project configuration files of the input projects).")
-                  <*> argument str (metavar "FROM_PATH" <> help "Path to the dar-package from which to migrate from")
-                  <*> argument str (metavar "TO_PATH" <> help "Path to the dar-package to which to migrate to")
-          initCmd = Init <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
-          startCmd = Start
-                <$> optional (SandboxPort <$> option auto (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
-                <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
-                <*> (StartNavigator <$> flagYesNoAuto "start-navigator" True "Start navigator after sandbox" idm)
-                <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
-                <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
+commandParser = subparser $ fold
+    [ command "studio" (info (damlStudioCmd <**> helper) forwardOptions)
+    , command "new" (info (newCmd <**> helper) idm)
+    , command "migrate" (info (migrateCmd <**> helper) idm)
+    , command "init" (info (initCmd <**> helper) idm)
+    , command "start" (info (startCmd <**> helper) idm)
+    , command "deploy" (info (deployCmd <**> helper) idm)
+    , command "list-parties" (info (listPartiesCmd <**> helper) idm)
+    , command "allocate-party" (info (allocatePartyCmd <**> helper) idm)
+    , command "deploy-navigator" (info (deployNavigatorCmd <**> helper) forwardOptions)
+    , command "run-jar" (info runJarCmd forwardOptions)
+    ]
+  where
 
-          deployCmd = Deploy <$> hostAndPortFlags
-          listPartiesCmd = ListParties <$> hostAndPortFlags
-          allocatePartyCmd = AllocateParty <$> hostAndPortFlags
-              <*> argument str (metavar "PARTY" <> help "Party to be allocated on the ledger")
+    damlStudioCmd = DamlStudio
+        <$> option readReplacement
+            (long "replace" <>
+                help "Whether an existing extension should be overwritten. ('never' or 'always' for bundled extension version, 'published' for official published version of extension, defaults to 'published')" <>
+                value ReplaceExtPublished
+                )
+        <*> many (argument str (metavar "ARG"))
 
-          hostAndPortFlags = HostAndPortFlags <$> hostFlag <*> portFlag
+    runJarCmd = RunJar
+        <$> argument str (metavar "JAR" <> help "Path to JAR relative to SDK path")
+        <*> many (argument str (metavar "ARG"))
 
-          hostFlag :: Parser (Maybe String)
-          hostFlag = optional (option str (long "host" <> metavar "HOST_NAME" <> help "Hostname for the ledger"))
+    newCmd = asum
+        [ ListTemplates <$ flag' () (long "list" <> help "List the available project templates.")
+        , New
+            <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
+            <*> optional (argument str (metavar "TEMPLATE" <> help ("Name of the template used to create the project (default: " <> defaultProjectTemplate <> ")")))
+        ]
 
-          portFlag :: Parser (Maybe Int)
-          portFlag = optional (option auto (long "port" <> metavar "PORT_NUM" <> help "Port number for the ledger"))
+    migrateCmd =  Migrate
+        <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be   located")
+        <*> argument str (metavar "SOURCE" <> help "Path to the main source file ('source' entry of the project configuration files of the input projects).")
+        <*> argument str (metavar "FROM_PATH" <> help "Path to the dar-package from which to migrate from")
+        <*> argument str (metavar "TO_PATH" <> help "Path to the dar-package to which to migrate to")
 
-          readReplacement :: ReadM ReplaceExtension
-          readReplacement = maybeReader $ \case
-              "never" -> Just ReplaceExtNever
-              "always" -> Just ReplaceExtAlways
-              "published" -> Just ReplaceExtPublished
-              _ -> Nothing
+    initCmd = Init
+        <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
+
+    startCmd = Start
+        <$> optional (SandboxPort <$> option auto (long "sandbox-port" <> metavar "PORT_NUM" <>     help "Port number for the sandbox"))
+        <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
+        <*> (StartNavigator <$> flagYesNoAuto "start-navigator" True "Start navigator after sandbox" idm)
+        <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
+        <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
+
+    deployCmd = Deploy <$> hostAndPortFlags
+    listPartiesCmd = ListParties <$> hostAndPortFlags
+    allocatePartyCmd = AllocateParty <$> hostAndPortFlags
+        <*> argument str (metavar "PARTY" <> help "Party to be allocated on the ledger")
+
+    deployNavigatorCmd = DeployNavigator
+        <$> hostAndPortFlags
+        <*> many (argument str (metavar "ARG" <> help "Extra arguments to navigator."))
+
+    hostAndPortFlags = HostAndPortFlags <$> hostFlag <*> portFlag
+
+    hostFlag :: Parser (Maybe String)
+    hostFlag = optional (option str (long "host" <> metavar "HOST_NAME" <> help "Hostname for the ledger"))
+
+    portFlag :: Parser (Maybe Int)
+    portFlag = optional (option auto (long "port" <> metavar "PORT_NUM" <> help "Port number for the ledger"))
+
+    readReplacement :: ReadM ReplaceExtension
+    readReplacement = maybeReader $ \case
+        "never" -> Just ReplaceExtNever
+        "always" -> Just ReplaceExtAlways
+        "published" -> Just ReplaceExtPublished
+        _ -> Nothing
 
 runCommand :: Command -> IO ()
 runCommand DamlStudio {..} = runDamlStudio replaceExtension remainingArguments
@@ -109,3 +122,4 @@ runCommand Start {..} = runStart sandboxPortM startNavigator openBrowser onStart
 runCommand Deploy {..} = runDeploy flags
 runCommand ListParties {..} = runListParties flags
 runCommand AllocateParty {..} = runAllocateParty flags party
+runCommand DeployNavigator {..} = runDeployNavigator flags remainingArguments

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -735,7 +735,7 @@ allocatePartyIfRequired hp name = do
 -- future, Navigator should fetch the list of parties itself.
 runDeployNavigator :: HostAndPortFlags -> [String] -> IO ()
 runDeployNavigator flags remainingArguments = do
-    hostAndPort <- withHostAndPortDefaults flags
+    hostAndPort <- getHostAndPortDefaults flags
     putStrLn $ "Opening navigator at " <> show hostAndPort
     partyDetails <- Ledger.listParties hostAndPort
 

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -19,18 +19,6 @@ commands:
   path: damlc/damlc
   args: ["build", "--project-check"]
   desc: "Build the DAML project into a DAR file"
-- name: deploy
-  path: daml-helper/daml-helper
-#  desc: "Build the DAML project and deploy to the ledger"
-  args: ["deploy"]
-- name: list-parties
-  path: daml-helper/daml-helper
-#  desc: "List parties known to the ledger"
-  args: ["list-parties"]
-- name: allocate-party
-  path: daml-helper/daml-helper
-#  desc: "Allocate named party on the ledger"
-  args: ["allocate-party"]
 - name: test
   path: damlc/damlc
   args: ["test"]
@@ -58,6 +46,14 @@ commands:
   path: daml-helper/daml-helper
   desc: "Launch the Extractor"
   args: ["run-jar", "extractor/extractor.jar"]
+- name: ledger
+  path: daml-helper/daml-helper
+  desc: "Interact with a DAML ledger (experimental)"
+  args: ["ledger"]
+- name: deploy
+  path: daml-helper/daml-helper
+  desc: "Deploy DAML project to a ledger (experimental)"
+  args: ["deploy"]
 - name: ide
   path: damlc/damlc
   args: ["lax", "ide"]


### PR DESCRIPTION
Rather than have a bunch of `daml` commands that pertain to actions one can take on/with a ledger, I reorganized these as subcommands of a new `daml ledger` command.

What all of these commands have in common is that they take a `ledger.host` and `ledger.port` option from daml.yaml (or, alternatively, `--host` and `--port` flags). 

I kept the more high-level `daml deploy` as is, but added a `daml ledger upload-dar` command that only does the `upload-dar` part of `daml deploy` (and can be used outside of projects, unlike `daml deploy`).

Furthermore I added a `daml ledger navigator` command, which connects to the remote ledger with the list of parties coming from the ledger (requested by Soren).

So in summary we have:

* `daml deploy`: allocates project parties on ledger, then builds and uploads project DAR. *(Not sure this is the correct default behavior. But it is what it is for now.)*
* `daml ledger list-parties`: lists parties known to ledger
* `daml ledger allocate-party`: allocate a party on ledger (if it doesn't already exist)
* `daml ledger upload-dar`: uploads a specified DAR file to ledger; if DAR file is not specified, it will build and upload the project DAR file
* `daml ledger navigator`: launches Navigator on ledger with its list of parties.

TODO:
* [x] Open issue to have navigator fetch list of parties from remote ledger itself.
* [ ] Integration tests that use all the `daml ledger X` commands (separate PR).
* [ ] JSON output for the `daml ledger list-parties` command (separate PR).