### PR TITLE
Semantic tests fall back to wall-clock time if timeservice is not available

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
+++ b/ledger/ledger-api-integration-tests/src/test/semanticsuite/scala/com/digitalasset/platform/semantictest/SandboxSemanticTestsLfRunner.scala
@@ -5,28 +5,19 @@ package com.digitalasset.platform.semantictest
 
 import java.io._
 
-import akka.stream.scaladsl.Sink
 import com.digitalasset.daml.bazeltools.BazelRunfiles._
 import com.digitalasset.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.digitalasset.daml.lf.data.Ref.QualifiedName
 import com.digitalasset.daml.lf.engine.testing.SemanticTester
 import com.digitalasset.daml.lf.types.{Ledger => L}
-import com.digitalasset.grpc.adapter.client.akka.ClientAdapter
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   SuiteResourceManagementAroundAll
 }
-import com.digitalasset.ledger.api.v1.testing.time_service.GetTimeRequest
 import com.digitalasset.platform.apitesting.{MultiLedgerFixture, TestIdsGenerator}
 import com.digitalasset.platform.services.time.TimeProviderType
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.exceptions.TestCanceledException
 import org.scalatest.{AsyncWordSpec, Matchers}
-
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
-
-import scalaz.syntax.tag._
 
 class SandboxSemanticTestsLfRunner
     extends AsyncWordSpec
@@ -64,20 +55,6 @@ class SandboxSemanticTestsLfRunner
     } {
       s"run scenario: $name" in allFixtures { ledger =>
         for {
-          _ <- ClientAdapter
-            .serverStreaming(GetTimeRequest(ledger.ledgerId.unwrap), ledger.timeService.getTime)
-            .take(1)
-            .map(_.getCurrentTime)
-            .runWith(Sink.head)
-            .transformWith({
-              case Failure(throwable) =>
-                Future.failed(
-                  new TestCanceledException(
-                    "DAML scenario running requires implemented TimeService by the provided Ledger API endpoint.",
-                    throwable,
-                    3))
-              case Success(ts) => Future.successful(ts)
-            })
           _ <- new SemanticTester(
             parties =>
               new SemanticTestAdapter(


### PR DESCRIPTION
Instead of cancelling all semantic tests if the time service is not available, we can fall back to wall-clock time to provide the current time.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
