### PR TITLE
macOS: cache the bazel repo cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,39 +35,49 @@ jobs:
     pool:
       vmImage: 'macOS-10.14'
     variables:
-      cache-key: $(Build.StagingDirectory)/macos-nix-key
-      cache-path: /tmp/cache/
+      nix-cache-key: $(Build.StagingDirectory)/macos-nix-key
+      nix-cache-path: /tmp/nix-cache/
+      bazel-repo-cache-key: $(Build.StagingDirectory)/bazel-repo-cache-key
+      bazel-repo-cache-path: $(Agent.BuildDirectory)/.bazel-cache/repo
     steps:
       - template: ci/report-start.yml
       - checkout: self
-      - bash: echo $(git log -n1 --pretty=format:%H dev-env nix azure-pipelines.yml) >> $(cache-key)
-        displayName: cache key
+      - bash: echo $(git log -n1 --pretty=format:%H dev-env nix azure-pipelines.yml) >> $(nix-cache-key)
+        displayName: nix cache key
       - task: CacheBeta@0
         inputs:
-          key: $(cache-key)
-          path: $(cache-path)
+          key: $(nix-cache-key)
+          path: $(nix-cache-path)
       - bash: |
           set -euo pipefail
-          if [[ -e $(cache-path) ]]; then
+          if [[ -e $(nix-cache-path) ]]; then
               DIR=$(pwd)
               sudo mkdir /nix && sudo chown $USER /nix
               cd /nix
-              tar xzf $(cache-path)/nix.tar.gz
+              tar xzf $(nix-cache-path)/nix.tar.gz
               cd $DIR
               curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
           fi
         displayName: restore cache
+      - bash: echo $(git log -n1 --pretty=format:%H azure-pipelines.yml $(find . -name \*.bazel -or -name \*.bzl -or -name WORKSPACE -or -name BUILD)) >> $(bazel-repo-cache-key)
+        displayName: bazel repo cache key
+      - task: CacheBeta@0
+        inputs:
+          key: $(bazel-repo-cache-key)
+          path: $(bazel-repo-cache-path)
       - template: ci/build-unix.yml
         parameters:
           name: macos
       - bash: |
           set -euo pipefail
-          if [[ ! -e $(cache-path) ]]; then
-              mkdir -p $(cache-path)
+          if [[ ! -e $(nix-cache-path) ]]; then
+              mkdir -p $(nix-cache-path)
               cd /nix
-              GZIP=-9 tar czf $(cache-path)/nix.tar.gz store var
+              GZIP=-9 tar czf $(nix-cache-path)/nix.tar.gz store var
           fi
-        displayName: create cache
+        displayName: create nix cache
+      - bash: mkdir -p $(bazel-repo-cache-path)
+        displayName: ensure bazel repo cache exists
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 


### PR DESCRIPTION
macOS nodes are fresh and therefore have no cache; I figure the entire Bazel build (disk) cache is too big and volatile, and Bazel build products are fast enough to download from the GCS bucket, but external dependencies are often slow and/or flaky, so maybe this could help.

@moritzkiefer-da @aherrmann-da which other files can define external dependencies, other than `WORKSPACE` and `3rdparty`?