### PR TITLE
Implement deploy in terms of allocate-parties and upload-dar.

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -11,3 +11,4 @@ HEAD — ongoing
 
 + [DAML Docs] For ``damlc docs``, the ``--template`` argument now takes the path to a Mustache template when generating Markdown, Rst, and HTML output. The template can use ``title`` and ``body`` variables to control the appearance of the docs.
 + [DAML Assistant] Spaces in user names or other parts of file names should now be handled correctly.
++ [DAML Assistant] The ``daml deploy`` and ``daml ledger`` experimental commands were added. Use ``daml deploy --help`` and ``daml ledger --help`` to find out more about them.


### PR DESCRIPTION
By doing this, we are killing two birds with one stone: we ensure that `daml deploy` matches the default behavior of `daml ledger allocate-parties` and `daml ledger upload-dar`, and the `deploy` integration test now covers both `allocate-parties` and `upload-dar`.

Note that `allocate-parties` used to be `allocate-party`, but it makes sense to generalize to multiple parties. I'm keeping `allocate-party` as a single item alias for `allocate-parties`, but might drop it.

TODO: 

* [ ] refactor allocate-parties so that it only calls list-parties once