### PR TITLE
Avoid converting DARs to a strict bytestring

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -77,7 +77,7 @@ buildDar ::
     -> PackageConfigFields
     -> NormalizedFilePath
     -> FromDalf
-    -> IO (Maybe BS.ByteString)
+    -> IO (Maybe BSL.ByteString)
 buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
@@ -160,7 +160,7 @@ createArchive ::
     -> [NormalizedFilePath] -- ^ Module dependencies
     -> [(String, BS.ByteString)] -- ^ Data files
     -> [NormalizedFilePath] -- ^ Interface files
-    -> IO BS.ByteString
+    -> IO BSL.ByteString
 createArchive PackageConfigFields {..} pkgId dalf dalfDependencies fileDependencies dataFiles ifaces
  = do
     -- Reads all module source files, and pairs paths (with changed prefix)
@@ -185,7 +185,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies fileDependenc
                 , contents)
     let dalfName = pkgName </> pName <> ".dalf"
     let dependencies =
-            [ (pkgName </> T.unpack depName <> ".dalf", BSC.fromStrict bs)
+            [ (pkgName </> T.unpack depName <> ".dalf", BSL.fromStrict bs)
             | (depName, bs) <- dalfDependencies
             ]
     let dataFiles' =
@@ -201,7 +201,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies fileDependenc
         mkEntry (filePath, content) = Zip.toEntry filePath 0 content
         zipArchive =
             foldr (Zip.addEntryToArchive . mkEntry) Zip.emptyArchive allFiles
-    pure $ BSL.toStrict $ Zip.fromArchive zipArchive
+    pure $ Zip.fromArchive zipArchive
   where
     pkgName = fullPkgName pName pVersion pkgId
     modRoot = toNormalizedFilePath $ takeDirectory pMain

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -470,7 +470,7 @@ execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts
             dar <- mbErr "ERROR: Creation of DAR file failed." mbDar
             let fp = targetFilePath pName
             createDirectoryIfMissing True $ takeDirectory fp
-            B.writeFile fp dar
+            BSL.writeFile fp dar
             putStrLn $ "Created " <> fp <> "."
     where
         -- The default output filename is based on Maven coordinates if
@@ -533,9 +533,9 @@ execPackage projectOpts filePath opts mbOutFile dumpPom dalfInput = withProjectR
               exitFailure
           Just dar -> do
             createDirectoryIfMissing True $ takeDirectory targetFilePath
-            B.writeFile targetFilePath dar
+            BSL.writeFile targetFilePath dar
             putStrLn $ "Created " <> targetFilePath <> "."
-            when (unDumpPom dumpPom) $ createPomAndSHA256 dar
+            when (unDumpPom dumpPom) $ createPomAndSHA256 $ dar
   where
     -- This is somewhat ugly but our CLI parser guarantees that this will always be present.
     -- We could parametrize CliOptions by whether the package name is optional
@@ -579,9 +579,9 @@ execPackage projectOpts filePath opts mbOutFile dumpPom dalfInput = withProjectR
 
             writeAndAnnounce pomPath pomContent
             writeAndAnnounce (basePath <.> "dar" <.> "sha256")
-              (convertToBase Base16 $ Crypto.hashWith Crypto.SHA256 darContent)
+              (convertToBase Base16 $ Crypto.hashlazy @Crypto.SHA256 darContent)
             writeAndAnnounce (basePath <.> "pom" <.> "sha256")
-              (convertToBase Base16 $ Crypto.hashWith Crypto.SHA256 pomContent)
+              (convertToBase Base16 $ Crypto.hash @B.ByteString @Crypto.SHA256 pomContent)
           _ -> do
             putErrLn $ "ERROR: Not creating pom file as package name '" <> name <> "' is not a valid Maven coordinate (expected '<groupId>:<artifactId>:<version>')"
             exitFailure


### PR DESCRIPTION
Converting it to a strict bytestring only to then write it to disk
doesn’t make much sense.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
