### PR TITLE
Move simplification to GenerateRawDalf

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -181,7 +181,7 @@ generateRawDalfRule =
         -- GHC Core to DAML LF
         case convertModule lfVersion pkgMap0 file core of
             Left e -> return ([e], Nothing)
-            Right v -> return ([], Just v)
+            Right v -> return ([], Just $ LF.simplifyModule v)
 
 -- Generates and type checks the DALF for a module.
 generateDalfRule :: Rules ()
@@ -192,8 +192,7 @@ generateDalfRule =
         pkgMap <- useNoFile_ GeneratePackageMap
         let pkgs = map dalfPackagePkg $ Map.elems pkgMap
         let world = LF.initWorldSelf pkgs pkg
-        unsimplifiedRawDalf <- use_ GenerateRawDalf file
-        let rawDalf = LF.simplifyModule unsimplifiedRawDalf
+        rawDalf <- use_ GenerateRawDalf file
         setPriority priorityGenerateDalf
         pure $ toIdeResult $ do
             let liftError e = [ideErrorPretty file e]


### PR DESCRIPTION
This allows us to GC the unsimplified DALF which decreases memory
usage and GC pressure. This does make GenerateRawDalf slightly slower
which could in theory have an effect on IDE performance since we use
the raw DALF for the scenario service. However, I haven’t been able to
measure any regressions (if it does become an issue, we could disable
optimizations completely in the IDE). In fact, things seem to be
slightly faster.

On my testcase max memory usage does seem to go down a bit but not a
lot (3.0GB to 2.7GB but it fluctuates somewhat between runs).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
