### PR TITLE
hlb, testing sandbox must be run on a dynamically allocated port

### DIFF
--- a/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
@@ -30,7 +30,7 @@ data Sandbox = Sandbox { port :: Port, proh :: ProcessHandle }
 sandboxProcess :: SandboxSpec -> FilePath -> IO CreateProcess
 sandboxProcess SandboxSpec{dar} portFile = do
     binary <- locateRunfiles (mainWorkspace </> exe "ledger/sandbox/sandbox-binary")
-    pure $ proc binary [ dar, "--port-file", portFile]
+    pure $ proc binary [ dar, "--port-file", portFile, "-p", "0"]
 
 startSandboxProcess :: SandboxSpec -> FilePath -> IO (ProcessHandle,Maybe Handle)
 startSandboxProcess spec portFile = withDevNull $ \devNull -> do


### PR DESCRIPTION

Fix bug:
- The sandbox being used for the HLB tests is running on a fixed port (6865)
- It needs to run on a dynamically allocated port. It used to!
- Think this bug got introduced when we started using `--port-file`


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
