### PR TITLE
Use tasty-golden for daml-doc's golden tests

### DIFF
--- a/compiler/damlc/README.md
+++ b/compiler/damlc/README.md
@@ -82,6 +82,15 @@ At the moment, commands relying on ghc-pkg, e.g., `damlc build` do not
 work via `bazel run`. For testing, install the SDK with
 `daml-sdk-head` and then use `daml-head damlc`.
 
+
+## Updating daml-doc's golden tests
+
+Run
+```
+bazel run //compiler/damlc/tests:daml-doc -- --accept
+```
+to accept the current documentation as new golden files.
+
 ## Documentation
 
 Standard library docs are exposed under the bazel rules which you can build with:

--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -53,6 +53,7 @@ da_haskell_library(
         "filepath",
         "mtl",
         "tasty-hunit",
+        "tasty-golden",
         "text",
     ],
     src_strip_prefix = "test",

--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -47,7 +47,6 @@ da_haskell_library(
         "aeson-pretty",
         "base",
         "bytestring",
-        "Diff",
         "directory",
         "extra",
         "filepath",

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -285,9 +285,11 @@ fileTest damlFile = do
     else do
       doc <- runDamldoc damlFile (Just $ takeDirectory damlFile)
       pure $ flip map expectations $ \expectation ->
-        goldenVsString ("File: " <> expectation) expectation $ pure $
+        goldenVsStringDiff ("File: " <> expectation) diff expectation $ pure $
           case takeExtension expectation of
             ".rst" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderRst $ renderModule doc
             ".md" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderMd $ renderModule doc
             ".json" -> AP.encodePretty' jsonConf doc
             other -> error $ "Unsupported file extension " <> other
+  where
+    diff ref new = ["diff", ref, new]

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -14,22 +14,20 @@ import DA.Daml.Doc.Render
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Anchor
 
-import           DA.Test.Util
 import Development.IDE.Types.Location
 
 import           Control.Monad.Except
 import qualified Data.Aeson.Encode.Pretty as AP
-import           Data.Algorithm.Diff (getGroupedDiff)
-import           Data.Algorithm.DiffOutput (ppDiff)
-import qualified Data.ByteString.Lazy.Char8 as BS
 import           Data.List.Extra
 import qualified Data.Text          as T
 import qualified Data.Text.Extended as T
-import qualified Data.Text.Encoding as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
 import           System.Directory
 import           System.FilePath
 import           System.IO.Extra
 import qualified Test.Tasty.Extended as Tasty
+import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
 import Data.Maybe
 
@@ -242,7 +240,12 @@ damldocExpect importPathM testname input check =
     let testfile = dir </> testModule <.> "daml"
     -- write input to a file
     T.writeFileUtf8 testfile (T.unlines input)
+    doc <- runDamldoc testfile importPathM
+    check doc
 
+-- | Generate the docs for a given input file and optional import directory.
+runDamldoc :: FilePath -> Maybe FilePath -> IO ModuleDoc
+runDamldoc testfile importPathM = do
     opts <- defaultOptionsIO Nothing
 
     let opts' = opts
@@ -259,11 +262,10 @@ damldocExpect importPathM testname input check =
 
     case mbResult of
       Left err -> assertFailure $ unlines
-                  ["Parse error(s) for test file " <> testname, show err]
+                  ["Parse error(s) for test file " <> testfile, show err]
 
-      -- first module is the root we started from, so is the one that must satisfy the invariants
-      Right ms -> check $ head ms
-
+      -- first module is the root we started from, so is the one we're testing
+      Right docs -> pure $ head docs
 
 -- | For the given file <name>.daml (assumed), this test checks if any
 -- <name>.EXPECTED.<suffix> exists, and produces output according to <suffix>
@@ -280,35 +282,12 @@ fileTest damlFile = do
 
   if null expectations
     then pure []
-    else do input <- T.readFileUtf8 damlFile
-            mapM (goldenTest input) expectations
-
-  where goldenTest :: T.Text -> FilePath -> IO Tasty.TestTree
-        goldenTest input expectation =
-          let check docs = do
-                let extension = takeExtension expectation
-                ref <- T.readFileUtf8 expectation
-                case extension of
-                  ".rst"  -> expectEqual extension ref $ renderPage renderRst $ renderModule docs
-                  ".md"   -> expectEqual extension ref $ renderPage renderMd $ renderModule docs
-                  ".json" -> expectEqual extension ref
-                             (T.decodeUtf8 . BS.toStrict $
-                               AP.encodePretty' jsonConf docs)
-                  other  -> error $ "Unsupported file extension " <> other
-
-              expectEqual :: String -> T.Text -> T.Text -> Assertion
-              expectEqual extension ref actual
-                | standardizeEoL ref == standardizeEoL actual = pure ()
-                | otherwise = do
-                    let actualFile = replaceExtensions expectation ("ACTUAL" <> extension)
-                        asLines = lines . T.unpack
-                        diff = ppDiff $ getGroupedDiff (asLines ref) (asLines actual)
-
-                    T.writeFileUtf8 actualFile actual
-                    assertFailure $
-                      "Unexpected difference between " <> expectation <>
-                      " and actual output.\n" <>
-                      "Unexpected output has been written to " <> actualFile <> "\n" <>
-                      "Differences:\n" <> diff
-
-          in pure $  damldocExpect (Just $ takeDirectory damlFile) ("File: " <> expectation) [input] check
+    else do
+      doc <- runDamldoc damlFile (Just $ takeDirectory damlFile)
+      pure $ flip map expectations $ \expectation ->
+        goldenVsString ("File: " <> expectation) expectation $ pure $
+          case takeExtension expectation of
+            ".rst" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderRst $ renderModule doc
+            ".md" -> TL.encodeUtf8 $ TL.fromStrict $ renderPage renderMd $ renderModule doc
+            ".json" -> AP.encodePretty' jsonConf doc
+            other -> error $ "Unsupported file extension " <> other

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -292,4 +292,4 @@ fileTest damlFile = do
             ".json" -> AP.encodePretty' jsonConf doc
             other -> error $ "Unsupported file extension " <> other
   where
-    diff ref new = ["diff", ref, new]
+    diff ref new = ["diff", "--strip-trailing-cr", ref, new]

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -261,8 +261,8 @@ runDamldoc testfile importPathM = do
         [toNormalizedFilePath testfile]
 
     case mbResult of
-      Left err -> assertFailure $ unlines
-                  ["Parse error(s) for test file " <> testfile, show err]
+      Left err ->
+        assertFailure $ unlines ["Parse error(s) for test file " <> testfile, show err]
 
       -- first module is the root we started from, so is the one we're testing
       Right docs -> pure $ head docs


### PR DESCRIPTION
With our hand rolled version of golden tests it is pretty painful to update
the golden files when they must change. After this PR it is as simple as
```
> bazel run //compiler/damlc/tests:daml-doc -- --accept
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2429)
<!-- Reviewable:end -->
