### PR TITLE
Fix daml ledger navigator configuration.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -811,7 +811,8 @@ runLedgerNavigator flags remainingArguments = do
                 -- TODO We need to figure out a sane timeout for this step.
                 waitForHttpServer (putStr "." *> threadDelay 500000) (navigatorURL navigatorPort)
                 putStr . unlines $
-                    [ "Navigator is running at " <> navigatorURL navigatorPort
+                    [ ""
+                    , "Navigator is running at " <> navigatorURL navigatorPort
                     , "Use Ctrl+C to stop."
                     ]
                 exitWith =<< waitExitCode ph


### PR DESCRIPTION
Bugfix: `daml ledger navigator` was not configuring the navigator properly -- it was surreptitiously using the daml.yaml from the DAML_PROJECT directory instead of the configuration we wrote, and that configuration was itself not correct. Sadly I can't easily write a regression test for this...

I'm still not certain everything is right for all ledgers, but it works for Sandbox, and I'm sure we'll root out any remaining issues quickly, with Canton testing the navigator. (Note, this is still a workaround for #2418) 