### PR TITLE
hlb, use Int64 / Fixed E10 as appropriate

### DIFF
--- a/language-support/hs/bindings/src/DA/Ledger/Types.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Types.hs
@@ -58,6 +58,9 @@ module DA.Ledger.Types( -- High Level types for communication over Ledger API
 
     ) where
 
+import DA.Daml.LF.Ast.Base (E10)
+import Data.Fixed
+import Data.Int (Int64)
 import Data.Map (Map)
 import Data.Text.Lazy (Text)
 import Prelude hiding(Enum)
@@ -192,7 +195,7 @@ data Value
     | VContract ContractId
     | VList [Value]
     | VInt Int
-    | VDecimal Text
+    | VDecimal (Fixed E10)
     | VText Text
     | VTime MicroSecondsSinceEpoch
     | VParty Party
@@ -248,7 +251,7 @@ data LedgerConfiguration = LedgerConfiguration
     }
     deriving (Eq,Ord,Show)
 
-newtype MicroSecondsSinceEpoch = MicroSecondsSinceEpoch { unMicroSecondsSinceEpoch :: Int}
+newtype MicroSecondsSinceEpoch = MicroSecondsSinceEpoch { unMicroSecondsSinceEpoch :: Int64}
     deriving (Eq,Ord,Show)
 
 newtype DaysSinceEpoch = DaysSinceEpoch { unDaysSinceEpoch :: Int}
@@ -273,6 +276,6 @@ newtype AbsOffset = AbsOffset { unAbsOffset :: Text } deriving (Eq,Ord,Show)
 newtype Choice = Choice { unChoice :: Text } deriving (Eq,Ord,Show)
 
 newtype Party = Party { unParty :: Text } deriving (Eq,Ord)
-instance Show Party where show = Text.unpack . unParty
+instance Show Party where show p = "'" <> (Text.unpack $ unParty p) <> "'"
 
 newtype Verbosity = Verbosity { unVerbosity :: Bool } deriving (Eq,Ord,Show)

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -516,7 +516,7 @@ bucket = VRecord $ Record Nothing
     , RecordField "contract"$ VContract (ContractId "xxxxx")
     , RecordField "list"    $ VList []
     , RecordField "int"     $ VInt 42
-    , RecordField "decimal" $ VDecimal "123.456"
+    , RecordField "decimal" $ VDecimal (read "123.456")
     , RecordField "text"    $ VText "OMG lol"
     , RecordField "time"    $ VTime (MicroSecondsSinceEpoch $ 1000 * 1000 * 60 * 60 * 24 * 365 * 50)
     , RecordField "party"   $ VParty $ Party "good time"


### PR DESCRIPTION
Changes in response to previous PR:
- use `Int64` for `MicroSecondsSinceEpoch`
- use `Fixed E10` for `| VDecimal (Fixed E10)` in `Value`
- add single quotes to `Party` `show`


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
