### PR TITLE
Fixed bug when loading transactions with an empty workflow id

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/CommandTransactionChecks.scala
@@ -620,10 +620,11 @@ abstract class CommandTransactionChecks
           _.commands.ledgerId := context.ledgerId.unwrap
         )
 
-      "process valid commands successfully" in allFixtures { c =>
-        val cmdId = testIdsGenerator.testCommandId("valid-create-and-exercise-cmd")
+      def successfulCommands(c: LedgerContext, workflowId: String) = {
+        val cmdId = testIdsGenerator.testCommandId(s"valid-create-and-exercise-cmd-${UUID.randomUUID()}")
         val request = newRequest(c, validCreateAndExercise)
           .update(_.commands.commandId := cmdId)
+          .update(_.commands.workflowId := workflowId)
 
         for {
           GetLedgerEndResponse(Some(currentEnd)) <- c.transactionClient.getLedgerEnd
@@ -655,6 +656,15 @@ abstract class CommandTransactionChecks
           exercisedEvent.contractId shouldBe createdEvent.contractId
           exercisedEvent.consuming shouldBe true
         }
+
+      }
+
+      "process valid commands with workflow ids successfully" in allFixtures { c =>
+        successfulCommands(c, workflowId = UUID.randomUUID().toString)
+      }
+
+      "process valid commands with empty workflow ids successfully" in allFixtures { c =>
+        successfulCommands(c, workflowId = "")
       }
 
       "fail for invalid create arguments" in allFixtures { implicit c =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/Conversions.scala
@@ -5,7 +5,15 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql.util
 
 import java.sql.PreparedStatement
 
-import anorm.{Column, ParameterMetaData, RowParser, SqlMappingError, SqlParser, ToStatement}
+import anorm.{
+  Column,
+  MetaDataItem,
+  ParameterMetaData,
+  RowParser,
+  SqlMappingError,
+  SqlParser,
+  ToStatement
+}
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party}
 
@@ -57,6 +65,12 @@ object Conversions {
       implicit strToStm: ToStatement[String]): ToStatement[LedgerString] =
     subStringToStatement(strToStm)
 
+  def emptyStringToNullColumn(implicit c: Column[String]): Column[String] = new Column[String] {
+    override def apply(value: Any, meta: MetaDataItem) = value match {
+      case "" => c(null, meta)
+      case x => c(x, meta)
+    }
+  }
   def ledgerString(columnName: String)(implicit c: Column[String]): RowParser[Ref.LedgerString] =
     SqlParser.get[Ref.LedgerString](columnName)(columnToLedgerString(c))
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,4 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
++ [Ledger] Fixed a bug that prevented the ledger from loading transactions with empty workflow ids.


### PR DESCRIPTION
This happened because we translate empty workflow ids to None in the
API-to-domain translation layer. When we store the workflow id, we actually
convert the None case back to an empty string (and not a null value).

When loading the workflow id from the database, we parse the column as a regular
LedgerString, but unfortunately these cannot be empty. Therefore using empty workflow
ids on postgres has been broken since workflow id has changed from a tagged string
to LedgerString.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
