### PR TITLE
Fix pretty printing of empty annotations in DAML-LF AST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -70,7 +70,7 @@ prettyModuleRef :: (PackageRef, ModuleName) -> Doc ann
 prettyModuleRef (pkgRef, modName) = docPkgRef <> pretty modName
   where
     docPkgRef = case pkgRef of
-      PRSelf -> ""
+      PRSelf -> empty
       PRImport pkgId -> pretty pkgId <> ":"
 
 instance Pretty a => Pretty (Qualified a) where
@@ -80,7 +80,7 @@ instance Pretty a => Pretty (Qualified a) where
 instance Pretty SourceLoc where
   pPrint (SourceLoc mbModRef slin scol elin ecol) =
     hcat
-    [ maybe "" (\modRef -> prettyModuleRef modRef <> ":") mbModRef
+    [ maybe empty (\modRef -> prettyModuleRef modRef <> ":") mbModRef
     , int slin, ":", int scol, "-", int elin, ":", int ecol
     ]
 
@@ -436,7 +436,7 @@ instance Pretty DefDataType where
     where
       lhsDoc =
         serializableDoc <-> pretty tcon <-> hsep (map prettyAndKind params) <-> "="
-      serializableDoc = if serializable then "@serializable" else ""
+      serializableDoc = if serializable then "@serializable" else empty
       prettyVariantCon (name, typ) =
         "|" <-> pretty name <-> pPrintPrec prettyNormal precHighest typ
       prettyEnumCon name = "|" <-> pretty name
@@ -448,7 +448,7 @@ instance Pretty DefValue where
       [ hang (keyword_ kind <-> annot <-> prettyAndType binder <-> "=") 2 (pretty body) ]
     where
       kind = if isTest then "test" else "def"
-      annot = if noParties then "" else "@partyliterals"
+      annot = if noParties then empty else "@partyliterals"
 
 prettyTemplateChoice ::
   ModuleName -> TypeConName -> TemplateChoice -> Doc ann

--- a/libs-haskell/da-hs-base/src/Text/PrettyPrint/Annotated/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Text/PrettyPrint/Annotated/Extended.hs
@@ -34,7 +34,7 @@ import qualified Data.Text             as T
 import Data.List
 
 import           Text.PrettyPrint.Annotated.HughesPJ
-          hiding ( (<>), (<+>), empty, style, text, ($+$)
+          hiding ( (<>), (<+>), style, text, ($+$)
                  )
 import qualified Text.PrettyPrint.Annotated.HughesPJ  as PP
 


### PR DESCRIPTION
For example, we print two spaces if there's no annotation between `def` and
the function. This PR fixes this by using the `empty` document instead of the
document containing the empty string. (Please don't ask me why they are
different.)

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2453)
<!-- Reviewable:end -->
