### PR TITLE
language: put pkg version into pkgname

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -5,6 +5,7 @@ module DA.Daml.Compiler.Dar
     , FromDalf(..)
     , breakAt72Chars
     , PackageConfigFields(..)
+    , pkgNameVersion
     ) where
 
 import qualified Codec.Archive.Zip as Zip
@@ -127,6 +128,9 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
 fullPkgName :: String -> String -> String -> String
 fullPkgName n v h = intercalate "-" [n, v, h]
 
+pkgNameVersion :: String -> String -> String
+pkgNameVersion n v = n ++ "-" ++ v
+
 mkConfFile ::
        PackageConfigFields -> [String] -> String -> (String, BS.ByteString)
 mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = (confName, bs)
@@ -138,8 +142,8 @@ mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = (confName, bs)
         BSC.pack $
         unlines
             [ "name: " ++ pName
-            , "id: " ++ pName -- will change to key
-            , "key: " ++ pName -- will change to key
+            , "id: " ++ pkgNameVersion pName pVersion
+            , "key: " ++ pkgNameVersion pName pVersion
             , "version: " ++ pVersion
             , "exposed: True"
             , "exposed-modules: " ++
@@ -183,7 +187,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies fileDependenc
                 ( pkgName </>
                   fromNormalizedFilePath (makeRelative' ifaceRoot mPath)
                 , contents)
-    let dalfName = pkgName </> pName <> ".dalf"
+    let dalfName = pkgName </> pkgNameVersion pName pVersion <.> "dalf"
     let dependencies =
             [ (pkgName </> T.unpack depName <> ".dalf", BSL.fromStrict bs)
             | (depName, bs) <- dalfDependencies

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -460,7 +460,10 @@ execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts
         putStrLn $ "Compiling " <> pName <> " to a DAR."
         opts <- mkOptions options
         loggerH <- getLogger opts "package"
-        withDamlIdeState opts{optMbPackageName = Just pName} loggerH diagnosticsLogger $ \compilerH -> do
+        withDamlIdeState
+            opts {optMbPackageName = Just $ pkgNameVersion pName pVersion}
+            loggerH
+            diagnosticsLogger $ \compilerH -> do
             mbDar <-
                 buildDar
                     compilerH


### PR DESCRIPTION
This is a small step to solve the package name ambiguity problem.
Putting the package version into the package name allows to import a
package two times with different versions. Next step is to also have versioned daml-stdlib.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
