### PR TITLE
Only change project root once

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -89,7 +89,7 @@ throwError msg e = fail (T.unpack $ msg <> " " <> e)
 -- commands outside of the assistant.
 noassistantTests :: FilePath -> TestTree
 noassistantTests damlDir = testGroup "no assistant"
-    [ testCase "damlc build" $ withTempDir $ \projDir -> do
+    [ testCase "damlc build --init-package-db=no" $ withTempDir $ \projDir -> do
           writeFileUTF8 (projDir </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
               , "name: a"
@@ -105,6 +105,25 @@ noassistantTests damlDir = testGroup "no assistant"
               ]
           let damlcPath = damlDir </> "sdk" </> sdkVersion </> "damlc" </> "damlc"
           callProcess damlcPath ["build", "--project-root", projDir, "--init-package-db", "no"]
+    , testCase "damlc build --init-package-db=yes" $ withTempDir $ \tmpDir -> do
+          let projDir = tmpDir </> "foobar"
+          createDirectory projDir
+          writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: a"
+              , "version: \"1.0\""
+              , "source: Main.daml"
+              , "dependencies: [daml-prim, daml-stdlib]"
+              ]
+          writeFileUTF8 (projDir </> "Main.daml") $ unlines
+              [ "daml 1.2"
+              , "module Main where"
+              , "a : ()"
+              , "a = ()"
+              ]
+          let damlcPath = damlDir </> "sdk" </> sdkVersion </> "damlc" </> "damlc"
+          withCurrentDirectory tmpDir $
+              callProcess damlcPath ["build", "--project-root", "foobar", "--init-package-db", "yes"]
     ]
 
 packagingTests :: FilePath -> TestTree

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,3 +10,5 @@ HEAD — ongoing
 --------------
 
 + [Ledger] Fixed a bug that prevented the ledger from loading transactions with empty workflow ids.
++ [DAML Compiler] The ``--project-root`` option now works properly
+  with relative paths in ``daml build`.`


### PR DESCRIPTION
As described in #2449, calling withProjectRoot' twice breaks with
relative paths and is also just silly so this PR fixes this by
factoring out the actual logic from init from execInit which does the
project root thingy.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
