### PR TITLE
infra: add acls for google_storage_objects create via tf

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -29,6 +29,13 @@ resource "google_storage_bucket_object" "index_bazel_cache" {
   depends_on   = ["module.nix_cache"]
 }
 
+// Set ACL for ./index.html
+resource "google_storage_object_acl" "index_bazel_cache-acl" {
+  bucket         = "${module.bazel_cache.bucket_name}"
+  object         = "${google_storage_bucket_object.index_bazel_cache.name}"
+  predefined_acl = "publicRead"
+}
+
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
   bucket = "${module.bazel_cache.bucket_name}"

--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -38,6 +38,13 @@ resource "google_storage_bucket_object" "index_nix_cache" {
   depends_on   = ["module.nix_cache"]
 }
 
+// Set ACL for ./index.html
+resource "google_storage_object_acl" "index_nix_cache-acl" {
+  bucket         = "${module.nix_cache.bucket_name}"
+  object         = "${google_storage_bucket_object.index_nix_cache.name}"
+  predefined_acl = "publicRead"
+}
+
 // provide a nix-cache-info file setting a higher priority
 // than cache.nixos.org, so we prefer it
 resource "google_storage_bucket_object" "nix-cache-info" {
@@ -51,6 +58,13 @@ Priority: 10
   EOF
 
   content_type = "text/plain"
+}
+
+// Set ACL for ./nix-cache-info
+resource "google_storage_object_acl" "nix-cache-info-acl" {
+  bucket         = "${module.nix_cache.bucket_name}"
+  object         = "${google_storage_bucket_object.nix-cache-info.name}"
+  predefined_acl = "publicRead"
 }
 
 output "nix_cache_ip" {


### PR DESCRIPTION
This ensures objects in the google storage bucket created by terraform
have the proper publicRead acl.

(Which they might not have when being created from scratch)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

cc @garyverhaegen-da @cocreature 
