### PR TITLE
Make DAML internal functions version independent

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -462,7 +462,7 @@ convertBind env x = convertBind2 env x
 
 convertBind2 :: Env -> CoreBind -> ConvertM [Definition]
 convertBind2 env (NonRec name x)
-    | Just internals <- lookupUFM (internalFunctions $ envLfVersion env) (envGHCModuleName env)
+    | Just internals <- lookupUFM internalFunctions (envGHCModuleName env)
     , getOccFS name `elementOfUniqSet` internals
     = pure []
     -- NOTE(MH): Desugaring `template X` will result in a type class
@@ -513,8 +513,8 @@ convertBind2 env (Rec xs) = concatMapM (\(a, b) -> convertBind env (NonRec a b))
 internalTypes :: UniqSet FastString
 internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap"]
 
-internalFunctions :: LF.Version -> UniqFM (UniqSet FastString)
-internalFunctions version = listToUFM $ map (bimap mkModuleNameFS mkUniqSet)
+internalFunctions :: UniqFM (UniqSet FastString)
+internalFunctions = listToUFM $ map (bimap mkModuleNameFS mkUniqSet)
     [ ("DA.Internal.Record",
         [ "getFieldPrim"
         , "setFieldPrim"
@@ -758,7 +758,7 @@ convertExpr env0 e = do
           withTmArg env (varV1, t) args $ \x args ->
             pure (ESome t x, args)
     go env (Var x) args
-        | Just internals <- lookupUFM (internalFunctions $ envLfVersion env) modName
+        | Just internals <- lookupUFM internalFunctions modName
         , getOccFS x `elementOfUniqSet` internals
         = unsupported "Direct call to internal function" x
         | getOccFS x == "()" = fmap (, args) $ pure EUnit


### PR DESCRIPTION
Right now, the set of internal functions seems to depend on the DAML-LF
version although it actually doesn't. Since GHC is smart enough this doesn't
bite us but doesn't feel particularly clean either. If the internal functions
ever start to depend on the DAML-LF version again, we should probably put
them into the environment of the conversion to DAML-LF.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2464)
<!-- Reviewable:end -->
