### PR TITLE
Avoid one indirection when constructing enum values

### DIFF
--- a/compiler/damlc/tests/daml-test-files/EnumLF.daml
+++ b/compiler/damlc/tests/daml-test-files/EnumLF.daml
@@ -4,7 +4,7 @@
 -- Check that enum types get translated to DAML-LF's enum types.
 -- @SINCE-LF 1.6
 -- @QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Color"]) | has("enum")
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["$$ctor$u003aRed"]) | .expr | has("enum_con")
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["red"]) | .expr | has("enum_con")
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["isRed"]) | .expr.abs.body.case.alts | .[0] | has("enum")
 -- @QUERY-LF .modules[] | .data_types[] | select(.name.segments == ["Tag"]) | (has("enum") | not)
 daml 1.2


### PR DESCRIPTION
For every enum constructor `Foo` we produce a function `$ctor:Foo` whose
value is simply `Foo`. When we convert `Foo` to DAML-LF, we convert to
a call of `$ctor:Foo`. Since enum constructors are always fully applied,
this indirection is useless. Thus, we remove it in this PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2469)
<!-- Reviewable:end -->
