### PR TITLE
disable reset service in hlb

### DIFF
--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -7,7 +7,8 @@ module DA.Ledger.Tests (main) where
 
 import Prelude hiding(Enum)
 import Control.Concurrent (MVar,newMVar,takeMVar,withMVar)
-import Control.Monad(unless, forM)
+--import Control.Monad(unless, forM)
+import Control.Monad(unless)
 import Control.Monad.IO.Class(liftIO)
 import DA.Bazel.Runfiles
 import DA.Daml.LF.Proto3.Archive (decodeArchive)
@@ -27,7 +28,7 @@ import qualified Data.ByteString as BS (readFile)
 import qualified Data.ByteString.Lazy as BSL (readFile,toStrict)
 import qualified Data.ByteString.UTF8 as BS (ByteString,fromString)
 import qualified Data.Map as Map
-import qualified Data.Set as Set
+--import qualified Data.Set as Set
 import qualified Data.Text.Lazy as Text(pack,unpack,fromStrict)
 import qualified Data.UUID as UUID (toString)
 
@@ -45,7 +46,7 @@ tests :: TestTree
 tests = testGroupWithSandbox "Ledger Bindings"
     [ tGetLedgerIdentity
     , tReset
-    , tMultipleResets
+    --, tMultipleResets
     , tListPackages
     , tGetPackage
     , tGetPackageBad
@@ -96,6 +97,7 @@ tReset withSandbox = testCase "reset" $ run withSandbox $ \_ -> do
     lid2 <- getLedgerIdentity
     liftIO $ assertBool "lid1 /= lid2" (lid1 /= lid2)
 
+{-
 tMultipleResets :: SandboxTest
 tMultipleResets withSandbox = testCase "multipleResets" $ run withSandbox $ \_pid -> do
     let resetsCount = 20
@@ -104,6 +106,7 @@ tMultipleResets withSandbox = testCase "multipleResets" $ run withSandbox $ \_pi
         Ledger.reset lid
         pure lid
     liftIO $ assertEqual "Ledger IDs are unique" resetsCount (Set.size $ Set.fromList lids)
+-}
 
 tListPackages :: SandboxTest
 tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \pid -> do
@@ -665,7 +668,7 @@ assertTextContains text frag =
 -- test with/out shared sandboxes...
 
 enableSharing :: Bool
-enableSharing = True
+enableSharing = False
 
 createSpec :: IO SandboxSpec
 createSpec = do


### PR DESCRIPTION
The interactions between the Haskell ledger bindings and the reset service of the sandbox have lead to a lot of instability lately. We'd like to see how much slower things get if we don't use it.