### PR TITLE
Fix shutdown order to avoid dead letter logging when stopping sandbox

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/LedgerApiServer.scala
@@ -69,8 +69,8 @@ object LedgerApiServer {
         override def servicesClosed(): Future[Unit] = impl.servicesClosed()
 
         override def close(): Unit = {
-          impl.close()
           serverEsf.close()
+          impl.close()
         }
       }
     }(mat.executionContext)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -11,4 +11,6 @@ HEAD — ongoing
 
 + [Ledger] Fixed a bug that prevented the ledger from loading transactions with empty workflow ids.
 + [DAML Compiler] The ``--project-root`` option now works properly
-  with relative paths in ``daml build`.`
+  with relative paths in ``daml build``.
++ [Ledger] Fixed internal shutdown order to avoid dead letter warnings when stopping Sandbox/Ledger API Server.
+  See issue `#1886 <https://github.com/digital-asset/daml/issues/1886>`__.


### PR DESCRIPTION
It looks like that closing the LedgerApiServer before closing the
AkkaExecutionSequencerPool (AESP) leads to a non-deterministic bunch of dead
letter warnings when stopping sandbox.

Closing the AESP first avoids these warnings.

Fixes #1886

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
