### PR TITLE
Upgrade haskell-lsp and lsp-test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -460,9 +460,9 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 # For the time being we build with GMP. See https://github.com/digital-asset/daml/issues/106
 use_integer_simple = not is_windows
 
-HASKELL_LSP_COMMIT = "d73e2ccb518724e6766833ee3d7e73289cbe0018"
+HASKELL_LSP_COMMIT = "bfbd8630504ebc57b70948689c37b85cfbe589da"
 
-HASKELL_LSP_HASH = "36b92431039e6289eb709b8872f5010a57d4a45e637e1c1c945bdb3128586081"
+HASKELL_LSP_HASH = "a301d9409c3a19a042bdf5763611c6a60af5cbc1ff0f281acbc19b3ee70dde5f"
 
 GHC_LIB_VERSION = "8.8.0.20190730.1"
 
@@ -541,8 +541,6 @@ hazel_repositories(
             ) +
             hazel_hackage("terminal-progress-bar", "0.4.1", "a61ca10c92cacc712dbbe28881dc23f41cc139760b7b2eef66bd0faa60ea5e24") +
             hazel_hackage("rope-utf16-splay", "0.3.1.0", "cbf878098355441ed7be445466fcb72d45390073a298b37649d762de2a7f8cc6") +
-            # This corresponds to our normalize-uri branch that enforces a consistent
-            # precent-encoding for URIs used as keys.
             hazel_github_external(
                 "alanz",
                 "haskell-lsp",
@@ -557,12 +555,16 @@ hazel_repositories(
                 name = "haskell-lsp-types",
                 directory = "/haskell-lsp-types/",
             ) +
-            # This corresponds to our custom-methods branch which makes
-            # lsp-test work with the custom methods changes in haskell-lsp.
-            hazel_github(
+            # lsp-test’s cabal file relies on haskell-lsp reexporting haskell-lsp-types.
+            # Hazel does not handle that for now, so we patch the cabal file
+            # to add an explicit dependency on haskell-lsp-types.
+            hazel_github_external(
+                "bubba",
                 "lsp-test",
-                "50c43452e19e494d71ccba1f7922d0b3b3fc69c3",
-                "65a56b35ddc8fa4deab10ac42efcdcbd36e875b715bb504d10b020a1e5fffd2c",
+                "d126623dc6895d325e3d204d74e2a22d4f515587",
+                "a2be2d812010eaadd4885fb0228370a5467627bbb6bd43177fd1f6e5a7eb05f8",
+                patch_args = ["-p1"],
+                patches = ["@com_github_digital_asset_daml//bazel_tools:haskell-lsp-test-no-reexport.patch"],
             ) +
             hazel_github_external(
                 "mpickering",

--- a/bazel_tools/haskell-lsp-test-no-reexport.patch
+++ b/bazel_tools/haskell-lsp-test-no-reexport.patch
@@ -1,0 +1,12 @@
+diff --git a/lsp-test.cabal b/lsp-test.cabal
+index 1c8350a..4d96585 100644
+--- a/lsp-test.cabal
++++ b/lsp-test.cabal
+@@ -37,6 +37,7 @@ library
+   default-language:    Haskell2010
+   build-depends:       base >= 4.10 && < 5
+                      , haskell-lsp == 0.15.*
++                     , haskell-lsp-types
+                      , aeson
+                      , aeson-pretty
+                      , ansi-terminal

--- a/compiler/hie-core/stack.yaml
+++ b/compiler/hie-core/stack.yaml
@@ -4,12 +4,12 @@ packages:
 
 extra-deps:
 - git: https://github.com/alanz/haskell-lsp.git
-  commit: d73e2ccb518724e6766833ee3d7e73289cbe0018
+  commit: bfbd8630504ebc57b70948689c37b85cfbe589da
   subdirs:
   - .
   - haskell-lsp-types
-- git: https://github.com/digital-asset/lsp-test.git
-  commit: 50c43452e19e494d71ccba1f7922d0b3b3fc69c3
+- git: https://github.com/bubba/lsp-test.git
+  commit: d126623dc6895d325e3d204d74e2a22d4f515587
 - git: https://github.com/mpickering/hie-bios.git
   commit: 8427e424a83c2f3d60bdd26c02478c00d2189a73
 nix:

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -10,10 +10,6 @@ da_haskell_test(
     data = [
         "//compiler/damlc",
     ],
-    # For some reason this test sometimes seems to time out on Windows.
-    # It hits the Bazel timeout rather than the timeout in lsp-tests
-    # so it looks like it locks up somehow.
-    flaky = is_windows,
     hazel_deps = [
         "aeson",
         "base",


### PR DESCRIPTION
There have been some fixes upstream that should hopefully mean that we
no longer need to mark the lsp-tests as flaky on Windows. I am having
trouble reproducing the flakiness locally, so let’s see what happens
on CI.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
