### PR TITLE
damldocs: Show only exported things.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
@@ -1,0 +1,136 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | This module processes export lists and then answers the question
+-- "is this *thing* exported?"
+module DA.Daml.Doc.Extract.Exports
+    ( ExportSet
+    , extractExports
+    , exportsType
+    , exportsConstr
+    , exportsFunction
+    , exportsField
+    ) where
+
+import DA.Daml.Doc.Types as DD
+
+import "ghc-lib" GHC as GHC
+import "ghc-lib-parser" RdrName
+import "ghc-lib-parser" OccName
+import "ghc-lib-parser" FieldLabel
+import "ghc-lib-parser" FastString
+
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+-- | Set of module exports.
+--
+-- Unlike Haddock, we don't ask the export list to dictate the order
+-- of docs; damldocs imposes its own order. So we can treat the export
+-- list as a set instead.
+data ExportSet
+    = ExportEverything
+    | ExportOnly !(Set.Set ExportedItem)
+
+-- | Particular exported item. We don't particularly care
+-- about re-exported modules for now, but we want to know
+-- if a module re-exports itself so we have a way to track
+-- it here.
+data ExportedItem
+    = ExportedType !Typename
+        -- ^ type is exported
+    | ExportedTypeAll !Typename
+        -- ^ all constructors and fields for a type are exported
+    | ExportedConstr !Typename
+        -- ^ constructor is exported
+    | ExportedFunction !Fieldname
+        -- ^ function or field is exported
+    | ExportedModule !GHC.ModuleName
+        -- ^ module is reexported
+    deriving (Eq, Ord)
+
+-- | Get set of exports from parsed module.
+--
+-- We work with the parsed module here rather than the typechecked
+-- module because damldocs generally works with parsed AST names.
+extractExports :: ParsedModule -> ExportSet
+extractExports pm
+    | (L _ ps) <- pm_parsed_source pm
+    , Just (L _ modName) <- hsmodName ps
+    , Just (L _ lies) <- hsmodExports ps
+    , exportedItems <- Set.fromList (concatMap (extractExportedItem modName) lies)
+    = if ExportedModule modName `Set.member` exportedItems
+        then ExportEverything
+        else ExportOnly exportedItems
+
+    | otherwise
+    = ExportEverything
+
+extractExportedItem :: GHC.ModuleName -> LIE GhcPs -> [ExportedItem]
+extractExportedItem modName (L _ ie) = exportIE ie
+  where
+    exportIE :: IE GhcPs -> [ExportedItem]
+    exportIE = \case
+        IEVar _ (L _ n) -> exportIEW n
+        IEThingAbs _ (L _ n) -> exportIEW n
+        IEThingAll _ (L _ n) -> addTypeAll $ exportIEW n
+        IEThingWith _ (L _ n) (IEWildcard _) _ _ -> addTypeAll $ exportIEW n
+        IEThingWith _ (L _ n) NoIEWildcard things fields -> concat
+            [ exportIEW n
+            , concatMap (exportIEW . unLoc) things
+            , [ ExportedFunction . Fieldname . T.pack . unpackFS $ x
+              | L _ (FieldLabel x _ _) <- fields
+              ]
+            ]
+        IEModuleContents _ (L _ n) -> [ExportedModule n]
+        IEGroup _ _ _ -> []
+        IEDoc _ _ -> []
+        IEDocNamed _ _ -> []
+        XIE _ -> []
+
+    exportIEW :: IEWrappedName RdrName -> [ExportedItem]
+    exportIEW = \case
+        IEName (L _ rdrName) -> exportRdrName rdrName
+        IEType (L _ rdrName) -> exportRdrName rdrName
+        IEPattern _ -> []
+
+    exportRdrName :: RdrName -> [ExportedItem]
+    exportRdrName = \case
+        Unqual n -> exportOccName n
+        Qual m n ->
+            if m == modName
+                then exportOccName n
+                else []
+        Orig _ _ -> []
+        Exact _ -> []
+
+    exportOccName :: OccName -> [ExportedItem]
+    exportOccName n
+        | isDataOcc n = [ExportedConstr . Typename . T.pack . occNameString $ n]
+        | isVarOcc n = [ExportedFunction . Fieldname . T.pack . occNameString $ n]
+        | otherwise = [ExportedType . Typename . T.pack . occNameString $ n]
+
+    addTypeAll :: [ExportedItem] -> [ExportedItem]
+    addTypeAll = concatMap $ \case
+        ExportedType ty -> [ExportedType ty, ExportedTypeAll ty]
+        item -> [item]
+
+exportsType :: ExportSet -> Typename -> Bool
+exportsType ExportEverything _ = True
+exportsType (ExportOnly xs) n = Set.member (ExportedType n) xs
+
+exportsConstr :: ExportSet -> Typename -> Typename -> Bool
+exportsConstr ExportEverything _ _ = True
+exportsConstr (ExportOnly xs) ty constr =
+    Set.member (ExportedTypeAll ty) xs
+    || Set.member (ExportedConstr constr) xs
+
+exportsFunction :: ExportSet -> Fieldname -> Bool
+exportsFunction ExportEverything _ = True
+exportsFunction (ExportOnly xs) n = Set.member (ExportedFunction n) xs
+
+exportsField :: ExportSet -> Typename -> Fieldname -> Bool
+exportsField ExportEverything _ _ = True
+exportsField (ExportOnly xs) ty field =
+    Set.member (ExportedTypeAll ty) xs
+    || Set.member (ExportedFunction field) xs

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
@@ -14,7 +14,7 @@ module DA.Daml.Doc.Extract.Exports
 
 import DA.Daml.Doc.Types as DD
 
-import "ghc-lib" GHC as GHC
+import "ghc-lib" GHC
 import "ghc-lib-parser" RdrName
 import "ghc-lib-parser" OccName
 import "ghc-lib-parser" FieldLabel

--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -77,13 +77,10 @@ class  Show a  where
 
 shows x = showsPrec (I# 0#) x
 
--- hiding because the function signatures aren't even showing up in the docs.
--- | HIDE
 showList__ : (a -> ShowS) ->  [a] -> ShowS
 showList__ _     []     s = "[]" ++ s
 showList__ showx (x::xs) s = "[" ++ showx x (showl showx xs s)
 
--- | HIDE
 showl : (a -> ShowS) -> [a] -> ShowS
 showl showx []      s = "]" ++ s
 showl showx (y::ys) s = "," ++ showx y (showl showx ys s)

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -43,7 +43,6 @@ import DA.Internal.Prelude
 
 -- | The `Party` type represents a party to a contract.
 data Party =
-  -- | HIDE
   Party Opaque
 -- Note that before DAML-LF 1.2 BEToText added single quotes around the party.
 -- now it does not, and the old behavior has been renamed BEPartyToQuotedText.
@@ -91,7 +90,6 @@ getParty = primitive @"SGetParty"
 
 -- | The `Date` type represents a date, for example `date 2007 Apr 5`.
 data Date =
-  -- | HIDE
   Date Opaque
 instance Show Date where show = primitive @"BEToText"
 instance Eq Date where (==) = primitive @"BEEqual"
@@ -100,7 +98,6 @@ instance Ord Date where (<=) = primitive @"BELessEq"
 -- | The `Time` type represents a specific datetime in UTC,
 -- for example `time (date 2007 Apr 5) 14 30 05`.
 data Time =
-  -- | HIDE
   Time Opaque
 instance Show Time where show = primitive @"BEToText"
 instance Eq Time where (==) = primitive @"BEEqual"
@@ -109,13 +106,11 @@ instance Ord Time where (<=) = primitive @"BELessEq"
 -- | The `TextMap a` type represents an associative array from keys of type
 -- `Text` to values of type `a`.
 data TextMap a =
-  -- | HIDE
   TextMap Opaque
 
 -- | The `ContractId a` type represents an ID for a contract created from a template `a`.
 --   You can use the ID to fetch the contract, among other things.
-data ContractId a = 
-  -- | HIDE
+data ContractId a =
   ContractId Opaque
 instance Eq (ContractId a) where (==) = primitive @"BEEqualContractId"
 instance Show (ContractId a) where show _ = "<contract-id>"
@@ -128,7 +123,6 @@ coerceContractId = primitive @"BECoerceContractId"
 -- | The `Update a` type represents an `Action` to update or query the ledger,
 --   before returning a value of type `a`. Examples include `create` and `fetch`.
 data Update a =
-  -- | HIDE
   Update Opaque
 
 instance Functor Update where
@@ -168,7 +162,6 @@ instance CanAbort Scenario where
 -- The type `Scenario a` describes a set of actions taken by various parties during
 -- the simulated scenario, before returning a value of type `a`.
 data Scenario a =
-  -- | HIDE
   Scenario Opaque
 
 instance Functor Scenario where

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -4,42 +4,24 @@
 
 <a name="class-exportlist-class1-82332"></a>**class** [Class1](#class-exportlist-class1-82332) t **where**
 
-> <a name="function-exportlist-member1-59742"></a>[member1](#function-exportlist-member1-59742)
-> 
-> > : t
-> 
-> <a name="function-exportlist-member1tick-30562"></a>[member1'](#function-exportlist-member1tick-30562)
-> 
-> > : t
 
 <a name="class-exportlist-class2-52219"></a>**class** [Class2](#class-exportlist-class2-52219) t **where**
 
-> <a name="function-exportlist-member2-87497"></a>[member2](#function-exportlist-member2-87497)
-> 
-> > : t
-> 
-> <a name="function-exportlist-member2tick-86995"></a>[member2'](#function-exportlist-member2tick-86995)
-> 
-> > : t
 
 <a name="class-exportlist-class3-53534"></a>**class** [Class3](#class-exportlist-class3-53534) t **where**
 
 > <a name="function-exportlist-member3-30944"></a>[member3](#function-exportlist-member3-30944)
-> 
-> > : t
-> 
-> <a name="function-exportlist-member3tick-14200"></a>[member3'](#function-exportlist-member3tick-14200)
-> 
+>
 > > : t
 
 <a name="class-exportlist-class4-65325"></a>**class** [Class4](#class-exportlist-class4-65325) t **where**
 
 > <a name="function-exportlist-member4-58699"></a>[member4](#function-exportlist-member4-58699)
-> 
+>
 > > : t
-> 
+>
 > <a name="function-exportlist-member4tick-28729"></a>[member4'](#function-exportlist-member4tick-28729)
-> 
+>
 > > : t
 
 ## Data Types
@@ -53,7 +35,7 @@
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
 > <a name="constr-exportlist-constr3-90820"></a>[Constr3](#constr-exportlist-constr3-90820)
-> 
+>
 > > (no fields)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
@@ -62,7 +44,7 @@
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
 > <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
-> 
+>
 > > | Field  | Type   | Description |
 > > | :----- | :----- | :---------- |
 > > | field5 | Int    |  |
@@ -70,13 +52,13 @@
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
 > <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
-> 
+>
 > > | Field  | Type   | Description |
 > > | :----- | :----- | :---------- |
 > > | field6 | Int    |  |
-> 
+>
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
-> 
+>
 
 ## Functions
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -11,17 +11,17 @@
 <a name="class-exportlist-class3-53534"></a>**class** [Class3](#class-exportlist-class3-53534) t **where**
 
 > <a name="function-exportlist-member3-30944"></a>[member3](#function-exportlist-member3-30944)
->
+> 
 > > : t
 
 <a name="class-exportlist-class4-65325"></a>**class** [Class4](#class-exportlist-class4-65325) t **where**
 
 > <a name="function-exportlist-member4-58699"></a>[member4](#function-exportlist-member4-58699)
->
+> 
 > > : t
->
+> 
 > <a name="function-exportlist-member4tick-28729"></a>[member4'](#function-exportlist-member4tick-28729)
->
+> 
 > > : t
 
 ## Data Types
@@ -35,7 +35,7 @@
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
 > <a name="constr-exportlist-constr3-90820"></a>[Constr3](#constr-exportlist-constr3-90820)
->
+> 
 > > (no fields)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
@@ -44,7 +44,7 @@
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
 > <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
->
+> 
 > > | Field  | Type   | Description |
 > > | :----- | :----- | :---------- |
 > > | field5 | Int    |  |
@@ -52,13 +52,13 @@
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
 > <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
->
+> 
 > > | Field  | Type   | Description |
 > > | :----- | :----- | :---------- |
 > > | field6 | Int    |  |
->
+> 
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
->
+> 
 
 ## Functions
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -1,0 +1,77 @@
+# <a name="module-exportlist-81980"></a>Module ExportList
+
+## Typeclasses
+
+<a name="class-exportlist-class1-82332"></a>**class** [Class1](#class-exportlist-class1-82332) t **where**
+
+> <a name="function-exportlist-member1-59742"></a>[member1](#function-exportlist-member1-59742)
+> 
+> > : t
+> 
+> <a name="function-exportlist-member1tick-30562"></a>[member1'](#function-exportlist-member1tick-30562)
+> 
+> > : t
+
+<a name="class-exportlist-class2-52219"></a>**class** [Class2](#class-exportlist-class2-52219) t **where**
+
+> <a name="function-exportlist-member2-87497"></a>[member2](#function-exportlist-member2-87497)
+> 
+> > : t
+> 
+> <a name="function-exportlist-member2tick-86995"></a>[member2'](#function-exportlist-member2tick-86995)
+> 
+> > : t
+
+<a name="class-exportlist-class3-53534"></a>**class** [Class3](#class-exportlist-class3-53534) t **where**
+
+> <a name="function-exportlist-member3-30944"></a>[member3](#function-exportlist-member3-30944)
+> 
+> > : t
+> 
+> <a name="function-exportlist-member3tick-14200"></a>[member3'](#function-exportlist-member3tick-14200)
+> 
+> > : t
+
+<a name="class-exportlist-class4-65325"></a>**class** [Class4](#class-exportlist-class4-65325) t **where**
+
+> <a name="function-exportlist-member4-58699"></a>[member4](#function-exportlist-member4-58699)
+> 
+> > : t
+> 
+> <a name="function-exportlist-member4tick-28729"></a>[member4'](#function-exportlist-member4tick-28729)
+> 
+> > : t
+
+## Data Types
+
+<a name="type-exportlist-data1-25282"></a>**data** [Data1](#type-exportlist-data1-25282)
+
+
+<a name="type-exportlist-data2-68729"></a>**data** [Data2](#type-exportlist-data2-68729)
+
+
+<a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
+
+
+<a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
+
+
+<a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
+
+
+<a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
+
+> <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
+> 
+> > | Field  | Type   | Description |
+> > | :----- | :----- | :---------- |
+> > | field6 | Int    |  |
+> 
+> <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
+> 
+
+## Functions
+
+<a name="function-exportlist-function1-77714"></a>[function1](#function-exportlist-function1-77714)
+
+> : Int

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -52,12 +52,20 @@
 
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
+> <a name="constr-exportlist-constr3-90820"></a>[Constr3](#constr-exportlist-constr3-90820)
+> 
+> > (no fields)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
 
 
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
+> <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
+> 
+> > | Field  | Type   | Description |
+> > | :----- | :----- | :---------- |
+> > | field5 | Int    |  |
 
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -1,0 +1,118 @@
+.. _module-exportlist-81980:
+
+Module ExportList
+-----------------
+
+Typeclasses
+^^^^^^^^^^^
+
+.. _class-exportlist-class1-82332:
+
+**class** `Class1 <class-exportlist-class1-82332_>`_ t **where**
+
+
+.. _class-exportlist-class2-52219:
+
+**class** `Class2 <class-exportlist-class2-52219_>`_ t **where**
+
+
+.. _class-exportlist-class3-53534:
+
+**class** `Class3 <class-exportlist-class3-53534_>`_ t **where**
+
+  .. _function-exportlist-member3-30944:
+  
+  `member3 <function-exportlist-member3-30944_>`_
+    : t
+
+.. _class-exportlist-class4-65325:
+
+**class** `Class4 <class-exportlist-class4-65325_>`_ t **where**
+
+  .. _function-exportlist-member4-58699:
+  
+  `member4 <function-exportlist-member4-58699_>`_
+    : t
+  
+  .. _function-exportlist-member4tick-28729:
+  
+  `member4' <function-exportlist-member4tick-28729_>`_
+    : t
+
+Data Types
+^^^^^^^^^^
+
+.. _type-exportlist-data1-25282:
+
+**data** `Data1 <type-exportlist-data1-25282_>`_
+
+
+.. _type-exportlist-data2-68729:
+
+**data** `Data2 <type-exportlist-data2-68729_>`_
+
+
+.. _type-exportlist-data3-43604:
+
+**data** `Data3 <type-exportlist-data3-43604_>`_
+
+  .. _constr-exportlist-constr3-90820:
+  
+  `Constr3 <constr-exportlist-constr3-90820_>`_
+  
+
+.. _type-exportlist-data4-87051:
+
+**data** `Data4 <type-exportlist-data4-87051_>`_
+
+
+.. _type-exportlist-data5-40974:
+
+**data** `Data5 <type-exportlist-data5-40974_>`_
+
+  .. _constr-exportlist-constr5-35310:
+  
+  `Constr5 <constr-exportlist-constr5-35310_>`_
+  
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - field5
+         - Int
+         - 
+
+.. _type-exportlist-data6-26325:
+
+**data** `Data6 <type-exportlist-data6-26325_>`_
+
+  .. _constr-exportlist-constr6-63065:
+  
+  `Constr6 <constr-exportlist-constr6-63065_>`_
+  
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - field6
+         - Int
+         - 
+  
+  .. _constr-exportlist-constr6tick-67971:
+  
+  `Constr6' <constr-exportlist-constr6tick-67971_>`_
+  
+
+Functions
+^^^^^^^^^
+
+.. _function-exportlist-function1-77714:
+
+`function1 <function-exportlist-function1-77714_>`_
+  : Int

--- a/compiler/damlc/tests/daml-test-files/ExportList.daml
+++ b/compiler/damlc/tests/daml-test-files/ExportList.daml
@@ -1,0 +1,75 @@
+daml 1.2
+module ExportList
+    ( function1
+    , Data1
+    , Data2 ()
+    , Data3 (Constr3)
+    , Data4 (field4)
+    , Data5 (Constr5, field5)
+    , Data6 (..)
+    , Class1
+    , Class2 ()
+    , Class3 (member3)
+    , Class4 (..)
+    ) where
+
+function0 : Int
+function0 = 10
+
+function1 : Int
+function1 = 10
+
+data Data0
+    = Constr0 with
+        field0 : Int
+    | Constr0'
+
+data Data1
+    = Constr1 with
+        field1 : Int
+    | Constr1'
+
+data Data2
+    = Constr2 with
+        field2 : Int
+    | Constr2'
+
+data Data3
+    = Constr3 with
+        field3 : Int
+    | Constr3'
+
+data Data4
+    = Constr4 with
+        field4 : Int
+    | Constr4'
+
+data Data5
+    = Constr5 with
+        field5 : Int
+    | Constr5'
+
+data Data6
+    = Constr6 with
+        field6 : Int
+    | Constr6'
+
+class Class0 t where
+    member0 : t
+    member0' : t
+
+class Class1 t where
+    member1 : t
+    member1' : t
+
+class Class2 t where
+    member2 : t
+    member2' : t
+
+class Class3 t where
+    member3 : t
+    member3' : t
+
+class Class4 t where
+    member4 : t
+    member4' : t


### PR DESCRIPTION
Fixes #38 finally!

I think this is pretty close to doing the right thing. The one case I can find where it doesn't really do the right thing is when you have a record field that is exported, but the constructor is not, so it won't show the field at all. This PR also doesn't take into account whether a field is exported as part of a type or is exported separately, but I think that's a minor difference. (Probably both of these can be solved at the same time, in a later PR.)

To test, I added a new test file `ExportList.daml` that uses the export list.

Also I removed some `-- | HIDE` annotations from the stdlib that are really unnecessary now. I looked through the stdlib docs and it seemed good.