### PR TITLE
Increase timeout on lsp-tests

### DIFF
--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -6,6 +6,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_test(
     name = "lsp-tests",
+    timeout = "long",
     srcs = glob(["src/**/*.hs"]),
     data = [
         "//compiler/damlc",

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -490,7 +490,7 @@ stressTests run _runScenarios = testGroup "Stress tests"
             [ "foo100 : Bool"
             , "foo100 = False"
             ]
-        withTimeout 30 $ do
+        withTimeout 90 $ do
             expectDiagnostics [("Foo0.daml", [(DsError, (4, 7), "Couldn't match expected type")])]
             void $ replaceDoc foo0 $ moduleContent "Foo0"
                 [ "import Foo1"


### PR DESCRIPTION
Now that they are no longer marked as flaky on Windows, we seem to be
hitting the actual Bazel timeout sometimes.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
