### PR TITLE
damldocs: Show relevant instances for types and classes.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
@@ -20,11 +20,18 @@ applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
             | Just new <- isMove md_descr = md{md_name = new, md_descr = Nothing}
             | otherwise = md
 
-        g m1 m2 = m1{md_adts = md_adts m1 ++ md_adts m2
-                    ,md_functions = md_functions m1 ++ md_functions m2
-                    ,md_templates = md_templates m2 ++ md_templates m2
-                    ,md_classes = md_classes m1 ++ md_classes m2
-                    }
+        g m1 m2 = ModuleDoc
+            { md_anchor = md_anchor m1
+            , md_name = md_name m1
+            , md_descr = md_descr m1
+            , md_adts = md_adts m1 ++ md_adts m2
+            , md_functions = md_functions m1 ++ md_functions m2
+            , md_templates = md_templates m2 ++ md_templates m2
+            , md_templateInstances =
+                md_templateInstances m1 ++ md_templateInstances m2
+            , md_classes = md_classes m1 ++ md_classes m2
+            , md_instances = md_instances m1 ++ md_instances m2
+            }
 
         -- Bring Prelude module to the front.
         modulePriorityKey :: Modulename -> (Int,Modulename)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -105,6 +105,7 @@ extractDocs extractOpts ideOpts fp = do
             md_descr = modDoc dc_tcmod
             md_templates = getTemplateDocs ctx typeMap templateInstanceClassMap
             md_functions = mapMaybe (getFctDocs ctx Nothing) dc_decls
+            md_instances = []
 
             filteredAdts -- all ADT docs without templates or choices
                 = MS.elems . MS.withoutKeys typeMap . Set.unions

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -32,6 +32,7 @@ import           "ghc-lib-parser" TyCon
 import           "ghc-lib-parser" ConLike
 import           "ghc-lib-parser" DataCon
 import           "ghc-lib-parser" InstEnv
+import           "ghc-lib-parser" CoreSyn
 import           "ghc-lib-parser" Var
 import           "ghc-lib-parser" Id
 import           "ghc-lib-parser" Name
@@ -556,6 +557,7 @@ getInstanceDocs ctx ClsInst{..} =
     in InstanceDoc
         { id_context = typeToContext ctx ty
         , id_type = typeToType ctx ty
+        , id_isOrphan = isOrphan is_orphan
         }
 
 ------------------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -318,6 +318,7 @@ getClsDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ c@ClassDecl{..})) docs) = do
             let theta = classSCTheta cls
             guard (notNull theta)
             Just (TypeTuple $ map (typeToType ctx) theta)
+        cl_instances = [] -- filled out later in 'distributeInstanceDocs'
     guard (exportsType dc_exports cl_name)
     Just ClassDoc {..}
   where
@@ -351,6 +352,7 @@ getTypeDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
                 tycon <- MS.lookup ad_name dc_tycons
                 rhs <- synTyConRhs_maybe tycon
                 Just (typeToType ctx rhs)
+            ad_instances = [] -- filled out later in 'distributeInstanceDocs'
         guard (exportsType dc_exports ad_name)
         Just (ad_name, TypeSynDoc {..})
 
@@ -360,6 +362,7 @@ getTypeDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
             ad_args = map (tyVarText . unLoc) $ hsq_explicit tcdTyVars
             ad_anchor = Just $ typeAnchor dc_modname ad_name
             ad_constrs = mapMaybe (constrDoc ad_name) . dd_cons $ tcdDataDefn
+            ad_instances = [] -- filled out later in 'distributeInstanceDocs'
         guard (exportsType dc_exports ad_name)
         Just (ad_name, ADTDoc {..})
   where
@@ -443,6 +446,7 @@ getTemplateDocs DocCtx{..} typeMap templateInstanceMap =
                              , ad_descr   = Nothing
                              , ad_args = []
                              , ad_constrs = []
+                             , ad_instances = []
                              }
     -- Assuming one constructor (record or prefix), extract the fields, if any.
     -- For choices without arguments, GHC returns a prefix constructor, so we

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -318,7 +318,7 @@ getClsDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ c@ClassDecl{..})) docs) = do
             let theta = classSCTheta cls
             guard (notNull theta)
             Just (TypeTuple $ map (typeToType ctx) theta)
-        cl_instances = [] -- filled out later in 'distributeInstanceDocs'
+        cl_instances = Nothing -- filled out later in 'distributeInstanceDocs'
     guard (exportsType dc_exports cl_name)
     Just ClassDoc {..}
   where
@@ -352,7 +352,7 @@ getTypeDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
                 tycon <- MS.lookup ad_name dc_tycons
                 rhs <- synTyConRhs_maybe tycon
                 Just (typeToType ctx rhs)
-            ad_instances = [] -- filled out later in 'distributeInstanceDocs'
+            ad_instances = Nothing -- filled out later in 'distributeInstanceDocs'
         guard (exportsType dc_exports ad_name)
         Just (ad_name, TypeSynDoc {..})
 
@@ -362,7 +362,7 @@ getTypeDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
             ad_args = map (tyVarText . unLoc) $ hsq_explicit tcdTyVars
             ad_anchor = Just $ typeAnchor dc_modname ad_name
             ad_constrs = mapMaybe (constrDoc ad_name) . dd_cons $ tcdDataDefn
-            ad_instances = [] -- filled out later in 'distributeInstanceDocs'
+            ad_instances = Nothing -- filled out later in 'distributeInstanceDocs'
         guard (exportsType dc_exports ad_name)
         Just (ad_name, ADTDoc {..})
   where
@@ -446,7 +446,7 @@ getTemplateDocs DocCtx{..} typeMap templateInstanceMap =
                              , ad_descr   = Nothing
                              , ad_args = []
                              , ad_constrs = []
-                             , ad_instances = []
+                             , ad_instances = Nothing
                              }
     -- Assuming one constructor (record or prefix), extract the fields, if any.
     -- For choices without arguments, GHC returns a prefix constructor, so we

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -43,6 +43,7 @@ instance RenderDoc ModuleDoc where
         , section "Templates" md_templates
         , section "Template Instances" md_templateInstances
         , section "Typeclasses" md_classes
+        , section "Typeclass Instances" (filter id_isOrphan md_instances)
         , section "Data Types" md_adts
         , section "Functions" md_functions
         ]
@@ -110,6 +111,7 @@ instance RenderDoc ClassDoc where
         , RenderBlock $ mconcat
             [ renderDoc cl_descr
             , renderDoc cl_functions
+            , renderDoc cl_instances
             ]
         ]
 
@@ -126,6 +128,7 @@ instance RenderDoc ADTDoc where
                 , renderType ad_rhs
                 ]
             , renderDoc ad_descr
+            , renderDoc ad_instances
             ]
         ]
 
@@ -138,6 +141,7 @@ instance RenderDoc ADTDoc where
         , RenderBlock $ mconcat
             [ renderDoc ad_descr
             , renderDoc ad_constrs
+            , renderDoc ad_instances
             ]
         ]
 
@@ -175,6 +179,14 @@ instance RenderDoc FunctionDoc where
             , renderDoc fct_descr
             ]
         ]
+
+instance RenderDoc InstanceDoc where
+    renderDoc InstanceDoc{..} =
+        RenderParagraph . renderUnwords . concat $
+            [ [RenderStrong "instance"]
+            , renderContext id_context
+            , [renderType id_type]
+            ]
 
 fieldTable :: [FieldDoc] -> RenderOut
 fieldTable fields = RenderRecordFields

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -43,7 +43,7 @@ instance RenderDoc ModuleDoc where
         , section "Templates" md_templates
         , section "Template Instances" md_templateInstances
         , section "Typeclasses" md_classes
-        , section "Typeclass Instances" (filter id_isOrphan md_instances)
+        , section "Orphan Typeclass Instances" (filter id_isOrphan md_instances)
         , section "Data Types" md_adts
         , section "Functions" md_functions
         ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -14,6 +14,8 @@ import Data.List.Extra
 import System.FilePath (pathSeparator) -- because FilePattern uses it
 import System.FilePattern
 import qualified Data.Text as T
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 -- | Documentation filtering options, applied in the order given here
 data DocOption =
@@ -140,6 +142,61 @@ instance IsEmpty FieldDoc
 instance IsEmpty FunctionDoc
   where isEmpty FunctionDoc{..} = isNothing fct_descr
 
--- | Add instances to everything.
+type InstanceMap = Map.Map Anchor (Set.Set InstanceDoc)
+
+-- | Add relevant instances to every type and class.
 distributeInstanceDocs :: [ModuleDoc] -> [ModuleDoc]
-distributeInstanceDocs = id
+distributeInstanceDocs docs =
+    let instanceMap = getInstanceMap docs
+    in map (addInstances instanceMap) docs
+
+  where
+
+    getInstanceMap :: [ModuleDoc] -> InstanceMap
+    getInstanceMap docs =
+        Map.unionsWith Set.union (map getModuleInstanceMap docs)
+
+    getModuleInstanceMap :: ModuleDoc -> InstanceMap
+    getModuleInstanceMap ModuleDoc{..} =
+        Map.unionsWith Set.union (map getInstanceInstanceMap md_instances)
+
+    getInstanceInstanceMap :: InstanceDoc -> InstanceMap
+    getInstanceInstanceMap inst = Map.fromList
+        [ (anchor, Set.singleton inst)
+        | anchor <- Set.toList . getTypeAnchors $ id_type inst ]
+
+    getTypeAnchors :: Type -> Set.Set Anchor
+    getTypeAnchors = \case
+        TypeApp anchorM _ args -> Set.unions
+            $ maybe Set.empty Set.singleton anchorM
+            : map getTypeAnchors args
+        TypeFun parts -> Set.unions $ map getTypeAnchors parts
+        TypeTuple parts -> Set.unions $ map getTypeAnchors parts
+        TypeList p -> getTypeAnchors p
+
+    addInstances :: InstanceMap -> ModuleDoc -> ModuleDoc
+    addInstances imap ModuleDoc{..} = ModuleDoc
+        { md_name = md_name
+        , md_anchor = md_anchor
+        , md_descr = md_descr
+        , md_functions = md_functions
+        , md_templates = md_templates
+        , md_templateInstances = md_templateInstances
+        , md_classes = map (addClassInstances imap) md_classes
+        , md_adts = map (addTypeInstances imap) md_adts
+        , md_instances = md_instances
+        }
+
+    addClassInstances :: InstanceMap -> ClassDoc -> ClassDoc
+    addClassInstances imap cl = cl
+        { cl_instances = maybe [] Set.toList $ do
+            anchor <- cl_anchor cl
+            Map.lookup anchor imap
+        }
+
+    addTypeInstances :: InstanceMap -> ADTDoc -> ADTDoc
+    addTypeInstances imap ad = ad
+        { ad_instances = maybe [] Set.toList $ do
+            anchor <- ad_anchor ad
+            Map.lookup anchor imap
+        }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -26,7 +26,7 @@ data DocOption =
 
 
 applyTransform :: [DocOption] -> [ModuleDoc] -> [ModuleDoc]
-applyTransform opts docs = maybeDoAnnotations opts' docs
+applyTransform opts = distributeInstanceDocs . maybeDoAnnotations opts'
   where
     opts' = nubOrd $ sort opts
 
@@ -139,3 +139,7 @@ instance IsEmpty FieldDoc
 
 instance IsEmpty FunctionDoc
   where isEmpty FunctionDoc{..} = isNothing fct_descr
+
+-- | Add instances to everything.
+distributeInstanceDocs :: [ModuleDoc] -> [ModuleDoc]
+distributeInstanceDocs = id

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -189,14 +189,14 @@ distributeInstanceDocs docs =
 
     addClassInstances :: InstanceMap -> ClassDoc -> ClassDoc
     addClassInstances imap cl = cl
-        { cl_instances = maybe [] Set.toList $ do
+        { cl_instances = Set.toList <$> do
             anchor <- cl_anchor cl
             Map.lookup anchor imap
         }
 
     addTypeInstances :: InstanceMap -> ADTDoc -> ADTDoc
     addTypeInstances imap ad = ad
-        { ad_instances = maybe [] Set.toList $ do
+        { ad_instances = Set.toList <$> do
             anchor <- ad_anchor ad
             Map.lookup anchor imap
         }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -8,8 +8,8 @@ module DA.Daml.Doc.Types(
     ) where
 
 import Data.Aeson
-import           Data.Text              (Text)
-import           Data.Hashable
+import Data.Text (Text)
+import Data.Hashable
 import GHC.Generics
 import Data.String
 
@@ -57,6 +57,7 @@ data ModuleDoc = ModuleDoc
   -- TODO will later be refactored to contain "documentation sections" with an
   -- optional header, containing groups of templates and ADTs. This can be done
   -- storing just linkIDs for them, the renderer would then search the lists.
+  , md_instances :: [InstanceDoc]
   }
   deriving (Eq, Show, Generic)
 
@@ -156,6 +157,12 @@ data FunctionDoc = FunctionDoc
   }
   deriving (Eq, Show, Generic)
 
+-- | Documentation on a typeclass instance.
+data InstanceDoc = InstanceDoc
+    { id_context :: Maybe Type
+    , id_rhs :: Type
+    } deriving (Eq, Ord, Show, Generic)
+
 -----------------------------------------------------
 -- generate JSON instances
 
@@ -211,6 +218,12 @@ instance ToJSON TemplateInstanceDoc where
     toJSON = genericToJSON aesonOptions
 
 instance FromJSON TemplateInstanceDoc where
+    parseJSON = genericParseJSON aesonOptions
+
+instance ToJSON InstanceDoc where
+    toJSON = genericToJSON aesonOptions
+
+instance FromJSON InstanceDoc where
     parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON ModuleDoc where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -160,7 +160,7 @@ data FunctionDoc = FunctionDoc
 -- | Documentation on a typeclass instance.
 data InstanceDoc = InstanceDoc
     { id_context :: Maybe Type
-    , id_rhs :: Type
+    , id_type :: Type
     } deriving (Eq, Ord, Show, Generic)
 
 -----------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -88,6 +88,7 @@ data ClassDoc = ClassDoc
   , cl_super :: Maybe Type
   , cl_args :: [Text]
   , cl_functions :: [FunctionDoc]
+  , cl_instances :: [InstanceDoc] -- relevant instances
   }
   deriving (Eq, Show, Generic)
 
@@ -98,6 +99,7 @@ data ADTDoc = ADTDoc
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_constrs :: [ADTConstr]  -- allowed to be empty
+  , ad_instances :: [InstanceDoc] -- relevant instances
   }
   | TypeSynDoc
   { ad_anchor :: Maybe Anchor
@@ -105,6 +107,7 @@ data ADTDoc = ADTDoc
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_rhs    :: Type
+  , ad_instances :: [InstanceDoc] -- relevant instances
   }
   deriving (Eq, Show, Generic)
 
@@ -159,8 +162,8 @@ data FunctionDoc = FunctionDoc
 
 -- | Documentation on a typeclass instance.
 data InstanceDoc = InstanceDoc
-    { id_context :: Maybe Type
-    , id_type :: Type
+    { id_type :: Type
+    , id_context :: Maybe Type
     } deriving (Eq, Ord, Show, Generic)
 
 -----------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -164,6 +164,7 @@ data FunctionDoc = FunctionDoc
 data InstanceDoc = InstanceDoc
     { id_type :: Type
     , id_context :: Maybe Type
+    , id_isOrphan :: Bool
     } deriving (Eq, Ord, Show, Generic)
 
 -----------------------------------------------------

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -88,7 +88,7 @@ data ClassDoc = ClassDoc
   , cl_super :: Maybe Type
   , cl_args :: [Text]
   , cl_functions :: [FunctionDoc]
-  , cl_instances :: [InstanceDoc] -- relevant instances
+  , cl_instances :: Maybe [InstanceDoc] -- relevant instances
   }
   deriving (Eq, Show, Generic)
 
@@ -99,7 +99,7 @@ data ADTDoc = ADTDoc
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_constrs :: [ADTConstr]  -- allowed to be empty
-  , ad_instances :: [InstanceDoc] -- relevant instances
+  , ad_instances :: Maybe [InstanceDoc] -- relevant instances
   }
   | TypeSynDoc
   { ad_anchor :: Maybe Anchor
@@ -107,7 +107,7 @@ data ADTDoc = ADTDoc
   , ad_descr  :: Maybe DocText
   , ad_args   :: [Text] -- retain names of type var.s
   , ad_rhs    :: Type
-  , ad_instances :: [InstanceDoc] -- relevant instances
+  , ad_instances :: Maybe [InstanceDoc] -- relevant instances
   }
   deriving (Eq, Show, Generic)
 

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -32,13 +32,13 @@ cases = [ ("Empty module",
            ModuleDoc Nothing "Empty" Nothing [] [] [] [] [] [])
         , ("Type def with argument",
            ModuleDoc (Just "module-typedef") "Typedef" Nothing [] []
-            [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
+            [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []]) []]
             [] [] []
           )
         , ("Two types",
            ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing [] []
-            [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
-            , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]]
+            [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" []) []
+            , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]] []
             ]
             [] [] []
           )
@@ -52,7 +52,7 @@ cases = [ ("Empty module",
           )
         , ("Module with only a type class",
            ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
-            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing]] [])
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing] []] [])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")
@@ -65,7 +65,8 @@ cases = [ ("Empty module",
                 "D"
                 Nothing
                 []
-                [RecordC (Just "constr-multilinefield-d") "D" Nothing [FieldDoc (Just "function-multilinefield-f") "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]]
+                [RecordC (Just "constr-multilinefield-d") "D" Nothing [FieldDoc (Just "function-multilinefield-f") "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]
+                []]
              []
              []
              []

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -32,13 +32,13 @@ cases = [ ("Empty module",
            ModuleDoc Nothing "Empty" Nothing [] [] [] [] [] [])
         , ("Type def with argument",
            ModuleDoc (Just "module-typedef") "Typedef" Nothing [] []
-            [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []]) []]
+            [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []]) Nothing]
             [] [] []
           )
         , ("Two types",
            ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing [] []
-            [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" []) []
-            , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]] []
+            [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" []) Nothing
+            , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]] Nothing
             ]
             [] [] []
           )
@@ -52,7 +52,7 @@ cases = [ ("Empty module",
           )
         , ("Module with only a type class",
            ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
-            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing] []] [])
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing] Nothing] [])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")
@@ -66,7 +66,7 @@ cases = [ ("Empty module",
                 Nothing
                 []
                 [RecordC (Just "constr-multilinefield-d") "D" Nothing [FieldDoc (Just "function-multilinefield-f") "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]
-                []]
+                Nothing]
              []
              []
              []

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -29,30 +29,30 @@ mkTestTree = do
 
 cases :: [(String, ModuleDoc)]
 cases = [ ("Empty module",
-           ModuleDoc Nothing "Empty" Nothing [] [] [] [] [])
+           ModuleDoc Nothing "Empty" Nothing [] [] [] [] [] [])
         , ("Type def with argument",
            ModuleDoc (Just "module-typedef") "Typedef" Nothing [] []
             [TypeSynDoc (Just "type-typedef-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [TypeApp Nothing "TTT" []])]
-            [] []
+            [] [] []
           )
         , ("Two types",
            ModuleDoc (Just "module-twotypes") "TwoTypes" Nothing [] []
             [ TypeSynDoc (Just "type-twotypes-t") "T" (Just "T descr") ["a"] (TypeApp Nothing "TT" [])
             , ADTDoc (Just "data-twotypes-d") "D" Nothing ["d"] [PrefixC (Just "constr-twotypes-d") "D" (Just "D descr") [TypeApp Nothing "a" []]]
             ]
-            [] []
+            [] [] []
           )
         , ("Documented function",
            ModuleDoc (Just "module-function1") "Function1" Nothing [] [] []
-            [FunctionDoc (Just "function-function1-f") "f" Nothing (TypeApp Nothing "TheType" []) (Just "the doc")] []
+            [FunctionDoc (Just "function-function1-f") "f" Nothing (TypeApp Nothing "TheType" []) (Just "the doc")] [] []
           )
         , ("Undocumented function",
            ModuleDoc (Just "module-function3") "Function3" Nothing [] [] []
-            [FunctionDoc (Just "function-function3-f") "f" Nothing (TypeApp Nothing "TheType" []) Nothing] []
+            [FunctionDoc (Just "function-function3-f") "f" Nothing (TypeApp Nothing "TheType" []) Nothing] [] []
           )
         , ("Module with only a type class",
            ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
-            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing]])
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing]] [])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")
@@ -68,6 +68,7 @@ cases = [ ("Empty module",
                 [RecordC (Just "constr-multilinefield-d") "D" Nothing [FieldDoc (Just "function-multilinefield-f") "f" (TypeApp Nothing "T" []) (Just "This is a multiline\nfield description")]]]
              []
              []
+             []
           )
         , ("Functions with context",
            ModuleDoc
@@ -77,7 +78,7 @@ cases = [ ("Empty module",
                 (Just $ TypeTuple [TypeApp Nothing "Eq" [TypeApp Nothing "t" []]])
                 (TypeFun [TypeApp Nothing "t" [], TypeApp Nothing "Bool" []])
                 (Just "function with context")
-            ] []
+            ] [] []
           )
         ]
 

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -228,6 +228,7 @@ emptyDocs name =
         md_adts = []
         md_functions = []
         md_classes = []
+        md_instances = []
     in ModuleDoc {..}
 
 -- | Compiles the given input string (in a tmp file) and checks generated doc.s

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -12,6 +12,7 @@ import           DA.Daml.Options.Types
 import DA.Daml.Doc.Extract
 import DA.Daml.Doc.Render
 import DA.Daml.Doc.Types
+import DA.Daml.Doc.Transform
 import DA.Daml.Doc.Anchor
 
 import Development.IDE.Types.Location
@@ -265,8 +266,15 @@ runDamldoc testfile importPathM = do
       Left err ->
         assertFailure $ unlines ["Parse error(s) for test file " <> testfile, show err]
 
-      -- first module is the root we started from, so is the one we're testing
-      Right docs -> pure $ head docs
+      Right docs -> do
+          let docs' = applyTransform [] docs
+                -- apply transforms to get instance data
+              name = md_name (head docs)
+                -- first module in docs is the one we're testing,
+                -- we need to find it in docs' because applyTransform
+                -- will reorder the docs
+              docM = find ((== name) . md_name) docs'
+          pure $ fromJust docM
 
 -- | For the given file <name>.daml (assumed), this test checks if any
 -- <name>.EXPECTED.<suffix> exists, and produces output according to <suffix>

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -1,0 +1,31 @@
+# <a name="module-deriving-95364"></a>Module Deriving
+
+## Data Types
+
+<a name="type-deriving-formula-84903"></a>**data** [Formula](#type-deriving-formula-84903) t
+
+> <a name="constr-deriving-tautology-41024"></a>[Tautology](#constr-deriving-tautology-41024)
+> 
+> 
+> <a name="constr-deriving-contradiction-93645"></a>[Contradiction](#constr-deriving-contradiction-93645)
+> 
+> 
+> <a name="constr-deriving-proposition-99264"></a>[Proposition](#constr-deriving-proposition-99264) t
+> 
+> 
+> <a name="constr-deriving-negation-52326"></a>[Negation](#constr-deriving-negation-52326) ([Formula](#type-deriving-formula-84903) t)
+> 
+> 
+> <a name="constr-deriving-conjunction-36676"></a>[Conjunction](#constr-deriving-conjunction-36676) \[[Formula](#type-deriving-formula-84903) t\]
+> 
+> 
+> <a name="constr-deriving-disjunction-94592"></a>[Disjunction](#constr-deriving-disjunction-94592) \[[Formula](#type-deriving-formula-84903) t\]
+> 
+> 
+> **instance** Functor [Formula](#type-deriving-formula-84903)
+> 
+> **instance** Eq t =\> Eq ([Formula](#type-deriving-formula-84903) t)
+> 
+> **instance** Ord t =\> Ord ([Formula](#type-deriving-formula-84903) t)
+> 
+> **instance** Show t =\> Show ([Formula](#type-deriving-formula-84903) t)

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -1,0 +1,49 @@
+.. _module-deriving-95364:
+
+Module Deriving
+---------------
+
+Data Types
+^^^^^^^^^^
+
+.. _type-deriving-formula-84903:
+
+**data** `Formula <type-deriving-formula-84903_>`_ t
+
+  .. _constr-deriving-tautology-41024:
+  
+  `Tautology <constr-deriving-tautology-41024_>`_
+  
+  
+  .. _constr-deriving-contradiction-93645:
+  
+  `Contradiction <constr-deriving-contradiction-93645_>`_
+  
+  
+  .. _constr-deriving-proposition-99264:
+  
+  `Proposition <constr-deriving-proposition-99264_>`_ t
+  
+  
+  .. _constr-deriving-negation-52326:
+  
+  `Negation <constr-deriving-negation-52326_>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  
+  
+  .. _constr-deriving-conjunction-36676:
+  
+  `Conjunction <constr-deriving-conjunction-36676_>`_ [`Formula <type-deriving-formula-84903_>`_ t]
+  
+  
+  .. _constr-deriving-disjunction-94592:
+  
+  `Disjunction <constr-deriving-disjunction-94592_>`_ [`Formula <type-deriving-formula-84903_>`_ t]
+  
+  
+  **instance** Functor `Formula <type-deriving-formula-84903_>`_
+  
+  **instance** Eq t => Eq (`Formula <type-deriving-formula-84903_>`_ t)
+  
+  **instance** Ord t => Ord (`Formula <type-deriving-formula-84903_>`_ t)
+  
+  **instance** Show t => Show (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -28,18 +28,23 @@
 
 <a name="type-exportlist-data1-25282"></a>**data** [Data1](#type-exportlist-data1-25282)
 
+> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) Int
 
 <a name="type-exportlist-data2-68729"></a>**data** [Data2](#type-exportlist-data2-68729)
 
+> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) Int
 
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
 > <a name="constr-exportlist-constr3-90820"></a>[Constr3](#constr-exportlist-constr3-90820)
 > 
 > > (no fields)
+> 
+> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) Int
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
 
+> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) Int
 
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
@@ -48,6 +53,8 @@
 > > | Field  | Type   | Description |
 > > | :----- | :----- | :---------- |
 > > | field5 | Int    |  |
+> 
+> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) Int
 
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
@@ -59,6 +66,8 @@
 > 
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
 > 
+> 
+> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) Int
 
 ## Functions
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -46,11 +46,13 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-25282_>`_
 
+  **instance** HasField "field1" `Data1 <type-exportlist-data1-25282_>`_ Int
 
 .. _type-exportlist-data2-68729:
 
 **data** `Data2 <type-exportlist-data2-68729_>`_
 
+  **instance** HasField "field2" `Data2 <type-exportlist-data2-68729_>`_ Int
 
 .. _type-exportlist-data3-43604:
 
@@ -60,11 +62,14 @@ Data Types
   
   `Constr3 <constr-exportlist-constr3-90820_>`_
   
+  
+  **instance** HasField "field3" `Data3 <type-exportlist-data3-43604_>`_ Int
 
 .. _type-exportlist-data4-87051:
 
 **data** `Data4 <type-exportlist-data4-87051_>`_
 
+  **instance** HasField "field4" `Data4 <type-exportlist-data4-87051_>`_ Int
 
 .. _type-exportlist-data5-40974:
 
@@ -84,6 +89,8 @@ Data Types
        * - field5
          - Int
          - 
+  
+  **instance** HasField "field5" `Data5 <type-exportlist-data5-40974_>`_ Int
 
 .. _type-exportlist-data6-26325:
 
@@ -108,6 +115,8 @@ Data Types
   
   `Constr6' <constr-exportlist-constr6tick-67971_>`_
   
+  
+  **instance** HasField "field6" `Data6 <type-exportlist-data6-26325_>`_ Int
 
 Functions
 ^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -9,6 +9,8 @@
 > > | Field | Type  | Description |
 > > | :---- | :---- | :---------- |
 > > | unNat | Int   |  |
+> 
+> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) Int
 
 ## Functions
 

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -24,6 +24,8 @@ Data Types
        * - unNat
          - Int
          - 
+  
+  **instance** HasField "unNat" `Nat <type-newtype-nat-61947_>`_ Int
 
 Functions
 ^^^^^^^^^


### PR DESCRIPTION
This PR shows relevant instances for types and classes. Also, orphan instances are shown in the module that declares them. The instance data is collected in the modules, and then "distributed" to the relevant types and classes inside `Transform.distributeInstanceDocs`. As part of testing this I discovered we weren't applying transforms in our tests, which seems like a mistake, so I added that.

Fixes #17. 