### PR TITLE
Fix release notes about improper freeze of 1.6

### DIFF
--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -7,22 +7,20 @@ package testing
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.language.LanguageMajorVersion.V1
-import com.digitalasset.daml.lf.language.LanguageMinorVersion
+import com.digitalasset.daml.lf.language.{LanguageVersion => LV}
 import com.digitalasset.daml_lf.{DamlLf1 => PLF}
 
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 // Important: do not use this in production code. It is designed for testing only.
-private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
+private[digitalasset] class EncodeV1(val minor: LV.Minor) {
 
   import EncodeV1._
   import Encode._
-  import LanguageMinorVersion.Implicits._
   import Name.ordering
 
-  private val enumVersion: LanguageMinorVersion = DecodeV1.enumVersion
+  private val version = LV(LV.Major.V1, minor)
 
   def encodePackage(pkgId: PackageId, pkg: Package): PLF.Package = {
     val moduleEncoder = new ModuleEncoder(pkgId)
@@ -178,7 +176,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
           builder.setCon(
             PLF.Type.Con.newBuilder().setTycon(tycon).accumulateLeft(args)(_ addArgs _))
         case TBuiltin(bType) =>
-          if (bType == BTArrow && V1.minorVersionOrdering.lteq(minor, "0")) {
+          if (bType == BTArrow && LV.ordering.lt(version, LV.v1_1)) {
             args match {
               case ImmArraySnoc(firsts, last) =>
                 builder.setFun(
@@ -273,7 +271,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
         case UpdateFetch(templateId, contractId) =>
           builder.setFetch(PLF.Update.Fetch.newBuilder().setTemplate(templateId).setCid(contractId))
         case UpdateExercise(templateId, choice, cid, actors, arg) =>
-          if (actors.isEmpty) assertSince("5", "Update.Exercise.actors optional")
+          if (actors.isEmpty) assertSince(LV.v1_5, "Update.Exercise.actors optional")
           builder.setExercise(
             PLF.Update.Exercise
               .newBuilder()
@@ -286,10 +284,10 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
         case UpdateGetTime =>
           builder.setGetTime(unit)
         case UpdateFetchByKey(rbk) =>
-          assertSince("2", "fetchByKey")
+          assertSince(LV.v1_2, "fetchByKey")
           builder.setFetchByKey(rbk)
         case UpdateLookupByKey(rbk) =>
-          assertSince("2", "lookupByKey")
+          assertSince(LV.v1_2, "lookupByKey")
           builder.setLookupByKey(rbk)
         case UpdateEmbedExpr(typ, body) =>
           builder.setEmbedExpr(PLF.Update.EmbedExpr.newBuilder().setType(typ).setBody(body))
@@ -350,7 +348,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
           builder.setVariant(
             PLF.CaseAlt.Variant.newBuilder().setCon(tyCon).setVariant(variant).setBinder(binder))
         case CPEnum(tyCon, con) =>
-          assertSince(enumVersion, "CaseAlt.Enum")
+          assertSince(LV.Features.enumVersion, "CaseAlt.Enum")
           builder.setEnum(PLF.CaseAlt.Enum.newBuilder().setCon(tyCon).setConstructor(con))
         case CPPrimCon(primCon) =>
           builder.setPrimCon(primCon)
@@ -359,10 +357,10 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
         case CPCons(head, tail) =>
           builder.setCons(PLF.CaseAlt.Cons.newBuilder().setVarHead(head).setVarTail(tail))
         case CPNone =>
-          assertSince("1", "CaseAlt.OptionalNone")
+          assertSince(LV.Features.optionalVersion, "CaseAlt.OptionalNone")
           builder.setOptionalNone(unit)
         case CPSome(x) =>
-          assertSince("1", "CaseAlt.OptionalSome")
+          assertSince(LV.Features.optionalVersion, "CaseAlt.OptionalSome")
           builder.setOptionalSome(PLF.CaseAlt.OptionalSome.newBuilder().setVarBody(x))
         case CPDefault =>
           builder.setDefault(unit)
@@ -419,7 +417,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
               .setVariantCon(variant)
               .setVariantArg(arg))
         case EEnumCon(tyCon, con) =>
-          assertSince(enumVersion, "Expr.Enum")
+          assertSince(LV.Features.enumVersion, "Expr.Enum")
           newBuilder.setEnumCon(PLF.Expr.EnumCon.newBuilder().setTycon(tyCon).setEnumCon(con))
         case ETupleCon(fields) =>
           newBuilder.setTupleCon(
@@ -460,10 +458,10 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
               .accumulateLeft(front)(_ addFront _)
               .setTail(tail))
         case ENone(typ) =>
-          assertSince("1", "Expr.OptionalNone")
+          assertSince(LV.Features.optionalVersion, "Expr.OptionalNone")
           newBuilder.setOptionalNone(PLF.Expr.OptionalNone.newBuilder().setType(typ))
         case ESome(typ, x) =>
-          assertSince("1", "Expr.OptionalSome")
+          assertSince(LV.Features.optionalVersion, "Expr.OptionalSome")
           newBuilder.setOptionalSome(PLF.Expr.OptionalSome.newBuilder().setType(typ).setBody(x))
         case ELocation(loc, expr) =>
           encodeExprBuilder(expr).setLocation(loc)
@@ -490,7 +488,7 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
           builder.setVariant(
             PLF.DefDataType.Fields.newBuilder().accumulateLeft(variants)(_ addFields _))
         case DataEnum(constructors) =>
-          assertSince(enumVersion, "DefDataType.Enum")
+          assertSince(LV.Features.enumVersion, "DefDataType.Enum")
           builder.setEnum(
             PLF.DefDataType.EnumConstructors
               .newBuilder()
@@ -555,8 +553,8 @@ private[digitalasset] class EncodeV1(val minor: LanguageMinorVersion) {
 
   }
 
-  private def assertSince(minMinorVersion: LanguageMinorVersion, description: String): Unit =
-    if (V1.minorVersionOrdering.lt(minor, minMinorVersion))
+  private def assertSince(minVersion: LV, description: String): Unit =
+    if (LV.ordering.lt(version, minVersion))
       throw EncodeError(s"$description is not supported by DAML-LF 1.$minor")
 
 }

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -176,7 +176,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           builder.setCon(
             PLF.Type.Con.newBuilder().setTycon(tycon).accumulateLeft(args)(_ addArgs _))
         case TBuiltin(bType) =>
-          if (bType == BTArrow && LV.ordering.lt(version, LV.v1_1)) {
+          if (bType == BTArrow && LV.ordering.lt(version, LV.Features.arrowType)) {
             args match {
               case ImmArraySnoc(firsts, last) =>
                 builder.setFun(
@@ -271,7 +271,8 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
         case UpdateFetch(templateId, contractId) =>
           builder.setFetch(PLF.Update.Fetch.newBuilder().setTemplate(templateId).setCid(contractId))
         case UpdateExercise(templateId, choice, cid, actors, arg) =>
-          if (actors.isEmpty) assertSince(LV.v1_5, "Update.Exercise.actors optional")
+          if (actors.isEmpty)
+            assertSince(LV.Features.optionalExerciseActor, "Update.Exercise.actors optional")
           builder.setExercise(
             PLF.Update.Exercise
               .newBuilder()
@@ -284,10 +285,10 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
         case UpdateGetTime =>
           builder.setGetTime(unit)
         case UpdateFetchByKey(rbk) =>
-          assertSince(LV.v1_2, "fetchByKey")
+          assertSince(LV.Features.contractKeys, "fetchByKey")
           builder.setFetchByKey(rbk)
         case UpdateLookupByKey(rbk) =>
-          assertSince(LV.v1_2, "lookupByKey")
+          assertSince(LV.Features.contractKeys, "lookupByKey")
           builder.setLookupByKey(rbk)
         case UpdateEmbedExpr(typ, body) =>
           builder.setEmbedExpr(PLF.Update.EmbedExpr.newBuilder().setType(typ).setBody(body))
@@ -348,7 +349,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           builder.setVariant(
             PLF.CaseAlt.Variant.newBuilder().setCon(tyCon).setVariant(variant).setBinder(binder))
         case CPEnum(tyCon, con) =>
-          assertSince(LV.Features.enumVersion, "CaseAlt.Enum")
+          assertSince(LV.Features.enum, "CaseAlt.Enum")
           builder.setEnum(PLF.CaseAlt.Enum.newBuilder().setCon(tyCon).setConstructor(con))
         case CPPrimCon(primCon) =>
           builder.setPrimCon(primCon)
@@ -357,10 +358,10 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
         case CPCons(head, tail) =>
           builder.setCons(PLF.CaseAlt.Cons.newBuilder().setVarHead(head).setVarTail(tail))
         case CPNone =>
-          assertSince(LV.Features.optionalVersion, "CaseAlt.OptionalNone")
+          assertSince(LV.Features.optional, "CaseAlt.OptionalNone")
           builder.setOptionalNone(unit)
         case CPSome(x) =>
-          assertSince(LV.Features.optionalVersion, "CaseAlt.OptionalSome")
+          assertSince(LV.Features.optional, "CaseAlt.OptionalSome")
           builder.setOptionalSome(PLF.CaseAlt.OptionalSome.newBuilder().setVarBody(x))
         case CPDefault =>
           builder.setDefault(unit)
@@ -417,7 +418,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
               .setVariantCon(variant)
               .setVariantArg(arg))
         case EEnumCon(tyCon, con) =>
-          assertSince(LV.Features.enumVersion, "Expr.Enum")
+          assertSince(LV.Features.enum, "Expr.Enum")
           newBuilder.setEnumCon(PLF.Expr.EnumCon.newBuilder().setTycon(tyCon).setEnumCon(con))
         case ETupleCon(fields) =>
           newBuilder.setTupleCon(
@@ -458,10 +459,10 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
               .accumulateLeft(front)(_ addFront _)
               .setTail(tail))
         case ENone(typ) =>
-          assertSince(LV.Features.optionalVersion, "Expr.OptionalNone")
+          assertSince(LV.Features.optional, "Expr.OptionalNone")
           newBuilder.setOptionalNone(PLF.Expr.OptionalNone.newBuilder().setType(typ))
         case ESome(typ, x) =>
-          assertSince(LV.Features.optionalVersion, "Expr.OptionalSome")
+          assertSince(LV.Features.optional, "Expr.OptionalSome")
           newBuilder.setOptionalSome(PLF.Expr.OptionalSome.newBuilder().setType(typ).setBody(x))
         case ELocation(loc, expr) =>
           encodeExprBuilder(expr).setLocation(loc)
@@ -488,7 +489,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           builder.setVariant(
             PLF.DefDataType.Fields.newBuilder().accumulateLeft(variants)(_ addFields _))
         case DataEnum(constructors) =>
-          assertSince(LV.Features.enumVersion, "DefDataType.Enum")
+          assertSince(LV.Features.enum, "DefDataType.Enum")
           builder.setEnum(
             PLF.DefDataType.EnumConstructors
               .newBuilder()

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -40,7 +40,7 @@ object LanguageMajorVersion {
   case object V1
       extends LanguageMajorVersion(
         pretty = "1",
-        stableAscending = NonEmptyList("0", "1", "2", "3", "4", "5", "6"))
+        stableAscending = NonEmptyList("0", "1", "2", "3", "4", "5", "6")) {}
 
   val All: List[LanguageMajorVersion] = List(V0, V1)
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -40,7 +40,7 @@ object LanguageMajorVersion {
   case object V1
       extends LanguageMajorVersion(
         pretty = "1",
-        stableAscending = NonEmptyList("0", "1", "2", "3", "4", "5", "6")) {}
+        stableAscending = NonEmptyList("0", "1", "2", "3", "4", "5", "6"))
 
   val All: List[LanguageMajorVersion] = List(V0, V1)
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -35,17 +35,26 @@ object LanguageVersion {
         case (LanguageVersion(leftMajor, _), LanguageVersion(rightMajor, _)) =>
           LanguageMajorVersion.ordering.compare(leftMajor, rightMajor)
     }
-
-  val List(v1_0, v1_1, v1_2, v1_3, v1_4, v1_5, v1_6, _) =
-    Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))
-
   object Features {
 
-    val optionalVersion = v1_1
-    val partyOrderingVersion = v1_1
-    val mapVersion = v1_3
-    val enumVersion = v1_6
-    val internedIdsVersion = v1_6
+    private val List(v1_0, v1_1, v1_2, v1_3, v1_4, v1_5, v1_6, v1_dev) =
+      Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))
+
+    val default = v1_0
+    val arrowType = v1_1
+    val optional = v1_1
+    val partyOrdering = v1_1
+    val partyTextConversions = v1_2
+    val shaText = v1_2
+    val contractKeys = v1_3
+    val map = v1_3
+    val complexContactKeys = v1_4
+    val optionalExerciseActor = v1_5
+    val numberParsing = v1_5
+    val coerceContractId = v1_5
+    val textPacking = v1_6
+    val enum = v1_6
+    val internedIds = v1_6
 
     /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
       * compatibility, we introduce a new DAML-LF version where this restriction is in
@@ -55,7 +64,7 @@ object LanguageVersion {
       * * When executing a Ledger API command, we check that the template underpinning
       * said command is at least of that version.
       */
-    val checkSubmitterInMaintainersVersion = LanguageVersion(Major.V1, Minor.Dev)
+    val checkSubmitterInMaintainersVersion = v1_dev
 
   }
 }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.daml.lf.language
 
-import com.digitalasset.daml.lf.language.{LanguageMajorVersion => LMV}
-
 final case class LanguageVersion(major: LanguageMajorVersion, minor: LanguageMinorVersion) {
   def pretty: String = s"${major.pretty}.${minor.toProtoIdentifier}"
 }
@@ -17,10 +15,10 @@ object LanguageVersion {
   val Minor = LanguageMinorVersion
 
   val defaultV0: LanguageVersion =
-    LanguageVersion(LMV.V0, LMV.V0.maxSupportedStableMinorVersion)
+    LanguageVersion(Major.V0, Major.V0.maxSupportedStableMinorVersion)
 
   val defaultV1: LanguageVersion =
-    LanguageVersion(LMV.V1, LMV.V1.maxSupportedStableMinorVersion)
+    LanguageVersion(Major.V1, Major.V1.maxSupportedStableMinorVersion)
 
   private[lf] def apply(major: LanguageMajorVersion, minor: String): LanguageVersion =
     apply(major, Minor fromProtoIdentifier minor)
@@ -38,13 +36,26 @@ object LanguageVersion {
           LanguageMajorVersion.ordering.compare(leftMajor, rightMajor)
     }
 
-  /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
-    * compatibility, we introduce a new DAML-LF version where this restriction is in
-    * place, and then:
-    * * When committing a scenario, we check that the scenario code is at least of that
-    *   version;
-    * * When executing a Ledger API command, we check that the template underpinning
-    *   said command is at least of that version.
-    */
-  val checkSubmitterInMaintainers = LanguageVersion(LMV.V1, Minor.Dev)
+  val List(v1_0, v1_1, v1_2, v1_3, v1_4, v1_5, v1_6, _) =
+    Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))
+
+  object Features {
+
+    val optionalVersion = v1_1
+    val partyOrderingVersion = v1_1
+    val mapVersion = v1_3
+    val enumVersion = v1_6
+    val internedIdsVersion = v1_6
+
+    /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
+      * compatibility, we introduce a new DAML-LF version where this restriction is in
+      * place, and then:
+      * * When committing a scenario, we check that the scenario code is at least of that
+      * version;
+      * * When executing a Ledger API command, we check that the template underpinning
+      * said command is at least of that version.
+      */
+    val checkSubmitterInMaintainersVersion = LanguageVersion(Major.V1, Minor.Dev)
+
+  }
 }

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -224,20 +224,17 @@ Version: 1.6
 
   * **Add** intern package IDs in external package references.
 
+Version: 1.dev
+..............
+
   * **Change** Transaction submitter must be in the contract key
     maintainers when performing lookup or fetches by key. See
     `issue #1866 <https://github.com/digital-asset/daml/issues/1866>`_
 
-Version: 1.dev
-..............
+  * **Add** Nat kind and Nat type.
 
-  * Description:
-
-    * **Add** Nat kind and Nat type.
-
-    * **Replace** fixed scaled 'Decimal' type by parametric scaled
-      'Numeric' typer.
-
+  * **Replace** fixed scaled 'Decimal' type by parametricly  scaled
+    'Numeric' type.
 
 Abstract syntax
 ^^^^^^^^^^^^^^^

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -168,6 +168,7 @@ private[digitalasset] object VersionTimeline {
 
   def checkSubmitterInMaintainers(lfVers: LanguageVersion): Boolean = {
     import Implicits._
-    !(lfVers precedes LanguageVersion.checkSubmitterInMaintainers)
+    !(lfVers precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion)
   }
+
 }

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -198,13 +198,6 @@ DAML-LF
   + intern package IDs. See `issue #1614
     <https://github.com/digital-asset/daml/pull/1614>`__.
 
-  + **BREAKING CHANGE** Restrict contract key lookups. In short, when looking
-    up or fetching a key, the transaction submitter must be one of the key
-    maintainers. The restriction was done in the DAML-LF development version
-    (``1.dev``) until now.
-    See `issue #1866 <https://github.com/digital-asset/daml/issues/1866>`__.
-    This change is breaking, since this release makes DAML-LF ``1.6`` the
-    default compiler output.
 
 DAML Compiler
 ~~~~~~~~~~~~~
@@ -229,12 +222,11 @@ DAML Compiler
   + Add support for DAML-LF intern package IDs.
 
 - **BREAKING CHANGE** Make DAML-LF 1.6 the default output.
-  This change activates the support of ``enum`` type describes above, and the
-  `restriction about contract key lookup
-  <https://github.com/digital-asset/daml/issues/1866>`__ described in the
-  DAML-LF section
+  This change activates the support of ``enum`` type describes above.
 
-- **BREAKING CHANGE** Drop support for DAML-LF 1.5. Compiling to DAML-LF 1.6 requires some changes regarding enum types to applications using the Ledger API, see above. (The ledger server still supports DAML-LF 1.5.)
+- **BREAKING CHANGE** Drop support for DAML-LF 1.5. Compiling to DAML-LF 1.6
+  requires some changes regarding enum types to applications using the Ledger
+  API, see above. (The ledger server still supports DAML-LF 1.5.)
 
 Ledger API
 ~~~~~~~~~~

--- a/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/ContractKeysChecks.scala
+++ b/ledger/ledger-api-integration-tests/src/test/lib/scala/com/digitalasset/platform/apitesting/ContractKeysChecks.scala
@@ -119,7 +119,7 @@ class ContractKeysChecks
           choice = "FetchDelegated",
           arg = Value(Value.Sum.Record(fetchArg)),
         )
-        _ <- if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+        _ <- if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
           ctx.testingHelpers.simpleExercise(
             testIdsGenerator.testCommandId("SDVl8"),
             submitter = delegate,
@@ -140,7 +140,7 @@ class ContractKeysChecks
             "Expected the submitter 'Charlie' to be in maintainers 'Bob'",
           )
         }
-        _ <- if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+        _ <- if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
           ctx.testingHelpers.simpleExercise(
             testIdsGenerator.testCommandId("SDVl9"),
             submitter = delegate,
@@ -216,7 +216,7 @@ class ContractKeysChecks
         // this fetch still fails even if we do not check that the submitter
         // is in the lookup maintainer, since we have the visibility check
         // implement as part of #753.
-        _ <- if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+        _ <- if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
           ctx.testingHelpers.failingExercise(
             testIdsGenerator.testCommandId("TDVl6"),
             submitter = delegate,
@@ -239,7 +239,7 @@ class ContractKeysChecks
             "Expected the submitter 'Charlie' to be in maintainers 'Bob'",
           )
         }
-        _ <- if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+        _ <- if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
           ctx.testingHelpers.simpleExercise(
             testIdsGenerator.testCommandId("TDVl7"),
             submitter = delegate,
@@ -329,7 +329,7 @@ class ContractKeysChecks
                 RecordField(value = textKeyKey(Alice, key)),
                 RecordField(value = lookupSome(cid1.contractId)))))),
           Code.INVALID_ARGUMENT,
-          if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+          if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
             "requires authorizers"
           } else {
             "Expected the submitter 'Bob' to be in maintainers 'Alice'"
@@ -348,7 +348,7 @@ class ContractKeysChecks
                 RecordField(value = textKeyKey(Alice, "bogus-key")),
                 RecordField(value = lookupNone))))),
           Code.INVALID_ARGUMENT,
-          if (languageVersion precedes LanguageVersion.checkSubmitterInMaintainers) {
+          if (languageVersion precedes LanguageVersion.Features.checkSubmitterInMaintainersVersion) {
             "requires authorizers"
           } else {
             "Expected the submitter 'Bob' to be in maintainers 'Alice'"


### PR DESCRIPTION
#1367 do not properly freeze contract key lookup restriction (#1866) in 1.6
Consequently the restriction is still only available in 1.dev

This PR, fix the release notes and drop the comment about this change.

We also introduce some minor cleanup in the version handling in the engine. We hope reducing the chance of such improper freeze.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
