### PR TITLE
Review of #2486

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
@@ -11,8 +11,7 @@ import com.digitalasset.ledger.api.v1.active_contracts_service.{
 }
 import com.digitalasset.ledger.api.v1.admin.party_management_service.AllocatePartyRequest
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.digitalasset.ledger.api.v1.commands.Command.Command.{Create, Exercise}
-import com.digitalasset.ledger.api.v1.commands.{Command, Commands, CreateCommand, ExerciseCommand}
+import com.digitalasset.ledger.api.v1.commands.{Command, Commands}
 import com.digitalasset.ledger.api.v1.event.Event.Event.Created
 import com.digitalasset.ledger.api.v1.event.{CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.ledger_identity_service.GetLedgerIdentityRequest
@@ -33,7 +32,7 @@ import com.digitalasset.ledger.api.v1.transaction_service.{
   GetTransactionByIdRequest,
   GetTransactionsRequest
 }
-import com.digitalasset.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
+import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.client.binding.Primitive.Party
 import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
 import com.digitalasset.platform.testing.{FiniteStreamObserver, SingleItemObserver}
@@ -64,7 +63,7 @@ object LedgerBindings {
 
 }
 
-final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
+private[infrastructure] final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
     implicit ec: ExecutionContext) {
 
   private[this] val services = new LedgerServices(channel)
@@ -189,55 +188,49 @@ final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
       applicationId: String,
       commandId: String,
       template: Template[T]
-  ): Future[(String, Contract[T])] = {
-    submitAndWaitForTransaction(party, applicationId, commandId, template.create.command.command) {
-      t =>
-        t.transactionId -> t.events.collect {
-          case Event(Created(e)) => decodeCreated(e).get
-        }.head
-    }
-  }
-
-  def create(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      templateId: Identifier,
-      args: Map[String, Value.Sum]): Future[(String, String)] =
-    submitAndWaitForTransaction(party, applicationId, commandId, createCommand(templateId, args)) {
-      t =>
-        t.transactionId -> t.events.collect { case Event(Created(e)) => e.contractId }.head
-    }
-
-  def exercise(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      templateId: Identifier,
-      contractId: String,
-      choice: String,
-      args: Map[String, Value.Sum]
-  ): Future[String] =
-    submitAndWaitForTransactionId(
+  ): Future[Contract[T]] =
+    submitAndWaitForTransaction(
       party,
       applicationId,
       commandId,
-      exerciseCommand(templateId, contractId, choice, args))
+      Seq(template.create.command.command)).map(
+      _.events.collect {
+        case Event(Created(e)) => decodeCreated(e).get
+      }.head
+    )
+
+  def createAndGetTransactionId[T <: Template[T]: ValueDecoder](
+      party: Party,
+      applicationId: String,
+      commandId: String,
+      template: Template[T]
+  ): Future[(String, Contract[T])] =
+    submitAndWaitForTransaction(
+      party,
+      applicationId,
+      commandId,
+      Seq(template.create.command.command)).map(tx =>
+      tx.transactionId -> tx.events.collect {
+        case Event(Created(e)) => decodeCreated(e).get
+      }.head)
 
   def exercise[T](
       party: Party,
       applicationId: String,
       commandId: String,
-      exercise: Primitive.Update[T]
-  ): Future[String] =
-    submitAndWaitForTransactionId(party, applicationId, commandId, exercise.command.command)
+      exercise: Party => Primitive.Update[T]
+  ): Future[TransactionTree] =
+    submitAndWaitForTransactionTree(
+      party,
+      applicationId,
+      commandId,
+      Seq(exercise(party).command.command))
 
   private def submitAndWaitCommand[A](service: SubmitAndWaitRequest => Future[A])(
       party: Party,
       applicationId: String,
       commandId: String,
-      command: Command.Command,
-      commands: Command.Command*): Future[A] =
+      commands: Seq[Command.Command]): Future[A] =
     for {
       id <- ledgerId
       let <- time
@@ -251,7 +244,7 @@ final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
             party = party.unwrap,
             ledgerEffectiveTime = Some(new Timestamp(let.getEpochSecond, let.getNano)),
             maximumRecordTime = Some(new Timestamp(mrt.getEpochSecond, mrt.getNano)),
-            commands = new Command(command) +: commands.map(new Command(_))
+            commands = commands.map(new Command(_))
           ))))
     } yield a
 
@@ -259,77 +252,45 @@ final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
       party: Party,
       applicationId: String,
       commandId: String,
-      command: Command.Command,
-      commands: Command.Command*): Future[Unit] =
-    submitAndWaitCommand(services.command.submitAndWait)(
-      party,
-      applicationId,
-      commandId,
-      command,
-      commands: _*)
+      commands: Seq[Command.Command]
+  ): Future[Unit] =
+    submitAndWaitCommand(services.command.submitAndWait)(party, applicationId, commandId, commands)
       .map(_ => ())
 
   def submitAndWaitForTransactionId(
       party: Party,
       applicationId: String,
       commandId: String,
-      command: Command.Command,
-      commands: Command.Command*
+      commands: Seq[Command.Command]
   ): Future[String] =
     submitAndWaitCommand(services.command.submitAndWaitForTransactionId)(
       party,
       applicationId,
       commandId,
-      command,
-      commands: _*).map(_.transactionId)
+      commands).map(_.transactionId)
 
-  def submitAndWaitForTransaction[A](
+  def submitAndWaitForTransaction(
       party: Party,
       applicationId: String,
       commandId: String,
-      command: Command.Command,
-      commands: Command.Command*)(f: Transaction => A): Future[A] =
+      commands: Seq[Command.Command]
+  ): Future[Transaction] =
     submitAndWaitCommand(services.command.submitAndWaitForTransaction)(
       party,
       applicationId,
       commandId,
-      command,
-      commands: _*)
-      .map(r => f(r.transaction.get))
+      commands).map(_.transaction.get)
 
-  private def createCommand(templateId: Identifier, args: Map[String, Value.Sum]): Command.Command =
-    Create(
-      new CreateCommand(
-        Some(templateId),
-        Some(
-          new Record(
-            fields = args.map {
-              case (label, value) =>
-                new RecordField(label, Some(new Value(value)))
-            }(collection.breakOut)
-          ))
-      )
-    )
-
-  private def exerciseCommand(
-      templateId: Identifier,
-      contractId: String,
-      choice: String,
-      args: Map[String, Value.Sum]): Command.Command =
-    Exercise(
-      new ExerciseCommand(
-        templateId = Some(templateId),
-        contractId = contractId,
-        choice = choice,
-        choiceArgument = Some(
-          new Value(
-            Value.Sum.Record(new Record(
-              fields = args.map {
-                case (label, value) =>
-                  new RecordField(label, Some(new Value(value)))
-              }(collection.breakOut)
-            ))))
-      )
-    )
+  def submitAndWaitForTransactionTree(
+      party: Party,
+      applicationId: String,
+      commandId: String,
+      commands: Seq[Command.Command]
+  ): Future[TransactionTree] =
+    submitAndWaitCommand(services.command.submitAndWaitForTransactionTree)(
+      party,
+      applicationId,
+      commandId,
+      commands).map(_.transaction.get)
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -10,9 +10,9 @@ import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.ledger.api.v1.event.CreatedEvent
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree}
-import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
-import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
+import com.digitalasset.ledger.api.v1.value.Identifier
 import com.digitalasset.ledger.client.binding.Primitive.Party
+import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -53,28 +53,18 @@ final class LedgerTestContext(
 
   def create[T <: Template[T]: ValueDecoder](
       party: Party,
-      template: Template[T]): Future[(String, Contract[T])] =
+      template: Template[T]): Future[Contract[T]] =
     bindings.create(party, applicationId, nextCommandId(), template)
 
-  def create(
+  def createAndGetTransactionId[T <: Template[T]: ValueDecoder](
       party: Party,
-      templateId: Identifier,
-      args: Map[String, Value.Sum]): Future[(String, String)] =
-    bindings.create(party, applicationId, nextCommandId(), templateId, args)
-
-  def exercise(
-      party: Party,
-      templateId: Identifier,
-      contractId: String,
-      choice: String,
-      args: Map[String, Value.Sum]
-  ): Future[String] =
-    bindings.exercise(party, applicationId, nextCommandId(), templateId, contractId, choice, args)
+      template: Template[T]): Future[(String, Contract[T])] =
+    bindings.createAndGetTransactionId(party, applicationId, nextCommandId(), template)
 
   def exercise[T](
       party: Party,
-      exercise: Primitive.Update[T]
-  ): Future[String] = bindings.exercise(party, applicationId, nextCommandId(), exercise)
+      exercise: Party => Primitive.Update[T]
+  ): Future[TransactionTree] = bindings.exercise(party, applicationId, nextCommandId(), exercise)
 
   def flatTransactions(
       parties: Seq[Party],

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -57,11 +57,15 @@ private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
     Future.sequence(Vector.fill(n)(allocateParty()))
 
   final def create[T <: Template[T]: ValueDecoder](template: Template[T])(party: Party)(
-      implicit context: LedgerTestContext): Future[(String, Contract[T])] =
+      implicit context: LedgerTestContext): Future[Contract[T]] =
     context.create(party, template)
 
-  final def exercise[T](exercise: Primitive.Update[T])(party: Party)(
-      implicit context: LedgerTestContext): Future[String] =
+  final def createAndGetTransactionId[T <: Template[T]: ValueDecoder](template: Template[T])(
+      party: Party)(implicit context: LedgerTestContext): Future[(String, Contract[T])] =
+    context.createAndGetTransactionId(party, template)
+
+  final def exercise[T](exercise: Party => Primitive.Update[T])(party: Party)(
+      implicit context: LedgerTestContext): Future[TransactionTree] =
     context.exercise(party, exercise)
 
   final def flatTransactions(party: Party, parties: Party*)(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
@@ -60,13 +60,11 @@ private[infrastructure] final class SemanticTesterLedger(bindings: LedgerBinding
     Value.VersionedValue[Value.AbsoluteContractId]]] =
     for {
       apiCommands <- lfCommandToApiCommand(party, lfCommands)
-      command +: commands = apiCommands.commands.map(_.command)
       id <- bindings.submitAndWaitForTransactionId(
         Primitive.Party(party),
         context.applicationId,
         s"${context.applicationId}-${UUID.randomUUID}",
-        command,
-        commands: _*)
+        apiCommands.commands.map(_.command))
       tree <- bindings.getTransactionById(id, parties.toSeq.map(Primitive.Party(_: String)))
       events <- apiTransactionToLfEvents(tree)
     } yield events

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
@@ -16,11 +16,10 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
       "Divulged contracts should not be exposed by the transaction service") { implicit context =>
       for {
         Vector(alice, bob) <- allocateParties(2)
-        (_, divulgence1) <- create(Divulgence1(alice))(alice)
-        (_, divulgence2) <- create(Divulgence2(bob, alice))(bob)
-        _ <- exercise(
-          divulgence2.contractId
-            .exerciseDivulgence2Archive(alice, divulgence1.contractId))(alice)
+        divulgence1 <- create(Divulgence1(alice))(alice)
+        divulgence2 <- create(Divulgence2(bob, alice))(bob)
+        _ <- exercise(divulgence2.contractId.exerciseDivulgence2Archive(_, divulgence1.contractId))(
+          alice)
         bobTransactions <- flatTransactions(bob)
         bobTrees <- transactionTrees(bob)
         transactionsForBoth <- flatTransactions(alice, bob)
@@ -152,11 +151,10 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
       implicit context =>
         for {
           Vector(alice, bob) <- allocateParties(2)
-          (_, divulgence1) <- create(Divulgence1(alice))(alice)
-          (_, divulgence2) <- create(Divulgence2(bob, alice))(bob)
-          _ <- exercise(
-            divulgence2.contractId
-              .exerciseDivulgence2Fetch(alice, divulgence1.contractId))(alice)
+          divulgence1 <- create(Divulgence1(alice))(alice)
+          divulgence2 <- create(Divulgence2(bob, alice))(bob)
+          _ <- exercise(divulgence2.contractId.exerciseDivulgence2Fetch(_, divulgence1.contractId))(
+            alice)
           activeForBobOnly <- activeContracts(bob)
           activeForBoth <- activeContracts(alice, bob)
         } yield {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
@@ -10,86 +10,94 @@ import scalaz.Tag
 
 final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
 
-  val respectDisclosureRules =
+  private[this] val respectDisclosureRules =
     LedgerTest("RespectDisclosureRules", "The ledger should respect disclosure rules") {
       implicit context =>
         for {
           Vector(alice, bob, charlie) <- allocateParties(3)
 
-          // Create Witnesses contract
-          (witnessTxId, witnesses) <- create(WitnessesTemplate(alice, bob, charlie))(alice)
-          witnessTx <- transactionTreeById(witnessTxId, alice, bob, charlie)
+          // Create the Witnesses contract as Alice and get the resulting transaction as seen by all parties
+          (witnessesTransactionId, witnesses) <- createAndGetTransactionId(
+            WitnessesTemplate(alice, bob, charlie))(alice)
+          witnessesTransaction <- transactionTreeById(witnessesTransactionId, alice, bob, charlie)
 
-          // Divulge Witnesses contract to charlie, who's just an actor and thus cannot
-          // see it by default.
-          (_, divulgeWitness) <- create(DivulgeWitnesses(alice, charlie))(charlie)
-          _ <- exercise(divulgeWitness.contractId.exerciseDivulge(alice, witnesses.contractId))(
-            alice)
+          // Charlie is not a stakeholder of Witnesses and thus cannot see any such contract unless divulged.
+          // Such contract is divulged by creating a DivulgeWitness with Charlie as a stakeholder and exercising
+          // a choice as Alice that causes divulgence (in this case, the Witnesses instance previously
+          // created is fetched as part of the transaction).
+          divulgeWitness <- create(DivulgeWitnesses(alice, charlie))(charlie)
+          _ <- exercise(divulgeWitness.contractId.exerciseDivulge(_, witnesses.contractId))(alice)
 
-          // Now, first try the non-consuming choice
-          nonConsumingTxId <- exercise(
-            witnesses.contractId.exerciseWitnessesNonConsumingChoice(charlie))(charlie)
-          nonConsumingTx <- transactionTreeById(nonConsumingTxId, alice, bob, charlie)
+          // A non-consuming choice is exercised with the expectation
+          // that this will not cause the contract to be divulged
+          // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
+          nonConsuming <- exercise(witnesses.contractId.exerciseWitnessesNonConsumingChoice)(
+            charlie)
+          nonConsumingTransaction <- transactionTreeById(
+            nonConsuming.transactionId,
+            alice,
+            bob,
+            charlie)
 
-          // And then the consuming one
-          consumingTxId <- exercise(witnesses.contractId.exerciseWitnessesChoice(charlie))(charlie)
-          consumingTx <- transactionTreeById(consumingTxId, alice, bob, charlie)
+          // A consuming choice is exercised with the expectation
+          // that this will cause the contract to be divulged
+          // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
+          consumingTransaction <- exercise(witnesses.contractId.exerciseWitnessesChoice)(charlie)
+          consumingTree <- transactionTreeById(
+            consumingTransaction.transactionId,
+            alice,
+            bob,
+            charlie)
         } yield {
-          {
-            assert(
-              witnessTx.eventsById.size == 1,
-              s"The transaction for creating the Witness contract should only contain a single event, but has ${witnessTx.eventsById.size}"
-            )
-            val witnessEv = witnessTx.eventsById.head._2
-            assert(
-              witnessEv.kind.isCreated,
-              s"The event in the transaction for creating the Witness should be a CreatedEvent, but was ${witnessEv.kind}")
 
-            // stakeholders = signatories \cup observers
-            val expectedWitnesses = Tag.unsubst(Seq(alice, bob)).sorted
-            assert(
-              witnessEv.getCreated.witnessParties.sorted == expectedWitnesses,
-              s"The parties for witnessing the CreatedEvent should be ${expectedWitnesses}, but were ${witnessEv.getCreated.witnessParties}"
-            )
-          }
+          assert(
+            witnessesTransaction.eventsById.size == 1,
+            s"The transaction for creating the Witness contract should only contain a single event, but has ${witnessesTransaction.eventsById.size}"
+          )
+          val (_, witnessEv) = witnessesTransaction.eventsById.head
+          assert(
+            witnessEv.kind.isCreated,
+            s"The event in the transaction for creating the Witness should be a CreatedEvent, but was ${witnessEv.kind}")
 
-          {
-            assert(
-              nonConsumingTx.eventsById.size == 1,
-              s"The transaction for exercising the non-consuming choice should only contain a single event, but has ${nonConsumingTx.eventsById.size}"
-            )
-            val nonConsumingEv = nonConsumingTx.eventsById.head._2
-            assert(
-              nonConsumingEv.kind.isExercised,
-              s"The event in the transaction for exercising the non-consuming choice should be an ExercisedEvent, but was ${nonConsumingEv.kind}"
-            )
-            // signatories \cup actors
-            val expectedWitnesses = Tag.unsubst(Seq(alice, charlie)).sorted
-            assert(
-              nonConsumingEv.getExercised.witnessParties.sorted == expectedWitnesses,
-              s"The parties for witnessing the non-consuming ExercisedEvent should be ${expectedWitnesses}, but were ${nonConsumingEv.getCreated.witnessParties}"
-            )
-          }
+          val expectedWitnessesOfCreation = Tag.unsubst(Seq(alice, bob)).sorted
+          assert(
+            witnessEv.getCreated.witnessParties.sorted == expectedWitnessesOfCreation,
+            s"The parties for witnessing the CreatedEvent should be ${expectedWitnessesOfCreation}, but were ${witnessEv.getCreated.witnessParties}"
+          )
+          assert(
+            nonConsumingTransaction.eventsById.size == 1,
+            s"The transaction for exercising the non-consuming choice should only contain a single event, but has ${nonConsumingTransaction.eventsById.size}"
+          )
+          val nonConsumingEv = nonConsumingTransaction.eventsById.head._2
+          assert(
+            nonConsumingEv.kind.isExercised,
+            s"The event in the transaction for exercising the non-consuming choice should be an ExercisedEvent, but was ${nonConsumingEv.kind}"
+          )
 
-          {
-            assert(
-              consumingTx.eventsById.size == 1,
-              s"The transaction for exercising the consuming choice should only contain a single event, but has ${consumingTx.eventsById.size}"
-            )
-            val consumingEv = consumingTx.eventsById.head._2
-            assert(
-              consumingEv.kind.isExercised,
-              s"The event in the transaction for exercising the consuming choice should be an ExercisedEvent, but was ${consumingEv.kind}"
-            )
-            // stakeholders \cup actors
-            val expectedWitnesses = Tag.unsubst(Seq(alice, bob, charlie)).sorted
-            assert(
-              consumingEv.getExercised.witnessParties.sorted == expectedWitnesses,
-              s"The parties for witnessing the consuming ExercisedEvent should be ${expectedWitnesses}, but were ${consumingEv.getCreated.witnessParties}"
-            )
-          }
+          val expectedWitnessesOfNonConsumingChoice = Tag.unsubst(Seq(alice, charlie)).sorted
+          assert(
+            nonConsumingEv.getExercised.witnessParties.sorted == expectedWitnessesOfNonConsumingChoice,
+            s"The parties for witnessing the non-consuming ExercisedEvent should be ${expectedWitnessesOfNonConsumingChoice}, but were ${nonConsumingEv.getCreated.witnessParties}"
+          )
+          assert(
+            consumingTree.eventsById.size == 1,
+            s"The transaction for exercising the consuming choice should only contain a single event, but has ${consumingTree.eventsById.size}"
+          )
+
+          val (_, consumingEvent) = consumingTree.eventsById.head
+          assert(
+            consumingEvent.kind.isExercised,
+            s"The event in the transaction for exercising the consuming choice should be an ExercisedEvent, but was ${consumingEvent.kind}"
+          )
+          val expectedWitnessesOfConsumingChoice = Tag.unsubst(Seq(alice, bob, charlie)).sorted
+          assert(
+            consumingEvent.getExercised.witnessParties.sorted == expectedWitnessesOfConsumingChoice,
+            s"The parties for witnessing the consuming ExercisedEvent should be ${expectedWitnessesOfConsumingChoice}, but were ${consumingEvent.getCreated.witnessParties}"
+          )
 
         }
     }
+
   override val tests: Vector[LedgerTest] = Vector(respectDisclosureRules)
+
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
@@ -22,7 +22,7 @@ final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
           witnessesTransaction <- transactionTreeById(witnessesTransactionId, alice, bob, charlie)
 
           // Charlie is not a stakeholder of Witnesses and thus cannot see any such contract unless divulged.
-          // Such contract is divulged by creating a DivulgeWitness with Charlie as a stakeholder and exercising
+          // Such contract is divulged by creating a DivulgeWitness with Charlie as a signatory and exercising
           // a choice as Alice that causes divulgence (in this case, the Witnesses instance previously
           // created is fetched as part of the transaction).
           divulgeWitness <- create(DivulgeWitnesses(alice, charlie))(charlie)


### PR DESCRIPTION
- removes the need to provide the controller twice to `exercise`
- adds comments to `Witnesses`
- adds a new `createAndGetTransactionId` method
- removes `create` and `exercise` methods that are no longer used

Pick what you want, discard the rest, edit how you see fit. :slightly_smiling_face: 