### PR TITLE
damldocs: Small type rendering improvements.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -702,6 +702,13 @@ typeToType ctx = \case
     TyConApp tycon [b] | "[]" == packName (tyConName tycon) ->
         TypeList (typeToType ctx b)
 
+    -- Special case for unsaturated (->) to remove the levity arguments.
+    TyConApp tycon (_:_:bs) | isFunTyCon tycon ->
+        TypeApp
+            Nothing
+            (Typename "->")
+            (map (typeToType ctx) bs)
+
     TyConApp tycon bs ->
         TypeApp
             (tyConAnchor ctx tycon)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -721,6 +721,7 @@ typeToType ctx = \case
             TypeFun _ -> unexpected "function type in a type app"
             TypeList _ -> unexpected "list type in a type app"
             TypeTuple _ -> unexpected "tuple type in a type app"
+            TypeLit _ -> unexpected "type-level literal in a type app"
 
     -- ignore context
     ForAllTy _ b -> typeToType ctx b
@@ -733,7 +734,7 @@ typeToType ctx = \case
             b' -> TypeFun [typeToType ctx a, b']
 
     CastTy a _ -> typeToType ctx a
-    LitTy x -> TypeApp Nothing (Typename $ toText x) []
+    LitTy x -> TypeLit (toText x)
     CoercionTy _ -> unexpected "coercion" -- TODO?
 
   where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -145,3 +145,4 @@ t2hg _ _ (TypeTuple ts) =
 t2hg _ _ (TypeApp _ n []) = unTypename n
 t2hg _ f (TypeApp _ name args) = f $
     T.unwords (wrapOp (unTypename name) : map (t2hg inParens inParens) args)
+t2hg _ _ (TypeLit lit) = lit

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -213,7 +213,7 @@ renderTypePrec prec = \case
     TypeApp anchorM (Typename typename) args ->
         (if prec >= 2 && notNull args then renderInParens else id)
             . renderUnwords
-            $ maybeAnchorLink anchorM typename
+            $ maybeAnchorLink anchorM (wrapOp typename)
             : map (renderTypePrec 2) args
     TypeFun ts ->
         (if prec >= 1 then renderInParens else id)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -227,6 +227,8 @@ renderTypePrec prec = \case
         renderInParens
             . renderIntercalate ", "
             $ map (renderTypePrec 0) ts
+    TypeLit lit ->
+        RenderPlain lit
 
 -- | Render type context as a list of words. Nothing is rendered as [],
 -- and Just t is rendered as [render t, "=>"].

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -173,6 +173,7 @@ distributeInstanceDocs docs =
         TypeFun parts -> Set.unions $ map getTypeAnchors parts
         TypeTuple parts -> Set.unions $ map getTypeAnchors parts
         TypeList p -> getTypeAnchors p
+        TypeLit _ -> Set.empty
 
     addInstances :: InstanceMap -> ModuleDoc -> ModuleDoc
     addInstances imap ModuleDoc{..} = ModuleDoc

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -34,6 +34,7 @@ data Type = TypeApp !(Maybe Anchor) !Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax
+          | TypeLit Text -- ^ a literal (e.g. "foo") appearing at the type level
   deriving (Eq, Ord, Show, Generic)
 
 instance Hashable Type where


### PR DESCRIPTION
These are small improvements:

* Add parentheses around type operators.
* Remove levity arguments from unsaturated `(->)` in the stdlib docs. 

End result is we get `instance Functor ((->) a)` in the docs, instead of `instance Functor (-> LiftedRep LiftedRep a)`.