### PR TITLE
Remove the --dump-pom flag from damlc package

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -15,3 +15,5 @@ HEAD — ongoing
 + [Ledger] Fixed internal shutdown order to avoid dead letter warnings when stopping Sandbox/Ledger API Server.
   See issue `#1886 <https://github.com/digital-asset/daml/issues/1886>`__.
 + [DAML Compiler] Support generic template declarations and instances.
++ [DAML Compile] The ``--dump-pom`` flag from ``damlc package`` has been removed as packaging
+  has not relied on POM files for a while.


### PR DESCRIPTION
It doesn’t serve any purpose at this point so we might as well get rid
of it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
