### PR TITLE
Print stack traces in the scenario on failure

### DIFF
--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -197,8 +197,9 @@ message ScenarioError {
   // Location of the commit/mustFail if applicable.
   Location commit_loc = 5;
 
-  // Last seen location, if any.
-  Location last_loc = 6;
+  // Stack trace of the locations seen during the execution.
+  // The last seen location comes last.
+  repeated Location stack_trace = 6;
 
   // The current partial transaction if any.
   PartialTransaction partial_transaction = 7;

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -53,9 +53,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
       builder.setCommitLoc(convertLocation(loc))
     }
 
-    machine.lastLocation.foreach { loc =>
-      builder.setLastLoc(convertLocation(loc))
-    }
+    builder.addAllStackTrace(machine.stackTrace().asScala.map(convertLocation).toSeq.asJava)
 
     builder.setPartialTransaction(
       convertPartialTransaction(machine.ptx)

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -53,7 +53,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
       builder.setCommitLoc(convertLocation(loc))
     }
 
-    builder.addAllStackTrace(machine.stackTrace().asScala.map(convertLocation).toSeq.asJava)
+    builder.addAllStackTrace(machine.stackTrace().map(convertLocation).toSeq.asJava)
 
     builder.setPartialTransaction(
       convertPartialTransaction(machine.ptx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -186,6 +186,7 @@ object SExpr {
   final case class SELocation(loc: Location, expr: SExpr) extends SExpr {
     def execute(machine: Machine): Ctrl = {
       machine.lastLocation = Some(loc)
+      machine.kont.add(KLocation(loc))
       CtrlExpr(expr)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.daml.lf.speedy
 
+import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.SError._
@@ -64,7 +65,8 @@ object Speedy {
     def popEnv(count: Int): Unit =
       env.subList(env.size - count, env.size).clear
 
-    def stackTrace(): ArrayList[Location] = {
+    /* Compute a stack trace from the locations in the continuation stack. */
+    def stackTrace(): ImmArray[Location] = {
       val s = new ArrayList[Location]
       kont.forEach { k =>
         k match {
@@ -72,7 +74,7 @@ object Speedy {
           case _ => ()
         }
       }
-      s
+      ImmArray(s.asScala)
     }
 
     /** Perform a single step of the machine execution. */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -64,6 +64,17 @@ object Speedy {
     def popEnv(count: Int): Unit =
       env.subList(env.size - count, env.size).clear
 
+    def stackTrace(): ArrayList[Location] = {
+      val s = new ArrayList[Location]
+      kont.forEach { k =>
+        k match {
+          case KLocation(location) => { s.add(location); () }
+          case _ => ()
+        }
+      }
+      s
+    }
+
     /** Perform a single step of the machine execution. */
     def step(): SResult =
       try {
@@ -504,6 +515,13 @@ object Speedy {
 
     def execute(v: SValue, machine: Machine) = {
       machine.ctrl = CtrlExpr(fin)
+    }
+  }
+
+  /** A location frame stores a location annotation found in the AST. */
+  final case class KLocation(location: Location) extends Kont {
+    def execute(v: SValue, machine: Machine) = {
+      machine.ctrl = CtrlValue(v)
     }
   }
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -18,3 +18,4 @@ HEAD — ongoing
 + [DAML Compiler] Support generic template declarations and instances.
 + [DAML Compile] The ``--dump-pom`` flag from ``damlc package`` has been removed as packaging
   has not relied on POM files for a while.
++ [DAML Studio] Print stack trace when a scenario fails.


### PR DESCRIPTION
Currently, we only print the last source location, which is not
particularly helpful for debugging. Now, we put all source locations we
encounter during execution on the continuation stack and print them when
a scenario fails. This PR does not print the names of entered functions
or choices. We leave this for a future PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2497)
<!-- Reviewable:end -->
