### PR TITLE
Make the detail level of damlc inspect configurable

### DIFF
--- a/libs-haskell/da-hs-base/src/DA/Pretty.hs
+++ b/libs-haskell/da-hs-base/src/DA/Pretty.hs
@@ -21,6 +21,7 @@ module DA.Pretty
   , fcommasep
 
   , Pretty(..)
+  , PrettyLevel(..)
   , prettyNormal
   , pretty
 


### PR DESCRIPTION
Add a command line option to `damlc inspect` which allows for configuring the
details level of the pretty printed DAML-LF. Right now the only difference is
that levels bigger than 0 print all location information. Level 0, which is
the default, also prints location information top level declarations.

This feature is useful for debugging location information.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2498)
<!-- Reviewable:end -->
