### PR TITLE
copyright: do not add extra blank line

### DIFF
--- a/dev-env/bin/dade-copyright-headers
+++ b/dev-env/bin/dade-copyright-headers
@@ -126,6 +126,7 @@ def process_file(filename, check_only):
     lines = fp.readlines()
   # Pretend that the file has extra empty line at the end to handle files,
   # which consist only of the copyright notice and nothing else.
+  # label: ADD_BLANK_LINE
   lines.append('\n')
 
   # Process the file:
@@ -209,7 +210,8 @@ def process_file(filename, check_only):
            # copyright header existed, but was out of date, replace it.
           fp.write("".join(before_header))
           fp.write(header)
-          fp.write("".join(after_header))
+          # remove additional blank line added at ADD_BLANK_LINE
+          fp.write("".join(after_header[:-1]))
         elif 'skip' in filetypes[ext]:
           # no copyright header, but file type requires skipping lines
           skip_prefix = filetypes[ext]['skip']


### PR DESCRIPTION
The current copyright script adds an extra blank line at the end of every single file it modifies. This confuses our various code linters, including getting to cases where running `./fmt.sh` after the copyright update is not enough to make things work again (apparently typescript doesn't like files ending with more than one blank line).

This is a tiny fix that results in the copyright script strictly changing the lines it should change. It is not done as part of #2499 because we squash, but it is very much part of the same update.
