### PR TITLE
Add an option to build Haskell code with DWARF debug info

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,11 @@ load("//bazel_tools:os_info.bzl", "os_info")
 os_info(name = "os_info")
 
 load("@os_info//:os_info.bzl", "is_linux", "is_windows")
+load("//bazel_tools:ghc_dwarf.bzl", "ghc_dwarf")
+
+ghc_dwarf(name = "ghc_dwarf")
+
+load("@ghc_dwarf//:ghc_dwarf.bzl", "enable_ghc_dwarf")
 
 nixpkgs_local_repository(
     name = "nixpkgs",
@@ -249,7 +254,7 @@ exports_files(glob(["lib/**/*"]))
 
 # Used by Darwin and Linux
 haskell_register_ghc_nixpkgs(
-    attribute_path = "ghcStatic",
+    attribute_path = "ghcStaticDwarf" if enable_ghc_dwarf else "ghcStatic",
     build_file = "@io_tweag_rules_nixpkgs//nixpkgs:BUILD.pkg",
 
     # -fexternal-dynamic-refs is required so that we produce position-independent
@@ -265,7 +270,7 @@ haskell_register_ghc_nixpkgs(
         "-fexternal-dynamic-refs",
         "-hide-package=ghc-boot-th",
         "-hide-package=ghc-boot",
-    ],
+    ] + (["-g3"] if enable_ghc_dwarf else []),
     compiler_flags_select = {
         "@com_github_digital_asset_daml//:profiling_build": ["-fprof-auto"],
         "//conditions:default": [],

--- a/bazel_tools/ghc_dwarf.bzl
+++ b/bazel_tools/ghc_dwarf.bzl
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This repository rule exists so that we can switch the GHC attribute
+# name in `WORKSPACE` as we cannot use `select` theer.
+
+_ghc_dwarf_bzl_template = """
+enable_ghc_dwarf = {GHC_DWARF}
+"""
+
+def _ghc_dwarf_impl(repository_ctx):
+    enable_dwarf = repository_ctx.os.environ.get("GHC_DWARF", "") != ""
+    substitutions = {
+        "GHC_DWARF": enable_dwarf,
+    }
+    repository_ctx.file(
+        "ghc_dwarf.bzl",
+        _ghc_dwarf_bzl_template.format(**substitutions),
+        False,
+    )
+    repository_ctx.file(
+        "BUILD",
+        "",
+        False,
+    )
+
+ghc_dwarf = repository_rule(
+    implementation = _ghc_dwarf_impl,
+    local = True,
+)

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -4,7 +4,7 @@
 { system ? builtins.currentSystem
 , pkgs ? import ./nixpkgs.nix { inherit system; }
 }:
-rec {
+let shared = rec {
   inherit (pkgs)
     curl
     docker
@@ -99,8 +99,10 @@ rec {
   };
 
   bazel-cc-toolchain = pkgs.callPackage ./tools/bazel-cc-toolchain {};
-} // (if pkgs.stdenv.isLinux then {
+};
+in shared // (if pkgs.stdenv.isLinux then {
   inherit (pkgs)
     glibcLocales
     ;
+  ghcStaticDwarf = shared.ghcStatic.override { enableDwarf = true; };
   } else {})

--- a/nix/overrides/ghc-8.6.5.nix
+++ b/nix/overrides/ghc-8.6.5.nix
@@ -1,8 +1,9 @@
 { stdenv, targetPackages
 
 # build-tools
-, bootPkgs
+, bootPkgs, makeWrapper
 , autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx
+, elfutils
 
 , libiconv ? null, ncurses
 
@@ -32,9 +33,12 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, enableDwarf ? false
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+assert enableDwarf -> !stdenv.isDarwin; # elfutils libdw only works with ELF
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -66,12 +70,16 @@ let
     GhcRtsHcOpts += -fPIC -fexternal-dynamic-refs
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
+  '' + stdenv.lib.optionalString enableDwarf ''
+     GhcLibHcOpts += -g3
+     GhcRtsHcOpts += -g3
   '';
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ [libffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional enableDwarf elfutils
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget =
@@ -160,6 +168,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional enableDwarf [
+    "--enable-dwarf-unwind"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
@@ -179,7 +189,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx
-    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour makeWrapper
   ];
 
   # For building runtime libs
@@ -211,6 +221,9 @@ stdenv.mkDerivation (rec {
       egrep --quiet '^#!' <(head -n 1 $i) || continue
       sed -i -e '2i export PATH="$PATH:${stdenv.lib.makeBinPath [ targetPackages.stdenv.cc.bintools coreutils ]}"' $i
     done
+  '' + stdenv.lib.optionalString enableDwarf ''
+    wrapProgram $out/bin/ghc-8.6.5 --add-flags "-L${elfutils}/lib"
+    wrapProgram $out/bin/ghc --add-flags "-L${elfutils}/lib"
   '';
 
   passthru = {


### PR DESCRIPTION
For now, this only works on Linux (that’s a GHC limitation as far as I
know) and you have to enable it by setting the GHC_DWARF env var to a
non-empty string.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
