### PR TITLE
Add Command submission test

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
@@ -36,8 +36,8 @@ import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.client.binding.Primitive.Party
 import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
 import com.digitalasset.platform.testing.{FiniteStreamObserver, SingleItemObserver}
+import com.google.protobuf.empty.Empty
 import com.google.protobuf.timestamp.Timestamp
-import io.grpc.Channel
 import io.grpc.stub.StreamObserver
 import scalaz.Tag
 import scalaz.syntax.tag._
@@ -63,10 +63,9 @@ object LedgerBindings {
 
 }
 
-private[infrastructure] final class LedgerBindings(channel: Channel, commandTtlFactor: Double)(
-    implicit ec: ExecutionContext) {
-
-  private[this] val services = new LedgerServices(channel)
+private[infrastructure] final class LedgerBindings(
+    services: LedgerServices,
+    commandTtlFactor: Double)(implicit ec: ExecutionContext) {
 
   val ledgerId: Future[String] =
     for {
@@ -253,9 +252,8 @@ private[infrastructure] final class LedgerBindings(channel: Channel, commandTtlF
       applicationId: String,
       commandId: String,
       commands: Seq[Command.Command]
-  ): Future[Unit] =
+  ): Future[Empty] =
     submitAndWaitCommand(services.command.submitAndWait)(party, applicationId, commandId, commands)
-      .map(_ => ())
 
   def submitAndWaitForTransactionId(
       party: Party,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
@@ -36,7 +36,6 @@ import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.client.binding.Primitive.Party
 import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
 import com.digitalasset.platform.testing.{FiniteStreamObserver, SingleItemObserver}
-import com.google.protobuf.empty.Empty
 import com.google.protobuf.timestamp.Timestamp
 import io.grpc.stub.StreamObserver
 import scalaz.Tag
@@ -188,15 +187,12 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       template: Template[T]
   ): Future[Contract[T]] =
-    submitAndWaitForTransaction(
-      party,
-      applicationId,
-      commandId,
-      Seq(template.create.command.command)).map(
-      _.events.collect {
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(template.create.command))
+      response <- submitAndWaitForTransaction(request).map(_.events.collect {
         case Event(Created(e)) => decodeCreated(e).get
-      }.head
-    )
+      }.head)
+    } yield response
 
   def createAndGetTransactionId[T <: Template[T]: ValueDecoder](
       party: Party,
@@ -204,14 +200,13 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       template: Template[T]
   ): Future[(String, Contract[T])] =
-    submitAndWaitForTransaction(
-      party,
-      applicationId,
-      commandId,
-      Seq(template.create.command.command)).map(tx =>
-      tx.transactionId -> tx.events.collect {
-        case Event(Created(e)) => decodeCreated(e).get
-      }.head)
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(template.create.command))
+      response <- submitAndWaitForTransaction(request).map(tx =>
+        tx.transactionId -> tx.events.collect {
+          case Event(Created(e)) => decodeCreated(e).get
+        }.head)
+    } yield response
 
   def exercise[T](
       party: Party,
@@ -219,76 +214,43 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       exercise: Party => Primitive.Update[T]
   ): Future[TransactionTree] =
-    submitAndWaitForTransactionTree(
-      party,
-      applicationId,
-      commandId,
-      Seq(exercise(party).command.command))
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(exercise(party).command))
+      response <- submitAndWaitForTransactionTree(request)
+    } yield response
 
-  private def submitAndWaitCommand[A](service: SubmitAndWaitRequest => Future[A])(
+  def prepareSubmission(
       party: Party,
       applicationId: String,
       commandId: String,
-      commands: Seq[Command.Command]): Future[A] =
+      commands: Seq[Command]): Future[SubmitAndWaitRequest] =
     for {
       id <- ledgerId
       let <- time
       mrt = let.plusSeconds(math.floor(30 * commandTtlFactor).toLong)
-      a <- service(
-        new SubmitAndWaitRequest(
-          Some(new Commands(
+    } yield
+      new SubmitAndWaitRequest(
+        Some(
+          new Commands(
             ledgerId = id,
             applicationId = applicationId,
             commandId = commandId,
             party = party.unwrap,
             ledgerEffectiveTime = Some(new Timestamp(let.getEpochSecond, let.getNano)),
             maximumRecordTime = Some(new Timestamp(mrt.getEpochSecond, mrt.getNano)),
-            commands = commands.map(new Command(_))
-          ))))
-    } yield a
+            commands = commands
+          )))
 
-  def submitAndWait(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[Empty] =
-    submitAndWaitCommand(services.command.submitAndWait)(party, applicationId, commandId, commands)
+  def submitAndWait(request: SubmitAndWaitRequest): Future[Unit] =
+    services.command.submitAndWait(request).map(_ => ())
 
-  def submitAndWaitForTransactionId(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[String] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransactionId)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transactionId)
+  def submitAndWaitForTransactionId(request: SubmitAndWaitRequest): Future[String] =
+    services.command.submitAndWaitForTransactionId(request).map(_.transactionId)
 
-  def submitAndWaitForTransaction(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[Transaction] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransaction)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transaction.get)
+  def submitAndWaitForTransaction(request: SubmitAndWaitRequest): Future[Transaction] =
+    services.command.submitAndWaitForTransaction(request).map(_.transaction.get)
 
-  def submitAndWaitForTransactionTree(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[TransactionTree] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransactionTree)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transaction.get)
+  def submitAndWaitForTransactionTree(request: SubmitAndWaitRequest): Future[TransactionTree] =
+    services.command.submitAndWaitForTransactionTree(request).map(_.transaction.get)
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -23,7 +23,9 @@ private[testtool] final class LedgerSession private (
 
   private[this] val logger = LoggerFactory.getLogger(classOf[LedgerSession])
 
-  private[this] val bindings: LedgerBindings = new LedgerBindings(channel, config.commandTtlFactor)
+  val services: LedgerServices = new LedgerServices(channel)
+
+  val bindings: LedgerBindings = new LedgerBindings(services, config.commandTtlFactor)
 
   private[testtool] def createTestContext(applicationId: String): Future[LedgerTestContext] =
     bindings.ledgerEnd.map(new LedgerTestContext(applicationId, _, bindings))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -23,9 +23,9 @@ private[testtool] final class LedgerSession private (
 
   private[this] val logger = LoggerFactory.getLogger(classOf[LedgerSession])
 
-  val services: LedgerServices = new LedgerServices(channel)
+  private[this] val services: LedgerServices = new LedgerServices(channel)
 
-  val bindings: LedgerBindings = new LedgerBindings(services, config.commandTtlFactor)
+  private[this] val bindings: LedgerBindings = new LedgerBindings(services, config.commandTtlFactor)
 
   private[testtool] def createTestContext(applicationId: String): Future[LedgerTestContext] =
     bindings.ledgerEnd.map(new LedgerTestContext(applicationId, _, bindings))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -31,7 +31,7 @@ final class LedgerTestContext(
     () =>
       it.synchronized(it.next())
   }
-  private[this] val nextCommandId: () => String = {
+  val nextCommandId: () => String = {
     val it = Iterator.from(0).map(n => s"$applicationId-command-$n")
     () =>
       it.synchronized(it.next())

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
@@ -60,11 +60,12 @@ private[infrastructure] final class SemanticTesterLedger(bindings: LedgerBinding
     Value.VersionedValue[Value.AbsoluteContractId]]] =
     for {
       apiCommands <- lfCommandToApiCommand(party, lfCommands)
-      id <- bindings.submitAndWaitForTransactionId(
+      request <- bindings.prepareSubmission(
         Primitive.Party(party),
         context.applicationId,
         s"${context.applicationId}-${UUID.randomUUID}",
-        apiCommands.commands.map(_.command))
+        apiCommands.commands)
+      id <- bindings.submitAndWaitForTransactionId(request)
       tree <- bindings.getTransactionById(id, parties.toSeq.map(Primitive.Party(_: String)))
       events <- apiTransactionToLfEvents(tree)
     } yield events

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.ledger.api.testtool.tests

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -1,0 +1,221 @@
+package com.daml.ledger.api.testtool.tests
+
+import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTest, LedgerTestSuite}
+import com.digitalasset.ledger.test.Test.Dummy
+//import com.digitalasset.ledger.test.Test.Dummy._
+import com.google.protobuf.empty.Empty
+import scalaz.syntax.tag._
+
+final class CommandService(session: LedgerSession) extends LedgerTestSuite(session) {
+  private val submitAndWait = LedgerTest("CSsubmitAndWait", "SubmitAndWait returns empty") {
+    implicit context =>
+      for {
+        alice <- allocateParty()
+        empty <- session.bindings.submitAndWait(
+          alice,
+          context.applicationId,
+          context.nextCommandId(),
+          Seq(Dummy(alice).create.command.command))
+      } yield {
+        assert(empty == Empty())
+      }
+  }
+
+  private val submitAndWaitForTransactionId = LedgerTest(
+    "CSsubmitAndWaitForTransactionId",
+    "SubmitAndWaitForTransactionId returns a transaction id") { implicit context =>
+    for {
+      alice <- allocateParty()
+      transactionId <- session.bindings.submitAndWaitForTransactionId(
+        alice,
+        context.applicationId,
+        context.nextCommandId(),
+        Seq(Dummy(alice).create.command.command))
+    } yield {
+      assert(
+        transactionId.nonEmpty,
+        s"The returned transaction ID should be a non empty string, but was '$transactionId'.")
+    }
+  }
+
+  private val submitAndWaitForTransaction = LedgerTest(
+    "CSsubmitAndWaitForTransaction",
+    "SubmitAndWaitForTransaction returns a transaction") { implicit context =>
+    for {
+      alice <- allocateParty()
+      transaction <- session.bindings.submitAndWaitForTransaction(
+        alice,
+        context.applicationId,
+        context.nextCommandId(),
+        Seq(Dummy(alice).create.command.command))
+    } yield {
+      assert(
+        transaction.transactionId.nonEmpty,
+        s"The returned transaction ID should be a non empty string, but was '${transaction.transactionId}'.")
+
+      assert(
+        transaction.events.size == 1,
+        s"The returned transaction should contain 1 event, but contained ${transaction.events.size}")
+
+      val event = transaction.events.head
+      assert(
+        event.event.isCreated,
+        s"The returned transaction should contain a created-event, but was ${event.event}"
+      )
+
+      assert(
+        event.getCreated.getTemplateId == Dummy.id.unwrap,
+        s"The template ID of the created-event should by ${Dummy.id}, but was ${event.getCreated.getTemplateId}"
+      )
+    }
+  }
+
+  private val submitAndWaitForTransactionTree = LedgerTest(
+    "CSsubmitAndWaitForTransactionTree",
+    "SubmitAndWaitForTransactionTree returns a transaction tree") { implicit context =>
+    for {
+      alice <- allocateParty()
+      transactionTree <- session.bindings.submitAndWaitForTransactionTree(
+        alice,
+        context.applicationId,
+        context.nextCommandId(),
+        Seq(Dummy(alice).create.command.command))
+    } yield {
+      assert(
+        transactionTree.transactionId.nonEmpty,
+        s"The returned transaction ID should be a non empty string, but was '${transactionTree.transactionId}'.")
+
+      assert(
+        transactionTree.eventsById.size == 1,
+        s"The returned transaction tree should contain 1 event, but contained ${transactionTree.eventsById.size}")
+
+      val event = transactionTree.eventsById.head._2
+      assert(
+        event.kind.isCreated,
+        s"The returned transaction tree should contain a created-event, but was ${event.kind}")
+
+      assert(
+        event.getCreated.getTemplateId == Dummy.id.unwrap,
+        s"The template ID of the created-event should by ${Dummy.id}, but was ${event.getCreated.getTemplateId}"
+      )
+    }
+  }
+
+  private val resendingSubmitAndWait = LedgerTest(
+    "CSduplicateSubmitAndWait",
+    "SubmitAndWait returns Empty for a duplicate submission") { implicit context =>
+    for {
+      alice <- allocateParty()
+      commandId = context.nextCommandId()
+      empty1 <- session.bindings.submitAndWait(
+        alice,
+        context.applicationId,
+        commandId,
+        Seq(Dummy(alice).create.command.command))
+      empty2 <- session.bindings.submitAndWait(
+        alice,
+        context.applicationId,
+        commandId,
+        Seq(Dummy(alice).create.command.command))
+      transactions <- flatTransactions(alice)
+    } yield {
+      assert(empty1 == empty2, "The responses of SubmitAndWait did not match.")
+      assert(
+        transactions.size == 1,
+        s"Expected only 1 transaction, but received ${transactions.size}")
+
+    }
+  }
+
+  private val resendingSubmitAndWaitForTransactionId = LedgerTest(
+    "CSduplicateSubmitAndWaitForTransactionId",
+    "SubmitAndWaitForTransactionId returns the same transaction ID for a duplicate submission") {
+    implicit context =>
+      for {
+        alice <- allocateParty()
+        commandId = context.nextCommandId()
+        transactionId1 <- session.bindings.submitAndWaitForTransactionId(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+        transactionId2 <- session.bindings.submitAndWaitForTransactionId(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+      } yield {
+        assert(
+          transactionId1 == transactionId2,
+          s"The transaction IDs did not match: transactionId1=$transactionId1, transactionId2=$transactionId2")
+      }
+  }
+
+  private val resendingSubmitAndWaitForTransaction = LedgerTest(
+    "CSduplicateSubmitAndWaitForTransaction",
+    "SubmitAndWaitForTransaction returns the same transaction for a duplicate submission") {
+    implicit context =>
+      for {
+        alice <- allocateParty()
+        commandId = context.nextCommandId()
+        transaction1 <- session.bindings.submitAndWaitForTransaction(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+        transaction2 <- session.bindings.submitAndWaitForTransaction(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+      } yield {
+        assert(
+          transaction1 == transaction2,
+          s"The transaction did not match: transaction1=$transaction1, transaction2=$transaction2")
+      }
+  }
+
+  private val resendingSubmitAndWaitForTransactionTree = LedgerTest(
+    "CSduplicateSubmitAndWaitForTransactionTree",
+    "SubmitAndWaitForTransactionTree returns the same transaction for a duplicate submission") {
+    implicit context =>
+      for {
+        alice <- allocateParty()
+        commandId = context.nextCommandId()
+        transactionTree1 <- session.bindings.submitAndWaitForTransactionTree(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+        transactionTree2 <- session.bindings.submitAndWaitForTransactionTree(
+          alice,
+          context.applicationId,
+          commandId,
+          Seq(Dummy(alice).create.command.command))
+      } yield {
+        assert(
+          transactionTree1 == transactionTree2,
+          s"The transaction trees did not match: transactionTree1=$transactionTree1, transactionTree2=$transactionTree2")
+      }
+  }
+
+//  private val submitAndWaitWithInvalidLedgerId = LedgerTest(
+//    "CSsubmitAndWaitInvalidLedgerId",
+//    "SubmitAndWait should fail for invalid ledger ids") { implicit context =>
+//    for {
+//      alice <- allocateParty()
+//      _ <- session.bindings.submitAndWait()
+//    } yield {}
+//  }
+
+  override val tests: Vector[LedgerTest] = Vector(
+    submitAndWait,
+    submitAndWaitForTransaction,
+    submitAndWaitForTransactionId,
+    submitAndWaitForTransactionTree,
+    resendingSubmitAndWait,
+    resendingSubmitAndWaitForTransaction,
+    resendingSubmitAndWaitForTransactionId,
+    resendingSubmitAndWaitForTransactionTree,
+  )
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
@@ -21,7 +21,6 @@ package object tests {
    * - PackageManagementServiceIT
    * - PartyManagementServiceIT
    * - CommandSubmissionTtlIT
-   * - CommandServiceIT
    * - ActiveContractsServiceIT
    */
   val optional: Map[String, LedgerSession => LedgerTestSuite] = Map(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
@@ -30,7 +30,8 @@ package object tests {
     "TimeIT" -> (new Time(_)),
     "ContractKeysSubmitterIsMaintainerIT" -> (new ContractKeysSubmitterIsMaintainer(_)),
     "ContractKeysIT" -> (new ContractKeys(_)),
-    "WitnessesIT" -> (new Witnesses(_))
+    "WitnessesIT" -> (new Witnesses(_)),
+    "CommandServiceIT" -> (new CommandService(_))
   )
 
   val all = default ++ optional

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -186,7 +186,8 @@ client_server_test(
     server = "//ledger/sandbox:sandbox-binary",
     server_args = [
         "--port 0",
-        "-s",
+        "--static-time",
+        "--eager-package-loading",
         "ledger/test-common/SemanticTests.dar",
         "ledger/test-common/Test.dar",
         "ledger/test-common/Test-1.6.dar",
@@ -213,7 +214,8 @@ client_server_test(
     server = "//ledger/sandbox:sandbox-binary",
     server_args = [
         "--port 0",
-        "-w",
+        "--wall-clock-time",
+        "--eager-package-loading",
         "ledger/test-common/SemanticTests.dar",
         "ledger/test-common/Test.dar",
         "ledger/test-common/Test-1.6.dar",
@@ -243,7 +245,8 @@ client_server_test(
     server = "//ledger/sandbox:sandbox-ephemeral-postgres",
     server_args = [
         "--port 0",
-        "-s",
+        "--static-time",
+        "--eager-package-loading",
         "ledger/test-common/SemanticTests.dar",
         "ledger/test-common/Test.dar",
         "ledger/test-common/Test-1.6.dar",
@@ -274,7 +277,8 @@ client_server_test(
     server = "//ledger/sandbox:sandbox-ephemeral-postgres",
     server_args = [
         "--port 0",
-        "-w",
+        "--wall-clock-time",
+        "--eager-package-loading",
         "ledger/test-common/SemanticTests.dar",
         "ledger/test-common/Test.dar",
         "ledger/test-common/Test-1.6.dar",


### PR DESCRIPTION
This also makes the services and bindings fields in LedgerSession
public. I think this is okay, as we have tests that operate on various
levels of abstraction. As such we ought to make most of the primitives
available somehow.

Contributes to #1373.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
