### PR TITLE
exclude ledger migrations from copyright update

### DIFF
--- a/ledger/sandbox/src/main/resources/db/migration/NO_AUTO_COPYRIGHT
+++ b/ledger/sandbox/src/main/resources/db/migration/NO_AUTO_COPYRIGHT
@@ -1,0 +1,3 @@
+The files in this folder cannot change, as their hash is stored in the database
+when the migration is executed. Therefore, they should not be subject to the
+automatic copyright update.


### PR DESCRIPTION
See discussions on #2499 (which should be rebased on this one after it's merged).