### PR TITLE
language: make sure conf files are uniform accross OS's.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -156,9 +156,9 @@ mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = (confName, bs)
             , "exposed: True"
             , "exposed-modules: " ++
               unwords (fromMaybe pkgModuleNames pExposedModules)
-            , "import-dirs: ${pkgroot}" </> key
-            , "library-dirs: ${pkgroot}" </> key
-            , "data-dir: ${pkgroot}" </> key
+            , "import-dirs: ${pkgroot}" ++ "/" ++ key -- we really want '/' here
+            , "library-dirs: ${pkgroot}" ++ "/" ++ key
+            , "data-dir: ${pkgroot}" ++ "/" ++ key
             , "depends: " ++
               unwords
                   [ sanitizeBaseDeps $ dropExtension $ takeFileName dep


### PR DESCRIPTION
If a package is build on Windows, it puts '\' into the conf files, which
will not work on a Linux system. Now we always use '/' as path
separator.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
