### PR TITLE
Add a test that haddock comments are shown on hover

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -596,6 +596,15 @@ onHoverTests mbScenarioService = Tasty.testGroup "On hover tests"
         setFilesOfInterest [f]
         expectTextOnHover (f,8,[6..11]) $ HasType "Update ()" -- Delete choice
         expectTextOnHover (f,10,[6..13]) $ HasType "Party -> Update (ContractId Coin)" -- Transfer choice
+    , testCase' "Haddock comment" $ do
+        f <- makeModule "F"
+            [ "-- | Important docs"
+            , "f : a -> a"
+            , "f x = x"
+            ]
+        setFilesOfInterest [f]
+        expectNoErrors
+        expectTextOnHover (f,4,[0]) $ Contains "Important docs"
     ]
     where
         testCase' = testCase mbScenarioService


### PR DESCRIPTION
Apparently, we never had any tests for this, so this PR adds at least
a rudamentary test. The logic for this is rather stupid and easy to
break and might change soon so I’ll hold off on adding more extensive
tests until this works a bit better.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
