### PR TITLE
Change default lexer mode to Opt_KeepRawTokenStream

### DIFF
--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -249,7 +249,7 @@ damldocExpect importPathM testname input check =
 -- | Generate the docs for a given input file and optional import directory.
 runDamldoc :: FilePath -> Maybe FilePath -> IO ModuleDoc
 runDamldoc testfile importPathM = do
-    opts <- defaultOptionsIO Nothing
+    opts <- fmap (\opt -> opt {optHaddock=Haddock True}) $ defaultOptionsIO Nothing
 
     let opts' = opts
           { optImportPath =

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -6,6 +6,7 @@ module DA.Daml.Options.Types
     , EnableScenarioService(..)
     , ScenarioValidation(..)
     , DlintUsage(..)
+    , Haddock(..)
     , defaultOptionsIO
     , defaultOptions
     , mkOptions
@@ -64,7 +65,12 @@ data Options = Options
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
   , optCoreLinting :: Bool
     -- ^ Whether to enable linting of the generated GHC Core. (Used in testing.)
+  , optHaddock :: Haddock
+    -- ^ Whether to enable lexer option `Opt_Haddock` (default is `Haddock False`).
   } deriving Show
+
+newtype Haddock = Haddock Bool
+  deriving Show
 
 data DlintUsage
   = DlintEnabled { dlintUseDataDir :: FilePath, dlintAllowOverrides :: Bool }
@@ -145,6 +151,7 @@ defaultOptions mbVersion =
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optCoreLinting = False
+        , optHaddock = Haddock False
         }
 
 getBaseDir :: IO FilePath

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -843,6 +843,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> dlintUsageOpt
     <*> pure False
     <*> pure False
+    <*> pure (Haddock False)
   where
     optImportPath :: Parser [FilePath]
     optImportPath =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -193,7 +193,7 @@ data CmdArgs = Damldoc { cInputFormat :: InputFormat
 
 exec :: CmdArgs -> IO ()
 exec Damldoc{..} = do
-    opts <- defaultOptionsIO Nothing
+    opts <- fmap (\opts -> opts {optHaddock=Haddock True}) $ defaultOptionsIO Nothing
     runDamlDoc DamldocOptions
         { do_ideOptions = toCompileOpts opts { optMbPackageName = cPkgName } (IdeReportProgress False)
         , do_outputPath = cOutputPath

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -105,9 +105,8 @@ doctestHeader =
 shouldGenerate :: [T.Text] -> [T.Text] -> Assertion
 shouldGenerate input expected = withTempFile $ \tmpFile -> do
     T.writeFileUtf8 tmpFile $ T.unlines $ testModuleHeader <> input
-    opts <- defaultOptionsIO Nothing
+    opts <- fmap (\opts -> opts{optHaddock=Haddock True}) $ defaultOptionsIO Nothing
     vfs <- makeVFSHandle
     ideState <- initialise mainRule (const $ pure ()) noLogging (toCompileOpts opts (IdeReportProgress False)) vfs
     Just pm <- runAction ideState $ use GetParsedModule $ toNormalizedFilePath tmpFile
     genModuleContent (getDocTestModule pm) @?= T.unlines (doctestHeader <> expected)
-

--- a/compiler/hie-core/src/Development/IDE/Spans/Documentation.hs
+++ b/compiler/hie-core/src/Development/IDE/Spans/Documentation.hs
@@ -83,5 +83,10 @@ docHeaders :: [RealLocated AnnotationComment]
 docHeaders = mapMaybe (\(L _ x) -> wrk x)
   where
   wrk = \case
+    -- When `Opt_Haddock` is enabled.
     AnnDocCommentNext s -> Just $ T.pack s
+    -- When `Opt_KeepRawTokenStream` enabled.
+    AnnLineComment s  -> if "-- |" `isPrefixOf` s
+                            then Just $ T.pack s
+                            else Nothing
     _ -> Nothing


### PR DESCRIPTION
Change the default lexing mode to `Opt_KeepRawTokenStream`. Doing this enables hlint rules relating to pragmas, comments. The exception is `daml-doc` for which we arrange to parse in the presence of `Opt_Haddock`.