### PR TITLE
Review https://github.com/digital-asset/daml/pull/2508

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerBindings.scala
@@ -36,7 +36,6 @@ import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.client.binding.Primitive.Party
 import com.digitalasset.ledger.client.binding.{Contract, Primitive, Template, ValueDecoder}
 import com.digitalasset.platform.testing.{FiniteStreamObserver, SingleItemObserver}
-import com.google.protobuf.empty.Empty
 import com.google.protobuf.timestamp.Timestamp
 import io.grpc.stub.StreamObserver
 import scalaz.Tag
@@ -188,15 +187,12 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       template: Template[T]
   ): Future[Contract[T]] =
-    submitAndWaitForTransaction(
-      party,
-      applicationId,
-      commandId,
-      Seq(template.create.command.command)).map(
-      _.events.collect {
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(template.create.command))
+      response <- submitAndWaitForTransaction(request).map(_.events.collect {
         case Event(Created(e)) => decodeCreated(e).get
-      }.head
-    )
+      }.head)
+    } yield response
 
   def createAndGetTransactionId[T <: Template[T]: ValueDecoder](
       party: Party,
@@ -204,14 +200,13 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       template: Template[T]
   ): Future[(String, Contract[T])] =
-    submitAndWaitForTransaction(
-      party,
-      applicationId,
-      commandId,
-      Seq(template.create.command.command)).map(tx =>
-      tx.transactionId -> tx.events.collect {
-        case Event(Created(e)) => decodeCreated(e).get
-      }.head)
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(template.create.command))
+      response <- submitAndWaitForTransaction(request).map(tx =>
+        tx.transactionId -> tx.events.collect {
+          case Event(Created(e)) => decodeCreated(e).get
+        }.head)
+    } yield response
 
   def exercise[T](
       party: Party,
@@ -219,76 +214,43 @@ private[infrastructure] final class LedgerBindings(
       commandId: String,
       exercise: Party => Primitive.Update[T]
   ): Future[TransactionTree] =
-    submitAndWaitForTransactionTree(
-      party,
-      applicationId,
-      commandId,
-      Seq(exercise(party).command.command))
+    for {
+      request <- prepareSubmission(party, applicationId, commandId, Seq(exercise(party).command))
+      response <- submitAndWaitForTransactionTree(request)
+    } yield response
 
-  private def submitAndWaitCommand[A](service: SubmitAndWaitRequest => Future[A])(
+  def prepareSubmission(
       party: Party,
       applicationId: String,
       commandId: String,
-      commands: Seq[Command.Command]): Future[A] =
+      commands: Seq[Command]): Future[SubmitAndWaitRequest] =
     for {
       id <- ledgerId
       let <- time
       mrt = let.plusSeconds(math.floor(30 * commandTtlFactor).toLong)
-      a <- service(
-        new SubmitAndWaitRequest(
-          Some(new Commands(
+    } yield
+      new SubmitAndWaitRequest(
+        Some(
+          new Commands(
             ledgerId = id,
             applicationId = applicationId,
             commandId = commandId,
             party = party.unwrap,
             ledgerEffectiveTime = Some(new Timestamp(let.getEpochSecond, let.getNano)),
             maximumRecordTime = Some(new Timestamp(mrt.getEpochSecond, mrt.getNano)),
-            commands = commands.map(new Command(_))
-          ))))
-    } yield a
+            commands = commands
+          )))
 
-  def submitAndWait(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[Empty] =
-    submitAndWaitCommand(services.command.submitAndWait)(party, applicationId, commandId, commands)
+  def submitAndWait(request: SubmitAndWaitRequest): Future[Unit] =
+    services.command.submitAndWait(request).map(_ => ())
 
-  def submitAndWaitForTransactionId(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[String] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransactionId)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transactionId)
+  def submitAndWaitForTransactionId(request: SubmitAndWaitRequest): Future[String] =
+    services.command.submitAndWaitForTransactionId(request).map(_.transactionId)
 
-  def submitAndWaitForTransaction(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[Transaction] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransaction)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transaction.get)
+  def submitAndWaitForTransaction(request: SubmitAndWaitRequest): Future[Transaction] =
+    services.command.submitAndWaitForTransaction(request).map(_.transaction.get)
 
-  def submitAndWaitForTransactionTree(
-      party: Party,
-      applicationId: String,
-      commandId: String,
-      commands: Seq[Command.Command]
-  ): Future[TransactionTree] =
-    submitAndWaitCommand(services.command.submitAndWaitForTransactionTree)(
-      party,
-      applicationId,
-      commandId,
-      commands).map(_.transaction.get)
+  def submitAndWaitForTransactionTree(request: SubmitAndWaitRequest): Future[TransactionTree] =
+    services.command.submitAndWaitForTransactionTree(request).map(_.transaction.get)
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -23,9 +23,9 @@ private[testtool] final class LedgerSession private (
 
   private[this] val logger = LoggerFactory.getLogger(classOf[LedgerSession])
 
-  val services: LedgerServices = new LedgerServices(channel)
+  private[this] val services: LedgerServices = new LedgerServices(channel)
 
-  val bindings: LedgerBindings = new LedgerBindings(services, config.commandTtlFactor)
+  private[this] val bindings: LedgerBindings = new LedgerBindings(services, config.commandTtlFactor)
 
   private[testtool] def createTestContext(applicationId: String): Future[LedgerTestContext] =
     bindings.ledgerEnd.map(new LedgerTestContext(applicationId, _, bindings))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/SemanticTesterLedger.scala
@@ -60,11 +60,12 @@ private[infrastructure] final class SemanticTesterLedger(bindings: LedgerBinding
     Value.VersionedValue[Value.AbsoluteContractId]]] =
     for {
       apiCommands <- lfCommandToApiCommand(party, lfCommands)
-      id <- bindings.submitAndWaitForTransactionId(
+      request <- bindings.prepareSubmission(
         Primitive.Party(party),
         context.applicationId,
         s"${context.applicationId}-${UUID.randomUUID}",
-        apiCommands.commands.map(_.command))
+        apiCommands.commands)
+      id <- bindings.submitAndWaitForTransactionId(request)
       tree <- bindings.getTransactionById(id, parties.toSeq.map(Primitive.Party(_: String)))
       events <- apiTransactionToLfEvents(tree)
     } yield events

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/package.scala
@@ -21,7 +21,6 @@ package object tests {
    * - PackageManagementServiceIT
    * - PartyManagementServiceIT
    * - CommandSubmissionTtlIT
-   * - CommandServiceIT
    * - ActiveContractsServiceIT
    */
   val optional: Map[String, LedgerSession => LedgerTestSuite] = Map(


### PR DESCRIPTION
To not break encapsulation, I split command submission into preparation and and issuance, creating context-level helpers that allow to provide lens transformations that can _pollute_ an outgoing request before being actually issued.