### PR TITLE
langauge: fix: broken package imports in ide

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -298,6 +298,8 @@ execIde telemetry (Debug debug) enableScenarioService mbProfileDir = NS.withSock
                 Logger.GCP.logOptOut gcpState
                 f loggerH
             Undecided -> f loggerH
+    -- TODO we should allow different LF versions in the IDE.
+    initPackageDb LF.versionDefault (InitPkgDb True)
     dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
     opts <- defaultOptionsIO Nothing
     opts <- pure $ opts
@@ -310,8 +312,6 @@ execIde telemetry (Debug debug) enableScenarioService mbProfileDir = NS.withSock
     scenarioServiceConfig <- readScenarioServiceConfig
     withLogger $ \loggerH ->
         withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
-            -- TODO we should allow different LF versions in the IDE.
-            initPackageDb LF.versionDefault (InitPkgDb True)
             sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
             Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
             runLanguageServer $ \sendMsg vfs caps ->


### PR DESCRIPTION
We need to initialize the package database before we run
`defaultOptionsIO`, because the later filters package database path that
don't exist.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
