### PR TITLE
Wait for all gRPC requests to finish before shutting down gRPC

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -49,8 +49,6 @@ da_haskell_test(
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],
-    # The gRPC binding sometimes crash assertion on shutdown, see #2520.
-    flaky = True,
     hazel_deps = [
         "base",
         "extra",

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -47,6 +47,7 @@ data Options = Options
   { optServerJar :: FilePath
   , optScenarioServiceConfig :: ScenarioServiceConfig
   , optMaxConcurrency :: Int
+  -- This controls the number of parallel gRPC requests
   , optLogInfo :: String -> IO ()
   , optLogError :: String -> IO ()
   }
@@ -61,14 +62,17 @@ toLowLevelOpts Options{..} =
 data Handle = Handle
   { hLowLevelHandle :: LowLevel.Handle
   , hOptions :: Options
-  , hConcurrencySem :: QSem
-  -- ^ Limits the number of concurrent scenario executions.
+  , hConcurrencySem :: QSemN
+  -- ^ Limits the number of concurrent gRPC requests (not just scenario executions).
   , hContextLock :: Lock
   -- ^ Used to make updating and cloning a context via getNewCtx atomic.
   , hLoadedPackages :: IORef (S.Set LF.PackageId)
   , hLoadedModules :: IORef (MS.Map Hash (LF.ModuleName, BS.ByteString))
   , hContextId :: LowLevel.ContextId
   }
+
+withSem :: QSemN -> IO a -> IO a
+withSem sem = bracket_ (waitQSemN sem 1) (signalQSemN sem 1)
 
 withScenarioService :: Options -> (Handle -> IO a) -> IO a
 withScenarioService hOptions f = do
@@ -78,9 +82,11 @@ withScenarioService hOptions f = do
          (LowLevel.deleteCtx hLowLevelHandle) $ \hContextId -> do
              hLoadedPackages <- liftIO $ newIORef S.empty
              hLoadedModules <- liftIO $ newIORef MS.empty
-             hConcurrencySem <- liftIO $ newQSem (optMaxConcurrency hOptions)
+             hConcurrencySem <- liftIO $ newQSemN (optMaxConcurrency hOptions)
              hContextLock <- liftIO newLock
-             f Handle {..}
+             f Handle {..} `finally`
+                 -- Wait for gRPC requests to exit, otherwise gRPC gets very unhappy.
+                 liftIO (waitQSemN hConcurrencySem $ optMaxConcurrency hOptions)
 
 data ScenarioServiceConfig = ScenarioServiceConfig
     { cnfGrpcMaxMessageSize :: Maybe Int -- In bytes
@@ -116,7 +122,7 @@ data Context = Context
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
-getNewCtx Handle{..} Context{..} = withLock hContextLock $ do
+getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencySem $ do
   loadedPackages <- readIORef hLoadedPackages
   loadedModules <- readIORef hLoadedModules
   let
@@ -144,11 +150,11 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ do
     Right () -> LowLevel.cloneCtx hLowLevelHandle hContextId
 
 deleteCtx :: Handle -> LowLevel.ContextId -> IO (Either LowLevel.BackendError ())
-deleteCtx Handle{..} ctxId = do
+deleteCtx Handle{..} ctxId = withSem hConcurrencySem $
   LowLevel.deleteCtx hLowLevelHandle ctxId
 
 gcCtxs :: Handle -> [LowLevel.ContextId] -> IO (Either LowLevel.BackendError ())
-gcCtxs Handle{..} ctxIds = withLock hContextLock $
+gcCtxs Handle{..} ctxIds = withLock hContextLock $ withSem hConcurrencySem $
     -- We never want to GC the root context so we always add that
     -- explicitly. Adding it twice is harmless so we do not check
     -- if it is already present.
@@ -165,14 +171,22 @@ runScenario Handle{..} ctxId name = do
   -- immediately. However, we cannot cancel the actual execution of the scenario.
   -- Therefore, we launch run the synchronous execution request in a separate thread
   -- that takes care of managing the semaphore. This thread keeps running
-  -- even if `runScenario` was aborted and ensures that we track the actual
-  -- number of running executions rather than the number of calls to `runScenario`
-  -- that have not been canceled.
-  let handleException (Right _) = pure ()
-      handleException (Left ex) = putMVar resVar (Left (LowLevel.ExceptionError ex))
-  _ <- flip forkFinally handleException $ bracket_ (waitQSem hConcurrencySem) (signalQSem hConcurrencySem) $ do
-    r <- LowLevel.runScenario hLowLevelHandle ctxId name
-    putMVar resVar r
+  -- even if `runScenario` was aborted (we cannot abort the FFI calls anyway)
+  -- and ensures that we track the actual number of running executions rather
+  -- than the number of calls to `runScenario` that have not been canceled.
+  _ <- mask $ \restore -> do
+      -- Rather than using a bracket in the new thread
+      -- we can be a bit more clever and don’t even
+      -- launch the new thread until we acquire the
+      -- semaphore.
+      waitQSemN hConcurrencySem 1
+      _ <- forkIO $ do
+        r <- try $ restore $ LowLevel.runScenario hLowLevelHandle ctxId name
+        case r of
+            Left ex -> putMVar resVar (Left $ LowLevel.ExceptionError ex)
+            Right r -> putMVar resVar r
+        signalQSemN hConcurrencySem 1
+      pure ()
   takeMVar resVar
 
 newtype Hash = Hash Int deriving (Eq, Ord, NFData, Show)

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -328,62 +328,52 @@ java_binary(
 daml_test(
     name = "ledger-api-daml-test",
     srcs = glob(["source/app-dev/code-snippets/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "bindings-java-daml-test",
     srcs = glob(["source/app-dev/bindings-java/code-snippets/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "patterns-daml-test",
     srcs = glob(["source/daml/patterns/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "daml-studio-daml-test",
     srcs = glob(["source/daml/daml-studio/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "daml-ref-daml-test",
     timeout = "long",
     srcs = glob(["source/daml/code-snippets/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "introduction-daml-test",
     srcs = glob(["source/getting-started/introduction/code/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "quickstart-daml-test",
     srcs = glob(["source/getting-started/quickstart/template-root/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "ledger-model-daml-test",
     srcs = glob(["source/concepts/ledger-model/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "java-bindings-docs-daml-test",
     srcs = glob(["source/app-dev/bindings-java/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 daml_test(
     name = "daml-intro-daml-test",
     srcs = glob(["source/daml/intro/daml/**/*.daml"]),
-    flaky = True,  # https://github.com/digital-asset/daml/issues/2520
 )
 
 filegroup(

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,3 +20,4 @@ HEAD — ongoing
   has not relied on POM files for a while.
 + [DAML Studio] Print stack trace when a scenario fails.
 + [Documentation] Added platform-independent tips for testing
++ [DAML Compiler] Some issues that caused ``damlc test`` to crash on shutdown have been fixed.


### PR DESCRIPTION
This fixes all flakiness in `damlc test` that I was able to
reproduce. Previously, I got it to fail in about 10% of the cases
whereas now I have successfully run tests 200 times under load without
issues.

There were two issues at play here:

1. We run scenarios in separate threads to be able to kill the running
Shake session quickly even if a scenario has an infinite loop or
something like that (there is a timeout but it’s quite long). This
could result in one of those left-over threads trying to issue a
request while we are already trying to shut down.

To fix that, we wait for the concurrency semaphore to be empty before
shutting down.

2. Just waiting for scenario executions is not quite sufficient as
`runAction` does not wait for all rules to finish (we could just use
runActionSync in `damlc test` but I’d rather make this work
properly). While we do wait for all scenario executions to finish
there is one gRPC request in offInterest that we do not wait for:
gcCtxs.

To fix this, I’ve now routed all gRPC requests through the semaphore
which means that we will also wait for these requests to finish (or
prevent them from spawning).

This makes more sense anyway as scenario executions are mostly fairly
cheap requests while things like setting up the context are expensive
so we want to limit their concurrency.

We should make the concurrency limit configurable but I’ll leave that
for a separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
