### PR TITLE
Remove dependency on isolated sandboxes from HS ledger bindings tests

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_repl", "da_haskell_test")
 load("//rules_daml:daml.bzl", "daml_compile")
+load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_library(
     name = "hs-ledger",
@@ -52,8 +53,8 @@ da_haskell_test(
         ":for-upload.dar",
         "//ledger/sandbox:sandbox-binary",
     ],
-    # The gRPC binding sometimes throw assertion on shutdown, see #2520.
-    flaky = True,
+    # Sometimes, we seem to be seeing segfaults on Windows.
+    flaky = is_windows,
     hazel_deps = [
         "async",
         "base",


### PR DESCRIPTION
The only tests that relied on this, were the ones for package
management and party management but we can fairly easily remove that
dependency by only checking the diff in packages and thereby folding
the listKnown* and uploadParty/uploadDar file into a combined test.

I’ve also bumped one timeout that I’ve seen fail on CI and managed to
get to fail locally under load.

I am unable to get the tests to fail now locally so I’ve marked them
as non-flaky on everything but Windows (we’ve seen weird segfaults
there).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
