### PR TITLE
hie-core exe: initDynLinker

### DIFF
--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -25,6 +25,7 @@ import Development.IDE.Types.Logger
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
+import Linker
 import Development.IDE.LSP.LanguageServer
 import System.Directory.Extra as IO
 import System.Environment
@@ -125,6 +126,9 @@ showEvent lock (EventFileDiagnostics (toNormalizedFilePath -> file) diags) =
 showEvent lock e = withLock lock $ print e
 
 newSession' :: Cradle -> IO HscEnv
-newSession' cradle = getLibdir >>= \libdir -> runGhc (Just libdir) $ do
-    initializeFlagsWithCradle "" cradle
-    getSession
+newSession' cradle = getLibdir >>= \libdir -> do
+    env <- runGhc (Just libdir) $ do
+        initializeFlagsWithCradle "" cradle
+        getSession
+    initDynLinker env
+    pure env


### PR DESCRIPTION
The hie-core tests are flaky in stack. They can fail with the following error message

```
hie-core: panic! (the 'impossible' happened)\n  (GHC version 8.6.5 for x86_64-unknown-linux):
        Dynamic linker not initialised

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

Explicitly initializing the dynamic linker at session startup should avoid this issue.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
