### PR TITLE
Compute last seen location in speedy from stack trace

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -162,7 +162,7 @@ prettyScenarioError world ScenarioError{..} = runM scenarioErrorNodes world $ do
 
     , if V.null scenarioErrorStackTrace
       then Nothing
-      else Just $ vcat $ "Stack trace:" : map ppStackTraceEntry (reverse $ V.toList scenarioErrorStackTrace)
+      else Just $ vcat $ "Stack trace:" : map ppStackTraceEntry (V.toList scenarioErrorStackTrace)
 
     , Just $ "Ledger time:" <-> prettyTimestamp scenarioErrorLedgerTime
 

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -192,7 +192,7 @@ message ScenarioError {
   Location commit_loc = 5;
 
   // Stack trace of the locations seen during the execution.
-  // The last seen location comes last.
+  // The last seen location comes first.
   repeated Location stack_trace = 6;
 
   // The current partial transaction if any.

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -53,7 +53,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
       builder.setCommitLoc(convertLocation(loc))
     }
 
-    builder.addAllStackTrace(machine.stackTrace().map(convertLocation).toSeq.asJava)
+    builder.addAllStackTrace(machine.stackTrace.map(convertLocation).toSeq.asJava)
 
     builder.setPartialTransaction(
       convertPartialTransaction(machine.ptx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -3,7 +3,6 @@
 
 package com.digitalasset.daml.lf.speedy
 
-import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.SError._
@@ -31,8 +30,9 @@ object Speedy {
        * once the control has been evaluated.
        */
       var kont: ArrayList[Kont],
-      /* The last encountered location */
-      var lastLocation: Option[Location],
+      /* A stack trace of the locations annotations during execution. The
+         location seen last is the head of the list. */
+      var stackTrace: List[Location],
       /* The current partial transaction */
       var ptx: PartialTransaction,
       /* Committers of the action. */
@@ -65,24 +65,46 @@ object Speedy {
     def popEnv(count: Int): Unit =
       env.subList(env.size - count, env.size).clear
 
+    /** The last seens location, i.e., the top of the stack trace. */
+    def lastLocation(): Option[Location] = stackTrace.headOption
+
     /** Push a single location to the continuation stack for the sake of
         maintaining a stack trace. */
     def pushLocation(loc: Location): Unit = {
-      lastLocation = Some(loc)
-      val last_index = kont.size() - 1
-      val last_kont = if (last_index >= 0) Some(kont.get(last_index)) else None
-      last_kont match {
-        // NOTE(MH): If the top of the continuation stack is the monadic token,
-        // we push location information under it to account for the implicit
-        // lambda binding the token.
-        case Some(KArg(Array(SEValue(SToken)))) => kont.add(last_index, KLocation(loc))
-        // NOTE(MH): When we use a cached top level value, we need to put the
-        // stack trace it produced back on the continuation stack to get
-        // complete stack trace at the use site. Thus, we store the stack traces
-        // of top level values separately during their execution.
-        case Some(KCacheVal(v, stack_trace)) =>
-          kont.set(last_index, KCacheVal(v, loc :: stack_trace)); ()
-        case _ => kont.add(KLocation(loc)); ()
+      def kontAt(index: Int) = if (index >= 0) Some(kont.get(index)) else None
+      stackTrace = loc :: stackTrace
+
+      // popIndex will contain the index of the KPopLocation frame in the
+      // continuation stack.
+      var popIndex = kont.size() - 1
+
+      // NOTE(MH): If the top of the continuation stack is the monadic token,
+      // we push location information under it to account for the implicit
+      // lambda binding the token.
+      kontAt(popIndex) match {
+        case Some(KArg(Array(SEValue(SToken)))) => popIndex -= 1
+        case _ => ()
+      }
+
+      kontAt(popIndex) match {
+        case Some(KPopLocation(n)) => kont.set(popIndex, KPopLocation(n + 1))
+        case _ => {
+          popIndex += 1
+          kont.add(popIndex, KPopLocation(1))
+          ()
+        }
+      }
+
+      // NOTE(MH): When we use a cached top level value, we need to put the
+      // stack trace it produced back on the continuation stack to get
+      // complete stack trace at the use site. Thus, we maintain a stack
+      // trace in the KCacheVal frame as well, to which we need to add
+      // whenever it is directly under the KPopLocation frame for this
+      // location.
+      kontAt(popIndex - 1) match {
+        case Some(KCacheVal(v, cacheStackTrace)) =>
+          kont.set(popIndex - 1, KCacheVal(v, loc :: cacheStackTrace)); ()
+        case _ => ()
       }
     }
 
@@ -90,19 +112,6 @@ object Speedy {
         element of the list will be pushed last. */
     def pushStackTrace(locs: List[Location]): Unit =
       locs.reverse.foreach(pushLocation)
-
-    /** Compute a stack trace from the locations in the continuation stack.
-        The last seen location will come last. */
-    def stackTrace(): ImmArray[Location] = {
-      val s = new ArrayList[Location]
-      kont.forEach { k =>
-        k match {
-          case KLocation(location) => { s.add(location); () }
-          case _ => ()
-        }
-      }
-      ImmArray(s.asScala)
-    }
 
     /** Perform a single step of the machine execution. */
     def step(): SResult =
@@ -235,7 +244,7 @@ object Speedy {
         ctrl = null,
         env = emptyEnv,
         kont = new ArrayList[Kont](128),
-        lastLocation = None,
+        stackTrace = Nil,
         ptx = PartialTransaction.initial,
         committers = Set.empty,
         commitLocation = None,
@@ -551,8 +560,9 @@ object Speedy {
   }
 
   /** A location frame stores a location annotation found in the AST. */
-  final case class KLocation(location: Location) extends Kont {
+  final case class KPopLocation(count: Int) extends Kont {
     def execute(v: SValue, machine: Machine) = {
+      machine.stackTrace = machine.stackTrace.drop(count)
       machine.ctrl = CtrlValue(v)
     }
   }


### PR DESCRIPTION
Currently, we use as the last seen location literally the last location
annotation the interpreter has seen. This is inaccurate since it does not take
into account that we could already have left the scope of this annotation.

After this PR we use the top of the stack trace we maintain internally as the
last location. This is more accurate since it takes leaving scopes into
account.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2572)
<!-- Reviewable:end -->
