### PR TITLE
Recover indexer from errors

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/Indexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/Indexer.scala
@@ -17,14 +17,9 @@ trait Indexer {
     * Subscribes to an instance of ReadService.
     *
     * @param readService the ReadService to subscribe to
-    * @param onError     callback to signal error during feed processing
-    * @param onComplete  callback fired only once at normal feed termination.
     * @return a handle of IndexFeedHandle or a failed Future
     */
-  def subscribe(
-      readService: ReadService,
-      onError: Throwable => Unit,
-      onComplete: () => Unit): Future[IndexFeedHandle]
+  def subscribe(readService: ReadService): Future[IndexFeedHandle]
 
 }
 
@@ -37,4 +32,11 @@ trait IndexFeedHandle {
     * @return Done if success or a failed future in case of an error.
     */
   def stop(): Future[Done]
+
+  /**
+    * A future that completes when the feed terminates.
+    *
+    * @return Done if the feed terminates normally or a failed future in case of an error during feed processing.
+    */
+  def completed(): Future[Done]
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -49,8 +49,10 @@ object JdbcIndexer {
   private val logger = LoggerFactory.getLogger(classOf[JdbcIndexer])
   private[index] val asyncTolerance = 30.seconds
 
-  def create(readService: ReadService, jdbcUrl: String): Future[JdbcIndexer] = {
-    val actorSystem = ActorSystem("postgres-indexer")
+  def create(
+      actorSystem: ActorSystem,
+      readService: ReadService,
+      jdbcUrl: String): Future[JdbcIndexer] = {
     val materializer: ActorMaterializer = ActorMaterializer()(actorSystem)
     val metricsManager = MetricsManager(false)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/RecoveringIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/RecoveringIndexer.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.index
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+object RecoveringIndexer {
+  def apply(restartDelay: FiniteDuration, asyncTolerance: FiniteDuration): RecoveringIndexer =
+    new RecoveringIndexer(restartDelay, asyncTolerance)
+}
+
+/**
+  * A helper that restarts an indexer whenever an error occurs.
+  *
+  * @param restartDelay Time to wait before restarting the indexer after a failure
+  * @param asyncTolerance Time to wait for asynchronous operations to complete
+  */
+class RecoveringIndexer(restartDelay: FiniteDuration, asyncTolerance: FiniteDuration)
+    extends AutoCloseable {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private[this] val actorSystem = ActorSystem("RecoveringIndexer")
+
+  val closed = new AtomicBoolean(false)
+  val lastHandle = new AtomicReference[Option[IndexFeedHandle]](None)
+
+  /**
+    * Starts an indexer, and restarts it after the given delay whenever an error occurs.
+    *
+    * @param subscribe A function that creates a new indexer and calls subscribe() on it.
+    * @return A future that completes with [[akka.Done]] when the indexer finishes processing all read service updates.
+    */
+  def start(subscribe: () => Future[IndexFeedHandle]): Future[akka.Done] = {
+    logger.info("Starting Indexer Server")
+    implicit val ec: ExecutionContext = DEC
+    val completedF = for {
+      handle <- subscribe()
+      _ = {
+        logger.info("Started Indexer Server")
+        lastHandle.set(Some(handle))
+      }
+      completed <- handle.completed()
+      _ = logger.info("Successfully finished processing state updates")
+    } yield completed
+
+    completedF.recoverWith {
+      case NonFatal(t) =>
+        logger.error(s"Error while running indexer, restart scheduled after $restartDelay", t)
+        lastHandle.set(None)
+        after(restartDelay, actorSystem.scheduler)(start(subscribe))
+    }(DEC)
+  }
+
+  override def close(): Unit = {
+    if (closed.compareAndSet(false, true)) {
+      val _ = lastHandle.get.foreach(h => Await.result(h.stop(), asyncTolerance))
+    }
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -19,8 +19,11 @@ object StandaloneIndexerServer {
     val indexer =
       RecoveringIndexer(actorSystem.scheduler, 10.seconds, JdbcIndexer.asyncTolerance)
 
-    indexer.start(() =>
-      PostgresIndexer.create(readService, jdbcUrl).flatMap(_.subscribe(readService))(DEC))
+    indexer.start(
+      () =>
+        PostgresIndexer
+          .create(actorSystem, readService, jdbcUrl)
+          .flatMap(_.subscribe(readService))(DEC))
 
     indexer
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.platform.index
 
+import akka.actor.ActorSystem
 import com.daml.ledger.participant.state.v1.ReadService
 import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
 
@@ -11,9 +12,12 @@ import scala.concurrent.duration._
 // Main entry point to start an indexer server.
 // See v2.ReferenceServer for the usage
 object StandaloneIndexerServer {
+  private[this] val actorSystem = ActorSystem("StandaloneIndexerServer")
+
   def apply(readService: ReadService, jdbcUrl: String): AutoCloseable = {
 
-    val indexer = RecoveringIndexer(10.seconds, JdbcIndexer.asyncTolerance)
+    val indexer =
+      RecoveringIndexer(actorSystem.scheduler, 10.seconds, JdbcIndexer.asyncTolerance)
 
     indexer.start(() =>
       PostgresIndexer.create(readService, jdbcUrl).flatMap(_.subscribe(readService))(DEC))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -21,7 +21,7 @@ object StandaloneIndexerServer {
 
     indexer.start(
       () =>
-        PostgresIndexer
+        JdbcIndexer
           .create(actorSystem, readService, jdbcUrl)
           .flatMap(_.subscribe(readService))(DEC))
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -3,61 +3,21 @@
 
 package com.digitalasset.platform.index
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-
-import akka.actor.ActorSystem
-import akka.pattern.after
 import com.daml.ledger.participant.state.v1.ReadService
 import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.control.NonFatal
 
 // Main entry point to start an indexer server.
 // See v2.ReferenceServer for the usage
 object StandaloneIndexerServer {
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
-  private[this] val restartDelay: FiniteDuration = 5.seconds
-  private[this] val actorSystem = ActorSystem("StandaloneIndexerServer")
-
   def apply(readService: ReadService, jdbcUrl: String): AutoCloseable = {
 
-    val closed = new AtomicBoolean(false)
-    val lastHandle = new AtomicReference[Option[IndexFeedHandle]](None)
+    val indexer = RecoveringIndexer(10.seconds, JdbcIndexer.asyncTolerance)
 
-    def restart(): Future[akka.Done] = {
-      logger.info("Starting Indexer Server")
-      implicit val ec: ExecutionContext = DEC
-      val completedF = for {
-        server <- JdbcIndexer.create(readService, jdbcUrl)
-        handle <- server.subscribe(readService)
-        _ = {
-          logger.info("Started Indexer Server")
-          lastHandle.set(Some(handle))
-        }
-        completed <- handle.completed()
-        _ = logger.info("Successfully finished processing state updates")
-      } yield completed
+    indexer.start(() =>
+      PostgresIndexer.create(readService, jdbcUrl).flatMap(_.subscribe(readService))(DEC))
 
-      completedF.recoverWith {
-        case NonFatal(t) =>
-          logger.error(s"Error while running indexer, restart scheduled after $restartDelay", t)
-          after(restartDelay, actorSystem.scheduler)(restart())
-      }(DEC)
-    }
-
-    restart()
-
-    new AutoCloseable {
-      override def close(): Unit = {
-        if (closed.compareAndSet(false, true)) {
-          val _ =
-            lastHandle.get.foreach(h => Await.result(h.stop(), JdbcIndexer.asyncTolerance))
-        }
-      }
-    }
+    indexer
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -3,13 +3,14 @@
 
 package com.digitalasset.platform.index
 
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import com.daml.ledger.participant.state.v1.ReadService
 import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 // Main entry point to start an indexer server.
 // See v2.ReferenceServer for the usage
@@ -17,22 +18,38 @@ object StandaloneIndexerServer {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def apply(readService: ReadService, jdbcUrl: String): AutoCloseable = {
-    val server = JdbcIndexer.create(readService, jdbcUrl)
-    val indexHandleF = server.flatMap(
-      _.subscribe(
-        readService,
-        t => logger.error("error while processing state updates", t),
-        () => logger.info("successfully finished processing state updates")))(DEC)
-
-    val indexFeedHandle = Await.result(indexHandleF, JdbcIndexer.asyncTolerance)
-    logger.info("Started Indexer Server")
 
     val closed = new AtomicBoolean(false)
+    val lastHandle = new AtomicReference[Option[IndexFeedHandle]](None)
+
+    def restart(): Future[akka.Done] = {
+      logger.info("Starting Indexer Server")
+      implicit val ec: ExecutionContext = DEC
+      val completedF = for {
+        server <- JdbcIndexer.create(readService, jdbcUrl)
+        handle <- server.subscribe(readService)
+        _ = {
+          logger.info("Started Indexer Server")
+          lastHandle.set(Some(handle))
+        }
+        completed <- handle.completed()
+        _ = logger.info("Successfully finished processing state updates")
+      } yield completed
+
+      completedF.recoverWith {
+        case NonFatal(t) =>
+          logger.error("Error while processing state updates", t)
+          restart()
+      }(DEC)
+    }
+
+    restart()
 
     new AutoCloseable {
       override def close(): Unit = {
         if (closed.compareAndSet(false, true)) {
-          val _ = Await.result(indexFeedHandle.stop(), JdbcIndexer.asyncTolerance)
+          val _ =
+            lastHandle.get.foreach(h => Await.result(h.stop(), JdbcIndexer.asyncTolerance))
         }
       }
     }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
@@ -1,0 +1,180 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.index
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+case class SubscribeResult(
+    name: String,
+    subscribeDelay: FiniteDuration,
+    subscribeSucceeds: Boolean,
+    completeDelay: FiniteDuration,
+    completeSucceeds: Boolean)
+
+sealed abstract class IndexerEvent {
+  def name: String
+}
+final case class EventStreamFail(name: String) extends IndexerEvent
+final case class EventStreamComplete(name: String) extends IndexerEvent
+final case class EventStopCalled(name: String) extends IndexerEvent
+final case class EventSubscribeCalled(name: String) extends IndexerEvent
+final case class EventSubscribeSuccess(name: String) extends IndexerEvent
+final case class EventSubscribeFail(name: String) extends IndexerEvent
+
+class TestIndexer(results: Iterator[SubscribeResult]) {
+  private[this] val actorSystem = ActorSystem("TestIndexer")
+  private[this] val scheduler = actorSystem.scheduler
+
+  val actions = new ConcurrentLinkedQueue[IndexerEvent]()
+
+  class TestIndexerFeedHandle(result: SubscribeResult) extends IndexFeedHandle {
+    private[this] val promise = Promise[akka.Done]()
+
+    if (result.completeSucceeds) {
+      scheduler.scheduleOnce(result.completeDelay)({
+        actions.add(EventStreamComplete(result.name))
+        promise.trySuccess(akka.Done)
+        ()
+      })(DEC)
+    } else {
+      scheduler.scheduleOnce(result.completeDelay)({
+        actions.add(EventStreamFail(result.name))
+        promise.tryFailure(new RuntimeException("Random simulated failure: subscribe"))
+        ()
+      })(DEC)
+    }
+
+    override def stop(): Future[akka.Done] = {
+      actions.add(EventStopCalled(result.name))
+      promise.trySuccess(akka.Done)
+      promise.future
+    }
+
+    override def completed(): Future[akka.Done] = {
+      promise.future
+    }
+  }
+
+  def subscribe(): Future[IndexFeedHandle] = {
+    val result = results.next()
+    actions.add(EventSubscribeCalled(result.name))
+    if (result.subscribeSucceeds) {
+      after(result.subscribeDelay, scheduler)({
+        actions.add(EventSubscribeSuccess(result.name))
+        Future.successful(new TestIndexerFeedHandle(result))
+      })(DEC)
+    } else {
+      after(result.subscribeDelay, scheduler)({
+        actions.add(EventSubscribeFail(result.name))
+        Future.failed(new RuntimeException("Random simulated failure: subscribe"))
+      })(DEC)
+    }
+  }
+}
+
+class RecoveringIndexerIT extends WordSpec with Matchers {
+
+  private[this] implicit val ec: ExecutionContext = DEC
+
+  "RecoveringIndexer" should {
+
+    "work when the stream completes" in {
+      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      val testIndexer = new TestIndexer(
+        List(
+          SubscribeResult("A", 10.millis, true, 10.millis, true)
+        ).iterator)
+
+      val end = recoveringIndexer.start(() => testIndexer.subscribe())
+      Await.result(end, 10.seconds)
+
+      List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[
+        IndexerEvent](
+        EventSubscribeCalled("A"),
+        EventSubscribeSuccess("A"),
+        EventStreamComplete("A")
+      )
+    }
+
+    "work when the stream is stopped" in {
+      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      // Stream completes after 1sec, but stop() is called before
+      val testIndexer = new TestIndexer(
+        List(
+          SubscribeResult("A", 10.millis, true, 1000.millis, true) // Stream completes after a long delay
+        ).iterator)
+
+      val end = recoveringIndexer.start(() => testIndexer.subscribe())
+      Thread.sleep(50)
+      recoveringIndexer.close()
+      Await.result(end, 10.seconds)
+
+      List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[
+        IndexerEvent](
+        EventSubscribeCalled("A"),
+        EventSubscribeSuccess("A"),
+        EventStopCalled("A")
+      )
+    }
+
+    "recover failures" in {
+      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      // Subscribe fails, then the stream fails, then the stream completes without errors.
+      val testIndexer = new TestIndexer(
+        List(
+          SubscribeResult("A", 10.millis, false, 10.millis, true), // Subscribe fails
+          SubscribeResult("B", 10.millis, true, 10.millis, false), // Stream fails
+          SubscribeResult("C", 10.millis, true, 10.millis, true) // Stream completes
+        ).iterator)
+
+      val end = recoveringIndexer.start(() => testIndexer.subscribe())
+      Await.result(end, 10.seconds)
+
+      List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[
+        IndexerEvent](
+        EventSubscribeCalled("A"),
+        EventSubscribeFail("A"),
+        EventSubscribeCalled("B"),
+        EventSubscribeSuccess("B"),
+        EventStreamFail("B"),
+        EventSubscribeCalled("C"),
+        EventSubscribeSuccess("C"),
+        EventStreamComplete("C")
+      )
+    }
+
+    "respect restart delay" in {
+      val recoveringIndexer = new RecoveringIndexer(500.millis, 1.second)
+      // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.
+      val testIndexer = new TestIndexer(
+        List(
+          SubscribeResult("A", 0.millis, false, 0.millis, true), // Subscribe fails
+          SubscribeResult("B", 0.millis, true, 0.millis, true) // Stream completes
+        ).iterator)
+
+      val t0 = System.nanoTime()
+      val end = recoveringIndexer.start(() => testIndexer.subscribe())
+      Await.result(end, 10.seconds)
+      val t1 = System.nanoTime()
+
+      (t1 - t0) should be >= 500L * 1000L * 1000L
+      List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[
+        IndexerEvent](
+        EventSubscribeCalled("A"),
+        EventSubscribeFail("A"),
+        EventSubscribeCalled("B"),
+        EventSubscribeSuccess("B"),
+        EventStreamComplete("B")
+      )
+    }
+  }
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
@@ -109,14 +109,14 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
 
     "work when the stream is stopped" in {
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
-      // Stream completes after 1sec, but stop() is called before
+      // Stream completes after 10sec, but stop() is called before
       val testIndexer = new TestIndexer(
         List(
-          SubscribeResult("A", 10.millis, true, 1000.millis, true) // Stream completes after a long delay
+          SubscribeResult("A", 10.millis, true, 10000.millis, true) // Stream completes after a long delay
         ).iterator)
 
       val end = recoveringIndexer.start(() => testIndexer.subscribe())
-      scheduler.scheduleOnce(50.millis, () => recoveringIndexer.close())
+      scheduler.scheduleOnce(100.millis, () => recoveringIndexer.close())
 
       end map { _ =>
         List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
@@ -85,6 +85,7 @@ class RecoveringIndexerIT extends WordSpec with Matchers {
 
   private[this] implicit val ec: ExecutionContext = DEC
   private[this] val actorSystem = ActorSystem("RecoveringIndexerIT")
+  private[this] val scheduler = actorSystem.scheduler
 
   "RecoveringIndexer" should {
 
@@ -115,8 +116,7 @@ class RecoveringIndexerIT extends WordSpec with Matchers {
         ).iterator)
 
       val end = recoveringIndexer.start(() => testIndexer.subscribe())
-      Thread.sleep(50)
-      recoveringIndexer.close()
+      scheduler.scheduleOnce(50.millis, () => recoveringIndexer.close())
       Await.result(end, 10.seconds)
 
       List(testIndexer.actions.toArray: _*) should contain theSameElementsInOrderAs List[

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/RecoveringIndexerSpec.scala
@@ -84,11 +84,12 @@ class TestIndexer(results: Iterator[SubscribeResult]) {
 class RecoveringIndexerIT extends WordSpec with Matchers {
 
   private[this] implicit val ec: ExecutionContext = DEC
+  private[this] val actorSystem = ActorSystem("RecoveringIndexerIT")
 
   "RecoveringIndexer" should {
 
     "work when the stream completes" in {
-      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
       val testIndexer = new TestIndexer(
         List(
           SubscribeResult("A", 10.millis, true, 10.millis, true)
@@ -106,7 +107,7 @@ class RecoveringIndexerIT extends WordSpec with Matchers {
     }
 
     "work when the stream is stopped" in {
-      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
       // Stream completes after 1sec, but stop() is called before
       val testIndexer = new TestIndexer(
         List(
@@ -127,7 +128,7 @@ class RecoveringIndexerIT extends WordSpec with Matchers {
     }
 
     "recover failures" in {
-      val recoveringIndexer = new RecoveringIndexer(10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
         List(
@@ -153,7 +154,7 @@ class RecoveringIndexerIT extends WordSpec with Matchers {
     }
 
     "respect restart delay" in {
-      val recoveringIndexer = new RecoveringIndexer(500.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 500.millis, 1.second)
       // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.
       val testIndexer = new TestIndexer(
         List(


### PR DESCRIPTION
Makes sure `StandaloneIndexerServer` handles failures by restarting the indexer in case of errors. 

Also includes a change in the `Indexer` interface, to make it easier to react to failures.

Fixes #2065 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
