### PR TITLE
daml-lf: make LF parser numeric compatible 

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -6,7 +6,7 @@ package archive
 
 import com.digitalasset.daml.lf.archive.Decode.ParseError
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.data.{Decimal, ImmArray, Time}
+import com.digitalasset.daml.lf.data.{Decimal, ImmArray, Numeric, Time}
 import ImmArray.ImmArraySeq
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.language.Util._
@@ -701,8 +701,10 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           PLInt64(lfPrimLit.getInt64)
         case PLF.PrimLit.SumCase.NUMERIC =>
           checkDecimal(lfPrimLit.getNumeric)
-          val d = Decimal.fromString(lfPrimLit.getNumeric)
-          d.fold(e => throw ParseError("error parsing decimal: " + e), PLDecimal)
+          Decimal
+            .fromString(lfPrimLit.getNumeric)
+            .flatMap(Numeric.fromBigDecimal(Decimal.scale, _))
+            .fold(e => throw ParseError("error parsing decimal: " + e), PLDecimal)
         case PLF.PrimLit.SumCase.TEXT =>
           PLText(lfPrimLit.getText)
         case PLF.PrimLit.SumCase.PARTY =>

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
@@ -22,6 +22,10 @@ abstract class NumericModule {
     * any valid scale `s` we denote `(Numeric s)` the set of Numerics of
     * scale `s`. Numerics are encoded using java BigDecimal, where the scale
     * is the scale of the Numeric.
+    *
+    * We use java BigDecimals instead of scala ones because:
+    *  - We prefer to use here lower level methods from java
+    *  - We want two numerics with different scales to be different (w.r.t. ==)
     */
   type Numeric <: BigDecimal
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -271,7 +271,7 @@ object Ast {
   }
 
   final case class PLInt64(override val value: Long) extends PrimLit
-  final case class PLDecimal(override val value: Decimal) extends PrimLit
+  final case class PLDecimal(override val value: Numeric) extends PrimLit
   // Text should be treated as Utf8, data.Utf8 provide emulation functions for that
   final case class PLText(override val value: String) extends PrimLit
   final case class PLTimestamp(override val value: Time.Timestamp) extends PrimLit

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -46,7 +46,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
 
   private lazy val literal: Parsers.Parser[PrimLit] =
     acceptMatch[PrimLit]("Number", { case Number(l) => PLInt64(l) }) |
-      acceptMatch("Decimal", { case Decimal(d) => PLDecimal(d) }) |
+      acceptMatch("Numeric", { case Numeric(d) => PLDecimal(d) }) |
       acceptMatch("Text", { case Text(s) => PLText(s) }) |
       acceptMatch("Timestamp", { case Timestamp(l) => PLTimestamp(l) }) |
       acceptMatch("Date", { case Date(l) => PLDate(l) }) |

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -70,7 +70,7 @@ private[parser] object Lexer extends RegexParsers {
       """\"([^\\\"]|\\n|\\r|\\\"|\\\'|\\\\)*\"""".r >> toText |
       """\d+-\d+-\d+T\d+:\d+:\d+(\.\d+)?Z""".r >> toTimestamp |
       """\d{4}-\d{2}-\d{2}""".r >> toDate |
-      """-?\d+\.\d*""".r >> toDecimal |
+      """-?\d+\.\d*""".r >> toNumeric |
       """-?\d+""".r >> toNumber
 
   private def toTimestamp(s: String): Parser[Timestamp] =
@@ -89,10 +89,10 @@ private[parser] object Lexer extends RegexParsers {
           Error(s"cannot interpret $s as a Timestamp", in)
     }
 
-  private def toDecimal(s: String): Parser[Decimal] =
+  private def toNumeric(s: String): Parser[Numeric] =
     (in: Input) =>
-      data.Decimal.fromString(s) match {
-        case Right(x) => Success(Decimal(x), in)
+      data.Numeric.fromString(s) match {
+        case Right(x) => Success(Numeric(x), in)
         case Left(_) => Error(s"cannot interpret $s as a Decimal", in)
     }
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -56,7 +56,7 @@ private[parser] object Token {
   final case class ContractId(s: String) extends Token
   final case class Timestamp(value: data.Time.Timestamp) extends Token
   final case class Date(value: data.Time.Date) extends Token
-  final case class Decimal(value: data.Decimal) extends Token
+  final case class Numeric(value: data.Numeric) extends Token
   final case class Number(value: Long) extends Token
   final case class SimpleString(s: String) extends Token
   final case class Text(s: String) extends Token

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -3,8 +3,10 @@
 
 package com.digitalasset.daml.lf.testing.parser
 
+import java.math.BigDecimal
+
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.data.{Decimal, ImmArray, Time}
+import com.digitalasset.daml.lf.data.{ImmArray, Numeric, Time}
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -117,9 +119,9 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "string to parse" -> "expected literal",
         "1" -> PLInt64(1),
         "-2" -> PLInt64(-2),
-        "1.0" -> PLDecimal(Decimal.assertFromBigDecimal(1)),
-        "1.0" -> PLDecimal(Decimal.assertFromBigDecimal(1)),
-        "-1.0" -> PLDecimal(Decimal.assertFromBigDecimal(-1)),
+        "1.0000000000" -> PLDecimal(Numeric.assertFromBigDecimal(10, BigDecimal.ONE)),
+        "1.0" -> PLDecimal(Numeric.assertFromBigDecimal(1, BigDecimal.ONE)),
+        "-10.00" -> PLDecimal(Numeric.assertFromBigDecimal(2, BigDecimal.TEN.negate)),
         """"some text"""" -> PLText("some text"),
         """ " \n\r\"\\ " """ -> PLText(" \n\r\"\\ "),
         """ "français" """ -> PLText("français"),
@@ -139,8 +141,8 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "string to parsed",
         "9223372036854775808",
         "-9223372036854775809",
-        "10000000000000000000000000000.",
-        "-10000000000000000000000000000.",
+        "10000000000000000000000000000.0000000000",
+        "-100000000000000000000000000000000000000.",
         "0000-01-01",
         "2100-02-29",
         "2019-13-28",


### PR DESCRIPTION
This PR is part of the effort to implement variable scaled Numeric type (See #2289)

This make the DAML-LF parsed Numeric (delivered in #2556)

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
