### PR TITLE
damldocs: External docs links.

### DIFF
--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -27,6 +27,7 @@ da_haskell_library(
         "ghc-lib",
         "hashable",
         "mtl",
+        "network-uri",
         "prettyprinter",
         "stache",
         "text",

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -47,14 +47,14 @@ renderMdText env = \case
     RenderConcat ts -> mconcatMap (renderMdText env) ts
     RenderPlain text -> escapeMd text
     RenderStrong text -> T.concat ["**", escapeMd text, "**"]
-    RenderLink anchor text ->
-        case lookupAnchor env anchor of
+    RenderLink ref text ->
+        case lookupReference env ref of
             Nothing -> escapeMd text
             Just anchorLoc -> T.concat
                 ["["
                 , escapeMd text
                 , "]("
-                , anchorHyperlink anchorLoc anchor
+                , anchorHyperlink anchorLoc (referenceAnchor ref)
                 , ")"]
     RenderDocsInline docText ->
         T.unwords . T.lines . unDocText $ docText

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -54,7 +54,7 @@ renderMdText env = \case
                 ["["
                 , escapeMd text
                 , "]("
-                , anchorRelativeHyperlink anchorLoc anchor
+                , anchorHyperlink anchorLoc anchor
                 , ")"]
     RenderDocsInline docText ->
         T.unwords . T.lines . unDocText $ docText

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -51,7 +51,7 @@ renderMdText env = \case
         case lookupReference env ref of
             Nothing -> escapeMd text
             Just anchorLoc -> T.concat
-                ["["
+                [ "["
                 , escapeMd text
                 , "]("
                 , anchorHyperlink anchorLoc (referenceAnchor ref)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -17,6 +17,7 @@ import System.FilePath
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import qualified Network.URI as URI
 
 data RenderOut
     = RenderSpaced [RenderOut]
@@ -78,16 +79,18 @@ data RenderEnv = RenderEnv
 data AnchorLocation
     = SameFile -- ^ anchor is in same file
     | SameFolder FilePath -- ^ anchor is in a file within same folder
-    -- TODO: | External URL -- ^ anchor is in on a page at the given URL
+    | External URI.URI -- ^ anchor at the given URL
 
-
--- | Build relative hyperlink from anchor and anchor location.
-anchorRelativeHyperlink :: AnchorLocation -> Anchor -> T.Text
-anchorRelativeHyperlink anchorLoc (Anchor anchor) =
+-- | Build hyperlink from anchor and anchor location. Hyperlink is
+-- relative for anchors in the same package, absolute for external
+-- packages.
+anchorHyperlink :: AnchorLocation -> Anchor -> T.Text
+anchorHyperlink anchorLoc (Anchor anchor) =
     case anchorLoc of
         SameFile -> "#" <> anchor
         SameFolder fileName -> T.concat [T.pack fileName, "#", anchor]
-
+        External uri -> T.pack . show $
+            uri { URI.uriFragment = "#" <> T.unpack anchor }
 
 
 type RenderFormatter = RenderEnv -> RenderOut -> [T.Text]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -34,7 +34,7 @@ data RenderText
     = RenderConcat [RenderText]
     | RenderPlain T.Text
     | RenderStrong T.Text
-    | RenderLink Anchor T.Text
+    | RenderLink Reference T.Text
     | RenderDocsInline DocText
 
 chunks :: RenderOut -> [RenderOut]
@@ -67,7 +67,7 @@ renderUnwords = renderIntercalate " "
 
 -- | Environment in which to generate final documentation.
 data RenderEnv = RenderEnv
-    { lookupAnchor :: Anchor -> Maybe AnchorLocation
+    { lookupReference :: Reference -> Maybe AnchorLocation
         -- ^ get location of anchor relative to render output, if available
     }
 
@@ -118,6 +118,8 @@ renderPage formatter output =
         | Set.member anchor localAnchors = Just SameFile
         | otherwise = Nothing
 
+    lookupReference = lookupAnchor . referenceAnchor
+
     renderEnv = RenderEnv {..}
 
 -- | Render a folder of modules.
@@ -139,6 +141,7 @@ renderFolder formatter fileMap =
                 [ SameFile <$ guard (Set.member anchor localAnchors)
                 , SameFolder <$> Map.lookup anchor globalAnchors
                 ]
+            lookupReference = lookupAnchor . referenceAnchor
             renderEnv = RenderEnv {..}
         in T.unlines (formatter renderEnv output)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -57,7 +57,10 @@ instance RenderDoc ModuleDoc where
 
 
 maybeAnchorLink :: Maybe Anchor -> T.Text -> RenderText
-maybeAnchorLink = maybe RenderPlain RenderLink
+maybeAnchorLink = maybe RenderPlain (RenderLink . Reference Nothing)
+
+maybeReferenceLink :: Maybe Reference -> T.Text -> RenderText
+maybeReferenceLink = maybe RenderPlain RenderLink
 
 instance RenderDoc TemplateDoc where
     renderDoc TemplateDoc{..} = mconcat
@@ -210,10 +213,10 @@ renderType = renderTypePrec  0
 -- * precedence 2: brackets around function types and type application
 renderTypePrec :: Int -> Type -> RenderText
 renderTypePrec prec = \case
-    TypeApp anchorM (Typename typename) args ->
+    TypeApp referenceM (Typename typename) args ->
         (if prec >= 2 && notNull args then renderInParens else id)
             . renderUnwords
-            $ maybeAnchorLink anchorM (wrapOp typename)
+            $ maybeReferenceLink referenceM (wrapOp typename)
             : map (renderTypePrec 2) args
     TypeFun ts ->
         (if prec >= 1 then renderInParens else id)

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -37,16 +37,16 @@ renderRstText env = \case
     RenderConcat ts -> mconcatMap (renderRstText env) ts
     RenderPlain text -> text
     RenderStrong text -> T.concat ["**", text, "**"]
-    RenderLink anchor text ->
-        case lookupAnchor env anchor of
+    RenderLink ref text ->
+        case lookupReference env ref of
             Nothing -> text
             Just anchorLoc@(External _) ->
                 T.concat
                     ["`", text, " <"
-                    , anchorHyperlink anchorLoc anchor
+                    , anchorHyperlink anchorLoc (referenceAnchor ref)
                     , ">`_"]
             Just _ ->
-                T.concat ["`", text, " <", unAnchor anchor, "_>`_"]
+                T.concat ["`", text, " <", unAnchor (referenceAnchor ref), "_>`_"]
     RenderDocsInline docText ->
         T.unwords (docTextToRst docText)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -40,7 +40,13 @@ renderRstText env = \case
     RenderLink anchor text ->
         case lookupAnchor env anchor of
             Nothing -> text
-            Just _ -> T.concat ["`", text, " <", unAnchor anchor, "_>`_"]
+            Just anchorLoc@(External _) ->
+                T.concat
+                    ["`", text, " <"
+                    , anchorHyperlink anchorLoc anchor
+                    , ">`_"]
+            Just _ ->
+                T.concat ["`", text, " <", unAnchor anchor, "_>`_"]
     RenderDocsInline docText ->
         T.unwords (docTextToRst docText)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -165,11 +165,13 @@ distributeInstanceDocs docs =
         [ (anchor, Set.singleton inst)
         | anchor <- Set.toList . getTypeAnchors $ id_type inst ]
 
+    -- | Get the set of internal references i.e. anchors in the type expression.
     getTypeAnchors :: Type -> Set.Set Anchor
     getTypeAnchors = \case
-        TypeApp anchorM _ args -> Set.unions
-            $ maybe Set.empty Set.singleton anchorM
+        TypeApp (Just (Reference Nothing anchor)) _ args -> Set.unions
+            $ Set.singleton anchor
             : map getTypeAnchors args
+        TypeApp _ _ args -> Set.unions $ map getTypeAnchors args
         TypeFun parts -> Set.unions $ map getTypeAnchors parts
         TypeTuple parts -> Set.unions $ map getTypeAnchors parts
         TypeList p -> getTypeAnchors p

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -29,8 +29,12 @@ newtype Typename = Typename { unTypename :: Text }
 newtype Modulename = Modulename { unModulename :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
+-- | Name of daml package, e.g. "daml-prim", "daml-stdlib"
+newtype Packagename = Packagename { unPackagename :: Text }
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+
 -- | Type expression, possibly a (nested) type application
-data Type = TypeApp !(Maybe Anchor) !Typename [Type] -- ^ Type application
+data Type = TypeApp !(Maybe Reference) !Typename [Type] -- ^ Type application
           | TypeFun [Type] -- ^ Function type
           | TypeList Type   -- ^ List syntax
           | TypeTuple [Type] -- ^ Tuple syntax
@@ -40,7 +44,13 @@ data Type = TypeApp !(Maybe Anchor) !Typename [Type] -- ^ Type application
 instance Hashable Type where
   hashWithSalt salt = hashWithSalt salt . show
 
--- | Anchors are URL-safe ids into the docs.
+-- | A docs reference, possibly external (i.e. in another package).
+data Reference = Reference
+    { referencePackage :: Maybe Packagename
+    , referenceAnchor :: Anchor
+    } deriving (Eq, Ord, Show, Generic)
+
+-- | Anchors are URL-safe (and RST-safe!) ids into the docs.
 newtype Anchor = Anchor { unAnchor :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
 
@@ -170,6 +180,12 @@ data InstanceDoc = InstanceDoc
 
 -----------------------------------------------------
 -- generate JSON instances
+
+instance ToJSON Reference where
+    toJSON = genericToJSON aesonOptions
+
+instance FromJSON Reference where
+    parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON Type where
     toJSON = genericToJSON aesonOptions

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -22,10 +22,10 @@
 > <a name="constr-deriving-disjunction-94592"></a>[Disjunction](#constr-deriving-disjunction-94592) \[[Formula](#type-deriving-formula-84903) t\]
 > 
 > 
-> **instance** Functor [Formula](#type-deriving-formula-84903)
+> **instance** [Functor](https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448) [Formula](#type-deriving-formula-84903)
 > 
-> **instance** Eq t =\> Eq ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) t =\> [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** Ord t =\> Ord ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Ord](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960) t =\> [Ord](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** Show t =\> Show ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) t =\> [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) ([Formula](#type-deriving-formula-84903) t)

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -40,10 +40,10 @@ Data Types
   `Disjunction <constr-deriving-disjunction-94592_>`_ [`Formula <type-deriving-formula-84903_>`_ t]
   
   
-  **instance** Functor `Formula <type-deriving-formula-84903_>`_
+  **instance** `Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
   
-  **instance** Eq t => Eq (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t => `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** Ord t => Ord (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t => `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** Show t => Show (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t => `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -28,11 +28,11 @@
 
 <a name="type-exportlist-data1-25282"></a>**data** [Data1](#type-exportlist-data1-25282)
 
-> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) Int
+> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data2-68729"></a>**data** [Data2](#type-exportlist-data2-68729)
 
-> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) Int
+> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
@@ -40,37 +40,37 @@
 > 
 > > (no fields)
 > 
-> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) Int
+> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
 
-> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) Int
+> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
 > <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
 > 
-> > | Field  | Type   | Description |
-> > | :----- | :----- | :---------- |
-> > | field5 | Int    |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | field5                                                                         | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) Int
+> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
 > <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
 > 
-> > | Field  | Type   | Description |
-> > | :----- | :----- | :---------- |
-> > | field6 | Int    |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | field6                                                                         | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
 > 
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
 > 
 > 
-> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) Int
+> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-exportlist-function1-77714"></a>[function1](#function-exportlist-function1-77714)
 
-> : Int
+> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -46,13 +46,13 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-25282_>`_
 
-  **instance** HasField "field1" `Data1 <type-exportlist-data1-25282_>`_ Int
+  **instance** HasField "field1" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data2-68729:
 
 **data** `Data2 <type-exportlist-data2-68729_>`_
 
-  **instance** HasField "field2" `Data2 <type-exportlist-data2-68729_>`_ Int
+  **instance** HasField "field2" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data3-43604:
 
@@ -63,13 +63,13 @@ Data Types
   `Constr3 <constr-exportlist-constr3-90820_>`_
   
   
-  **instance** HasField "field3" `Data3 <type-exportlist-data3-43604_>`_ Int
+  **instance** HasField "field3" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data4-87051:
 
 **data** `Data4 <type-exportlist-data4-87051_>`_
 
-  **instance** HasField "field4" `Data4 <type-exportlist-data4-87051_>`_ Int
+  **instance** HasField "field4" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data5-40974:
 
@@ -87,10 +87,10 @@ Data Types
          - Type
          - Description
        * - field5
-         - Int
+         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField "field5" `Data5 <type-exportlist-data5-40974_>`_ Int
+  **instance** HasField "field5" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data6-26325:
 
@@ -108,7 +108,7 @@ Data Types
          - Type
          - Description
        * - field6
-         - Int
+         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
          - 
   
   .. _constr-exportlist-constr6tick-67971:
@@ -116,7 +116,7 @@ Data Types
   `Constr6' <constr-exportlist-constr6tick-67971_>`_
   
   
-  **instance** HasField "field6" `Data6 <type-exportlist-data6-26325_>`_ Int
+  **instance** HasField "field6" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -124,4 +124,4 @@ Functions
 .. _function-exportlist-function1-77714:
 
 `function1 <function-exportlist-function1-77714_>`_
-  : Int
+  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -4,13 +4,13 @@
 
 <a name="type-iou12-iou-45923"></a>**template** [Iou](#type-iou12-iou-45923)
 
-> | Field      | Type       | Description |
-> | :--------- | :--------- | :---------- |
-> | issuer     | Party      |  |
-> | owner      | Party      |  |
-> | currency   | Text       | only 3-letter symbols are allowed |
-> | amount     | Decimal    | must be positive |
-> | regulators | \[Party\]  | `regulators` may observe any use of the `Iou` |
+> | Field                                                                                  | Type                                                                                   | Description |
+> | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
+> | issuer                                                                                 | Party                                                                                  |  |
+> | owner                                                                                  | Party                                                                                  |  |
+> | currency                                                                               | [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)       | only 3-letter symbols are allowed |
+> | amount                                                                                 | [Decimal](https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602) | must be positive |
+> | regulators                                                                             | \[Party\]                                                                              | `regulators` may observe any use of the `Iou` |
 > 
 > * **Choice External:Archive**
 >   
@@ -33,9 +33,9 @@
 >   splits into two `Iou`s with
 >   smaller amounts
 >   
->   | Field       | Type        | Description |
->   | :---------- | :---------- | :---------- |
->   | splitAmount | Decimal     | must be between zero and original amount |
+>   | Field                                                                                  | Type                                                                                   | Description |
+>   | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                            | [Decimal](https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602) | must be between zero and original amount |
 > 
 > * **Choice Transfer**
 >   

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -24,10 +24,10 @@ Templates
        - Party
        - 
      * - currency
-       - Text
+       - `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
        - only 3-letter symbols are allowed
      * - amount
-       - Decimal
+       - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
        - must be positive
      * - regulators
        - [Party]
@@ -67,7 +67,7 @@ Templates
          - Type
          - Description
        * - splitAmount
-         - Decimal
+         - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
          - must be between zero and original amount
   
   + **Choice Transfer**

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -6,21 +6,21 @@
 
 > <a name="constr-newtype-nat-99832"></a>[Nat](#constr-newtype-nat-99832)
 > 
-> > | Field | Type  | Description |
-> > | :---- | :---- | :---------- |
-> > | unNat | Int   |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | unNat                                                                          | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) Int
+> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-newtype-mknat-8513"></a>[mkNat](#function-newtype-mknat-8513)
 
-> : Int -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-unsafemknat-96593"></a>[unsafeMkNat](#function-newtype-unsafemknat-96593)
 
-> : Int -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-zero0-10450"></a>[zero0](#function-newtype-zero0-10450)
 
@@ -32,12 +32,12 @@
 
 <a name="function-newtype-unnat1-26452"></a>[unNat1](#function-newtype-unnat1-26452)
 
-> : [Nat](#type-newtype-nat-61947) -\> Int
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat2-96339"></a>[unNat2](#function-newtype-unnat2-96339)
 
-> : [Nat](#type-newtype-nat-61947) -\> Int
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat3-97654"></a>[unNat3](#function-newtype-unnat3-97654)
 
-> : [Nat](#type-newtype-nat-61947) -\> Int
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -22,10 +22,10 @@ Data Types
          - Type
          - Description
        * - unNat
-         - Int
+         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField "unNat" `Nat <type-newtype-nat-61947_>`_ Int
+  **instance** HasField "unNat" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -33,12 +33,12 @@ Functions
 .. _function-newtype-mknat-8513:
 
 `mkNat <function-newtype-mknat-8513_>`_
-  : Int -> `Nat <type-newtype-nat-61947_>`_
+  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unsafemknat-96593:
 
 `unsafeMkNat <function-newtype-unsafemknat-96593_>`_
-  : Int -> `Nat <type-newtype-nat-61947_>`_
+  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-zero0-10450:
 
@@ -53,14 +53,14 @@ Functions
 .. _function-newtype-unnat1-26452:
 
 `unNat1 <function-newtype-unnat1-26452_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> Int
+  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat2-96339:
 
 `unNat2 <function-newtype-unnat2-96339_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> Int
+  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat3-97654:
 
 `unNat3 <function-newtype-unnat3-97654_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> Int
+  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.md
@@ -4,11 +4,11 @@
 
 <a name="type-proposal-proposal-1384"></a>**template** Template t =\> [Proposal](#type-proposal-proposal-1384) t
 
-> | Field     | Type      | Description |
-> | :-------- | :-------- | :---------- |
-> | asset     | t         |  |
-> | receivers | \[Party\] |  |
-> | name      | Text      |  |
+> | Field                                                                            | Type                                                                             | Description |
+> | :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------- | :---------- |
+> | asset                                                                            | t                                                                                |  |
+> | receivers                                                                        | \[Party\]                                                                        |  |
+> | name                                                                             | [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703) |  |
 > 
 > * **Choice Accept**
 >   

--- a/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
@@ -24,7 +24,7 @@ Templates
        - [Party]
        - 
      * - name
-       - Text
+       - `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
        - 
   
   + **Choice Accept**

--- a/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.md
@@ -4,11 +4,11 @@
 
 <a name="type-proposaliou-iou-51326"></a>**template** [Iou](#type-proposaliou-iou-51326)
 
-> | Field   | Type    | Description |
-> | :------ | :------ | :---------- |
-> | issuer  | Party   |  |
-> | owner   | Party   |  |
-> | amount  | Decimal |  |
+> | Field                                                                                  | Type                                                                                   | Description |
+> | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
+> | issuer                                                                                 | Party                                                                                  |  |
+> | owner                                                                                  | Party                                                                                  |  |
+> | amount                                                                                 | [Decimal](https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602) |  |
 > 
 > * **Choice External:Archive**
 >   

--- a/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.rst
@@ -24,7 +24,7 @@ Templates
        - Party
        - 
      * - amount
-       - Decimal
+       - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
        - 
   
   + **Choice External:Archive**


### PR DESCRIPTION
This PR adds the ability to have external i.e. cross-package links between docs. Right now it is hardcoded to create links to the standard library docs at docs.daml.com. In the future, the mapping of "external package name -> docs URL" will be configurable.