### PR TITLE
Don't fix --port flag in daml ledger navigator

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -811,7 +811,6 @@ runLedgerNavigator flags remainingArguments = do
             navigatorArgs = concat
                 [ ["server"]
                 , [host hostAndPort, show (port hostAndPort)]
-                , navigatorPortNavigatorArgs navigatorPort
                 , remainingArguments
                 ]
 
@@ -819,15 +818,8 @@ runLedgerNavigator flags remainingArguments = do
         unsetEnv "DAML_PROJECT" -- necessary to prevent config contamination
         withCurrentDirectory confDir $ do
             withJar navigatorPath navigatorArgs $ \ph -> do
-                putStrLn "Waiting for navigator to start: "
-                -- TODO We need to figure out a sane timeout for this step.
-                waitForHttpServer (putStr "." *> threadDelay 500000) (navigatorURL navigatorPort)
-                putStr . unlines $
-                    [ ""
-                    , "Navigator is running at " <> navigatorURL navigatorPort
-                    , "Use Ctrl+C to stop."
-                    ]
-                exitWith =<< waitExitCode ph
+                exitCode <- waitExitCode ph
+                exitWith exitCode
 
   where
     navigatorConfig :: [PartyDetails] -> T.Text
@@ -847,7 +839,6 @@ runLedgerNavigator flags remainingArguments = do
           ]
         , ["  }"]
         ]
-    navigatorPort = NavigatorPort 7500
 
 getDarPath :: IO FilePath
 getDarPath = do


### PR DESCRIPTION
We don't need a fixed navigator `--port` in `daml ledger navigator` -- that was a vestigial thing caused by reusing `daml start` code for `daml ledger navigator`, because `daml start` actually cared about when the navigator is available, but `daml ledger navigator` doesn't really care. So I removed all of that logic and freed up the `--port` flag on the navigator.

The user can now run `daml ledger navigator -- --port 333` to set the navigator's port (as opposed to the ledger port). We might add a separate optional `--navigator-port` flag in the future to all of the daml-helper commands that start up a navigator.

Fixes #2584.