### PR TITLE
language: Check for different SDK versions when building pkg db

### DIFF
--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -6,11 +6,13 @@ module DA.Daml.LF.Reader
     , ManifestData(..)
     , manifestFromDar
     , multiLineContent
+    , getManifestField
     ) where
 
 import Codec.Archive.Zip
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
+import qualified Data.ByteString.Char8 as BSC
 import qualified Data.HashMap.Strict as Map
 import Data.List.Extra
 import System.FilePath
@@ -53,3 +55,14 @@ manifestFromDar dar = manifestDataFromDar dar manifest
         manifestLines = multiLineContent $ UTF8.toString manifestEntry
         manifest = manifestMapToManifest $ Map.fromList $ map lineToKeyValue manifestLines
 
+-- | Get a single field from the manifest zip entry.
+getManifestField :: Entry -> String -> Maybe String
+getManifestField manifest field =
+    headMay
+        [ value
+        | l <-
+              lines $
+              replace "\n " "" $ BSC.unpack $ BSL.toStrict $ fromEntry manifest
+              -- the newline replacement is for reassembling multilines
+        , Just value <- [stripPrefix (field ++ ": ") l]
+        ]


### PR DESCRIPTION
This fixes #2510. We check whether packages were compiled with different
SDK versions and emit an understandable error if so.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
