### PR TITLE
Default to `-c opt` in Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -97,4 +97,9 @@ build:darwin --protocopt=--include_source_info
 # using ComSpec environment variable. By default it's not passed from Bazel client environment.
 test:windows --test_env=ComSpec
 
+# We default to -c opt. We compile Haskell with -O1 anyway since otherwise
+# it is unusably slow and the C deps change rarely so there is little reason
+# to not compile them with optimizations.
+build -c opt
+
 try-import %workspace%/.bazelrc.local

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,6 +253,8 @@ exports_files(glob(["lib/**/*"]))
 ) if not is_windows else None
 
 common_ghc_flags = [
+    # We default to -c opt but we also want -O1 in -c dbg builds
+    # since we use them for profiling.
     "-O1",
     "-hide-package=ghc-boot-th",
     "-hide-package=ghc-boot",

--- a/bazel_tools/haskell-opt.patch
+++ b/bazel_tools/haskell-opt.patch
@@ -1,0 +1,13 @@
+diff --git a/haskell/private/actions/compile.bzl b/haskell/private/actions/compile.bzl
+index ac8725f5..3f6e4b40 100644
+--- a/haskell/private/actions/compile.bzl
++++ b/haskell/private/actions/compile.bzl
+@@ -250,7 +250,7 @@ def _compilation_defaults(hs, cc, java, dep_info, plugin_dep_info, cc_info, srcs
+ 
+     # Compilation mode.  Allow rule-supplied compiler flags to override it.
+     if hs.mode == "opt":
+-        args.add("-O2")
++        args.add("-O")
+ 
+     args.add("-static")
+     if with_profiling:

--- a/deps.bzl
+++ b/deps.bzl
@@ -49,6 +49,7 @@ def daml_deps():
                 "@com_github_digital_asset_daml//bazel_tools:haskell_public_ghci_repl_wrapper.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell-windows-library-dirs.patch",
                 "@com_github_digital_asset_daml//bazel_tools:haskell-no-isystem.patch",
+                "@com_github_digital_asset_daml//bazel_tools:haskell-opt.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,


### PR DESCRIPTION
This makes sure that C dependencies like gRPC or zlib get compiled
with optimizations. I patched rules_haskell to use -O instead of -O2
since the latter slows down compilation while not making things
faster (according to my measurements).

It does seem to make `damlc test` slightly faster in my tests but it might also be noise.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
