### PR TITLE
Switch to a streaming zip encoding

### DIFF
--- a/3rdparty/c/bzip2.BUILD
+++ b/3rdparty/c/bzip2.BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "bz2",
+    srcs = [
+        "blocksort.c",
+        "bzlib.c",
+        "compress.c",
+        "crctable.c",
+        "decompress.c",
+        "huffman.c",
+        "randtable.c",
+    ],
+    hdrs = [
+        "bzlib.h",
+        "bzlib_private.h",
+    ],
+    includes = [
+        ".",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/3rdparty/haskell/BUILD.bindings-DSL
+++ b/3rdparty/haskell/BUILD.bindings-DSL
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_haskell//haskell:defs.bzl", "haskell_library")
+load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
+
+haskell_library(
+  name = "lib",
+  visibility = ["//visibility:public"],
+  srcs = [":Bindings/Utilities.hs"],
+  deps = [hazel_library("base"), ":bindings-DSL-cbits"],
+)
+
+
+cc_library(
+  name = "bindings-DSL-cbits",
+  visibility = ["//visibility:public"],
+  hdrs = [":bindings.dsl.h", ":bindings.cmacros.h"],
+)

--- a/3rdparty/haskell/bzlib-conduit.patch
+++ b/3rdparty/haskell/bzlib-conduit.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Data/Conduit/BZlib/Internal.hsc b/src/Data/Conduit/BZlib/Internal.hsc
+index f980d35..18d6e3a 100644
+--- a/src/Data/Conduit/BZlib/Internal.hsc
++++ b/src/Data/Conduit/BZlib/Internal.hsc
+@@ -1,7 +1,7 @@
+ {-# LANGUAGE ForeignFunctionInterface #-}
+ 
+ #include <bzlib.h>
+-#include <bindings.dsl.h>
++#include "bindings.dsl.h"
+ 
+ module Data.Conduit.BZlib.Internal where
+ 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -494,6 +494,7 @@ hazel_repositories(
         },
     ),
     exclude_packages = [
+        "bindings-DSL",
         "clock",
         # Excluded since we build it via the http_archive line above.
         "ghc-lib-parser",
@@ -515,6 +516,7 @@ hazel_repositories(
         {
             "z": "@com_github_madler_zlib//:z",
             "ffi": "" if is_windows else "@libffi_nix//:ffi",
+            "bz2": "@bzip2//:bz2",
         },
     ),
     ghc_workspaces = {
@@ -586,6 +588,12 @@ hazel_repositories(
                 "91dd121ac565009f2fc215c50f3365ed66705071a698a545e869041b5d7ff4da",
                 patch_args = ["-p1"],
                 patches = ["@com_github_digital_asset_daml//bazel_tools:haskell-c2hs.patch"],
+            ) + hazel_hackage(
+                "bzlib-conduit",
+                "0.3.0.2",
+                "eb2c732b3d4ab5f7b367c51eef845e597ade19da52c03ee11954d35b6cfc4128",
+                patch_args = ["-p1"],
+                patches = ["@com_github_digital_asset_daml//3rdparty/haskell:bzlib-conduit.patch"],
             ),
         pkgs = packages,
     ),
@@ -609,6 +617,15 @@ hazel_custom_package_hackage(
     build_file = "//3rdparty/haskell:BUILD.zlib",
     sha256 = "0dcc7d925769bdbeb323f83b66884101084167501f11d74d21eb9bc515707fed",
     version = "0.6.2",
+)
+
+hazel_custom_package_hackage(
+    package_name = "bindings-DSL",
+    # Without a custom build file, packages depending on bindings-DSL
+    # fail to find bindings.dsl.h.
+    build_file = "//3rdparty/haskell:BUILD.bindings-DSL",
+    sha256 = "63de32380c68d1cc5e9c7b3622d67832c786da21163ba0c8a4835e6dd169194f",
+    version = "1.0.25",
 )
 
 hazel_custom_package_hackage(

--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -9,7 +9,7 @@ module DA.Daml.LF.Reader
     , getManifestField
     ) where
 
-import Codec.Archive.Zip
+import "zip-archive" Codec.Archive.Zip
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
 import qualified Data.ByteString.Char8 as BSC

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -120,6 +120,7 @@ da_haskell_library(
         "vector",
         "xml",
         "yaml",
+        "zip",
         "zip-archive",
         "unordered-containers",
         "uniplate",

--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_library(
     hazel_deps = [
         "base",
         "bytestring",
+        "conduit",
         "containers",
         "directory",
         "extra",
@@ -27,7 +28,7 @@ da_haskell_library(
         "text",
         "time",
         "transformers",
-        "zip-archive",
+        "zip",
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],

--- a/compiler/damlc/lib/DA/Cli/Visual.hs
+++ b/compiler/damlc/lib/DA/Cli/Visual.hs
@@ -19,7 +19,7 @@ import qualified Data.NameMap as NM
 import qualified Data.Set as Set
 import qualified DA.Pretty as DAP
 import qualified DA.Daml.LF.Proto3.Archive as Archive
-import qualified Codec.Archive.Zip as ZIPArchive
+import qualified "zip-archive" Codec.Archive.Zip as ZIPArchive
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString as B
 import Data.Generics.Uniplate.Data

--- a/deps.bzl
+++ b/deps.bzl
@@ -79,6 +79,15 @@ def daml_deps():
             sha256 = "6d4d6640ca3121620995ee255945161821218752b551a1a180f4215f7d124d45",
         )
 
+    if "bzip2" not in native.existing_rules():
+        http_archive(
+            name = "bzip2",
+            build_file = "@com_github_digital_asset_daml//3rdparty/c:bzip2.BUILD",
+            strip_prefix = "bzip2-1.0.8",
+            urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
+            sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
+        )
+
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -14,3 +14,5 @@ HEAD — ongoing
 + [DAML Compiler] The DAML compiler was accidentally compiled without
   optimizations on Windows. This has been fixed which should improve
   the performance of ``damlc`` and ``daml studio`` on Windows.
++ [DAML Compiler] ``damlc build`` should no longer leak file handles so
+  ``ulimit`` workarounds should no longer be necessary.


### PR DESCRIPTION
This switches the creation of the archive in `daml build` from
`zip-archive` to `zip`. This has a few advantages:

1. It gets rid of lazy IO for reading all the interface and source
files. This avoids the high usage of file handles in `daml build`.

2. It seems to be a slight improvement in max memory usage and runtime
and a giant improvement in allocations (but I think the latter
probably comes primarily from the fact that the locations are moved to
the bzip C library). The improvement in max memory usage is less than
I expected so probably there is still something off somewhere.

For now, I only switched over `createArchive`. Archive reading is
still done using `zip-archive`. We might want to switch that over in a
separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
