### PR TITLE
Make the DAML-LF AST in Scala land look less like a DSL

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -250,7 +250,7 @@ object Speedy {
       val compiler = Compiler(compiledPackages.packages)
       Right({ (checkSubmitterInMaintainers: Boolean, expr: Expr) =>
         initial(checkSubmitterInMaintainers, compiledPackages).copy(
-          ctrl = CtrlExpr(compiler.compile(expr)(SEValue(SToken))))
+          ctrl = CtrlExpr(SEApp(compiler.compile(expr), Array(SEValue(SToken)))))
       })
     }
 
@@ -260,7 +260,7 @@ object Speedy {
         compiledPackages: CompiledPackages): Machine =
       initial(checkSubmitterInMaintainers, compiledPackages).copy(
         // apply token
-        ctrl = CtrlExpr(sexpr(SEValue(SToken))),
+        ctrl = CtrlExpr(SEApp(sexpr, Array(SEValue(SToken)))),
       )
 
     // Used from repl.
@@ -272,7 +272,7 @@ object Speedy {
       val compiler = Compiler(compiledPackages.packages)
       val sexpr =
         if (scenario)
-          compiler.compile(expr)(SEValue(SToken))
+          SEApp(compiler.compile(expr), Array(SEValue(SToken)))
         else
           compiler.compile(expr)
 


### PR DESCRIPTION
Currently, the `SExpr` class has a method `apply`, which is basically an
alias for `SEApp`. Using this method makes the code harder to read, at
least of me. After all, ASTs are _data_ and not _control_. Thus, having
a DSL for them seems a bit overkill.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
