### PR TITLE
Revert DAML-LF proto change for Numeric

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -193,11 +193,11 @@ instance Pretty BuiltinExpr where
     BEGreater t   -> maybeParens (prec > precEApp) ("GREATER"    <-> prettyBTyArg lvl t)
     BEGreaterEq t -> maybeParens (prec > precEApp) ("GREATER_EQ" <-> prettyBTyArg lvl t)
     BEToText t    -> maybeParens (prec > precEApp) ("TO_TEXT"    <-> prettyBTyArg lvl t)
-    BEAddDecimal -> "ADD_NUMERIC"
-    BESubDecimal -> "SUB_NUMERIC"
-    BEMulDecimal -> "MUL_NUMERIC"
-    BEDivDecimal -> "DIV_NUMERIC"
-    BERoundDecimal -> "ROUND_NUMERIC"
+    BEAddDecimal -> "ADD_DECIMAL"
+    BESubDecimal -> "SUB_DECIMAL"
+    BEMulDecimal -> "MUL_DECIMAL"
+    BEDivDecimal -> "DIV_DECIMAL"
+    BERoundDecimal -> "ROUND_DECIMAL"
     BEAddInt64 -> "ADD_INT64"
     BESubInt64 -> "SUB_INT64"
     BEMulInt64 -> "MUL_INT64"
@@ -216,8 +216,8 @@ instance Pretty BuiltinExpr where
     BEAppendText -> "APPEND_TEXT"
     BETimestamp ts -> pretty (timestampToText ts)
     BEDate date -> pretty (dateToText date)
-    BEInt64ToDecimal -> "INT64_TO_NUMERIC"
-    BEDecimalToInt64 -> "NUMERIC_TO_INT64"
+    BEInt64ToDecimal -> "INT64_TO_DECIMAL"
+    BEDecimalToInt64 -> "DECIMAL_TO_INT64"
     BETimestampToUnixMicroseconds -> "TIMESTAMP_TO_UNIX_MICROSECONDS"
     BEUnixMicrosecondsToTimestamp -> "UNIX_MICROSECONDS_TO_TIMESTAMP"
     BEDateToUnixDays -> "DATE_TO_UNIX_DAYS"
@@ -229,7 +229,7 @@ instance Pretty BuiltinExpr where
     BEEqualContractId -> "EQUAL_CONTRACT_ID"
     BEPartyFromText -> "FROM_TEXT_PARTY"
     BEInt64FromText -> "FROM_TEXT_INT64"
-    BEDecimalFromText -> "FROM_TEXT_NUMERIC"
+    BEDecimalFromText -> "FROM_TEXT_DECIMAL"
     BEPartyToQuotedText -> "PARTY_TO_QUOTED_TEXT"
     BETextToCodePoints -> "TEXT_TO_CODE_POINTS"
     BETextFromCodePoints -> "TEXT_FROM_CODE_POINTS"

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -167,7 +167,7 @@ decodeChoice LF1.TemplateChoice{..} =
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
 decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
-  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqual BTDecimal
+  LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
   LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
   LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
@@ -175,35 +175,35 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
-  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEq BTDecimal
+  LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
   LF1.BuiltinFunctionLEQ_TEXT    -> BELessEq BTText
   LF1.BuiltinFunctionLEQ_TIMESTAMP    -> BELessEq BTTimestamp
   LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
   LF1.BuiltinFunctionLEQ_PARTY -> BELessEq BTParty
 
   LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
-  LF1.BuiltinFunctionLESS_NUMERIC -> BELess BTDecimal
+  LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
   LF1.BuiltinFunctionLESS_TEXT    -> BELess BTText
   LF1.BuiltinFunctionLESS_TIMESTAMP    -> BELess BTTimestamp
   LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
   LF1.BuiltinFunctionLESS_PARTY -> BELess BTParty
 
   LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
-  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEq BTDecimal
+  LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
   LF1.BuiltinFunctionGEQ_TEXT    -> BEGreaterEq BTText
   LF1.BuiltinFunctionGEQ_TIMESTAMP    -> BEGreaterEq BTTimestamp
   LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
   LF1.BuiltinFunctionGEQ_PARTY -> BEGreaterEq BTParty
 
   LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
-  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreater BTDecimal
+  LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
   LF1.BuiltinFunctionGREATER_TEXT    -> BEGreater BTText
   LF1.BuiltinFunctionGREATER_TIMESTAMP    -> BEGreater BTTimestamp
   LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
   LF1.BuiltinFunctionGREATER_PARTY -> BEGreater BTParty
 
   LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
-  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToText BTDecimal
+  LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
   LF1.BuiltinFunctionTO_TEXT_TEXT    -> BEToText BTText
   LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> BEToText BTTimestamp
   LF1.BuiltinFunctionTO_TEXT_PARTY   -> BEToText BTParty
@@ -211,15 +211,15 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
   LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
   LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BEDecimalFromText
+  LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
   LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
   LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
 
-  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddDecimal
-  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubDecimal
-  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulDecimal
-  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivDecimal
-  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundDecimal
+  LF1.BuiltinFunctionADD_DECIMAL   -> BEAddDecimal
+  LF1.BuiltinFunctionSUB_DECIMAL   -> BESubDecimal
+  LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
+  LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
+  LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
 
   LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
   LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
@@ -250,8 +250,8 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> BETimestampToUnixMicroseconds
   LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> BEUnixMicrosecondsToTimestamp
 
-  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToDecimal
-  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BEDecimalToInt64
+  LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
+  LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
 
   LF1.BuiltinFunctionTRACE -> BETrace
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
@@ -477,7 +477,7 @@ decodeVarWithType LF1.VarWithType{..} =
 decodePrimLit :: MonadDecode m => LF1.PrimLit -> m BuiltinExpr
 decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumInt64 sInt -> pure $ BEInt64 sInt
-  LF1.PrimLitSumNumeric sDec -> case readMaybe (TL.unpack sDec) of
+  LF1.PrimLitSumDecimal sDec -> case readMaybe (TL.unpack sDec) of
     Nothing -> throwError $ ParseError ("bad fixed while decoding Decimal: '" <> TL.unpack sDec <> "'")
     Just dec -> return (BEDecimal dec)
   LF1.PrimLitSumTimestamp sTime -> pure $ BETimestamp sTime
@@ -491,14 +491,11 @@ decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumArrow (LF1.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
-  LF1.KindSumNat LF1.Unit ->
-    -- FixMe https://github.com/digital-asset/daml/issues/2289
-    throwError $ ParseError "nat kind not supported"
 
 decodePrim :: LF1.PrimType -> Decode BuiltinType
 decodePrim = pure . \case
   LF1.PrimTypeINT64 -> BTInt64
-  LF1.PrimTypeNUMERIC -> BTDecimal
+  LF1.PrimTypeDECIMAL -> BTDecimal
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
@@ -532,9 +529,6 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
     decodeImpl $ foldr TForall body <$> traverse decodeTypeVarWithKind (V.toList binders)
   LF1.TypeSumTuple (LF1.Type_Tuple flds) ->
     TTuple <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
-  LF1.TypeSumNat _ ->
-    -- FixMe https://github.com/digital-asset/daml/issues/2289
-    throwError $ ParseError "nat type not supported"
   where
     decodeWithArgs :: V.Vector LF1.Type -> DecodeImpl Type -> DecodeImpl Type
     decodeWithArgs args fun = foldl TApp <$> fun <*> traverse decodeType args

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -140,7 +140,7 @@ encodeKind version = P.Kind . Just . \case
 encodeBuiltinType :: Version -> BuiltinType -> P.Enumerated P.PrimType
 encodeBuiltinType _version = P.Enumerated . Right . \case
     BTInt64 -> P.PrimTypeINT64
-    BTDecimal -> P.PrimTypeNUMERIC
+    BTDecimal -> P.PrimTypeDECIMAL
     BTText -> P.PrimTypeTEXT
     BTTimestamp -> P.PrimTypeTIMESTAMP
     BTParty -> P.PrimTypePARTY
@@ -192,7 +192,7 @@ encodeTypeConApp encctx@EncodeCtx{..} (TypeConApp tycon args) = Just $ P.Type_Co
 encodeBuiltinExpr :: BuiltinExpr -> P.ExprSum
 encodeBuiltinExpr = \case
     BEInt64 x -> lit $ P.PrimLitSumInt64 x
-    BEDecimal dec -> lit $ P.PrimLitSumNumeric (TL.pack (show dec))
+    BEDecimal dec -> lit $ P.PrimLitSumDecimal (TL.pack (show dec))
     BEText x -> lit $ P.PrimLitSumText (TL.fromStrict x)
     BETimestamp x -> lit $ P.PrimLitSumTimestamp x
     BEParty x -> lit $ P.PrimLitSumParty $ TL.fromStrict $ unPartyLiteral x
@@ -205,7 +205,7 @@ encodeBuiltinExpr = \case
 
     BEEqual typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionEQUAL_INT64
-      BTDecimal -> builtin P.BuiltinFunctionEQUAL_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionEQUAL_DECIMAL
       BTText -> builtin P.BuiltinFunctionEQUAL_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionEQUAL_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionEQUAL_DATE
@@ -215,7 +215,7 @@ encodeBuiltinExpr = \case
 
     BELessEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLEQ_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionLEQ_DECIMAL
       BTText -> builtin P.BuiltinFunctionLEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLEQ_DATE
@@ -224,7 +224,7 @@ encodeBuiltinExpr = \case
 
     BELess typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLESS_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLESS_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionLESS_DECIMAL
       BTText -> builtin P.BuiltinFunctionLESS_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLESS_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLESS_DATE
@@ -233,7 +233,7 @@ encodeBuiltinExpr = \case
 
     BEGreaterEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGEQ_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionGEQ_DECIMAL
       BTText -> builtin P.BuiltinFunctionGEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGEQ_DATE
@@ -242,7 +242,7 @@ encodeBuiltinExpr = \case
 
     BEGreater typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGREATER_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGREATER_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionGREATER_DECIMAL
       BTText -> builtin P.BuiltinFunctionGREATER_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGREATER_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGREATER_DATE
@@ -251,7 +251,7 @@ encodeBuiltinExpr = \case
 
     BEToText typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionTO_TEXT_INT64
-      BTDecimal -> builtin P.BuiltinFunctionTO_TEXT_NUMERIC
+      BTDecimal -> builtin P.BuiltinFunctionTO_TEXT_DECIMAL
       BTText -> builtin P.BuiltinFunctionTO_TEXT_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionTO_TEXT_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionTO_TEXT_DATE
@@ -260,15 +260,15 @@ encodeBuiltinExpr = \case
     BETextFromCodePoints -> builtin P.BuiltinFunctionTEXT_FROM_CODE_POINTS
     BEPartyFromText -> builtin P.BuiltinFunctionFROM_TEXT_PARTY
     BEInt64FromText -> builtin P.BuiltinFunctionFROM_TEXT_INT64
-    BEDecimalFromText-> builtin P.BuiltinFunctionFROM_TEXT_NUMERIC
+    BEDecimalFromText-> builtin P.BuiltinFunctionFROM_TEXT_DECIMAL
     BETextToCodePoints -> builtin P.BuiltinFunctionTEXT_TO_CODE_POINTS
     BEPartyToQuotedText -> builtin P.BuiltinFunctionTO_QUOTED_TEXT_PARTY
 
-    BEAddDecimal -> builtin P.BuiltinFunctionADD_NUMERIC
-    BESubDecimal -> builtin P.BuiltinFunctionSUB_NUMERIC
-    BEMulDecimal -> builtin P.BuiltinFunctionMUL_NUMERIC
-    BEDivDecimal -> builtin P.BuiltinFunctionDIV_NUMERIC
-    BERoundDecimal -> builtin P.BuiltinFunctionROUND_NUMERIC
+    BEAddDecimal -> builtin P.BuiltinFunctionADD_DECIMAL
+    BESubDecimal -> builtin P.BuiltinFunctionSUB_DECIMAL
+    BEMulDecimal -> builtin P.BuiltinFunctionMUL_DECIMAL
+    BEDivDecimal -> builtin P.BuiltinFunctionDIV_DECIMAL
+    BERoundDecimal -> builtin P.BuiltinFunctionROUND_DECIMAL
 
     BEAddInt64 -> builtin P.BuiltinFunctionADD_INT64
     BESubInt64 -> builtin P.BuiltinFunctionSUB_INT64
@@ -277,8 +277,8 @@ encodeBuiltinExpr = \case
     BEModInt64 -> builtin P.BuiltinFunctionMOD_INT64
     BEExpInt64 -> builtin P.BuiltinFunctionEXP_INT64
 
-    BEInt64ToDecimal -> builtin P.BuiltinFunctionINT64_TO_NUMERIC
-    BEDecimalToInt64 -> builtin P.BuiltinFunctionNUMERIC_TO_INT64
+    BEInt64ToDecimal -> builtin P.BuiltinFunctionINT64_TO_DECIMAL
+    BEDecimalToInt64 -> builtin P.BuiltinFunctionDECIMAL_TO_INT64
 
     BEFoldl -> builtin P.BuiltinFunctionFOLDL
     BEFoldr -> builtin P.BuiltinFunctionFOLDR

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -168,9 +168,6 @@ message Kind {
     Unit star = 1;
     // Kind of polymorphic type.
     Arrow arrow = 2;
-    // kind of TNat type;
-    // *Available since version 1.dev*
-    Unit nat = 3;
   }
 }
 
@@ -185,9 +182,8 @@ enum PrimType {
   // Builtin type 'Int64'
   INT64 = 2;
 
-  // Builtin type 'Numeric'
-  // was named `DECIMAL` in version 1.6 or earlier
-  NUMERIC = 3;
+  // Builtin type 'Decimal'
+  DECIMAL = 3;
 
   // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
 
@@ -298,10 +294,6 @@ message Type {
     Fun fun = 4;
     Forall forall = 5;
     Tuple tuple = 7;
-    // *Available since version 1.dev*
-    // *Must be between 0 and 38 (bounds inclusive)*
-    // use standard signed long for future usage.
-    sint64 nat = 11;
   }
 
   reserved 6; // This was list. Removed in favour of PrimType.LIST
@@ -327,11 +319,11 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_NUMERIC = 0;    // Called `ADD_DECIMAL` in version 1.6 or earlier
-  SUB_NUMERIC = 1;    // Called `SUB_DECIMAL` in version 1.6 or earlier
-  MUL_NUMERIC = 2;    // Called `MUL_DECIMAL` in version 1.6 or earlier
-  DIV_NUMERIC = 3;    // Called `DIV_DECIMAL` in version 1.6 or earlier
-  ROUND_NUMERIC = 6;  // Called `DIV_DECIMAL` in version 1.6 or earlier
+  ADD_DECIMAL = 0;
+  SUB_DECIMAL = 1;
+  MUL_DECIMAL = 2;
+  DIV_DECIMAL = 3;
+  ROUND_DECIMAL = 6;
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -356,35 +348,35 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_NUMERIC = 34;  // Called `LEQ_DECIMAL` in version 1.6 or earlier
+  LEQ_DECIMAL = 34;
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
   LEQ_DATE = 67;
   LEQ_PARTY = 89; // *Available Since version 1.1*
 
   LESS_INT64 = 39;
-  LESS_NUMERIC = 40;  // Called `LESS_DECIMAL` in version 1.6 or earlier
+  LESS_DECIMAL = 40;
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
   LESS_DATE = 68;
   LESS_PARTY = 90; // *Available Since version 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_NUMERIC = 46;  // Called `GEQ_DECIMAL` in version 1.6 or earlier
+  GEQ_DECIMAL = 46;
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
   GEQ_DATE = 69;
   GEQ_PARTY = 91; // *Available Since version 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_NUMERIC = 52;  // Called `GREATED_DECIMAL` in version 1.6 or earlier
+  GREATER_DECIMAL = 52;
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
   GREATER_DATE = 70;
   GREATER_PARTY = 92; // *Available Since version 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_NUMERIC = 58;  // Called `GREATED_DECIMAL` in version 1.6 or earlier
+  TO_TEXT_DECIMAL = 58;
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
   TO_TEXT_DATE = 71;
@@ -392,7 +384,7 @@ enum BuiltinFunction {
   TO_TEXT_PARTY = 94; // *Available Since version 1.2*
   FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
   FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
-  FROM_TEXT_NUMERIC = 104; // *Available Since version 1.5*, was named `GREATER_DECIMAL` in version 1.5 and 1.6
+  FROM_TEXT_DECIMAL = 104; // *Available Since version 1.5*
   SHA256_TEXT = 93; // *Available Since version 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
@@ -401,13 +393,13 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_NUMERIC = 76;  // was named `INT64_TO_NUMERIC` in version 1.6 or earlier
-  NUMERIC_TO_INT64 = 77;  // was named `NUMERIC_TO_INT64` in version 1.6 or earlier
+  INT64_TO_DECIMAL = 76;
+  DECIMAL_TO_INT64 = 77;
 
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_NUMERIC = 80;  // was named `EQUAL_NUMERIC` in version 1.6 or earlier
+  EQUAL_DECIMAL = 80;
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
   EQUAL_DATE = 83;
@@ -420,8 +412,8 @@ enum BuiltinFunction {
 
   COERCE_CONTRACT_ID = 102;
 
-  TEXT_FROM_CODE_POINTS = 105;  // *Available since version 1.6*
-  TEXT_TO_CODE_POINTS = 106; // *Available since version 1.6*
+  TEXT_FROM_CODE_POINTS = 105;  // : List Int64 -> Text   *Available since version 1.6*
+  TEXT_TO_CODE_POINTS = 106; //: Text -> List Int64    *Available since version 1.6*
   // Next id is 107. 106 is TEXT_TO_CODE_POINTS.
 }
 
@@ -444,7 +436,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string numeric = 2;
+    string decimal = 2;
 
     // Unicode string literal ('LitText')
     string text = 4;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -264,9 +264,6 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           val params = kArrow.getParamsList.asScala
           assertNonEmpty(params, "params")
           (params :\ decodeKind(kArrow.getResult))((param, kind) => KArrow(decodeKind(param), kind))
-        case PLF.Kind.SumCase.NAT =>
-          // FixMe: https://github.com/digital-asset/daml/issues/2289
-          throw ParseError("nat kind not supported")
         case PLF.Kind.SumCase.SUM_NOT_SET =>
           throw ParseError("Kind.SUM_NOT_SET")
       }
@@ -306,9 +303,6 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           TTuple(
             ImmArray(fields.map(ft => name(ft.getField) -> decodeType(ft.getType)))
           )
-        case PLF.Type.SumCase.NAT =>
-          // FixMe: https://github.com/digital-asset/daml/issues/2289
-          throw ParseError("nat type not supported")
 
         case PLF.Type.SumCase.SUM_NOT_SET =>
           throw ParseError("Type.SUM_NOT_SET")
@@ -699,10 +693,10 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
       lfPrimLit.getSumCase match {
         case PLF.PrimLit.SumCase.INT64 =>
           PLInt64(lfPrimLit.getInt64)
-        case PLF.PrimLit.SumCase.NUMERIC =>
-          checkDecimal(lfPrimLit.getNumeric)
+        case PLF.PrimLit.SumCase.DECIMAL =>
+          checkDecimal(lfPrimLit.getDecimal)
           Decimal
-            .fromString(lfPrimLit.getNumeric)
+            .fromString(lfPrimLit.getDecimal)
             .flatMap(Numeric.fromBigDecimal(Decimal.scale, _))
             .fold(e => throw ParseError("error parsing decimal: " + e), PLDecimal)
         case PLF.PrimLit.SumCase.TEXT =>
@@ -748,7 +742,7 @@ private[lf] object DecodeV1 {
       BOOL -> (BTBool -> default),
       TEXT -> (BTText -> default),
       INT64 -> (BTInt64 -> default),
-      NUMERIC -> (BTDecimal -> default),
+      DECIMAL -> (BTDecimal -> default),
       TIMESTAMP -> (BTTimestamp -> default),
       PARTY -> (BTParty -> default),
       LIST -> (BTList -> default),
@@ -766,19 +760,19 @@ private[lf] object DecodeV1 {
     import PLF.BuiltinFunction._, LV.Features._
 
     Map[PLF.BuiltinFunction, (Ast.BuiltinFunction, LV)](
-      ADD_NUMERIC -> (BAddDecimal -> default),
-      SUB_NUMERIC -> (BSubDecimal -> default),
-      MUL_NUMERIC -> (BMulDecimal -> default),
-      DIV_NUMERIC -> (BDivDecimal -> default),
-      ROUND_NUMERIC -> (BRoundDecimal -> default),
+      ADD_DECIMAL -> (BAddDecimal -> default),
+      SUB_DECIMAL -> (BSubDecimal -> default),
+      MUL_DECIMAL -> (BMulDecimal -> default),
+      DIV_DECIMAL -> (BDivDecimal -> default),
+      ROUND_DECIMAL -> (BRoundDecimal -> default),
       ADD_INT64 -> (BAddInt64 -> default),
       SUB_INT64 -> (BSubInt64 -> default),
       MUL_INT64 -> (BMulInt64 -> default),
       DIV_INT64 -> (BDivInt64 -> default),
       MOD_INT64 -> (BModInt64 -> default),
       EXP_INT64 -> (BExpInt64 -> default),
-      INT64_TO_NUMERIC -> (BInt64ToDecimal -> default),
-      NUMERIC_TO_INT64 -> (BDecimalToInt64 -> default),
+      INT64_TO_DECIMAL -> (BInt64ToDecimal -> default),
+      DECIMAL_TO_INT64 -> (BDecimalToInt64 -> default),
       FOLDL -> (BFoldl -> default),
       FOLDR -> (BFoldr -> default),
       MAP_EMPTY -> (BMapEmpty -> map),
@@ -790,27 +784,27 @@ private[lf] object DecodeV1 {
       APPEND_TEXT -> (BAppendText -> default),
       ERROR -> (BError -> default),
       LEQ_INT64 -> (BLessEqInt64 -> default),
-      LEQ_NUMERIC -> (BLessEqDecimal -> default),
+      LEQ_DECIMAL -> (BLessEqDecimal -> default),
       LEQ_TEXT -> (BLessEqText -> default),
       LEQ_TIMESTAMP -> (BLessEqTimestamp -> default),
       LEQ_PARTY -> (BLessEqParty -> partyOrdering),
       GEQ_INT64 -> (BGreaterEqInt64 -> default),
-      GEQ_NUMERIC -> (BGreaterEqDecimal -> default),
+      GEQ_DECIMAL -> (BGreaterEqDecimal -> default),
       GEQ_TEXT -> (BGreaterEqText -> default),
       GEQ_TIMESTAMP -> (BGreaterEqTimestamp -> default),
       GEQ_PARTY -> (BGreaterEqParty -> partyOrdering),
       LESS_INT64 -> (BLessInt64 -> default),
-      LESS_NUMERIC -> (BLessDecimal -> default),
+      LESS_DECIMAL -> (BLessDecimal -> default),
       LESS_TEXT -> (BLessText -> default),
       LESS_TIMESTAMP -> (BLessTimestamp -> default),
       LESS_PARTY -> (BLessParty -> partyOrdering),
       GREATER_INT64 -> (BGreaterInt64 -> default),
-      GREATER_NUMERIC -> (BGreaterDecimal -> default),
+      GREATER_DECIMAL -> (BGreaterDecimal -> default),
       GREATER_TEXT -> (BGreaterText -> default),
       GREATER_TIMESTAMP -> (BGreaterTimestamp -> default),
       GREATER_PARTY -> (BGreaterParty -> partyOrdering),
       TO_TEXT_INT64 -> (BToTextInt64 -> default),
-      TO_TEXT_NUMERIC -> (BToTextDecimal -> default),
+      TO_TEXT_DECIMAL -> (BToTextDecimal -> default),
       TO_TEXT_TIMESTAMP -> (BToTextTimestamp -> default),
       TO_TEXT_PARTY -> (BToTextParty -> partyTextConversions),
       TO_TEXT_TEXT -> (BToTextText -> default),
@@ -818,7 +812,7 @@ private[lf] object DecodeV1 {
       TEXT_FROM_CODE_POINTS -> (BToTextCodePoints -> textPacking),
       FROM_TEXT_PARTY -> (BFromTextParty -> partyTextConversions),
       FROM_TEXT_INT64 -> (BFromTextInt64 -> numberParsing),
-      FROM_TEXT_NUMERIC -> (BFromTextDecimal -> numberParsing),
+      FROM_TEXT_DECIMAL -> (BFromTextDecimal -> numberParsing),
       TEXT_TO_CODE_POINTS -> (BFromTextCodePoints -> textPacking),
       SHA256_TEXT -> (BSHA256Text -> shaText),
       DATE_TO_UNIX_DAYS -> (BDateToUnixDays -> default),
@@ -833,7 +827,7 @@ private[lf] object DecodeV1 {
       UNIX_MICROSECONDS_TO_TIMESTAMP -> (BUnixMicrosecondsToTimestamp -> default),
       GREATER_DATE -> (BGreaterDate -> default),
       EQUAL_INT64 -> (BEqualInt64 -> default),
-      EQUAL_NUMERIC -> (BEqualDecimal -> default),
+      EQUAL_DECIMAL -> (BEqualDecimal -> default),
       EQUAL_TEXT -> (BEqualText -> default),
       EQUAL_TIMESTAMP -> (BEqualTimestamp -> default),
       EQUAL_DATE -> (BEqualDate -> default),

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -334,7 +334,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       val builder = PLF.PrimLit.newBuilder()
       primLit match {
         case PLInt64(value) => builder.setInt64(value)
-        case PLDecimal(value) => builder.setNumeric(Decimal.toString(value))
+        case PLDecimal(value) => builder.setDecimal(Decimal.toString(value))
         case PLText(value) => builder.setText(value)
         case PLTimestamp(value) => builder.setTimestamp(value.micros)
         case PLParty(party) => builder.setParty(party)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -16,4 +16,4 @@ HEAD — ongoing
   the performance of ``damlc`` and ``daml studio`` on Windows.
 + [DAML Compiler] ``damlc build`` should no longer leak file handles so
   ``ulimit`` workarounds should no longer be necessary.
-+ [DAML-LF] **Breaking** Rename back ``NUMERIC`` by ``DECIMAL`` in archive Protobuf definition.
++ [DAML-LF] **Breaking** Rename ``NUMERIC`` back to ``DECIMAL`` in Protobuf definition.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -16,3 +16,4 @@ HEAD — ongoing
   the performance of ``damlc`` and ``daml studio`` on Windows.
 + [DAML Compiler] ``damlc build`` should no longer leak file handles so
   ``ulimit`` workarounds should no longer be necessary.
++ [DAML-LF] **Breaking** Rename back ``NUMERIC`` by ``DECIMAL`` in archive Protobuf definition.


### PR DESCRIPTION
In this PR w revert the change made to DAML-LF Protobuf definition made for Numerics (#2289) which are in development.

We decided to simplify the Numeric encoding in the Protobuf specially for dealing with versioning. 

We will reintroduce new change for numeric in the ongoing PR. 

This partially reverts commit 0ffe5945b8afd5b93d4f69d28ff6d34bddc4159b.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
