### PR TITLE
langauge: leave the source argument in the docu

### DIFF
--- a/docs/source/migrate/index.rst
+++ b/docs/source/migrate/index.rst
@@ -23,6 +23,8 @@ and creates a new project containing generated code to migrate contracts from ``
 
   Available options:
     TARGET_PATH              Path where the new project should be located
+    SOURCE                   Path to the main source file ('source' entry of the
+                             project configuration files of the input projects).
     FROM_PATH                Path to the dar-package from which to migrate from
     TO_PATH                  Path to the dar-package to which to migrate to
     -h,--help                Show this help text


### PR DESCRIPTION
Let's have the correct help text in the docu until we know what we do
about MANIFEST and know whether we can drop the SOURCE argument from the
command.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
