### PR TITLE
language: use generic templates for upgrades

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -94,7 +94,7 @@ upgradeTemplates :: String -> [String]
 upgradeTemplates n =
     [ "type " <> n <> "Upgrade = Upgrade A." <> n <> " B." <> n
     , "type " <> n <> "Rollback = Rollback A." <> n <> " B." <> n
-    , "instance Convertable A." <> n <> " B." <> n <> " where"
+    , "instance Convertible A." <> n <> " B." <> n <> " where"
     , "    convert = conv"
     ]
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -94,8 +94,7 @@ upgradeTemplates :: String -> [String]
 upgradeTemplates n =
     [ "type " <> n <> "Upgrade = Upgrade A." <> n <> " B." <> n
     , "type " <> n <> "Rollback = Rollback A." <> n <> " B." <> n
-    , "instance Convertible A." <> n <> " B." <> n <> " where"
-    , "    convert = conv"
+    , "instance Convertible A." <> n <> " B." <> n
     ]
 
 -- | Generate the full source for a daml-lf package.

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -87,40 +87,15 @@ generateUpgradeModule templateNames modName qualA qualB =
         , "import " <> modName <> qualB <> " qualified as B"
         , "import " <> modName <> "AInstances()"
         , "import " <> modName <> "BInstances()"
-        , "import DA.Next.Set"
         , "import DA.Upgrade"
         ]
 
 upgradeTemplates :: String -> [String]
 upgradeTemplates n =
-    [ "template " <> n <> "Upgrade"
-    , "    with"
-    , "        op : Party"
-    , "    where"
-    , "        signatory op"
-    , "        nonconsuming choice Upgrade: ContractId B." <> n
-    , "            with"
-    , "                inC : ContractId A." <> n
-    , "                sigs : [Party]"
-    , "            controller sigs"
-    , "                do"
-    , "                    d <- fetch inC"
-    , "                    assert $ fromList sigs == fromList (signatory d)"
-    , "                    create $ conv d"
-    , "template " <> n <> "Rollback"
-    , "    with"
-    , "        op : Party"
-    , "    where"
-    , "        signatory op"
-    , "        nonconsuming choice Rollback: ContractId A." <> n
-    , "            with"
-    , "                inC : ContractId B." <> n
-    , "                sigs : [Party]"
-    , "            controller sigs"
-    , "                do"
-    , "                    d <- fetch inC"
-    , "                    assert $ fromList sigs == fromList (signatory d)"
-    , "                    create $ conv d"
+    [ "type " <> n <> "Upgrade = Upgrade A." <> n <> " B." <> n
+    , "type " <> n <> "Rollback = Rollback A." <> n <> " B." <> n
+    , "instance Convertable A." <> n <> " B." <> n <> " where"
+    , "    convert = conv"
     ]
 
 -- | Generate the full source for a daml-lf package.

--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -8,8 +8,7 @@
 daml 1.2
 
 module DA.Upgrade
-  ( conv
-  , iso
+  ( iso
   , Convertible(..)
   , GenConvertible
   , Upgrade(..)
@@ -61,10 +60,12 @@ template (Template i, Template o, Convertible o i) => Rollback i o
 -- | Types, for which there exists a conversion.
 class Convertible a b where
   convert : a -> b
+  default convert : (Generic a repA, Generic b repB, GenConvertible repA repB) => a -> b
+  convert = to . cv . from
 
--- | GenConvertible data types that are isomorphic and have the same meta-data up to package id.
-conv : (Generic a repA, Generic b repB, GenConvertible repA repB) => a -> b
-conv = to . cv . from
+-- | Generically convert data types that are isomorphic and have the same meta-data up to package id.
+genConvert : (Generic a repA, Generic b repB, GenConvertible repA repB) => a -> b
+genConvert = to . cv . from
 
 -- | Generic representations that are isomorphic and have the same meta-data up to package id.
 class GenConvertible a b where
@@ -92,7 +93,7 @@ instance GenConvertible (K1 R c) (K1 R c) where cv = identity
 instance GenConvertible c1 c2 => GenConvertible (K1 R (c1 x)) (K1 R (c2 x)) where
   cv = K1 . cv . unK1
 instance (Generic x repX, Generic y repY, GenConvertible repX repY) => GenConvertible (K1 R x) (K1 R y) where
-  cv = K1 . conv . unK1
+  cv = K1 . genConvert . unK1
 
 -- | This class describes meta-data that is equal up to package id.
 class MetaEquiv (m1: Meta) (m2: Meta)

--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -10,8 +10,8 @@ daml 1.2
 module DA.Upgrade
   ( conv
   , iso
-  , Convertable(..)
-  , GenConvertable
+  , Convertible(..)
+  , GenConvertible
   , Upgrade(..)
   , Rollback(..)
   )
@@ -24,7 +24,7 @@ import DA.Next.Set
 -- Upgrade templates
 ----------------------------------------------------------------------------------------------------
 
-template (Template i, Template o, Convertable i o) => Upgrade i o
+template (Template i, Template o, Convertible i o) => Upgrade i o
     with
         op : Party
     where
@@ -39,7 +39,7 @@ template (Template i, Template o, Convertable i o) => Upgrade i o
                     assert $ fromList sigs == fromList (signatory d)
                     create $ convert d
 
-template (Template i, Template o, Convertable o i) => Rollback i o
+template (Template i, Template o, Convertible o i) => Rollback i o
     with
         op : Party
     where
@@ -59,39 +59,39 @@ template (Template i, Template o, Convertable o i) => Rollback i o
 ----------------------------------------------------------------------------------------------------
 
 -- | Types, for which there exists a conversion.
-class Convertable a b where
+class Convertible a b where
   convert : a -> b
 
--- | GenConvertable data types that are isomorphic and have the same meta-data up to package id.
-conv : (Generic a repA, Generic b repB, GenConvertable repA repB) => a -> b
+-- | GenConvertible data types that are isomorphic and have the same meta-data up to package id.
+conv : (Generic a repA, Generic b repB, GenConvertible repA repB) => a -> b
 conv = to . cv . from
 
 -- | Generic representations that are isomorphic and have the same meta-data up to package id.
-class GenConvertable a b where
+class GenConvertible a b where
   cv : a x -> b x
 
 -- copy values
-instance GenConvertable V1 V1 where cv = identity
-instance GenConvertable U1 U1 where cv = identity
+instance GenConvertible V1 V1 where cv = identity
+instance GenConvertible U1 U1 where cv = identity
 
 -- Isomorphic types in different packages
-instance (MetaEquiv c1 c2, GenConvertable f1 f2) => GenConvertable (M1 i1 c1 f1) (M1 i2 c2 f2) where
+instance (MetaEquiv c1 c2, GenConvertible f1 f2) => GenConvertible (M1 i1 c1 f1) (M1 i2 c2 f2) where
   cv = M1 . cv . unM1
 
 -- products
-instance (GenConvertable a1 a2, GenConvertable b1 b2) => GenConvertable (a1 :*: b1) (a2 :*: b2) where
+instance (GenConvertible a1 a2, GenConvertible b1 b2) => GenConvertible (a1 :*: b1) (a2 :*: b2) where
   cv ~(P1 a b) = P1 (cv a) (cv b)
 
 -- sums
-instance (GenConvertable a1 a2, GenConvertable b1 b2) => GenConvertable (a1 :+: b1) (a2 :+: b2) where
+instance (GenConvertible a1 a2, GenConvertible b1 b2) => GenConvertible (a1 :+: b1) (a2 :+: b2) where
   cv (L1 a) = L1 $ cv a
   cv (R1 b) = R1 $ cv b
 
 -- recursion
-instance GenConvertable (K1 R c) (K1 R c) where cv = identity
-instance GenConvertable c1 c2 => GenConvertable (K1 R (c1 x)) (K1 R (c2 x)) where
+instance GenConvertible (K1 R c) (K1 R c) where cv = identity
+instance GenConvertible c1 c2 => GenConvertible (K1 R (c1 x)) (K1 R (c2 x)) where
   cv = K1 . cv . unK1
-instance (Generic x repX, Generic y repY, GenConvertable repX repY) => GenConvertable (K1 R x) (K1 R y) where
+instance (Generic x repX, Generic y repY, GenConvertible repX repY) => GenConvertible (K1 R x) (K1 R y) where
   cv = K1 . conv . unK1
 
 -- | This class describes meta-data that is equal up to package id.

--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -10,41 +10,88 @@ daml 1.2
 module DA.Upgrade
   ( conv
   , iso
+  , Convertable(..)
+  , GenConvertable
+  , Upgrade(..)
+  , Rollback(..)
   )
   where
 
 import DA.Generics
+import DA.Next.Set
 
--- | Convert data types that are isomorphic and have the same meta-data up to package id.
-conv : (Generic a repA, Generic b repB, Conv repA repB) => a -> b
+----------------------------------------------------------------------------------------------------
+-- Upgrade templates
+----------------------------------------------------------------------------------------------------
+
+template (Template i, Template o, Convertable i o) => Upgrade i o
+    with
+        op : Party
+    where
+        signatory op
+        nonconsuming choice DoUpgrade: ContractId o
+            with
+                inC : ContractId i
+                sigs : [Party]
+            controller sigs
+                do
+                    d <- fetch inC
+                    assert $ fromList sigs == fromList (signatory d)
+                    create $ convert d
+
+template (Template i, Template o, Convertable o i) => Rollback i o
+    with
+        op : Party
+    where
+        signatory op
+        nonconsuming choice DoRollback: ContractId i
+            with
+                inC : ContractId o
+                sigs : [Party]
+            controller sigs
+                do
+                    d <- fetch inC
+                    assert $ fromList sigs == fromList (signatory d)
+                    create $ convert d
+
+----------------------------------------------------------------------------------------------------
+-- Data type conversion
+----------------------------------------------------------------------------------------------------
+
+-- | Types, for which there exists a conversion.
+class Convertable a b where
+  convert : a -> b
+
+-- | GenConvertable data types that are isomorphic and have the same meta-data up to package id.
+conv : (Generic a repA, Generic b repB, GenConvertable repA repB) => a -> b
 conv = to . cv . from
 
 -- | Generic representations that are isomorphic and have the same meta-data up to package id.
-class Conv a b where
+class GenConvertable a b where
   cv : a x -> b x
 
 -- copy values
-instance Conv V1 V1 where cv = identity
-instance Conv U1 U1 where cv = identity
+instance GenConvertable V1 V1 where cv = identity
+instance GenConvertable U1 U1 where cv = identity
 
 -- Isomorphic types in different packages
-instance (MetaEquiv c1 c2, Conv f1 f2) => Conv (M1 i1 c1 f1) (M1 i2 c2 f2) where
+instance (MetaEquiv c1 c2, GenConvertable f1 f2) => GenConvertable (M1 i1 c1 f1) (M1 i2 c2 f2) where
   cv = M1 . cv . unM1
 
 -- products
-instance (Conv a1 a2, Conv b1 b2) => Conv (a1 :*: b1) (a2 :*: b2) where
+instance (GenConvertable a1 a2, GenConvertable b1 b2) => GenConvertable (a1 :*: b1) (a2 :*: b2) where
   cv ~(P1 a b) = P1 (cv a) (cv b)
 
 -- sums
-instance (Conv a1 a2, Conv b1 b2) => Conv (a1 :+: b1) (a2 :+: b2) where
+instance (GenConvertable a1 a2, GenConvertable b1 b2) => GenConvertable (a1 :+: b1) (a2 :+: b2) where
   cv (L1 a) = L1 $ cv a
   cv (R1 b) = R1 $ cv b
 
 -- recursion
-instance Conv (K1 R c) (K1 R c) where cv = identity
-instance Conv c1 c2 => Conv (K1 R (c1 x)) (K1 R (c2 x)) where
+instance GenConvertable (K1 R c) (K1 R c) where cv = identity
+instance GenConvertable c1 c2 => GenConvertable (K1 R (c1 x)) (K1 R (c2 x)) where
   cv = K1 . cv . unK1
-instance (Generic x repX, Generic y repY, Conv repX repY) => Conv (K1 R x) (K1 R y) where
+instance (Generic x repX, Generic y repY, GenConvertable repX repY) => GenConvertable (K1 R x) (K1 R y) where
   cv = K1 . conv . unK1
 
 -- | This class describes meta-data that is equal up to package id.

--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -60,6 +60,7 @@ template (Template i, Template o, Convertible o i) => Rollback i o
 -- | Types, for which there exists a conversion.
 class Convertible a b where
   convert : a -> b
+  -- | HIDE
   default convert : (Generic a repA, Generic b repB, GenConvertible repA repB) => a -> b
   convert = to . cv . from
 

--- a/docs/source/migrate/foo-upgrade-2.0.0/build.cmd
+++ b/docs/source/migrate/foo-upgrade-2.0.0/build.cmd
@@ -1,4 +1,4 @@
 :: Copyright (c) 2019 The DAML Authors. All rights reserved.
 :: SPDX-License-Identifier: Apache-2.0
 
-daml build --init-package-db=no --package @("foo-1.0.0",[("Foo","FooA")])@ --package @("foo-2.0.0",[("Foo","FooB")])@
+daml build --init-package-db=no --package "(\"foo-1.0.0\",[(\"Foo\",\"FooA\")])" --package "(\"foo-2.0.0\",[(\"Foo\",\"FooB\")])"

--- a/docs/source/migrate/foo-upgrade-2.0.0/daml/Foo.daml
+++ b/docs/source/migrate/foo-upgrade-2.0.0/daml/Foo.daml
@@ -7,34 +7,8 @@ import FooA qualified as A
 import FooB qualified as B
 import FooAInstances()
 import FooBInstances()
-import DA.Next.Set
 import DA.Upgrade
-template FooUpgrade
-    with
-        op : Party
-    where
-        signatory op
-        nonconsuming choice Upgrade: ContractId B.Foo
-            with
-                inC : ContractId A.Foo
-                sigs : [Party]
-            controller sigs
-                do
-                    d <- fetch inC
-                    assert $ fromList sigs == fromList (signatory d)
-                    create $ conv d
-template FooRollback
-    with
-        op : Party
-    where
-        signatory op
-        nonconsuming choice Rollback: ContractId A.Foo
-            with
-                inC : ContractId B.Foo
-                sigs : [Party]
-            controller sigs
-                do
-                    d <- fetch inC
-                    assert $ fromList sigs == fromList (signatory d)
-                    create $ conv d
+type FooUpgrade = Upgrade A.Foo B.Foo
+type FooRollback = Rollback A.Foo B.Foo
+instance Convertible A.Foo B.Foo
 

--- a/docs/source/migrate/foo-upgrade-2.0.0/daml/FooManual.daml
+++ b/docs/source/migrate/foo-upgrade-2.0.0/daml/FooManual.daml
@@ -7,34 +7,13 @@ import FooA qualified as A
 import FooB qualified as B
 import FooAInstances()
 import FooBInstances()
-import DA.Next.Set
 import DA.Upgrade
-template FooUpgrade
-    with
-        op : Party
-    where
-        signatory op
-        nonconsuming choice Upgrade: ContractId B.Foo
-            with
-                inC : ContractId A.Foo
-                sigs : [Party]
-            controller sigs
-                do
-                    d <- fetch inC
-                    assert $ fromList sigs == fromList (signatory d)
-                    create $ Foo with a = d.a; b = "updated"; p = d.p
-template FooRollback
-    with
-        op : Party
-    where
-        signatory op
-        nonconsuming choice Rollback: ContractId A.Foo
-            with
-                inC : ContractId B.Foo
-                sigs : [Party]
-            controller sigs
-                do
-                    d <- fetch inC
-                    assert $ fromList sigs == fromList (signatory d)
-                    create $ Foo with a = d.a; p = d.p
+type FooUpgrade = Upgrade A.Foo B.Foo
+type FooRollback = Rollback A.Foo B.Foo
+
+instance Convertible A.Foo B.Foo where
+    convert d = B.Foo with a = d.a; p = d.p; t = "upgraded"
+
+instance Convertible B.Foo A.Foo where
+    convert d = A.Foo with a = d.a; p = d.p
 

--- a/docs/source/migrate/index.rst
+++ b/docs/source/migrate/index.rst
@@ -92,11 +92,11 @@ an example:
   :lines: 4-14
 
 The new template types are defined via a type alias and use generic templates to update or rollback
-contract instances defined in the DAML standard library (see
-https://docs.daml.com/daml/reference/base.html#module-da-upgrade). The ``Upgrade`` template offers a
-choice to input a contract instance defined in ``foo-1.0.0`` and create a new one that has been
-converted to a contract instance defined in ``foo-2.0.0``. The ``Rollback`` template implements the
-reversed workflow.
+contract instances defined in the DAML standard library (see `DA.Upgrade
+<https://docs.daml.com/daml/reference/base.html#module-da-upgrade>`__). The ``Upgrade`` template
+offers a choice to input a contract instance defined in ``foo-1.0.0`` and create a new one that has
+been converted to a contract instance defined in ``foo-2.0.0``. The ``Rollback`` template implements
+the reversed workflow.
 
 The last line generates a ``Convertible`` instance for the ``Foo`` template of both packages. This
 is a manifestation that instances of the ``Foo`` template in ``foo-1.0.0`` can be converted to


### PR DESCRIPTION
Instead of generating templates we now have generic upgrade/rollback
templates in the standart library and we just create instances for them in the
migration project. I will update the documentation in a follow up PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
