### PR TITLE
Run semantic and divulgence tests on reference-v2

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -62,30 +62,13 @@ da_scala_binary(
     ],
 )
 
-conformance_tests_to_run = [
-    "ActiveContractsServiceIT",
-    "CommandServiceIT",
-    "CommandSubmissionTtlIT",
-    "CommandTransactionChecksLowLevelIT",
-    "ContractKeysIT",
-    "DivulgenceIT",
-    "PackageManagementServiceIT",
-    "PartyManagementServiceIT",
-    "TransactionBackpressureIT",
-    "TransactionServiceTests",
-    "WitnessesIT",
-]
-
 client_server_test(
     name = "conformance-test",
     timeout = "long",
     client = "//ledger/ledger-api-test-tool:ledger-api-test-tool",
     client_args = [
-        # disabling all tests for now, so that at least we have the infrastructure
-        # to slowly add and fix tests one after the other.
         "--all-tests",
-        # "--include {}".format(",".join(conformance_tests_to_run)),
-        "--exclude SemanticTests,DivulgenceIT,TimeIT",
+        "--exclude TimeIT",
     ],
     data = [
         "//ledger/test-common:SemanticTests.dar",


### PR DESCRIPTION
Semantic and divulgence tests have been mistakenly disabled for the reference DAML-on-X implementation. This PR amends this.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
