### PR TITLE
Add an extraArguments config in the VSCode extension

### DIFF
--- a/compiler/daml-extension/package.json
+++ b/compiler/daml-extension/package.json
@@ -105,6 +105,11 @@
                     ],
                     "default": "From consent popup",
                     "description": "Controls whether you send DAML usage data to Digital Asset"
+                },
+                "daml.extraArguments": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Extra arguments passed to `damlc ide`. This can be used to enable additional warnings via `--ghc-option -W`"
                 }
             }
         },

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,8 +20,8 @@ HEAD — ongoing
 + [DAML Compiler] Allow more contexts in generic templates. Specifically, template constraints can
   have arguments besides type variables, if the FlexibleContexts extension is enabled.
 + [DAML Studio] ``damlc ide`` now also accepts ``--ghc-option`` arguments like ``damlc build``
-  so ``damlc ide --ghc-option -W`` launches the IDE with more warnings. Note that
-  an option for the VSCode extension to pass additional options is still work in progress.
+  so ``damlc ide --ghc-option -W`` launches the IDE with more warnings.
 + [DAML Integration Kit] Participant State API and kvutils was extended with support for
   changing the ledger configuration. See changelog in respective ``package.scala`` files.
-
++ [DAML Studio] The VSCode extension now has a configuration field for
+  passing extra arguments to ``damlc ide``.


### PR DESCRIPTION
This allows passing extra arguments like `--ghc-option -W`.

I’ve also removed the logic for the old assistant while I was touching the flags anyway.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
