### PR TITLE
Fix VSCode extension if extraArguments is empty

### DIFF
--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -175,7 +175,9 @@ export function createLanguageClient(config: vscode.WorkspaceConfiguration, tele
     } else if (telemetryConsent === false){
         args.push('--optOutTelemetry')
     }
-    const extraArgs = config.get("extraArguments", "").split(" ");
+    const extraArgsString = config.get("extraArguments", "").trim();
+    // split on an empty string returns an array with a single empty string
+    const extraArgs = extraArgsString === "" ? [] : extraArgsString.split(" ");
     args = args.concat(extraArgs);
     const serverArgs : string[] = addIfInConfig(config, args,
         [ ['debug', ['--debug']]


### PR DESCRIPTION
Apparently somebody thought that splitting an empty string should
return a singleton array …

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
