### PR TITLE
Refactor gRPC request cancellation support in gRPC-haskell

### DIFF
--- a/language-support/hs/bindings/src/DA/Ledger/GrpcWrapUtils.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/GrpcWrapUtils.hs
@@ -51,9 +51,9 @@ unwrapWithInvalidArgument = \case
 sendToStream :: Show b => Int -> a -> (b -> Perhaps c) -> Stream c -> (ClientRequest 'ServerStreaming a b -> IO (ClientResult 'ServerStreaming b)) -> IO ()
 sendToStream timeout request convertResponse stream rpc = do
     res <- rpc $
-        ClientReaderRequestCC request timeout emptyMdm
-        (\cc -> onClose stream $ \_cancel -> clientCallCancel cc)
-        $ \_mdm recv -> do
+        ClientReaderRequest request timeout emptyMdm
+        $ \clientCall _mdm recv -> do
+          onClose stream $ \_ -> clientCallCancel clientCall
           fix $ \again -> do
             recv >>= \case
                 Left e ->  failToStream (show e)

--- a/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Client.hs
+++ b/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Client.hs
@@ -250,39 +250,27 @@ compileNormalRequestResults x =
 -- clientReader (client side of server streaming mode)
 
 -- | First parameter is initial server metadata.
-type ClientReaderHandler = MetadataMap -> StreamRecv ByteString -> IO ()
+type ClientReaderHandler = ClientCall -> MetadataMap -> StreamRecv ByteString -> IO ()
 type ClientReaderResult  = (MetadataMap, C.StatusCode, StatusDetails)
 
-clientReaderCC :: Client
+clientReader :: Client
                -> RegisteredMethod 'ServerStreaming
                -> TimeoutSeconds
                -> ByteString -- ^ The body of the request
                -> MetadataMap -- ^ Metadata to send with the request
-               -> (ClientCall -> IO ())
                -> ClientReaderHandler
                -> IO (Either GRPCIOError ClientReaderResult)
-clientReaderCC cl@Client{ clientCQ = cq } rm tm body initMeta fCC f =
+clientReader cl@Client{ clientCQ = cq } rm tm body initMeta  f =
   withClientCall cl rm tm go
   where
     go cc@(unsafeCC -> c) = runExceptT $ do
-      liftIO $ fCC cc
       void $ runOps' c cq [ OpSendInitialMetadata initMeta
                           , OpSendMessage body
                           , OpSendCloseFromClient
                           ]
       srvMD <- recvInitialMetadata c cq
-      liftIO $ f srvMD (streamRecvPrim c cq)
+      liftIO $ f cc srvMD (streamRecvPrim c cq)
       recvStatusOnClient c cq
-
-clientReader :: Client
-             -> RegisteredMethod 'ServerStreaming
-             -> TimeoutSeconds
-             -> ByteString -- ^ The body of the request
-             -> MetadataMap -- ^ Metadata to send with the request
-             -> ClientReaderHandler
-             -> IO (Either GRPCIOError ClientReaderResult)
-clientReader cl rm tm body initMeta f =
-  clientReaderCC cl rm tm body initMeta fCC f where fCC _ = return ()
 
 --------------------------------------------------------------------------------
 -- clientWriter (client side of client streaming mode)
@@ -332,7 +320,8 @@ pattern CWRFinal mmsg initMD trailMD st ds
 -- clientRW (client side of bidirectional streaming mode)
 
 type ClientRWHandler
-  =  IO (Either GRPCIOError MetadataMap)
+  =  ClientCall
+  -> IO (Either GRPCIOError MetadataMap)
   -> StreamRecv ByteString
   -> StreamSend ByteString
   -> WritesDone
@@ -358,7 +347,7 @@ clientRW' :: Client
           -> MetadataMap
           -> ClientRWHandler
           -> IO (Either GRPCIOError ClientRWResult)
-clientRW' (clientCQ -> cq) (unsafeCC -> c) initMeta f = runExceptT $ do
+clientRW' (clientCQ -> cq) cc@(unsafeCC -> c) initMeta f = runExceptT $ do
   sendInitialMetadata c cq initMeta
 
   -- 'mdmv' is used to synchronize between callers of 'getMD' and 'recv'
@@ -418,7 +407,7 @@ clientRW' (clientCQ -> cq) (unsafeCC -> c) initMeta f = runExceptT $ do
     -- programmer.
     writesDone = writesDonePrim c cq
 
-  liftIO (f getMD recv send writesDone)
+  liftIO (f cc getMD recv send writesDone)
   recvStatusOnClient c cq -- Finish()
 
 --------------------------------------------------------------------------------

--- a/nix/third-party/gRPC-haskell/examples/hellos/hellos-client/Main.hs
+++ b/nix/third-party/gRPC-haskell/examples/hellos/hellos-client/Main.hs
@@ -42,7 +42,7 @@ doHelloSS c n = do
   let pay        = SSRqt "server streaming mode" (fromIntegral n)
       enc        = BL.toStrict . toLazyByteString $ pay
       err desc e = fail $ "doHelloSS: " ++ desc ++ " error: " ++ show e
-  eea <- clientReader c rm n enc mempty $ \_md recv -> do
+  eea <- clientReader c rm n enc mempty $ \_cc _md recv -> do
     n' <- flip fix (0::Int) $ \go i -> recv >>= \case
       Left e          -> err "recv" e
       Right Nothing   -> return i
@@ -84,7 +84,7 @@ doHelloBi c n = do
   let pay        = BiRqtRpy "bidi payload"
       enc        = BL.toStrict . toLazyByteString $ pay
       err desc e = fail $ "doHelloBi: " ++ desc ++ " error: " ++ show e
-  eea <- clientRW c rm n mempty $ \_getMD recv send writesDone -> do
+  eea <- clientRW c rm n mempty $ \_cc _getMD recv send writesDone -> do
     -- perform n writes on a worker thread
     thd <- async $ do
       replicateM_ n $ send enc >>= \case

--- a/nix/third-party/gRPC-haskell/src/Network/GRPC/HighLevel/Client.hs
+++ b/nix/third-party/gRPC-haskell/src/Network/GRPC/HighLevel/Client.hs
@@ -58,9 +58,8 @@ data ClientRequest (streamType :: GRPCMethodType) request response where
   -- | The final field will be invoked once, and it should repeatedly
   -- invoke its final argument (of type @(StreamRecv response)@)
   -- in order to obtain the streaming response incrementally.
-  ClientReaderRequestCC :: request -> TimeoutSeconds -> MetadataMap -> (LL.ClientCall -> IO ()) -> (MetadataMap -> StreamRecv response -> IO ()) -> ClientRequest 'ServerStreaming request response
-  ClientReaderRequest :: request -> TimeoutSeconds -> MetadataMap -> (MetadataMap -> StreamRecv response -> IO ()) -> ClientRequest 'ServerStreaming request response
-  ClientBiDiRequest :: TimeoutSeconds -> MetadataMap -> (MetadataMap -> StreamRecv response -> StreamSend request -> WritesDone -> IO ()) -> ClientRequest 'BiDiStreaming request response
+  ClientReaderRequest :: request -> TimeoutSeconds -> MetadataMap -> (LL.ClientCall -> MetadataMap -> StreamRecv response -> IO ()) -> ClientRequest 'ServerStreaming request response
+  ClientBiDiRequest :: TimeoutSeconds -> MetadataMap -> (LL.ClientCall -> MetadataMap -> StreamRecv response -> StreamSend request -> WritesDone -> IO ()) -> ClientRequest 'BiDiStreaming request response
 
 data ClientResult (streamType :: GRPCMethodType) response where
   ClientNormalResponse :: response -> MetadataMap -> MetadataMap -> StatusCode -> StatusDetails -> ClientResult 'Normal response
@@ -117,20 +116,14 @@ clientRequest client (RegisteredMethod method) (ClientWriterRequest timeout meta
         Left err -> ClientErrorResponse (ClientErrorNoParse err)
         Right parsedRsp ->
           ClientWriterResponse parsedRsp initMD_ trailMD_ rspCode_ details_
-clientRequest client (RegisteredMethod method) (ClientReaderRequestCC req timeout meta fCC handler) =
-    mkResponse <$> LL.clientReaderCC client method timeout (BL.toStrict (toLazyByteString req)) meta fCC (\m recv -> handler m (convertRecv recv))
-  where
-    mkResponse (Left ioError_) = ClientErrorResponse (ClientIOError ioError_)
-    mkResponse (Right (meta_, rspCode_, details_)) =
-      ClientReaderResponse meta_ rspCode_ details_
 clientRequest client (RegisteredMethod method) (ClientReaderRequest req timeout meta handler) =
-    mkResponse <$> LL.clientReader client method timeout (BL.toStrict (toLazyByteString req)) meta (\m recv -> handler m (convertRecv recv))
+    mkResponse <$> LL.clientReader client method timeout (BL.toStrict (toLazyByteString req)) meta (\cc m recv -> handler cc m (convertRecv recv))
   where
     mkResponse (Left ioError_) = ClientErrorResponse (ClientIOError ioError_)
     mkResponse (Right (meta_, rspCode_, details_)) =
       ClientReaderResponse meta_ rspCode_ details_
 clientRequest client (RegisteredMethod method) (ClientBiDiRequest timeout meta handler) =
-    mkResponse <$> LL.clientRW client method timeout meta (\_m recv send writesDone -> handler meta (convertRecv recv) (convertSend send) writesDone)
+    mkResponse <$> LL.clientRW client method timeout meta (\cc _m recv send writesDone -> handler cc meta (convertRecv recv) (convertSend send) writesDone)
   where
     mkResponse (Left ioError_) = ClientErrorResponse (ClientIOError ioError_)
     mkResponse (Right (meta_, rspCode_, details_)) =


### PR DESCRIPTION
Previously, we had a separate constructor that took an additional
callback that had access to the client call so that we could use that
for cancellation. This PR removes the separate constructor and instead
changes the callback accepted by ClientReaderRequest (and for
consistency also the one accepted by ClientBiDiRequest) to pass the
client call.

This seems like a simpler solution so I’m more hopeful that we will be
able to upstream this change (this is the only API breaking change we
made afaik). There are two caveats here:

1. This will break existing consumers that use ClientReaderRequest. At
this stage in gRPC-haskell this is very reasonable and upstream
doesn’t seem to try very hard to avoid those.

2. The callback is called slightly later than the custom callback we
added before so you have to wait a bit longer until you can cancel
things. At least on our test suite that doesn’t seem to make a
difference.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
