### PR TITLE
Make gRPC-haskell safe against async exceptions

### DIFF
--- a/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server.hs
+++ b/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server.hs
@@ -26,7 +26,7 @@ import           Control.Concurrent.STM.TVar           (TVar
                                                         , writeTVar
                                                         , readTVarIO
                                                         , newTVarIO)
-import           Control.Exception                     (bracket, finally)
+import           Control.Exception                     (bracket)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except

--- a/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
+++ b/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
@@ -3,7 +3,7 @@
 
 module Network.GRPC.LowLevel.Server.Unregistered where
 
-import           Control.Exception                                  (finally)
+import           Control.Exception                                  (bracket, finally)
 import           Control.Monad
 import           Control.Monad.Trans.Except
 import           Data.ByteString                                    (ByteString)
@@ -30,9 +30,12 @@ withServerCall :: Server
                -> (ServerCall -> IO (Either GRPCIOError a))
                -> IO (Either GRPCIOError a)
 withServerCall s f =
-  serverCreateCall s >>= \case
-    Left e  -> return (Left e)
-    Right c -> f c `finally` do
+  bracket (serverCreateCall s) cleanup $ \case
+    Left e -> return (Left e)
+    Right c -> f c
+  where
+    cleanup (Left _) = pure ()
+    cleanup (Right c) = do
       grpcDebug "withServerCall: destroying."
       destroyServerCall c
 
@@ -44,13 +47,13 @@ withServerCall s f =
 withServerCallAsync :: Server
                     -> (ServerCall -> IO ())
                     -> IO ()
-withServerCallAsync s f =
+withServerCallAsync s f = mask $ \unmask ->
   serverCreateCall s >>= \case
     Left e -> do grpcDebug $ "withServerCallAsync: call error: " ++ show e
                  return ()
     Right c -> do wasForkSuccess <- forkServer s handler
                   unless wasForkSuccess destroy
-                where handler = f c `finally` destroy
+                where handler = unmask (f c) `finally` destroy
                       -- TODO: We sometimes never finish cleanup if the server
                       -- is shutting down and calls killThread. This causes gRPC
                       -- core to complain about leaks.  I think the cause of

--- a/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
+++ b/nix/third-party/gRPC-haskell/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
@@ -3,7 +3,7 @@
 
 module Network.GRPC.LowLevel.Server.Unregistered where
 
-import           Control.Exception                                  (bracket, finally)
+import           Control.Exception                                  (bracket, finally, mask)
 import           Control.Monad
 import           Control.Monad.Trans.Except
 import           Data.ByteString                                    (ByteString)


### PR DESCRIPTION
This replaces the call to mask_ that I added in clientRequest as a
rudamentary fix by a proper fix that fixes the way async exceptions
are handled and should hopefully be more reasonable to upstream:

gRPC-haskell had a lot of cases where they did something like

```
do x <- allocateResource
   f x `finally` cleanup x
```

That breaks if you get an exception after allocating the resource but
before the exception handler is installed by finally. I replaced all
of those instances by `bracket` where possible and one explicit call
to `mask` where it is not possible.

There is a bit of boilerplate here since the resource allocation
returns an `Either` but given that there doesn’t seem to be an
existing utils module where I could put this and I don’t want to
depend on `extra` for things like `whenRight` (since I want to
upstream this), I’ve just kept the boilerplate for now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
