### PR TITLE
damldocs: Only strip implied typeclass member constraint, not all constraints.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -350,12 +350,11 @@ getClsDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ c@ClassDecl{..})) docs) = do
     -- for comparison because it is more accurate than typenames (which are
     -- generally susceptible to qualification and shadowing).
     matchesMemberContext :: Maybe Anchor -> [T.Text] -> DDoc.Type -> Bool
-    matchesMemberContext cl_anchor cl_args ty = and
-        [ cl_anchor == getTypeAppAnchor ty
-        , Just [(Just (Typename arg), Just []) | arg <- cl_args] ==
+    matchesMemberContext cl_anchor cl_args ty =
+        cl_anchor == getTypeAppAnchor ty &&
+        Just [(Just (Typename arg), Just []) | arg <- cl_args] ==
             (map (\arg -> (getTypeAppName arg, getTypeAppArgs arg))
             <$> getTypeAppArgs ty)
-        ]
 
     subdocs = memberDocs c
 getClsDocs _ _ = Nothing

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -41,6 +41,21 @@ data Type = TypeApp !(Maybe Reference) !Typename [Type] -- ^ Type application
           | TypeLit Text -- ^ a literal (e.g. "foo") appearing at the type level
   deriving (Eq, Ord, Show, Generic)
 
+getTypeAppAnchor :: Type -> Maybe Anchor
+getTypeAppAnchor = \case
+    TypeApp refM _ _ -> referenceAnchor <$> refM
+    _ -> Nothing
+
+getTypeAppName :: Type -> Maybe Typename
+getTypeAppName = \case
+    TypeApp _ n _ -> Just n
+    _ -> Nothing
+
+getTypeAppArgs :: Type -> Maybe [Type]
+getTypeAppArgs = \case
+    TypeApp _ _ a -> Just a
+    _ -> Nothing
+
 instance Hashable Type where
   hashWithSalt salt = hashWithSalt salt . show
 

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -1,0 +1,16 @@
+# <a name="module-constrainedclassmethod-95187"></a>Module ConstrainedClassMethod
+
+This module tests the case where a class method contains a constraint
+not present in the class itself.
+
+## Typeclasses
+
+<a name="class-constrainedclassmethod-a-35350"></a>**class** [A](#class-constrainedclassmethod-a-35350) t **where**
+
+> <a name="function-constrainedclassmethod-foo-58176"></a>[foo](#function-constrainedclassmethod-foo-58176)
+> 
+> > : t -\> t
+> 
+> <a name="function-constrainedclassmethod-bar-13431"></a>[bar](#function-constrainedclassmethod-bar-13431)
+> 
+> > : t -\> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -13,4 +13,10 @@ not present in the class itself.
 > 
 > <a name="function-constrainedclassmethod-bar-13431"></a>[bar](#function-constrainedclassmethod-bar-13431)
 > 
-> > : t -\> t
+> > : [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) t =\> t -\> t
+
+<a name="class-constrainedclassmethod-b-99749"></a>**class** [B](#class-constrainedclassmethod-b-99749) t **where**
+
+> <a name="function-constrainedclassmethod-baz-40143"></a>[baz](#function-constrainedclassmethod-baz-40143)
+> 
+> > : [B](#class-constrainedclassmethod-b-99749) b =\> b -\> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -1,0 +1,24 @@
+.. _module-constrainedclassmethod-95187:
+
+Module ConstrainedClassMethod
+-----------------------------
+
+This module tests the case where a class method contains a constraint
+not present in the class itself.
+
+Typeclasses
+^^^^^^^^^^^
+
+.. _class-constrainedclassmethod-a-35350:
+
+**class** `A <class-constrainedclassmethod-a-35350_>`_ t **where**
+
+  .. _function-constrainedclassmethod-foo-58176:
+  
+  `foo <function-constrainedclassmethod-foo-58176_>`_
+    : t -> t
+  
+  .. _function-constrainedclassmethod-bar-13431:
+  
+  `bar <function-constrainedclassmethod-bar-13431_>`_
+    : t -> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -21,4 +21,13 @@ Typeclasses
   .. _function-constrainedclassmethod-bar-13431:
   
   `bar <function-constrainedclassmethod-bar-13431_>`_
-    : t -> t
+    : `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t => t -> t
+
+.. _class-constrainedclassmethod-b-99749:
+
+**class** `B <class-constrainedclassmethod-b-99749_>`_ t **where**
+
+  .. _function-constrainedclassmethod-baz-40143:
+  
+  `baz <function-constrainedclassmethod-baz-40143_>`_
+    : `B <class-constrainedclassmethod-b-99749_>`_ b => b -> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
@@ -1,0 +1,10 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
+
+daml 1.2
+-- | This module tests the case where a class method contains a constraint
+-- not present in the class itself.
+module ConstrainedClassMethod where
+
+class A t where
+    foo : t -> t
+    bar : Eq t => t -> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
@@ -8,3 +8,6 @@ module ConstrainedClassMethod where
 class A t where
     foo : t -> t
     bar : Eq t => t -> t
+
+class B t where
+    baz : B b => b -> t


### PR DESCRIPTION
I realized the logic used for stripping out the implied context in typeclass member function docs was overzealous, causing all constraints to be removed. So this PR fixes that and adds a test case.

This is such an edge case that I'm not surprised it wasn't noticed before.