### PR TITLE
Fix party management service test error output

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -77,7 +77,7 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
       for {
         parties <- ledger.allocateParties(100)
       } yield {
-        val nonUniqueNames = parties.groupBy(Tag.unwrap).filter(_._2.size > 1)
+        val nonUniqueNames = parties.groupBy(Tag.unwrap).mapValues(_.size).filter(_._2 > 1)
         assert(nonUniqueNames.isEmpty, s"There are non-unique party names: ${nonUniqueNames
           .map { case (name, count) => s"$name ($count)" } mkString (", ")}")
       }


### PR DESCRIPTION
Small fix on top of #2630 (the error output would have listed the entire list of duplicate parties instead of just the count).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
