### PR TITLE
Publish built Docker image as latest

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -181,8 +181,9 @@ jobs:
               fi
               echo "Building version ${version#v}..."
               cd ci/docker/daml-sdk
-              docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
+              docker build -t digitalasset/daml-sdk:${version#v} -t digitalasset/daml-sdk:latest --build-arg VERSION=${version#v} .
               docker push digitalasset/daml-sdk:${version#v}
+              docker push digitalasset/daml-sdk:latest
               cd "$DIR"
               echo "Done."
             fi


### PR DESCRIPTION
The `latest` tag has a special significance in Docker, in that it's going to be used by default if no tag is provided when running `docker pull`. This should push the Docker image to the public image hub with the `latest` tag as well as its actual version. Users can then choose to pinning to a version (which is the best course of action for most of the interactions) and just pulling the latest one (which probably makes it easy to experiment and possibly make sure to keep up to date in certain scenarios).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
