### PR TITLE
daml-lf: udpate LF protobuf for numerics

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -164,10 +164,13 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceRetType" templateChoiceRetType decodeType
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
+-- FixMe: https://github.com/digital-asset/daml/issues/2289
+--   NUMERIC and DECIMAL builtins should map to different internal builtin
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
 decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
   LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqual BTDecimal
   LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
   LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
@@ -176,6 +179,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
+  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEq BTDecimal
   LF1.BuiltinFunctionLEQ_TEXT    -> BELessEq BTText
   LF1.BuiltinFunctionLEQ_TIMESTAMP    -> BELessEq BTTimestamp
   LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
@@ -183,6 +187,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
   LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
+  LF1.BuiltinFunctionLESS_NUMERIC -> BELess BTDecimal
   LF1.BuiltinFunctionLESS_TEXT    -> BELess BTText
   LF1.BuiltinFunctionLESS_TIMESTAMP    -> BELess BTTimestamp
   LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
@@ -190,6 +195,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
   LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
+  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEq BTDecimal
   LF1.BuiltinFunctionGEQ_TEXT    -> BEGreaterEq BTText
   LF1.BuiltinFunctionGEQ_TIMESTAMP    -> BEGreaterEq BTTimestamp
   LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
@@ -197,6 +203,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
   LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
+  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreater BTDecimal
   LF1.BuiltinFunctionGREATER_TEXT    -> BEGreater BTText
   LF1.BuiltinFunctionGREATER_TIMESTAMP    -> BEGreater BTTimestamp
   LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
@@ -204,6 +211,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
   LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToText BTDecimal
   LF1.BuiltinFunctionTO_TEXT_TEXT    -> BEToText BTText
   LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> BEToText BTTimestamp
   LF1.BuiltinFunctionTO_TEXT_PARTY   -> BEToText BTParty
@@ -212,6 +220,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
   LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
   LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BEDecimalFromText
   LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
   LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
 
@@ -220,6 +229,11 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
   LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
   LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
+  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddDecimal
+  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubDecimal
+  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulDecimal
+  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivDecimal
+  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundDecimal
 
   LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
   LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
@@ -252,6 +266,8 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
   LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToDecimal
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BEDecimalToInt64
 
   LF1.BuiltinFunctionTRACE -> BETrace
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
@@ -480,6 +496,9 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumDecimal sDec -> case readMaybe (TL.unpack sDec) of
     Nothing -> throwError $ ParseError ("bad fixed while decoding Decimal: '" <> TL.unpack sDec <> "'")
     Just dec -> return (BEDecimal dec)
+    -- FixMe: https://github.com/digital-asset/daml/issues/2289
+    --  should handle numerics
+  LF1.PrimLitSumNumeric _ -> throwError (ParseError "Numeric not supported")
   LF1.PrimLitSumTimestamp sTime -> pure $ BETimestamp sTime
   LF1.PrimLitSumText x           -> pure $ BEText $ TL.toStrict x
   LF1.PrimLitSumParty p          -> pure $ BEParty $ PartyLiteral $ TL.toStrict p
@@ -488,6 +507,9 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
 decodeKind :: LF1.Kind -> Decode Kind
 decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumStar LF1.Unit -> pure KStar
+  -- FixMe: https://github.com/digital-asset/daml/issues/2289
+  --  should handle nat kind
+  LF1.KindSumNat LF1.Unit ->  throwError (ParseError "Nat kind not supported")
   LF1.KindSumArrow (LF1.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
@@ -496,6 +518,9 @@ decodePrim :: LF1.PrimType -> Decode BuiltinType
 decodePrim = pure . \case
   LF1.PrimTypeINT64 -> BTInt64
   LF1.PrimTypeDECIMAL -> BTDecimal
+  -- FixMe: https://github.com/digital-asset/daml/issues/2289
+  --  Should be different from LF1.PrimTypeDECIMAL
+  LF1.PrimTypeNUMERIC -> BTDecimal
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
@@ -514,6 +539,9 @@ decodeType :: LF1.Type -> DecodeImpl Type
 decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumVar (LF1.Type_Var var args) ->
     decodeWithArgs args $ TVar <$> decodeName TypeVarName var
+  -- FixMe: https://github.com/digital-asset/daml/issues/2289
+  --   should handle nat type
+  LF1.TypeSumNat _ -> throwError (ParseError "Nat kind not supported")
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -165,12 +165,12 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
 -- FixMe: https://github.com/digital-asset/daml/issues/2289
---   NUMERIC and DECIMAL builtins should map to different internal builtin
+--   drop the `error "Numeric not implemented"` in the following function
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
 decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
   LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
-  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqual BTDecimal
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> error "Numeric not implemented"
   LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
   LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
@@ -179,48 +179,48 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_TEXT    -> BELessEq BTText
-  LF1.BuiltinFunctionLEQ_TIMESTAMP    -> BELessEq BTTimestamp
+  LF1.BuiltinFunctionLEQ_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionLEQ_TEXT -> BELessEq BTText
+  LF1.BuiltinFunctionLEQ_TIMESTAMP -> BELessEq BTTimestamp
   LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
   LF1.BuiltinFunctionLEQ_PARTY -> BELessEq BTParty
 
   LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
   LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
-  LF1.BuiltinFunctionLESS_NUMERIC -> BELess BTDecimal
-  LF1.BuiltinFunctionLESS_TEXT    -> BELess BTText
-  LF1.BuiltinFunctionLESS_TIMESTAMP    -> BELess BTTimestamp
+  LF1.BuiltinFunctionLESS_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionLESS_TEXT -> BELess BTText
+  LF1.BuiltinFunctionLESS_TIMESTAMP -> BELess BTTimestamp
   LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
   LF1.BuiltinFunctionLESS_PARTY -> BELess BTParty
 
   LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
   LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_TEXT    -> BEGreaterEq BTText
-  LF1.BuiltinFunctionGEQ_TIMESTAMP    -> BEGreaterEq BTTimestamp
+  LF1.BuiltinFunctionGEQ_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionGEQ_TEXT -> BEGreaterEq BTText
+  LF1.BuiltinFunctionGEQ_TIMESTAMP -> BEGreaterEq BTTimestamp
   LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
   LF1.BuiltinFunctionGEQ_PARTY -> BEGreaterEq BTParty
 
   LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
   LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_TEXT    -> BEGreater BTText
-  LF1.BuiltinFunctionGREATER_TIMESTAMP    -> BEGreater BTTimestamp
+  LF1.BuiltinFunctionGREATER_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionGREATER_TEXT -> BEGreater BTText
+  LF1.BuiltinFunctionGREATER_TIMESTAMP -> BEGreater BTTimestamp
   LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
   LF1.BuiltinFunctionGREATER_PARTY -> BEGreater BTParty
 
   LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
   LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_TEXT    -> BEToText BTText
-  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP    -> BEToText BTTimestamp
-  LF1.BuiltinFunctionTO_TEXT_PARTY   -> BEToText BTParty
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionTO_TEXT_TEXT -> BEToText BTText
+  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP -> BEToText BTTimestamp
+  LF1.BuiltinFunctionTO_TEXT_PARTY -> BEToText BTParty
   LF1.BuiltinFunctionTO_TEXT_DATE -> BEToText BTDate
   LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
   LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
   LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
   LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BEDecimalFromText
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> error "Numeric not implemented"
   LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
   LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
 
@@ -229,11 +229,11 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
   LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
   LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
-  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddDecimal
-  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubDecimal
-  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulDecimal
-  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivDecimal
-  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundDecimal
+  LF1.BuiltinFunctionADD_NUMERIC   -> error "Numeric not implemented"
+  LF1.BuiltinFunctionSUB_NUMERIC   -> error "Numeric not implemented"
+  LF1.BuiltinFunctionMUL_NUMERIC   -> error "Numeric not implemented"
+  LF1.BuiltinFunctionDIV_NUMERIC   -> error "Numeric not implemented"
+  LF1.BuiltinFunctionROUND_NUMERIC -> error "Numeric not implemented"
 
   LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
   LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
@@ -266,8 +266,8 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
   LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
-  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToDecimal
-  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BEDecimalToInt64
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> error "Numeric not implemented"
 
   LF1.BuiltinFunctionTRACE -> BETrace
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
@@ -508,8 +508,7 @@ decodeKind :: LF1.Kind -> Decode Kind
 decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumStar LF1.Unit -> pure KStar
   -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  --  should handle nat kind
-  LF1.KindSumNat LF1.Unit ->  throwError (ParseError "Nat kind not supported")
+  LF1.KindSumNat LF1.Unit -> error "Numeric not implemented"
   LF1.KindSumArrow (LF1.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
@@ -519,8 +518,7 @@ decodePrim = pure . \case
   LF1.PrimTypeINT64 -> BTInt64
   LF1.PrimTypeDECIMAL -> BTDecimal
   -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  --  Should be different from LF1.PrimTypeDECIMAL
-  LF1.PrimTypeNUMERIC -> BTDecimal
+  LF1.PrimTypeNUMERIC -> error "Numeric not implemented"
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
@@ -540,8 +538,7 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumVar (LF1.Type_Var var args) ->
     decodeWithArgs args $ TVar <$> decodeName TypeVarName var
   -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  --   should handle nat type
-  LF1.TypeSumNat _ -> throwError (ParseError "Nat kind not supported")
+  LF1.TypeSumNat _ -> error "Numeric not implemented"
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -33,7 +33,7 @@
 //        2019-06-12: Add Package.interned_package_ids and PackageRef.interned_id
 //        2019-07-04: Transaction submitters must be in contract key maintainers when looking up. See #1866.
 // * dev (special staging area for the next version to be released)
-//        2019-07-29: Rename DECIMAL in NUMERIC. Add nat kind and nat types
+//        2019-07-29: Add nat kind and Nat types, Numeric types and Numeric builtins
 
 syntax = "proto3";
 package daml_lf_1;
@@ -60,7 +60,7 @@ message PackageRef {
 
     // An index into `interned_package_ids` of the Package containing
     // this reference.
-    uint64 interned_id = 3; /* Available since version 1.6 */
+    uint64 interned_id = 3; // *Available in versions >= 1.6*
   }
 }
 
@@ -169,7 +169,7 @@ message Kind {
     // Kind of polymorphic type.
     Arrow arrow = 2;
     // kind of TNat type;
-    // *Available since version 1.dev*
+    // *Available in versions >= 1.dev*
     Unit nat = 3;
   }
 }
@@ -187,7 +187,7 @@ enum PrimType {
 
   // Builtin type for legacy 'Decimal'
   // Alias for (Numeric 10)
-  // *available until version 1.6*
+  // *available in version < 1.dev*
   DECIMAL = 3;
 
   // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
@@ -219,19 +219,19 @@ enum PrimType {
   CONTRACT_ID = 13;
 
   // Builtin type 'Optional'
-  // *Available since version 1.1*
+  // *Available in versions >= 1.1*
   OPTIONAL = 14;
 
   // Builtin type `TArrow`
-  // *Available since version 1.1*
+  // *Available in versions >= 1.1*
   ARROW = 15;
 
   // Builtin type 'TMap`
-  // *Available since version 1.3*
+  // *Available in versions >= 1.3*
   MAP = 16;
 
   // Builtin type 'Numeric'
-  // *Available since version 1.dev*
+  // *Available in versions >= 1.dev*
   NUMERIC = 17;
 
 }
@@ -272,7 +272,7 @@ message Type {
   }
 
   // n-ary function type
-  // *Available until version 1.2*
+  // *Available in versions < 1.2*
   message Fun {
     // type of the arguments
     // *Must be non-empty*
@@ -303,7 +303,7 @@ message Type {
     Fun fun = 4;
     Forall forall = 5;
     Tuple tuple = 7;
-    // *Available since version 1.dev*
+    // *Available in versions >= 1.dev*
     // *Must be between 0 and 38 (bounds inclusive)*
     // use standard signed long for future usage.
     sint64 nat = 11;
@@ -332,17 +332,17 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_DECIMAL = 0; // *Available until version 1.6*
-  SUB_DECIMAL = 1; // *Available until version 1.6*
-  MUL_DECIMAL = 2; // *Available until version 1.6*
-  DIV_DECIMAL = 3; // *Available until version 1.6*
-  ROUND_DECIMAL = 6; // *Available until version 1.6*
+  ADD_DECIMAL = 0; // *Available in versions < 1.dev*
+  SUB_DECIMAL = 1; // *Available in versions < 1.dev*
+  MUL_DECIMAL = 2; // *Available in versions < 1.dev*
+  DIV_DECIMAL = 3; // *Available in versions < 1.dev*
+  ROUND_DECIMAL = 6; // *Available in versions < 1.dev*
 
-  ADD_NUMERIC = 107;    // *Available since version 1.dev*
-  SUB_NUMERIC = 108;    // *Available since version 1.dev*
-  MUL_NUMERIC = 109;    // *Available since version 1.dev*
-  DIV_NUMERIC = 110;    // *Available since version 1.dev*
-  ROUND_NUMERIC = 111;  // *Available since version 1.dev*
+  ADD_NUMERIC = 107;    // *Available in versions >= 1.dev*
+  SUB_NUMERIC = 108;    // *Available in versions >= 1.dev*
+  MUL_NUMERIC = 109;    // *Available in versions >= 1.dev*
+  DIV_NUMERIC = 110;    // *Available in versions >= 1.dev*
+  ROUND_NUMERIC = 111;  // *Available in versions >= 1.dev*
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -367,50 +367,50 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_DECIMAL = 34;  // *available until version 1.6*
-  LEQ_NUMERIC = 112;  // *Available since version 1.dev*
+  LEQ_DECIMAL = 34;  // *Available in versions < 1.dev*
+  LEQ_NUMERIC = 112;  // *Available in versions >= 1.dev*
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
   LEQ_DATE = 67;
-  LEQ_PARTY = 89; // *Available Since version 1.1*
+  LEQ_PARTY = 89; // *Available in versions >= 1.1*
 
   LESS_INT64 = 39;
-  LESS_DECIMAL = 40;  // *available until version 1.6*
-  LESS_NUMERIC = 113;  // *available since version 1.dev*
+  LESS_DECIMAL = 40;  // *Available in versions < 1.dev*
+  LESS_NUMERIC = 113;  // *Available in versions >= 1.dev*
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
   LESS_DATE = 68;
-  LESS_PARTY = 90; // *Available Since version 1.1*
+  LESS_PARTY = 90; // *Available in versions >= 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_DECIMAL = 46;  // *available until version 1.6*
-  GEQ_NUMERIC = 114;  // *available since version 1.dev*
+  GEQ_DECIMAL = 46;  // *Available in versions < 1.dev*
+  GEQ_NUMERIC = 114;  // *Available in versions >= 1.dev*
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
   GEQ_DATE = 69;
-  GEQ_PARTY = 91; // *Available Since version 1.1*
+  GEQ_PARTY = 91; // *Available in versions >= 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_DECIMAL = 52;  // *available until version 1.6*
-  GREATER_NUMERIC = 115;  // *available since version 1.dev*
+  GREATER_DECIMAL = 52;  // *Available in versions < 1.dev*
+  GREATER_NUMERIC = 115;  // *Available in versions >= 1.dev*
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
   GREATER_DATE = 70;
-  GREATER_PARTY = 92; // *Available Since version 1.1*
+  GREATER_PARTY = 92; // *Available in versions >= 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_DECIMAL = 58;  // *available until version 1.6*
-  TO_TEXT_NUMERIC = 116;  // *available since version 1.dev*
+  TO_TEXT_DECIMAL = 58;  // *Available in versions < 1.dev*
+  TO_TEXT_NUMERIC = 116;  // *Available in versions >= 1.dev*
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
   TO_TEXT_DATE = 71;
   TO_QUOTED_TEXT_PARTY = 63; // legacy, remove in next major version
-  TO_TEXT_PARTY = 94; // *Available Since version 1.2*
-  FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
-  FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
-  FROM_TEXT_DECIMAL = 104; // *Available between version 1.5 and 1.6
-  FROM_TEXT_NUMERIC = 117;  // *available since version 1.dev*
-  SHA256_TEXT = 93; // *Available Since version 1.2*
+  TO_TEXT_PARTY = 94; // *Available in versions >= 1.2*
+  FROM_TEXT_PARTY = 95; // *Available in versions >= 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
+  FROM_TEXT_INT64 = 103; // *Available in versions >= 1.5*
+  FROM_TEXT_DECIMAL = 104; // *Available in versions 1.5 and 1.6
+  FROM_TEXT_NUMERIC = 117;  // *Available in versions >= 1.dev*
+  SHA256_TEXT = 93; // *Available in versions >= 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
   UNIX_DAYS_TO_DATE = 73; // Int64 -> Date
@@ -418,17 +418,17 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_DECIMAL = 76;  // *available until version 1.6*
-  DECIMAL_TO_INT64 = 77;  // *available until version 1.6*
+  INT64_TO_DECIMAL = 76;  // *Available in versions < 1.dev*
+  DECIMAL_TO_INT64 = 77;  // *Available in versions < 1.dev*
 
-  INT64_TO_NUMERIC = 118;  // *available since version 1.dev*
-  NUMERIC_TO_INT64 = 119;  // *available since version 1.dev*
+  INT64_TO_NUMERIC = 118;  // *Available in versions >= 1.dev*
+  NUMERIC_TO_INT64 = 119;  // *Available in versions >= 1.dev*
 
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_DECIMAL = 80;  // *available until version 1.6*
-  EQUAL_NUMERIC = 120;  // *available since version 1.dev*
+  EQUAL_DECIMAL = 80;  // *Available in versions < 1.dev*
+  EQUAL_NUMERIC = 120;  // *Available in versions >= 1.dev*
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
   EQUAL_DATE = 83;
@@ -441,8 +441,8 @@ enum BuiltinFunction {
 
   COERCE_CONTRACT_ID = 102;
 
-  TEXT_FROM_CODE_POINTS = 105;  // *Available since version 1.6*
-  TEXT_TO_CODE_POINTS = 106; // *Available since version 1.6*
+  TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
+  TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
   // Next id is 121. 120 is EQUAL_NUMERIC.
 }
 
@@ -465,7 +465,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string decimal = 2; /* available until version 1.6 */
+    string decimal = 2; // *Available in versions < 1.dev*
 
     // Unicode string literal ('LitText')
     string text = 4;
@@ -500,7 +500,7 @@ message PrimLit {
     //        `-?([0-1]\d*|0)\.(\d*)
     //
     // The number of decimal digits indicate the scale of the number.
-    string numeric = 9; // *available since version 1.dev*
+    string numeric = 9; // *Available in versions >= 1.dev*
   }
 
   reserved 3; // This was char.
@@ -582,7 +582,7 @@ message Expr {
   }
 
    // Enum construction ('ExpEnumCon')
-   // *Available since version 1.6*
+   // *Available in versions >= 1.6*
    message EnumCon {
 
      // Name of the type constructor name
@@ -744,7 +744,7 @@ message Expr {
     VariantCon variant_con = 8;
 
     // Enum construction ('ExpEnumCon')
-    EnumCon enum_con = 28;  // *Available since version 1.6*
+    EnumCon enum_con = 28;  // *Available in versions >= 1.6*
 
     // Tuple construction ('ExpTupleCon')
     TupleCon tuple_con = 9;
@@ -786,11 +786,11 @@ message Expr {
     Scenario scenario = 21;
 
     // empty optional value ('ExpNone')
-    // *Available since version 1.1*
+    // *Available in versions >= 1.1*
     OptionalNone optional_none = 26;
 
     // non empty optional value ('ExpSome')
-    // *Available since version 1.1*
+    // *Available in versions >= 1.1*
     OptionalSome optional_some = 27;
   }
 
@@ -817,7 +817,7 @@ message CaseAlt {
   }
 
   // Enum pattern
-  // *Available since version 1.6*
+  // *Available in versions >= 1.6*
   message Enum {
 
     // name of the type constructor
@@ -840,7 +840,7 @@ message CaseAlt {
   }
 
   // Non empty option patterm
-  // *Available since version 1.1*
+  // *Available in versions >= 1.1*
   message OptionalSome {
     string var_body = 1;
   }
@@ -851,9 +851,9 @@ message CaseAlt {
     PrimCon prim_con = 3;
     Unit nil = 4;
     Cons cons = 5;
-    Unit optional_none = 7; // * Available since version 1.1*
-    OptionalSome optional_some = 8; // * Available since version 1.1*
-    Enum enum = 9; // * Available since version 1.6*
+    Unit optional_none = 7; // *Available in versions >= 1.1*
+    OptionalSome optional_some = 8; // *Available in versions >= 1.1*
+    Enum enum = 9; // *Available in versions >= 1.6*
   }
 
   Expr body = 6;
@@ -922,7 +922,7 @@ message Update {
   }
 
   // Retrieve by key Update
-  // *Available since version 1.2*
+  // *Available in versions >= 1.2*
   message RetrieveByKey {
     TypeConName template = 1;
     Expr key = 2;
@@ -935,8 +935,8 @@ message Update {
     Exercise exercise = 4;
     Fetch fetch = 5;
     Unit get_time = 6;
-    RetrieveByKey lookup_by_key = 8; //*Available since version 1.2*
-    RetrieveByKey fetch_by_key = 9; //*Available since version 1.2*
+    RetrieveByKey lookup_by_key = 8; // *Available in versions >= 1.2*
+    RetrieveByKey fetch_by_key = 9; // *Available in versions >= 1.2*
     // see similar constructor in `Scenario` on why this is useful.
     EmbedExpr embed_expr = 7;
   }
@@ -1092,7 +1092,7 @@ message DefTemplate {
   Location location = 9;
 
   // They key definition for the template, if present
-  DefKey key = 10; // optional // *Available since version 1.3*
+  DefKey key = 10; // optional // *Available in versions >= 1.3*
 }
 
 // Data type definition
@@ -1101,7 +1101,7 @@ message DefDataType {
     repeated FieldWithType fields = 1;
   }
 
-  // *Available since version 1.6*
+  // *Available in versions >= 1.6*
   message EnumConstructors {
     repeated string constructors = 1;
   }
@@ -1116,7 +1116,7 @@ message DefDataType {
   oneof DataCons {
     Fields record = 3; // Records without fields are explicitly allowed.
     Fields variant = 4; // Variants without constructors are explicitly allowed.
-    EnumConstructors enum = 7; // *Available since version 1.6*
+    EnumConstructors enum = 7; // *Available in versions >= 1.6*
   }
 
   // If true, this data type preserves serializability in the sense that when
@@ -1183,5 +1183,5 @@ message Module {
 
 message Package {
   repeated Module modules = 1;
-  repeated string interned_package_ids = 2; /* Available since version 1.6 */
+  repeated string interned_package_ids = 2; // *Available in versions >= 1.6*
 }

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -168,6 +168,9 @@ message Kind {
     Unit star = 1;
     // Kind of polymorphic type.
     Arrow arrow = 2;
+    // kind of TNat type;
+    // *Available since version 1.dev*
+    Unit nat = 3;
   }
 }
 
@@ -182,7 +185,9 @@ enum PrimType {
   // Builtin type 'Int64'
   INT64 = 2;
 
-  // Builtin type 'Decimal'
+  // Builtin type for legacy 'Decimal'
+  // Alias for (Numeric 10)
+  // *available until version 1.6*
   DECIMAL = 3;
 
   // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
@@ -224,6 +229,10 @@ enum PrimType {
   // Builtin type 'TMap`
   // *Available since version 1.3*
   MAP = 16;
+
+  // Builtin type 'Numeric'
+  // *Available since version 1.dev*
+  NUMERIC = 17;
 
 }
 
@@ -294,6 +303,10 @@ message Type {
     Fun fun = 4;
     Forall forall = 5;
     Tuple tuple = 7;
+    // *Available since version 1.dev*
+    // *Must be between 0 and 38 (bounds inclusive)*
+    // use standard signed long for future usage.
+    sint64 nat = 11;
   }
 
   reserved 6; // This was list. Removed in favour of PrimType.LIST
@@ -319,11 +332,17 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_DECIMAL = 0;
-  SUB_DECIMAL = 1;
-  MUL_DECIMAL = 2;
-  DIV_DECIMAL = 3;
-  ROUND_DECIMAL = 6;
+  ADD_DECIMAL = 0; // *Available until version 1.6*
+  SUB_DECIMAL = 1; // *Available until version 1.6*
+  MUL_DECIMAL = 2; // *Available until version 1.6*
+  DIV_DECIMAL = 3; // *Available until version 1.6*
+  ROUND_DECIMAL = 6; // *Available until version 1.6*
+
+  ADD_NUMERIC = 107;    // *Available since version 1.dev*
+  SUB_NUMERIC = 108;    // *Available since version 1.dev*
+  MUL_NUMERIC = 109;    // *Available since version 1.dev*
+  DIV_NUMERIC = 110;    // *Available since version 1.dev*
+  ROUND_NUMERIC = 111;  // *Available since version 1.dev*
 
   ADD_INT64 = 7;
   SUB_INT64 = 8;
@@ -348,35 +367,40 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_DECIMAL = 34;
+  LEQ_DECIMAL = 34;  // *available until version 1.6*
+  LEQ_NUMERIC = 112;  // *Available since version 1.dev*
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
   LEQ_DATE = 67;
   LEQ_PARTY = 89; // *Available Since version 1.1*
 
   LESS_INT64 = 39;
-  LESS_DECIMAL = 40;
+  LESS_DECIMAL = 40;  // *available until version 1.6*
+  LESS_NUMERIC = 113;  // *available since version 1.dev*
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
   LESS_DATE = 68;
   LESS_PARTY = 90; // *Available Since version 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_DECIMAL = 46;
+  GEQ_DECIMAL = 46;  // *available until version 1.6*
+  GEQ_NUMERIC = 114;  // *available since version 1.dev*
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
   GEQ_DATE = 69;
   GEQ_PARTY = 91; // *Available Since version 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_DECIMAL = 52;
+  GREATER_DECIMAL = 52;  // *available until version 1.6*
+  GREATER_NUMERIC = 115;  // *available since version 1.dev*
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
   GREATER_DATE = 70;
   GREATER_PARTY = 92; // *Available Since version 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_DECIMAL = 58;
+  TO_TEXT_DECIMAL = 58;  // *available until version 1.6*
+  TO_TEXT_NUMERIC = 116;  // *available since version 1.dev*
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
   TO_TEXT_DATE = 71;
@@ -384,7 +408,8 @@ enum BuiltinFunction {
   TO_TEXT_PARTY = 94; // *Available Since version 1.2*
   FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
   FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
-  FROM_TEXT_DECIMAL = 104; // *Available Since version 1.5*
+  FROM_TEXT_DECIMAL = 104; // *Available between version 1.5 and 1.6
+  FROM_TEXT_NUMERIC = 117;  // *available since version 1.dev*
   SHA256_TEXT = 93; // *Available Since version 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
@@ -393,13 +418,17 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_DECIMAL = 76;
-  DECIMAL_TO_INT64 = 77;
+  INT64_TO_DECIMAL = 76;  // *available until version 1.6*
+  DECIMAL_TO_INT64 = 77;  // *available until version 1.6*
+
+  INT64_TO_NUMERIC = 118;  // *available since version 1.dev*
+  NUMERIC_TO_INT64 = 119;  // *available since version 1.dev*
 
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_DECIMAL = 80;
+  EQUAL_DECIMAL = 80;  // *available until version 1.6*
+  EQUAL_NUMERIC = 120;  // *available since version 1.dev*
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
   EQUAL_DATE = 83;
@@ -412,9 +441,9 @@ enum BuiltinFunction {
 
   COERCE_CONTRACT_ID = 102;
 
-  TEXT_FROM_CODE_POINTS = 105;  // : List Int64 -> Text   *Available since version 1.6*
-  TEXT_TO_CODE_POINTS = 106; //: Text -> List Int64    *Available since version 1.6*
-  // Next id is 107. 106 is TEXT_TO_CODE_POINTS.
+  TEXT_FROM_CODE_POINTS = 105;  // *Available since version 1.6*
+  TEXT_TO_CODE_POINTS = 106; // *Available since version 1.6*
+  // Next id is 121. 120 is EQUAL_NUMERIC.
 }
 
 // Builtin literals
@@ -425,7 +454,7 @@ message PrimLit {
     //  64-bit integer literal ('LitInt64')
     sint64 int64 = 1;
 
-    // Decimal literal ('LitDecimal')
+    // Legacy Decimal literal ('LitDecimal')
     //
     // Serialization of number in ``[-1E28, 1E28]``
     // with at most 10 digits of decimal precision.
@@ -436,7 +465,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string decimal = 2;
+    string decimal = 2; /* available until version 1.6 */
 
     // Unicode string literal ('LitText')
     string text = 4;
@@ -462,6 +491,16 @@ message PrimLit {
     //
     // *Must be in range '0001-01-01' to '9999-12-31'*
     int32 date = 8;
+
+    // Numeric literal ('LitNumeric')
+    //
+    // Serialization of number with precision 38 and scale between 0 and 38
+    //
+    // *Must be a string that matched
+    //        `-?([0-1]\d*|0)\.(\d*)
+    //
+    // The number of decimal digits indicate the scale of the number.
+    string numeric = 9; // *available since version 1.dev*
   }
 
   reserved 3; // This was char.

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -332,11 +332,11 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_DECIMAL = 0; // *Available in versions < 1.dev*
-  SUB_DECIMAL = 1; // *Available in versions < 1.dev*
-  MUL_DECIMAL = 2; // *Available in versions < 1.dev*
-  DIV_DECIMAL = 3; // *Available in versions < 1.dev*
-  ROUND_DECIMAL = 6; // *Available in versions < 1.dev*
+  ADD_DECIMAL = 0; // *Deprecated in versions >= 1.dev*
+  SUB_DECIMAL = 1; // *Deprecated in versions >= 1.dev*
+  MUL_DECIMAL = 2; // *Deprecated in versions >= 1.dev*
+  DIV_DECIMAL = 3; // *Deprecated in versions >= 1.dev*
+  ROUND_DECIMAL = 6; // *Deprecated in versions >= 1.dev*
 
   ADD_NUMERIC = 107;    // *Available in versions >= 1.dev*
   SUB_NUMERIC = 108;    // *Available in versions >= 1.dev*
@@ -367,7 +367,7 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_DECIMAL = 34;  // *Available in versions < 1.dev*
+  LEQ_DECIMAL = 34;  // *Deprecated in versions >= 1.dev*
   LEQ_NUMERIC = 112;  // *Available in versions >= 1.dev*
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
@@ -375,7 +375,7 @@ enum BuiltinFunction {
   LEQ_PARTY = 89; // *Available in versions >= 1.1*
 
   LESS_INT64 = 39;
-  LESS_DECIMAL = 40;  // *Available in versions < 1.dev*
+  LESS_DECIMAL = 40;  // *Deprecated in versions >= 1.dev*
   LESS_NUMERIC = 113;  // *Available in versions >= 1.dev*
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
@@ -383,7 +383,7 @@ enum BuiltinFunction {
   LESS_PARTY = 90; // *Available in versions >= 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_DECIMAL = 46;  // *Available in versions < 1.dev*
+  GEQ_DECIMAL = 46;  // *Deprecated in versions >= 1.dev*
   GEQ_NUMERIC = 114;  // *Available in versions >= 1.dev*
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
@@ -391,7 +391,7 @@ enum BuiltinFunction {
   GEQ_PARTY = 91; // *Available in versions >= 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_DECIMAL = 52;  // *Available in versions < 1.dev*
+  GREATER_DECIMAL = 52;  // *Deprecated in versions >= 1.dev*
   GREATER_NUMERIC = 115;  // *Available in versions >= 1.dev*
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
@@ -399,7 +399,7 @@ enum BuiltinFunction {
   GREATER_PARTY = 92; // *Available in versions >= 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_DECIMAL = 58;  // *Available in versions < 1.dev*
+  TO_TEXT_DECIMAL = 58;  // *Deprecated in versions >= 1.dev*
   TO_TEXT_NUMERIC = 116;  // *Available in versions >= 1.dev*
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
@@ -418,8 +418,8 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_DECIMAL = 76;  // *Available in versions < 1.dev*
-  DECIMAL_TO_INT64 = 77;  // *Available in versions < 1.dev*
+  INT64_TO_DECIMAL = 76;  // *Deprecated in versions >= 1.dev*
+  DECIMAL_TO_INT64 = 77;  // *Deprecated in versions >= 1.dev*
 
   INT64_TO_NUMERIC = 118;  // *Available in versions >= 1.dev*
   NUMERIC_TO_INT64 = 119;  // *Available in versions >= 1.dev*
@@ -427,7 +427,7 @@ enum BuiltinFunction {
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_DECIMAL = 80;  // *Available in versions < 1.dev*
+  EQUAL_DECIMAL = 80;  // *Deprecated in versions >= 1.dev*
   EQUAL_NUMERIC = 120;  // *Available in versions >= 1.dev*
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
@@ -465,7 +465,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string decimal = 2; // *Available in versions < 1.dev*
+    string decimal = 2; // *Deprecated in versions >= 1.dev*
 
     // Unicode string literal ('LitText')
     string text = 4;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -369,7 +369,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         ImmArray(lfTyConApp.getArgsList.asScala.map(decodeType))
       )
 
-    private[this] def decodeExpr(lfExpr: PLF.Expr, definition: String): Expr =
+    private[lf] def decodeExpr(lfExpr: PLF.Expr, definition: String): Expr =
       decodeLocation(lfExpr, definition) match {
         case None => decodeExprBody(lfExpr, definition)
         case Some(loc) => ELocation(loc, decodeExprBody(lfExpr, definition))
@@ -731,7 +731,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         case PLF.PrimLit.SumCase.NUMERIC =>
           assertSince(LV.Features.numeric, "PrimLit.numeric")
           Numeric
-            .fromString(lfPrimLit.getDecimal)
+            .fromString(lfPrimLit.getNumeric)
             .fold(e => throw ParseError("error parsing numeric: " + e), PLNumeric)
         case PLF.PrimLit.SumCase.TEXT =>
           PLText(lfPrimLit.getText)

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -3,22 +3,30 @@
 
 package com.digitalasset.daml.lf.archive
 
-import com.digitalasset.daml.bazeltools.BazelRunfiles._
-import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.daml.lf.language.{Ast, LanguageMajorVersion, LanguageVersion}
-import com.digitalasset.daml_lf.DamlLf1
-import com.digitalasset.daml_lf.DamlLf1.PackageRef
-
-import org.scalatest.{Inside, Matchers, OptionValues, WordSpec}
-
+import java.math.BigDecimal
 import java.nio.file.{Files, Paths}
+
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.daml.lf.archive.DecodeV1.BuiltinFunctionInfo
+import com.digitalasset.daml.lf.archive.Reader.ParseError
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
+import com.digitalasset.daml.lf.language.Util._
+import com.digitalasset.daml.lf.language.{Ast, LanguageVersion => LV}
+import com.digitalasset.daml_lf.DamlLf1
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{Inside, Matchers, OptionValues, WordSpec}
 
 import scala.collection.JavaConverters._
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues {
+class DecodeV1Spec
+    extends WordSpec
+    with Matchers
+    with Inside
+    with OptionValues
+    with TableDrivenPropertyChecks {
 
-  "The keys of primTypeTable correspond to Protobuf DamlLf1.PrimType" in {
+  "The entries of primTypeInfos correspond to Protobuf DamlLf1.PrimType" in {
 
     (Set(DamlLf1.PrimType.UNRECOGNIZED, DamlLf1.PrimType.DECIMAL) ++
       DecodeV1.builtinTypeInfos.map(_.proto)) shouldBe
@@ -26,14 +34,379 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
 
   }
 
-  "The keys of builtinFunctionMap correspond to Protobuf DamlLf1.BuiltinFunction" in {
+  "The entries of builtinFunctionInfos correspond to Protobuf DamlLf1.BuiltinFunction" in {
 
     (Set(DamlLf1.BuiltinFunction.UNRECOGNIZED) ++ DecodeV1.builtinFunctionInfos.map(_.proto)) shouldBe
       DamlLf1.BuiltinFunction.values().toSet
+  }
+
+  private val dummyModule = DamlLf1.Module
+    .newBuilder()
+    .setName(DamlLf1.DottedName.newBuilder().addSegments("dummyModule")) build ()
+
+  private def moduleDecoder(minVersion: LV.Minor) =
+    new DecodeV1(minVersion)
+      .ModuleDecoder(
+        Ref.PackageId.assertFromString("noPkgId"),
+        ImmArray.empty.toSeq,
+        dummyModule,
+        onlySerializableDataDefs = false)
+
+  private val preNumericMinVersions = Table(
+    "minVersion",
+    List(1, 4, 6).map(i => LV.Minor.Stable(i.toString)): _*
+  )
+
+  // FixMe: https://github.com/digital-asset/daml/issues/2289
+  //        add stable version when numerics are released
+  private val postNumericMinVersions = Table(
+    "minVersion",
+    LV.Minor.Dev
+  )
+
+  "decodeKind" should {
+
+    "reject nat kind if lf version < 1.dev" in {
+
+      val input = DamlLf1.Kind.newBuilder().setNat(DamlLf1.Unit.newBuilder()).build()
+
+      forEvery(preNumericMinVersions) { minVersion =>
+        an[ParseError] shouldBe thrownBy(moduleDecoder(minVersion).decodeKind(input))
+      }
+    }
+
+    "accept nat kind if lf version >= 1.dev" in {
+      val input = DamlLf1.Kind.newBuilder().setNat(DamlLf1.Unit.newBuilder()).build()
+
+      forEvery(postNumericMinVersions) { minVersion =>
+        moduleDecoder(minVersion).decodeKind(input) shouldBe Ast.KNat
+      }
+    }
+  }
+
+  "decodeType" should {
+
+    import DamlLf1.PrimType._
+
+    def buildNat(i: Long) = DamlLf1.Type.newBuilder().setNat(i).build()
+
+    val validNatTypes = List(0, 1, 2, 5, 11, 35, 37, 38)
+    val invlidNatTypes = List(Long.MinValue, -100, -2, -1, 39, 40, 200, Long.MaxValue)
+
+    "reject nat type if lf version < 1.dev" in {
+
+      val testCases =
+        Table("proto nat type", (validNatTypes.map(_.toLong) ++ invlidNatTypes).map(buildNat): _*)
+
+      forEvery(preNumericMinVersions) { minVersion =>
+        val decoder = moduleDecoder(minVersion)
+        forEvery(testCases) { natType =>
+          an[ParseError] shouldBe thrownBy(decoder.decodeType(natType))
+        }
+      }
+    }
+
+    "accept only valid nat types if lf version >= 1.dev" in {
+      val positiveTestCases =
+        Table("proto nat type" -> "nat", validNatTypes.map(v => buildNat(v.toLong) -> v): _*)
+      val negativeTestCases = Table("proto nat type", invlidNatTypes.map(buildNat): _*)
+
+      forEvery(postNumericMinVersions) { minVersion =>
+        val decoder = moduleDecoder(minVersion)
+        forEvery(positiveTestCases) { (natType, nat) =>
+          decoder.decodeType(natType) shouldBe Ast.TNat(nat)
+        }
+        forEvery(negativeTestCases) { natType =>
+          an[ParseError] shouldBe thrownBy(decoder.decodeType(natType))
+        }
+      }
+    }
+
+    def buildPrimType(primType: DamlLf1.PrimType, args: DamlLf1.Type*) =
+      DamlLf1.Type
+        .newBuilder()
+        .setPrim(DamlLf1.Type.Prim.newBuilder().setPrim(primType).addAllArgs(args.asJava))
+        .build()
+
+    val decimalTestCases = Table(
+      "input" -> "expected output",
+      buildPrimType(DECIMAL) ->
+        TNumeric(Ast.TNat(10)),
+      buildPrimType(DECIMAL, buildPrimType(TEXT)) ->
+        Ast.TApp(TNumeric(Ast.TNat(10)), TText),
+      buildPrimType(ARROW, buildPrimType(TEXT), buildPrimType(DECIMAL)) ->
+        TFun(TText, TNumeric(Ast.TNat(10))),
+    )
+
+    val numericTestCases = Table(
+      "input" -> "expected output",
+      buildPrimType(NUMERIC) ->
+        TNumeric.cons,
+      buildPrimType(NUMERIC, DamlLf1.Type.newBuilder().setNat(10).build()) ->
+        TNumeric(Ast.TNat(10)),
+      buildPrimType(NUMERIC, buildPrimType(TEXT)) ->
+        Ast.TApp(TNumeric.cons, TText),
+      buildPrimType(ARROW, buildPrimType(TEXT), buildPrimType(NUMERIC)) ->
+        TFun(TText, TNumeric.cons),
+    )
+
+    "translate TDecimal to TApp(TNumeric, TNat(10)) if version =< 1.dev" in {
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(decimalTestCases) { (input, expectedOutput) =>
+          decoder.decodeType(input) shouldBe expectedOutput
+        }
+      }
+    }
+
+    "reject Numeric types if version =< 1.dev" in {
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(numericTestCases) { (input, _) =>
+          a[ParseError] shouldBe thrownBy(decoder.decodeType(input))
+        }
+      }
+    }
+
+    "translate TNumeric as is if version >= 1.dev" in {
+      forEvery(postNumericMinVersions) { minVersion =>
+        val decoder = moduleDecoder(minVersion)
+        forEvery(numericTestCases) { (input, expectedOutput) =>
+          decoder.decodeType(input) shouldBe expectedOutput
+        }
+      }
+    }
+
+    // FixMe: https://github.com/digital-asset/daml/issues/2289
+    //  reactive the test once the decoder is not so lenient
+    "reject Decimal types if version =< 1.dev" ignore {
+      forEvery(postNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(decimalTestCases) { (input, _) =>
+          a[ParseError] shouldBe thrownBy(decoder.decodeType(input))
+        }
+      }
+    }
+  }
+
+  "decodeExpr" should {
+
+    def toProto(b: BuiltinFunctionInfo) =
+      DamlLf1.Expr.newBuilder().setBuiltin(b.proto).build()
+
+    def toDecimalProto(s: String) =
+      DamlLf1.Expr.newBuilder().setPrimLit(DamlLf1.PrimLit.newBuilder().setDecimal(s)).build()
+
+    def toNumericProto(s: String) =
+      DamlLf1.Expr.newBuilder().setPrimLit(DamlLf1.PrimLit.newBuilder().setNumeric(s)).build()
+
+    def toScala(b: BuiltinFunctionInfo) =
+      Ast.EBuiltin(b.builtin)
+
+    // All the legacy decimal bultins.
+    val decimalBuilttins =
+      DecodeV1.builtinFunctionInfos.filter(_.handleLegacyDecimal)
+
+    // All the numeric versions of the former.
+    val numericBuilttins = {
+      val isNumeric = decimalBuilttins.map(_.builtin).toSet
+      DecodeV1.builtinFunctionInfos.filter(info =>
+        !info.handleLegacyDecimal && isNumeric(info.builtin))
+    }
+
+    // Two other unrelated builtins, no need to test more.
+    val otherBuiltins =
+      DecodeV1.builtinFunctionInfos.filter(
+        info =>
+          info.proto == DamlLf1.BuiltinFunction.ADD_INT64 ||
+            info.proto == DamlLf1.BuiltinFunction.APPEND_TEXT)
+    assert(otherBuiltins.length == 2)
+
+    val decimalBuiltinTestCases = Table("decimal builtinInfo", numericBuilttins: _*)
+    val numericBuiltinTestCases = Table("numeric builtinInfo", numericBuilttins: _*)
+    val negativeBuiltinTestCases = Table("other builtinInfo", otherBuiltins: _*)
+
+    "translate non numeric/decimal builtin as is for any version" in {
+      val allVersions = Table("all versions", preNumericMinVersions ++ postNumericMinVersions: _*)
+
+      forEvery(allVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(negativeBuiltinTestCases) { info =>
+          decoder.decodeExpr(toProto(info), "test") shouldBe toScala(info)
+        }
+      }
+    }
+
+    "transparently apply TNat(10) to Decimal builtins if version < 1.dev" in {
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+
+        forEvery(decimalBuiltinTestCases) { info =>
+          if (LV.ordering.gteq(LV(LV.Major.V1, version), info.minVersion))
+            decoder.decodeExpr(toProto(info), "test") shouldBe Ast
+              .ETyApp(toScala(info), Ast.TNat(10))
+        }
+      }
+    }
+
+    "reject Numeric builtins if version < 1.dev" in {
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+
+        forEvery(numericBuiltinTestCases) { info =>
+          an[ParseError] shouldBe thrownBy(decoder.decodeExpr(toProto(info), "test"))
+        }
+      }
+    }
+
+    "translate Numeric builtins as is if version >= 1.dev" in {
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+
+        forEvery(numericBuiltinTestCases) { info =>
+          if (LV.ordering.gteq(LV(LV.Major.V1, version), info.minVersion))
+            decoder.decodeExpr(toProto(info), "test") shouldBe toScala(info)
+        }
+      }
+    }
+
+    // FixMe: https://github.com/digital-asset/daml/issues/2289
+    //  reactive the test once the decoder is not so lenient
+    "reject Decimal builtins if version >= 1.dev" ignore {
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+
+        forEvery(decimalBuiltinTestCases) { info =>
+          an[ParseError] shouldBe thrownBy(decoder.decodeExpr(toProto(info), "test"))
+        }
+      }
+    }
+
+    "parse properly decimal literal" in {
+
+      val testCases =
+        Table(
+          "string",
+          "9999999999999999999999999999.9999999999",
+          "0000000000000000000000000000.0000000000",
+          "0.0",
+          "-0.0",
+          "42",
+          "3.1415",
+          "+1.0",
+          "-9999999999999999999999999999.9999999999"
+        )
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(testCases) { string =>
+          decoder.decodeExpr(toDecimalProto(string), "test") match {
+            case Ast.EPrimLit(Ast.PLNumeric(num)) =>
+              num shouldBe new BigDecimal(string).setScale(10)
+            case _ =>
+              throw new Error("")
+          }
+        }
+      }
+    }
+
+    "reject improper decimal literal" in {
+
+      val testCases =
+        Table(
+          "string",
+          "10000000000000000000000000000.0000000000",
+          "1000000000000000000000000000000",
+          "0.00000000001",
+          "0.0.0",
+          "0.",
+          "+-0.0",
+        )
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(testCases) { string =>
+          a[ParseError] shouldBe thrownBy(decoder.decodeExpr(toDecimalProto(string), "test"))
+        }
+      }
+    }
+
+    "reject numeric literal if version < 1.dev" in {
+
+      forEvery(preNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        a[ParseError] shouldBe thrownBy(decoder.decodeExpr(toNumericProto("0.0"), "test"))
+      }
+    }
+
+    "parse properly numeric literals" in {
+
+      val testCases =
+        Table(
+          "string",
+          "9999999999999999999999999999.9999999999",
+          "0.0000000000",
+          "1000000000000000000000000000000.",
+          "99999999999999999999999999999999999999.",
+          "-0.0",
+          "0.",
+          "3.1415",
+          "-99999999999999999999.999999999999999999"
+        )
+
+      forEvery(postNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(testCases) { string =>
+          decoder.decodeExpr(toNumericProto(string), "test") match {
+            case Ast.EPrimLit(Ast.PLNumeric(num)) =>
+              num shouldBe new BigDecimal(string)
+            case _ =>
+              throw new Error("")
+          }
+        }
+      }
+    }
+
+    "reject improper numeric literals" in {
+
+      val testCases =
+        Table(
+          "string",
+          "10000000000000000000000000000.0000000000",
+          "-1000000000000000000000000000000000000000.",
+          "0.000000000000000000000000000000000000001",
+          "0000000000000000000000000000.0000000000",
+          "0.0.0",
+          "+0.0",
+          "0"
+        )
+
+      forEvery(postNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        forEvery(testCases) { string =>
+          a[ParseError] shouldBe thrownBy(decoder.decodeExpr(toNumericProto(string), "test"))
+        }
+      }
+    }
+
+    // FixMe: https://github.com/digital-asset/daml/issues/2289
+    //  enable the test once the dev decoder is not so lenien
+    "reject numeric decimal if version >= 1.dev" ignore {
+
+      forEvery(postNumericMinVersions) { version =>
+        val decoder = moduleDecoder(version)
+        a[ParseError] shouldBe thrownBy(decoder.decodeExpr(toDecimalProto("0.0"), "test"))
+      }
+    }
 
   }
 
   "decodeModuleRef" should {
+
     lazy val ((pkgId, dalfProto), majorVersion) = {
       val dalfFile =
         Files.newInputStream(Paths.get(rlocation("daml-lf/archive/DarReaderTest.dalf")))
@@ -50,7 +423,7 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
         .collectFirst {
           case dv if dv.getNameWithType.getNameList.asScala.lastOption contains "reverseCopy" =>
             val pr = dv.getExpr.getVal.getModule.getPackageRef
-            pr.getSumCase shouldBe PackageRef.SumCase.INTERNED_ID
+            pr.getSumCase shouldBe DamlLf1.PackageRef.SumCase.INTERNED_ID
             pr.getInternedId
         }
         .value
@@ -58,7 +431,7 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
     }
 
     "take a dalf with interned IDs" in {
-      majorVersion should ===(LanguageMajorVersion.V1)
+      majorVersion should ===(LV.Major.V1)
 
       dalfProto.getMinor should !==("dev")
 
@@ -67,7 +440,7 @@ class DecodeV1Spec extends WordSpec with Matchers with Inside with OptionValues 
     }
 
     "decode resolving the interned package ID" in {
-      val decoder = Decode.decoders(LanguageVersion(majorVersion, dalfProto.getMinor))
+      val decoder = Decode.decoders(LV(majorVersion, dalfProto.getMinor))
       inside(
         decoder.decoder
           .decodePackage(pkgId, decoder.extract(dalfProto))

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -91,12 +91,12 @@ class DecodeV1Spec
     def buildNat(i: Long) = DamlLf1.Type.newBuilder().setNat(i).build()
 
     val validNatTypes = List(0, 1, 2, 5, 11, 35, 37, 38)
-    val invlidNatTypes = List(Long.MinValue, -100, -2, -1, 39, 40, 200, Long.MaxValue)
+    val invalidNatTypes = List(Long.MinValue, -100, -2, -1, 39, 40, 200, Long.MaxValue)
 
     "reject nat type if lf version < 1.dev" in {
 
       val testCases =
-        Table("proto nat type", (validNatTypes.map(_.toLong) ++ invlidNatTypes).map(buildNat): _*)
+        Table("proto nat type", (validNatTypes.map(_.toLong) ++ invalidNatTypes).map(buildNat): _*)
 
       forEvery(preNumericMinVersions) { minVersion =>
         val decoder = moduleDecoder(minVersion)
@@ -109,7 +109,7 @@ class DecodeV1Spec
     "accept only valid nat types if lf version >= 1.dev" in {
       val positiveTestCases =
         Table("proto nat type" -> "nat", validNatTypes.map(v => buildNat(v.toLong) -> v): _*)
-      val negativeTestCases = Table("proto nat type", invlidNatTypes.map(buildNat): _*)
+      val negativeTestCases = Table("proto nat type", invalidNatTypes.map(buildNat): _*)
 
       forEvery(postNumericMinVersions) { minVersion =>
         val decoder = moduleDecoder(minVersion)
@@ -150,7 +150,7 @@ class DecodeV1Spec
         TFun(TText, TNumeric.cons),
     )
 
-    "translate TDecimal to TApp(TNumeric, TNat(10)) if version =< 1.dev" in {
+    "translate TDecimal to TApp(TNumeric, TNat(10))" in {
       forEvery(preNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
         forEvery(decimalTestCases) { (input, expectedOutput) =>
@@ -159,7 +159,7 @@ class DecodeV1Spec
       }
     }
 
-    "reject Numeric types if version =< 1.dev" in {
+    "reject Numeric types if version < 1.dev" in {
       forEvery(preNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
         forEvery(numericTestCases) { (input, _) =>
@@ -179,7 +179,7 @@ class DecodeV1Spec
 
     // FixMe: https://github.com/digital-asset/daml/issues/2289
     //  reactive the test once the decoder is not so lenient
-    "reject Decimal types if version =< 1.dev" ignore {
+    "reject Decimal types if version >= 1.dev" ignore {
       forEvery(postNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
         forEvery(decimalTestCases) { (input, _) =>

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -195,9 +195,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           }
         case TBuiltin(bType) =>
           val (proto, typs) =
-            // FixMe: https://github.com/digital-asset/daml/issues/2289
-            // enable the following check once it is possible to encode numeric in the proto
-            if (bType == BTNumeric /*&& versionIsOlderThan(LV.Features.numeric)*/ )
+            if (bType == BTNumeric && versionIsOlderThan(LV.Features.numeric))
               PLF.PrimType.DECIMAL -> ignoreFirstTNatForDecimalLegacy(args)
             else
               builtinTypeInfoMap(bType).proto -> args
@@ -354,9 +352,10 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       primLit match {
         case PLInt64(value) => builder.setInt64(value)
         case PLNumeric(value) =>
-          if (versionIsOlderThan(LV.Features.numeric))
+          if (versionIsOlderThan(LV.Features.numeric)) {
+            assert(value.scale == Decimal.scale)
             builder.setDecimal(Numeric.toUnscaledString(value))
-          else
+          } else
             builder.setNumeric(Numeric.toString(value))
         case PLText(value) => builder.setText(value)
         case PLTimestamp(value) => builder.setTimestamp(value.micros)

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -72,12 +72,12 @@ to interpret previous versions of the language in a backward
 compatibility way.
 
 In the following of this document, we will use annotations between
-square brackets such as *[Available since version x.y]* and *[Changed
-in version x.y]* to emphasize that a particular feature is concerned
-with a change introduced in DAML x.y version. In addition, we will
-mark lines within inference rules with annotations of the form
-``[DAML-LF < x.y]`` and ``[DAML-LF ≥ x.y]`` to make the respective
-line conditional upon the DAML-LF version.
+square brackets such as *[Available in version < x.y]*, *[Available in
+versions >= x.y]*, and *[Changed in version x.y]* to emphasize that a
+particular feature is concerned with a change introduced in DAML x.y
+version. In addition, we will mark lines within inference rules with
+annotations of the form ``[DAML-LF < x.y]`` and ``[DAML-LF ≥ x.y]`` to
+make the respective line conditional upon the DAML-LF version.
 
 The version 1.dev is a special staging area for the next 1.x version to
 be released. Compliant implementations are not required to implement any
@@ -2103,7 +2103,7 @@ Int64 functions
   in ``Some``. If the input does not match the regexp ``[+-]?\d+`` or
   if the result of the conversion overflows, returns ``None``.
 
-  [*Available since version 1.5*]
+  [*Available in versions >= 1.5*]
 
 Numeric functions
 ~~~~~~~~~~~~~~~~~
@@ -2192,7 +2192,7 @@ Numeric functions
   ``None``.  The scale of the output is given by the type parameter
   `α`.
 
-  [*Available since version 1.5*]
+  [*Available in versions >= 1.5*]
 
 String functions
 ~~~~~~~~~~~~~~~~
@@ -2217,7 +2217,7 @@ String functions
   hashing of the UTF-8 string and returns it encoded as a Hexadecimal
   string (lower-case).
 
-  [*Available since version 1.2*]
+  [*Available in versions >= 1.2*]
 
 * ``LESS_EQ_TEXT : 'Text' → 'Text' → 'Bool'``
 
@@ -2254,7 +2254,7 @@ String functions
   <https://en.wikipedia.org/wiki/Code_point>`_ of the input
   string represented as integer.
 
-  [*Available since version 1.6*]
+  [*Available in versions >= 1.6*]
 
 * ``TEXT_TO_CODE_POINTS``: 'List' 'Int64' → 'Text'
 
@@ -2264,7 +2264,7 @@ String functions
   from `0x000000` to `0x00D7FF` or in the range from `0x00DFFF`
   to `0x10FFFF` (bounds included).
 
-  [*Available since version 1.6*]
+  [*Available in versions >= 1.6*]
 
 Timestamp functions
 ~~~~~~~~~~~~~~~~~~~
@@ -2383,22 +2383,22 @@ Party functions
 * ``LESS_EQ_PARTY : 'Party' → 'Party' → 'Bool'``
 
   Returns ``'True'`` if the first party is less or equal than the
-  second, ``'False'`` otherwise. [*Available since version 1.1*]
+  second, ``'False'`` otherwise. [*Available in versions >= 1.1*]
 
 * ``GREATER_EQ_PARTY : 'Party' → 'Party' → 'Bool'``
 
   Returns ``'True'`` if the first party is greater or equal than the
-  second, ``'False'`` otherwise. [*Available since version 1.1*]
+  second, ``'False'`` otherwise. [*Available in versions >= 1.1*]
 
 * ``LESS_PARTY : 'Party' → 'Party' → 'Bool'``
 
   Returns ``'True'`` if the first party is strictly less than the
-  second, ``'False'`` otherwise. [*Available since version 1.1*]
+  second, ``'False'`` otherwise. [*Available in versions >= 1.1*]
 
 * ``GREATER_PARTY : 'Party' → 'Party' → 'Bool'``
 
   Returns ``'True'`` if the first party is strictly greater than the
-  second, ``'False'`` otherwise. [*Available since version 1.1*]
+  second, ``'False'`` otherwise. [*Available in versions >= 1.1*]
 
 * ``EQUAL_PARTY : 'Party' → 'Party' → 'Bool'``
 
@@ -2421,14 +2421,14 @@ Party functions
     ∀ p. FROM_TEXT_PARTY (TO_TEXT_PARTY p) = 'Some' p
     ∀ txt p. FROM_TEXT_PARTY txt = 'Some' p → TO_TEXT_PARTY p = txt
 
-  [*Available since version 1.2*]
+  [*Available in versions >= 1.2*]
 
 * ``FROM_TEXT_PARTY : 'Text' → 'Optional' 'Party'``
 
   Given the string representation of the party, returns the party,
   if the input string is a `PartyId strings <Literals_>`_.
 
-  [*Available since version 1.2*]
+  [*Available in versions >= 1.2*]
 
 ContractId functions
 ~~~~~~~~~~~~~~~~~~~~
@@ -2442,7 +2442,7 @@ ContractId functions
 
   Returns the given contract id unchanged at a different type.
 
-  [*Available since version 1.5*]
+  [*Available in versions >= 1.5*]
 
 List functions
 ~~~~~~~~~~~~~~
@@ -2469,7 +2469,7 @@ Map functions
 
   Returns the empty map.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 * ``MAP_INSERT : ∀ α.  'Text' → α → 'Map' α → 'Map' α``
 
@@ -2477,33 +2477,33 @@ Map functions
   present in the map, the associated value is replaced with the
   supplied value.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 * ``MAP_LOOKUP : ∀ α. 'Text' → 'Map' α → 'Optional' α``
 
   Lookups the value at a key in the map.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 * ``MAP_DELETE : ∀ α. 'Text' → 'Map' α → 'Map' α``
 
   Deletes a key and its value from the map. When the key is not a
   member of the map, the original map is returned.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 * ``MAP_LIST : ∀ α. 'Map' α → 'List' ⟨ key: 'Text', value: α  ⟩``
 
   Converts to a list of key/value pairs. The output list is guaranteed to be
   sorted according to the ordering of its keys.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 * ``MAP_SIZE : ∀ α. 'Map' α → 'Int64'``
 
   Return the number of elements in the map.
 
-  [*Available since version 1.3*]
+  [*Available in versions >= 1.3*]
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~
@@ -2618,12 +2618,12 @@ message::
   }
 
 One should use either the field ``self`` to refer the current package or
-one of ``interned_id`` [available since version 1.6] or ``package_id``
+one of ``interned_id`` [Available in versions >= 1.6] or ``package_id``
 to refer to an external package. During deserialization ``self``
 references are replaced by the actual digest of the package in which it
 appears.
 
-[*Available since version 1.6*]
+[*Available in versions >= 1.6*]
 
 ``Package.interned_package_ids`` is a list of package IDs.
 ``interned_id``, if used, must be a valid zero-based index into this
@@ -2689,7 +2689,7 @@ introduced to the serialization format since version 1.0
 Option type
 ...........
 
-[*Available since version 1.1*]
+[*Available in versions >= 1.1*]
 
 DAML-LF 1.1 is the first version that supports option type.
 
@@ -2700,7 +2700,7 @@ this data structure.
 Party ordering
 ..............
 
-[*Available since version 1.1*]
+[*Available in versions >= 1.1*]
 
 DAML-LF 1.1 is the first version that supports the built-in functions
 ``LESS_EQ_PARTY``, ``GREATER_EQ_PARTY``, ``LESS_PARTY``, and
@@ -2749,7 +2749,7 @@ The deserialization process will reject:
 Flexible controllers
 ....................
 
-[*Available since version 1.2*]
+[*Available in versions >= 1.2*]
 
 Version 1.2 changes what is in scope when the controllers of a choice are
 computed.
@@ -2797,7 +2797,7 @@ validation phases can be distinguished.
 SHA-256 Hashing
 ...............
 
-[*Available since version 1.2*]
+[*Available in versions >= 1.2*]
 
 DAML-LF 1.2 is the first version that supports the built-in functions
 ``SHA256_TEXT`` to hash string.
@@ -2808,7 +2808,7 @@ program using this functions.
 Contract Key
 ............
 
-[*Available since version 1.3*]
+[*Available in versions >= 1.3*]
 
 Since DAML-LF 1.3, a contract key can be associated to a contract at
 creation. Subsequently, the contract can be retrieved by the corresponding
@@ -2826,7 +2826,7 @@ the message ``DefTemplate`` .
 Map
 ...
 
-[*Available since version 1.3*]
+[*Available in versions >= 1.3*]
 
 The deserialization process will reject any DAML-LF 1.2 (or earlier)
 program using the builtin functions : ``MAP_EMPTY``, ``MAP_INSERT``,
@@ -2835,7 +2835,7 @@ program using the builtin functions : ``MAP_EMPTY``, ``MAP_INSERT``,
 Enum
 ....
 
-[*Available since version 1.6*]
+[*Available in versions >= 1.6*]
 
 The deserialization process will reject any DAML-LF 1.5 (or earlier)
 program using the field ``enum`` in ``DefDataType`` messages, the
@@ -2845,7 +2845,7 @@ in ``Expr`` messages.
 intern package IDs
 ..................
 
-[*Available since version 1.6*]
+[*Available in versions >= 1.6*]
 
 In ``PackageRef``, the alternative ``interned_id`` may be used in place
 of ``package_id``, in which case the package ID will be that at the
@@ -2855,7 +2855,7 @@ See `Package reference`_.
 Nat kind and Nat types
 ......................
 
-[*Available since version 1.dev*]
+[*Available in versions >= 1.dev*]
 
 The deserialization process will reject any DAML-LF 1.6 (or earlier)
 that uses ``nat`` field in ``Kind`` or ``Type`` messages.
@@ -2872,7 +2872,7 @@ section.
 Parametric scaled Decimals
 ..........................
 
-[*Available since version 1.dev*]
+[*Available in versions >= 1.dev*]
 
 DAML-LF 1.dev is the first version that supports parametric scaled
 decimals. Prior versions have decimal number with a fixed scale of 10
@@ -2906,7 +2906,7 @@ On the one hand, in case of DAML-LF 1.6 (or earlier) archive:
   + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)
   + ``EQUAL_DECIMAL`` message is translated to ``(EQUAL_NUMERIC @10)
   + ``TO_TEXT_DECIMAL`` message is translated to ``(TO_TEXT_NUMERIC @10)
-  + ``FROM_TEXT_DECIMAL`` message is translated to ``(FROM_TEXT_NUMERIC @10)  [*Available since version 1.5*]
+  + ``FROM_TEXT_DECIMAL`` message is translated to ``(FROM_TEXT_NUMERIC @10)  [*Available in versions >= 1.5*]
   + ``INT64_TO_DECIMAL`` message is translated to ``(INT64_TO_NUMERIC @10)
   + ``DECIMAL_TO_INT64`` message is translated to ``(NUMERIC_TO_INT64 @10)
 

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -233,7 +233,7 @@ Version: 1.dev
 
   * **Add** Nat kind and Nat type.
 
-  * **Replace** fixed scaled 'Decimal' type by parametricly  scaled
+  * **Replace** fixed scaled 'Decimal' type by parametrically scaled
     'Numeric' type.
 
 Abstract syntax
@@ -2117,7 +2117,7 @@ Numeric functions
 * ``SUB_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Numeric' α``
 
   Subtracts the second decimal from the first one.  The
-  scale of the inputs and the ouput is given by the type parameter
+  scale of the inputs and the output is given by the type parameter
   `α`.  Throws an error if overflow.
 
 * ``MUL_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Numeric' α``
@@ -2125,7 +2125,7 @@ Numeric functions
   Multiplies the two decimals and rounds the result to the closest
   multiple of ``10⁻ᵅ`` using `banker's rounding convention
   <https://en.wikipedia.org/wiki/Rounding#Round_half_to_even>`_.  The
-  scale of the inputs and the ouput is given by the type parameter
+  scale of the inputs and the output is given by the type parameter
   `α`. Throws an error in case of overflow.
 
 * ``DIV_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Numeric' α``
@@ -2134,7 +2134,7 @@ Numeric functions
   the closest multiple of ``10⁻ᵅ`` using `banker's rounding convention
   <https://en.wikipedia.org/wiki/Rounding#Round_half_to_even>`_ (where
   `n` is given as the type parameter).  The scale of the inputs and
-  the ouput is given by the type parameter `α`.  Throws an error in
+  the output is given by the type parameter `α`.  Throws an error in
   case of overflow.
 
 * ``ROUND_NUMERIC : ∀ (α : nat) . 'Int64' → 'Numeric' α → 'Numeric' α``
@@ -2144,49 +2144,48 @@ Numeric functions
   half-way between two multiples, rounds toward the even one,
   following the `banker's rounding convention
   <https://en.wikipedia.org/wiki/Rounding#Round_half_to_even>`_.  The
-  scale of the inputs and the ouput is given by the type parameter
+  scale of the inputs and the output is given by the type parameter
   `α`.  Throws an exception if the integer is not between `α-37` and
   `α` inclusive.
 
 * ``LESS_EQ_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is less or equal than the
+  Returns ``'True'`` if the first numeric is less or equal than the
   second, ``'False'`` otherwise.  The scale of the inputs is given by
   the type parameter `α`.
 
 * ``GREATER_EQ_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is greater or equal than the
+  Returns ``'True'`` if the first numeric is greater or equal than the
   second, ``'False'`` otherwise. The scale of the inputs is given by
   the type parameter `α`.
 
 * ``LESS_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is strictly less than the
+  Returns ``'True'`` if the first numeric is strictly less than the
   second, ``'False'`` otherwise.  The scale of the inputs is given by
   the type parameter `α`.
 
-
 * ``GREATER_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is strictly greater than the
+  Returns ``'True'`` if the first numeric is strictly greater than the
   second, ``'False'`` otherwise.  The scale of the inputs is given by
   the type parameter `α`.
 
 * ``EQUAL_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Numeric' α → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is equal to the second,
+  Returns ``'True'`` if the first numeric is equal to the second,
   ``'False'`` otherwise.  The scale of the inputs is given by the type
   parameter `α`.
 
 * ``TO_TEXT_NUMERIC : ∀ (α : nat) . 'Numeric' α → 'Text'``
 
-  Returns the decimal string representation of the decimal.  The scale
+  Returns the numeric string representation of the numeric.  The scale
   of the input is given by the type parameter `α`.
 
 * ``FROM_TEXT_NUMERIC : ∀ (α : nat) .'Text' → 'Optional' 'Numeric' α``
 
-  Given a string representation of a decimal returns the decimal
+  Given a string representation of a numeric returns the numeric
   wrapped in ``Some``. If the input does not match the regexp
   ``[+-]?\d+(\.d+)?`` or if the result of the conversion cannot
   be mapped into a decimal without loss of precision, returns
@@ -2222,27 +2221,27 @@ String functions
 
 * ``LESS_EQ_TEXT : 'Text' → 'Text' → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is lexicographically less
+  Returns ``'True'`` if the first string is lexicographically less
   or equal than the second, ``'False'`` otherwise.
 
 * ``GREATER_EQ_TEXT : 'Text' → 'Text' → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is lexicographically
+  Returns ``'True'`` if the first string is lexicographically
   greater or equal than the second, ``'False'`` otherwise.
 
 * ``LESS_TEXT : 'Text' → 'Text' → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is lexicographically
+  Returns ``'True'`` if the first string is lexicographically
   strictly less than the second, ``'False'`` otherwise.
 
 * ``GREATER_TEXT : 'Text' → 'Text' → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is lexicographically
+  Returns ``'True'`` if the first string is lexicographically
   strictly greater than the second, ``'False'`` otherwise.
 
 * ``EQUAL_TEXT : 'Text' → 'Text' → 'Bool'``
 
-  Returns ``'True'`` if the first decimal is equal to the second,
+  Returns ``'True'`` if the first string is equal to the second,
   ``'False'`` otherwise.
 
 * ``TO_TEXT_TEXT : 'Text' → 'Text'``
@@ -2466,59 +2465,59 @@ List functions
 Map functions
 ~~~~~~~~~~~~~
 
- * ``MAP_EMPTY : ∀ α. 'Map' α``
+* ``MAP_EMPTY : ∀ α. 'Map' α``
 
-   Returns the empty map.
+  Returns the empty map.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
- * ``MAP_INSERT : ∀ α.  'Text' → α → 'Map' α → 'Map' α``
+* ``MAP_INSERT : ∀ α.  'Text' → α → 'Map' α → 'Map' α``
 
-   Inserts a new key and value in the map. If the key is already
-   present in the map, the associated value is replaced with the
-   supplied value.
+  Inserts a new key and value in the map. If the key is already
+  present in the map, the associated value is replaced with the
+  supplied value.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
- * ``MAP_LOOKUP : ∀ α. 'Text' → 'Map' α → 'Optional' α``
+* ``MAP_LOOKUP : ∀ α. 'Text' → 'Map' α → 'Optional' α``
 
-   Lookups the value at a key in the map.
+  Lookups the value at a key in the map.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
- * ``MAP_DELETE : ∀ α. 'Text' → 'Map' α → 'Map' α``
+* ``MAP_DELETE : ∀ α. 'Text' → 'Map' α → 'Map' α``
 
-   Deletes a key and its value from the map. When the key is not a
-   member of the map, the original map is returned.
+  Deletes a key and its value from the map. When the key is not a
+  member of the map, the original map is returned.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
- * ``MAP_LIST : ∀ α. 'Map' α → 'List' ⟨ key: 'Text', value: α  ⟩``
+* ``MAP_LIST : ∀ α. 'Map' α → 'List' ⟨ key: 'Text', value: α  ⟩``
 
-   Converts to a list of key/value pairs. The output list is guaranteed to be
-   sorted according to the ordering of its keys.
+  Converts to a list of key/value pairs. The output list is guaranteed to be
+  sorted according to the ordering of its keys.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
- * ``MAP_SIZE : ∀ α. 'Map' α → 'Int64'``
+* ``MAP_SIZE : ∀ α. 'Map' α → 'Int64'``
 
-   Return the number of elements in the map.
+  Return the number of elements in the map.
 
-   [*Available since version 1.3*]
+  [*Available since version 1.3*]
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~
 
 * ``INT64_TO_NUMERIC : ∀ (α : nat) . 'Int64' → 'Numeric' α``
 
-  Returns a decimal representation of the integer.  The scale of the
-  output and the ouput is given by the type parameter `α`. Throws an
+  Returns a numeric representation of the integer.  The scale of the
+  output and the output is given by the type parameter `α`. Throws an
   error in case of overflow.
 
 * ``NUMERIC_TO_INT64 : ∀ (α : nat) . 'Numeric' α → 'Int64'``
 
-  Returns the integral part of the given decimal -- in other words,
-  rounds towards 0. The scale of the input and the ouput is given by
+  Returns the integral part of the given numeric -- in other words,
+  rounds towards 0. The scale of the input and the output is given by
   the type parameter `α`.  Throws an error in case of overflow.
 
 * ``TIMESTAMP_TO_UNIX_MICROSECONDS : 'Timestamp' → 'Int64'``
@@ -2877,21 +2876,12 @@ Parametric scaled Decimals
 
 DAML-LF 1.dev is the first version that supports parametric scaled
 decimals. Prior versions have decimal number with a fixed scale of 10
-called Decimal. Backward compatibility with the current specification
-is achieved by
-
-1. Renaming the fields and the enum values containing "``decimal``" in
-   the Protocol buffer definition with "``numeric``" instead,
-2. Unconditionally fixing the scale of Numeric literals to ``10`` when
-   reading DAML-LF 1.6 (or earlier),
-3. Automatically applying the Numeric types and the numeric
-   builtin functions to the Nat type ``10`` when reading DAML-LF
-   1.6 (or earlier).
-
+called Decimal.  Backward compatibility with the current specification
+is achieved as follows:
 
 On the one hand, in case of DAML-LF 1.6 (or earlier) archive:
 
-- The ``numeric`` fields of the ``PrimLit`` message must match the
+- The ``decimal`` fields of the ``PrimLit`` message must match the
   regexp::
 
     ``[+-]?\d{1,28}(.[0-9]\d{1-10})?``
@@ -2900,13 +2890,32 @@ On the one hand, in case of DAML-LF 1.6 (or earlier) archive:
   contains such field to a numeric literal of scale 10. The
   deserialization process will reject any non-compliant program.
 
-- ``PrimType`` message with a field ``numeric`` set are translated to
+- ``PrimType`` message with a field ``decimal`` set are translated to
   ``(Numeric 10)`` type when deserialized.
 
-- Any ``BuiltinFunction`` message that corresponds to a numeric
-  builtin (all those builtins that contains ``NUMERIC`` within their
-  name) are silently applied to the ``nat`` type ``10`` when
-  deserialized to expression.
+- Decimal ``BuiltinFunction`` messages are translated as follows :
+
+  + ``ADD_DECIMAL`` message is translated to ``(ADD_NUMERIC @10)
+  + ``SUB_DECIMAL`` message is translated to ``(SUB_NUMERIC @10)
+  + ``MUL_DECIMAL`` message is translated to ``(MUL_NUMERIC @10)
+  + ``DIV_DECIMAL`` message is translated to ``(DIV_NUMERIC @10)
+  + ``ROUND_DECIMAL`` message is translated to ``(ROUND_NUMERIC @10)
+  + ``LESS_EQ_DECIMAL`` message is translated to ``(LESS_EQ_NUMERIC @10)
+  + ``GREATER_EQ_DECIMAL`` message is translated to ``(GREATER_EQ_NUMERIC @10)
+  + ``LESS_DECIMAL`` message is translated to ``(LESS_NUMERIC @10)
+  + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)
+  + ``EQUAL_DECIMAL`` message is translated to ``(EQUAL_NUMERIC @10)
+  + ``TO_TEXT_DECIMAL`` message is translated to ``(TO_TEXT_NUMERIC @10)
+  + ``FROM_TEXT_DECIMAL`` message is translated to ``(FROM_TEXT_NUMERIC @10)  [*Available since version 1.5*]
+  + ``INT64_TO_DECIMAL`` message is translated to ``(INT64_TO_NUMERIC @10)
+  + ``DECIMAL_TO_INT64`` message is translated to ``(NUMERIC_TO_INT64 @10)
+
+- Numeric types, literals and builtins cannot be refer directly. In
+  other words ``numeric`` fields in ``PrimLit`` and ``PrimType``
+  messages must remain unset and ``BuiltinFunction`` containing
+  ``NUMERIC`` in their name are forbiddens. The deserialization
+  process will reject any DAML-LF 1.6 (or earlier) that does not
+  comply those restrictions.
 
 On the other hand, starting from DAML-LF 1.dev:
 
@@ -2921,15 +2930,12 @@ On the other hand, starting from DAML-LF 1.dev:
   converting the message to numeric literals. The deserialization
   process will reject any non-compliant program.
 
-- ``PrimType`` messages with a field ``numeric`` set and
-  ``BuiltinFunction`` messages that corresponds to a numeric builtin
-  are straightforwardly translated to the corresponding types or
-  expressions without implicit application.
-
-
-
-
-
+- Decimal types, literals and builtins cannot be refer directly. In
+  other words ``decimal`` fields in ``PrimLit`` and ``PrimType``
+  messages must remain unset and ``BuiltinFunction`` containing
+  ``DECIMAL`` in their name are forbiddens. The deserialization
+  process will reject any DAML-LF 1.dev (or latter) that does not
+  comply those restrictions.
 
 .. Local Variables:
 .. eval: (flyspell-mode 1)

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2895,27 +2895,27 @@ On the one hand, in case of DAML-LF 1.6 (or earlier) archive:
 
 - Decimal ``BuiltinFunction`` messages are translated as follows :
 
-  + ``ADD_DECIMAL`` message is translated to ``(ADD_NUMERIC @10)
-  + ``SUB_DECIMAL`` message is translated to ``(SUB_NUMERIC @10)
-  + ``MUL_DECIMAL`` message is translated to ``(MUL_NUMERIC @10)
-  + ``DIV_DECIMAL`` message is translated to ``(DIV_NUMERIC @10)
-  + ``ROUND_DECIMAL`` message is translated to ``(ROUND_NUMERIC @10)
-  + ``LESS_EQ_DECIMAL`` message is translated to ``(LESS_EQ_NUMERIC @10)
-  + ``GREATER_EQ_DECIMAL`` message is translated to ``(GREATER_EQ_NUMERIC @10)
-  + ``LESS_DECIMAL`` message is translated to ``(LESS_NUMERIC @10)
-  + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)
-  + ``EQUAL_DECIMAL`` message is translated to ``(EQUAL_NUMERIC @10)
-  + ``TO_TEXT_DECIMAL`` message is translated to ``(TO_TEXT_NUMERIC @10)
-  + ``FROM_TEXT_DECIMAL`` message is translated to ``(FROM_TEXT_NUMERIC @10)  [*Available in versions >= 1.5*]
-  + ``INT64_TO_DECIMAL`` message is translated to ``(INT64_TO_NUMERIC @10)
-  + ``DECIMAL_TO_INT64`` message is translated to ``(NUMERIC_TO_INT64 @10)
+  + ``ADD_DECIMAL`` message is translated to ``(ADD_NUMERIC @10)``
+  + ``SUB_DECIMAL`` message is translated to ``(SUB_NUMERIC @10)``
+  + ``MUL_DECIMAL`` message is translated to ``(MUL_NUMERIC @10)``
+  + ``DIV_DECIMAL`` message is translated to ``(DIV_NUMERIC @10)``
+  + ``ROUND_DECIMAL`` message is translated to ``(ROUND_NUMERIC @10)``
+  + ``LESS_EQ_DECIMAL`` message is translated to ``(LESS_EQ_NUMERIC @10)``
+  + ``GREATER_EQ_DECIMAL`` message is translated to ``(GREATER_EQ_NUMERIC @10)``
+  + ``LESS_DECIMAL`` message is translated to ``(LESS_NUMERIC @10)``
+  + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)``
+  + ``EQUAL_DECIMAL`` message is translated to ``(EQUAL_NUMERIC @10)``
+  + ``TO_TEXT_DECIMAL`` message is translated to ``(TO_TEXT_NUMERIC @10)``
+  + ``FROM_TEXT_DECIMAL`` message is translated to ``(FROM_TEXT_NUMERIC @10)``  [*Available in versions >= 1.5*]
+  + ``INT64_TO_DECIMAL`` message is translated to ``(INT64_TO_NUMERIC @10)``
+  + ``DECIMAL_TO_INT64`` message is translated to ``(NUMERIC_TO_INT64 @10)``
 
-- Numeric types, literals and builtins cannot be refer directly. In
-  other words ``numeric`` fields in ``PrimLit`` and ``PrimType``
-  messages must remain unset and ``BuiltinFunction`` containing
-  ``NUMERIC`` in their name are forbiddens. The deserialization
-  process will reject any DAML-LF 1.6 (or earlier) that does not
-  comply those restrictions.
+- Numeric types, literals and builtins cannot be referred directly.
+  In other words ``numeric`` fields in ``PrimLit`` and ``PrimType``
+  messages must remain unset and Numeric ``BuiltinFunction`` (those
+  containing ``NUMERIC`` in their name) are forbidden. The
+  deserialization process will reject any DAML-LF 1.6 (or earlier)
+  that does not comply those restrictions.
 
 On the other hand, starting from DAML-LF 1.dev:
 
@@ -2925,17 +2925,17 @@ On the other hand, starting from DAML-LF 1.dev:
   ``[-]?([1-9]\d*|0).\d*``
 
   with the addition constrains that it contains at most 38 digits
-  (ignoring possibly leading ``0``). The deserialization process will
-  use the number of digits on the right of the dot as scale when
-  converting the message to numeric literals. The deserialization
-  process will reject any non-compliant program.
+  (ignoring a possibly leading ``0``). The deserialization process
+  will use the number of digits on the right of the decimal dot
+  as scale when converting the message to numeric literals. The
+  deserialization process will reject any non-compliant program.
 
-- Decimal types, literals and builtins cannot be refer directly. In
-  other words ``decimal`` fields in ``PrimLit`` and ``PrimType``
-  messages must remain unset and ``BuiltinFunction`` containing
-  ``DECIMAL`` in their name are forbiddens. The deserialization
-  process will reject any DAML-LF 1.dev (or latter) that does not
-  comply those restrictions.
+- Decimal types, literals and builtins cannot be referred directly.
+  In other words ``decimal`` fields in ``PrimLit`` and ``PrimType``
+  messages must remain unset and Decimal ``BuiltinFunction`` (those
+  containing ``DECIMAL`` in their name are forbidden). The
+  deserialization process will reject any DAML-LF 1.dev (or latter)
+  that does not comply those restrictions.
 
 .. Local Variables:
 .. eval: (flyspell-mode 1)

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -136,27 +136,24 @@ test_daml_lf_target_versions = [
             src = "//daml-lf/encoder:testing-dar-%s" % target,
             package_prefix = "test",
         ),
+        java_test(
+            name = "tests-%s" % target,
+            srcs = glob([
+                "src/test/java/**/*$All$*.java",
+                "src/test/java/**/*%s*.java" % mangle_for_java(target),
+            ]),
+            test_class = "com.digitalasset.testing.AllTestsFor$%s$" % mangle_for_java(target),
+            deps = [
+                ":test-model-%s.jar" % target,
+                "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+                "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_api",
+                "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_engine",
+                "//3rdparty/jvm/org/junit/platform:junit_platform_runner",
+                "//language-support/java/bindings:bindings-java",
+            ],
+        ),
     ]
     for target in test_daml_lf_target_versions
-]
-
-[
-    java_test(
-        name = "tests-%s" % target,
-        srcs = glob([
-            "src/test/java-%s/**/*.java" % target,
-        ]),
-        test_class = "com.digitalasset.lf_%s.AllTests" % mangle_for_java(target),
-        deps = [
-            ":test-model-%s.jar" % target,
-            "//3rdparty/jvm/com/google/protobuf:protobuf_java",
-            "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_api",
-            "//3rdparty/jvm/org/junit/jupiter:junit_jupiter_engine",
-            "//3rdparty/jvm/org/junit/platform:junit_platform_runner",
-            "//language-support/java/bindings:bindings-java",
-        ],
-    )
-    for target in ["1.6"]
 ]
 
 ########################################################

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_0$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_0$.java
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.testing;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DecimalTestFor$All$.class
+})
+public class AllTestsFor$1_0$ { }

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_1$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_1$.java
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.testing;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DecimalTestFor$All$.class
+})
+public class AllTestsFor$1_1$ { }

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_3$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_3$.java
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.testing;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DecimalTestFor$All$.class
+})
+public class AllTestsFor$1_3$ { }

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_6$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_6$.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.testing;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DecimalTestFor$All$.class,
+        EnumTestFor$1_6$1_dev$.class,
+})
+public class AllTestsFor$1_6$ { }

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_dev$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/AllTestsFor$1_dev$.java
@@ -1,14 +1,14 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf_1_6;
+package com.digitalasset.testing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        EnumTest.class
+        DecimalTestFor$All$.class,
+        EnumTestFor$1_6$1_dev$.class
 })
-public class AllTests {
-}
+public class AllTestsFor$1_dev$ { }

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestFor$All$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/DecimalTestFor$All$.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.testing;
+
+
+import com.daml.ledger.javaapi.data.Decimal;
+import com.daml.ledger.javaapi.data.Party;
+import com.daml.ledger.javaapi.data.Record;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import test.decimal.Box;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@RunWith(JUnitPlatform.class)
+public class DecimalTestFor$All$ {
+
+    private String[] goodValues = {
+            "-9999999999999999999999999999.9999999999",
+            "-1.0",
+            "0.0",
+            "1.0",
+            "3.1415926536",
+            "42.0",
+            "9999999999999999999999999999.9999999999",
+    };
+
+    @Test
+    void decimal2Value2Decimal() {
+        for(String s : goodValues) {
+            Box b = new Box(new BigDecimal(s), "alice");;
+            assertEquals(Box.fromValue(b.toValue()), b);
+        }
+    }
+
+    @Test
+    void value2Decimal2value() {
+        Record.Field partiField = new Record.Field("party", new Party("alice"));
+        for(String s : goodValues) {
+            Record record = new Record(
+                    new Record.Field("x", new Decimal(new BigDecimal(s))),
+                    partiField
+            );
+            assertEquals(Box.fromValue(record).toValue(), record);
+        }
+    }
+
+}

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestFor$1_6$1_dev$.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/EnumTestFor$1_6$1_dev$.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.lf_1_6;
+package com.digitalasset.testing;
 
 
 import com.daml.ledger.javaapi.data.DamlEnum;
@@ -19,7 +19,7 @@ import test.enum$.coloredtree.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
-public class EnumTest {
+public class EnumTestFor$1_6$1_dev$ {
 
     @Test
     void enum2Value2Enum() {


### PR DESCRIPTION
This PR advance the Numeric Issue #2289.

It updates the Protobuf to handle numeric.  In particular it adds 
 * nat kind
 * nat types
 * numeric literals 
 * numeric buildins

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
