### PR TITLE
hlb, remove dependency on DAML-LF libs

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -26,9 +26,6 @@ da_haskell_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//compiler/daml-lf-ast",
-        "//compiler/daml-lf-proto",
-        "//daml-lf/archive:daml_lf_haskell_proto",
         "//ledger-api/grpc-definitions:ledger-api-haskellpb",
     ],
 )

--- a/language-support/hs/bindings/examples/chat/src/DA/Ledger/App/Chat/ChatLedger.hs
+++ b/language-support/hs/bindings/examples/chat/src/DA/Ledger/App/Chat/ChatLedger.hs
@@ -13,7 +13,6 @@ import DA.Ledger.App.Chat.Logging (Logger)
 import Data.List as List
 import Data.Maybe (maybeToList)
 import System.Random (randomIO)
-import qualified DA.Daml.LF.Ast as LF(Package)
 import qualified Data.Text.Lazy as Text (pack)
 import qualified Data.UUID as UUID
 
@@ -48,7 +47,7 @@ connect log = do
         xs@(_:_:_) -> fail $ "found multiple packages containing Chat: " <> show (map fst xs)
         [(pid,_)] -> return Handle{log,lid,pid}
 
-containsChat :: LF.Package -> Bool
+containsChat :: Package -> Bool
 containsChat package = "Chat" `isInfixOf` show package -- TODO: be more principled
 
 sendCommand :: Party -> Handle -> ChatContract -> IO (Maybe Rejection)

--- a/language-support/hs/bindings/examples/nim/src/DA/Ledger/App/Nim/NimLedger.hs
+++ b/language-support/hs/bindings/examples/nim/src/DA/Ledger/App/Nim/NimLedger.hs
@@ -12,7 +12,6 @@ import DA.Ledger.App.Nim.NimCommand
 import DA.Ledger.App.Nim.NimTrans
 import Data.List as List
 import System.Random(randomIO)
-import qualified DA.Daml.LF.Ast as LF(Package)
 import qualified Data.Text.Lazy as Text (pack)
 import qualified Data.UUID as UUID
 
@@ -47,7 +46,7 @@ connect log = do
         xs@(_:_:_) -> fail $ "found multiple packages containing Nim: " <> show (map fst xs)
         [(pid,_)] -> return Handle{log,lid,pid}
 
-containsNim :: LF.Package -> Bool
+containsNim :: Package -> Bool
 containsNim package = "Nim" `isInfixOf` show package -- TODO: be more principled
 
 sendCommand :: Party -> Handle -> NimCommand -> IO (Maybe Rejection)

--- a/language-support/hs/bindings/src/DA/Ledger/Services/PackageService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/PackageService.hs
@@ -5,7 +5,7 @@
 
 module DA.Ledger.Services.PackageService (
     listPackages,
-    getPackage,
+    getPackage, Package(..),
     getPackageStatus, PackageStatus(..),
     ) where
 
@@ -15,10 +15,8 @@ import DA.Ledger.LedgerService
 import DA.Ledger.Types
 import Network.GRPC.HighLevel.Generated
 import Proto3.Suite.Types(Enumerated(..))
-import qualified DA.Daml.LF.Ast as LF(Package)
-import qualified DA.Daml.LF.Proto3.Decode as Decode(decodePayload)
 import qualified Data.Vector as Vector
-import qualified Proto3.Suite(fromByteString)
+import Data.ByteString(ByteString)
 
 listPackages :: LedgerId -> LedgerService [PackageId]
 listPackages lid =
@@ -31,7 +29,9 @@ listPackages lid =
         ListPackagesResponse xs <- unwrap response
         return $ map PackageId $ Vector.toList xs
 
-getPackage :: LedgerId -> PackageId -> LedgerService (Maybe LF.Package)
+data Package = Package ByteString deriving (Eq,Ord,Show)
+
+getPackage :: LedgerId -> PackageId -> LedgerService (Maybe Package)
 getPackage lid pid =
     makeLedgerService $ \timeout config ->
     withGRPCClient config $ \client -> do
@@ -43,11 +43,8 @@ getPackage lid pid =
             >>= \case
             Nothing ->
                 return Nothing
-            Just (GetPackageResponse _ bs _) -> do
-                let ap = either (error . show) id (Proto3.Suite.fromByteString bs)
-                case Decode.decodePayload ap of
-                    Left e -> fail (show e)
-                    Right package -> return (Just package)
+            Just (GetPackageResponse _ bs _) ->
+                return $ Just $ Package bs
 
 getPackageStatus :: LedgerId -> PackageId -> LedgerService PackageStatus
 getPackageStatus lid pid =

--- a/language-support/hs/bindings/src/DA/Ledger/Services/PackageService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/PackageService.hs
@@ -29,7 +29,7 @@ listPackages lid =
         ListPackagesResponse xs <- unwrap response
         return $ map PackageId $ Vector.toList xs
 
-data Package = Package ByteString deriving (Eq,Ord,Show)
+newtype Package = Package ByteString deriving (Eq,Ord,Show)
 
 getPackage :: LedgerId -> PackageId -> LedgerService (Maybe Package)
 getPackage lid pid =

--- a/language-support/hs/bindings/src/DA/Ledger/Types.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Types.hs
@@ -58,7 +58,6 @@ module DA.Ledger.Types( -- High Level types for communication over Ledger API
 
     ) where
 
-import DA.Daml.LF.Ast.Base (E10)
 import Data.Fixed
 import Data.Int (Int64)
 import Data.Map (Map)
@@ -188,6 +187,10 @@ data Event
     deriving (Eq,Ord,Show)
 
 -- value.proto
+
+data E10
+instance HasResolution E10 where
+    resolution _ = 10000000000 -- 10^-10 resolution
 
 data Value
     = VRecord Record

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -121,8 +121,8 @@ tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \pid _te
 tGetPackage :: SandboxTest
 tGetPackage withSandbox = testCase "getPackage" $ run withSandbox $ \pid _testId -> do
     lid <-  getLedgerIdentity
-    Just package <- getPackage lid pid
-    liftIO $ assertBool "contents" ("currency" `isInfixOf` show package)
+    Just (Package bs) <- getPackage lid pid
+    liftIO $ assertBool "contents" ("currency" `isInfixOf` show bs)
 
 tGetPackageBad :: SandboxTest
 tGetPackageBad withSandbox = testCase "getPackage/bad" $ run withSandbox $ \_pid _testId -> do


### PR DESCRIPTION

- Remove dependency, from the Haskell ledger bindings, on DAML-LF libs.
- This is prep for making HLB available externally to the DAML repo.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
