### PR TITLE
daml-sdk-head also installs HEAD jars

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -19,6 +19,7 @@ fi
 
 NUKE=0
 PROFILING=0
+SKIP_JARS=0
 for opt in "$@" ; do
   case $opt in
     "--nuke")
@@ -26,6 +27,9 @@ for opt in "$@" ; do
       ;;
     "--profiling")
       PROFILING=1
+      ;;
+    "--skip-jars")
+      SKIP_JARS=1;
       ;;
     *)
       echo "Unknown option: $opt"
@@ -95,3 +99,25 @@ chmod +x $DAML_HOME/bin/daml-head
 trap - EXIT
 echo "$(tput setaf 3)Successfully installed daml-head command.$(tput sgr 0)"
 
+if [ "$SKIP_JARS" -eq "0" ]; then
+    echo "$(tput setaf 3)Installing JARs as 100.0.0...$(tput sgr 0)"
+
+    cp "$REPO_ROOT/VERSION" "$REPO_ROOT/VERSION.head-build-in-progress"
+
+    function cleanup() {
+      echo "$(tput setaf 3)FAILED TO INSTALL JARS! $(tput sgr 0)"
+      mv "$REPO_ROOT/VERSION.head-build-in-progress" "$REPO_ROOT/VERSION"
+    }
+    trap cleanup EXIT
+
+    echo "0.0.0" > "$REPO_ROOT/VERSION"
+
+    bazel build //release:release
+    tmp=$(mktemp -d)
+    "$REPO_ROOT/bazel-bin/release/release" --artifacts "$REPO_ROOT/release/artifacts.yaml" --release-dir $tmp --all-artifacts --install-head-jars
+
+    mv "$REPO_ROOT/VERSION.head-build-in-progress" "$REPO_ROOT/VERSION"
+    trap - EXIT
+
+    echo "$(tput setaf 3)Done installing JARs as 100.0.0.$(tput sgr 0)"
+fi

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -25,6 +25,7 @@ data Options = Options
   , optsFullLogging :: Bool
   , optsLogLevel :: LogLevel
   , optsAllArtifacts :: AllArtifacts
+  , optsLocallyInstallJars :: Bool
   } deriving (Eq, Show)
 
 optsParser :: Parser Options
@@ -36,6 +37,7 @@ optsParser = Options
   <*> switch (long "full-logging" <> help "full logging detail")
   <*> option readLogLevel (long "log-level" <> metavar "debug|info|warn|error (default: info)" <> help "Specify log level during release run" <> value LevelInfo )
   <*> (AllArtifacts <$> switch (long "all-artifacts" <> help "Produce all artifacts including platform-independent artifacts on MacOS"))
+  <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")
   where
     readLogLevel :: ReadM LogLevel
     readLogLevel = do

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -11,3 +11,4 @@ HEAD — ongoing
 
 + [Sandbox] The sandbox now properly sets the connection pool properties ``minimumIdle``, ``maximumPoolSize``, and ``connectionTimeout``.
 + [Java codegen] Fix bug caused the generation of duplicate methods that affected sources with data constructors with type parameters that are either non-unique or not presented in the same order as in the corresponding data type declaration. See `#2367 <https://github.com/digital-asset/daml/issues/2367>`__.
+* [Dev Tooling] `daml-sdk-head` now installs current-workdir versions of all the published JARs (as version `100.0.0`) to the local Maven repo (`~/.m2`), to allow local testing of unreleased versions of the SDK against JVM-based applications. (Disable with `--skip-jars`)


### PR DESCRIPTION
We've had multiple requests that boil down to "we want to test DAML applications against non-released versions". I believe, for Java-bases apps at least, the best way to provide that capability is to extend `daml-sdk-head` to not only install the current-workdir version of the SDK (as it currently does) in PATH, but to also additionally install the current-workdir version of all the JARs we publish to the local Maven repository (`~/.m2`).

This PR does that.

Note: I have gone for `0.0.0-SNAPSHOT` as the version number for the SDK components here. I understand that moves away from the typical `0.0.0` we use for "head", but the Maven ecosystem assigns special meaning to version numbers that *do not* end with `-SNAPSHOT` and considers them stable releases, i.e. artifacts that are never supposed to change.