### PR TITLE
damldocs: Rewrite class method extraction and fix handling of default methods.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Annotate.hs
@@ -53,9 +53,10 @@ applyHide = concatMap onModule
         -- as that would be a security risk
         onTemplate x = [x | not $ isHide $ td_descr x]
         onFunction x = [x | not $ isHide $ fct_descr x]
+        onMethod x = [x | not $ isHide $ cm_descr x]
         onClass x
             | isHide $ cl_descr x = []
-            | ClassDoc {..} <- x = [x { cl_functions = concatMap onFunction cl_functions }]
+            | ClassDoc {..} <- x = [x { cl_methods = concatMap onMethod cl_methods }]
 
         onADT x
             | isHide $ ad_descr x = []

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -101,20 +101,21 @@ cls2hoogle ClassDoc{..} = concat
                  ++ maybe [] ((:["=>"]) . type2hoogle) cl_super
                  ++ wrapOp (unTypename cl_name) : cl_args
       , "" ]
-    , concatMap (fct2hoogle . addToContext) cl_functions
+    , concatMap classMethod2hoogle cl_methods
     ]
-  where
-    addToContext :: FunctionDoc -> FunctionDoc
-    addToContext fndoc = fndoc { fct_context = newContext (fct_context fndoc) }
 
-    newContext :: Maybe Type -> Maybe Type
-    newContext = \case
-        Nothing -> Just contextTy
-        Just (TypeTuple ctx) -> Just (TypeTuple (contextTy : ctx))
-        Just ctx -> Just (TypeTuple [contextTy, ctx])
-
-    contextTy :: Type
-    contextTy = TypeApp Nothing cl_name [TypeApp Nothing (Typename arg) [] | arg <- cl_args]
+classMethod2hoogle :: ClassMethodDoc -> [T.Text]
+classMethod2hoogle ClassMethodDoc{..} | cm_isDefault = [] -- hide default methods from hoogle search
+classMethod2hoogle ClassMethodDoc{..} = concat
+    [ hooglify cm_descr
+    , [ urlTag cm_anchor
+      , T.unwords . concat $
+          [ [wrapOp (unFieldname cm_name), "::"]
+          , maybe [] ((:["=>"]) . type2hoogle) cm_globalContext
+          , [type2hoogle cm_type]
+          ]
+      , "" ]
+    ]
 
 fct2hoogle :: FunctionDoc -> [T.Text]
 fct2hoogle FunctionDoc{..} = concat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -122,7 +122,7 @@ instance RenderDoc ClassMethodDoc where
     renderDoc ClassMethodDoc{..} = mconcat
         [ renderDoc cm_anchor
         , RenderParagraph . renderUnwords . concat $
-            [ if cm_isDefault then [ RenderStrong "default" ] else []
+            [ [ RenderStrong "default" | cm_isDefault ]
             , [ maybeAnchorLink cm_anchor (wrapOp (unFieldname cm_name)) ]
             ]
         , RenderBlock $ mconcat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -113,8 +113,27 @@ instance RenderDoc ClassDoc where
             ]
         , RenderBlock $ mconcat
             [ renderDoc cl_descr
-            , renderDoc cl_functions
+            , renderDoc cl_methods
             , renderDoc cl_instances
+            ]
+        ]
+
+instance RenderDoc ClassMethodDoc where
+    renderDoc ClassMethodDoc{..} = mconcat
+        [ renderDoc cm_anchor
+        , RenderParagraph . renderUnwords . concat $
+            [ if cm_isDefault then [ RenderStrong "default" ] else []
+            , [ maybeAnchorLink cm_anchor (wrapOp (unFieldname cm_name)) ]
+            ]
+        , RenderBlock $ mconcat
+            [ RenderParagraph . renderUnwords . concat $
+                [ [RenderPlain ":"]
+                , renderContext cm_localContext
+                    -- TODO: use localContext only when rendering inside ClassDoc,
+                    -- otherwise use globalContext
+                , [renderType cm_type]
+                ]
+            , renderDoc cm_descr
             ]
         ]
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -122,7 +122,10 @@ instance IsEmpty ChoiceDoc
 
 instance IsEmpty ClassDoc
   where isEmpty ClassDoc{..} =
-          isNothing cl_descr && all isEmpty cl_functions
+          isNothing cl_descr && all isEmpty cl_methods
+
+instance IsEmpty ClassMethodDoc where
+    isEmpty ClassMethodDoc{..} = isNothing cm_descr
 
 instance IsEmpty ADTDoc
   where isEmpty ADTDoc{..} =

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -52,7 +52,7 @@ cases = [ ("Empty module",
           )
         , ("Module with only a type class",
            ModuleDoc (Just "module-onlyclass") "OnlyClass" Nothing [] [] [] []
-            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [FunctionDoc (Just "function-onlyclass-member") "member" Nothing (TypeApp Nothing "a" []) Nothing] Nothing] [])
+            [ClassDoc (Just "class-onlyclass-c") "C" Nothing Nothing ["a"] [ClassMethodDoc (Just "function-onlyclass-member") "member" False Nothing Nothing (TypeApp Nothing "a" []) Nothing] Nothing] [])
         , ("Multiline field description",
            ModuleDoc
              (Just "module-multilinefield")

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -194,8 +194,8 @@ unitTests =
                    ("Expected a class description and a function description, got " <> show md)
                    (isJust $ do cls <- getSingle $ md_classes md
                                 check (Just "Class description" == cl_descr cls)
-                                member <- getSingle $ cl_functions cls
-                                check (Just "Member description" == fct_descr member)))
+                                member <- getSingle $ cl_methods cls
+                                check (Just "Member description" == cm_descr member)))
          ]
 
 

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -38,10 +38,16 @@
 
 <a name="class-defaultmethods-myshow-63359"></a>**class** [MyShow](#class-defaultmethods-myshow-63359) t **where**
 
-> <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
-> 
-> > : t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> Default implementation with a separate type signature for the default method.
 > 
 > <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
 > 
 > > : t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> > 
+> > Doc for method.
+> 
+> **default** myShow
+> 
+> > : [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) t =\> t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> > 
+> > Doc for default.

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -1,0 +1,47 @@
+# <a name="module-defaultmethods-97307"></a>Module DefaultMethods
+
+## Typeclasses
+
+<a name="class-defaultmethods-d-4635"></a>**class** [D](#class-defaultmethods-d-4635) a **where**
+
+> <a name="function-defaultmethods-x-92038"></a>[x](#function-defaultmethods-x-92038)
+> 
+> > : a
+> 
+> <a name="function-defaultmethods-y-38115"></a>[y](#function-defaultmethods-y-38115)
+> 
+> > : a
+
+<a name="class-defaultmethods-foldablex-48748"></a>**class** [FoldableX](#class-defaultmethods-foldablex-48748) t **where**
+
+> <a name="function-defaultmethods-foldrx-33654"></a>[foldrX](#function-defaultmethods-foldrx-33654)
+> 
+> > : (a -\> b -\> b) -\> b -\> t a -\> b
+
+<a name="class-defaultmethods-traversablex-59027"></a>**class** ([Functor](https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448) t, [FoldableX](#class-defaultmethods-foldablex-48748) t) =\> [TraversableX](#class-defaultmethods-traversablex-59027) t **where**
+
+> <a name="function-defaultmethods-traversex-21140"></a>[traverseX](#function-defaultmethods-traversex-21140)
+> 
+> > : Applicative m =\> (a -\> m b) -\> t a -\> m (t b)
+> 
+> <a name="function-defaultmethods-sequencex-86855"></a>[sequenceX](#function-defaultmethods-sequencex-86855)
+> 
+> > : Applicative m =\> t (m a) -\> m (t a)
+
+<a name="class-defaultmethods-id-77721"></a>**class** [Id](#class-defaultmethods-id-77721) a **where**
+
+> <a name="function-defaultmethods-id-57162"></a>[id](#function-defaultmethods-id-57162)
+> 
+> > : a -\> a
+> 
+> **instance** [Id](#class-defaultmethods-id-77721) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+
+<a name="class-defaultmethods-myshow-63359"></a>**class** [MyShow](#class-defaultmethods-myshow-63359) t **where**
+
+> <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
+> 
+> > : t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> 
+> <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
+> 
+> > : t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -1,0 +1,69 @@
+.. _module-defaultmethods-97307:
+
+Module DefaultMethods
+---------------------
+
+Typeclasses
+^^^^^^^^^^^
+
+.. _class-defaultmethods-d-4635:
+
+**class** `D <class-defaultmethods-d-4635_>`_ a **where**
+
+  .. _function-defaultmethods-x-92038:
+  
+  `x <function-defaultmethods-x-92038_>`_
+    : a
+  
+  .. _function-defaultmethods-y-38115:
+  
+  `y <function-defaultmethods-y-38115_>`_
+    : a
+
+.. _class-defaultmethods-foldablex-48748:
+
+**class** `FoldableX <class-defaultmethods-foldablex-48748_>`_ t **where**
+
+  .. _function-defaultmethods-foldrx-33654:
+  
+  `foldrX <function-defaultmethods-foldrx-33654_>`_
+    : (a -> b -> b) -> b -> t a -> b
+
+.. _class-defaultmethods-traversablex-59027:
+
+**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) => `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
+
+  .. _function-defaultmethods-traversex-21140:
+  
+  `traverseX <function-defaultmethods-traversex-21140_>`_
+    : Applicative m => (a -> m b) -> t a -> m (t b)
+  
+  .. _function-defaultmethods-sequencex-86855:
+  
+  `sequenceX <function-defaultmethods-sequencex-86855_>`_
+    : Applicative m => t (m a) -> m (t a)
+
+.. _class-defaultmethods-id-77721:
+
+**class** `Id <class-defaultmethods-id-77721_>`_ a **where**
+
+  .. _function-defaultmethods-id-57162:
+  
+  `id <function-defaultmethods-id-57162_>`_
+    : a -> a
+  
+  **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+
+.. _class-defaultmethods-myshow-63359:
+
+**class** `MyShow <class-defaultmethods-myshow-63359_>`_ t **where**
+
+  .. _function-defaultmethods-myshow-41356:
+  
+  `myShow <function-defaultmethods-myshow-41356_>`_
+    : t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+  
+  .. _function-defaultmethods-myshow-41356:
+  
+  `myShow <function-defaultmethods-myshow-41356_>`_
+    : t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -58,12 +58,17 @@ Typeclasses
 
 **class** `MyShow <class-defaultmethods-myshow-63359_>`_ t **where**
 
-  .. _function-defaultmethods-myshow-41356:
-  
-  `myShow <function-defaultmethods-myshow-41356_>`_
-    : t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+  Default implementation with a separate type signature for the default method.
   
   .. _function-defaultmethods-myshow-41356:
   
   `myShow <function-defaultmethods-myshow-41356_>`_
     : t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    
+    Doc for method.
+  
+  **default** myShow
+  
+    : `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t => t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    
+    Doc for default.

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.daml
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.daml
@@ -31,3 +31,10 @@ class Id a where
   id = \x -> x
 
 instance Id Int where
+
+-- Default implementation with a separate type signature for the default method.
+class MyShow t where
+  myShow : t -> Text
+
+  default myShow : Show t => t -> Text
+  myShow = show

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.daml
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.daml
@@ -32,9 +32,10 @@ class Id a where
 
 instance Id Int where
 
--- Default implementation with a separate type signature for the default method.
+-- | Default implementation with a separate type signature for the default method.
 class MyShow t where
+  -- | Doc for method.
   myShow : t -> Text
-
+  -- | Doc for default.
   default myShow : Show t => t -> Text
   myShow = show

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.md
@@ -1,0 +1,19 @@
+# <a name="module-multiplenames-52925"></a>Module MultipleNames
+
+Test multiple names sharing the same type signature.
+
+## Typeclasses
+
+<a name="class-multiplenames-foo-65985"></a>**class** [Foo](#class-multiplenames-foo-65985) t **where**
+
+> <a name="function-multiplenames-foo1-60996"></a>[foo1](#function-multiplenames-foo1-60996)
+> 
+> > : t
+> > 
+> > This documentation is duplicated.
+> 
+> <a name="function-multiplenames-foo2-88479"></a>[foo2](#function-multiplenames-foo2-88479)
+> 
+> > : t
+> > 
+> > This documentation is duplicated.

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
@@ -1,0 +1,27 @@
+.. _module-multiplenames-52925:
+
+Module MultipleNames
+--------------------
+
+Test multiple names sharing the same type signature.
+
+Typeclasses
+^^^^^^^^^^^
+
+.. _class-multiplenames-foo-65985:
+
+**class** `Foo <class-multiplenames-foo-65985_>`_ t **where**
+
+  .. _function-multiplenames-foo1-60996:
+  
+  `foo1 <function-multiplenames-foo1-60996_>`_
+    : t
+    
+    This documentation is duplicated.
+  
+  .. _function-multiplenames-foo2-88479:
+  
+  `foo2 <function-multiplenames-foo2-88479_>`_
+    : t
+    
+    This documentation is duplicated.

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.daml
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.daml
@@ -1,0 +1,8 @@
+daml 1.2
+
+-- | Test multiple names sharing the same type signature.
+module MultipleNames where
+
+class Foo t where
+    -- | This documentation is duplicated.
+    foo1, foo2 : t


### PR DESCRIPTION
Fixes #2659 and some other problems with the handling of class methods.

As part of this, I changed how typeclass method docs are stored, and rewrote the extraction of class methods to actually keep track of the type signature and docs of a generic default method. (Previously it only fetched the type signature and docs for the exported typeclass method! And also caused duplicate anchors.)

I added a test case for generic default methods.