### PR TITLE
damlc: Add Numeric primitives and type-level nats.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -13,6 +13,7 @@ module DA.Daml.LF.Ast.Base(
 
 import Data.Hashable
 import Data.Data
+import Numeric.Natural
 import GHC.Generics(Generic)
 import Data.Int
 import           Control.DeepSeq
@@ -130,6 +131,7 @@ data SourceLoc = SourceLoc
 -- | Kinds.
 data Kind
   = KStar
+  | KNat
   | KArrow Kind Kind
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
@@ -137,6 +139,7 @@ data Kind
 data BuiltinType
   = BTInt64
   | BTDecimal
+  | BTNumeric
   | BTText
   | BTTimestamp
   | BTDate
@@ -173,6 +176,8 @@ data Type
   -- | Type for tuples aka structural records. Parameterized by the names of the
   -- fields and their types.
   | TTuple      ![(FieldName, Type)]
+  -- | Type-level natural numbers
+  | TNat !Natural
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Fully applied qualified type constructor.
@@ -193,6 +198,7 @@ data BuiltinExpr
   -- Literals
   = BEInt64      !Int64          -- :: Int64
   | BEDecimal    !(Fixed E10)    -- :: Decimal, precision 38, scale 10
+  -- TODO (#2289): add numeric literals
   | BEText       !T.Text         -- :: Text
   | BETimestamp  !Int64          -- :: Timestamp, microseconds since unix epoch
   | BEParty      !PartyLiteral   -- :: Party
@@ -217,6 +223,19 @@ data BuiltinExpr
   | BEDivDecimal                 -- :: Decimal -> Decimal -> Decimal, automatically rounds to even, crashes on divisor = 0 and on overflow
   | BERoundDecimal               -- :: Int64 -> Decimal -> Decimal, the Int64 is the required scale. Note that this doesn't modify the scale of the type itself, it just zeroes things outside that scale out. Can be negative. Crashes if the scale is > 10 or < -27.
 
+  -- Numeric arithmetic and comparisons
+  | BEEqualNumeric               -- :: ∀n. Numeric n -> Numeric n -> Bool, where t is the builtin type
+  | BELessNumeric                -- :: ∀(s:nat). Numeric s -> Numeric s -> Bool
+  | BELessEqNumeric              -- :: ∀(s:nat). Numeric s -> Numeric s -> Bool
+  | BEGreaterEqNumeric           -- :: ∀(s:nat). Numeric s -> Numeric s -> Bool
+  | BEGreaterNumeric             -- :: ∀(s:nat). Numeric s -> Numeric s -> Bool
+  | BEToTextNumeric              -- :: ∀(s:nat). Numeric s -> Text
+  | BEAddNumeric                 -- :: ∀(s:nat). Numeric s -> Numeric s -> Numeric s, crashes on overflow
+  | BESubNumeric                 -- :: ∀(s:nat). Numeric s -> Numeric s -> Numeric s, crashes on overflow
+  | BEMulNumeric                 -- :: ∀(s:nat). Numeric s -> Numeric s -> Numeric s, crashes on overflow and underflow, automatically rounds to even (see <https://en.wikipedia.org/wiki/Rounding#Round_half_to_even>)
+  | BEDivNumeric                 -- :: ∀(s:nat). Numeric s -> Numeric s -> Numeric s, automatically rounds to even, crashes on divisor = 0 and on overflow
+  | BERoundNumeric              -- :: ∀(s:nat). Int64 -> Numeric s -> Numeric s, the Int64 is the required scale. Note that this doesn't modify the scale of the type itself, it just zeroes things outside that scale out. Can be negative. Crashes if the scale is > 10 or < -27.
+
   -- Integer arithmetic
   | BEAddInt64                 -- :: Int64 -> Int64 -> Int64, crashes on overflow
   | BESubInt64                 -- :: Int64 -> Int64 -> Int64, crashes on overflow
@@ -228,6 +247,8 @@ data BuiltinExpr
   -- Numerical conversion
   | BEInt64ToDecimal           -- :: Int64 -> Decimal, always succeeds since 10^28 > 2^63
   | BEDecimalToInt64           -- :: Decimal -> Int64, only converts the whole part, crashes if it doesn't fit
+  | BEInt64ToNumeric           -- :: ∀(s:nat). Int64 -> Numeric s, crashes if it doesn't fit (TODO: verify?)
+  | BENumericToInt64           -- :: ∀(s:nat). Numeric s -> Int64, only converts the whole part, crashes if it doesn't fit
 
   -- Time conversion
   | BETimestampToUnixMicroseconds -- :: Timestamp -> Int64, in microseconds
@@ -255,6 +276,7 @@ data BuiltinExpr
   | BEPartyFromText              -- :: Text -> Optional Party
   | BEInt64FromText              -- :: Text -> Optional Int64
   | BEDecimalFromText            -- :: Text -> Optional Decimal
+  | BENumericFromText            -- :: ∀(s:nat). Text -> Optional (Numeric s)
   | BETextToCodePoints           -- :: Text -> List Int64
   | BETextFromCodePoints         -- :: List Int64 -> Text
   | BEPartyToQuotedText          -- :: Party -> Text

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -18,6 +18,7 @@ module DA.Daml.LF.Ast.Optics(
     builtinType
     ) where
 
+import Numeric.Natural
 import Control.Lens
 import Control.Lens.Ast
 import Control.Lens.MonoTraversal
@@ -99,6 +100,7 @@ builtinType f =
         TBuiltin x -> TBuiltin <$> f x
         TForall b body -> TForall b <$> builtinType f body
         TTuple fs -> TTuple <$> (traverse . _2) (builtinType f) fs
+        TNat n -> pure $ TNat n
 
 type ModuleRef = (PackageRef, ModuleName)
 
@@ -137,6 +139,8 @@ instance MonoTraversable ModuleRef BuiltinExpr where monoTraverse _ = pure
 -- https://github.com/digital-asset/daml/pull/2327#discussion_r308445649 for
 -- discussion
 instance MonoTraversable ModuleRef SourceLoc where monoTraverse _ = pure
+
+instance MonoTraversable ModuleRef Natural where monoTraverse _ = pure
 
 instance MonoTraversable ModuleRef TypeConApp
 instance MonoTraversable ModuleRef Type

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -103,6 +103,7 @@ prettyHasType  = ":"
 instance Pretty Kind where
   pPrintPrec lvl prec = \case
     KStar -> "*"
+    KNat -> "nat"
     KArrow k1 k2 ->
       maybeParens (prec > precKArrow) $
         pPrintPrec lvl (succ precKArrow) k1 <-> prettyFunArrow <-> pPrintPrec lvl precKArrow k2
@@ -118,6 +119,7 @@ instance Pretty BuiltinType where
   pPrint = \case
     BTInt64          -> "Int64"
     BTDecimal        -> "Decimal"
+    BTNumeric -> "Numeric"
     BTText           -> "Text"
     BTTimestamp      -> "Timestamp"
     BTParty          -> "Party"
@@ -163,6 +165,7 @@ instance Pretty Type where
             (prettyForall <-> hsep (map (prettyAndKind lvl) vs) <> "."
              <-> pPrintPrec lvl precTForall t1)
     TTuple fields -> prettyTuple lvl prettyHasType fields
+    TNat n -> integer (fromIntegral n)
 
 precEApp, precEAbs :: Rational
 precEApp = 2
@@ -198,6 +201,20 @@ instance Pretty BuiltinExpr where
     BEMulDecimal -> "MUL_DECIMAL"
     BEDivDecimal -> "DIV_DECIMAL"
     BERoundDecimal -> "ROUND_DECIMAL"
+    BEAddNumeric -> "ADD_NUMERIC"
+    BESubNumeric -> "SUB_NUMERIC"
+    BEMulNumeric -> "MUL_NUMERIC"
+    BEDivNumeric -> "DIV_NUMERIC"
+    BERoundNumeric -> "ROUND_NUMERIC"
+    BEInt64ToNumeric -> "INT64_TO_NUMERIC"
+    BENumericToInt64 -> "NUMERIC_TO_INT64"
+    BEEqualNumeric -> "EQUAL_NUMERIC"
+    BELessEqNumeric -> "LEQ_NUMERIC"
+    BELessNumeric -> "LESS_NUMERIC"
+    BEGreaterEqNumeric -> "GEQ_NUMERIC"
+    BEGreaterNumeric -> "GREATER_NUMERIC"
+    BENumericFromText -> "FROM_TEXT_NUMERIC"
+    BEToTextNumeric -> "TO_TEXT_NUMERIC"
     BEAddInt64 -> "ADD_INT64"
     BESubInt64 -> "SUB_INT64"
     BEMulInt64 -> "MUL_INT64"

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -31,6 +31,7 @@ freeVars e = go Set.empty e Set.empty
         TBuiltin _ -> acc
         TForall (v, _k) s -> go (Set.insert v boundVars) s acc
         TTuple fs -> foldl' (\acc (_, t) -> go boundVars t acc) acc fs
+        TNat _ -> Set.empty
 
 -- | Auxiliary data structure to track bound variables in the test for alpha
 -- equivalence.
@@ -104,6 +105,7 @@ substitute subst = go (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.emp
             in  TForall (v1, k) (go fvSubst1 subst1 t)
         | otherwise -> TForall (v0, k) (go fvSubst0 (Map.delete v0 subst0) t)
       TTuple fs -> TTuple (map (second go0) fs)
+      TNat n -> TNat n
       where
         go0 = go fvSubst0 subst0
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -162,13 +162,14 @@ pattern TParty      = TBuiltin BTParty
 pattern TDate       = TBuiltin BTDate
 pattern TArrow      = TBuiltin BTArrow
 
-pattern TList, TOptional, TMap, TUpdate, TScenario, TContractId :: Type -> Type
+pattern TList, TOptional, TMap, TUpdate, TScenario, TContractId, TNumeric :: Type -> Type
 pattern TList typ = TApp (TBuiltin BTList) typ
 pattern TOptional typ = TApp (TBuiltin BTOptional) typ
 pattern TMap typ = TApp (TBuiltin BTMap) typ
 pattern TUpdate typ = TApp (TBuiltin BTUpdate) typ
 pattern TScenario typ = TApp (TBuiltin BTScenario) typ
 pattern TContractId typ = TApp (TBuiltin BTContractId) typ
+pattern TNumeric n = TApp (TBuiltin BTNumeric) n
 
 pattern TMapEntry :: Type -> Type
 pattern TMapEntry a = TTuple [(FieldName "key", TText), (FieldName "value", a)]
@@ -189,13 +190,18 @@ _TOptional = prism' TOptional $ \case
   _ -> Nothing
 
 _TUpdate :: Prism' Type Type
-_TUpdate = prism' TList $ \case
+_TUpdate = prism' TUpdate $ \case
   TUpdate typ -> Just typ
   _ -> Nothing
 
 _TScenario :: Prism' Type Type
-_TScenario = prism' TList $ \case
+_TScenario = prism' TScenario $ \case
   TScenario typ -> Just typ
+  _ -> Nothing
+
+_TNumeric :: Prism' Type Type
+_TNumeric = prism' TNumeric $ \case
+  TNumeric n -> Just n
   _ -> Nothing
 
 _TConApp :: Prism' Type (Qualified TypeConName, [Type])

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -164,13 +164,11 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceRetType" templateChoiceRetType decodeType
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
--- FixMe: https://github.com/digital-asset/daml/issues/2289
---   drop the `error "Numeric not implemented"` in the following function
 decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
 decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
   LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
-  LF1.BuiltinFunctionEQUAL_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqualNumeric
   LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
   LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
@@ -179,7 +177,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEqNumeric
   LF1.BuiltinFunctionLEQ_TEXT -> BELessEq BTText
   LF1.BuiltinFunctionLEQ_TIMESTAMP -> BELessEq BTTimestamp
   LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
@@ -187,7 +185,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
   LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
-  LF1.BuiltinFunctionLESS_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionLESS_NUMERIC -> BELessNumeric
   LF1.BuiltinFunctionLESS_TEXT -> BELess BTText
   LF1.BuiltinFunctionLESS_TIMESTAMP -> BELess BTTimestamp
   LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
@@ -195,7 +193,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
   LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEqNumeric
   LF1.BuiltinFunctionGEQ_TEXT -> BEGreaterEq BTText
   LF1.BuiltinFunctionGEQ_TIMESTAMP -> BEGreaterEq BTTimestamp
   LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
@@ -203,7 +201,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
   LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreaterNumeric
   LF1.BuiltinFunctionGREATER_TEXT -> BEGreater BTText
   LF1.BuiltinFunctionGREATER_TIMESTAMP -> BEGreater BTTimestamp
   LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
@@ -211,7 +209,7 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
   LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToTextNumeric
   LF1.BuiltinFunctionTO_TEXT_TEXT -> BEToText BTText
   LF1.BuiltinFunctionTO_TEXT_TIMESTAMP -> BEToText BTTimestamp
   LF1.BuiltinFunctionTO_TEXT_PARTY -> BEToText BTParty
@@ -220,7 +218,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
   LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
   LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BENumericFromText
   LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
   LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
 
@@ -229,11 +227,11 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
   LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
   LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
-  LF1.BuiltinFunctionADD_NUMERIC   -> error "Numeric not implemented"
-  LF1.BuiltinFunctionSUB_NUMERIC   -> error "Numeric not implemented"
-  LF1.BuiltinFunctionMUL_NUMERIC   -> error "Numeric not implemented"
-  LF1.BuiltinFunctionDIV_NUMERIC   -> error "Numeric not implemented"
-  LF1.BuiltinFunctionROUND_NUMERIC -> error "Numeric not implemented"
+  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddNumeric
+  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubNumeric
+  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulNumeric
+  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivNumeric
+  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundNumeric
 
   LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
   LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
@@ -266,8 +264,8 @@ decodeBuiltinFunction = pure . \case
 
   LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
   LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
-  LF1.BuiltinFunctionINT64_TO_NUMERIC -> error "Numeric not implemented"
-  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> error "Numeric not implemented"
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToNumeric
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BENumericToInt64
 
   LF1.BuiltinFunctionTRACE -> BETrace
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
@@ -507,8 +505,7 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
 decodeKind :: LF1.Kind -> Decode Kind
 decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
   LF1.KindSumStar LF1.Unit -> pure KStar
-  -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  LF1.KindSumNat LF1.Unit -> error "Numeric not implemented"
+  LF1.KindSumNat LF1.Unit -> pure KNat
   LF1.KindSumArrow (LF1.Kind_Arrow params mbResult) -> do
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
@@ -517,8 +514,7 @@ decodePrim :: LF1.PrimType -> Decode BuiltinType
 decodePrim = pure . \case
   LF1.PrimTypeINT64 -> BTInt64
   LF1.PrimTypeDECIMAL -> BTDecimal
-  -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  LF1.PrimTypeNUMERIC -> error "Numeric not implemented"
+  LF1.PrimTypeNUMERIC -> BTNumeric
   LF1.PrimTypeTEXT    -> BTText
   LF1.PrimTypeTIMESTAMP -> BTTimestamp
   LF1.PrimTypePARTY   -> BTParty
@@ -537,8 +533,9 @@ decodeType :: LF1.Type -> DecodeImpl Type
 decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumVar (LF1.Type_Var var args) ->
     decodeWithArgs args $ TVar <$> decodeName TypeVarName var
-  -- FixMe: https://github.com/digital-asset/daml/issues/2289
-  LF1.TypeSumNat _ -> error "Numeric not implemented"
+  LF1.TypeSumNat n ->
+    pure $ TNat (fromIntegral n)
+    -- TODO (#2289): determine if some bounds check should be made here.
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -123,6 +123,20 @@ safetyStep = \case
       BEMulDecimal        -> Safe 1
       BEDivDecimal        -> Safe 1
       BERoundDecimal      -> Safe 1
+      BEEqualNumeric      -> Safe 2
+      BELessNumeric       -> Safe 2
+      BELessEqNumeric     -> Safe 2
+      BEGreaterNumeric    -> Safe 2
+      BEGreaterEqNumeric  -> Safe 2
+      BEAddNumeric        -> Safe 1
+      BESubNumeric        -> Safe 1
+      BEMulNumeric        -> Safe 1
+      BEDivNumeric        -> Safe 1
+      BEInt64ToNumeric    -> Safe 0
+      BENumericToInt64    -> Safe 0
+      BENumericFromText   -> Safe 1
+      BEToTextNumeric     -> Safe 1
+      BERoundNumeric      -> Safe 1
       BEAddInt64          -> Safe 1
       BESubInt64          -> Safe 1
       BEMulInt64          -> Safe 1

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -104,6 +104,7 @@ kindOfBuiltin :: BuiltinType -> Kind
 kindOfBuiltin = \case
   BTInt64 -> KStar
   BTDecimal -> KStar
+  BTNumeric -> KNat `KArrow` KStar
   BTText -> KStar
   BTTimestamp -> KStar
   BTParty -> KStar
@@ -136,6 +137,7 @@ kindOf = \case
   TBuiltin btype -> pure (kindOfBuiltin btype)
   TForall (v, k) t1 -> introTypeVar v k $ checkType t1 KStar $> KStar
   TTuple recordType -> checkRecordType recordType $> KStar
+  TNat _ -> pure KNat
 
 typeOfBuiltin :: MonadGamma m => BuiltinExpr -> m Type
 typeOfBuiltin = \case
@@ -165,6 +167,21 @@ typeOfBuiltin = \case
   BEMulDecimal       -> pure $ tBinop TDecimal
   BEDivDecimal       -> pure $ tBinop TDecimal
   BERoundDecimal     -> pure $ TInt64 :-> TDecimal :-> TDecimal
+  BEEqualNumeric     -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
+  BELessNumeric      -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
+  BELessEqNumeric    -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
+  BEGreaterNumeric   -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
+  BEGreaterEqNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
+  BEAddNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TNumeric tAlpha
+  BESubNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TNumeric tAlpha
+  BEMulNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TNumeric tAlpha
+  BEDivNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TNumeric tAlpha
+  BERoundNumeric -> pure $ TForall (alpha, KNat) $ TInt64 :-> TNumeric tAlpha :-> TNumeric tAlpha
+  BEInt64ToNumeric -> pure $ TForall (alpha, KNat) $ TInt64 :-> TNumeric tAlpha
+  BENumericToInt64 -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TInt64
+  BEToTextNumeric -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TText
+  BENumericFromText -> pure $ TForall (alpha, KNat) $ TText :-> TOptional (TNumeric tAlpha)
+
   BEAddInt64         -> pure $ tBinop TInt64
   BESubInt64         -> pure $ tBinop TInt64
   BEMulInt64         -> pure $ tBinop TInt64

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -56,6 +56,7 @@ data UnserializabilityReason
   | URDataType !(Qualified TypeConName)  -- ^ It uses a data type which is not serializable.
   | URHigherKinded !TypeVarName !Kind  -- ^ A data type has a higher kinded parameter.
   | URUninhabitatedType  -- ^ A type without values, e.g., a variant with no constructors.
+  | URNumeric -- ^ It contains an unapplied Numeric type constructor.
 
 data Error
   = EUnknownTypeVar        !TypeVarName
@@ -155,6 +156,7 @@ instance Pretty UnserializabilityReason where
       "unserializable data type" <-> pretty tcon
     URHigherKinded v k -> "higher-kinded type variable" <-> pretty v <:> pretty k
     URUninhabitatedType -> "variant type without constructors"
+    URNumeric -> "unapplied Numeric"
 
 instance Pretty Error where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -12,6 +12,7 @@ module DA.Daml.LF.TypeChecker.Error(
 
 import DA.Pretty
 import qualified Data.Text as T
+import Numeric.Natural
 
 import DA.Daml.LF.Ast
 import DA.Daml.LF.Ast.Pretty
@@ -57,6 +58,8 @@ data UnserializabilityReason
   | URHigherKinded !TypeVarName !Kind  -- ^ A data type has a higher kinded parameter.
   | URUninhabitatedType  -- ^ A type without values, e.g., a variant with no constructors.
   | URNumeric -- ^ It contains an unapplied Numeric type constructor.
+  | URNumericNotFixed
+  | URNumericOutOfRange !Natural
 
 data Error
   = EUnknownTypeVar        !TypeVarName
@@ -157,6 +160,8 @@ instance Pretty UnserializabilityReason where
     URHigherKinded v k -> "higher-kinded type variable" <-> pretty v <:> pretty k
     URUninhabitatedType -> "variant type without constructors"
     URNumeric -> "unapplied Numeric"
+    URNumericNotFixed -> "Numeric scale is not fixed"
+    URNumericOutOfRange n -> "Numeric scale " <> integer (fromIntegral n) <> " is out of range (needs to be between 0 and 38)"
 
 instance Pretty Error where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -53,9 +53,14 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
       TList typ -> go typ
       TOptional typ -> go typ
       TMap typ -> go typ
-      TNumeric n -> go n
-        -- TODO (#2289): decide if n should be forced to be a static nat
-        -- literal within LF's bounds for the numeric type (0 <= n <= 38).
+      TNumeric (TNat n)
+          | n <= 38 -> noConditions
+          | otherwise -> Left (URNumericOutOfRange n)
+      TNumeric _ -> Left URNumericNotFixed
+          -- We statically enforce bounds check for Numeric type,
+          -- requiring 0 <= n <= 38 for the argument to Numeric.
+          -- If the argument isn't given explicitly, we can't
+          -- guarantee serializability.
       TNat _ -> noConditions
       TVar v
         | v `HS.member` vars -> noConditions

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -53,6 +53,10 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
       TList typ -> go typ
       TOptional typ -> go typ
       TMap typ -> go typ
+      TNumeric n -> go n
+        -- TODO (#2289): decide if n should be forced to be a static nat
+        -- literal within LF's bounds for the numeric type (0 <= n <= 38).
+      TNat _ -> noConditions
       TVar v
         | v `HS.member` vars -> noConditions
         | otherwise -> Left (URFreeVar v)
@@ -86,6 +90,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTContractId -> Left URContractId  -- 'ContractId' is used as a higher-kinded type constructor
                                            -- (or polymorphically in DAML-LF <= 1.4).
         BTArrow -> Left URFunction
+        BTNumeric -> Left URNumeric -- 'Numeric' is used as a higher-kinded type constructor.
       TForall{} -> Left URForall
       TTuple{} -> Left URTuple
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -509,6 +509,9 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
                     noExt
                     HsBoxedTuple
                     [noLoc $ convType ty | (_fldName, ty) <- fls]
+            -- TODO (#2289): Add support for nat kind.
+            LF.TNat _ -> error "nat kind not yet suppported in upgrades"
+
     convBuiltInTy :: LF.BuiltinType -> HsType GhcPs
     convBuiltInTy =
         \case
@@ -527,6 +530,8 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
             LF.BTOptional -> mkLfInternalPrelude "Optional"
             LF.BTMap -> mkLfInternalType "TextMap"
             LF.BTArrow -> mkTyConTypeUnqual funTyCon
+            -- TODO (#2289): Add support for Numeric types.
+            LF.BTNumeric -> error "Numeric type not yet supported in upgrades"
     mkGhcType =
         HsTyVar noExt NotPromoted .
         noLoc . mkOrig gHC_TYPES . mkOccName varName
@@ -629,6 +634,8 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
             LF.BTOptional -> (damlStdlibUnitId, LF.ModuleName ["DA", "Internal", "Prelude"])
             LF.BTMap -> (damlStdlibUnitId, LF.ModuleName ["DA", "Internal", "LF"])
             LF.BTArrow -> (primUnitId, translateModName funTyCon)
+            -- TODO (#2289): Add support for Numeric types.
+            LF.BTNumeric -> error "Numeric type not yet supported in upgrades"
 
     translateModName ::
            forall a. NamedThing a


### PR DESCRIPTION
A step towards #2289 in the compiler.

This PR adds support for the nat kind, for type-level natural numbers, and the Numeric primitive type and operations. This PR does not remove or replace the Decimal type, nor does it yet support Numeric literals, nor does it touch the standard libraries, nor hook up DAML programs to the new Numeric types in any way.