### PR TITLE
Fix the safety of the empty map in the DAML-LF simplifier

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -133,7 +133,7 @@ safetyStep = \case
       BEDecimalToInt64    -> Safe 0 -- crash if the decimal doesn't fit
       BEFoldl             -> Safe 2
       BEFoldr             -> Safe 2
-      BEMapEmpty          -> Safe 1
+      BEMapEmpty          -> Safe 0
       BEMapInsert         -> Safe 3
       BEMapLookup         -> Safe 2
       BEMapDelete         -> Safe 2


### PR DESCRIPTION
Currently, we use `Safe 1` as the safety of the `BEMapEmpty` primitive. This
is clearly wrong since `BEMapEmtpy` is not supposed to be applied to a value
(but only to a type). Thus, it must be `Safe 0`. This has not caused any
problems in the past because the type checker would have caught any
application of `BEMapEmpty` to a value.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2679)
<!-- Reviewable:end -->
