### PR TITLE
Shutdown IdeState in withDamlIdeState

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/IdeState.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/IdeState.hs
@@ -9,6 +9,7 @@ module DA.Cli.Damlc.IdeState
 
 import qualified Language.Haskell.LSP.Messages as LSP
 
+import Control.Exception
 import DA.Daml.Options
 import DA.Daml.Options.Types
 import qualified DA.Service.Logger as Logger
@@ -45,8 +46,10 @@ withDamlIdeState opts@Options{..} loggerH eventHandler f = do
         vfs <- makeVFSHandle
         -- We only use withDamlIdeState outside of the IDE where we do not care about
         -- progress reporting.
-        ideState <- getDamlIdeState opts mbScenarioService loggerH eventHandler vfs (IdeReportProgress False)
-        f ideState
+        bracket
+            (getDamlIdeState opts mbScenarioService loggerH eventHandler vfs (IdeReportProgress False))
+            shutdown
+            f
 
 -- | Adapter to the IDE logger module.
 toIdeLogger :: Logger.Handle IO -> IdeLogger.Logger

--- a/compiler/hie-core/src/Development/IDE/Core/Shake.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Shake.hs
@@ -352,13 +352,13 @@ shakeRun IdeState{shakeExtras=ShakeExtras{..}, ..} acts = modifyVar shakeAbort $
     bar <- newBarrier
     start <- offsetTime
     thread <- forkFinally (shakeRunDatabaseProfile shakeProfileDir shakeDb acts) $ \res -> do
-        signalBarrier bar res
         runTime <- start
         let res' = case res of
                 Left e -> "exception: " <> displayException e
                 Right _ -> "completed"
         logDebug logger $ T.pack $
             "Finishing shakeRun (took " ++ showDuration runTime ++ ", " ++ res' ++ ")"
+        signalBarrier bar res
     -- important: we send an async exception to the thread, then wait for it to die, before continuing
     return (do killThread thread; void $ waitBarrier bar, either throwIO return =<< waitBarrier bar)
 


### PR DESCRIPTION
Noticed this while trying to debug the segfaults.

I don’t have a concrete case where this causes issues (usually we only
call this once on startup so leaks are not an issue) but we might as
well do it properly.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
