### PR TITLE
Allow boundedly polymorphic recursive functions without type annotation

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -492,8 +492,8 @@ convertBind2 env (NonRec name x)
     -- lifting where the lifted version of `f` happens to be `name`.)
     -- This workaround should be removed once we either have a proper lambda
     -- lifter or DAML-LF supports local recursion.
-    | (as, Let (Rec [(f, Lam v y)]) (Var f')) <- collectTyBinders x, f == f'
-    = convertBind2 env $ NonRec name $ mkLams as $ Lam v $ Let (NonRec f $ mkTyApps (Var name) $ map mkTyVarTy as) y
+    | (as, Let (Rec [(f, Lam v y)]) (Var f')) <- collectBinders x, f == f'
+    = convertBind2 env $ NonRec name $ mkLams as $ Lam v $ Let (NonRec f $ mkVarApps (Var name) as) y
     | otherwise
     = withRange (convNameLoc name) $ do
     x' <- convertExpr env x

--- a/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
@@ -1,0 +1,28 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- @INFO range=12:1-13:21; Use foldl
+-- @INFO range=16:1-17:17; Use foldl
+-- @INFO range=20:1-21:17; Use foldl
+daml 1.2
+module ConstrainedRecursion where
+
+import DA.Assert
+
+sumInferred z (x :: xs) = sumInferred (z + x) xs
+sumInferred z [] = z
+
+sumPoly : Additive a => a -> [a] -> a
+sumPoly z (x :: xs) = sumPoly (z + x) xs
+sumPoly z [] = z
+
+sumMono : Int -> [Int] -> Int
+sumMono z (x :: xs) = sumMono (z + x) xs
+sumMono z [] = z
+
+test = scenario do
+    sumInferred 0 [1, 2, 3] === 6
+    sumInferred 0.0 [1.0, 2.0, 3.0] === 6.0
+    sumPoly 0 [1, 2, 3] === 6
+    sumPoly 0.0 [1.0, 2.0, 3.0] === 6.0
+    sumMono 0 [1, 2, 3] === 6

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -276,6 +276,7 @@ readFileAnns file = do
             ("UNTIL-LF", x) -> Just $ UntilLF $ fromJust $ LF.parseVersion $ trim x
             ("ERROR",x) -> Just (DiagnosticFields (DSeverity DsError : parseFields x))
             ("WARN",x) -> Just (DiagnosticFields (DSeverity DsWarning : parseFields x))
+            ("INFO",x) -> Just (DiagnosticFields (DSeverity DsInfo : parseFields x))
             ("QUERY-LF", x) -> Just $ QueryLF x
             ("TODO",x) -> Just $ Todo x
             _ -> error $ "Can't understand test annotation in " ++ show file ++ ", got " ++ show x


### PR DESCRIPTION
Currently, recursive top level functions whose type is boundedly polymorphic
require a type annotation to make it through the conversion to DAML-LF.

This PR changes the conversion slightly such that a type annotation is n o
longer required.

This fixes #2669.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2684)
<!-- Reviewable:end -->
