### PR TITLE
Fix damlc manifest writer

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -117,6 +117,7 @@ da_haskell_library(
         "tasty",
         "temporary",
         "text",
+        "utf8-string",
         "vector",
         "xml",
         "yaml",

--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -28,6 +28,7 @@ da_haskell_library(
         "text",
         "time",
         "transformers",
+        "utf8-string",
         "zip",
     ],
     src_strip_prefix = "src",


### PR DESCRIPTION
Previously, we didn’t broke at 72 chars instead of 72 bytes and we did
not take the newline character into account.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
