### PR TITLE
Extend release readme with intructions for manual testing comment

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -82,4 +82,6 @@
    for all releases since the last public release, convert them to
    markdown and insert them in the textbox, then uncheck the `This is
    a pre-release` checkbox at the bottom.
+1. Leave a comment like "All manual tests have passed" on the release PR on
+   GitHub.
 1. Finally, announce the release in the relevant Slack channels.


### PR DESCRIPTION
Add a step to the release process readme such that people leave a comment
like "All manual tests have passed" on the release PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2691)
<!-- Reviewable:end -->
