### PR TITLE
Add a new operator for integer division and deprecate the Fractional instance

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -14,6 +14,7 @@ module GHC.Num
   , Signed (..)
   , Number (..)
   , (%)
+  , div
   ) where
 
 import GHC.Base
@@ -32,7 +33,7 @@ infixl 6 +
 infixl 7 *
 infixr 8 ^
 infixl 7 /
-infixl 7 %
+infixl 7 %, `div`
 
 -- | Use the `Additive` class for types that can be added.
 -- Instances have to respect the following laws:
@@ -121,7 +122,7 @@ instance Multiplicative Decimal where
         | n == 0 = 1.0
         | n == 2 = x * x
         | n < 0 = 1.0 / x ^ (negate n)
-        | n % 2 == 0 = (x ^ (n / 2)) ^ 2
+        | n % 2 == 0 = (x ^ (n `div` 2)) ^ 2
         | otherwise = x * x ^ (n - 1)
 
 instance Number Decimal where
@@ -153,6 +154,10 @@ instance Fractional Int where
     (/) = primitive @"BEDivInt64"
     recip x = 1 / x
 
--- | `x % y` calculates the remainder of `x` by `y`
+-- | `x `div` y` returns the quotient of dividing `x` by `y`.
+div : Int -> Int -> Int
+div = primitive @"BEDivInt64"
+
+-- | `x % y` calculates the remainder of dividing `x` by `y`.
 (%) : Int -> Int -> Int
 (%) = primitive @"BEModInt64"

--- a/compiler/damlc/daml-stdlib-src/DA/Date.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Date.daml
@@ -46,24 +46,24 @@ fromGregorian (year, month, day) = date year month day
 toGregorian : Date -> (Int, Month, Int)
 toGregorian date =
   let a = dateToDaysSinceEpoch date + 2472632
-      b = (4 * a + 3) / 146097
-      c = a - (b * 146097) / 4
-      d = (4 * c + 3) / 1461
-      e = c - (1461 * d) / 4
-      m = (5 * e + 2) / 153
-      year = b * 100 + d - 4800 + m / 10
-      mth = m + 3 - 12 * (m / 10)
-      day = e - (153 * m + 2) / 5 + 1
+      b = (4 * a + 3) `div` 146097
+      c = a - (b * 146097) `div` 4
+      d = (4 * c + 3) `div` 1461
+      e = c - (1461 * d) `div` 4
+      m = (5 * e + 2) `div` 153
+      year = b * 100 + d - 4800 + m `div` 10
+      mth = m + 3 - 12 * (m `div` 10)
+      day = e - (153 * m + 2) `div` 5 + 1
    in (year, toEnum $ mth - 1, day)
 
 -- | Given the three values (year, month, day), constructs a `Date` value.
 -- `date (y, m, d)` turns the year `y`, month `m`, and day `d` into a `Date` value.
 date : Int -> Month -> Int -> Date
 date year month day =
-  let a = (14 - (fromMonth month)) / 12
+  let a = (14 - (fromMonth month)) `div` 12
       y = year + 4800 - a
       m = (fromMonth month) + 12 * a - 3
-      date = day + (153 * m + 2) / 5 + y * 365 + y / 4 - y / 100 + y / 400 - 2472633
+      date = day + (153 * m + 2) `div` 5 + y * 365 + y `div` 4 - y `div` 100 + y `div` 400 - 2472633
       ml = monthDayCount year month
   in daysSinceEpochToDate date
   -- assert day >= 1 && ml >= day
@@ -123,7 +123,7 @@ datetime year month day h m s = time (date year month day) h m s
 -- yesterday if retrieved when the market opens in say Singapore.
 toDateUTC : Time -> Date
 toDateUTC t =
-  daysSinceEpochToDate $ (/ microsecondsPerDay) $ timeToMicrosecondsSinceEpoch t
+  daysSinceEpochToDate $ (`div` microsecondsPerDay) $ timeToMicrosecondsSinceEpoch t
 
 -- | Within a `scenario`, pass the simulated scenario to given date.
 passToDate : Date -> Scenario Time

--- a/compiler/damlc/daml-stdlib-src/DA/Time.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Time.daml
@@ -45,7 +45,7 @@ subTime d1 d2 =
 
 -- | Returns the number of whole days in a time offset. Fraction of time is rounded towards zero.
 wholeDays : RelTime -> Int
-wholeDays (RelTime rt) = rt / microsecondsPerDay
+wholeDays (RelTime rt) = rt `div` microsecondsPerDay
 
 -- | A number of days in relative time.
 days : Int -> RelTime

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,3 +13,7 @@ HEAD — ongoing
   file to be a pointer to the source directory of the DAML code contained in a project relative to
   the project root. This is breaking projects, where the ``source`` field of the project is pointing
   to a non-toplevel location in the source code directory structure.
++ [DAML Standard Library] Add a new ``div`` operator for integer
+  division. The ``Fractional`` instance of ``Int`` and thereby using
+  ``/`` on ``Int`` is deprecated and the instance will be removed in
+  SDK 0.13.25.


### PR DESCRIPTION
Sadly, we cannot attach deprecation warnings to instances, see
https://gitlab.haskell.org/ghc/ghc/issues/12014.

The name is taken from Haskell. I don’t care too much about the
specific name but `div` makes it at least more obvious what it does
than something like Python’s `//` to people that have never seen it
before.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
