### PR TITLE
Remove libffi hack from ghc-lib

### DIFF
--- a/3rdparty/haskell/BUILD.ghc-lib-parser
+++ b/3rdparty/haskell/BUILD.ghc-lib-parser
@@ -32,7 +32,7 @@ haskell_library(
     hazel_library("process"),
     hazel_library("hpc"),
     "ghc-lib-parser-cbits"
-  ] + ([hazel_library("Win32")] if is_windows else ["@libffi_nix//:ffi", hazel_library("unix")]),
+  ] + ([hazel_library("Win32")] if is_windows else [hazel_library("unix")]),
   compiler_flags = [
     "-XHaskell2010",
     "-XNoImplicitPrelude",
@@ -58,7 +58,7 @@ haskell_library(
 cc_library(
   name = "ghc-lib-parser-cbits",
   visibility = ["//visibility:public"],
-  deps = ["@haskell_rts//:lib"] + ([hazel_library("Win32")] if is_windows else ["@libffi_nix//:ffi", hazel_cbits("unix"), hazel_library("unix")]) + [
+  deps = ["@haskell_rts//:lib"] + ([hazel_library("Win32")] if is_windows else [hazel_cbits("unix"), hazel_library("unix")]) + [
     hazel_cbits("ghc-prim"),
     hazel_cbits("base"),
     hazel_cbits("containers"),

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -541,7 +541,6 @@ hazel_repositories(
         hazel_default_extra_libs,
         {
             "z": "@com_github_madler_zlib//:z",
-            "ffi": "" if is_windows else "@libffi_nix//:ffi",
             "bz2": "@bzip2//:bz2",
         },
     ),
@@ -685,28 +684,6 @@ nixpkgs_package(
         visibility = ["//visibility:public"],
     )
     """,
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
-)
-
-nixpkgs_package(
-    name = "libffi_nix",
-    attribute_path = "libffi.dev",
-    build_file_content = """
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "include",
-    srcs = glob(["include/**/*.h"]),
-)
-
-cc_library(
-    name = "ffi",
-    hdrs = [":include"],
-    strip_include_prefix = "include",
-)
-""",
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,

--- a/bazel_tools/ghc-lib-no-ffi.patch
+++ b/bazel_tools/ghc-lib-no-ffi.patch
@@ -1,0 +1,8 @@
+--- a/ghc-lib.cabal	2019-08-30 09:14:05.199708631 +0200
++++ b/ghc-lib.cabal	2019-08-30 09:14:13.923814400 +0200
+@@ -652,5 +652,3 @@
+         X86.Ppr
+         X86.RegInfo
+         X86.Regs
+-    extra-libraries:
+-        ffi

--- a/bazel_tools/ghci-template.sh
+++ b/bazel_tools/ghci-template.sh
@@ -4,5 +4,6 @@
 
 ENV_FILE=$1
 ARGS_FILE=$2
+RULES_HASKELL_EXEC_ROOT=$(dirname $(readlink ${BUILD_WORKSPACE_DIRECTORY}/bazel-out))/
 echo "{ENV}" > "$ENV_FILE"
 echo "{ARGS}" > "$ARGS_FILE"

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -15,7 +15,6 @@ let shared = rec {
     imagemagick
     jdk8
     jq
-    libffi
     nodejs
     patchelf
     postgresql

--- a/nix/ghc.nix
+++ b/nix/ghc.nix
@@ -49,6 +49,7 @@ let
     inherit (pkgs) buildLlvmPackages;
     enableIntegerSimple = true;
     enableRelocatedStaticLibs = true;
+    libffi = null;
   };
 
   packages = pkgs.callPackage "${toString pkgs.path}/pkgs/development/haskell-modules" {

--- a/util.bzl
+++ b/util.bzl
@@ -23,6 +23,8 @@ def hazel_ghclibs(version, shaParser, shaLibrary):
                 "url": "https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-" + version + ".tar.gz",
                 "stripPrefix": "ghc-lib-" + version,
                 "sha256": shaLibrary,
+                "patches": ["@com_github_digital_asset_daml//bazel_tools:ghc-lib-no-ffi.patch"],
+                "patch_args": ["-p1"],
             },
         ),
     ]


### PR DESCRIPTION
We currently use a custom cabal file for ghc-lib that has libffi in
the extra-libraries section so Hazel adds the headers. Forcing GHC to
use the bundled libffi should hopefully remove the need for this hack
which simplifies things.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
