### PR TITLE
make release step idempotent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,25 +210,32 @@ jobs:
         persistCredentials: true
       - bash: |
           set -euxo pipefail
-          git tag v$(cat VERSION)
-          git push origin v$(cat VERSION)
-          mkdir $(Build.StagingDirectory)/release
+          if git tag v$(cat VERSION); then
+            git push origin v$(cat VERSION)
+            mkdir $(Build.StagingDirectory)/release
+          else
+            echo "##vso[task.setvariable variable=skip-github]TRUE"
+          fi
       - task: DownloadPipelineArtifact@0
         inputs:
           artifactName: $(artifact-linux)
           targetPath: $(Build.StagingDirectory)/release
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - task: DownloadPipelineArtifact@0
         inputs:
           artifactName: $(artifact-macos)
           targetPath: $(Build.StagingDirectory)/release
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - task: DownloadPipelineArtifact@0
         inputs:
           artifactName: $(artifact-windows)
           targetPath: $(Build.StagingDirectory)/release
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - task: DownloadPipelineArtifact@0
         inputs:
           artifactName: $(artifact-windows-installer)
           targetPath: $(Build.StagingDirectory)/release
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - task: GitHubRelease@0
         inputs:
           gitHubConnection: 'garyverhaegen-da'
@@ -240,6 +247,7 @@ jobs:
           assetUploadMode: 'replace'
           addChangeLog: false
           isPrerelease: true
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 


### PR DESCRIPTION
At the moment, if we try to run the build of a release commit after it
has succeeded, the `git tag` step fails. We do not normally try to
rebuild old commits that had succeeded, but sometimes Azure gets
confused when we ask for rerunning specific jobs within a build, and
reruns the whole build.

This creates two (small, bubt annoying) problems:
1. It adds noise to the #team-daml channel as it notifies of the build
failure, and
2. It marks the commit as failed with a red cross on the github list of
commits, which obviously doesn't look great for release commits.

This fixes that. Note that if a release does fail after the `git tag`
step (e.g. some network error between Azure and GitHub), this **does
not** change the necessary steps to remediate, as that situation would
already be broken in the current setup. (Steps to remediate would
essentially boil down to deleting the tag on GitHub before rerunning so
the build can create it again.)