### PR TITLE
Add Numeric literals in daml-lf-ast and daml-lf-proto.

### DIFF
--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel_tools:haskell.bzl", "da_haskell_library")
+load("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
 
 da_haskell_library(
     name = "daml-lf-ast",
@@ -26,6 +26,23 @@ da_haskell_library(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        "//libs-haskell/da-hs-base",
+    ],
+)
+
+da_haskell_test(
+    name = "tests",
+    srcs = glob(["test/**/*.hs"]),
+    hazel_deps = [
+        "base",
+        "tasty",
+        "tasty-hunit",
+    ],
+    main_function = "DA.Daml.LF.Ast.Tests.main",
+    src_strip_prefix = "test",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":daml-lf-ast",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_library(
         "base",
         "containers",
         "deepseq",
+        "Decimal",
         "extra",
         "hashable",
         "lens",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -24,7 +24,8 @@ import Data.Fixed
 import qualified "template-haskell" Language.Haskell.TH as TH
 import qualified Control.Lens.TH as Lens.TH
 
-import           DA.Daml.LF.Ast.Version
+import DA.Daml.LF.Ast.Version
+import DA.Daml.LF.Ast.Numeric
 
 infixr 1 `KArrow`
 
@@ -198,7 +199,7 @@ data BuiltinExpr
   -- Literals
   = BEInt64      !Int64          -- :: Int64
   | BEDecimal    !(Fixed E10)    -- :: Decimal, precision 38, scale 10
-  -- TODO (#2289): add numeric literals
+  | BENumeric    !Numeric        -- :: Numeric, precision 38, scale 0 through 37
   | BEText       !T.Text         -- :: Text
   | BETimestamp  !Int64          -- :: Timestamp, microseconds since unix epoch
   | BEParty      !PartyLiteral   -- :: Party

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -6,6 +6,7 @@ module DA.Daml.LF.Ast.Numeric
     ( Numeric
     , numeric
     , numericScale
+    , numericMaxScale
     ) where
 
 import Control.DeepSeq

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -1,0 +1,83 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Numeric literals, with scale attached.
+module DA.Daml.LF.Ast.Numeric
+    ( Numeric
+    , numeric
+    , numericScale
+    ) where
+
+import Numeric.Natural
+
+import Data.Data
+import Data.Decimal
+import Control.DeepSeq
+import GHC.Generics(Generic)
+
+-- | Numeric literal. This must encode both the mantissa (up to 38 digits) and
+-- the scale (0-37), the latter controlling how many digits appear after the
+-- decimal point. Furthermore, when reading or writing a numeric instance,
+-- we need to show every significant digit after the decimal point, in order
+-- to preserve the scale. For scale 0, the decimal point needs to be shown
+-- without a digit.
+--
+-- Internally we use Data.Decimal to represent these because it has the ability
+-- to encode every Numeric alongside its scale, and it mostly does what we want
+-- with Show and Read, with a few adjustments:
+--
+-- * we perform bounds checks with smart constructor 'numeric'
+-- * for scale 0, we have to add the decimal point in the Show instance
+-- * when reading, we check numeric bounds for scale and mantissa
+-- * we add Data, NFData, Generic instances
+-- * we don't add Num instances (for now anyway)
+--
+newtype Numeric = Numeric { numericDecimal :: Decimal }
+  deriving (Eq, Ord, Generic)
+
+-- | Smart constructor for Numeric literals.
+numeric :: Natural -> Integer -> Numeric
+numeric s m
+    | s > numericMaxScale = error "numeric error: scale too large"
+    | m > numericMaxMantissa = error "numeric error: mantissa too large"
+    | otherwise = Numeric $ Decimal (fromIntegral s) m
+
+-- | Upper bound for numeric scale (inclusive).
+numericMaxScale :: Natural
+numericMaxScale = 37
+
+-- | Upper bound for numeric mantissa (inclusive).
+numericMaxMantissa :: Integer
+numericMaxMantissa = 10^(38::Int)-1
+
+-- | Get scale associated with numeric literal. This is the
+-- number of decimal places after the decimal point. Ranges
+-- between 0 and 'numericMaxScale' (inclusive).
+numericScale :: Numeric -> Natural
+numericScale = fromIntegral . decimalPlaces . numericDecimal
+
+-- | Get mantissa associated with numeric literal. This is
+-- the raw integer value of the numeric before adding the
+-- decimal point. Ranges between 0 and 'numericMaxMantissa'
+-- (inclusive).
+numericMantissa :: Numeric -> Integer
+numericMantissa = decimalMantissa . numericDecimal
+
+instance Show Numeric where
+    showsPrec p n
+        | numericScale n == 0 = shows (numericDecimal n) . ("." ++)
+        | otherwise = showsPrec p (numericDecimal n)
+
+instance Data Numeric where
+    gfoldl k z n = z numeric `k` numericScale n `k` numericMantissa n
+    gunfold k z _ = k (k (z numeric))
+    dataTypeOf _ = tyNumeric
+    toConstr _ = conNumeric
+
+tyNumeric :: DataType
+tyNumeric = mkDataType "DA.Daml.LF.Ast.Numeric.Numeric" [conNumeric]
+
+conNumeric :: Constr
+conNumeric = mkConstr tyNumeric "numeric" ["numericScale", "numericMantissa"] Prefix
+
+instance NFData Numeric

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -19,10 +19,10 @@ import Numeric.Natural
 
 -- | Numeric literal. This must encode both the mantissa (up to 38 digits) and
 -- the scale (0-37), the latter controlling how many digits appear after the
--- decimal point. Furthermore, when reading or writing a numeric instance,
+-- decimal point. Furthermore, when reading or writing a Numeric value,
 -- we need to show every significant digit after the decimal point, in order
 -- to preserve the scale. For scale 0, the decimal point needs to be shown
--- without a digit.
+-- without any following digits.
 --
 -- Internally we use Data.Decimal to represent these because it has the ability
 -- to encode every Numeric alongside its scale, and it mostly does what we want

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -10,10 +10,11 @@ module DA.Daml.LF.Ast.Numeric
 
 import Numeric.Natural
 
+import Control.Arrow (first)
+import Control.DeepSeq
 import Data.Data
 import Data.Decimal
-import Control.DeepSeq
-import GHC.Generics(Generic)
+import GHC.Generics (Generic)
 
 -- | Numeric literal. This must encode both the mantissa (up to 38 digits) and
 -- the scale (0-37), the latter controlling how many digits appear after the
@@ -81,3 +82,13 @@ conNumeric :: Constr
 conNumeric = mkConstr tyNumeric "numeric" ["numericScale", "numericMantissa"] Prefix
 
 instance NFData Numeric
+
+instance Read Numeric where
+    readsPrec p = filter (numericValid . fst) . map (first Numeric) . readsPrec p
+
+-- | Check Numeric is valid. Any Numeric constructed from outside this
+-- module should already satisfy this, but just in case.
+numericValid :: Numeric -> Bool
+numericValid n =
+    numericScale n <= numericMaxScale
+    && numericMantissa n <= numericMaxMantissa

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -185,6 +185,7 @@ instance Pretty BuiltinExpr where
   pPrintPrec lvl prec = \case
     BEInt64 n -> pretty (toInteger n)
     BEDecimal dec -> string (show dec)
+    BENumeric n -> string (show n)
     BEText t -> string (show t) -- includes the double quotes, and escapes characters
     BEParty p -> pretty p
     BEUnit -> keyword_ "unit"

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -1,4 +1,6 @@
-module DA.Daml.LF.Ast.Tests where
+module DA.Daml.LF.Ast.Tests
+    ( main
+    ) where
 
 import Data.Foldable
 import Text.Read

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Daml.LF.Ast.Tests
     ( main
     ) where

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -1,0 +1,36 @@
+module DA.Daml.LF.Ast.Tests where
+
+import Data.Foldable
+import Text.Read
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import DA.Daml.LF.Ast.Numeric
+
+main :: IO ()
+main = defaultMain $ testGroup "DA.Daml.LF.Ast"
+    [ numericTests
+    ]
+
+numericExamples :: [(String, Numeric)]
+numericExamples =
+    [ ("0.", numeric 0 0)
+    , ("42.", numeric 0 42)
+    , ("-100.", numeric 0 (-100))
+    , ("100.00", numeric 2 10000)
+    , ("123.45", numeric 2 12345)
+    , ("1.0000", numeric 4 10000)
+    , ("1.2345", numeric 4 12345)
+    , ("0." ++ replicate 32 '0' ++ "54321", numeric 37 54321)
+    , ("-9." ++ replicate 37 '9', numeric 37 (1 - 10^(38::Int)))
+    ]
+
+numericTests :: TestTree
+numericTests = testGroup "Numeric"
+    [ testCase "show" $ do
+        for_ numericExamples $ \(str,num) -> do
+            assertEqual "show produced wrong string" str (show num)
+    , testCase "read" $ do
+        for_ numericExamples $ \(str,num) -> do
+            assertEqual "read produced wrong numeric or failed" (Just num) (readMaybe str)
+    ]

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -494,9 +494,9 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumDecimal sDec -> case readMaybe (TL.unpack sDec) of
     Nothing -> throwError $ ParseError ("bad fixed while decoding Decimal: '" <> TL.unpack sDec <> "'")
     Just dec -> return (BEDecimal dec)
-    -- FixMe: https://github.com/digital-asset/daml/issues/2289
-    --  should handle numerics
-  LF1.PrimLitSumNumeric _ -> throwError (ParseError "Numeric not supported")
+  LF1.PrimLitSumNumeric sNum -> case readMaybe (TL.unpack sNum) of
+    Nothing -> throwError $ ParseError ("bad Numeric literal: '" <> TL.unpack sNum <> "'")
+    Just n -> return (BENumeric n)
   LF1.PrimLitSumTimestamp sTime -> pure $ BETimestamp sTime
   LF1.PrimLitSumText x           -> pure $ BEText $ TL.toStrict x
   LF1.PrimLitSumParty p          -> pure $ BEParty $ PartyLiteral $ TL.toStrict p

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -199,6 +199,7 @@ encodeBuiltinExpr :: BuiltinExpr -> P.ExprSum
 encodeBuiltinExpr = \case
     BEInt64 x -> lit $ P.PrimLitSumInt64 x
     BEDecimal dec -> lit $ P.PrimLitSumDecimal (TL.pack (show dec))
+    BENumeric n -> lit $ P.PrimLitSumNumeric (TL.pack (show n))
     BEText x -> lit $ P.PrimLitSumText (TL.fromStrict x)
     BETimestamp x -> lit $ P.PrimLitSumTimestamp x
     BEParty x -> lit $ P.PrimLitSumParty $ TL.fromStrict $ unPartyLiteral x

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -104,6 +104,7 @@ safetyStep = \case
     case b of
       BEInt64 _           -> Safe 0
       BEDecimal _         -> Safe 0
+      BENumeric _         -> Safe 0
       BEText _            -> Safe 0
       BETimestamp _       -> Safe 0
       BEParty _           -> Safe 0

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -43,6 +43,7 @@ import           Safe.Exact (zipExactMay)
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.Ast.Optics (dataConsType)
 import           DA.Daml.LF.Ast.Type
+import           DA.Daml.LF.Ast.Numeric
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
 
@@ -143,6 +144,7 @@ typeOfBuiltin :: MonadGamma m => BuiltinExpr -> m Type
 typeOfBuiltin = \case
   BEInt64 _          -> pure TInt64
   BEDecimal _        -> pure TDecimal
+  BENumeric n        -> pure (TNumeric (TNat (numericScale n)))
   BEText    _        -> pure TText
   BETimestamp _      -> pure TTimestamp
   BEParty   _        -> pure TParty

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -24,6 +24,7 @@ import           Data.Foldable (for_)
 import qualified Data.HashSet as HS
 
 import DA.Daml.LF.Ast
+import DA.Daml.LF.Ast.Numeric (numericMaxScale)
 import DA.Daml.LF.Ast.Optics (_PRSelfModule, dataConsType)
 import DA.Daml.LF.TypeChecker.Env
 import DA.Daml.LF.TypeChecker.Error
@@ -54,13 +55,13 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
       TOptional typ -> go typ
       TMap typ -> go typ
       TNumeric (TNat n)
-          | n <= 38 -> noConditions
+          | n <= numericMaxScale -> noConditions
           | otherwise -> Left (URNumericOutOfRange n)
       TNumeric _ -> Left URNumericNotFixed
           -- We statically enforce bounds check for Numeric type,
-          -- requiring 0 <= n <= 38 for the argument to Numeric.
-          -- If the argument isn't given explicitly, we can't
-          -- guarantee serializability.
+          -- requiring 0 <= n <= 'numericMaxScale' for the argument
+          -- to Numeric. If the argument isn't given explicitly, we
+          -- can't guarantee serializability.
       TNat _ -> noConditions
       TVar v
         | v `HS.member` vars -> noConditions


### PR DESCRIPTION
This PR adds the Numeric literal in daml-lf-ast, encoding/decoding for it in daml-lf-proto, and type checking, etc as part of #2289.

The (soon-to-be-deprecated) Decimal literal was represented with a fixed decimal point number (`Fixed E10`). This doesn't work for Numerics since the whole point is to have a parametrized decimal point number. Numeric literals in DAML-LF carry the scale implicitly (as the number of digits after the decimal point), so we need to both store the value and keep track of the scale.

I tried to find an existing decimal library that would do this for us, and the closest I found was `Data.Decimal`. The module `DA.Daml.LF.Ast.Numeric` implements a `Numeric` type for DAML-LF Numeric literals, based on `Data.Decimal`, with a few adjustments. I added a number of tests to make sure we're handling read/show correctly for Numeric literals.