### PR TITLE
leger-api-test-tool: semantics equality

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
@@ -22,11 +22,16 @@ private[engine] class CommandPreprocessor(compiledPackages: ConcurrentCompiledPa
 
     valueTranslator.translateValue(ty0, v0) match {
       case ResultNeedPackage(pkgId, resume) =>
-        Result.needPackage(compiledPackages, pkgId, x => resume(Some(x)))
+        ResultNeedPackage(
+          pkgId, {
+            case None => ResultError(Error(s"Couldn't find package $pkgId"))
+            case Some(pkg) =>
+              compiledPackages.addPackage(pkgId, pkg).flatMap(_ => resume(Some(pkg)))
+          }
+        )
       case result =>
         result
     }
-
   }
 
   private[engine] def preprocessCreate(

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
@@ -3,299 +3,30 @@
 
 package com.digitalasset.daml.lf.engine
 
-import java.util
-
 import com.digitalasset.daml.lf.command._
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.speedy.{SValue, Command => SpeedyCommand}
-import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value._
 
 import scala.annotation.tailrec
-import scala.collection.immutable.HashMap
-
-private[engine] object CommandPreprocessor {
-  def apply(compiledPackages: ConcurrentCompiledPackages): CommandPreprocessor = {
-    new CommandPreprocessor(compiledPackages)
-  }
-
-  private def ArrayList[X](as: X*): util.ArrayList[X] = {
-    val a = new util.ArrayList[X](as.length)
-    as.foreach(a.add)
-    a
-  }
-
-  // we use this for easier error handling in translateValues
-  private final case class CommandPreprocessingException(err: Error)
-      extends RuntimeException(err.toString, null, true, false)
-
-  private def fail(s: String): Nothing =
-    throw CommandPreprocessingException(Error(s))
-}
 
 private[engine] class CommandPreprocessor(compiledPackages: ConcurrentCompiledPackages) {
 
-  import CommandPreprocessor.{ArrayList, CommandPreprocessingException, fail}
+  private val valueTranslator = new ValueTranslator(compiledPackages)
 
-  // note: all the types in params must be closed.
-  //
-  // this is not tail recursive, but it doesn't really matter, since types are bounded
-  // by what's in the source, which should be short enough...
-  private[this] def replaceParameters(params: ImmArray[(TypeVarName, Type)], typ0: Type): Type =
-    if (params.isEmpty) { // optimization
-      typ0
-    } else {
-      val paramsMap: Map[TypeVarName, Type] = Map(params.toSeq: _*)
-
-      def go(typ: Type): Type =
-        typ match {
-          case TVar(v) =>
-            paramsMap.get(v) match {
-              case None =>
-                fail(s"Got out of bounds type variable $v when replacing parameters")
-              case Some(ty) => ty
-            }
-          case TTyCon(_) | TBuiltin(_) | TNat(_) => typ
-          case TApp(tyfun, arg) => TApp(go(tyfun), go(arg))
-          case forall: TForall =>
-            fail(
-              s"Unexpected forall when replacing parameters in command translation -- all types should be serializable, and foralls are not: $forall")
-          case tuple: TTuple =>
-            fail(
-              s"Unexpected tuple when replacing parameters in command translation -- all types should be serializable, and tuples are not: $tuple")
-        }
-
-      go(typ0)
-    }
-
-  // since we get these values from third-party users of the library, check the recursion limit
-  // here, too.
   private[engine] def translateValue(
       ty0: Type,
       v0: VersionedValue[AbsoluteContractId]): Result[SValue] = {
-    import SValue._
-    import scalaz.std.option._
-    import scalaz.syntax.traverse.ToTraverseOps
 
-    def exceptionToResultError[A](x: => Result[A]): Result[A] =
-      try {
-        x
-      } catch {
-        case CommandPreprocessingException(err) => ResultError(err)
-      }
-
-    def go(nesting: Int, ty: Type, value: Value[AbsoluteContractId]): Result[SValue] = {
-      // we use this to restart when we get a new package that allows us to make progress.
-      def restart = exceptionToResultError(go(nesting, ty, value))
-
-      if (nesting > Value.MAXIMUM_NESTING) {
-        fail(s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}")
-      } else {
-        val newNesting = nesting + 1
-        (ty, value) match {
-          // simple values
-          case (TUnit, ValueUnit) =>
-            ResultDone(SUnit(()))
-          case (TBool, ValueBool(b)) =>
-            ResultDone(SBool(b))
-          case (TInt64, ValueInt64(i)) =>
-            ResultDone(SInt64(i))
-          case (TTimestamp, ValueTimestamp(t)) =>
-            ResultDone(STimestamp(t))
-          case (TDate, ValueDate(t)) =>
-            ResultDone(SDate(t))
-          case (TText, ValueText(t)) =>
-            ResultDone(SText(t))
-          case (TNumeric(TNat(10)), ValueNumeric(d)) =>
-            Numeric.fromBigDecimal(Decimal.scale, d).fold(fail, d => ResultDone(SNumeric(d)))
-          case (TParty, ValueParty(p)) =>
-            ResultDone(SParty(p))
-          case (TContractId(typ), ValueContractId(c)) =>
-            typ match {
-              case TTyCon(_) => ResultDone(SContractId(c))
-              case _ => fail(s"Expected a type constructor but found $typ.")
-            }
-
-          // optional
-          case (TOptional(elemType), ValueOptional(mb)) =>
-            mb.traverseU(go(newNesting, elemType, _)).map(SOptional)
-
-          // list
-          case (TList(elemType), ValueList(ls)) =>
-            ls.toImmArray.traverseU(go(newNesting, elemType, _)).map(es => SList(FrontStack(es)))
-
-          // map
-          case (TMap(elemType), ValueMap(map)) =>
-            map.toImmArray
-              .traverseU {
-                case (key0, value0) => go(newNesting, elemType, value0).map(key0 -> _)
-              }
-              .map(l => SMap(HashMap(l.toSeq: _*)))
-
-          // variants
-          case (TTyConApp(tyCon, tyConArgs), ValueVariant(mbVariantId, constructorName, val0)) =>
-            val variantId = tyCon
-            mbVariantId match {
-              case Some(variantId_) if variantId != variantId_ =>
-                fail(
-                  s"Mismatching variant id, the type tells us $variantId, but the value tells us $variantId_")
-              case _ =>
-                compiledPackages.getPackage(variantId.packageId) match {
-                  // if the package is not there, look it up and restart. stack safe since this will be done
-                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
-                  // would consume stack regardless
-                  case None =>
-                    Result.needPackage(
-                      variantId.packageId,
-                      compiledPackages.addPackage(variantId.packageId, _).flatMap(_ => restart)
-                    )
-                  case Some(pkg) =>
-                    PackageLookup.lookupVariant(pkg, variantId.qualifiedName) match {
-                      case Left(err) => ResultError(err)
-                      case Right((dataTypParams, DataVariant(variants))) =>
-                        variants.find(_._1 == constructorName) match {
-                          case None =>
-                            fail(
-                              s"Couldn't find provided variant constructor $constructorName in variant $variantId")
-                          case Some((_, argTyp)) =>
-                            if (dataTypParams.length != tyConArgs.length) {
-                              sys.error(
-                                "TODO(FM) impossible: type constructor applied to wrong number of parameters, this should never happen on a well-typed package, return better error")
-                            }
-                            val instantiatedArgTyp =
-                              replaceParameters(dataTypParams.map(_._1).zip(tyConArgs), argTyp)
-                            go(newNesting, instantiatedArgTyp, val0).map(
-                              SVariant(tyCon, constructorName, _))
-                        }
-                    }
-                }
-            }
-          // records
-          case (TTyConApp(tyCon, tyConArgs), ValueRecord(mbRecordId, flds)) =>
-            val recordId = tyCon
-            mbRecordId match {
-              case Some(recordId_) if recordId != recordId_ =>
-                fail(
-                  s"Mismatching record id, the type tells us $recordId, but the value tells us $recordId_")
-              case _ =>
-                compiledPackages.getPackage(recordId.packageId) match {
-                  // if the package is not there, look it up and restart. stack safe since this will be done
-                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
-                  // would consume stack regardless
-                  case None =>
-                    Result.needPackage(
-                      recordId.packageId,
-                      compiledPackages.addPackage(recordId.packageId, _).flatMap(_ => restart)
-                    )
-                  case Some(pkg) =>
-                    PackageLookup.lookupRecord(pkg, recordId.qualifiedName) match {
-                      case Left(err) => ResultError(err)
-                      case Right((dataTypParams, DataRecord(recordFlds, _))) =>
-                        // note that we check the number of fields _before_ checking if we can do
-                        // field reordering by looking at the labels. this means that it's forbidden to
-                        // repeat keys even if we provide all the labels, which might be surprising
-                        // since in JavaScript / Scala / most languages (but _not_ JSON, interestingly)
-                        // it's ok to do `{"a": 1, "a": 2}`, where the second occurrence would just win.
-                        if (recordFlds.length != flds.length) {
-                          fail(
-                            s"Expecting ${recordFlds.length} field for record $recordId, but got ${flds.length}")
-                        }
-                        if (dataTypParams.length != tyConArgs.length) {
-                          sys.error(
-                            "TODO(FM) impossible: type constructor applied to wrong number of parameters, this should never happen on a well-typed package, return better error")
-                        }
-                        val params = dataTypParams.map(_._1).zip(tyConArgs)
-                        labeledRecordToMap(flds)
-                          .fold {
-                            recordFlds.zip(flds).traverseU {
-                              case ((lbl, typ), (mbLbl, v)) =>
-                                mbLbl
-                                  .filter(_ != lbl)
-                                  .foreach(lbl_ =>
-                                    fail(
-                                      s"Mismatching record label $lbl_ (expecting $lbl) for record $recordId"))
-                                val replacedTyp = replaceParameters(params, typ)
-                                go(newNesting, replacedTyp, v).map(e => (lbl, e))
-                            }
-                          } { labeledRecords =>
-                            recordFlds.traverseU {
-                              case ((lbl, typ)) =>
-                                labeledRecords
-                                  .get(lbl)
-                                  .fold(fail(s"Missing record label $lbl for record $recordId")) {
-                                    v =>
-                                      val replacedTyp = replaceParameters(params, typ)
-                                      go(newNesting, replacedTyp, v).map(e => (lbl, e))
-                                  }
-                            }
-                          }
-                          .map(
-                            flds =>
-                              SRecord(
-                                tyCon,
-                                Name.Array(flds.map(_._1).toSeq: _*),
-                                ArrayList(flds.map(_._2).toSeq: _*)
-                            ))
-                    }
-                }
-            }
-
-          case (TTyCon(id), ValueEnum(mbId, constructor)) =>
-            mbId match {
-              case Some(id_) if id_ != id =>
-                fail(s"Mismatching enum id, the type tells us $id, but the value tells us $id_")
-              case _ =>
-                compiledPackages.getPackage(id.packageId) match {
-                  // if the package is not there, look it up and restart. stack safe since this will be done
-                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
-                  // would consume stack regardless
-                  case None =>
-                    Result.needPackage(
-                      id.packageId,
-                      compiledPackages.addPackage(id.packageId, _).flatMap(_ => restart)
-                    )
-                  case Some(pkg) =>
-                    PackageLookup.lookupEnum(pkg, id.qualifiedName) match {
-                      case Left(err) => ResultError(err)
-                      case Right(DataEnum(constructors)) =>
-                        if (!constructors.toSeq.contains(constructor))
-                          fail(
-                            s"Couldn't find provided variant constructor $constructor in enum $id")
-                        ResultDone(SEnum(id, constructor))
-
-                    }
-                }
-            }
-
-          // every other pairs of types and values are invalid
-          case (otherType, otherValue) =>
-            fail(s"mismatching type: $otherType and value: $otherValue")
-        }
-      }
+    valueTranslator.translateValue(ty0, v0) match {
+      case ResultNeedPackage(pkgId, resume) =>
+        Result.needPackage(compiledPackages, pkgId, x => resume(Some(x)))
+      case result =>
+        result
     }
 
-    exceptionToResultError(go(0, ty0, v0.value))
-  }
-
-  private[engine] def labeledRecordToMap(
-      fields: ImmArray[(Option[String], Value[AbsoluteContractId])])
-    : Option[Map[String, Value[AbsoluteContractId]]] = {
-    @tailrec
-    def go(
-        fields: ImmArray[(Option[String], Value[AbsoluteContractId])],
-        map: Map[String, Value[AbsoluteContractId]])
-      : Option[Map[String, Value[AbsoluteContractId]]] = {
-      fields match {
-        case ImmArray() => Some(map)
-        case ImmArrayCons((None, _), _) => None
-        case ImmArrayCons((Some(label), value), tail) =>
-          go(tail, map + (label -> value))
-      }
-    }
-    go(fields, Map.empty)
   }
 
   private[engine] def preprocessCreate(

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -45,7 +45,7 @@ import com.digitalasset.daml.lf.speedy.{Command => SpeedyCommand}
   */
 final class Engine {
   private[this] val _compiledPackages = ConcurrentCompiledPackages()
-  private[this] val _commandTranslation = CommandPreprocessor(_compiledPackages)
+  private[this] val _commandTranslation = new CommandPreprocessor(_compiledPackages)
 
   /**
     * Executes commands `cmds` under the authority of `cmds.submitter` and returns one of the following:

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -1,0 +1,287 @@
+package com.digitalasset.daml.lf.engine
+
+import java.util
+
+import com.digitalasset.daml.lf.CompiledPackages
+import com.digitalasset.daml.lf.data.Ref.Name
+import com.digitalasset.daml.lf.data._
+import com.digitalasset.daml.lf.language.Ast._
+import com.digitalasset.daml.lf.language.Util._
+import com.digitalasset.daml.lf.speedy.SValue
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.HashMap
+
+private[engine] object ValueTranslator {
+
+  private def ArrayList[X](as: X*): util.ArrayList[X] = {
+    val a = new util.ArrayList[X](as.length)
+    as.foreach(a.add)
+    a
+  }
+
+  // we use this for easier error handling in translateValues
+  private final case class ValueTranslationException(err: Error)
+      extends RuntimeException(err.toString, null, true, false)
+
+  private def fail(s: String): Nothing =
+    throw ValueTranslationException(Error(s))
+
+}
+
+private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
+
+  import ValueTranslator._
+
+  // note: all the types in params must be closed.
+  //
+  // this is not tail recursive, but it doesn't really matter, since types are bounded
+  // by what's in the source, which should be short enough...
+  private[this] def replaceParameters(params: ImmArray[(TypeVarName, Type)], typ0: Type): Type =
+    if (params.isEmpty) { // optimization
+      typ0
+    } else {
+      val paramsMap: Map[TypeVarName, Type] = Map(params.toSeq: _*)
+
+      def go(typ: Type): Type =
+        typ match {
+          case TVar(v) =>
+            paramsMap.get(v) match {
+              case None =>
+                fail(s"Got out of bounds type variable $v when replacing parameters")
+              case Some(ty) => ty
+            }
+          case TTyCon(_) | TBuiltin(_) | TNat(_) => typ
+          case TApp(tyfun, arg) => TApp(go(tyfun), go(arg))
+          case forall: TForall =>
+            fail(
+              s"Unexpected forall when replacing parameters in command translation -- all types should be serializable, and foralls are not: $forall")
+          case tuple: TTuple =>
+            fail(
+              s"Unexpected tuple when replacing parameters in command translation -- all types should be serializable, and tuples are not: $tuple")
+        }
+
+      go(typ0)
+    }
+
+  private[this] def labeledRecordToMap(
+      fields: ImmArray[(Option[String], Value[AbsoluteContractId])])
+    : Option[Map[String, Value[AbsoluteContractId]]] = {
+    @tailrec
+    def go(
+        fields: ImmArray[(Option[String], Value[AbsoluteContractId])],
+        map: Map[String, Value[AbsoluteContractId]])
+      : Option[Map[String, Value[AbsoluteContractId]]] = {
+      fields match {
+        case ImmArray() => Some(map)
+        case ImmArrayCons((None, _), _) => None
+        case ImmArrayCons((Some(label), value), tail) =>
+          go(tail, map + (label -> value))
+      }
+    }
+    go(fields, Map.empty)
+  }
+
+  // since we get these values from third-party users of the library, check the recursion limit
+  // here, too.
+  private[engine] def translateValue(
+      ty0: Type,
+      v0: VersionedValue[AbsoluteContractId]): Result[SValue] = {
+    import SValue._
+    import scalaz.std.option._
+    import scalaz.syntax.traverse.ToTraverseOps
+
+    def exceptionToResultError[A](x: => Result[A]): Result[A] =
+      try {
+        x
+      } catch {
+        case ValueTranslationException(err) => ResultError(err)
+      }
+
+    def go(nesting: Int, ty: Type, value: Value[AbsoluteContractId]): Result[SValue] = {
+      // we use this to restart when we get a new package that allows us to make progress.
+      def restart = exceptionToResultError(go(nesting, ty, value))
+
+      if (nesting > Value.MAXIMUM_NESTING) {
+        fail(s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}")
+      } else {
+        val newNesting = nesting + 1
+        (ty, value) match {
+          // simple values
+          case (TUnit, ValueUnit) =>
+            ResultDone(SUnit(()))
+          case (TBool, ValueBool(b)) =>
+            ResultDone(SBool(b))
+          case (TInt64, ValueInt64(i)) =>
+            ResultDone(SInt64(i))
+          case (TTimestamp, ValueTimestamp(t)) =>
+            ResultDone(STimestamp(t))
+          case (TDate, ValueDate(t)) =>
+            ResultDone(SDate(t))
+          case (TText, ValueText(t)) =>
+            ResultDone(SText(t))
+          case (TNumeric(TNat(10)), ValueNumeric(d)) =>
+            Numeric.fromBigDecimal(Decimal.scale, d).fold(fail, d => ResultDone(SNumeric(d)))
+          case (TParty, ValueParty(p)) =>
+            ResultDone(SParty(p))
+          case (TContractId(typ), ValueContractId(c)) =>
+            typ match {
+              case TTyCon(_) => ResultDone(SContractId(c))
+              case _ => fail(s"Expected a type constructor but found $typ.")
+            }
+
+          // optional
+          case (TOptional(elemType), ValueOptional(mb)) =>
+            mb.traverseU(go(newNesting, elemType, _)).map(SOptional)
+
+          // list
+          case (TList(elemType), ValueList(ls)) =>
+            ls.toImmArray.traverseU(go(newNesting, elemType, _)).map(es => SList(FrontStack(es)))
+
+          // map
+          case (TMap(elemType), ValueMap(map)) =>
+            map.toImmArray
+              .traverseU {
+                case (key0, value0) => go(newNesting, elemType, value0).map(key0 -> _)
+              }
+              .map(l => SMap(HashMap(l.toSeq: _*)))
+
+          // variants
+          case (TTyConApp(tyCon, tyConArgs), ValueVariant(mbVariantId, constructorName, val0)) =>
+            val variantId = tyCon
+            mbVariantId match {
+              case Some(variantId_) if variantId != variantId_ =>
+                fail(
+                  s"Mismatching variant id, the type tells us $variantId, but the value tells us $variantId_")
+              case _ =>
+                compiledPackages.getPackage(variantId.packageId) match {
+                  // if the package is not there, look it up and restart. stack safe since this will be done
+                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
+                  // would consume stack regardless
+                  case None =>
+                    Result.needPackage(variantId.packageId, _ => restart)
+                  case Some(pkg) =>
+                    PackageLookup.lookupVariant(pkg, variantId.qualifiedName) match {
+                      case Left(err) => ResultError(err)
+                      case Right((dataTypParams, DataVariant(variants))) =>
+                        variants.find(_._1 == constructorName) match {
+                          case None =>
+                            fail(
+                              s"Couldn't find provided variant constructor $constructorName in variant $variantId")
+                          case Some((_, argTyp)) =>
+                            if (dataTypParams.length != tyConArgs.length) {
+                              sys.error(
+                                "TODO(FM) impossible: type constructor applied to wrong number of parameters, this should never happen on a well-typed package, return better error")
+                            }
+                            val instantiatedArgTyp =
+                              replaceParameters(dataTypParams.map(_._1).zip(tyConArgs), argTyp)
+                            go(newNesting, instantiatedArgTyp, val0).map(
+                              SVariant(tyCon, constructorName, _))
+                        }
+                    }
+                }
+            }
+          // records
+          case (TTyConApp(tyCon, tyConArgs), ValueRecord(mbRecordId, flds)) =>
+            val recordId = tyCon
+            mbRecordId match {
+              case Some(recordId_) if recordId != recordId_ =>
+                fail(
+                  s"Mismatching record id, the type tells us $recordId, but the value tells us $recordId_")
+              case _ =>
+                compiledPackages.getPackage(recordId.packageId) match {
+                  // if the package is not there, look it up and restart. stack safe since this will be done
+                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
+                  // would consume stack regardless
+                  case None =>
+                    Result.needPackage(recordId.packageId, _ => restart)
+                  case Some(pkg) =>
+                    PackageLookup.lookupRecord(pkg, recordId.qualifiedName) match {
+                      case Left(err) => ResultError(err)
+                      case Right((dataTypParams, DataRecord(recordFlds, _))) =>
+                        // note that we check the number of fields _before_ checking if we can do
+                        // field reordering by looking at the labels. this means that it's forbidden to
+                        // repeat keys even if we provide all the labels, which might be surprising
+                        // since in JavaScript / Scala / most languages (but _not_ JSON, interestingly)
+                        // it's ok to do `{"a": 1, "a": 2}`, where the second occurrence would just win.
+                        if (recordFlds.length != flds.length) {
+                          fail(
+                            s"Expecting ${recordFlds.length} field for record $recordId, but got ${flds.length}")
+                        }
+                        if (dataTypParams.length != tyConArgs.length) {
+                          sys.error(
+                            "TODO(FM) impossible: type constructor applied to wrong number of parameters, this should never happen on a well-typed package, return better error")
+                        }
+                        val params = dataTypParams.map(_._1).zip(tyConArgs)
+                        labeledRecordToMap(flds)
+                          .fold {
+                            recordFlds.zip(flds).traverseU {
+                              case ((lbl, typ), (mbLbl, v)) =>
+                                mbLbl
+                                  .filter(_ != lbl)
+                                  .foreach(lbl_ =>
+                                    fail(
+                                      s"Mismatching record label $lbl_ (expecting $lbl) for record $recordId"))
+                                val replacedTyp = replaceParameters(params, typ)
+                                go(newNesting, replacedTyp, v).map(e => (lbl, e))
+                            }
+                          } { labeledRecords =>
+                            recordFlds.traverseU {
+                              case ((lbl, typ)) =>
+                                labeledRecords
+                                  .get(lbl)
+                                  .fold(fail(s"Missing record label $lbl for record $recordId")) {
+                                    v =>
+                                      val replacedTyp = replaceParameters(params, typ)
+                                      go(newNesting, replacedTyp, v).map(e => (lbl, e))
+                                  }
+                            }
+                          }
+                          .map(
+                            flds =>
+                              SRecord(
+                                tyCon,
+                                Name.Array(flds.map(_._1).toSeq: _*),
+                                ArrayList(flds.map(_._2).toSeq: _*)
+                            ))
+                    }
+                }
+            }
+
+          case (TTyCon(id), ValueEnum(mbId, constructor)) =>
+            mbId match {
+              case Some(id_) if id_ != id =>
+                fail(s"Mismatching enum id, the type tells us $id, but the value tells us $id_")
+              case _ =>
+                compiledPackages.getPackage(id.packageId) match {
+                  // if the package is not there, look it up and restart. stack safe since this will be done
+                  // very few times as the cache gets warm. this is also why we do not use the `Result.needDataType`, which
+                  // would consume stack regardless
+                  case None =>
+                    Result.needPackage(id.packageId, _ => restart)
+                  case Some(pkg) =>
+                    PackageLookup.lookupEnum(pkg, id.qualifiedName) match {
+                      case Left(err) => ResultError(err)
+                      case Right(DataEnum(constructors)) =>
+                        if (!constructors.toSeq.contains(constructor))
+                          fail(
+                            s"Couldn't find provided variant constructor $constructor in enum $id")
+                        ResultDone(SEnum(id, constructor))
+
+                    }
+                }
+            }
+
+          // every other pairs of types and values are invalid
+          case (otherType, otherValue) =>
+            fail(s"mismatching type: $otherType and value: $otherValue")
+        }
+      }
+    }
+
+    exceptionToResultError(go(0, ty0, v0.value))
+  }
+
+}

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.daml.lf.engine
 
 import java.util

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -79,7 +79,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
 
     val compiledPackage = ConcurrentCompiledPackages()
     assert(compiledPackage.addPackage(pkgId, pkg) == ResultDone(()))
-    val preprocessor = CommandPreprocessor(compiledPackage)
+    val preprocessor = new CommandPreprocessor(compiledPackage)
     import preprocessor.translateValue
     val valueVersion = ValueVersion("last")
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -121,7 +121,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
   // TODO make these two per-test, so that we make sure not to pollute the package cache and other possibly mutable stuff
   val engine = Engine()
-  val commandTranslator = CommandPreprocessor(ConcurrentCompiledPackages())
+  val commandTranslator = new CommandPreprocessor(ConcurrentCompiledPackages())
 
   "valid data variant identifier" should {
     "found and return the argument types" in {
@@ -407,7 +407,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val (optionalPkgId, optionalPkg @ _, allOptionalPackages) =
         loadPackage("daml-lf/tests/Optional.dar")
 
-      val translator = CommandPreprocessor(ConcurrentCompiledPackages.apply())
+      val translator = new CommandPreprocessor(ConcurrentCompiledPackages.apply())
 
       val id = Identifier(optionalPkgId, "Optional:Rec")
       val someValue = assertAsVersionedValue(
@@ -433,7 +433,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "returns correct error when resuming" in {
-      val translator = CommandPreprocessor(ConcurrentCompiledPackages.apply())
+      val translator = new CommandPreprocessor(ConcurrentCompiledPackages.apply())
       val id = Identifier(basicTestsPkgId, "BasicTests:MyRec")
       val wrongRecord = assertAsVersionedValue(
         ValueRecord(Some(id), ImmArray(Some[Name]("wrongLbl") -> ValueText("foo"))))

--- a/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticsEquality.scala
+++ b/daml-lf/testing-tools/src/main/scala/com/digitalasset/daml/lf/engine/testing/SemanticsEquality.scala
@@ -1,0 +1,143 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine
+package testing
+
+import com.digitalasset.daml.lf.CompiledPackages
+import com.digitalasset.daml.lf.data.Ref.Identifier
+import com.digitalasset.daml.lf.language.Ast
+import com.digitalasset.daml.lf.transaction.Node.KeyWithMaintainers
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
+
+class SemanticsEquality(compiledPackages: CompiledPackages) {
+
+  type Value = VersionedValue[AbsoluteContractId]
+
+  private def getDef(id: Identifier) =
+    for {
+      pkg <- compiledPackages.getPackage(id.packageId)
+      mod <- pkg.modules.get(id.qualifiedName.module)
+      dfn <- mod.definitions.get(id.qualifiedName.name)
+    } yield dfn
+
+  private def getTemplate(id: Identifier) =
+    getDef(id).flatMap {
+      case Ast.DDataType(_, _, Ast.DataRecord(_, Some(template))) => Some(template)
+      case _ => None
+    }
+
+  private val valueTranslator = new ValueTranslator(compiledPackages)
+
+  private def assertDone[X](r: Result[X]) = r match {
+    case ResultDone(x) => x
+    case err => sys.error(s"unexpected failure: $err")
+  }
+
+  def equalValue(
+      typ: Ast.Type,
+      v1: Value,
+      v2: Value
+  ): Boolean =
+    assertDone(valueTranslator.translateValue(typ, v1)) == assertDone(
+      valueTranslator.translateValue(typ, v2))
+
+  private def equalKey(
+      typ: Option[Ast.TemplateKey],
+      v1: Option[KeyWithMaintainers[Value]],
+      v2: Option[KeyWithMaintainers[Value]],
+  ): Boolean =
+    (typ, v1, v2) match {
+      case (None, None, None) => true
+      case (Some(t), Some(x1), Some(x2)) =>
+        equalValue(t.typ, x1.key, x2.key) && x1.maintainers == x2.maintainers
+      case _ => false
+    }
+
+  private def equalResult(
+      typ: Ast.Type,
+      v1: Option[Value],
+      v2: Option[Value]
+  ) =
+    (v1, v2) match {
+      case (None, None) => true
+      case (Some(x1), Some(x2)) => equalValue(typ, x1, x2)
+      case _ => false
+    }
+
+  def equalEvent[Nid](
+      e1: Event[Nid, AbsoluteContractId, Value],
+      e2: Event[Nid, AbsoluteContractId, Value]): Boolean =
+    (e1, e2) match {
+      case ( //
+          CreateEvent(
+            contractId1,
+            templateId1,
+            contractKey1,
+            argument1,
+            agreementText1,
+            signatories1,
+            observers1,
+            witnesses1
+          ),
+          CreateEvent(
+            contractId2,
+            templateId2,
+            contractKey2,
+            argument2,
+            agreementText2,
+            signatories2,
+            observers2,
+            witnesses2) //
+          ) =>
+        val keyTyp = getTemplate(templateId1).get.key
+
+        contractId1 == contractId2 &&
+        templateId1 == templateId2 &&
+        equalKey(keyTyp, contractKey1, contractKey2)
+        equalValue(Ast.TTyCon(templateId1), argument1, argument2) &&
+        agreementText1 == agreementText2
+        signatories1 == signatories2 &&
+        observers1 == observers2 &&
+        witnesses1 == witnesses2
+      case ( //
+          ExerciseEvent(
+            contractId1,
+            templateId1,
+            choice1,
+            choiceArgument1,
+            actingParties1,
+            isConsuming1,
+            children1,
+            stakeholders1,
+            witnesses1,
+            exerciseResult1),
+          ExerciseEvent(
+            contractId2,
+            templateId2,
+            choice2,
+            choiceArgument2,
+            actingParties2,
+            isConsuming2,
+            children2,
+            stakeholders2,
+            witnesses2,
+            exerciseResult2) //
+          ) =>
+        val choice = getTemplate(templateId1).get.choices(choice1)
+
+        contractId1 == contractId2 &&
+        templateId1 == templateId2 &&
+        choice1 == choice2 &&
+        equalValue(choice.argBinder._2, choiceArgument1, choiceArgument2) &&
+        actingParties1 == actingParties2 &&
+        isConsuming1 == isConsuming2 &&
+        children1 == children2 &&
+        stakeholders1 == stakeholders2 &&
+        witnesses1 == witnesses2 &&
+        equalResult(choice.returnType, exerciseResult1, exerciseResult2)
+
+      case _ => false
+    }
+
+}


### PR DESCRIPTION
In this PR we compare events in the ledger api test tool using a "semantics" equality. 

This makes test more resilient to the noise in the encoding of  the leger API value. 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
