### PR TITLE
Make sure ActiveContractService sends out a consistent snapshot

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.platform.sandbox.stores.ledger.sql
 
 import akka.NotUsed

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
@@ -1,0 +1,89 @@
+package com.digitalasset.platform.sandbox.stores.ledger.sql
+
+import akka.NotUsed
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import com.daml.ledger.participant.state.index.v2
+import com.digitalasset.daml.lf.archive.Decode
+import com.digitalasset.daml.lf.data.Ref.{PackageId, TransactionIdString}
+import com.digitalasset.daml.lf.language.Ast
+import com.digitalasset.daml.lf.transaction.Node
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml_lf.DamlLf
+import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.api.domain.LedgerId
+import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
+import com.digitalasset.platform.akkastreams.dispatcher.SubSource.RangeSource
+import com.digitalasset.platform.common.util.DirectExecutionContext
+import com.digitalasset.platform.sandbox.stores.ActiveContracts
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.LedgerReadDao
+import com.digitalasset.platform.sandbox.stores.ledger.{LedgerEntry, LedgerSnapshot, ReadOnlyLedger}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: LedgerReadDao)(
+    implicit mat: Materializer)
+    extends ReadOnlyLedger {
+
+  implicit private val DEC: ExecutionContext = DirectExecutionContext
+
+  protected final val dispatcher: Dispatcher[Long, LedgerEntry] = Dispatcher[Long, LedgerEntry](
+    RangeSource(ledgerDao.getLedgerEntries(_, _)),
+    0l,
+    headAtInitialization
+  )
+
+  override def lookupKey(key: Node.GlobalKey): Future[Option[AbsoluteContractId]] =
+    ledgerDao.lookupKey(key)
+
+  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
+    dispatcher.startingAt(offset.getOrElse(0))
+
+  override def ledgerEnd: Long = dispatcher.getHead()
+
+  override def snapshot(): Future[LedgerSnapshot] =
+    // instead of looking up the latest ledger end, we can only take the latest known ledgerEnd in the scope of SqlLedger.
+    // If we don't do that, we can miss contracts from a partially inserted batch insert of ledger entries
+    // scenario:
+    // 1. batch insert transactions A and B at offsets 5 and 6 respectively; A is a huge transaction, B is a small transaction
+    // 2. B is inserted earlier than A and the ledger_end column in the parameters table is updated
+    // 3. A GetActiveContractsRequest comes in and we look at the latest ledger_end offset in the database. We will see 6 (from transaction B).
+    // 4. If we finish streaming the active contracts up to offset 6 before transaction A is properly inserted into the DB, the client will not see the contracts from transaction A
+    // The fix to that is to use the latest known headRef, which is updated AFTER a batch has been inserted completely.
+    //TODO (robert): SQL DAO does not know about ActiveContract, this method does a (trivial) mapping from DAO Contract to Ledger ActiveContract. Intended? The DAO layer was introduced its own Contract abstraction so it can also reason read archived ones if it's needed. In hindsight, this might be necessary at all  so we could probably collapse the two
+    ledgerDao
+      .getActiveContractSnapshot(ledgerEnd)
+      .map(s => LedgerSnapshot(s.offset, s.acs.map(c => (c.contractId, c.toActiveContract))))(DEC)
+
+  override def lookupContract(
+      contractId: AbsoluteContractId): Future[Option[ActiveContracts.ActiveContract]] =
+    ledgerDao
+      .lookupActiveContract(contractId)
+      .map(_.map(c => c.toActiveContract))(DEC)
+
+  override def lookupTransaction(
+      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =
+    ledgerDao
+      .lookupTransaction(transactionId)
+
+  override def parties: Future[List[domain.PartyDetails]] =
+    ledgerDao.getParties
+
+  override def listLfPackages(): Future[Map[PackageId, v2.PackageDetails]] =
+    ledgerDao.listLfPackages
+
+  override def getLfArchive(packageId: PackageId): Future[Option[DamlLf.Archive]] =
+    ledgerDao.getLfArchive(packageId)
+
+  override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
+    ledgerDao
+      .getLfArchive(packageId)
+      .flatMap(archiveO =>
+        Future.fromTry(Try(archiveO.map(archive => Decode.decodeArchive(archive)._2))))(DEC)
+
+  override def close(): Unit = {
+    dispatcher.close()
+    ledgerDao.close()
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
@@ -166,7 +166,8 @@ trait LedgerReadDao extends AutoCloseable {
     *
     * @param mat the Akka stream materializer to be used for the contract stream.
     */
-  def getActiveContractSnapshot()(implicit mat: Materializer): Future[LedgerSnapshot]
+  def getActiveContractSnapshot(untilExclusive: LedgerOffset)(
+      implicit mat: Materializer): Future[LedgerSnapshot]
 
   /** Returns a list of all known parties. */
   def getParties: Future[List[PartyDetails]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
@@ -45,8 +45,9 @@ private class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, mm: MetricsManager)
   override def lookupKey(key: Node.GlobalKey): Future[Option[Value.AbsoluteContractId]] =
     mm.timedFuture("LedgerDao:lookupKey", ledgerDao.lookupKey(key))
 
-  override def getActiveContractSnapshot()(implicit mat: Materializer): Future[LedgerSnapshot] =
-    ledgerDao.getActiveContractSnapshot()
+  override def getActiveContractSnapshot(untilExclusive: LedgerOffset)(
+      implicit mat: Materializer): Future[LedgerSnapshot] =
+    ledgerDao.getActiveContractSnapshot(untilExclusive)
 
   override def getLedgerEntries(
       startInclusive: LedgerOffset,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/PostgresDaoSpec.scala
@@ -490,11 +490,11 @@ class PostgresDaoSpec
       // The resulting snapshot should contain N-1 contracts
       for {
         startingOffset <- ledgerDao.lookupLedgerEnd()
-        startingSnapshot <- ledgerDao.getActiveContractSnapshot()
+        startingSnapshot <- ledgerDao.getActiveContractSnapshot(startingOffset)
         _ <- runSequentially(N, _ => storeCreateTransaction())
         _ <- storeExerciseTransaction(AbsoluteContractId(s"cId$startingOffset"))
         snapshotOffset <- ledgerDao.lookupLedgerEnd()
-        snapshot <- ledgerDao.getActiveContractSnapshot()
+        snapshot <- ledgerDao.getActiveContractSnapshot(snapshotOffset)
         _ <- runSequentially(M, _ => storeCreateTransaction())
         endingOffset <- ledgerDao.lookupLedgerEnd()
         startingSnapshotSize <- startingSnapshot.acs.map(_ => 1).runWith(sumSink)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,3 +20,5 @@ HEAD — ongoing
 + [DAML Compiler] **BREAKING CHANGE** Enable the language extension ``MonoLocalBinds`` by default. ``let`` and ``where`` bindings introducing polymorphic functions that are used at different types now need an explicit type annotation. Without the type annotation the type of the first use site will be inferred and use sites at different types will fail with a type mismatch error.
 + [Ledger] H2 Database support in the Ledger API Server.
 + [Ledger Api] *BREAKING CHANGE** In Protobuf ``Value`` message, rename ``decimal` field to ``numeric``.
++ [Sandbox] Fixed a bug that could lead to an inconsistent snapshot of active contracts being served
+  by the ActiveContractsService under high load.


### PR DESCRIPTION
instead of looking up the latest ledger end, we can only take the latest known ledgerEnd in the scope of SqlLedger.
If we don't do that, we can miss contracts from a partially inserted batch insert of ledger entries
scenario:
1. batch insert transactions A and B at offsets 5 and 6 respectively; A is a huge transaction, B is a small transaction
2. B is inserted earlier than A and the ledger_end column in the parameters table is updated
3. A GetActiveContractsRequest comes in and we look at the latest ledger_end offset in the database. We will see 6 (from transaction B).
4. If we finish streaming the active contracts up to offset 6 before transaction A is properly inserted into the DB, the client will not see the contracts from transaction A
The fix to that is to use the latest known head to the dispatcher, which is updated AFTER a batch has been inserted completely.

This PR also factors out the basic readonly functionality that is
duplicated between SqlLedger and ReadOnlySqlLedger into a class
BaseLedger.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
