### PR TITLE
Add kvutils envelope

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -5,9 +5,9 @@
 // Protocol buffer messages used by the participant state key-value utilities
 // for implementing a DAML ledger backed by a key-value store.
 //
-// These messages must only be produced and consumed by the methods in
+// These messages should only be produced and consumed by the methods in
 // `KeyValueCommitting`, `KeyValueConsumption` and `KeyValueSubmission` objects.
-// You must not embed these messages in other protocol buffer messages.
+//
 
 syntax = "proto3";
 package com.daml.ledger.participant.state.kvutils;
@@ -21,6 +21,35 @@ import "da/daml_lf.proto";
 import "daml-lf/transaction/src/main/protobuf/transaction.proto";
 import "daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/value.proto";
 
+
+// Envelope with which we wrap all kvutils messages that are sent over the network
+// or persisted on disk. The envelope specifies the kvutils version that defines how
+// a message is decoded and processed. Optionally the message payload may be stored
+// compressed.
+message Envelope {
+  enum MessageKind {
+    SUBMISSION = 0;
+    LOG_ENTRY = 1;
+    STATE_VALUE = 2;
+  }
+
+  enum CompressionSchema {
+    NONE = 0;
+    GZIP = 1;
+  }
+
+  // Kvutils version number
+  int64 version = 1;
+
+  // Kind of message contained within.
+  MessageKind kind = 2;
+
+  // Compression schema, if any, used to compress the message.
+  CompressionSchema compression = 3;
+
+  // The enclosed, potentially compressed, message
+  bytes message = 4;
+}
 
 // A submission to the ledger: a payload and its inputs if any.
 // Produced by [[KeyValueSubmission]].

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+import com.google.protobuf.ByteString
+import scala.util.Try
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
+
+/** Envelope is a wrapping for "top-level" kvutils messages that provides
+  * versioning and compression and should be used when storing or transmitting
+  * kvutils messages.
+  */
+object Envelope {
+
+  sealed trait Message extends Product with Serializable
+
+  final case class SubmissionMessage(submission: Proto.DamlSubmission) extends Message
+
+  final case class LogEntryMessage(logEntry: Proto.DamlLogEntry) extends Message
+
+  final case class StateValueMessage(value: Proto.DamlStateValue) extends Message
+
+  private def enclose(
+      kind: Proto.Envelope.MessageKind,
+      bytes: ByteString,
+      compression: Boolean = true): ByteString =
+    Proto.Envelope.newBuilder
+      .setVersion(Version.version)
+      .setKind(kind)
+      .setMessage(if (compression) compress(bytes) else bytes)
+      .setCompression(
+        if (compression)
+          Proto.Envelope.CompressionSchema.GZIP
+        else
+          Proto.Envelope.CompressionSchema.NONE
+      )
+      .build
+      .toByteString
+
+  def enclose(sub: Proto.DamlSubmission): ByteString = enclose(sub, true)
+  def enclose(sub: Proto.DamlSubmission, compression: Boolean): ByteString =
+    enclose(Proto.Envelope.MessageKind.SUBMISSION, sub.toByteString, compression)
+
+  def enclose(logEntry: Proto.DamlLogEntry): ByteString = enclose(logEntry, true)
+  def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): ByteString =
+    enclose(Proto.Envelope.MessageKind.LOG_ENTRY, logEntry.toByteString, compression)
+
+  def enclose(stateValue: Proto.DamlStateValue): ByteString = enclose(stateValue, true)
+  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): ByteString =
+    enclose(Proto.Envelope.MessageKind.STATE_VALUE, stateValue.toByteString, compression)
+
+  def open(envelopeBytes: ByteString): Either[String, Message] =
+    for {
+      envelope <- Try(Proto.Envelope.parseFrom(envelopeBytes)).toEither.left.map(_.getMessage)
+      _ <- Either.cond(
+        envelope.getVersion == Version.version,
+        (),
+        s"Unsupported version ${envelope.getVersion}")
+      uncompressedMessage <- envelope.getCompression match {
+        case Proto.Envelope.CompressionSchema.GZIP =>
+          Try(decompress(envelope.getMessage)).toEither.left.map(_.getMessage)
+        case Proto.Envelope.CompressionSchema.NONE =>
+          Right(envelope.getMessage)
+        case Proto.Envelope.CompressionSchema.UNRECOGNIZED =>
+          Left(s"Unrecognized compression schema: ${envelope.getCompressionValue}")
+      }
+      message <- envelope.getKind match {
+        case Proto.Envelope.MessageKind.LOG_ENTRY =>
+          Try(Proto.DamlLogEntry.parseFrom(uncompressedMessage)).toEither.left
+            .map(_.getMessage)
+            .right
+            .map(LogEntryMessage)
+        case Proto.Envelope.MessageKind.SUBMISSION =>
+          Try(Proto.DamlSubmission.parseFrom(uncompressedMessage)).toEither.left
+            .map(_.getMessage)
+            .right
+            .map(SubmissionMessage)
+        case Proto.Envelope.MessageKind.STATE_VALUE =>
+          Try(Proto.DamlStateValue.parseFrom(uncompressedMessage)).toEither.left
+            .map(_.getMessage)
+            .right
+            .map(StateValueMessage)
+        case Proto.Envelope.MessageKind.UNRECOGNIZED =>
+          Left(s"Unrecognized message kind: ${envelope.getKind} ")
+      }
+    } yield message
+
+  private def compress(payload: ByteString): ByteString = {
+    val out = ByteString.newOutput
+    val gzipOut = new GZIPOutputStream(out)
+    gzipOut.write(payload.toByteArray)
+    gzipOut.close()
+    out.toByteString
+  }
+
+  private def decompress(payload: ByteString): ByteString = {
+    val gzipIn = new GZIPInputStream(payload.newInput)
+    ByteString.readFrom(gzipIn)
+  }
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -7,6 +7,10 @@ package com.daml.ledger.participant.state.kvutils
   * and the changelog of kvutils.
   *
   * Changes:
+  * [since 100.13.21]:
+  * - Added 'Envelope' for compressing and versioning kvutils messages that are transmitted
+  *   or stored on disk. [[Envelope.enclose]] and [[Envelope.open]] should be now used for
+  *   submissions and for results from processing them.
   *
   * [since 100.13.16]: *BACKWARDS INCOMPATIBLE*
   * - Log entries are no longer used as inputs to submission processing. The
@@ -20,7 +24,5 @@ package com.daml.ledger.participant.state.kvutils
   * - Bug in command deduplication fixed: rejected commands are now deduplicated correctly.
   */
 object Version {
-
-  // FIXME(JM): Introduce versioned messages.
-  // final val protoVersion: Long = 0
+  val version: Long = 0
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/EnvelopeSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/EnvelopeSpec.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
+import org.scalatest.{Matchers, WordSpec}
+
+class EnvelopeSpec extends WordSpec with Matchers {
+  "envelope" should {
+
+    "be able to enclose and open" in {
+      val subm = Proto.DamlSubmission.getDefaultInstance
+
+      Envelope.open(Envelope.enclose(subm)) shouldEqual
+        Right(Envelope.SubmissionMessage(subm))
+
+      val logEntry = Proto.DamlLogEntry.getDefaultInstance
+      Envelope.open(Envelope.enclose(logEntry)) shouldEqual
+        Right(Envelope.LogEntryMessage(logEntry))
+
+      val stateValue = Proto.DamlStateValue.getDefaultInstance
+      Envelope.open(Envelope.enclose(stateValue)) shouldEqual
+        Right(Envelope.StateValueMessage(stateValue))
+    }
+  }
+}


### PR DESCRIPTION
The kvutils envelope is meant to be used whenever a kvutils produced
data is stored and transmitted over the network. It adds both versioning
and compression to the original message.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
