### PR TITLE
langauge: suppress warnings for unrecognised pragams in upgrades

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -733,7 +733,8 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                     "daml build --init-package-db=no" <> " --package " <>
                     escape (show (pkgName1, [(m, m ++ "A") | m <- eqModNamesStr])) <>
                     " --package " <>
-                    escape (show (pkgName2, [(m, m ++ "B") | m <- eqModNamesStr]))
+                    escape (show (pkgName2, [(m, m ++ "B") | m <- eqModNamesStr])) <>
+                    " --ghc-option -Wno-unrecognised-pragmas"
         forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
             [genSrc1, genSrc2] <-
                 forM [(pkgId1, lfPkg1), (pkgId2, lfPkg2)] $ \(pkgId, pkg) -> do


### PR DESCRIPTION
This make the build of upgrade modules a bit more quiet. The warnings
appear because in the generated generic instances there is an
unrecognised {-# NO_OVERLAPP #-} pragma annotation.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
