### PR TITLE
Remove Decimal type and operations from daml-lf-ast

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -4,9 +4,11 @@
 -- | DAML-LF Numeric literals, with scale attached.
 module DA.Daml.LF.Ast.Numeric
     ( Numeric
+    , E10
     , numeric
     , numericScale
     , numericMaxScale
+    , numericFromDecimal
     ) where
 
 import Control.DeepSeq
@@ -16,6 +18,7 @@ import Data.Decimal
 import Data.Maybe
 import GHC.Generics (Generic)
 import Numeric.Natural
+import Data.Fixed
 
 -- | Numeric literal. This must encode both the mantissa (up to 38 digits) and
 -- the scale (0-37), the latter controlling how many digits appear after the
@@ -95,6 +98,15 @@ instance Data Numeric where
     gunfold k z _ = k (k (z numeric))
     dataTypeOf _ = tyNumeric
     toConstr _ = conNumeric
+
+-- | Resolution for legacy Decimal literal.
+data E10
+instance HasResolution E10 where
+  resolution _ = 10000000000 -- 10^-10 resolution
+
+-- | Convert a legacy Decimal literal into a Numeric literal.
+numericFromDecimal :: Fixed E10 -> Numeric
+numericFromDecimal (MkFixed n) = numeric 10 n
 
 tyNumeric :: DataType
 tyNumeric = mkDataType "DA.Daml.LF.Ast.Numeric.Numeric" [conNumeric]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -118,7 +118,6 @@ instance Pretty TypeConApp where
 instance Pretty BuiltinType where
   pPrint = \case
     BTInt64          -> "Int64"
-    BTDecimal        -> "Decimal"
     BTNumeric -> "Numeric"
     BTText           -> "Text"
     BTTimestamp      -> "Timestamp"
@@ -184,7 +183,6 @@ instance Pretty PartyLiteral where
 instance Pretty BuiltinExpr where
   pPrintPrec lvl prec = \case
     BEInt64 n -> pretty (toInteger n)
-    BEDecimal dec -> string (show dec)
     BENumeric n -> string (show n)
     BEText t -> string (show t) -- includes the double quotes, and escapes characters
     BEParty p -> pretty p
@@ -197,11 +195,6 @@ instance Pretty BuiltinExpr where
     BEGreater t   -> maybeParens (prec > precEApp) ("GREATER"    <-> prettyBTyArg lvl t)
     BEGreaterEq t -> maybeParens (prec > precEApp) ("GREATER_EQ" <-> prettyBTyArg lvl t)
     BEToText t    -> maybeParens (prec > precEApp) ("TO_TEXT"    <-> prettyBTyArg lvl t)
-    BEAddDecimal -> "ADD_DECIMAL"
-    BESubDecimal -> "SUB_DECIMAL"
-    BEMulDecimal -> "MUL_DECIMAL"
-    BEDivDecimal -> "DIV_DECIMAL"
-    BERoundDecimal -> "ROUND_DECIMAL"
     BEAddNumeric -> "ADD_NUMERIC"
     BESubNumeric -> "SUB_NUMERIC"
     BEMulNumeric -> "MUL_NUMERIC"
@@ -234,8 +227,6 @@ instance Pretty BuiltinExpr where
     BEAppendText -> "APPEND_TEXT"
     BETimestamp ts -> pretty (timestampToText ts)
     BEDate date -> pretty (dateToText date)
-    BEInt64ToDecimal -> "INT64_TO_DECIMAL"
-    BEDecimalToInt64 -> "DECIMAL_TO_INT64"
     BETimestampToUnixMicroseconds -> "TIMESTAMP_TO_UNIX_MICROSECONDS"
     BEUnixMicrosecondsToTimestamp -> "UNIX_MICROSECONDS_TO_TIMESTAMP"
     BEDateToUnixDays -> "DATE_TO_UNIX_DAYS"
@@ -247,7 +238,6 @@ instance Pretty BuiltinExpr where
     BEEqualContractId -> "EQUAL_CONTRACT_ID"
     BEPartyFromText -> "FROM_TEXT_PARTY"
     BEInt64FromText -> "FROM_TEXT_INT64"
-    BEDecimalFromText -> "FROM_TEXT_DECIMAL"
     BEPartyToQuotedText -> "PARTY_TO_QUOTED_TEXT"
     BETextToCodePoints -> "TEXT_TO_CODE_POINTS"
     BETextFromCodePoints -> "TEXT_FROM_CODE_POINTS"

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -73,6 +73,7 @@ alphaEquiv = go (AlphaEnv 0 Map.empty Map.empty)
             and bs
         where
           agree (l1, t1) (l2, t2) = l1 == l2 && go0 t1 t2
+      (TNat n1, TNat n2) -> n1 == n2
       (_, _) -> False
       where
         go0 = go env0

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -155,7 +155,6 @@ pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow
 pattern TUnit       = TBuiltin BTUnit
 pattern TBool       = TBuiltin BTBool
 pattern TInt64      = TBuiltin BTInt64
-pattern TDecimal    = TBuiltin BTDecimal
 pattern TText       = TBuiltin BTText
 pattern TTimestamp  = TBuiltin BTTimestamp
 pattern TParty      = TBuiltin BTParty
@@ -169,7 +168,9 @@ pattern TMap typ = TApp (TBuiltin BTMap) typ
 pattern TUpdate typ = TApp (TBuiltin BTUpdate) typ
 pattern TScenario typ = TApp (TBuiltin BTScenario) typ
 pattern TContractId typ = TApp (TBuiltin BTContractId) typ
+
 pattern TNumeric n = TApp (TBuiltin BTNumeric) n
+pattern TDecimal = TNumeric (TNat 10)
 
 pattern TMapEntry :: Type -> Type
 pattern TMapEntry a = TTuple [(FieldName "key", TText), (FieldName "value", a)]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -54,6 +54,12 @@ data Feature = Feature
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 
+notSupports :: Version -> Feature -> Bool
+notSupports version feature = not (supports version feature)
+
+featureNumeric :: Feature
+featureNumeric = Feature "Parametrised-scale Numeric type" versionDev
+
 renderMinorVersion :: MinorVersion -> String
 renderMinorVersion = \case
   PointStable minor -> show minor

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -9,8 +9,9 @@ module DA.Daml.LF.Proto3.DecodeV1
     , Error(..)
     ) where
 
-import           DA.Daml.LF.Ast as LF
-import           DA.Daml.LF.Proto3.Error
+import DA.Daml.LF.Ast as LF
+import DA.Daml.LF.Ast.Numeric as LF
+import DA.Daml.LF.Proto3.Error
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(throwError))
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
@@ -164,112 +165,115 @@ decodeChoice LF1.TemplateChoice{..} =
     <*> mayDecode "templateChoiceRetType" templateChoiceRetType decodeType
     <*> mayDecode "templateChoiceUpdate" templateChoiceUpdate decodeExpr
 
-decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m BuiltinExpr
+-- | Decode DAML-LF built-in function. As specified in #2289, the
+-- legacy @Decimal@ built-in functions get converted to @Numeric@
+-- built-in functions with the scale @10@ applied automatically.
+decodeBuiltinFunction :: MonadDecode m => LF1.BuiltinFunction -> m Expr
 decodeBuiltinFunction = pure . \case
-  LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
-  LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
-  LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqualNumeric
-  LF1.BuiltinFunctionEQUAL_TEXT -> BEEqual BTText
-  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> BEEqual BTTimestamp
-  LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
-  LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
-  LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
+  LF1.BuiltinFunctionEQUAL_INT64 -> EBuiltin $ BEEqual BTInt64
+  LF1.BuiltinFunctionEQUAL_DECIMAL -> ETyApp (EBuiltin BEEqualNumeric) (TNat 10)
+  LF1.BuiltinFunctionEQUAL_NUMERIC -> EBuiltin BEEqualNumeric
+  LF1.BuiltinFunctionEQUAL_TEXT -> EBuiltin $ BEEqual BTText
+  LF1.BuiltinFunctionEQUAL_TIMESTAMP -> EBuiltin $ BEEqual BTTimestamp
+  LF1.BuiltinFunctionEQUAL_DATE -> EBuiltin $ BEEqual BTDate
+  LF1.BuiltinFunctionEQUAL_PARTY -> EBuiltin $ BEEqual BTParty
+  LF1.BuiltinFunctionEQUAL_BOOL -> EBuiltin $ BEEqual BTBool
 
-  LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
-  LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal
-  LF1.BuiltinFunctionLEQ_NUMERIC -> BELessEqNumeric
-  LF1.BuiltinFunctionLEQ_TEXT -> BELessEq BTText
-  LF1.BuiltinFunctionLEQ_TIMESTAMP -> BELessEq BTTimestamp
-  LF1.BuiltinFunctionLEQ_DATE -> BELessEq BTDate
-  LF1.BuiltinFunctionLEQ_PARTY -> BELessEq BTParty
+  LF1.BuiltinFunctionLEQ_INT64 -> EBuiltin $ BELessEq BTInt64
+  LF1.BuiltinFunctionLEQ_DECIMAL -> ETyApp (EBuiltin BELessEqNumeric) (TNat 10)
+  LF1.BuiltinFunctionLEQ_NUMERIC -> EBuiltin BELessEqNumeric
+  LF1.BuiltinFunctionLEQ_TEXT -> EBuiltin $ BELessEq BTText
+  LF1.BuiltinFunctionLEQ_TIMESTAMP -> EBuiltin $ BELessEq BTTimestamp
+  LF1.BuiltinFunctionLEQ_DATE -> EBuiltin $ BELessEq BTDate
+  LF1.BuiltinFunctionLEQ_PARTY -> EBuiltin $ BELessEq BTParty
 
-  LF1.BuiltinFunctionLESS_INT64 -> BELess BTInt64
-  LF1.BuiltinFunctionLESS_DECIMAL -> BELess BTDecimal
-  LF1.BuiltinFunctionLESS_NUMERIC -> BELessNumeric
-  LF1.BuiltinFunctionLESS_TEXT -> BELess BTText
-  LF1.BuiltinFunctionLESS_TIMESTAMP -> BELess BTTimestamp
-  LF1.BuiltinFunctionLESS_DATE -> BELess BTDate
-  LF1.BuiltinFunctionLESS_PARTY -> BELess BTParty
+  LF1.BuiltinFunctionLESS_INT64 -> EBuiltin $ BELess BTInt64
+  LF1.BuiltinFunctionLESS_DECIMAL -> ETyApp (EBuiltin BELessNumeric) (TNat 10)
+  LF1.BuiltinFunctionLESS_NUMERIC -> EBuiltin BELessNumeric
+  LF1.BuiltinFunctionLESS_TEXT -> EBuiltin $ BELess BTText
+  LF1.BuiltinFunctionLESS_TIMESTAMP -> EBuiltin $ BELess BTTimestamp
+  LF1.BuiltinFunctionLESS_DATE -> EBuiltin $ BELess BTDate
+  LF1.BuiltinFunctionLESS_PARTY -> EBuiltin $ BELess BTParty
 
-  LF1.BuiltinFunctionGEQ_INT64 -> BEGreaterEq BTInt64
-  LF1.BuiltinFunctionGEQ_DECIMAL -> BEGreaterEq BTDecimal
-  LF1.BuiltinFunctionGEQ_NUMERIC -> BEGreaterEqNumeric
-  LF1.BuiltinFunctionGEQ_TEXT -> BEGreaterEq BTText
-  LF1.BuiltinFunctionGEQ_TIMESTAMP -> BEGreaterEq BTTimestamp
-  LF1.BuiltinFunctionGEQ_DATE -> BEGreaterEq BTDate
-  LF1.BuiltinFunctionGEQ_PARTY -> BEGreaterEq BTParty
+  LF1.BuiltinFunctionGEQ_INT64 -> EBuiltin $ BEGreaterEq BTInt64
+  LF1.BuiltinFunctionGEQ_DECIMAL -> ETyApp (EBuiltin BEGreaterEqNumeric) (TNat 10)
+  LF1.BuiltinFunctionGEQ_NUMERIC -> EBuiltin BEGreaterEqNumeric
+  LF1.BuiltinFunctionGEQ_TEXT -> EBuiltin $ BEGreaterEq BTText
+  LF1.BuiltinFunctionGEQ_TIMESTAMP -> EBuiltin $ BEGreaterEq BTTimestamp
+  LF1.BuiltinFunctionGEQ_DATE -> EBuiltin $ BEGreaterEq BTDate
+  LF1.BuiltinFunctionGEQ_PARTY -> EBuiltin $ BEGreaterEq BTParty
 
-  LF1.BuiltinFunctionGREATER_INT64 -> BEGreater BTInt64
-  LF1.BuiltinFunctionGREATER_DECIMAL -> BEGreater BTDecimal
-  LF1.BuiltinFunctionGREATER_NUMERIC -> BEGreaterNumeric
-  LF1.BuiltinFunctionGREATER_TEXT -> BEGreater BTText
-  LF1.BuiltinFunctionGREATER_TIMESTAMP -> BEGreater BTTimestamp
-  LF1.BuiltinFunctionGREATER_DATE -> BEGreater BTDate
-  LF1.BuiltinFunctionGREATER_PARTY -> BEGreater BTParty
+  LF1.BuiltinFunctionGREATER_INT64 -> EBuiltin $ BEGreater BTInt64
+  LF1.BuiltinFunctionGREATER_DECIMAL -> ETyApp (EBuiltin BEGreaterNumeric) (TNat 10)
+  LF1.BuiltinFunctionGREATER_NUMERIC -> EBuiltin BEGreaterNumeric
+  LF1.BuiltinFunctionGREATER_TEXT -> EBuiltin $ BEGreater BTText
+  LF1.BuiltinFunctionGREATER_TIMESTAMP -> EBuiltin $ BEGreater BTTimestamp
+  LF1.BuiltinFunctionGREATER_DATE -> EBuiltin $ BEGreater BTDate
+  LF1.BuiltinFunctionGREATER_PARTY -> EBuiltin $ BEGreater BTParty
 
-  LF1.BuiltinFunctionTO_TEXT_INT64 -> BEToText BTInt64
-  LF1.BuiltinFunctionTO_TEXT_DECIMAL -> BEToText BTDecimal
-  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> BEToTextNumeric
-  LF1.BuiltinFunctionTO_TEXT_TEXT -> BEToText BTText
-  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP -> BEToText BTTimestamp
-  LF1.BuiltinFunctionTO_TEXT_PARTY -> BEToText BTParty
-  LF1.BuiltinFunctionTO_TEXT_DATE -> BEToText BTDate
-  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
-  LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
-  LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText
-  LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> BEDecimalFromText
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> BENumericFromText
-  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> BETextToCodePoints
-  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> BEPartyToQuotedText
+  LF1.BuiltinFunctionTO_TEXT_INT64 -> EBuiltin $ BEToText BTInt64
+  LF1.BuiltinFunctionTO_TEXT_DECIMAL -> ETyApp (EBuiltin BEToTextNumeric) (TNat 10)
+  LF1.BuiltinFunctionTO_TEXT_NUMERIC -> EBuiltin BEToTextNumeric
+  LF1.BuiltinFunctionTO_TEXT_TEXT -> EBuiltin $ BEToText BTText
+  LF1.BuiltinFunctionTO_TEXT_TIMESTAMP -> EBuiltin $ BEToText BTTimestamp
+  LF1.BuiltinFunctionTO_TEXT_PARTY -> EBuiltin $ BEToText BTParty
+  LF1.BuiltinFunctionTO_TEXT_DATE -> EBuiltin $ BEToText BTDate
+  LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> EBuiltin BETextFromCodePoints
+  LF1.BuiltinFunctionFROM_TEXT_PARTY -> EBuiltin $ BEPartyFromText
+  LF1.BuiltinFunctionFROM_TEXT_INT64 -> EBuiltin $ BEInt64FromText
+  LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> ETyApp (EBuiltin BENumericFromText) (TNat 10)
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> EBuiltin $ BENumericFromText
+  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> EBuiltin $ BETextToCodePoints
+  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> EBuiltin $ BEPartyToQuotedText
 
-  LF1.BuiltinFunctionADD_DECIMAL   -> BEAddDecimal
-  LF1.BuiltinFunctionSUB_DECIMAL   -> BESubDecimal
-  LF1.BuiltinFunctionMUL_DECIMAL   -> BEMulDecimal
-  LF1.BuiltinFunctionDIV_DECIMAL   -> BEDivDecimal
-  LF1.BuiltinFunctionROUND_DECIMAL -> BERoundDecimal
-  LF1.BuiltinFunctionADD_NUMERIC   -> BEAddNumeric
-  LF1.BuiltinFunctionSUB_NUMERIC   -> BESubNumeric
-  LF1.BuiltinFunctionMUL_NUMERIC   -> BEMulNumeric
-  LF1.BuiltinFunctionDIV_NUMERIC   -> BEDivNumeric
-  LF1.BuiltinFunctionROUND_NUMERIC -> BERoundNumeric
+  LF1.BuiltinFunctionADD_DECIMAL   -> ETyApp (EBuiltin BEAddNumeric) (TNat 10)
+  LF1.BuiltinFunctionSUB_DECIMAL   -> ETyApp (EBuiltin BESubNumeric) (TNat 10)
+  LF1.BuiltinFunctionMUL_DECIMAL   -> ETyApp (EBuiltin BEMulNumeric) (TNat 10)
+  LF1.BuiltinFunctionDIV_DECIMAL   -> ETyApp (EBuiltin BEDivNumeric) (TNat 10)
+  LF1.BuiltinFunctionROUND_DECIMAL -> ETyApp (EBuiltin BERoundNumeric) (TNat 10)
+  LF1.BuiltinFunctionADD_NUMERIC   -> EBuiltin BEAddNumeric
+  LF1.BuiltinFunctionSUB_NUMERIC   -> EBuiltin BESubNumeric
+  LF1.BuiltinFunctionMUL_NUMERIC   -> EBuiltin BEMulNumeric
+  LF1.BuiltinFunctionDIV_NUMERIC   -> EBuiltin BEDivNumeric
+  LF1.BuiltinFunctionROUND_NUMERIC -> EBuiltin BERoundNumeric
 
-  LF1.BuiltinFunctionADD_INT64 -> BEAddInt64
-  LF1.BuiltinFunctionSUB_INT64 -> BESubInt64
-  LF1.BuiltinFunctionMUL_INT64 -> BEMulInt64
-  LF1.BuiltinFunctionDIV_INT64 -> BEDivInt64
-  LF1.BuiltinFunctionMOD_INT64 -> BEModInt64
-  LF1.BuiltinFunctionEXP_INT64 -> BEExpInt64
+  LF1.BuiltinFunctionADD_INT64 -> EBuiltin BEAddInt64
+  LF1.BuiltinFunctionSUB_INT64 -> EBuiltin BESubInt64
+  LF1.BuiltinFunctionMUL_INT64 -> EBuiltin BEMulInt64
+  LF1.BuiltinFunctionDIV_INT64 -> EBuiltin BEDivInt64
+  LF1.BuiltinFunctionMOD_INT64 -> EBuiltin BEModInt64
+  LF1.BuiltinFunctionEXP_INT64 -> EBuiltin BEExpInt64
 
-  LF1.BuiltinFunctionFOLDL          -> BEFoldl
-  LF1.BuiltinFunctionFOLDR          -> BEFoldr
-  LF1.BuiltinFunctionEQUAL_LIST     -> BEEqualList
-  LF1.BuiltinFunctionAPPEND_TEXT    -> BEAppendText
-  LF1.BuiltinFunctionERROR          -> BEError
+  LF1.BuiltinFunctionFOLDL          -> EBuiltin BEFoldl
+  LF1.BuiltinFunctionFOLDR          -> EBuiltin BEFoldr
+  LF1.BuiltinFunctionEQUAL_LIST     -> EBuiltin BEEqualList
+  LF1.BuiltinFunctionAPPEND_TEXT    -> EBuiltin BEAppendText
+  LF1.BuiltinFunctionERROR          -> EBuiltin BEError
 
-  LF1.BuiltinFunctionMAP_EMPTY      -> BEMapEmpty
-  LF1.BuiltinFunctionMAP_INSERT     -> BEMapInsert
-  LF1.BuiltinFunctionMAP_LOOKUP     -> BEMapLookup
-  LF1.BuiltinFunctionMAP_DELETE     -> BEMapDelete
-  LF1.BuiltinFunctionMAP_TO_LIST    -> BEMapToList
-  LF1.BuiltinFunctionMAP_SIZE       -> BEMapSize
+  LF1.BuiltinFunctionMAP_EMPTY      -> EBuiltin BEMapEmpty
+  LF1.BuiltinFunctionMAP_INSERT     -> EBuiltin BEMapInsert
+  LF1.BuiltinFunctionMAP_LOOKUP     -> EBuiltin BEMapLookup
+  LF1.BuiltinFunctionMAP_DELETE     -> EBuiltin BEMapDelete
+  LF1.BuiltinFunctionMAP_TO_LIST    -> EBuiltin BEMapToList
+  LF1.BuiltinFunctionMAP_SIZE       -> EBuiltin BEMapSize
 
-  LF1.BuiltinFunctionEXPLODE_TEXT -> BEExplodeText
-  LF1.BuiltinFunctionIMPLODE_TEXT -> BEImplodeText
-  LF1.BuiltinFunctionSHA256_TEXT  -> BESha256Text
+  LF1.BuiltinFunctionEXPLODE_TEXT -> EBuiltin BEExplodeText
+  LF1.BuiltinFunctionIMPLODE_TEXT -> EBuiltin BEImplodeText
+  LF1.BuiltinFunctionSHA256_TEXT  -> EBuiltin BESha256Text
 
-  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> BEDateToUnixDays
-  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> BEUnixDaysToDate
-  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> BETimestampToUnixMicroseconds
-  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> BEUnixMicrosecondsToTimestamp
+  LF1.BuiltinFunctionDATE_TO_UNIX_DAYS -> EBuiltin BEDateToUnixDays
+  LF1.BuiltinFunctionUNIX_DAYS_TO_DATE -> EBuiltin BEUnixDaysToDate
+  LF1.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS -> EBuiltin BETimestampToUnixMicroseconds
+  LF1.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP -> EBuiltin BEUnixMicrosecondsToTimestamp
 
-  LF1.BuiltinFunctionINT64_TO_DECIMAL -> BEInt64ToDecimal
-  LF1.BuiltinFunctionDECIMAL_TO_INT64 -> BEDecimalToInt64
-  LF1.BuiltinFunctionINT64_TO_NUMERIC -> BEInt64ToNumeric
-  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> BENumericToInt64
+  LF1.BuiltinFunctionINT64_TO_DECIMAL -> ETyApp (EBuiltin BEInt64ToNumeric) (TNat 10)
+  LF1.BuiltinFunctionDECIMAL_TO_INT64 -> ETyApp (EBuiltin BENumericToInt64) (TNat 10)
+  LF1.BuiltinFunctionINT64_TO_NUMERIC -> EBuiltin BEInt64ToNumeric
+  LF1.BuiltinFunctionNUMERIC_TO_INT64 -> EBuiltin BENumericToInt64
 
-  LF1.BuiltinFunctionTRACE -> BETrace
-  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
-  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> BECoerceContractId
+  LF1.BuiltinFunctionTRACE -> EBuiltin BETrace
+  LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> EBuiltin BEEqualContractId
+  LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> EBuiltin BECoerceContractId
 
 decodeLocation :: LF1.Location -> DecodeImpl SourceLoc
 decodeLocation (LF1.Location mbModRef mbRange) = do
@@ -289,7 +293,7 @@ decodeExprSum :: Maybe LF1.ExprSum -> DecodeImpl Expr
 decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
   LF1.ExprSumVar var -> EVar <$> decodeName ExprVarName var
   LF1.ExprSumVal val -> EVal <$> decodeValName val
-  LF1.ExprSumBuiltin (Proto.Enumerated (Right bi)) -> EBuiltin <$> decodeBuiltinFunction bi
+  LF1.ExprSumBuiltin (Proto.Enumerated (Right bi)) -> decodeBuiltinFunction bi
   LF1.ExprSumBuiltin (Proto.Enumerated (Left num)) -> throwError (UnknownEnum "ExprSumBuiltin" num)
   LF1.ExprSumPrimCon (Proto.Enumerated (Right con)) -> pure $ EBuiltin $ case con of
     LF1.PrimConCON_UNIT -> BEUnit
@@ -493,7 +497,7 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
   LF1.PrimLitSumInt64 sInt -> pure $ BEInt64 sInt
   LF1.PrimLitSumDecimal sDec -> case readMaybe (TL.unpack sDec) of
     Nothing -> throwError $ ParseError ("bad fixed while decoding Decimal: '" <> TL.unpack sDec <> "'")
-    Just dec -> return (BEDecimal dec)
+    Just dec -> return (BENumeric (numericFromDecimal dec))
   LF1.PrimLitSumNumeric sNum -> case readMaybe (TL.unpack sNum) of
     Nothing -> throwError $ ParseError ("bad Numeric literal: '" <> TL.unpack sNum <> "'")
     Just n -> return (BENumeric n)
@@ -510,24 +514,26 @@ decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
     result <- mayDecode "kind_ArrowResult" mbResult decodeKind
     foldr KArrow result <$> traverse decodeKind (V.toList params)
 
-decodePrim :: LF1.PrimType -> Decode BuiltinType
+-- | Decode DAML-LF Primitive Type. As specified in #2289, the
+-- legacy @Decimal@ type gets converted to @Numeric 10@ automatically.
+decodePrim :: LF1.PrimType -> Decode Type
 decodePrim = pure . \case
-  LF1.PrimTypeINT64 -> BTInt64
-  LF1.PrimTypeDECIMAL -> BTDecimal
-  LF1.PrimTypeNUMERIC -> BTNumeric
-  LF1.PrimTypeTEXT    -> BTText
-  LF1.PrimTypeTIMESTAMP -> BTTimestamp
-  LF1.PrimTypePARTY   -> BTParty
-  LF1.PrimTypeUNIT    -> BTUnit
-  LF1.PrimTypeBOOL    -> BTBool
-  LF1.PrimTypeLIST    -> BTList
-  LF1.PrimTypeUPDATE  -> BTUpdate
-  LF1.PrimTypeSCENARIO -> BTScenario
-  LF1.PrimTypeDATE -> BTDate
-  LF1.PrimTypeCONTRACT_ID -> BTContractId
-  LF1.PrimTypeOPTIONAL -> BTOptional
-  LF1.PrimTypeMAP -> BTMap
-  LF1.PrimTypeARROW -> BTArrow
+  LF1.PrimTypeINT64 -> TBuiltin BTInt64
+  LF1.PrimTypeDECIMAL -> TDecimal
+  LF1.PrimTypeNUMERIC -> TBuiltin BTNumeric
+  LF1.PrimTypeTEXT    -> TBuiltin BTText
+  LF1.PrimTypeTIMESTAMP -> TBuiltin BTTimestamp
+  LF1.PrimTypePARTY   -> TBuiltin BTParty
+  LF1.PrimTypeUNIT    -> TBuiltin BTUnit
+  LF1.PrimTypeBOOL    -> TBuiltin BTBool
+  LF1.PrimTypeLIST    -> TBuiltin BTList
+  LF1.PrimTypeUPDATE  -> TBuiltin BTUpdate
+  LF1.PrimTypeSCENARIO -> TBuiltin BTScenario
+  LF1.PrimTypeDATE -> TBuiltin BTDate
+  LF1.PrimTypeCONTRACT_ID -> TBuiltin BTContractId
+  LF1.PrimTypeOPTIONAL -> TBuiltin BTOptional
+  LF1.PrimTypeMAP -> TBuiltin BTMap
+  LF1.PrimTypeARROW -> TBuiltin BTArrow
 
 decodeType :: LF1.Type -> DecodeImpl Type
 decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
@@ -539,7 +545,7 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do
-    decodeWithArgs args $ TBuiltin <$> (decodeImpl $ decodePrim prim)
+    decodeWithArgs args $ (decodeImpl $ decodePrim prim)
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Left idx)) _args) ->
     throwError (UnknownEnum "Prim" idx)
   LF1.TypeSumFun (LF1.Type_Fun params mbResult) -> do

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -219,12 +219,12 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionTO_TEXT_PARTY -> EBuiltin $ BEToText BTParty
   LF1.BuiltinFunctionTO_TEXT_DATE -> EBuiltin $ BEToText BTDate
   LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> EBuiltin BETextFromCodePoints
-  LF1.BuiltinFunctionFROM_TEXT_PARTY -> EBuiltin $ BEPartyFromText
-  LF1.BuiltinFunctionFROM_TEXT_INT64 -> EBuiltin $ BEInt64FromText
+  LF1.BuiltinFunctionFROM_TEXT_PARTY -> EBuiltin BEPartyFromText
+  LF1.BuiltinFunctionFROM_TEXT_INT64 -> EBuiltin BEInt64FromText
   LF1.BuiltinFunctionFROM_TEXT_DECIMAL -> ETyApp (EBuiltin BENumericFromText) (TNat 10)
-  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> EBuiltin $ BENumericFromText
-  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> EBuiltin $ BETextToCodePoints
-  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> EBuiltin $ BEPartyToQuotedText
+  LF1.BuiltinFunctionFROM_TEXT_NUMERIC -> EBuiltin BENumericFromText
+  LF1.BuiltinFunctionTEXT_TO_CODE_POINTS -> EBuiltin BETextToCodePoints
+  LF1.BuiltinFunctionTO_QUOTED_TEXT_PARTY -> EBuiltin BEPartyToQuotedText
 
   LF1.BuiltinFunctionADD_DECIMAL   -> ETyApp (EBuiltin BEAddNumeric) (TNat 10)
   LF1.BuiltinFunctionSUB_DECIMAL   -> ETyApp (EBuiltin BESubNumeric) (TNat 10)
@@ -545,7 +545,7 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do
-    decodeWithArgs args $ (decodeImpl $ decodePrim prim)
+    decodeWithArgs args . decodeImpl $ decodePrim prim
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Left idx)) _args) ->
     throwError (UnknownEnum "Prim" idx)
   LF1.TypeSumFun (LF1.Type_Fun params mbResult) -> do

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -141,7 +141,6 @@ encodeKind version = P.Kind . Just . \case
 encodeBuiltinType :: Version -> BuiltinType -> P.Enumerated P.PrimType
 encodeBuiltinType _version = P.Enumerated . Right . \case
     BTInt64 -> P.PrimTypeINT64
-    BTDecimal -> P.PrimTypeDECIMAL
     BTText -> P.PrimTypeTEXT
     BTTimestamp -> P.PrimTypeTIMESTAMP
     BTParty -> P.PrimTypePARTY
@@ -198,7 +197,6 @@ encodeTypeConApp encctx@EncodeCtx{..} (TypeConApp tycon args) = Just $ P.Type_Co
 encodeBuiltinExpr :: BuiltinExpr -> P.ExprSum
 encodeBuiltinExpr = \case
     BEInt64 x -> lit $ P.PrimLitSumInt64 x
-    BEDecimal dec -> lit $ P.PrimLitSumDecimal (TL.pack (show dec))
     BENumeric n -> lit $ P.PrimLitSumNumeric (TL.pack (show n))
     BEText x -> lit $ P.PrimLitSumText (TL.fromStrict x)
     BETimestamp x -> lit $ P.PrimLitSumTimestamp x
@@ -212,7 +210,6 @@ encodeBuiltinExpr = \case
 
     BEEqual typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionEQUAL_INT64
-      BTDecimal -> builtin P.BuiltinFunctionEQUAL_DECIMAL
       BTText -> builtin P.BuiltinFunctionEQUAL_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionEQUAL_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionEQUAL_DATE
@@ -222,7 +219,6 @@ encodeBuiltinExpr = \case
 
     BELessEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLEQ_DECIMAL
       BTText -> builtin P.BuiltinFunctionLEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLEQ_DATE
@@ -231,7 +227,6 @@ encodeBuiltinExpr = \case
 
     BELess typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionLESS_INT64
-      BTDecimal -> builtin P.BuiltinFunctionLESS_DECIMAL
       BTText -> builtin P.BuiltinFunctionLESS_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionLESS_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionLESS_DATE
@@ -240,7 +235,6 @@ encodeBuiltinExpr = \case
 
     BEGreaterEq typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGEQ_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGEQ_DECIMAL
       BTText -> builtin P.BuiltinFunctionGEQ_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGEQ_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGEQ_DATE
@@ -249,7 +243,6 @@ encodeBuiltinExpr = \case
 
     BEGreater typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionGREATER_INT64
-      BTDecimal -> builtin P.BuiltinFunctionGREATER_DECIMAL
       BTText -> builtin P.BuiltinFunctionGREATER_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionGREATER_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionGREATER_DATE
@@ -264,7 +257,6 @@ encodeBuiltinExpr = \case
 
     BEToText typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionTO_TEXT_INT64
-      BTDecimal -> builtin P.BuiltinFunctionTO_TEXT_DECIMAL
       BTText -> builtin P.BuiltinFunctionTO_TEXT_TEXT
       BTTimestamp -> builtin P.BuiltinFunctionTO_TEXT_TIMESTAMP
       BTDate -> builtin P.BuiltinFunctionTO_TEXT_DATE
@@ -274,16 +266,9 @@ encodeBuiltinExpr = \case
     BETextFromCodePoints -> builtin P.BuiltinFunctionTEXT_FROM_CODE_POINTS
     BEPartyFromText -> builtin P.BuiltinFunctionFROM_TEXT_PARTY
     BEInt64FromText -> builtin P.BuiltinFunctionFROM_TEXT_INT64
-    BEDecimalFromText-> builtin P.BuiltinFunctionFROM_TEXT_DECIMAL
     BENumericFromText-> builtin P.BuiltinFunctionFROM_TEXT_NUMERIC
     BETextToCodePoints -> builtin P.BuiltinFunctionTEXT_TO_CODE_POINTS
     BEPartyToQuotedText -> builtin P.BuiltinFunctionTO_QUOTED_TEXT_PARTY
-
-    BEAddDecimal -> builtin P.BuiltinFunctionADD_DECIMAL
-    BESubDecimal -> builtin P.BuiltinFunctionSUB_DECIMAL
-    BEMulDecimal -> builtin P.BuiltinFunctionMUL_DECIMAL
-    BEDivDecimal -> builtin P.BuiltinFunctionDIV_DECIMAL
-    BERoundDecimal -> builtin P.BuiltinFunctionROUND_DECIMAL
 
     BEAddNumeric -> builtin P.BuiltinFunctionADD_NUMERIC
     BESubNumeric -> builtin P.BuiltinFunctionSUB_NUMERIC
@@ -297,9 +282,6 @@ encodeBuiltinExpr = \case
     BEDivInt64 -> builtin P.BuiltinFunctionDIV_INT64
     BEModInt64 -> builtin P.BuiltinFunctionMOD_INT64
     BEExpInt64 -> builtin P.BuiltinFunctionEXP_INT64
-
-    BEInt64ToDecimal -> builtin P.BuiltinFunctionINT64_TO_DECIMAL
-    BEDecimalToInt64 -> builtin P.BuiltinFunctionDECIMAL_TO_INT64
 
     BEInt64ToNumeric -> builtin P.BuiltinFunctionINT64_TO_NUMERIC
     BENumericToInt64 -> builtin P.BuiltinFunctionNUMERIC_TO_INT64

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -103,7 +103,6 @@ safetyStep = \case
   EBuiltinF b ->
     case b of
       BEInt64 _           -> Safe 0
-      BEDecimal _         -> Safe 0
       BENumeric _         -> Safe 0
       BEText _            -> Safe 0
       BETimestamp _       -> Safe 0
@@ -119,11 +118,6 @@ safetyStep = \case
       BEGreater _         -> Safe 2
       BEToText _          -> Safe 1
       BETextFromCodePoints  -> Safe 1
-      BEAddDecimal        -> Safe 1
-      BESubDecimal        -> Safe 1
-      BEMulDecimal        -> Safe 1
-      BEDivDecimal        -> Safe 1
-      BERoundDecimal      -> Safe 1
       BEEqualNumeric      -> Safe 2
       BELessNumeric       -> Safe 2
       BELessEqNumeric     -> Safe 2
@@ -144,8 +138,6 @@ safetyStep = \case
       BEDivInt64          -> Safe 1
       BEModInt64          -> Safe 1
       BEExpInt64          -> Safe 1
-      BEInt64ToDecimal    -> Safe 1
-      BEDecimalToInt64    -> Safe 0 -- crash if the decimal doesn't fit
       BEFoldl             -> Safe 2
       BEFoldr             -> Safe 2
       BEMapEmpty          -> Safe 0
@@ -168,7 +160,6 @@ safetyStep = \case
       BEPartyToQuotedText -> Safe 1
       BEPartyFromText -> Safe 1
       BEInt64FromText -> Safe 1
-      BEDecimalFromText -> Safe 1
       BETextToCodePoints -> Safe 1
       BECoerceContractId -> Safe 1
   ERecConF _ fs -> minimum (Safe 0 : map snd fs)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -104,7 +104,6 @@ kindOfDataType = foldr (KArrow . snd) KStar . dataParams
 kindOfBuiltin :: BuiltinType -> Kind
 kindOfBuiltin = \case
   BTInt64 -> KStar
-  BTDecimal -> KStar
   BTNumeric -> KNat `KArrow` KStar
   BTText -> KStar
   BTTimestamp -> KStar
@@ -143,7 +142,6 @@ kindOf = \case
 typeOfBuiltin :: MonadGamma m => BuiltinExpr -> m Type
 typeOfBuiltin = \case
   BEInt64 _          -> pure TInt64
-  BEDecimal _        -> pure TDecimal
   BENumeric n        -> pure (TNumeric (TNat (numericScale n)))
   BEText    _        -> pure TText
   BETimestamp _      -> pure TTimestamp
@@ -162,13 +160,7 @@ typeOfBuiltin = \case
   BEPartyToQuotedText -> pure $ TParty :-> TText
   BEPartyFromText    -> pure $ TText :-> TOptional TParty
   BEInt64FromText    -> pure $ TText :-> TOptional TInt64
-  BEDecimalFromText  -> pure $ TText :-> TOptional TDecimal
   BETextToCodePoints -> pure $ TText :-> TList TInt64
-  BEAddDecimal       -> pure $ tBinop TDecimal
-  BESubDecimal       -> pure $ tBinop TDecimal
-  BEMulDecimal       -> pure $ tBinop TDecimal
-  BEDivDecimal       -> pure $ tBinop TDecimal
-  BERoundDecimal     -> pure $ TInt64 :-> TDecimal :-> TDecimal
   BEEqualNumeric     -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
   BELessNumeric      -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
   BELessEqNumeric    -> pure $ TForall (alpha, KNat) $ TNumeric tAlpha :-> TNumeric tAlpha :-> TBool
@@ -190,8 +182,6 @@ typeOfBuiltin = \case
   BEDivInt64         -> pure $ tBinop TInt64
   BEModInt64         -> pure $ tBinop TInt64
   BEExpInt64         -> pure $ tBinop TInt64
-  BEInt64ToDecimal   -> pure $ TInt64 :-> TDecimal
-  BEDecimalToInt64   -> pure $ TDecimal :-> TInt64
   BEExplodeText      -> pure $ TText :-> TList TText
   BEAppendText       -> pure $ tBinop TText
   BEImplodeText      -> pure $ TList TText :-> TText

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -60,6 +60,7 @@ data UnserializabilityReason
   | URNumeric -- ^ It contains an unapplied Numeric type constructor.
   | URNumericNotFixed
   | URNumericOutOfRange !Natural
+  | URTypeLevelNat
 
 data Error
   = EUnknownTypeVar        !TypeVarName
@@ -162,6 +163,7 @@ instance Pretty UnserializabilityReason where
     URNumeric -> "unapplied Numeric"
     URNumericNotFixed -> "Numeric scale is not fixed"
     URNumericOutOfRange n -> "Numeric scale " <> integer (fromIntegral n) <> " is out of range (needs to be between 0 and 38)"
+    URTypeLevelNat -> "type-level nat"
 
 instance Pretty Error where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -62,7 +62,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
           -- requiring 0 <= n <= 'numericMaxScale' for the argument
           -- to Numeric. If the argument isn't given explicitly, we
           -- can't guarantee serializability.
-      TNat _ -> noConditions
+      TNat _ -> Left URTypeLevelNat
       TVar v
         | v `HS.member` vars -> noConditions
         | otherwise -> Left (URFreeVar v)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -81,7 +81,6 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
       TApp tfun targ -> HS.union <$> go tfun <*> go targ
       TBuiltin builtin -> case builtin of
         BTInt64 -> noConditions
-        BTDecimal -> noConditions
         BTText -> noConditions
         BTTimestamp -> noConditions
         BTDate -> noConditions

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -625,7 +625,7 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
             LF.BTInt64 -> (primUnitId, translateModName intTyCon)
             LF.BTNumeric -> (primUnitId, LF.ModuleName ["GHC", "Types"])
                 -- This is here because of TDecimal, for now.
-                -- TODO (#2898): actually supply a general numeric type in GHC.Types
+                -- TODO (#2289): actually supply a general numeric type in GHC.Types
             LF.BTText -> (primUnitId, LF.ModuleName ["GHC", "Types"])
             LF.BTTimestamp -> (damlStdlibUnitId, LF.ModuleName ["DA", "Internal", "LF"])
             LF.BTDate -> (damlStdlibUnitId, LF.ModuleName ["DA", "Internal", "LF"])

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -94,6 +94,7 @@ import Control.Monad.Fail
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
 import           DA.Daml.LF.Ast as LF
+import           DA.Daml.LF.Ast.Numeric as LF
 import           Data.Data hiding (TyCon)
 import           Data.Foldable (foldlM)
 import           Data.Int
@@ -219,7 +220,7 @@ convertRational num denom
     -- upper limit.
     if | 10 ^ maxPrecision `mod` denom == 0 &&
              abs (r * 10 ^ maxPrecision) <= upperBound128Bit - 1 ->
-           pure $ EBuiltin $ BEDecimal $ fromRational r
+             pure $ EBuiltin $ BENumeric $ numericFromDecimal $ fromRational r
        | otherwise ->
            unsupported
                ("Rational is out of bounds: " ++
@@ -803,7 +804,7 @@ convertExpr env0 e = do
     go env o@(Case scrutinee bind _ [alt@(DataAlt con, vs, x)]) args = fmap (, args) $ do
         convertType env (varType bind) >>= \case
           TText -> asLet
-          TDecimal -> asLet
+          TNumeric _ -> asLet
           TParty -> asLet
           TTimestamp -> asLet
           TDate -> asLet

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -44,6 +44,17 @@ convertPrim _ "SGetParty" (t1@TText :-> TScenario TParty) =
     ETmLam (varV1, t1) $ EScenario $ SGetParty $ EVar varV1
 
 -- Comparison
+convertPrim _ "BEEqual" (TDecimal :-> TDecimal :-> TBool) =
+    ETyApp (EBuiltin BEEqualNumeric) (TNat 10)
+convertPrim _ "BELess" (TDecimal :-> TDecimal :-> TBool) =
+    ETyApp (EBuiltin BELessNumeric) (TNat 10)
+convertPrim _ "BELessEq" (TDecimal :-> TDecimal :-> TBool) =
+    ETyApp (EBuiltin BELessEqNumeric) (TNat 10)
+convertPrim _ "BEGreaterEq" (TDecimal :-> TDecimal :-> TBool) =
+    ETyApp (EBuiltin BEGreaterNumeric) (TNat 10)
+convertPrim _ "BEGreater" (TDecimal :-> TDecimal :-> TBool) =
+    ETyApp (EBuiltin BEGreaterEqNumeric) (TNat 10)
+
 convertPrim _ "BEEqual" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
     EBuiltin $ BEEqual a1
 convertPrim _ "BELess" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
@@ -61,15 +72,15 @@ convertPrim _ "BEEqualContractId" (TContractId a1 :-> TContractId a2 :-> TBool) 
 
 -- Decimal arithmetic
 convertPrim _ "BEAddDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEAddDecimal
+    ETyApp (EBuiltin BEAddNumeric) (TNat 10)
 convertPrim _ "BESubDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BESubDecimal
+    ETyApp (EBuiltin BESubNumeric) (TNat 10)
 convertPrim _ "BEMulDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEMulDecimal
+    ETyApp (EBuiltin BEMulNumeric) (TNat 10)
 convertPrim _ "BEDivDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEDivDecimal
+    ETyApp (EBuiltin BEDivNumeric) (TNat 10)
 convertPrim _ "BERoundDecimal" (TInt64 :-> TDecimal :-> TDecimal) =
-    EBuiltin BERoundDecimal
+    ETyApp (EBuiltin BERoundNumeric) (TNat 10)
 
 -- Integer arithmetic
 convertPrim _ "BEAddInt64" (TInt64 :-> TInt64 :-> TInt64) =
@@ -97,9 +108,9 @@ convertPrim _ "BEUnixDaysToDate" (TInt64 :-> TDate) =
 
 -- Conversion to and from Decimal
 convertPrim _ "BEInt64ToDecimal" (TInt64 :-> TDecimal) =
-    EBuiltin BEInt64ToDecimal
+    ETyApp (EBuiltin BEInt64ToNumeric) (TNat 10)
 convertPrim _ "BEDecimalToInt64" (TDecimal :-> TInt64) =
-    EBuiltin BEDecimalToInt64
+    ETyApp (EBuiltin BENumericToInt64) (TNat 10)
 
 -- List operations
 convertPrim _ "BEFoldl" ((b1 :-> a1 :-> b2) :-> b3 :-> TList a2 :-> b4) | a1 == a2, b1 == b2, b2 == b3, b3 == b4 =
@@ -112,6 +123,8 @@ convertPrim _ "BEError" (TText :-> t2) =
     ETyApp (EBuiltin BEError) t2
 
 -- Text operations
+convertPrim _ "BEToText" (TDecimal :-> TText) =
+    ETyApp (EBuiltin BEToTextNumeric) (TNat 10)
 convertPrim _ "BEToText" (TBuiltin x :-> TText) =
     EBuiltin $ BEToText x
 convertPrim _ "BEExplodeText" (TText :-> TList TText) =
@@ -131,7 +144,7 @@ convertPrim _ "BEPartyFromText" (TText :-> TOptional TParty) =
 convertPrim _ "BEInt64FromText" (TText :-> TOptional TInt64) =
     EBuiltin BEInt64FromText
 convertPrim _ "BEDecimalFromText" (TText :-> TOptional TDecimal) =
-    EBuiltin BEDecimalFromText
+    ETyApp (EBuiltin BENumericFromText) (TNat 10)
 convertPrim _ "BETextToCodePoints" (TText :-> TList TInt64) =
     EBuiltin BETextToCodePoints
 convertPrim _ "BETextFromCodePoints" (TList TInt64 :-> TText) =


### PR DESCRIPTION
This PR removes the `Decimal` type from daml-lf-ast.

When decoding in daml-lf-proto, we convert `Decimal` to `Numeric 10` automatically, and we convert the primitive `Decimal` operations into corresponding `Numeric` operations (applied at scale 10), as specified in #2289.

When converting core to LF, we change the `Decimal` type, literals, and primitives to the corresponding `Numeric 10` type, literals, and primitives. This leaves updating the standard library a separate step.

My guess is that we can only merge this once the decimal->numeric changes are part of an official DAML-LF version? I'm not sure what the process is here.