### PR TITLE
Dispatcher: Provide sub-source in startingAt

### DIFF
--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherTest.scala
@@ -38,7 +38,7 @@ class DispatcherTest extends WordSpec with AkkaBeforeAndAfterAll with Matchers w
 
       // compromise between catching flakes and not taking too long
       0 until 25 foreach { _ =>
-        val d = Dispatcher(OneAfterAnother(readSuccessor, readElement), 0, 0)
+        val d = Dispatcher(0, 0)
         head.set(0)
 
         // Verify that the results are what we expected
@@ -46,7 +46,9 @@ class DispatcherTest extends WordSpec with AkkaBeforeAndAfterAll with Matchers w
           elements.updateAndGet(m => m + (i -> i))
           head.set(i + 1)
           d.signalNewHead(i + 1)
-          d.startingAt(i).toMat(Sink.collection)(Keep.right[NotUsed, Future[Seq[(Int, Int)]]]).run()
+          d.startingAt(i, OneAfterAnother(readSuccessor, readElement))
+            .toMat(Sink.collection)(Keep.right[NotUsed, Future[Seq[(Int, Int)]]])
+            .run()
         }
 
         d.close()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
@@ -43,17 +43,16 @@ private[ledger] class LedgerEntries[T](identify: T => String) {
     newOffset
   }
 
-  private val dispatcher = Dispatcher[Long, T](
-    RangeSource(
-      (inclusiveStart, exclusiveEnd) =>
-        Source[(Long, T)](state.get().items.range(inclusiveStart, exclusiveEnd)),
-    ),
-    ledgerBeginning,
-    ledgerEnd
-  )
+  private val dispatcher = Dispatcher[Long](ledgerBeginning, ledgerEnd)
 
   def getSource(offset: Option[Long]): Source[(Long, T), NotUsed] =
-    dispatcher.startingAt(offset.getOrElse(ledgerBeginning))
+    dispatcher.startingAt(
+      offset.getOrElse(ledgerBeginning),
+      RangeSource(
+        (inclusiveStart, exclusiveEnd) =>
+          Source[(Long, T)](state.get().items.range(inclusiveStart, exclusiveEnd)),
+      )
+    )
 
   def publish(item: T): Long = {
     val newHead = store(item)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
@@ -31,8 +31,7 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
 
   implicit private val DEC: ExecutionContext = DirectExecutionContext
 
-  protected final val dispatcher: Dispatcher[Long, LedgerEntry] = Dispatcher[Long, LedgerEntry](
-    RangeSource(ledgerDao.getLedgerEntries(_, _)),
+  protected final val dispatcher: Dispatcher[Long] = Dispatcher[Long](
     0l,
     headAtInitialization
   )
@@ -41,7 +40,7 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
     ledgerDao.lookupKey(key)
 
   override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
-    dispatcher.startingAt(offset.getOrElse(0))
+    dispatcher.startingAt(offset.getOrElse(0), RangeSource(ledgerDao.getLedgerEntries(_, _)))
 
   override def ledgerEnd: Long = dispatcher.getHead()
 


### PR DESCRIPTION
This allows using the dispatcher in situations where the index is common,
but different data streams are materialized from it.

The practical reason for this is to allow using a single dispatcher to read
from both the ledger_entries and configuration_entries tables, which share
the same ledger offset construction.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
