### PR TITLE
Suggestion: add default dlint.yaml

### DIFF
--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -5,6 +5,7 @@ genrule(
     name = "templates-tarball",
     srcs = glob([
         "default-gitignore",
+        "default-dlint-yaml",
         "skeleton/**",
         "migrate/**",
         "quickstart-java/**",
@@ -24,6 +25,7 @@ genrule(
             mkdir -p $$OUT/$$d
             cp -rL $$SRC/$$d/* $$OUT/$$d/
             cp $$SRC/default-gitignore $$OUT/$$d/.gitignore
+            cp $$SRC/default-dlint-yaml $$OUT/$$d/.dlint.yaml
         done
 
         ## special cases we should work to remove

--- a/templates/default-dlint-yaml
+++ b/templates/default-dlint-yaml
@@ -1,0 +1,8 @@
+# This file controls the behaviour of the dlint linting tool. Below are two
+# examples of how to enable or disable a rule.
+
+# This rule is enabled by default. Uncomment to disable.
+#- ignore: {name: Use fewer imports}
+
+# This rule is disabled by default. Uncomment to enable.
+#- suggest: {name: Use module export list}


### PR DESCRIPTION
While I think we should have some documentation for this on [docs.daml.com](https://docs.daml.com) and ideally some way to query the dlint engine itself (something like `daml dlint --list-rules` maybe?) to get a list of the rules in the current version, I believe another nice way to make our user's life a bit easier is to include a default dlint config file in each template, that lists all of the available rules.

@cocreature @shayne-fletcher-da This is a quick draft based on Slack comments; if the idea seems valid I'm happy to flesh this out to actually list all of the options (though I'll need a quick pointer to where I can find them).