### PR TITLE
Make party and command identifiers unique across runs

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -20,6 +20,17 @@ object LedgerApiTestTool {
 
   private[this] val logger = LoggerFactory.getLogger(getClass.getName.stripSuffix("$"))
 
+  // The suffix that will be appended to all party and command identifiers to ensure
+  // they are unique across test runs (but still somewhat stable within a single test run)
+  // This implementation could fail based on the limitations of System.nanoTime, that you
+  // can read on here: https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--
+  // Still, the only way in which this can fail is if two test runs target the same ledger
+  // with the identifier suffix being computed to the same value, which at the very least
+  // requires this to happen on what is resolved by the JVM as the very same millisecond.
+  // This is very unlikely to fail and allows to easily "date" parties on a ledger used
+  // for testing and compare data related to subsequent runs without any reference
+  private[this] val identifierSuffix = f"${System.nanoTime}%x"
+
   private[this] val uncaughtExceptionErrorMessage =
     "UNEXPECTED UNCAUGHT EXCEPTION ON MAIN THREAD, GATHER THE STACKTRACE AND OPEN A _DETAILED_ TICKET DESCRIBING THE ISSUE HERE: https://github.com/digital-asset/daml/issues/new"
 
@@ -89,10 +100,11 @@ object LedgerApiTestTool {
           config.tlsConfig,
           config.commandSubmissionTtlScaleFactor)),
       testsToRun.values.toVector,
-      config.timeoutScaleFactor
+      config.timeoutScaleFactor,
+      identifierSuffix
     )
 
-    runner.run {
+    runner.verifyRequirementsAndRun {
       case Success(summaries) =>
         new ColorizedPrintStreamReporter(System.out, config.verbose).report(summaries)
         sys.exit(exitCode(summaries, config.mustFail))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -26,11 +26,20 @@ private[testtool] final class LedgerSession private (
 
   private[this] val services: LedgerServices = new LedgerServices(channel)
 
-  private[testtool] def createTestContext(applicationId: String): Future[LedgerTestContext] =
+  private[testtool] def createTestContext(
+      applicationId: String,
+      identifierSuffix: String): Future[LedgerTestContext] =
     for {
       id <- services.identity.getLedgerIdentity(new GetLedgerIdentityRequest).map(_.ledgerId)
       end <- services.transaction.getLedgerEnd(new GetLedgerEndRequest(id)).map(_.getOffset)
-    } yield new LedgerTestContext(id, applicationId, end, services, config.commandTtlFactor)
+    } yield
+      new LedgerTestContext(
+        id,
+        applicationId,
+        identifierSuffix,
+        end,
+        services,
+        config.commandTtlFactor)
 
   private[testtool] def close(): Unit = {
     logger.info(s"Disconnecting from ledger at ${config.host}:${config.port}...")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -78,6 +78,7 @@ object LedgerTestContext {
 private[testtool] final class LedgerTestContext private[infrastructure] (
     val ledgerId: String,
     val applicationId: String,
+    val identifierSuffix: String,
     referenceOffset: LedgerOffset,
     services: LedgerServices,
     commandTtlFactor: Double)(implicit ec: ExecutionContext) {
@@ -96,12 +97,12 @@ private[testtool] final class LedgerTestContext private[infrastructure] (
     timestamp(i.plusSeconds(math.floor(defaultTtlSeconds * commandTtlFactor).toLong))
 
   private[this] val nextPartyHintId: () => String = {
-    val it = Iterator.from(0).map(n => s"$applicationId-party-$n")
+    val it = Iterator.from(0).map(n => s"$applicationId-$identifierSuffix-party-$n")
     () =>
       it.synchronized(it.next())
   }
   private[this] val nextCommandId: () => String = {
-    val it = Iterator.from(0).map(n => s"$applicationId-command-$n")
+    val it = Iterator.from(0).map(n => s"$applicationId-$identifierSuffix-command-$n")
     () =>
       it.synchronized(it.next())
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuiteRunner.{
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future, Promise}
-import scala.util.Try
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 object LedgerTestSuiteRunner {
@@ -138,7 +138,7 @@ final class LedgerTestSuiteRunner(
 
   def verifyRequirementsAndRun(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
     verifyRequirements.fold(
-      throwable => completionCallback(throwable),
+      throwable => completionCallback(Failure(throwable)),
       _ => run(completionCallback)
     )
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -50,7 +50,14 @@ object LedgerTestSuiteRunner {
 final class LedgerTestSuiteRunner(
     endpoints: Vector[LedgerSessionConfiguration],
     suiteConstructors: Vector[LedgerSession => LedgerTestSuite],
-    timeoutScaleFactor: Double) {
+    timeoutScaleFactor: Double,
+    identifierSuffix: String) {
+
+  private[this] val verifyRequirements: Try[Unit] =
+    Try {
+      require(timeoutScaleFactor > 0, "The timeout scale factor must be strictly positive")
+      require(identifierSuffix.nonEmpty, "The identifier suffix cannot be an empty string")
+    }
 
   private def initSessions()(implicit ec: ExecutionContext): Future[Vector[LedgerSession]] =
     Future.sequence(endpoints.map(LedgerSession.getOrCreate))
@@ -66,7 +73,7 @@ final class LedgerTestSuiteRunner(
     val testTimeout = new TestTimeout(execution, test.description, scaledTimeout, session.config)
     val startedTest =
       session
-        .createTestContext(test.shortIdentifier)
+        .createTestContext(test.shortIdentifier, identifierSuffix)
         .flatMap { context =>
           val start = System.nanoTime()
           val result = test(context).map(_ => Duration.ofNanos(System.nanoTime() - start))
@@ -114,12 +121,10 @@ final class LedgerTestSuiteRunner(
       implicit ec: ExecutionContext): Vector[Future[LedgerTestSummary]] =
     suite.tests.map(test => summarize(suite, test, run(test, suite.session)))
 
-  def run(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
-
+  private def run(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
     implicit val ec: ExecutionContextExecutorService =
       ExecutionContext.fromExecutorService(
         Executors.newSingleThreadExecutor(new Thread(_, s"test-tool-dispatcher")))
-
     initSessions()
       .map(initTestSuites)
       .flatMap(suites => Future.sequence(suites.flatMap(run)))
@@ -129,7 +134,13 @@ final class LedgerTestSuiteRunner(
         completionCallback(result)
         ec.shutdown()
       }
+  }
 
+  def verifyRequirementsAndRun(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
+    verifyRequirements.fold(
+      throwable => completionCallback(throwable),
+      _ => run(completionCallback)
+    )
   }
 
 }


### PR DESCRIPTION
Make the command identifiers generated by the test tool unique across runs.

The current implementations uses the result of `System.nanoTime`, which is very unlikely to fail (and if it does, it does so for relatively straightforward reasons) and produces a reasonable amount of noise, while having the nice property of allowing parties to be "dated" on existing ledgers.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
