### PR TITLE
Convert Decimal type, literals, and primitives to Numeric when feature is available.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -190,10 +190,6 @@ data TypeConApp = TypeConApp
   }
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
-data E10
-instance HasResolution E10 where
-  resolution _ = 10000000000 -- 10^-10 resolution
-
 -- | Builtin operation or literal.
 data BuiltinExpr
   -- Literals

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -4,15 +4,18 @@
 -- | DAML-LF Numeric literals, with scale attached.
 module DA.Daml.LF.Ast.Numeric
     ( Numeric
+    , E10
     , numeric
     , numericScale
     , numericMaxScale
+    , numericFromDecimal
     ) where
 
 import Control.DeepSeq
 import Control.Monad
 import Data.Data
 import Data.Decimal
+import Data.Fixed
 import Data.Maybe
 import GHC.Generics (Generic)
 import Numeric.Natural
@@ -65,6 +68,15 @@ numericScale = fromIntegral . decimalPlaces . numericDecimal
 -- (inclusive).
 numericMantissa :: Numeric -> Integer
 numericMantissa = decimalMantissa . numericDecimal
+
+-- | Fixed scale for (legacy) Decimal literals.
+data E10
+instance HasResolution E10 where
+  resolution _ = 10000000000 -- 10^-10 resolution
+
+-- | Convert a decimal literal into a numeric literal.
+numericFromDecimal :: Fixed E10 -> Numeric
+numericFromDecimal (MkFixed n) = numeric 10 n
 
 instance Show Numeric where
     showsPrec p n

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -73,6 +73,7 @@ alphaEquiv = go (AlphaEnv 0 Map.empty Map.empty)
             and bs
         where
           agree (l1, t1) (l2, t2) = l1 == l2 && go0 t1 t2
+      (TNat n1, TNat n2) -> n1 == n2
       (_, _) -> False
       where
         go0 = go env0

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -151,11 +151,12 @@ infixr 1 :->
 pattern (:->) :: Type -> Type -> Type
 pattern a :-> b = TArrow `TApp` a `TApp` b
 
-pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow :: Type
+pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow, TNumeric10 :: Type
 pattern TUnit       = TBuiltin BTUnit
 pattern TBool       = TBuiltin BTBool
 pattern TInt64      = TBuiltin BTInt64
-pattern TDecimal    = TBuiltin BTDecimal
+pattern TDecimal    = TBuiltin BTDecimal -- legacy decimal (LF version <= 1.6)
+pattern TNumeric10  = TNumeric (TNat 10) -- new decimal
 pattern TText       = TBuiltin BTText
 pattern TTimestamp  = TBuiltin BTTimestamp
 pattern TParty      = TBuiltin BTParty

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -27,6 +27,10 @@ version1_5 = V1 $ PointStable 5
 version1_6 :: Version
 version1_6 = V1 $ PointStable 6
 
+-- | DAML-LF version 1.7
+version1_7 :: Version
+version1_7 = versionDev -- Update once 1.7 is out.
+
 -- | The DAML-LF version used by default.
 versionDefault :: Version
 versionDefault = version1_6
@@ -36,7 +40,7 @@ versionDev :: Version
 versionDev = V1 PointDev
 
 supportedOutputVersions :: [Version]
-supportedOutputVersions = [version1_6, versionDev]
+supportedOutputVersions = [version1_6, version1_7, versionDev]
 
 supportedInputVersions :: [Version]
 supportedInputVersions = version1_5 : supportedOutputVersions
@@ -54,7 +58,7 @@ data Feature = Feature
 featureNumeric :: Feature
 featureNumeric = Feature
     { featureName = "Numeric type"
-    , featureMinVersion = versionDev -- TODO (#2289): Update when stabilized.
+    , featureMinVersion = version1_7
     }
 
 supports :: Version -> Feature -> Bool

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -51,6 +51,12 @@ data Feature = Feature
 -- featureTextCodePoints :: Feature
 -- featureTextCodePoints = Feature "Conversion between text and code points" version1_6
 
+featureNumeric :: Feature
+featureNumeric = Feature
+    { featureName = "Numeric type"
+    , featureMinVersion = versionDev -- TODO: Update when stabilized.
+    }
+
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -54,7 +54,7 @@ data Feature = Feature
 featureNumeric :: Feature
 featureNumeric = Feature
     { featureName = "Numeric type"
-    , featureMinVersion = versionDev -- TODO: Update when stabilized.
+    , featureMinVersion = versionDev -- TODO (#2289): Update when stabilized.
     }
 
 supports :: Version -> Feature -> Bool

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -60,6 +60,7 @@ data UnserializabilityReason
   | URNumeric -- ^ It contains an unapplied Numeric type constructor.
   | URNumericNotFixed
   | URNumericOutOfRange !Natural
+  | URTypeLevelNat
 
 data Error
   = EUnknownTypeVar        !TypeVarName
@@ -162,6 +163,7 @@ instance Pretty UnserializabilityReason where
     URNumeric -> "unapplied Numeric"
     URNumericNotFixed -> "Numeric scale is not fixed"
     URNumericOutOfRange n -> "Numeric scale " <> integer (fromIntegral n) <> " is out of range (needs to be between 0 and 38)"
+    URTypeLevelNat -> "type-level nat"
 
 instance Pretty Error where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -62,7 +62,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
           -- requiring 0 <= n <= 'numericMaxScale' for the argument
           -- to Numeric. If the argument isn't given explicitly, we
           -- can't guarantee serializability.
-      TNat _ -> noConditions
+      TNat _ -> Left URTypeLevelNat
       TVar v
         | v `HS.member` vars -> noConditions
         | otherwise -> Left (URFreeVar v)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -804,6 +804,7 @@ convertExpr env0 e = do
         convertType env (varType bind) >>= \case
           TText -> asLet
           TDecimal -> asLet
+          TNumeric _ -> asLet
           TParty -> asLet
           TTimestamp -> asLet
           TDate -> asLet
@@ -1073,7 +1074,10 @@ convertTyCon env t
     | Just m <- nameModule_maybe (getName t), m == gHC_TYPES =
         case getOccText t of
             "Text" -> pure TText
-            "Decimal" -> pure TDecimal
+            "Decimal" ->
+                if envLfVersion env `supports` featureNumeric
+                    then pure (TNumeric (TNat 10))
+                    else pure TDecimal
             _ -> defaultTyCon
     -- TODO(DEL-6953): We need to add a condition on the package name as well.
     | Just m <- nameModule_maybe (getName t), GHC.moduleName m == mkModuleName "DA.Internal.LF" =

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -185,7 +185,7 @@ convertPrim _ "BEDecimalToInt64" (TNumeric10 :-> TInt64) =
     ETyApp (EBuiltin BENumericToInt64) (TNat 10)
 convertPrim _ "BEToText" (TNumeric10 :-> TText) =
     ETyApp (EBuiltin BEToTextNumeric) (TNat 10)
-convertPrim _ "BEDecimalFromText" (TText :-> TNumeric10) =
+convertPrim _ "BEDecimalFromText" (TText :-> TOptional TNumeric10) =
     ETyApp (EBuiltin BENumericFromText) (TNat 10)
 
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -14,6 +14,15 @@ import           DA.Daml.LF.Ast
 import           DA.Pretty (renderPretty)
 import qualified Data.Text as T
 
+-- | Use a Numeric primitive (applied to scale = 10) or a
+-- Decimal primitive depending on whether the Numeric feature
+-- is available at the specified DAML-LF Version.
+numericOrDecimalPrim :: Version -> BuiltinExpr -> BuiltinExpr -> Expr
+numericOrDecimalPrim version numericPrim decimalPrim =
+    if version `supports` featureNumeric
+        then ETyApp (EBuiltin numericPrim) (TNat 10)
+        else EBuiltin decimalPrim
+
 convertPrim :: Version -> String -> Type -> Expr
 -- Update
 convertPrim _ "UPure" (a1 :-> TUpdate a2) | a1 == a2 =
@@ -44,32 +53,42 @@ convertPrim _ "SGetParty" (t1@TText :-> TScenario TParty) =
     ETmLam (varV1, t1) $ EScenario $ SGetParty $ EVar varV1
 
 -- Comparison
-convertPrim _ "BEEqual" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
-    EBuiltin $ BEEqual a1
-convertPrim _ "BELess" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
-    EBuiltin $ BELess a1
-convertPrim _ "BELessEq" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
-    EBuiltin $ BELessEq a1
-convertPrim _ "BEGreaterEq" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
-    EBuiltin $ BEGreaterEq a1
-convertPrim _ "BEGreater" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
-    EBuiltin $ BEGreater a1
+convertPrim v "BEEqual" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
+    if a1 == BTDecimal
+        then numericOrDecimalPrim v BEEqualNumeric (BEEqual a1)
+        else EBuiltin $ BEEqual a1
+convertPrim v "BELess" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
+    if a1 == BTDecimal
+        then numericOrDecimalPrim v BELessNumeric (BELess a1)
+        else EBuiltin $ BELess a1
+convertPrim v "BELessEq" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
+    if a1 == BTDecimal
+        then numericOrDecimalPrim v BELessEqNumeric (BELessEq a1)
+        else EBuiltin $ BELessEq a1
+convertPrim v "BEGreaterEq" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
+    if a1 == BTDecimal
+        then numericOrDecimalPrim v BEGreaterEqNumeric (BEGreaterEq a1)
+        else EBuiltin $ BEGreaterEq a1
+convertPrim v "BEGreater" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
+    if a1 == BTDecimal
+        then numericOrDecimalPrim v BEGreaterNumeric (BEGreater a1)
+        else EBuiltin $ BEGreater a1
 convertPrim _ "BEEqualList" ((a1 :-> a2 :-> TBool) :-> TList a3 :-> TList a4 :-> TBool) | a1 == a2, a2 == a3, a3 == a4 =
     EBuiltin BEEqualList `ETyApp` a1
 convertPrim _ "BEEqualContractId" (TContractId a1 :-> TContractId a2 :-> TBool) | a1 == a2 =
     EBuiltin BEEqualContractId `ETyApp` a1
 
 -- Decimal arithmetic
-convertPrim _ "BEAddDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEAddDecimal
-convertPrim _ "BESubDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BESubDecimal
-convertPrim _ "BEMulDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEMulDecimal
-convertPrim _ "BEDivDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
-    EBuiltin BEDivDecimal
-convertPrim _ "BERoundDecimal" (TInt64 :-> TDecimal :-> TDecimal) =
-    EBuiltin BERoundDecimal
+convertPrim v "BEAddDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
+    numericOrDecimalPrim v BEAddNumeric BEAddDecimal
+convertPrim v "BESubDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
+    numericOrDecimalPrim v BESubNumeric BESubDecimal
+convertPrim v "BEMulDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
+    numericOrDecimalPrim v BEMulNumeric BEMulDecimal
+convertPrim v "BEDivDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
+    numericOrDecimalPrim v BEDivNumeric BEDivDecimal
+convertPrim v "BERoundDecimal" (TInt64 :-> TDecimal :-> TDecimal) =
+    numericOrDecimalPrim v BERoundNumeric BERoundDecimal
 
 -- Integer arithmetic
 convertPrim _ "BEAddInt64" (TInt64 :-> TInt64 :-> TInt64) =
@@ -96,10 +115,10 @@ convertPrim _ "BEUnixDaysToDate" (TInt64 :-> TDate) =
     EBuiltin BEUnixDaysToDate
 
 -- Conversion to and from Decimal
-convertPrim _ "BEInt64ToDecimal" (TInt64 :-> TDecimal) =
-    EBuiltin BEInt64ToDecimal
-convertPrim _ "BEDecimalToInt64" (TDecimal :-> TInt64) =
-    EBuiltin BEDecimalToInt64
+convertPrim v "BEInt64ToDecimal" (TInt64 :-> TDecimal) =
+    numericOrDecimalPrim v BEInt64ToNumeric BEInt64ToDecimal
+convertPrim v "BEDecimalToInt64" (TDecimal :-> TInt64) =
+    numericOrDecimalPrim v BENumericToInt64 BEDecimalToInt64
 
 -- List operations
 convertPrim _ "BEFoldl" ((b1 :-> a1 :-> b2) :-> b3 :-> TList a2 :-> b4) | a1 == a2, b1 == b2, b2 == b3, b3 == b4 =
@@ -112,8 +131,10 @@ convertPrim _ "BEError" (TText :-> t2) =
     ETyApp (EBuiltin BEError) t2
 
 -- Text operations
-convertPrim _ "BEToText" (TBuiltin x :-> TText) =
-    EBuiltin $ BEToText x
+convertPrim v "BEToText" (TBuiltin x :-> TText) =
+    if x == BTDecimal
+        then numericOrDecimalPrim v BEToTextNumeric (BEToText x)
+        else EBuiltin $ BEToText x
 convertPrim _ "BEExplodeText" (TText :-> TList TText) =
     EBuiltin BEExplodeText
 convertPrim _ "BEImplodeText" (TList TText :-> TText) =
@@ -130,8 +151,8 @@ convertPrim _ "BEPartyFromText" (TText :-> TOptional TParty) =
     EBuiltin BEPartyFromText
 convertPrim _ "BEInt64FromText" (TText :-> TOptional TInt64) =
     EBuiltin BEInt64FromText
-convertPrim _ "BEDecimalFromText" (TText :-> TOptional TDecimal) =
-    EBuiltin BEDecimalFromText
+convertPrim v "BEDecimalFromText" (TText :-> TOptional TDecimal) =
+    numericOrDecimalPrim v BENumericFromText BEDecimalFromText
 convertPrim _ "BETextToCodePoints" (TText :-> TList TInt64) =
     EBuiltin BETextToCodePoints
 convertPrim _ "BETextFromCodePoints" (TList TInt64 :-> TText) =


### PR DESCRIPTION
A better alternative to #2712 for now. This PR updates the LF converter to use the new Numeric type instead of Decimal if it's available, and updates the conversion of Decimal primitives accordingly.