### PR TITLE
Add a method to initialize speedy from a non-update expression

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -280,6 +280,15 @@ object Speedy {
         ctrl = CtrlExpr(sexpr),
       )
     }
+
+    // Construct a machine from an SExpr. This is useful when you don’t have
+    // an update expression and build’s behavior of applying the expression to
+    // a token is not appropriate.
+    def fromSExpr(
+        sexpr: SExpr,
+        checkSubmitterInMaintainers: Boolean,
+        compiledPackages: CompiledPackages): Machine =
+      initial(checkSubmitterInMaintainers, compiledPackages).copy(ctrl = CtrlExpr(sexpr))
   }
 
   /** Control specifies the thing that the machine should be reducing.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -249,8 +249,10 @@ object Speedy {
         compiledPackages: CompiledPackages): Either[SError, (Boolean, Expr) => Machine] = {
       val compiler = Compiler(compiledPackages.packages)
       Right({ (checkSubmitterInMaintainers: Boolean, expr: Expr) =>
-        initial(checkSubmitterInMaintainers, compiledPackages).copy(
-          ctrl = CtrlExpr(SEApp(compiler.compile(expr), Array(SEValue(SToken)))))
+        fromSExpr(
+          SEApp(compiler.compile(expr), Array(SEValue(SToken))),
+          checkSubmitterInMaintainers,
+          compiledPackages)
       })
     }
 
@@ -258,10 +260,7 @@ object Speedy {
         checkSubmitterInMaintainers: Boolean,
         sexpr: SExpr,
         compiledPackages: CompiledPackages): Machine =
-      initial(checkSubmitterInMaintainers, compiledPackages).copy(
-        // apply token
-        ctrl = CtrlExpr(SEApp(sexpr, Array(SEValue(SToken)))),
-      )
+      fromSExpr(SEApp(sexpr, Array(SEValue(SToken))), checkSubmitterInMaintainers, compiledPackages)
 
     // Used from repl.
     def fromExpr(
@@ -276,9 +275,7 @@ object Speedy {
         else
           compiler.compile(expr)
 
-      initial(checkSubmitterInMaintainers, compiledPackages).copy(
-        ctrl = CtrlExpr(sexpr),
-      )
+      fromSExpr(sexpr, checkSubmitterInMaintainers, compiledPackages)
     }
 
     // Construct a machine from an SExpr. This is useful when you don’t have


### PR DESCRIPTION
We need something like this for DAML triggers. You can kind of fake it
since all the individual fields of Machine are exposed but `initial`
is private (for good reasons as it sets ctrl to null) which makes this
rather annoying to do.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
