### PR TITLE
Fix ghc-pkg runfiles

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -6,6 +6,13 @@ load("//rules_daml:daml.bzl", "daml_compile", "daml_doc_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//bazel_tools/packaging:packaging.bzl", "package_app")
 
+# This is a gross hack: ghc-pkg is linked dynamically so to distribute
+# it we have to throw it at package_app. However, the result of that
+# is a tarball so if we try to add that to resources `bazel run` is
+# not going to work. We thus use the dynamically linked executable in the runfiles of damlc
+# and the tarball produced by package_app in the resources of damlc-dist.
+ghc_pkg = "@rules_haskell_ghc_windows_amd64//:bin/ghc-pkg.exe" if is_windows else "@ghc_nix//:lib/ghc-8.6.5/bin/ghc-pkg"
+
 da_haskell_binary(
     name = "damlc",
     srcs = ["exe/Main.hs"],
@@ -18,6 +25,7 @@ da_haskell_binary(
     ] if is_windows else [],
     data = [
         "//compiler/damlc/daml-ide-core:dlint.yaml",
+        ghc_pkg,
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
     ],

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -78,6 +78,7 @@ import System.Directory.Extra
 import System.Environment
 import System.Exit
 import System.FilePath
+import System.Info.Extra
 import System.IO.Extra
 #ifndef mingw32_HOST_OS
 import System.Posix.Files
@@ -475,7 +476,9 @@ createProjectPackageDb (AllowDifferentSdkVersions allowDiffSdkVersions) lfVersio
         "Package dependencies from different SDK versions: " ++
         intercalate ", " uniqSdkVersions
     ghcPkgPath <-
-        locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghc-pkg")
+        if isWindows
+          then locateRunfiles "rules_haskell_ghc_windows_amd64/bin"
+          else locateRunfiles "ghc_nix/lib/ghc-8.6.5/bin"
     callProcess
         (ghcPkgPath </> exe "ghc-pkg")
         [ "recache"


### PR DESCRIPTION
This allows us to run "damlc build" in Bazel rules which is a
prerequisite for doing anything with DAML packages as they don’t work
with "damlc package".

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
