### PR TITLE
Rename referencedContracts to divulgedContracts

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -262,7 +262,7 @@ object KeyValueConsumption {
       transaction = makeCommittedTransaction(entryId, relTx),
       transactionId = hexTxId,
       recordTime = recordTime,
-      referencedContracts = List.empty // TODO(JM): rename this to additionalContracts. Always empty here.
+      divulgedContracts = List.empty
     )
   }
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger
+package participant.state.v1
+
+import com.digitalasset.daml.lf.value.Value
+
+/** A divulged contract, that is, a contract that has been revealed to a non-stakeholder
+  * after its creation.
+  * For more information on divulgence, see:
+  * https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
+  *
+  * @param contractId: The absolute contract identifier.
+  * @param contractInst: The contract instance.
+  * @param divulgedTo:
+  *    The optional set of parties to which the contract has been divulged to. If not set, then
+  *    the set of parties this contract is revealed to is derived from the associated transaction.
+  *    This primary purpose of this field is to allow synthetic divulgence after a ledger pruning event.
+  */
+final case class DivulgedContract(
+    contractId: Value.AbsoluteContractId,
+    contractInst: AbsoluteContractInst,
+    divulgedTo: Option[Set[Party]]
+)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
@@ -13,13 +13,8 @@ import com.digitalasset.daml.lf.value.Value
   *
   * @param contractId: The absolute contract identifier.
   * @param contractInst: The contract instance.
-  * @param divulgedTo:
-  *    The optional set of parties to which the contract has been divulged to. If not set, then
-  *    the set of parties this contract is revealed to is derived from the associated transaction.
-  *    This primary purpose of this field is to allow synthetic divulgence after a ledger pruning event.
   */
 final case class DivulgedContract(
     contractId: Value.AbsoluteContractId,
-    contractInst: AbsoluteContractInst,
-    divulgedTo: Option[Set[Party]]
+    contractInst: AbsoluteContractInst
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
@@ -5,7 +5,6 @@ package com.daml.ledger
 package participant.state.v1
 
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml_lf.DamlLf
 
 /** An update to the (abstract) participant state.
@@ -116,11 +115,11 @@ object Update {
     *   ledgers to implement a fine-grained privacy model.
     *
     * @param transactionMeta:
-    *   the metadata of the transaction that was provided by the submitter.
+    *   The metadata of the transaction that was provided by the submitter.
     *   It is visible to all parties that can see the transaction.
     *
     * @param transaction:
-    *   the view of the transaction that was accepted. This view must
+    *   The view of the transaction that was accepted. This view must
     *   include at least the projection of the accepted transaction to the
     *   set of all parties hosted at this participant. See
     *   https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
@@ -136,14 +135,8 @@ object Update {
     *   determines how this transaction's recordTime relates to its
     *   [[TransactionMeta.ledgerEffectiveTime]].
     *
-    * @param referencedContracts:
-    *   A list of all contracts that were created before this transaction
-    *   and referenced by it (via fetch, consuming, or non-consuming
-    *   exercise nodes). This list is provided to enable consumers of
-    *   [[ReadService.stateUpdates]] to implement the divulgence semantics
-    *   as described here:
-    *   https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
-    *
+    * @param divulgedContracts:
+    *   List of divulged contracts. See [[DivulgedContract]] for details.
     */
   final case class TransactionAccepted(
       optSubmitterInfo: Option[SubmitterInfo],
@@ -151,7 +144,7 @@ object Update {
       transaction: CommittedTransaction,
       transactionId: TransactionId,
       recordTime: Timestamp,
-      referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)]
+      divulgedContracts: List[DivulgedContract]
   ) extends Update {
     override def description: String = s"Accept transaction $transactionId"
   }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Version.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Version.scala
@@ -3,5 +3,11 @@
 
 package com.daml.ledger.participant.state.v1
 
-/** changelog... */
+/** This file contains the changelog for the participant state API
+  * and version constants (currently none).
+  *
+  * Changes:
+  * [since 100.13.21]:
+  * - Rename referencedContracts to divulgedContracts in [[Update.TransactionAccepted]].
+  */
 object Version {}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -190,7 +190,7 @@ class JdbcIndexer private (
           transaction,
           transactionId,
           recordTime,
-          referencedContracts) =>
+          divulgedContracts) =>
         val toAbsCoid: ContractId => AbsoluteContractId =
           SandboxEventIdFormatter.makeAbsCoid(transactionId)
 


### PR DESCRIPTION
We do not want to provide all referenced contracts as that would
require the ReadService to be able to read all those contracts, or
we would need to bundle the referenced contracts with the transaction.

The new type should match what was discussed in #2488.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
