### PR TITLE
Adding max-inbound-message-size startup parameter

### DIFF
--- a/ledger-service/http-json/README.md
+++ b/ledger-service/http-json/README.md
@@ -10,11 +10,12 @@ daml-head sandbox --wall-clock-time --ledgerid MyLedger ./.daml/dist/quickstart-
 ### Start HTTP service from the DAML project root
 This will build the service first, can take up to 5-10 minutes when running first time.
 ```
-$ bazel run //ledger-service/http-json:http-json-binary -- localhost 6865 7575
+$ bazel run //ledger-service/http-json:http-json-binary -- localhost 6865 7575 4194304
 ```
 Where:
  - localhost 6865 -- sandbox host and port
  - 7575 -- HTTP service port
+ - 4194304 -- max inbound message size in bytes (the max size of the message received from the ledger). To set the same limit on the sandbox side, use ` --maxInboundMessageSize` command line parameter.
 
 ## Example session
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -39,6 +39,8 @@ import scala.{util => u}
 
 object HttpService extends StrictLogging {
 
+  val DefaultMaxInboundMessageSize: Int = 4194304
+
   private type ET[A] = EitherT[Future, Error, A]
 
   final case class Error(message: String)
@@ -48,6 +50,7 @@ object HttpService extends StrictLogging {
       ledgerPort: Int,
       applicationId: ApplicationId,
       httpPort: Int,
+      maxInboundMessageSize: Int = DefaultMaxInboundMessageSize,
       validateJwt: Endpoints.ValidateJwt = decodeJwt)(
       implicit asys: ActorSystem,
       mat: Materializer,
@@ -64,7 +67,8 @@ object HttpService extends StrictLogging {
 
     val bindingEt: EitherT[Future, Error, ServerBinding] = for {
       clientChannel <- FutureUtil
-        .either(LedgerClientJwt.singleHostChannel(ledgerHost, ledgerPort, clientConfig)(ec, aesf))
+        .either(LedgerClientJwt
+          .singleHostChannel(ledgerHost, ledgerPort, clientConfig, maxInboundMessageSize)(ec, aesf))
         .leftMap(e => Error(e.getMessage)): ET[io.grpc.Channel]
 
       client <- FutureUtil

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
@@ -31,12 +31,17 @@ object LedgerClientJwt {
   type GetActiveContracts =
     (Jwt, TransactionFilter, Boolean) => Source[GetActiveContractsResponse, Future[String]]
 
-  def singleHostChannel(hostIp: String, port: Int, configuration: LedgerClientConfiguration)(
+  def singleHostChannel(
+      hostIp: String,
+      port: Int,
+      configuration: LedgerClientConfiguration,
+      maxInboundMessageSize: Int)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory): Throwable \/ Channel = \/.fromTryCatchNonFatal {
 
     val builder: NettyChannelBuilder = NettyChannelBuilder
       .forAddress(hostIp, port)
+      .maxInboundMessageSize(maxInboundMessageSize)
 
     configuration.sslContext
       .fold {


### PR DESCRIPTION
so we can download large DARs to collect TemplateIDs for the future TemplateID resolution.

```
$ bazel run //ledger-service/http-json:http-json-bin -- localhost 6865 7575 41943040
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
