### PR TITLE
Escape all text in rst docs.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -7,7 +7,7 @@ module DA.Daml.Doc.Render.Markdown
   ) where
 
 import DA.Daml.Doc.Types
-import DA.Daml.Doc.Render.Util (adjust)
+import DA.Daml.Doc.Render.Util (adjust, escapeText)
 import DA.Daml.Doc.Render.Monoid
 
 import Data.List.Extra
@@ -78,13 +78,7 @@ bullet [] = []
 bullet (x : xs) = ("* " <> x) : indent xs
 
 escapeMd :: T.Text -> T.Text
-escapeMd = T.pack . concatMap escapeChar . T.unpack
-  where
-    escapeChar c
-        | shouldEscape c = ['\\', c]
-        | otherwise = [c]
-
-    shouldEscape = (`elem` ("[]*_~`<>\\&" :: String))
+escapeMd = escapeText (`elem` ("[]*_~`<>\\&" :: String))
 
 -- | Render fields as a pipe-table, like this:
 -- >  | Field    | Type     | Description

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -66,7 +66,7 @@ spaced = intercalate [""] . respace
     respace = \case
         [line1] : (line2 : block) : xs
             | any (`T.isPrefixOf` line1) ["`", "**type**", "**template instance**"]
-            , any (`T.isPrefixOf` line2) ["  :", "  ="] ->
+            , any (`T.isPrefixOf` line2) ["  \\:", "  \\="] ->
                 (line1 : line2 : block) : respace xs
         x : xs -> x : respace xs
         [] -> []

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Util.hs
@@ -10,6 +10,7 @@ module DA.Daml.Doc.Render.Util
   , bold
   , inParens
   , wrapOp
+  , escapeText
   ) where
 
 import qualified Data.Text as T
@@ -52,3 +53,11 @@ wrapOp t =
     isIdChar c = ('A' <= c && c <= 'Z')
               || ('a' <= c && c <= 'z')
               || ('_' == c)
+
+-- | Add backslashes before each character that passes the predicate.
+escapeText :: (Char -> Bool) -> T.Text -> T.Text
+escapeText p = T.pack . concatMap escapeChar . T.unpack
+  where
+    escapeChar c
+      | p c = ['\\', c]
+      | otherwise = [c]

--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Render/Tests.hs
@@ -90,7 +90,7 @@ expectRst =
             [ ".. _type-typedef-t:"
             , ""
             , "**type** `T <type-typedef-t_>`_ a"
-            , "  = TT TTT"
+            , "  \\= TT TTT"
             , "  "
             , "  T descr"
             ] []
@@ -99,7 +99,7 @@ expectRst =
             [ ".. _type-twotypes-t:"
             , ""
             , "**type** `T <type-twotypes-t_>`_ a"
-            , "  = TT"
+            , "  \\= TT"
             , "  "
             , "  T descr"
             , ""
@@ -118,7 +118,7 @@ expectRst =
             [ ".. _function-function1-f:"
             , ""
             , "`f <function-function1-f_>`_"
-            , "  : TheType"
+            , "  \\: TheType"
             , "  "
             , "  the doc"
             ]
@@ -126,7 +126,7 @@ expectRst =
             [ ".. _function-function3-f:"
             , ""
             , "`f <function-function3-f_>`_"
-            , "  : TheType"
+            , "  \\: TheType"
             ]
         , mkExpectRst "module-onlyclass" "OnlyClass" ""
             []
@@ -137,7 +137,7 @@ expectRst =
             , "  .. _function-onlyclass-member:"
             , "  "
             , "  `member <function-onlyclass-member_>`_"
-            , "    : a"
+            , "    \\: a"
             ]
             []
             []
@@ -168,7 +168,7 @@ expectRst =
             [ ".. _function-g:"
             , ""
             , "`g <function-g_>`_"
-            , "  : Eq t => t -> Bool"
+            , "  \\: Eq t \\=\\> t \\-\\> Bool"
             , "  "
             , "  function with context"
             ]

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -4,7 +4,7 @@ Module ConstrainedClassMethod
 -----------------------------
 
 This module tests the case where a class method contains a constraint
-not present in the class itself.
+not present in the class itself\.
 
 Typeclasses
 ^^^^^^^^^^^
@@ -16,12 +16,12 @@ Typeclasses
   .. _function-constrainedclassmethod-foo-58176:
   
   `foo <function-constrainedclassmethod-foo-58176_>`_
-    : t -\> t
+    \: t \-\> t
   
   .. _function-constrainedclassmethod-bar-13431:
   
   `bar <function-constrainedclassmethod-bar-13431_>`_
-    : `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t =\> t -\> t
+    \: `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t \=\> t \-\> t
 
 .. _class-constrainedclassmethod-b-99749:
 
@@ -30,4 +30,4 @@ Typeclasses
   .. _function-constrainedclassmethod-baz-40143:
   
   `baz <function-constrainedclassmethod-baz-40143_>`_
-    : `B <class-constrainedclassmethod-b-99749_>`_ b =\> b -\> t
+    \: `B <class-constrainedclassmethod-b-99749_>`_ b \=\> b \-\> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -16,12 +16,12 @@ Typeclasses
   .. _function-constrainedclassmethod-foo-58176:
   
   `foo <function-constrainedclassmethod-foo-58176_>`_
-    : t -> t
+    : t -\> t
   
   .. _function-constrainedclassmethod-bar-13431:
   
   `bar <function-constrainedclassmethod-bar-13431_>`_
-    : `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t => t -> t
+    : `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t =\> t -\> t
 
 .. _class-constrainedclassmethod-b-99749:
 
@@ -30,4 +30,4 @@ Typeclasses
   .. _function-constrainedclassmethod-baz-40143:
   
   `baz <function-constrainedclassmethod-baz-40143_>`_
-    : `B <class-constrainedclassmethod-b-99749_>`_ b => b -> t
+    : `B <class-constrainedclassmethod-b-99749_>`_ b =\> b -\> t

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -27,21 +27,21 @@ Typeclasses
   .. _function-defaultmethods-foldrx-33654:
   
   `foldrX <function-defaultmethods-foldrx-33654_>`_
-    : (a -> b -> b) -> b -> t a -> b
+    : (a -\> b -\> b) -\> b -\> t a -\> b
 
 .. _class-defaultmethods-traversablex-59027:
 
-**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) => `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
+**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) =\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
 
   .. _function-defaultmethods-traversex-21140:
   
   `traverseX <function-defaultmethods-traversex-21140_>`_
-    : Applicative m => (a -> m b) -> t a -> m (t b)
+    : Applicative m =\> (a -\> m b) -\> t a -\> m (t b)
   
   .. _function-defaultmethods-sequencex-86855:
   
   `sequenceX <function-defaultmethods-sequencex-86855_>`_
-    : Applicative m => t (m a) -> m (t a)
+    : Applicative m =\> t (m a) -\> m (t a)
 
 .. _class-defaultmethods-id-77721:
 
@@ -50,7 +50,7 @@ Typeclasses
   .. _function-defaultmethods-id-57162:
   
   `id <function-defaultmethods-id-57162_>`_
-    : a -> a
+    : a -\> a
   
   **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
@@ -63,12 +63,12 @@ Typeclasses
   .. _function-defaultmethods-myshow-41356:
   
   `myShow <function-defaultmethods-myshow-41356_>`_
-    : t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    : t -\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
     
     Doc for method.
   
   **default** myShow
   
-    : `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t => t -> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    : `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t =\> t -\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
     
     Doc for default.

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -13,12 +13,12 @@ Typeclasses
   .. _function-defaultmethods-x-92038:
   
   `x <function-defaultmethods-x-92038_>`_
-    : a
+    \: a
   
   .. _function-defaultmethods-y-38115:
   
   `y <function-defaultmethods-y-38115_>`_
-    : a
+    \: a
 
 .. _class-defaultmethods-foldablex-48748:
 
@@ -27,21 +27,21 @@ Typeclasses
   .. _function-defaultmethods-foldrx-33654:
   
   `foldrX <function-defaultmethods-foldrx-33654_>`_
-    : (a -\> b -\> b) -\> b -\> t a -\> b
+    \: (a \-\> b \-\> b) \-\> b \-\> t a \-\> b
 
 .. _class-defaultmethods-traversablex-59027:
 
-**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) =\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
+**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
 
   .. _function-defaultmethods-traversex-21140:
   
   `traverseX <function-defaultmethods-traversex-21140_>`_
-    : Applicative m =\> (a -\> m b) -\> t a -\> m (t b)
+    \: Applicative m \=\> (a \-\> m b) \-\> t a \-\> m (t b)
   
   .. _function-defaultmethods-sequencex-86855:
   
   `sequenceX <function-defaultmethods-sequencex-86855_>`_
-    : Applicative m =\> t (m a) -\> m (t a)
+    \: Applicative m \=\> t (m a) \-\> m (t a)
 
 .. _class-defaultmethods-id-77721:
 
@@ -50,7 +50,7 @@ Typeclasses
   .. _function-defaultmethods-id-57162:
   
   `id <function-defaultmethods-id-57162_>`_
-    : a -\> a
+    \: a \-\> a
   
   **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
@@ -58,17 +58,17 @@ Typeclasses
 
 **class** `MyShow <class-defaultmethods-myshow-63359_>`_ t **where**
 
-  Default implementation with a separate type signature for the default method.
+  Default implementation with a separate type signature for the default method\.
   
   .. _function-defaultmethods-myshow-41356:
   
   `myShow <function-defaultmethods-myshow-41356_>`_
-    : t -\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    \: t \-\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
     
-    Doc for method.
+    Doc for method\.
   
   **default** myShow
   
-    : `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t =\> t -\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    \: `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
     
-    Doc for default.
+    Doc for default\.

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -42,8 +42,8 @@ Data Types
   
   **instance** `Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
   
-  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t =\> `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t \=\> `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t =\> `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t \=\> `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t =\> `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t \=\> `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -32,18 +32,18 @@ Data Types
   
   .. _constr-deriving-conjunction-36676:
   
-  `Conjunction <constr-deriving-conjunction-36676_>`_ [`Formula <type-deriving-formula-84903_>`_ t]
+  `Conjunction <constr-deriving-conjunction-36676_>`_ \[`Formula <type-deriving-formula-84903_>`_ t\]
   
   
   .. _constr-deriving-disjunction-94592:
   
-  `Disjunction <constr-deriving-disjunction-94592_>`_ [`Formula <type-deriving-formula-84903_>`_ t]
+  `Disjunction <constr-deriving-disjunction-94592_>`_ \[`Formula <type-deriving-formula-84903_>`_ t\]
   
   
   **instance** `Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
   
-  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t => `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t =\> `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t => `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t =\> `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t => `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t =\> `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -23,7 +23,7 @@ Typeclasses
   .. _function-exportlist-member3-30944:
   
   `member3 <function-exportlist-member3-30944_>`_
-    : t
+    \: t
 
 .. _class-exportlist-class4-65325:
 
@@ -32,12 +32,12 @@ Typeclasses
   .. _function-exportlist-member4-58699:
   
   `member4 <function-exportlist-member4-58699_>`_
-    : t
+    \: t
   
   .. _function-exportlist-member4tick-28729:
   
   `member4' <function-exportlist-member4tick-28729_>`_
-    : t
+    \: t
 
 Data Types
 ^^^^^^^^^^
@@ -46,13 +46,13 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-25282_>`_
 
-  **instance** HasField "field1" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field1\" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data2-68729:
 
 **data** `Data2 <type-exportlist-data2-68729_>`_
 
-  **instance** HasField "field2" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field2\" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data3-43604:
 
@@ -63,13 +63,13 @@ Data Types
   `Constr3 <constr-exportlist-constr3-90820_>`_
   
   
-  **instance** HasField "field3" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field3\" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data4-87051:
 
 **data** `Data4 <type-exportlist-data4-87051_>`_
 
-  **instance** HasField "field4" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field4\" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data5-40974:
 
@@ -90,7 +90,7 @@ Data Types
          - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField "field5" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field5\" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data6-26325:
 
@@ -116,7 +116,7 @@ Data Types
   `Constr6' <constr-exportlist-constr6tick-67971_>`_
   
   
-  **instance** HasField "field6" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field6\" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -124,4 +124,4 @@ Functions
 .. _function-exportlist-function1-77714:
 
 `function1 <function-exportlist-function1-77714_>`_
-  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -25,7 +25,7 @@ Templates
        - 
      * - currency
        - `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
-       - only 3-letter symbols are allowed
+       - only 3\-letter symbols are allowed
      * - amount
        - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
        - must be positive
@@ -33,7 +33,7 @@ Templates
        - \[Party\]
        - ``regulators`` may observe any use of the ``Iou``
   
-  + **Choice External:Archive**
+  + **Choice External\:Archive**
     
   
   + **Choice DoNothing**
@@ -41,7 +41,7 @@ Templates
   
   + **Choice Merge**
     
-    merges two "compatible" ``Iou``s
+    merges two \"compatible\" ``Iou``s
     
     .. list-table::
        :widths: 15 10 30
@@ -52,7 +52,7 @@ Templates
          - Description
        * - otherCid
          - ContractId `Iou <type-iou12-iou-45923_>`_
-         - Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original ``Iou``.
+         - Must have same owner, issuer, and currency\. The regulators may differ, and are taken from the original ``Iou``\.
   
   + **Choice Split**
     
@@ -91,8 +91,8 @@ Functions
 .. _function-iou12-main-35518:
 
 `main <function-iou12-main-35518_>`_
-  : Scenario ()
+  \: Scenario ()
   
-  A single test scenario covering all functionality that ``Iou`` implements.
+  A single test scenario covering all functionality that ``Iou`` implements\.
   This description contains a link(http://example.com), some bogus \<inline html\>,
-  and words\_ with\_ underscore, to test damldoc capabilities.
+  and words\_ with\_ underscore, to test damldoc capabilities\.

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -30,7 +30,7 @@ Templates
        - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
        - must be positive
      * - regulators
-       - [Party]
+       - \[Party\]
        - ``regulators`` may observe any use of the ``Iou``
   
   + **Choice External:Archive**
@@ -94,5 +94,5 @@ Functions
   : Scenario ()
   
   A single test scenario covering all functionality that ``Iou`` implements.
-  This description contains a link(http://example.com), some bogus <inline html>,
+  This description contains a link(http://example.com), some bogus \<inline html\>,
   and words\_ with\_ underscore, to test damldoc capabilities.

--- a/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/MultipleNames.EXPECTED.rst
@@ -3,7 +3,7 @@
 Module MultipleNames
 --------------------
 
-Test multiple names sharing the same type signature.
+Test multiple names sharing the same type signature\.
 
 Typeclasses
 ^^^^^^^^^^^
@@ -15,13 +15,13 @@ Typeclasses
   .. _function-multiplenames-foo1-60996:
   
   `foo1 <function-multiplenames-foo1-60996_>`_
-    : t
+    \: t
     
-    This documentation is duplicated.
+    This documentation is duplicated\.
   
   .. _function-multiplenames-foo2-88479:
   
   `foo2 <function-multiplenames-foo2-88479_>`_
-    : t
+    \: t
     
-    This documentation is duplicated.
+    This documentation is duplicated\.

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -33,12 +33,12 @@ Functions
 .. _function-newtype-mknat-8513:
 
 `mkNat <function-newtype-mknat-8513_>`_
-  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -> `Nat <type-newtype-nat-61947_>`_
+  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unsafemknat-96593:
 
 `unsafeMkNat <function-newtype-unsafemknat-96593_>`_
-  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -> `Nat <type-newtype-nat-61947_>`_
+  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-zero0-10450:
 
@@ -53,14 +53,14 @@ Functions
 .. _function-newtype-unnat1-26452:
 
 `unNat1 <function-newtype-unnat1-26452_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat2-96339:
 
 `unNat2 <function-newtype-unnat2-96339_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat3-97654:
 
 `unNat3 <function-newtype-unnat3-97654_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -25,7 +25,7 @@ Data Types
          - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField "unNat" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"unNat\" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -33,34 +33,34 @@ Functions
 .. _function-newtype-mknat-8513:
 
 `mkNat <function-newtype-mknat-8513_>`_
-  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unsafemknat-96593:
 
 `unsafeMkNat <function-newtype-unsafemknat-96593_>`_
-  : `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ -\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-zero0-10450:
 
 `zero0 <function-newtype-zero0-10450_>`_
-  : `Nat <type-newtype-nat-61947_>`_
+  \: `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-one1-53872:
 
 `one1 <function-newtype-one1-53872_>`_
-  : `Nat <type-newtype-nat-61947_>`_
+  \: `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unnat1-26452:
 
 `unNat1 <function-newtype-unnat1-26452_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat2-96339:
 
 `unNat2 <function-newtype-unnat2-96339_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat3-97654:
 
 `unNat3 <function-newtype-unnat3-97654_>`_
-  : `Nat <type-newtype-nat-61947_>`_ -\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
@@ -8,7 +8,7 @@ Templates
 
 .. _type-proposal-proposal-1384:
 
-**template** Template t => `Proposal <type-proposal-proposal-1384_>`_ t
+**template** Template t =\> `Proposal <type-proposal-proposal-1384_>`_ t
 
   .. list-table::
      :widths: 15 10 30
@@ -21,7 +21,7 @@ Templates
        - t
        - 
      * - receivers
-       - [Party]
+       - \[Party\]
        - 
      * - name
        - `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_

--- a/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Proposal.EXPECTED.rst
@@ -8,7 +8,7 @@ Templates
 
 .. _type-proposal-proposal-1384:
 
-**template** Template t =\> `Proposal <type-proposal-proposal-1384_>`_ t
+**template** Template t \=\> `Proposal <type-proposal-proposal-1384_>`_ t
 
   .. list-table::
      :widths: 15 10 30
@@ -30,5 +30,5 @@ Templates
   + **Choice Accept**
     
   
-  + **Choice External:Archive**
+  + **Choice External\:Archive**
     

--- a/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ProposalIou.EXPECTED.rst
@@ -27,7 +27,7 @@ Templates
        - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
        - 
   
-  + **Choice External:Archive**
+  + **Choice External\:Archive**
     
   
   + **Choice Burn**
@@ -39,4 +39,4 @@ Template Instances
 .. _type-proposaliou-proposaliou-81988:
 
 **template instance** `ProposalIou <type-proposaliou-proposaliou-81988_>`_
-  = Proposal `Iou <type-proposaliou-iou-51326_>`_
+  \= Proposal `Iou <type-proposaliou-iou-51326_>`_


### PR DESCRIPTION
This PR attempts to escape all characters in the Rst docs that need escaping. Fixes #2732.

[CW: potentiall harmful knowledge about character escaping in Sphinx/RST below] 

Link text seems to go through some kind of double unescaping, so in the case of documenting the `(\\)` operator, it needs to show up in the Rst source as `(\\\\\\\\)`. 🙃 