### PR TITLE
language: check dflags for errors

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -303,5 +303,6 @@ daml_doc_test(
     name = "daml-stdlib-doctest",
     package_name = "daml-stdlib",
     srcs = ["//compiler/damlc/daml-stdlib-src"],
+    flags = ["--no-dflags-check"],
     ignored_srcs = ["LibraryModules.daml"],
 )

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -63,6 +63,9 @@ data Options = Options
   -- ^ Information about dlint usage.
   , optIsGenerated :: Bool
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
+  , optDflagCheck :: Bool
+    -- ^ Whether to check dflags. In some cases we want to turn this check of. For example when
+    -- migrating or running the daml doc test.
   , optCoreLinting :: Bool
     -- ^ Whether to enable linting of the generated GHC Core. (Used in testing.)
   , optHaddock :: Haddock
@@ -150,6 +153,7 @@ defaultOptions mbVersion =
         , optScenarioValidation = ScenarioValidationFull
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
+        , optDflagCheck = True
         , optCoreLinting = False
         , optHaddock = Haddock False
         }

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -273,12 +273,15 @@ setupDamlGHC options@Options{..} = do
 -- Checks:
 --    * thisInstalledUnitId not contained in loaded packages.
 checkDFlags :: DynFlags -> IO DynFlags
-checkDFlags dflags@DynFlags {..} = do
-    case lookupPackage dflags $ DefiniteUnitId $ DefUnitId thisInstalledUnitId of
-        Nothing -> pure dflags
-        Just _conf ->
-            fail $
-            "Package " <> installedUnitIdString thisInstalledUnitId <>
-            " imports a package with the same name. \
+checkDFlags dflags@DynFlags {..}
+    | thisInstalledUnitId == toInstalledUnitId primUnitId = pure dflags
+    | otherwise = do
+        case lookupPackage dflags $
+             DefiniteUnitId $ DefUnitId thisInstalledUnitId of
+            Nothing -> pure dflags
+            Just _conf ->
+                fail $
+                "Package " <> installedUnitIdString thisInstalledUnitId <>
+                " imports a package with the same name. \
             \ Please check your dependencies and rename the package you are compiling \
             \ or the dependency."

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -274,7 +274,7 @@ setupDamlGHC options@Options{..} = do
 --    * thisInstalledUnitId not contained in loaded packages.
 checkDFlags :: Options -> DynFlags -> IO DynFlags
 checkDFlags Options {..} dflags@DynFlags {..}
-    | optIsGenerated || thisInstalledUnitId == toInstalledUnitId primUnitId =
+    | not optDflagCheck || thisInstalledUnitId == toInstalledUnitId primUnitId =
         pure dflags
     | otherwise = do
         case lookupPackage dflags $

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -706,6 +706,7 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
                         , optPackageDbs = [projectPkgDb]
                         , optIfaceDir = Just (dbPath </> installedUnitIdString iuid)
                         , optIsGenerated = True
+                        , optDflagCheck = False
                         , optMbPackageName = Just $ installedUnitIdString iuid
                         }
                 withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
@@ -874,6 +875,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure (optScenarioValidation $ defaultOptions Nothing)
     <*> dlintUsageOpt
     <*> pure False
+    <*> optNoDflagCheck
     <*> pure False
     <*> pure (Haddock False)
   where
@@ -932,6 +934,15 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
             , "Use --jobs=N to explicitely set the number of threads to N."
             , "Note that the output is not deterministic for > 1 job."
             ]
+
+
+    optNoDflagCheck :: Parser Bool
+    optNoDflagCheck =
+      flag True False $
+      help "Dont check generated GHC DynFlags for errors." <>
+      long "no-dflags-check" <>
+      internal
+
 
 
 optGhcCustomOptions :: Parser [String]

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -149,10 +149,11 @@ def _daml_doctest_impl(ctx):
       set -eou pipefail
       DAMLC=$(rlocation $TEST_WORKSPACE/{damlc})
       rlocations () {{ for i in $@; do echo $(rlocation $TEST_WORKSPACE/$i); done; }}
-      $DAMLC doctest --package-name {package_name}-`cat $(rlocation $TEST_WORKSPACE/{version_file})` $(rlocations "{files}")
+      $DAMLC doctest {flags} --package-name {package_name}-`cat $(rlocation $TEST_WORKSPACE/{version_file})` $(rlocations "{files}")
     """.format(
         damlc = ctx.executable.damlc.short_path,
         package_name = ctx.attr.package_name,
+        flags = " ".join(ctx.attr.flags),
         version_file = ctx.file.version.path,
         files = " ".join([
             f.short_path
@@ -188,6 +189,10 @@ daml_doc_test = rule(
             cfg = "host",
             allow_files = True,
             default = Label("//compiler/damlc"),
+        ),
+        "flags": attr.string_list(
+            default = [],
+            doc = "Flags for damlc invokation.",
         ),
         "package_name": attr.string(),
         "version": attr.label(


### PR DESCRIPTION
We add a check when we build the dflags for cases that will lead to a
failed build and emmit a clearer error message. Currently this only
includes a check, to see whether the current installed unit id is also
imported as a package from the package database. Fixes #2742.
  
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
