### PR TITLE
Randomize hint to ensure PartyManagement tests are rerunnable on the same ledger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,8 +197,7 @@ jobs:
       vmImage: "Ubuntu-16.04"
     condition: and(succeeded(),
                    eq( dependencies.Linux.outputs['release.has_released'], 'true' ),
-                   eq( dependencies.macOS.outputs['release.has_released'], 'true' ),
-                   eq( dependencies.Windows.outputs['release.has_released'], 'true' ))
+                   eq( dependencies.macOS.outputs['release.has_released'], 'true' ))
     variables:
       artifact-linux: $[ dependencies.Linux.outputs['publish.artifact'] ]
       artifact-macos: $[ dependencies.macOS.outputs['publish.artifact'] ]

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -22,15 +22,16 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
       }
     }
 
+  private val pMAllocateWithHint = "PMAllocateWithHint"
   private[this] val allocateWithHint =
     LedgerTest(
-      "PMAllocateWithHint",
+      pMAllocateWithHint,
       "It should be possible to provide a hint when allocating a party"
     ) { context =>
       for {
         ledger <- context.participant()
         party <- ledger.allocateParty(
-          partyHintId = Some(Random.alphanumeric.take(10).mkString),
+          partyHintId = Some(pMAllocateWithHint + "_" + Random.alphanumeric.take(10).mkString),
           displayName = Some("Bob Ross"))
       } yield
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
@@ -48,15 +49,16 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
     }
 
+  private val pMAllocateWithoutDisplayName = "PMAllocateWithoutDisplayName"
   private[this] val allocateWithoutDisplayName =
     LedgerTest(
-      "PMAllocateWithoutDisplayName",
+      pMAllocateWithoutDisplayName,
       "It should be possible to not provide a display name when allocating a party"
     ) { context =>
       for {
         ledger <- context.participant()
         party <- ledger.allocateParty(
-          partyHintId = Some(Random.alphanumeric.take(10).mkString),
+          partyHintId = Some(pMAllocateWithoutDisplayName + "_" + Random.alphanumeric.take(10).mkString),
           displayName = None)
       } yield
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -6,6 +6,8 @@ package com.daml.ledger.api.testtool.tests
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTest, LedgerTestSuite}
 import scalaz.Tag
 
+import scala.util.Random
+
 final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(session) {
 
   private[this] val nonEmptyParticipantId =
@@ -28,7 +30,7 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
       for {
         ledger <- context.participant()
         party <- ledger.allocateParty(
-          partyHintId = Some("PMAllocateWithHint"),
+          partyHintId = Some(Random.alphanumeric.take(10).mkString),
           displayName = Some("Bob Ross"))
       } yield
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
@@ -54,7 +56,7 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
       for {
         ledger <- context.participant()
         party <- ledger.allocateParty(
-          partyHintId = Some("PMAllocateWithoutDisplayName"),
+          partyHintId = Some(Random.alphanumeric.take(10).mkString),
           displayName = None)
       } yield
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -58,7 +58,8 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
       for {
         ledger <- context.participant()
         party <- ledger.allocateParty(
-          partyHintId = Some(pMAllocateWithoutDisplayName + "_" + Random.alphanumeric.take(10).mkString),
+          partyHintId =
+            Some(pMAllocateWithoutDisplayName + "_" + Random.alphanumeric.take(10).mkString),
           displayName = None)
       } yield
         assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")


### PR DESCRIPTION
At present if you run the ledger-api-test-tool suite more than once on the same ledger instance, two tests fail on the second run because they reuse a party that has already been created

`bazel run -- //ledger/ledger-api-test-tool localhost:6865 --all-tests`

```
PartyManagement

- It should be possible to provide a hint when allocating a party ... Failed due to an unexpected exception
  INVALID_ARGUMENT: Invalid argument: Party already exists
- It should be possible to not provide a display name when allocating a party ... Failed due to an unexpected exception
  INVALID_ARGUMENT: Invalid argument: Party already exists
```

This PR includes a small change to randomize the hint so that the same party will not be repeated for these two tests, and the entire suite will therefore be rerunnable against the same ledger instance.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.