### PR TITLE
Update ghc-lib version with different desugaring of template instances

### DIFF
--- a/3rdparty/haskell/BUILD.ghc-lib-parser
+++ b/3rdparty/haskell/BUILD.ghc-lib-parser
@@ -52,7 +52,7 @@ haskell_library(
     "-I/compiler", "-I/compiler/utils"
   ],
   package_name = "ghc-lib-parser",
-  version = "8.8.1.20190916",
+  version = "8.8.1.20190905",
 )
 
 cc_library(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -484,12 +484,12 @@ GRPC_HASKELL_COMMIT = "11681ec6b99add18a8d1315f202634aea343d146"
 
 GRPC_HASKELL_HASH = "c6201f4e2fd39f25ca1d47b1dac4efdf151de88a2eb58254d61abc2760e58fda"
 
-GHC_LIB_VERSION = "8.8.1.20190918"
+GHC_LIB_VERSION = "8.8.1.20190905"
 
 http_archive(
     name = "haskell_ghc__lib__parser",
     build_file = "//3rdparty/haskell:BUILD.ghc-lib-parser",
-    sha256 = "c42c61ebdc241b2f42162c0cee1547d6acc33f32019730bcfb6441b9dd0b92ba",
+    sha256 = "03a8e450ebdcbbb5dd3c1f2d7d69e09e19ccb3eb0402ca6e6f346e3ffd7c52b7",
     strip_prefix = "ghc-lib-parser-{}".format(GHC_LIB_VERSION),
     urls = ["https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-{}.tar.gz".format(GHC_LIB_VERSION)],
 )
@@ -561,7 +561,7 @@ hazel_repositories(
 
             # Read [Working on ghc-lib] for ghc-lib update instructions at
             # https://github.com/digital-asset/daml/blob/master/ghc-lib/working-on-ghc-lib.md.
-            hazel_ghclibs(GHC_LIB_VERSION, "c42c61ebdc241b2f42162c0cee1547d6acc33f32019730bcfb6441b9dd0b92ba", "1305b7959d4ee9cdb95d51e6a6f87664a8311cd84c36a8d5e496ce523c203d0d") +
+            hazel_ghclibs(GHC_LIB_VERSION, "03a8e450ebdcbbb5dd3c1f2d7d69e09e19ccb3eb0402ca6e6f346e3ffd7c52b7", "4e0a7a7c22b032dbae488903924211e3239e471d470216693e699c7a078d1822") +
             hazel_github_external("digital-asset", "hlint", "db0b8f15624d0f5ba7a8062dfe6efb2cbf981e9e", "8a50fbe5aabda59f88550b0fd6d7dff10e2d1e6789c95e142a0d553cc09d05dd") +
             hazel_github_external("awakesecurity", "proto3-wire", "4f355bbac895d577d8a28f567ab4380f042ccc24", "031e05d523a887fbc546096618bc11dceabae224462a6cdd6aab11c1658e17a3") +
             hazel_github_external(


### PR DESCRIPTION
Generate a `type` synonym instead of a `newtype` for a `template instance`. Follows change in https://github.com/digital-asset/ghc/pull/35.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
