### PR TITLE
reduce risk of double posting to hubspot

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -103,6 +103,16 @@ jobs:
           done
 
           git checkout $CUR_SHA
+
+          echo "Done building docs bundle. Checking versions again to avoid race condition..."
+          S3_VERSIONS=$(mktemp)
+          aws s3 cp s3://docs-daml-com/versions.json $S3_VERSIONS
+          if diff $S3_VERSIONS $DOCDIR/versions.json; then
+            echo "No more new version, another process must have pushed already."
+            exit 0
+          fi
+          echo "Pushing new versions file first..."
+          aws s3 cp $DOCDIR/versions.json s3://docs-daml-com/versions.json --acl public-read
           echo "Pushing to S3 bucket..."
           aws s3 sync $DOCDIR \
                       s3://docs-daml-com/ \


### PR DESCRIPTION
Latest release got published twice to both Hubspot and Twitter. This is because the Azure cron is not very reliable and the relevant one started at x:26 rather than x:00. Unfortunately, the next one was right on time and started at (x+1):00, and building the documentation took 41 minutes for the first one. This means that when the second run started, it identified the latest release as a new one (the first build being still 7 minutes from completing), and started the build anew.

This change should hopefully reduce the window of opportunity for that race condition by checking the state of the s3 repository again _after_ having locally built the new version of the docs.