### PR TITLE
Drop deprecated TextMap.filter from daml-stdlib

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/TextMap.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/TextMap.daml
@@ -15,7 +15,6 @@ module DA.TextMap
   , null
   , lookup
   , member
-  , filter
   , filterWithKey
   , delete
   , insert
@@ -73,11 +72,6 @@ lookup = primitive @"BEMapLookup"
 -- | Is the key a member of the map?
 member : Text -> TextMap v -> Bool
 member x m = isSome $ lookup x m
-
-{-# DEPRECATED filter "Use 'filterWithKey' instead of 'filter'" #-}
--- | DEPRECATED: Use `filterWithKey` instead.
-filter : (Text -> v -> Bool) -> TextMap v -> TextMap v
-filter = filterWithKey
 
 -- | Filter all values that satisfy some predicate.
 filterWithKey : (Text -> v -> Bool) -> TextMap v -> TextMap v


### PR DESCRIPTION
It has been deprecated for a while now with a hint to use `filterWithKey`
instead. We should add
```haskell
filter : (v -> Bool) -> TextMap v -> TextMap v
```
after the next SDK release instead. This is tracked in #2760.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2761)
<!-- Reviewable:end -->
