### PR TITLE
add damlc-options to daml.yaml

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -76,6 +76,7 @@ data PackageConfigFields = PackageConfigFields
     , pVersion :: String
     , pDependencies :: [String]
     , pSdkVersion :: String
+    , cliOpts :: Maybe [String]
     }
 
 buildDar ::

--- a/compiler/damlc/lib/DA/Cli/Args.hs
+++ b/compiler/damlc/lib/DA/Cli/Args.hs
@@ -5,29 +5,23 @@
 --   mode which discards unused flags
 --   We use feature flags in the daml IDE and this stops the compiler from
 --   falling over whenever it receives a flag it doesn't recognize.
-module DA.Cli.Args (execParserLax) where
+module DA.Cli.Args (lax) where
 
 import qualified Options.Applicative as Op
 import Options.Applicative hiding (customExecParser, execParser)
 import Options.Applicative.Internal
 import Options.Applicative.BashCompletion
 import Options.Applicative.Common
-import System.Environment
-import System.IO
 
 -- | Runs the argument parser in a normal way unless the first argument is "lax"
 --   In this case it discards invalid flags and continues
-execParserLax :: Op.ParserInfo a -> IO a
-execParserLax = customExecParser Op.defaultPrefs
-
-customExecParser :: Op.ParserPrefs -> Op.ParserInfo a -> IO a
-customExecParser pprefs pinfo = do
-  args <- getArgs
-  filteredArgs <-
+lax :: Op.ParserInfo a -> [String] -> ([String], ParserResult a)
+lax pinfo args =
+  let (errMsgs, filteredArgs) =
         case args of
-          "lax":xs -> removeUnknownFlags pprefs pinfo xs
-          xs -> pure xs
-  Op.handleParseResult $ Op.execParserPure pprefs pinfo filteredArgs
+          "lax":xs -> removeUnknownFlags Op.defaultPrefs pinfo xs
+          xs -> ([], xs)
+   in (errMsgs, Op.execParserPure Op.defaultPrefs pinfo filteredArgs)
 
 -- | If the parser fails on an unrecognized flags remove those flags
 --   Worst case O(N^2)
@@ -35,7 +29,7 @@ removeUnknownFlags
   :: Op.ParserPrefs   -- ^ Global preferences for this parser
   -> Op.ParserInfo a  -- ^ Description of the program to run
   -> [String]         -- ^ Program arguments
-  -> IO [String]
+  -> ([String], [String])
 removeUnknownFlags pprefs pinfo args =
   noBadFlags wrk args
   where
@@ -47,10 +41,12 @@ removeUnknownFlags pprefs pinfo args =
 
 noBadFlags :: ([String] -> Either ParseError a)
            -> [String]
-           -> IO [String]
+           -> ([String], [String])
 noBadFlags f args = case f args of
-    Left (UnexpectedError arg@('-':_) _) -> do
-      hPutStrLn stderr $
-        " [WARN] argument '"<>arg<>"' has been discarded due to the 'lax' command"
-      noBadFlags f $ filter (arg /=) args
-    _ -> pure args
+    Left (UnexpectedError arg@('-':_) _) ->
+      let errMsg = " [WARN] argument '"
+                   <>arg<>
+                   "' has been discarded due to the 'lax' command"
+          (errs, valid) = noBadFlags f $ filter (arg /=) args
+      in (errMsg:errs, valid)
+    _ -> ([], args)

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -15,10 +15,10 @@ import Control.Exception.Safe (catchIO)
 import Control.Monad.Except
 import Control.Monad.Extra (whenM)
 import DA.Bazel.Runfiles
-import DA.Cli.Args
+import qualified DA.Cli.Args as ParseArgs
 import DA.Cli.Damlc.Base
 import DA.Cli.Damlc.BuildInfo
-import DA.Cli.Damlc.Command.Damldoc (cmdDamlDoc)
+import qualified DA.Cli.Damlc.Command.Damldoc as Damldoc
 import DA.Cli.Damlc.IdeState
 import DA.Cli.Damlc.Test
 import DA.Daml.Visual
@@ -90,6 +90,26 @@ import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 -- Commands
 --------------------------------------------------------------------------------
 
+data CommandName =
+    Build
+  | Clean
+  | Compile
+  | DamlDoc
+  | DocTest
+  | Ide
+  | Init
+  | Inspect
+  | InspectDar
+  | License
+  | Lint
+  | MergeDars
+  | Migrate
+  | Package
+  | Test
+  | Visual
+  deriving (Ord, Show, Eq)
+data Command = Command CommandName (IO ())
+
 cmdIde :: Mod CommandFields Command
 cmdIde =
     command "ide" $ info (helper <*> cmd) $
@@ -153,17 +173,17 @@ cmdTest numProcessors =
     junitOutput = optional $ strOption $ long "junit" <> metavar "FILENAME" <> help "Filename of JUnit output file"
     colorOutput = switch $ long "color" <> help "Colored test results"
 
-runTestsInProjectOrFiles :: ProjectOpts -> Maybe [FilePath] -> UseColor -> Maybe FilePath -> Options -> IO ()
-runTestsInProjectOrFiles projectOpts Nothing color mbJUnitOutput cliOptions =
-    withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath _ -> do
+runTestsInProjectOrFiles :: ProjectOpts -> Maybe [FilePath] -> UseColor -> Maybe FilePath -> Options -> Command
+runTestsInProjectOrFiles projectOpts Nothing color mbJUnitOutput cliOptions = Command Test effect
+  where effect = withExpectProjectRoot (projectRoot projectOpts) "daml test" $ \pPath _ -> do
         project <- readProjectConfig $ ProjectPath pPath
         case parseProjectConfig project of
             Left err -> throwIO err
             Right PackageConfigFields {..} -> do
               files <- getDamlFiles pSrc
               execTest files color mbJUnitOutput cliOptions
-runTestsInProjectOrFiles projectOpts (Just inFiles) color mbJUnitOutput cliOptions =
-    withProjectRoot' projectOpts $ \relativize -> do
+runTestsInProjectOrFiles projectOpts (Just inFiles) color mbJUnitOutput cliOptions = Command Test effect
+  where effect = withProjectRoot' projectOpts $ \relativize -> do
         inFiles' <- mapM (fmap toNormalizedFilePath . relativize) inFiles
         execTest inFiles' color mbJUnitOutput cliOptions
 
@@ -183,7 +203,8 @@ cmdVisual :: Mod CommandFields Command
 cmdVisual =
     command "visual" $ info (helper <*> cmd) $ progDesc "Generate visual from dar" <> fullDesc
     where
-      cmd = execVisual <$> inputDarOpt <*> dotFileOpt
+      cmd = vis <$> inputDarOpt <*> dotFileOpt
+      vis a b = Command Visual $ execVisual a b
 
 
 cmdBuild :: Int -> Mod CommandFields Command
@@ -280,8 +301,10 @@ cmdDocTest numProcessors =
 --------------------------------------------------------------------------------
 
 execLicense :: Command
-execLicense = B.putStr licenseData
+execLicense =
+  Command License effect
   where
+    effect = B.putStr licenseData
     licenseData :: B.ByteString
     licenseData = $(embedFile "compiler/daml-licenses/licenses/licensing.md")
 
@@ -291,65 +314,68 @@ execIde :: Telemetry
         -> [String]
         -> Maybe FilePath
         -> Command
-execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = NS.withSocketsDo $ do
-    let threshold =
-            if debug
-            then Logger.Debug
-            -- info is used pretty extensively for debug messages in our code base so
-            -- I've set the no debug threshold at warning
-            else Logger.Warning
-    loggerH <- Logger.IO.newIOLogger
-      stderr
-      (Just 5000)
-      -- NOTE(JM): ^ Limit the message length to 5000 characters as VSCode
-      -- performance will be significatly impacted by large log output.
-      threshold
-      "LanguageServer"
-    let withLogger f = case telemetry of
-            OptedIn -> Logger.GCP.withGcpLogger (>= Logger.Warning) loggerH $ \gcpState loggerH' -> do
-                Logger.GCP.logMetaData gcpState
-                f loggerH'
-            OptedOut -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
-                Logger.GCP.logOptOut gcpState
-                f loggerH
-            Undecided -> f loggerH
-    -- TODO we should allow different LF versions in the IDE.
-    initPackageDb LF.versionDefault (InitPkgDb True) (AllowDifferentSdkVersions False)
-    dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-    opts <- defaultOptionsIO Nothing
-    opts <- pure $ opts
-        { optScenarioService = enableScenarioService
-        , optScenarioValidation = ScenarioValidationLight
-        , optShakeProfiling = mbProfileDir
-        , optThreads = 0
-        , optDlintUsage = DlintEnabled dlintDataDir True
-        , optGhcCustomOpts = ghcOpts
-        }
-    scenarioServiceConfig <- readScenarioServiceConfig
-    withLogger $ \loggerH ->
-        withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
-            sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
-            Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
-            runLanguageServer $ \sendMsg vfs caps ->
-                getDamlIdeState opts mbScenarioService loggerH sendMsg vfs (clientSupportsProgress caps)
+execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Command Ide effect
+  where effect = NS.withSocketsDo $ do
+          let threshold =
+                  if debug
+                  then Logger.Debug
+                  -- info is used pretty extensively for debug messages in our code base so
+                  -- I've set the no debug threshold at warning
+                  else Logger.Warning
+          loggerH <- Logger.IO.newIOLogger
+            stderr
+            (Just 5000)
+            -- NOTE(JM): ^ Limit the message length to 5000 characters as VSCode
+            -- performance will be significatly impacted by large log output.
+            threshold
+            "LanguageServer"
+          let withLogger f = case telemetry of
+                  OptedIn -> Logger.GCP.withGcpLogger (>= Logger.Warning) loggerH $ \gcpState loggerH' -> do
+                      Logger.GCP.logMetaData gcpState
+                      f loggerH'
+                  OptedOut -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
+                      Logger.GCP.logOptOut gcpState
+                      f loggerH
+                  Undecided -> f loggerH
+          -- TODO we should allow different LF versions in the IDE.
+          initPackageDb LF.versionDefault (InitPkgDb True) (AllowDifferentSdkVersions False)
+          dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+          opts <- defaultOptionsIO Nothing
+          opts <- pure $ opts
+              { optScenarioService = enableScenarioService
+              , optScenarioValidation = ScenarioValidationLight
+              , optShakeProfiling = mbProfileDir
+              , optThreads = 0
+              , optDlintUsage = DlintEnabled dlintDataDir True
+              , optGhcCustomOpts = ghcOpts
+              }
+          scenarioServiceConfig <- readScenarioServiceConfig
+          withLogger $ \loggerH ->
+              withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
+                  sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
+                  Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
+                  runLanguageServer $ \sendMsg vfs caps ->
+                      getDamlIdeState opts mbScenarioService loggerH sendMsg vfs (clientSupportsProgress caps)
 
 
 execCompile :: FilePath -> FilePath -> Options -> Command
-execCompile inputFile outputFile opts = withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize -> do
-    loggerH <- getLogger opts "compile"
-    inputFile <- toNormalizedFilePath <$> relativize inputFile
-    opts' <- mkOptions opts
-    withDamlIdeState opts' loggerH diagnosticsLogger $ \ide -> do
-        setFilesOfInterest ide (Set.singleton inputFile)
-        runAction ide $ do
-          when (optWriteInterface opts') $ do
-              files <- nubSort . concatMap transitiveModuleDeps <$> use GetDependencies inputFile
-              mbIfaces <- writeIfacesAndHie (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts') files
-              void $ liftIO $ mbErr "ERROR: Compilation failed." mbIfaces
-          mbDalf <- getDalf inputFile
-          dalf <- liftIO $ mbErr "ERROR: Compilation failed." mbDalf
-          liftIO $ write dalf
+execCompile inputFile outputFile opts =
+  Command Compile effect
   where
+    effect = withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize -> do
+      loggerH <- getLogger opts "compile"
+      inputFile <- toNormalizedFilePath <$> relativize inputFile
+      opts' <- mkOptions opts
+      withDamlIdeState opts' loggerH diagnosticsLogger $ \ide -> do
+          setFilesOfInterest ide (Set.singleton inputFile)
+          runAction ide $ do
+            when (optWriteInterface opts') $ do
+                files <- nubSort . concatMap transitiveModuleDeps <$> use GetDependencies inputFile
+                mbIfaces <- writeIfacesAndHie (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts') files
+                void $ liftIO $ mbErr "ERROR: Compilation failed." mbIfaces
+            mbDalf <- getDalf inputFile
+            dalf <- liftIO $ mbErr "ERROR: Compilation failed." mbDalf
+            liftIO $ write dalf
     write bs
       | outputFile == "-" = putStrLn $ render Colored $ DA.Pretty.pretty bs
       | otherwise = do
@@ -358,20 +384,22 @@ execCompile inputFile outputFile opts = withProjectRoot' (ProjectOpts Nothing (P
 
 execLint :: FilePath -> Options -> Command
 execLint inputFile opts =
-  withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize ->
-  do
-    loggerH <- getLogger opts "lint"
-    inputFile <- toNormalizedFilePath <$> relativize inputFile
-    opts <- (setDlintDataDir <=< mkOptions) opts
-    withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> do
-        setFilesOfInterest ide (Set.singleton inputFile)
-        runAction ide $ getDlintIdeas inputFile
-        diags <- getDiagnostics ide
-        if null diags then
-          hPutStrLn stderr "No hints"
-        else
-          exitFailure
+  Command Lint effect
   where
+     effect =
+       withProjectRoot' (ProjectOpts Nothing (ProjectCheck "" False)) $ \relativize ->
+       do
+         loggerH <- getLogger opts "lint"
+         inputFile <- toNormalizedFilePath <$> relativize inputFile
+         opts <- (setDlintDataDir <=< mkOptions) opts
+         withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> do
+             setFilesOfInterest ide (Set.singleton inputFile)
+             runAction ide $ getDlintIdeas inputFile
+             diags <- getDiagnostics ide
+             if null diags then
+               hPutStrLn stderr "No hints"
+             else
+               exitFailure
      setDlintDataDir :: Options -> IO Options
      setDlintDataDir opts = do
        defaultDir <-locateRunfiles $
@@ -390,7 +418,8 @@ parseProjectConfig project = do
     dependencies <-
         queryProjectConfigRequired ["dependencies"] project
     sdkVersion <- queryProjectConfigRequired ["sdk-version"] project
-    Right $ PackageConfigFields name main exposedModules version dependencies sdkVersion
+    cliOpts <- queryProjectConfig ["build-options"] project
+    Right $ PackageConfigFields name main exposedModules version dependencies sdkVersion cliOpts
 
 -- | We assume that this is only called within `withProjectRoot`.
 withPackageConfig :: (PackageConfigFields -> IO a) -> IO a
@@ -402,10 +431,11 @@ withPackageConfig f = do
 
 -- | If we're in a daml project, read the daml.yaml field and create the project local package
 -- database. Otherwise do nothing.
-execInit :: LF.Version -> ProjectOpts -> IO ()
+execInit :: LF.Version -> ProjectOpts -> Command
 execInit lfVersion projectOpts =
-    withProjectRoot' projectOpts $ \_relativize ->
-        initPackageDb
+  Command Init effect
+  where effect = withProjectRoot' projectOpts $ \_relativize ->
+          initPackageDb
             lfVersion
             (InitPkgDb True)
             (AllowDifferentSdkVersions False)
@@ -495,46 +525,50 @@ createProjectPackageDb (AllowDifferentSdkVersions allowDiffSdkVersions) lfVersio
 mbErr :: String -> Maybe a -> IO a
 mbErr err = maybe (hPutStrLn stderr err >> exitFailure) pure
 
-execBuild :: ProjectOpts -> Options -> Maybe FilePath -> InitPkgDb -> IO ()
-execBuild projectOpts options mbOutFile initPkgDb = withProjectRoot' projectOpts $ \_relativize -> do
-    initPackageDb (optDamlLfVersion options) initPkgDb (AllowDifferentSdkVersions False)
-    withPackageConfig $ \pkgConfig@PackageConfigFields{..} -> do
-        putStrLn $ "Compiling " <> pName <> " to a DAR."
-        opts <- mkOptions options
-        loggerH <- getLogger opts "package"
-        withDamlIdeState
-            opts {optMbPackageName = Just $ pkgNameVersion pName pVersion}
-            loggerH
-            diagnosticsLogger $ \compilerH -> do
-            mbDar <-
-                buildDar
-                    compilerH
-                    pkgConfig
-                    (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts)
-                    (FromDalf False)
-            dar <- mbErr "ERROR: Creation of DAR file failed." mbDar
-            let fp = targetFilePath $ pkgNameVersion pName pVersion
-            createDirectoryIfMissing True $ takeDirectory fp
-            Zip.createArchive fp dar
-            putStrLn $ "Created " <> fp <> "."
-    where
-        targetFilePath name = fromMaybe (distDir </> name <.> "dar") mbOutFile
+execBuild :: ProjectOpts -> Options -> Maybe FilePath -> InitPkgDb -> Command
+execBuild projectOpts options mbOutFile initPkgDb =
+  Command Build effect
+  where effect = withProjectRoot' projectOpts $ \_relativize -> do
+            initPackageDb (optDamlLfVersion options) initPkgDb (AllowDifferentSdkVersions False)
+            withPackageConfig $ \pkgConfig@PackageConfigFields{..} -> do
+                putStrLn $ "Compiling " <> pName <> " to a DAR."
+                opts <- mkOptions options
+                loggerH <- getLogger opts "package"
+                withDamlIdeState
+                    opts {optMbPackageName = Just $ pkgNameVersion pName pVersion}
+                    loggerH
+                    diagnosticsLogger $ \compilerH -> do
+                    mbDar <-
+                        buildDar
+                            compilerH
+                            pkgConfig
+                            (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts)
+                            (FromDalf False)
+                    dar <- mbErr "ERROR: Creation of DAR file failed." mbDar
+                    let fp = targetFilePath $ pkgNameVersion pName pVersion
+                    createDirectoryIfMissing True $ takeDirectory fp
+                    Zip.createArchive fp dar
+                    putStrLn $ "Created " <> fp <> "."
+            where
+                targetFilePath name = fromMaybe (distDir </> name <.> "dar") mbOutFile
 
 -- | Remove any build artifacts if they exist.
-execClean :: ProjectOpts -> IO ()
-execClean projectOpts = do
-    withProjectRoot' projectOpts $ \_relativize -> do
-        isProject <- doesFileExist projectConfigName
-        when isProject $ do
-            let removeAndWarn path = do
-                    whenM (doesDirectoryExist path) $ do
-                        putStrLn ("Removing directory " <> path)
-                        removePathForcibly path
-                    whenM (doesFileExist path) $ do
-                        putStrLn ("Removing file " <> path)
-                        removePathForcibly path
-            removeAndWarn damlArtifactDir
-            putStrLn "Removed build artifacts."
+execClean :: ProjectOpts -> Command
+execClean projectOpts =
+  Command Clean effect
+  where effect = do
+            withProjectRoot' projectOpts $ \_relativize -> do
+                isProject <- doesFileExist projectConfigName
+                when isProject $ do
+                    let removeAndWarn path = do
+                            whenM (doesDirectoryExist path) $ do
+                                putStrLn ("Removing directory " <> path)
+                                removePathForcibly path
+                            whenM (doesFileExist path) $ do
+                                putStrLn ("Removing file " <> path)
+                                removePathForcibly path
+                    removeAndWarn damlArtifactDir
+                    putStrLn "Removed build artifacts."
 
 lfVersionString :: LF.Version -> String
 lfVersionString = DA.Pretty.renderPretty
@@ -544,35 +578,38 @@ execPackage:: ProjectOpts
             -> Options
             -> Maybe FilePath
             -> FromDalf
-            -> IO ()
-execPackage projectOpts filePath opts mbOutFile dalfInput = withProjectRoot' projectOpts $ \relativize -> do
-    loggerH <- getLogger opts "package"
-    filePath <- relativize filePath
-    opts' <- mkOptions opts
-    withDamlIdeState opts' loggerH diagnosticsLogger $ \ide -> do
-        -- We leave the sdk version blank and the list of exposed modules empty.
-        -- This command is being removed anytime now and not present
-        -- in the new daml assistant.
-        mbDar <- buildDar ide
-                          PackageConfigFields
-                            { pName = fromMaybe (takeBaseName filePath) $ optMbPackageName opts
-                            , pSrc = filePath
-                            , pExposedModules = Nothing
-                            , pVersion = ""
-                            , pDependencies = []
-                            , pSdkVersion = ""
-                            }
-                          (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts')
-                          dalfInput
-        case mbDar of
-          Nothing -> do
-              hPutStrLn stderr "ERROR: Creation of DAR file failed."
-              exitFailure
-          Just dar -> do
-            createDirectoryIfMissing True $ takeDirectory targetFilePath
-            Zip.createArchive targetFilePath dar
-            putStrLn $ "Created " <> targetFilePath <> "."
+            -> Command
+execPackage projectOpts filePath opts mbOutFile dalfInput =
+  Command Package effect
   where
+    effect = withProjectRoot' projectOpts $ \relativize -> do
+      loggerH <- getLogger opts "package"
+      filePath <- relativize filePath
+      opts' <- mkOptions opts
+      withDamlIdeState opts' loggerH diagnosticsLogger $ \ide -> do
+          -- We leave the sdk version blank and the list of exposed modules empty.
+          -- This command is being removed anytime now and not present
+          -- in the new daml assistant.
+          mbDar <- buildDar ide
+                            PackageConfigFields
+                              { pName = fromMaybe (takeBaseName filePath) $ optMbPackageName opts
+                              , pSrc = filePath
+                              , pExposedModules = Nothing
+                              , pVersion = ""
+                              , pDependencies = []
+                              , pSdkVersion = ""
+                              , cliOpts = Nothing
+                              }
+                            (toNormalizedFilePath $ fromMaybe ifaceDir $ optIfaceDir opts')
+                            dalfInput
+          case mbDar of
+            Nothing -> do
+                hPutStrLn stderr "ERROR: Creation of DAR file failed."
+                exitFailure
+            Just dar -> do
+              createDirectoryIfMissing True $ takeDirectory targetFilePath
+              Zip.createArchive targetFilePath dar
+              putStrLn $ "Created " <> targetFilePath <> "."
     -- This is somewhat ugly but our CLI parser guarantees that this will always be present.
     -- We could parametrize CliOptions by whether the package name is optional
     -- but I don’t think that is worth the complexity of carrying around a type parameter.
@@ -589,29 +626,32 @@ execPackage projectOpts filePath opts mbOutFile dalfInput = withProjectRoot' pro
     targetFilePath = fromMaybe defaultDarFile mbOutFile
 
 execInspect :: FilePath -> FilePath -> Bool -> DA.Pretty.PrettyLevel -> Command
-execInspect inFile outFile jsonOutput lvl = do
-    bytes <-
-        if "dar" `isExtensionOf` inFile
-            then do
-                dar <- B.readFile inFile
-                dalfs <- either fail pure $ readDalfs $ ZipArchive.toArchive $ BSL.fromStrict dar
-                pure $! BSL.toStrict $ mainDalf dalfs
-            else B.readFile inFile
+execInspect inFile outFile jsonOutput lvl =
+  Command Inspect effect
+  where
+    effect = do
+      bytes <-
+          if "dar" `isExtensionOf` inFile
+              then do
+                  dar <- B.readFile inFile
+                  dalfs <- either fail pure $ readDalfs $ ZipArchive.toArchive $ BSL.fromStrict dar
+                  pure $! BSL.toStrict $ mainDalf dalfs
+              else B.readFile inFile
 
-    if jsonOutput
-    then do
-      archive :: PLF.ArchivePayload <- errorOnLeft "Cannot decode archive" (PS.fromByteString bytes)
-      writeOutputBSL outFile
-       $ Aeson.Pretty.encodePretty
-       $ Proto.JSONPB.toAesonValue archive
-    else do
-      (pkgId, lfPkg) <- errorOnLeft "Cannot decode package" $
-                 Archive.decodeArchive bytes
-      writeOutput outFile $ render Plain $
-        DA.Pretty.vsep
-          [ DA.Pretty.keyword_ "package" DA.Pretty.<-> DA.Pretty.text (LF.unPackageId pkgId) DA.Pretty.<-> DA.Pretty.keyword_ "where"
-          , DA.Pretty.nest 2 (DA.Pretty.pPrintPrec lvl 0 lfPkg)
-          ]
+      if jsonOutput
+      then do
+        archive :: PLF.ArchivePayload <- errorOnLeft "Cannot decode archive" (PS.fromByteString bytes)
+        writeOutputBSL outFile
+         $ Aeson.Pretty.encodePretty
+         $ Proto.JSONPB.toAesonValue archive
+      else do
+        (pkgId, lfPkg) <- errorOnLeft "Cannot decode package" $
+                   Archive.decodeArchive bytes
+        writeOutput outFile $ render Plain $
+          DA.Pretty.vsep
+            [ DA.Pretty.keyword_ "package" DA.Pretty.<-> DA.Pretty.text (LF.unPackageId pkgId) DA.Pretty.<-> DA.Pretty.keyword_ "where"
+            , DA.Pretty.nest 2 (DA.Pretty.pPrintPrec lvl 0 lfPkg)
+            ]
 
 errorOnLeft :: Show a => String -> Either a b -> IO b
 errorOnLeft desc = \case
@@ -619,26 +659,29 @@ errorOnLeft desc = \case
   Right x  -> return x
 
 execInspectDar :: FilePath -> Command
-execInspectDar inFile = do
-    bytes <- B.readFile inFile
+execInspectDar inFile =
+  Command InspectDar effect
+  where
+    effect = do
+      bytes <- B.readFile inFile
 
-    putStrLn "DAR archive contains the following files: \n"
-    let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
-    let files = [ZipArchive.eRelativePath e | e <- ZipArchive.zEntries dar]
-    mapM_ putStrLn files
+      putStrLn "DAR archive contains the following files: \n"
+      let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
+      let files = [ZipArchive.eRelativePath e | e <- ZipArchive.zEntries dar]
+      mapM_ putStrLn files
 
-    putStrLn "\nDAR archive contains the following packages: \n"
-    let dalfEntries =
-            [e | e <- ZipArchive.zEntries dar, ".dalf" `isExtensionOf` ZipArchive.eRelativePath e]
-    forM_ dalfEntries $ \dalfEntry -> do
-        let dalf = BSL.toStrict $ ZipArchive.fromEntry dalfEntry
-        (pkgId, _lfPkg) <-
-            errorOnLeft
-                ("Cannot decode package " <> ZipArchive.eRelativePath dalfEntry)
-                (Archive.decodeArchive dalf)
-        putStrLn $
-            (dropExtension $ takeFileName $ ZipArchive.eRelativePath dalfEntry) <> " " <>
-            show (LF.unPackageId pkgId)
+      putStrLn "\nDAR archive contains the following packages: \n"
+      let dalfEntries =
+              [e | e <- ZipArchive.zEntries dar, ".dalf" `isExtensionOf` ZipArchive.eRelativePath e]
+      forM_ dalfEntries $ \dalfEntry -> do
+          let dalf = BSL.toStrict $ ZipArchive.fromEntry dalfEntry
+          (pkgId, _lfPkg) <-
+              errorOnLeft
+                  ("Cannot decode package " <> ZipArchive.eRelativePath dalfEntry)
+                  (Archive.decodeArchive dalf)
+          putStrLn $
+              (dropExtension $ takeFileName $ ZipArchive.eRelativePath dalfEntry) <> " " <>
+              show (LF.unPackageId pkgId)
 
 execMigrate ::
        ProjectOpts
@@ -647,142 +690,144 @@ execMigrate ::
     -> FilePath
     -> Maybe FilePath
     -> Command
-execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir = do
-    opts <- mkOptions opts0
-    inFile1 <- makeAbsolute inFile1_
-    inFile2 <- makeAbsolute inFile2_
-    loggerH <- getLogger opts "migrate"
-    withProjectRoot' projectOpts $ \_relativize
-     -> do
-        -- initialise the package database
-        initPackageDb (optDamlLfVersion opts) (InitPkgDb True) (AllowDifferentSdkVersions True)
-        -- for all contained dalfs, generate source, typecheck and generate interface files and
-        -- overwrite the existing ones.
-        dbPath <- makeAbsolute $
-                projectPackageDatabase </>
-                lfVersionString (optDamlLfVersion opts)
-        (diags, pkgMap) <- generatePackageMap [dbPath]
-        unless (null diags) $ Logger.logWarning loggerH $ showDiagnostics diags
-        let pkgMap0 = MS.map dalfPackageId pkgMap
-        let genSrcs =
-                [ ( unitId
-                  , generateSrcPkgFromLf (dalfPackageId dalfPkg) pkgMap0 dalf)
-                | (unitId, dalfPkg) <- MS.toList pkgMap
-                , LF.ExternalPackage _ dalf <- [dalfPackagePkg dalfPkg]
-                ]
-        -- order the packages in topological order
-        packageState <-
-            generatePackageState (dbPath : optPackageDbs opts) False []
-        let (depGraph, vertexToNode, _keyToVertex) =
-                graphFromEdges $ do
-                    (uid, src) <- genSrcs
-                    let iuid = toInstalledUnitId uid
-                    Just pkgInfo <-
-                        [ lookupInstalledPackage
-                              (fakeDynFlags
-                                   {pkgState = pdfPkgState packageState})
-                              iuid
-                        ]
-                    pure (src, iuid, depends pkgInfo)
-        let unitIdsTopoSorted = reverse $ topSort depGraph
-        projectPkgDb <- makeAbsolute projectPackageDatabase
-        forM_ unitIdsTopoSorted $ \vertex -> do
-            let (src, iuid, _) = vertexToNode vertex
-            let iuidString = installedUnitIdString iuid
-            let workDir = genDir </> iuidString
-            createDirectoryIfMissing True workDir
-            -- we change the working dir so that we get correct file paths for the interface files.
-            withCurrentDirectory workDir $
-             -- typecheck and generate interface files
-             do
-                forM_ src $ \(fp, content) -> do
-                    let path = fromNormalizedFilePath fp
-                    createDirectoryIfMissing True $ takeDirectory path
-                    writeFile path content
-                opts' <-
-                    mkOptions $
-                    opts
-                        { optWriteInterface = True
-                        , optPackageDbs = [projectPkgDb]
-                        , optIfaceDir = Just (dbPath </> installedUnitIdString iuid)
-                        , optIsGenerated = True
-                        , optDflagCheck = False
-                        , optMbPackageName = Just $ installedUnitIdString iuid
-                        }
-                withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
-                    forM_ src $ \(fp, _content) -> do
-                        mbCore <- runAction ide $ getGhcCore fp
-                        when (isNothing mbCore) $
-                            fail $
-                            "Compilation of generated source for " <>
-                            installedUnitIdString iuid <>
-                            " failed."
-        -- get the package name and the lf-package
-        [(pkgName1, pkgId1, lfPkg1), (pkgName2, pkgId2, lfPkg2)] <-
-            forM [inFile1, inFile2] $ \inFile -> do
-                bytes <- B.readFile inFile
-                let pkgName = takeBaseName inFile
-                let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
-                -- get the main pkg
-                dalfManifest <- either fail pure $ readDalfManifest dar
-                mainDalfEntry <- getEntry (mainDalfPath dalfManifest) dar
-                (mainPkgId, mainLfPkg) <- decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
-                pure (pkgName, mainPkgId, mainLfPkg)
-        -- generate upgrade modules and instances modules
-        let eqModNames =
-                (NM.names $ LF.packageModules lfPkg1) `intersect`
-                (NM.names $ LF.packageModules lfPkg2)
-        let eqModNamesStr = map (T.unpack . LF.moduleNameString) eqModNames
-        let buildCmd escape =
-                    "daml build --init-package-db=no" <> " --package " <>
-                    escape (show (pkgName1, [(m, m ++ "A") | m <- eqModNamesStr])) <>
-                    " --package " <>
-                    escape (show (pkgName2, [(m, m ++ "B") | m <- eqModNamesStr])) <>
-                    " --ghc-option -Wno-unrecognised-pragmas"
-        forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
-            [genSrc1, genSrc2] <-
-                forM [(pkgId1, lfPkg1), (pkgId2, lfPkg2)] $ \(pkgId, pkg) -> do
-                    generateSrcFromLf (Qualify False) pkgId pkgMap0 <$> getModule m pkg
-            let upgradeModPath =
-                    (joinPath $ fromMaybe "" mbDir : map T.unpack modName) <>
-                    ".daml"
-            let instancesModPath1 =
-                    replaceBaseName upgradeModPath $
-                    takeBaseName upgradeModPath <> "AInstances"
-            let instancesModPath2 =
-                    replaceBaseName upgradeModPath $
-                    takeBaseName upgradeModPath <> "BInstances"
-            templateNames <-
-                map (T.unpack . T.intercalate "." . LF.unTypeConName) .
-                NM.names . LF.moduleTemplates <$>
-                getModule m lfPkg1
-            let generatedUpgradeMod =
-                    generateUpgradeModule
-                        templateNames
-                        (T.unpack $ LF.moduleNameString m)
-                        "A"
-                        "B"
-            let generatedInstancesMod1 =
-                    generateGenInstancesModule "A" (pkgName1, genSrc1)
-            let generatedInstancesMod2 =
-                    generateGenInstancesModule "B" (pkgName2, genSrc2)
-                escapeUnix arg = "'" <> arg <> "'"
-                escapeWindows arg = T.unpack $ "\"" <> T.replace "\"" "\\\"" (T.pack arg) <> "\""
-            forM_
-                [ (upgradeModPath, generatedUpgradeMod)
-                , (instancesModPath1, generatedInstancesMod1)
-                , (instancesModPath2, generatedInstancesMod2)
-                , ("build.sh", "#!/bin/sh\n" ++ buildCmd escapeUnix)
-                , ("build.cmd", buildCmd escapeWindows)
-                ] $ \(path, mod) -> do
-                createDirectoryIfMissing True $ takeDirectory path
-                writeFile path mod
+execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir =
+  Command Migrate effect
+  where
+    effect = do
+      opts <- mkOptions opts0
+      inFile1 <- makeAbsolute inFile1_
+      inFile2 <- makeAbsolute inFile2_
+      loggerH <- getLogger opts "migrate"
+      withProjectRoot' projectOpts $ \_relativize
+       -> do
+          -- initialise the package database
+          initPackageDb (optDamlLfVersion opts) (InitPkgDb True) (AllowDifferentSdkVersions True)
+          -- for all contained dalfs, generate source, typecheck and generate interface files and
+          -- overwrite the existing ones.
+          dbPath <- makeAbsolute $
+                  projectPackageDatabase </>
+                  lfVersionString (optDamlLfVersion opts)
+          (diags, pkgMap) <- generatePackageMap [dbPath]
+          unless (null diags) $ Logger.logWarning loggerH $ showDiagnostics diags
+          let pkgMap0 = MS.map dalfPackageId pkgMap
+          let genSrcs =
+                  [ ( unitId
+                    , generateSrcPkgFromLf (dalfPackageId dalfPkg) pkgMap0 dalf)
+                  | (unitId, dalfPkg) <- MS.toList pkgMap
+                  , LF.ExternalPackage _ dalf <- [dalfPackagePkg dalfPkg]
+                  ]
+          -- order the packages in topological order
+          packageState <-
+              generatePackageState (dbPath : optPackageDbs opts) False []
+          let (depGraph, vertexToNode, _keyToVertex) =
+                  graphFromEdges $ do
+                      (uid, src) <- genSrcs
+                      let iuid = toInstalledUnitId uid
+                      Just pkgInfo <-
+                          [ lookupInstalledPackage
+                                (fakeDynFlags
+                                     {pkgState = pdfPkgState packageState})
+                                iuid
+                          ]
+                      pure (src, iuid, depends pkgInfo)
+          let unitIdsTopoSorted = reverse $ topSort depGraph
+          projectPkgDb <- makeAbsolute projectPackageDatabase
+          forM_ unitIdsTopoSorted $ \vertex -> do
+              let (src, iuid, _) = vertexToNode vertex
+              let iuidString = installedUnitIdString iuid
+              let workDir = genDir </> iuidString
+              createDirectoryIfMissing True workDir
+              -- we change the working dir so that we get correct file paths for the interface files.
+              withCurrentDirectory workDir $
+               -- typecheck and generate interface files
+               do
+                  forM_ src $ \(fp, content) -> do
+                      let path = fromNormalizedFilePath fp
+                      createDirectoryIfMissing True $ takeDirectory path
+                      writeFile path content
+                  opts' <-
+                      mkOptions $
+                      opts
+                          { optWriteInterface = True
+                          , optPackageDbs = [projectPkgDb]
+                          , optIfaceDir = Just (dbPath </> installedUnitIdString iuid)
+                          , optIsGenerated = True
+                          , optDflagCheck = False
+                          , optMbPackageName = Just $ installedUnitIdString iuid
+                          }
+                  withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
+                      forM_ src $ \(fp, _content) -> do
+                          mbCore <- runAction ide $ getGhcCore fp
+                          when (isNothing mbCore) $
+                              fail $
+                              "Compilation of generated source for " <>
+                              installedUnitIdString iuid <>
+                              " failed."
+          -- get the package name and the lf-package
+          [(pkgName1, pkgId1, lfPkg1), (pkgName2, pkgId2, lfPkg2)] <-
+              forM [inFile1, inFile2] $ \inFile -> do
+                  bytes <- B.readFile inFile
+                  let pkgName = takeBaseName inFile
+                  let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
+                  -- get the main pkg
+                  dalfManifest <- either fail pure $ readDalfManifest dar
+                  mainDalfEntry <- getEntry (mainDalfPath dalfManifest) dar
+                  (mainPkgId, mainLfPkg) <- decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
+                  pure (pkgName, mainPkgId, mainLfPkg)
+          -- generate upgrade modules and instances modules
+          let eqModNames =
+                  (NM.names $ LF.packageModules lfPkg1) `intersect`
+                  (NM.names $ LF.packageModules lfPkg2)
+          let eqModNamesStr = map (T.unpack . LF.moduleNameString) eqModNames
+          let buildCmd escape =
+                      "daml build --init-package-db=no" <> " --package " <>
+                      escape (show (pkgName1, [(m, m ++ "A") | m <- eqModNamesStr])) <>
+                      " --package " <>
+                      escape (show (pkgName2, [(m, m ++ "B") | m <- eqModNamesStr])) <>
+                      " --ghc-option -Wno-unrecognised-pragmas"
+          forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
+              [genSrc1, genSrc2] <-
+                  forM [(pkgId1, lfPkg1), (pkgId2, lfPkg2)] $ \(pkgId, pkg) -> do
+                      generateSrcFromLf (Qualify False) pkgId pkgMap0 <$> getModule m pkg
+              let upgradeModPath =
+                      (joinPath $ fromMaybe "" mbDir : map T.unpack modName) <>
+                      ".daml"
+              let instancesModPath1 =
+                      replaceBaseName upgradeModPath $
+                      takeBaseName upgradeModPath <> "AInstances"
+              let instancesModPath2 =
+                      replaceBaseName upgradeModPath $
+                      takeBaseName upgradeModPath <> "BInstances"
+              templateNames <-
+                  map (T.unpack . T.intercalate "." . LF.unTypeConName) .
+                  NM.names . LF.moduleTemplates <$>
+                  getModule m lfPkg1
+              let generatedUpgradeMod =
+                      generateUpgradeModule
+                          templateNames
+                          (T.unpack $ LF.moduleNameString m)
+                          "A"
+                          "B"
+              let generatedInstancesMod1 =
+                      generateGenInstancesModule "A" (pkgName1, genSrc1)
+              let generatedInstancesMod2 =
+                      generateGenInstancesModule "B" (pkgName2, genSrc2)
+                  escapeUnix arg = "'" <> arg <> "'"
+                  escapeWindows arg = T.unpack $ "\"" <> T.replace "\"" "\\\"" (T.pack arg) <> "\""
+              forM_
+                  [ (upgradeModPath, generatedUpgradeMod)
+                  , (instancesModPath1, generatedInstancesMod1)
+                  , (instancesModPath2, generatedInstancesMod2)
+                  , ("build.sh", "#!/bin/sh\n" ++ buildCmd escapeUnix)
+                  , ("build.cmd", buildCmd escapeWindows)
+                  ] $ \(path, mod) -> do
+                  createDirectoryIfMissing True $ takeDirectory path
+                  writeFile path mod
 #ifndef mingw32_HOST_OS
-        setFileMode "build.sh" $ stdFileMode `unionFileModes` ownerExecuteMode
+          setFileMode "build.sh" $ stdFileMode `unionFileModes` ownerExecuteMode
 #endif
 
-        putStrLn "Generation of migration project complete."
-  where
+          putStrLn "Generation of migration project complete."
     decode dalf =
         errorOnLeft
             "Cannot decode daml-lf archive"
@@ -801,22 +846,24 @@ getEntry fp dar =
 
 -- | Merge two dars. The idea is that the second dar is a delta. Hence, we take the main in the
 -- manifest from the first.
-execMergeDars :: FilePath -> FilePath -> Maybe FilePath -> IO ()
-execMergeDars darFp1 darFp2 mbOutFp = do
-    let outFp = fromMaybe darFp1 mbOutFp
-    bytes1 <- B.readFile darFp1
-    bytes2 <- B.readFile darFp2
-    let dar1 = ZipArchive.toArchive $ BSL.fromStrict bytes1
-    let dar2 = ZipArchive.toArchive $ BSL.fromStrict bytes2
-    mf <- mergeManifests dar1 dar2
-    let merged =
-            ZipArchive.Archive
-                (nubSortOn ZipArchive.eRelativePath $ mf : ZipArchive.zEntries dar1 ++ ZipArchive.zEntries dar2)
-                -- nubSortOn keeps the first occurence
-                Nothing
-                BSL.empty
-    BSL.writeFile outFp $ ZipArchive.fromArchive merged
+execMergeDars :: FilePath -> FilePath -> Maybe FilePath -> Command
+execMergeDars darFp1 darFp2 mbOutFp =
+  Command MergeDars effect
   where
+    effect = do
+      let outFp = fromMaybe darFp1 mbOutFp
+      bytes1 <- B.readFile darFp1
+      bytes2 <- B.readFile darFp2
+      let dar1 = ZipArchive.toArchive $ BSL.fromStrict bytes1
+      let dar2 = ZipArchive.toArchive $ BSL.fromStrict bytes2
+      mf <- mergeManifests dar1 dar2
+      let merged =
+              ZipArchive.Archive
+                  (nubSortOn ZipArchive.eRelativePath $ mf : ZipArchive.zEntries dar1 ++ ZipArchive.zEntries dar2)
+                  -- nubSortOn keeps the first occurence
+                  Nothing
+                  BSL.empty
+      BSL.writeFile outFp $ ZipArchive.fromArchive merged
     mergeManifests dar1 dar2 = do
         manifest1 <- either fail pure $ readDalfManifest dar1
         manifest2 <- either fail pure $ readDalfManifest dar2
@@ -826,21 +873,24 @@ execMergeDars darFp1 darFp2 mbOutFp = do
         pure $ ZipArchive.toEntry manifestPath 0 $ BSLC.unlines $
             map (\(k, v) -> breakAt72Bytes $ BSL.fromStrict $ k <> ": " <> v) attrs1
 
-execDocTest :: Options -> [FilePath] -> IO ()
-execDocTest opts files = do
-    let files' = map toNormalizedFilePath files
-    logger <- getLogger opts "doctest"
-    -- We don’t add a logger here since we will otherwise emit logging messages twice.
-    importPaths <-
-        withDamlIdeState opts { optScenarioService = EnableScenarioService False }
-            logger (const $ pure ()) $ \ideState -> runAction ideState $ do
-        pmS <- catMaybes <$> uses GetParsedModule files'
-        -- This is horrible but we do not have a way to change the import paths in a running
-        -- IdeState at the moment.
-        pure $ nubOrd $ mapMaybe moduleImportPaths pmS
-    opts <- mkOptions opts { optImportPath = importPaths <> optImportPath opts, optHaddock = Haddock True }
-    withDamlIdeState opts logger diagnosticsLogger $ \ideState ->
-        docTest ideState files'
+execDocTest :: Options -> [FilePath] -> Command
+execDocTest opts files =
+  Command DocTest effect
+  where
+    effect = do
+      let files' = map toNormalizedFilePath files
+      logger <- getLogger opts "doctest"
+      -- We don’t add a logger here since we will otherwise emit logging messages twice.
+      importPaths <-
+          withDamlIdeState opts { optScenarioService = EnableScenarioService False }
+              logger (const $ pure ()) $ \ideState -> runAction ideState $ do
+          pmS <- catMaybes <$> uses GetParsedModule files'
+          -- This is horrible but we do not have a way to change the import paths in a running
+          -- IdeState at the moment.
+          pure $ nubOrd $ mapMaybe moduleImportPaths pmS
+      opts <- mkOptions opts { optImportPath = importPaths <> optImportPath opts, optHaddock = Haddock True }
+      withDamlIdeState opts logger diagnosticsLogger $ \ideState ->
+          docTest ideState files'
 
 --------------------------------------------------------------------------------
 -- main
@@ -968,7 +1018,7 @@ options numProcessors =
       <> cmdPackage numProcessors
       <> cmdBuild numProcessors
       <> cmdTest numProcessors
-      <> cmdDamlDoc
+      <> Damldoc.cmd (\cli -> Command DamlDoc $ Damldoc.exec cli)
       <> cmdVisual
       <> cmdInspectDar
       <> cmdDocTest numProcessors
@@ -996,12 +1046,37 @@ parserInfo numProcessors =
         ])
     )
 
+cliArgsFromDamlYaml :: IO [String]
+cliArgsFromDamlYaml = do
+    handle (\(_ :: ConfigError) -> return [])
+           $ do
+               project <- readProjectConfig $ ProjectPath "."
+               case parseProjectConfig project of
+                   Left _ -> return []
+                   Right pkgConfig -> case cliOpts pkgConfig of
+                       Nothing -> return []
+                       Just xs -> return xs
+
 main :: IO ()
 main = do
     -- We need this to ensure that logs are flushed on SIGTERM.
     installSignalHandlers
     numProcessors <- getNumProcessors
-    withProgName "damlc" $ join $ execParserLax (parserInfo numProcessors)
+    let parse = ParseArgs.lax (parserInfo numProcessors)
+    cliArgs <- getArgs
+    damlYamlArgs <- cliArgsFromDamlYaml
+    let (_, tempParseResult) = parse cliArgs
+    -- Note: need to parse given args first to decide whether we need to add
+    -- args from daml.yaml.
+    Command cmd _ <- handleParseResult tempParseResult
+    let args = if cmd `elem` [Build, Compile, Ide]
+               then cliArgs ++ damlYamlArgs
+               else cliArgs
+        (errMsgs, parseResult) = parse args
+    Command _ io <- handleParseResult parseResult
+    forM_ errMsgs $ \msg -> do
+        hPutStrLn stderr msg
+    withProgName "damlc" io
 
 withProjectRoot' :: ProjectOpts -> ((FilePath -> IO FilePath) -> IO a) -> IO a
 withProjectRoot' ProjectOpts{..} act =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
@@ -4,7 +4,6 @@
 module DA.Cli.Damlc.Base
     ( module DA.Cli.Options
     , module DA.Cli.Output
-    , Command
     , getLogger
     )
 where
@@ -14,8 +13,6 @@ import DA.Daml.Options.Types
 import qualified Data.Text as T
 import qualified DA.Service.Logger                 as Logger
 import qualified DA.Service.Logger.Impl.IO         as Logger.IO
-
-type Command = IO ()
 
 getLogger :: Options -> T.Text -> IO (Logger.Handle IO)
 getLogger Options {optDebug} name =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 
-module DA.Cli.Damlc.Command.Damldoc(cmdDamlDoc) where
+module DA.Cli.Damlc.Command.Damldoc(cmd, exec) where
 
 import DA.Cli.Options
 import DA.Daml.Doc.Driver
@@ -18,11 +18,11 @@ import qualified Data.Text as T
 
 ------------------------------------------------------------
 
-cmdDamlDoc :: Mod CommandFields (IO ())
-cmdDamlDoc = command "docs" $
-             info (helper <*> (exec <$> documentation)) $
-             progDesc "Generate documentation for the given DAML program."
-             <> fullDesc
+cmd :: (CmdArgs -> a) -> Mod CommandFields a
+cmd f = command "docs" $
+        info (helper <*> (f <$> documentation)) $
+        progDesc "Generate documentation for the given DAML program."
+        <> fullDesc
 
 documentation :: Parser CmdArgs
 documentation = Damldoc

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -100,6 +100,8 @@ The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory
     scenario-service:
       grpc-max-message-size: 134217728
       grpc-timeout: 60
+    build-options: ["--ghc-option", "-Werror",
+                    "--ghc-option", "-v"]
 
 
 Here is what each field means:
@@ -125,6 +127,8 @@ Here is what each field means:
   - ``grpc-timeout``: This option controls the timeout used for communicating
     with the scenario service. If unspecified this defaults to 60s. Unless you get
     errors, there should be no reason to modify this.
+
+- ``build-options``: a list of tokens that will be appended to some invocations of ``damlc`` (currently `build` and `ide`). Note that there is no further shell parsing applied.
 
 ..  TODO (@robin-da) document the dependency syntax
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -23,3 +23,6 @@ HEAD — ongoing
   ``"%templates"`` in place of ``"templateIds"`` to select which templates' contracts are
   returned.  See `issue #2777 <https://github.com/digital-asset/daml/issues/2777>`_.
 + [DAML Compiler] **BREAKING CHANGE** Move the DAML-LF produced by generic template instantiations closer to the surface syntax. See the documentation on `How DAML types are translated to DAML-LF <https://docs.daml.com/app-dev/daml-lf-translation.html#template-types>`__ for details.
++ [DAML Assistant] The `daml.yaml` file now supports an additional field
+  `build-options`, which you can use to list cli options you want added to
+  invocations of `daml build` and `daml ide`.


### PR DESCRIPTION
An attempt at addressing #2676.

One fairly annoying property of this patch as it stands is that YAML parsing doesn't naturally match shell parsing. In more concrete terms, to get the equivalent of
```
daml build --ghc-option -Werror
```
one would likely expect to be able to write [1]
```
damlc-options:
- --ghc-option -Werror
```
in their `daml.yaml` file. Unfortunately, as it stands, this would be the equivalent of
```
daml build "--ghc-option -Werror"
```
in a bash shell, and therefore will choke with

> Invalid option `--ghc-option -Werror'

The user should instead use
```
damlc-options:
- --ghc-option
- -Werror
```
which looks weird; my preference would be for
```
damlc-options: ["--ghc-options", "-Werror"]
```
which has the merit of looking pretty much like any other cli arguments passed from a non-shell, but from a usability perspective I would really prefer form [1] to work. The big caveat there is that we then need to properly parse quotes, i.e. it's not as easy as adding a `words` call. I'm looking into it but thought I'd open this up for comments in the meantime.