### PR TITLE
Implement party locality check in Ledger API

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
@@ -86,6 +86,7 @@ object ApiServices {
           ledgerId,
           contractStore,
           writeService,
+          partyManagementService,
           timeModel,
           timeProvider,
           new CommandExecutorImpl(engine, packagesService.getLfPackage)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
@@ -83,7 +83,7 @@ class ApiSubmissionService private (
   private val validator = TimeModelValidator(timeModel)
 
   private def isLocal(party: Ref.Party): Future[Boolean] =
-    partyManagementService.listParties().map(_.find(p => p.isLocal && p.party == party).isDefined)
+    partyManagementService.listParties().map(_.exists(p => p.isLocal && p.party == party))
 
   override def submit(request: SubmitRequest): Future[Unit] = {
     val commands = request.commands

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -69,6 +69,7 @@ trait TestHelpers {
       ledgerId,
       indexAndWriteService.indexService,
       indexAndWriteService.writeService,
+      indexAndWriteService.indexService,
       TimeModel.reasonableDefault,
       timeProvider,
       new CommandExecutorImpl(Engine(), packageStore.getLfPackage)


### PR DESCRIPTION
Requires party to be local for commands to go through.

Note that this will make all (old) integration tests fail because they don't use party allocation. To make them work it could make sense making this behavior configurable.

Depends on #2026.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
