### PR TITLE
Improve UX of generic templates over Ledger API

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -94,6 +94,7 @@ import Control.Monad.Fail
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
 import           DA.Daml.LF.Ast as LF
+import           DA.Daml.LF.Ast.Type as LF
 import           DA.Daml.LF.Ast.Numeric (numericFromDecimal)
 import           Data.Data hiding (TyCon)
 import           Data.Foldable (foldlM)
@@ -157,7 +158,8 @@ data Env = Env
     ,envAliases :: MS.Map Var LF.Expr
     ,envPkgMap :: MS.Map GHC.UnitId T.Text
     ,envLfVersion :: LF.Version
-    ,envNewtypes :: [(GHC.Type, (TyCon, Coercion))]
+    ,envNewtypes :: [(GHC.Type, TyCon)]
+    ,envInstances :: [(TyCon, [GHC.Type])]
     }
 
 -- v is an alias for x
@@ -254,10 +256,16 @@ convertModule lfVersion pkgMap file x = runConvertM (ConversionEnv file Nothing)
               Rec binds -> binds
           ]
         newtypes =
-          [ (wrappedT, (t, mkUnbranchedAxInstCo Representational co [] []))
+          [ (wrappedT, t)
           | ATyCon t <- eltsUFM (cm_types x)
-          , Just ([], wrappedT, co) <- [unwrapNewTyCon_maybe t]
+          , Just ([], wrappedT, _co) <- [unwrapNewTyCon_maybe t]
           ]
+        instances =
+            [ (c, ts)
+            | (name, _) <- binds
+            , DFunId _ <- [idDetails name]
+            , TypeCon c ts <- [varType name]
+            ]
         env = Env
           { envLFModuleName = lfModName
           , envGHCModuleName = ghcModName
@@ -266,6 +274,7 @@ convertModule lfVersion pkgMap file x = runConvertM (ConversionEnv file Nothing)
           , envPkgMap = pkgMap
           , envLfVersion = lfVersion
           , envNewtypes = newtypes
+          , envInstances = instances
           }
 
 -- TODO(MH): We should run this on an `LF.Expr` instead of a `GHC.Expr`.
@@ -278,17 +287,24 @@ convertGenericTemplate env x
     , (tyArgs, args) <- span isTypeArg args
     , Just tyArgs <- mapM isType_maybe tyArgs
     , Just (superClassDicts, signatories : observers : ensure : agreement : create : _fetch : archive : keyAndChoices) <- span isSuperClassDict <$> mapM isVar_maybe (dropWhile isTypeArg args)
-    , Just (polyType, _) <- splitFunTy_maybe (varType create)
-    , Just (monoTyCon, unwrapCo) <- findMonoTyp polyType
+    , Just (polyType@(TypeCon polyTyCon _), _) <- splitFunTy_maybe (varType create)
+    , Just monoTyCon <- findMonoTyp polyType
     = do
         let tplLocation = convNameLoc monoTyCon
-        polyType <- convertType env polyType
+        Ctors{_cCtors = [Ctor _ fields _]} <- toCtors env polyTyCon
+        polyType@(TConApp polyTyCon polyTyArgs) <- convertType env polyType
+        let polyTCA = TypeConApp polyTyCon polyTyArgs
         monoType@(TCon monoTyCon) <- convertTyCon env monoTyCon
-        (unwrapTpl, wrapTpl) <- convertCoercion env unwrapCo
-        let (unwrapCid, wrapCid)
-                | isReflCo unwrapCo = (id, id)
+        let monoTCA = TypeConApp monoTyCon []
+        let coerceRec fromType toType fromExpr =
+                ELet (Binding (rec, typeConAppToType fromType) fromExpr) $
+                ERecCon toType $ map (\field -> (field, ERecProj fromType field (EVar rec))) fields
+        let (unwrapTpl, wrapTpl, unwrapCid, wrapCid)
+                | null polyTyArgs = (id, id, id, id)
                 | otherwise =
-                    ( ETmApp $ mkETyApps (EBuiltin BECoerceContractId) [monoType, polyType]
+                    ( coerceRec monoTCA polyTCA
+                    , coerceRec polyTCA monoTCA
+                    , ETmApp $ mkETyApps (EBuiltin BECoerceContractId) [monoType, polyType]
                     , ETmApp $ mkETyApps (EBuiltin BECoerceContractId) [polyType, monoType]
                     )
         let tplTypeCon = qualObject monoTyCon
@@ -383,14 +399,15 @@ convertGenericTemplate env x
     -- NOTE(MH): We need the `$f` case since GHC inlines super class
     -- dictionaries without running the simplifier under some circumstances.
     isSuperClassDict v = any (`T.isPrefixOf` getOccText v) ["$cp", "$f"]
-    findMonoTyp :: GHC.Type -> Maybe (TyCon, Coercion)
+    findMonoTyp :: GHC.Type -> Maybe TyCon
     findMonoTyp t = case t of
-        TypeCon tcon [] -> Just (tcon, mkNomReflCo t)
+        TypeCon tcon [] -> Just tcon
         t -> snd <$> find (eqType t . fst) (envNewtypes env)
     this = mkVar "this"
     self = mkVar "self"
     arg = mkVar "arg"
     res = mkVar "res"
+    rec = mkVar "rec"
 convertGenericTemplate env x = unhandled "generic template" x
 
 data Consuming = PreConsuming
@@ -403,6 +420,23 @@ convertTypeDef env (ATyCon t)
   | GHC.moduleNameFS (GHC.moduleName (nameModule (getName t))) == "DA.Internal.LF"
   , getOccFS t `elementOfUniqSet` internalTypes
   = pure []
+convertTypeDef env (ATyCon t)
+    -- NOTE(MH): We detect `newtype` definitions produced by the desugring
+    -- of `template instance` declarations and inline the record definition
+    -- of the generic template.
+    | isNewTyCon t
+    , ([], TypeCon tpl args) <- newTyConRhs t
+    , any (\(c, args') -> getOccFS c == getOccFS tpl <> "Instance" && eqTypes args args') $ envInstances env
+    = do
+        ctors0 <- toCtors env tpl
+        args <- mapM (convertType env) args
+        let subst = MS.fromList $ zipExact (map fst (_cParams ctors0)) args
+        let ctors1 = ctors0
+                { _cTypeName = getName t
+                , _cParams = []
+                , _cCtors = map (\(Ctor n fs ts) -> Ctor n fs $ map (LF.substitute subst) ts) (_cCtors ctors0)
+                }
+        convertCtors env ctors1
 convertTypeDef env o@(ATyCon t) = withRange (convNameLoc t) $
     case tyConFlavour t of
       fl | fl `elem` [ClassFlavour,DataTypeFlavour,NewtypeFlavour] -> convertCtors env =<< toCtors env t

--- a/compiler/damlc/tests/daml-test-files/ProposalDesugared.daml
+++ b/compiler/damlc/tests/daml-test-files/ProposalDesugared.daml
@@ -164,7 +164,7 @@ instance IouInstance where
 
 -- The instantiation of the generic `Proposal a` template for `a = Iou`
 -- in its deugared form.
-newtype ProposalIou = MkProposalIou with unProposalIou : Proposal Iou -- ^ TEMPLATE_INSTANCE
+newtype ProposalIou = ProposalIou (Proposal Iou) -- ^ TEMPLATE_INSTANCE
 
 instance ProposalInstance Iou where
 

--- a/compiler/damlc/tests/daml-test-files/ProposalIou.daml
+++ b/compiler/damlc/tests/daml-test-files/ProposalIou.daml
@@ -3,6 +3,7 @@
 
 -- An IOU to be proposed using the generic proposal workflow.
 -- @SINCE-LF 1.5
+-- @QUERY-LF [.modules[] | .data_types[] | select(.name.segments == ["ProposalIou"]) | .record | .fields[] | .field] == ["asset", "receivers", "name"]
 daml 1.2
 module ProposalIou where
 

--- a/docs/source/app-dev/code-snippets/daml-lf-result.daml
+++ b/docs/source/app-dev/code-snippets/daml-lf-result.daml
@@ -13,3 +13,7 @@ data Iou = Iou { issuer: Party; owner: Party; currency: Text; amount: Decimal }
 data DoNothing = DoNothing {}
 data Transfer = Transfer { newOwner: Party }
 -- end snippet: data from choices
+
+-- start snippet: data from generic template
+data Proposal a = Proposal { proposal: a; proposers: [Party]; receivers: [Party] }
+-- end snippet: data from generic template

--- a/docs/source/app-dev/code-snippets/daml-lf-translation.daml
+++ b/docs/source/app-dev/code-snippets/daml-lf-translation.daml
@@ -43,9 +43,9 @@ template Template a => Proposal a
   where
 -- end code snippet: generic template data types
     signatory proposers
-    observers receivers
+    observer receivers
 
-    choice Accept: ContractId t
+    choice Accept: ContractId a
       controller receivers
       do
         create proposal

--- a/docs/source/app-dev/code-snippets/daml-lf-translation.daml
+++ b/docs/source/app-dev/code-snippets/daml-lf-translation.daml
@@ -16,9 +16,9 @@ data User = User { name: Username }
 template Iou
   with
     issuer: Party
-    owner : Party
-    currency : Text
-    amount : Decimal
+    owner: Party
+    currency: Text
+    amount: Decimal
   where
 -- end code snippet: template data types
     signatory issuer
@@ -28,8 +28,28 @@ template Iou
         do
           return ()
 
-      Transfer : ContractId Iou
-        with newOwner : Party
+      Transfer: ContractId Iou
+        with newOwner: Party
         do
           updateOwner newOwner
 -- end code snippet: choice data types
+
+-- start code snippet: generic template data types
+template Template a => Proposal a
+  with
+    proposal: a
+    proposers: [Party]
+    receivers: [Party]
+  where
+-- end code snippet: generic template data types
+    signatory proposers
+    observers receivers
+
+    choice Accept: ContractId t
+      controller receivers
+      do
+        create proposal
+
+-- start code snippet: generic template instantiation
+template instance IouProposal = Proposal Iou
+-- end code snippet: generic template instantiation

--- a/docs/source/app-dev/daml-lf-translation.rst
+++ b/docs/source/app-dev/daml-lf-translation.rst
@@ -220,6 +220,26 @@ This translates to the DAML-LF record declaration:
 
 	record Iou ↦ { issuer: Party; owner: Party; currency: Text; amount: Decimal }
 
+Similarly, the generic template definition
+
+.. literalinclude:: code-snippets/daml-lf-translation.daml
+   :language: daml
+   :start-after: -- start code snippet: generic template data types
+   :end-before: -- end code snippet: generic template data types
+
+results in the record declaration:
+
+.. literalinclude:: code-snippets/daml-lf-result.daml
+   :language: daml
+   :start-after: -- start snippet: data from generic template
+   :end-before: -- end snippet: data from generic template
+
+which translates to the DAML-LF record declaration:
+
+.. code-block:: none
+
+	record Proposal a ↦ { proposal: a; proposers: List Party; receivers: List Party }
+
 Choice data types
 =================
 
@@ -245,3 +265,21 @@ These translate to the DAML-LF record declarations:
 
 	record DoNothing ↦ {}
 	record Transfer ↦ { newOwner: Party }
+
+Generic template instantiations
+===============================
+
+In the context of the templates ``Iou`` and ``Proposal`` above, the generic template instantiation
+
+.. literalinclude:: code-snippets/daml-lf-translation.daml
+   :language: daml
+   :start-after: -- start code snippet: generic template instantiation
+   :end-before: -- end code snippet: generic template instantiation
+
+which does not produce a DAML data definition but only the DAML-LF record declaration:
+
+.. code-block:: none
+
+	record IouProposal ↦ { proposal: Iou; proposers: List Party; receivers: List Party }
+
+Note that ``IouProposal`` is a copy of ``Proposal`` with the type variable ``a`` replaced by ``Iou`` on the right hand side.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,5 +22,4 @@ HEAD — ongoing
 + [JSON API] **BREAKING CHANGE** The ``/contracts/search`` request payload must use
   ``"%templates"`` in place of ``"templateIds"`` to select which templates' contracts are
   returned.  See `issue #2777 <https://github.com/digital-asset/daml/issues/2777>`_.
-+ [DAML Compiler] Improve the UX of generic templates over the Ledger API.
 + [DAML Compiler] **BREAKING CHANGE** Move the DAML-LF produced by generic template instantiations closer to the surface syntax. See the documentation on `How DAML types are translated to DAML-LF <https://docs.daml.com/app-dev/daml-lf-translation.html#template-types>`__ for details.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -23,3 +23,4 @@ HEAD — ongoing
   ``"%templates"`` in place of ``"templateIds"`` to select which templates' contracts are
   returned.  See `issue #2777 <https://github.com/digital-asset/daml/issues/2777>`_.
 + [DAML Compiler] Improve the UX of generic templates over the Ledger API.
++ [DAML Compiler] **BREAKING CHANGE** Move the DAML-LF produced by generic template instantiations closer to the surface syntax. See the documentation on `How DAML types are translated to DAML-LF <https://docs.daml.com/app-dev/daml-lf-translation.html#template-types>`__ for details.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,3 +22,4 @@ HEAD — ongoing
 + [JSON API] **BREAKING CHANGE** The ``/contracts/search`` request payload must use
   ``"%templates"`` in place of ``"templateIds"`` to select which templates' contracts are
   returned.  See `issue #2777 <https://github.com/digital-asset/daml/issues/2777>`_.
++ [DAML Compiler] Improve the UX of generic templates over the Ledger API.


### PR DESCRIPTION
Currently, if you write
```
template Template t => Proposal t with
    receiver: Party
    asset: t
  where ...
template Iou with ...
template instance ProposalIou = Proposal Iou
```
you'll get the following DAML-LF types:
```
record Proposal t = { receiver : Party, asset : t }
record Iou = ...
record ProposalIou = { unpack : Proposal Iou }
```
The definition of `ProposalIou` is not particularly user friendly when used
over the Ledger API.

This PR changes the definition of `ProposalIou` to
```
record ProposalIou = { receiver : Party, asset : Iou }
```
Basically, the definition of `Proposal` is copied and `t` is instantiated
with `Iou`. This should make a much nicer UX.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2779)
<!-- Reviewable:end -->
