### PR TITLE
Fix restriction on child_event_ids

### DIFF
--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -170,7 +170,7 @@ message ExercisedEvent {
   // References to further events in the same transaction that appeared as a result of this ``ExercisedEvent``.
   // It contains only the immediate children of this event, not all members of the subtree rooted at this node.
   //
-  // Each element must be a valid PartyIdString (as described in ``value.proto``).
+  // Each element must be a valid LedgerString (as described in ``value.proto``).
   //
   // Optional
   repeated string child_event_ids = 11;


### PR DESCRIPTION
Unless I am missing something fundamental here all event_ids are
LedgerStrings not PartyIdStrings.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
