### PR TITLE
HTTP JSON API daemon: adding named CLI arguments

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -15,7 +15,6 @@ hj_scalacopts = [
 
 http_json_deps = [
     "//3rdparty/jvm/ch/qos/logback:logback_classic",
-    "//3rdparty/jvm/com/github/pureconfig",
     "//3rdparty/jvm/com/github/scopt",
     "//3rdparty/jvm/com/typesafe/akka:akka_http",
     "//3rdparty/jvm/com/typesafe/akka:akka_http_spray_json",

--- a/ledger-service/http-json/README.md
+++ b/ledger-service/http-json/README.md
@@ -10,7 +10,9 @@ daml-head sandbox --wall-clock-time --ledgerid MyLedger ./.daml/dist/quickstart-
 ### Start HTTP service from the DAML project root
 This will build the service first, can take up to 5-10 minutes when running first time.
 ```
-$ bazel run //ledger-service/http-json:http-json-binary -- localhost 6865 7575 4194304
+$ bazel run //ledger-service/http-json:http-json-binary -- \
+    --ledger-host localhost --ledger-port 6865 --http-port 7575 \
+    --max-inbound-message-size 4194304 --application-id HTTP-JSON-API-Gateway
 ```
 Where:
  - localhost 6865 -- sandbox host and port
@@ -29,8 +31,9 @@ $ cd iou-quickstart-java/
 $ daml-head build
 $ daml-head sandbox --wall-clock-time --ledgerid MyLedger ./.daml/dist/quickstart-0.0.1.dar
 
-cd <daml-root>/
-$ bazel run //ledger-service/http-json:http-json-binary -- localhost 6865 7575
+$ cd <daml-root>/
+$ bazel run //ledger-service/http-json:http-json-binary -- \
+    --ledger-host localhost --ledger-port 6865 --http-port 7575
 ```
 
 ### Choosing a party

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -38,7 +38,7 @@ object Main extends StrictLogging {
       case Some(config) =>
         main(config)
       case None =>
-        // error is printed out by scopt... yeah I know... why?
+        // error is printed out by scopt
         sys.exit(ErrorCodes.InvalidUsage)
     }
 
@@ -119,6 +119,6 @@ object Main extends StrictLogging {
       .action((x, c) => c.copy(maxInboundMessageSize = x))
       .optional()
       .text(
-        s"Optional max inbound message size in bytes. Defaults to ${EmptyConfig.maxInboundMessageSize}")
+        s"Optional max inbound message size in bytes. Defaults to ${EmptyConfig.maxInboundMessageSize: Int}")
   }
 }


### PR DESCRIPTION
See: #2775 

```
$ bazel run //ledger-service/http-json:http-json-binary -- \
    --ledger-host localhost --ledger-port 6865 --http-port 7575 \
    --max-inbound-message-size 4194304 --application-id HTTP-JSON-API-Gateway
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
