### PR TITLE
Fix hie.yaml so you can still load hie-core in hie-core

### DIFF
--- a/compiler/hie-core/hie.yaml
+++ b/compiler/hie-core/hie.yaml
@@ -9,6 +9,8 @@ cradle:
       - -XBangPatterns
       - -XDeriveGeneric
       - -XGeneralizedNewtypeDeriving
+      - -XOverloadedStrings
+      - -XDeriveFunctor
       - -XLambdaCase
       - -XNamedFieldPuns
       - -XRecordWildCards


### PR DESCRIPTION
I checked it now works, using `hie-core` in the `hie-core` directory.

As a heads up, I plan on working on hie-core at MuniHac this Friday + weekend, and encouraging other people to do similarly. If you have any beginner tickets on it or ongoing efforts around the IDE, please point me at them (I have plenty of things on my own todo list, so no need to make things that aren't already there).