### PR TITLE
Constrain ghc so that people with 8.4 don't get install plans

### DIFF
--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -34,7 +34,7 @@ library
         filepath,
         ghc-boot-th,
         ghc-boot,
-        ghc,
+        ghc >= 8.6,
         hashable,
         haskell-lsp-types,
         haskell-lsp,


### PR DESCRIPTION
This tripped up Ganesh at MuniHac.