### PR TITLE
#2326, GHC 8.4 compatibility

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -79,6 +79,7 @@
   - {name: ViewPatterns, within: []}
 
   # Shady extensions
+  - {name: ImplicitParams, within: []}
   - name: CPP
     within:
     - Development.IDE.Core.FileStore
@@ -89,7 +90,9 @@
     - DA.Signals
     - Development.IDE.Core.Compile
     - Development.IDE.GHC.Compat
-  - {name: ImplicitParams, within: []}
+    - Development.IDE.GHC.Util
+    - Development.IDE.Import.FindImports
+    - Development.IDE.Spans.Calculate
 
 - flags:
   - default: false

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -97,7 +97,7 @@
 - flags:
   - default: false
   - {name: [-Wno-missing-signatures, -Wno-orphans, -Wno-overlapping-patterns, -Wno-incomplete-patterns, -Wno-missing-fields, -Wno-unused-matches]}
-
+  - {name: [-Wno-dodgy-imports], within: Main}
 # - modules:
 #   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
 #   - {name: Control.Arrow, within: []} # Certain modules are banned entirely

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -1,5 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# OPTIONS_GHC -Wno-dodgy-imports #-} -- GHC no longer exports def in GHC 8.6 and above
 
 module Main(main) where
 

--- a/compiler/hie-core/exe/Main.hs
+++ b/compiler/hie-core/exe/Main.hs
@@ -26,6 +26,8 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Haskell.LSP.Messages
 import Linker
+import System.Info
+import Data.Version
 import Development.IDE.LSP.LanguageServer
 import System.Directory.Extra as IO
 import System.Environment
@@ -36,7 +38,7 @@ import qualified Data.Set as Set
 -- import CmdLineParser
 -- import DynFlags
 -- import Panic
-import GHC
+import GHC hiding (def)
 import qualified GHC.Paths
 
 import HIE.Bios
@@ -49,7 +51,7 @@ main :: IO ()
 main = do
     -- WARNING: If you write to stdout before runLanguageServer
     --          then the language server will not work
-    hPutStrLn stderr "Starting hie-core"
+    hPutStrLn stderr $ "Starting hie-core (GHC v" ++ showVersion compilerVersion ++ ")"
     Arguments{..} <- getArguments
 
     -- lock to avoid overlapping output on stdout

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -34,7 +34,7 @@ library
         filepath,
         ghc-boot-th,
         ghc-boot,
-        ghc >= 8.6,
+        ghc >= 8.4,
         hashable,
         haskell-lsp-types,
         haskell-lsp,

--- a/compiler/hie-core/hie-core.cabal
+++ b/compiler/hie-core/hie-core.cabal
@@ -45,7 +45,7 @@ library
         prettyprinter,
         rope-utf16-splay,
         safe-exceptions,
-        shake,
+        shake >= 0.17.5,
         sorted-list,
         stm,
         syb,

--- a/compiler/hie-core/src/Development/IDE/Core/Compile.hs
+++ b/compiler/hie-core/src/Development/IDE/Core/Compile.hs
@@ -278,8 +278,7 @@ runCpp dflags filename contents = withTempDir $ \dir -> do
             -- __FILE__ macro is wrong, ignoring that for now (likely not a real issue)
 
             -- Relative includes aren't going to work, so we fix that by adding to the include path.
-            let addSelf (IncludeSpecs quote global) = IncludeSpecs (takeDirectory filename : quote) global
-            dflags <- return dflags{includePaths = addSelf $ includePaths dflags}
+            dflags <- return $ addIncludePathsQuote (takeDirectory filename) dflags
 
             -- Location information is wrong, so we fix that by patching it afterwards.
             let inp = dir </> "___HIE_CORE_MAGIC___"

--- a/compiler/hie-core/src/Development/IDE/GHC/CPP.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/CPP.hs
@@ -20,6 +20,7 @@
 
 module Development.IDE.GHC.CPP(doCpp) where
 
+import Development.IDE.GHC.Compat
 import Packages
 import SysTools
 import Module

--- a/compiler/hie-core/src/Development/IDE/GHC/Util.hs
+++ b/compiler/hie-core/src/Development/IDE/GHC/Util.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# OPTIONS_GHC -Wno-missing-fields #-} -- to enable prettyPrint
+{-# LANGUAGE CPP #-}
 
 -- | GHC utility functions. Importantly, code using our GHC should never:
 --
@@ -20,7 +21,9 @@ module Development.IDE.GHC.Util(
 
 import Config
 import Data.List.Extra
+#if __GLASGOW_HASKELL__ >= 806
 import Fingerprint
+#endif
 import GHC
 import GhcMonad
 import GhcPlugins
@@ -75,15 +78,17 @@ runGhcEnv env act = do
 -- Fake DynFlags which are mostly undefined, but define enough to do a
 -- little bit.
 fakeDynFlags :: DynFlags
-fakeDynFlags = defaultDynFlags settings ([], [])
+fakeDynFlags = defaultDynFlags settings mempty
     where
         settings = Settings
                    { sTargetPlatform = platform
                    , sPlatformConstants = platformConstants
                    , sProgramName = "ghc"
                    , sProjectVersion = cProjectVersion
-                   , sOpt_P_fingerprint = fingerprint0
-                   }
+#if __GLASGOW_HASKELL__ >= 806
+                    , sOpt_P_fingerprint = fingerprint0
+#endif
+                    }
         platform = Platform
           { platformWordSize=8
           , platformOS=OSUnknown

--- a/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/hie-core/src/Development/IDE/LSP/CodeAction.hs
@@ -9,7 +9,7 @@ module Development.IDE.LSP.CodeAction
     ) where
 
 import           Language.Haskell.LSP.Types
-import GHC.LanguageExtensions.Type
+import Development.IDE.GHC.Compat
 import Development.IDE.Core.Rules
 import Development.IDE.LSP.Server
 import qualified Data.HashMap.Strict as Map
@@ -80,7 +80,7 @@ suggestAction _ _ = []
 
 -- | All the GHC extensions
 ghcExtensions :: Set.HashSet T.Text
-ghcExtensions = Set.fromList $ map (T.pack . show) [Cpp .. StarIsType] -- use enumerate from GHC 8.8 and beyond
+ghcExtensions = Set.fromList $ map (T.pack . show) ghcEnumerateExtensions
 
 
 textAtPosition :: Position -> T.Text -> (T.Text, T.Text)

--- a/compiler/hie-core/stack.yaml
+++ b/compiler/hie-core/stack.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - git: https://github.com/bubba/lsp-test.git
   commit: d126623dc6895d325e3d204d74e2a22d4f515587
 - git: https://github.com/mpickering/hie-bios.git
-  commit: 7a75f520b2e7a482440edd023be8e267a0fa153f
+  commit: 89e4ba24f87aac9909d9814b0e8c51b679a0ccd4
 nix:
   packages: [zlib]
 allow-newer: true

--- a/compiler/hie-core/stack84.yaml
+++ b/compiler/hie-core/stack84.yaml
@@ -1,0 +1,21 @@
+resolver: lts-12.26
+packages:
+- .
+
+extra-deps:
+- rope-utf16-splay-0.3.1.0
+- shake-0.18.3
+- filepattern-0.1.1
+- js-dgtable-0.5.2
+- git: https://github.com/alanz/haskell-lsp.git
+  commit: bfbd8630504ebc57b70948689c37b85cfbe589da
+  subdirs:
+  - .
+  - haskell-lsp-types
+- git: https://github.com/bubba/lsp-test.git
+  commit: d126623dc6895d325e3d204d74e2a22d4f515587
+- git: https://github.com/mpickering/hie-bios.git
+  commit: 89e4ba24f87aac9909d9814b0e8c51b679a0ccd4
+nix:
+  packages: [zlib]
+allow-newer: true


### PR DESCRIPTION
Fixed it up. After that, hie-core built with GHC 8.4 can compile hie-core.

I also added a message about which GHC you used on startup, since that seems to be a common mistake people are making.