### PR TITLE
ActiveContractsService stream now always returns at least 1 element

### DIFF
--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/active_contracts_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/active_contracts_service.proto
@@ -17,7 +17,9 @@ option csharp_namespace = "Com.DigitalAsset.Ledger.Api.V1";
 // Allows clients to initialize themselves according to a fairly recent state of the ledger without reading through all transactions that were committed since the ledger's creation.
 service ActiveContractsService {
 
-  // Returns a stream of the latest snapshot of active contracts. Getting an empty stream means that the active contracts set is empty and the client should listen to transactions using ``LEDGER_BEGIN``.
+  // Returns a stream of the latest snapshot of active contracts.
+  // If there are no active contracts, the stream returns a single GetActiveContractsResponse message with the offset at which the snapshot has been taken.
+  // Clients SHOULD use the offset in the last GetActiveContractsResponse message to continue streaming transactions with the transaction service.
   // Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.
   rpc GetActiveContracts (GetActiveContractsRequest) returns (stream GetActiveContractsResponse);
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/acs/ActiveContractSetClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/acs/ActiveContractSetClient.scala
@@ -19,6 +19,13 @@ import scalaz.syntax.tag._
 
 class ActiveContractSetClient(ledgerId: LedgerId, activeContractsService: ActiveContractsService)(
     implicit esf: ExecutionSequencerFactory) {
+  /*
+    Returns a stream of GetActiveContractsResponse messages. The materialized value will
+    be resolved to the offset that can be used as a starting offset for streaming transactions
+    via the transaction service.
+    If the stream completes before the offset can be set, the materialized future will
+    be failed with an exception.
+   */
   def getActiveContracts(
       filter: TransactionFilter,
       verbose: Boolean = false): Source[GetActiveContractsResponse, Future[String]] = {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/acs/ActiveContractSetSource.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/acs/ActiveContractSetSource.scala
@@ -25,6 +25,7 @@ object ActiveContractSetSource {
 
     ClientAdapter
       .serverStreaming(request, stub)
-      .viaMat(new ExtractMaterializedValue(r => Some(r.offset)))(Keep.right)
+      .viaMat(new ExtractMaterializedValue(r => if (r.offset.nonEmpty) Some(r.offset) else None))(
+        Keep.right)
   }
 }

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/util/akkastreams/ExtractSingleMaterializedValueTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/util/akkastreams/ExtractSingleMaterializedValueTest.scala
@@ -38,7 +38,7 @@ class ExtractSingleMaterializedValueTest
     }
 
     "there are multiple valid values" should {
-      "extract the first" in {
+      "extract the first matching element" in {
         val elemToExtract = -1
         val otherCandidateShuffledIn = -2
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -14,3 +14,4 @@ HEAD — ongoing
 + [Sandbox] Dramatically increased performance of the ActiveContractService by only loading the contracts that the parties in the transaction filter are allowed to see.
 + [DAML-LF] change signature of MUL_NUMERIC and DIV_NUMERIC
 + [DAML Integration Kit] fix contract key uniqueness check in kvutils.
++ [Ledger API] ActiveContractsService now specifies to always return at least one message with the offset. This removes a special case where clients would need to check if the stream was empty or not.


### PR DESCRIPTION
This removes the need for clients to handle the special case where the
stream might be empty.
Now the clients can always assume that they receive at least one
response element in the stream.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
