### PR TITLE
hie-core: Remove code pretty printing from diagnostic output

### DIFF
--- a/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
+++ b/compiler/hie-core/src/Development/IDE/Types/Diagnostics.hs
@@ -80,7 +80,6 @@ prettyDiagnostic (fp, LSP.Diagnostic{..}) =
               LSP.DsInfo -> annotate $ color Blue
               LSP.DsHint -> annotate $ color Magenta
             $ stringParagraphs _message
-        , slabel_ "Code:" $ pretty _code
         ]
     where
         sev = fromMaybe LSP.DsError _severity


### PR DESCRIPTION
In moving from v. 0.15 to 0.16, haskell-lsp changed the type of the
value which ended up being passed to `pretty` from `Maybe Text` to
`Maybe LSP.NumberOrString`, thereby breaking the line of code which is
removed in this commit.

After discussion with @ndmitchell, it was observed that this code was
never useful, and fixing it was not worth the trouble.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
