### PR TITLE
hie-core: Ignore packages that conflict with ghc in the hie.yaml

### DIFF
--- a/compiler/hie-core/hie.yaml
+++ b/compiler/hie-core/hie.yaml
@@ -20,6 +20,8 @@ cradle:
       - -XTypeApplications
       - -XViewPatterns
       - -package=ghc
+      - -ignore-package=ghc-lib-parser
+      - -ignore-package=ghc-lib
       - -DGHC_STABLE
       - -isrc
       - -iexe


### PR DESCRIPTION
Before if you had installed ghc-lib or ghc-lib-parser globally then you would get a conflict. Now it silently ignores them if installed, but won't complain if they aren't installed.