### PR TITLE
ghcide: make tests fail on unexpected diagnostic messages (#2813)

### DIFF
--- a/compiler/ghcide/test/BUILD.bazel
+++ b/compiler/ghcide/test/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_library(
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
         "base",
+        "extra",
         "containers",
         "haskell-lsp-types",
         "lens",

--- a/compiler/ghcide/test/exe/Main.hs
+++ b/compiler/ghcide/test/exe/Main.hs
@@ -147,7 +147,15 @@ diagnosticTests = testGroup "diagnostics"
 
 
 testSession :: String -> Session () -> TestTree
-testSession name = testCase name . run
+testSession name =
+  testCase name . run .
+      -- Check that any diagnostics produced were already consumed by the test case.
+      --
+      -- If in future we add test cases where we don't care about checking the diagnostics,
+      -- this could move elsewhere.
+      --
+      -- Experimentally, 0.5s seems to be long enough to wait for any final diagnostics to appear.
+      ( >> expectNoMoreDiagnostics 0.5)
 
 
 run :: Session a -> IO a


### PR DESCRIPTION
This has the downside of relying on a timeout, experimentally tuned
to be 0.5s, as we have no other way of knowing when the server has
finished sending us messages.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
