### PR TITLE
ghcide: support hs-boot files

### DIFF
--- a/compiler/ghcide/extension/package.json
+++ b/compiler/ghcide/extension/package.json
@@ -22,7 +22,8 @@
 		"languages": [{
 			"id": "haskell",
 			"extensions": [
-				"hs"
+				"hs",
+				"hs-boot"
 			]
 		}],
 		"configuration": {

--- a/compiler/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/compiler/ghcide/src/Development/IDE/Core/Rules.hs
@@ -183,12 +183,12 @@ getLocatedImportsRule =
     define $ \GetLocatedImports file -> do
         pm <- use_ GetParsedModule file
         let ms = pm_mod_summary pm
-        let imports = ms_textual_imps ms
+        let imports = [(False, imp) | imp <- ms_textual_imps ms] ++ [(True, imp) | imp <- ms_srcimps ms]
         env <- useNoFile_ GhcSession
         let dflags = addRelativeImport pm $ hsc_dflags env
         opt <- getIdeOptions
-        (diags, imports') <- fmap unzip $ forM imports $ \(mbPkgName, modName) -> do
-            diagOrImp <- locateModule dflags (optExtensions opt) getFileExists modName mbPkgName
+        (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
+            diagOrImp <- locateModule dflags (optExtensions opt) getFileExists modName mbPkgName isSource
             case diagOrImp of
                 Left diags -> pure (diags, Left (modName, Nothing))
                 Right (FileImport path) -> pure ([], Left (modName, Just path))


### PR DESCRIPTION
Note - there's an interaction with the in-flight PR to support lhs files (#2803), in the sense
of support for .lhs-boot files. My change already recognises them when constructing the name
of derived files. But there will be a conflict in `extension/package.json` and when resolving it (i.e. whichever change lands second) we should also add `lhs-boot` to the list.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
