### PR TITLE
WIP: code action for type wildcards

### DIFF
--- a/compiler/ghcide/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/ghcide/src/Development/IDE/LSP/CodeAction.hs
@@ -65,6 +65,14 @@ suggestAction contents Diagnostic{_range=_range@Range{..},..}
     | renameSuggestions@(_:_) <- extractRenamableTerms _message
         = [ ("Replace with ‘" <> name <> "’", [mkRenameEdit contents _range name]) | name <- renameSuggestions ]
 
+-- Foo.hs:3:8: error:
+--     * Found type wildcard `_' standing for `p -> p1 -> p'
+
+    | "Found type wildcard" `T.isInfixOf` _message
+    , " standing for " `T.isInfixOf` _message
+    , typeSignature <- extractWildCardTypeSignature _message
+        =  [("Use type signature: ‘" <> typeSignature <> "’", [TextEdit _range typeSignature])]
+
 -- File.hs:22:8: error:
 --     Illegal lambda-case (use -XLambdaCase)
 -- File.hs:22:6: error:
@@ -100,6 +108,14 @@ mkRenameEdit contents range name =
       curr <- textInRange range <$> contents
       pure $ "`" `T.isPrefixOf` curr && "`" `T.isSuffixOf` curr
 
+extractWildCardTypeSignature :: T.Text -> T.Text
+extractWildCardTypeSignature =
+  -- inferring when parens are actually needed around the type signature would
+  -- require understanding both the precedence of the context of the _ and of
+  -- the signature itself. Inserting them unconditionally is ugly but safe.
+  ("(" `T.append`) . (`T.append` ")") .
+  T.takeWhile (/='\'') . T.dropWhile (=='`') . T.dropWhile (/='`') .
+  snd . T.breakOnEnd "standing for "
 
 extractRenamableTerms :: T.Text -> [T.Text]
 extractRenamableTerms msg

--- a/compiler/ghcide/src/Development/IDE/LSP/CodeAction.hs
+++ b/compiler/ghcide/src/Development/IDE/LSP/CodeAction.hs
@@ -112,10 +112,10 @@ extractRenamableTerms msg
                        . filter isKnownSymbol
                        . T.lines
     singleSuggestions = T.splitOn "), " -- Each suggestion is comma delimited
-    isKnownSymbol t = " (imported from" `T.isInfixOf` t || " (line " `T.isInfixOf` t
-    getEnclosed = T.dropWhile (== '‘')
-                . T.dropWhileEnd (== '’')
-                . T.dropAround (\c -> c /= '‘' && c /= '’')
+    isKnownSymbol t = " (imported from" `T.isInfixOf` t  || " (line " `T.isInfixOf` t
+    getEnclosed = T.dropWhile (== '`')
+                . T.dropWhileEnd (== '\'')
+                . T.dropAround (\c -> c /= '`' && c /= '\'')
 
 -- | If a range takes up a whole line (it begins at the start of the line and there's only whitespace
 -- between the end of the range and the next newline), extend the range to take up the whole line.

--- a/compiler/ghcide/test/exe/Main.hs
+++ b/compiler/ghcide/test/exe/Main.hs
@@ -187,6 +187,7 @@ diagnosticTests = testGroup "diagnostics"
 codeActionTests :: TestTree
 codeActionTests = testGroup "code actions"
   [ renameActionTests
+  , typeWildCardActionTests
   ]
 
 renameActionTests :: TestTree
@@ -261,6 +262,76 @@ renameActionTests = testGroup "rename actions"
             , "monus :: Int -> Int"
             , "monus x y = max 0 (x - y)"
             , "foo x y = x `monus` y"
+            ]
+      liftIO $ expectedContentAfterAction @=? contentAfterAction
+  ]
+
+typeWildCardActionTests :: TestTree
+typeWildCardActionTests = testGroup "type wildcard actions"
+  [ testSession "global signature" $ do
+      let content = T.unlines
+            [ "module Testing where"
+            , "func :: _"
+            , "func x = x"
+            ]
+      doc <- openDoc' "Testing.hs" "haskell" content
+      _ <- waitForDiagnostics
+      actionsOrCommands <- getCodeActions doc (Range (Position 2 1) (Position 2 10))
+      let [addSignature] = [action | CACodeAction action@(CodeAction { _title = actionTitle }) <- actionsOrCommands
+                                   , "Use type signature" `T.isInfixOf` actionTitle
+                           ]
+      executeCodeAction addSignature
+      contentAfterAction <- documentContents doc
+      let expectedContentAfterAction = T.unlines
+            [ "module Testing where"
+            , "func :: (p -> p)"
+            , "func x = x"
+            ]
+      liftIO $ expectedContentAfterAction @=? contentAfterAction
+  , testSession "multi-line message" $ do
+      let content = T.unlines
+            [ "module Testing where"
+            , "func :: _"
+            , "func x y = x + y"
+            ]
+      doc <- openDoc' "Testing.hs" "haskell" content
+      _ <- waitForDiagnostics
+      actionsOrCommands <- getCodeActions doc (Range (Position 2 1) (Position 2 10))
+      let [addSignature] = [action | CACodeAction action@(CodeAction { _title = actionTitle }) <- actionsOrCommands
+                                    , "Use type signature" `T.isInfixOf` actionTitle
+                              ]
+      executeCodeAction addSignature
+      contentAfterAction <- documentContents doc
+      let expectedContentAfterAction = T.unlines
+            [ "module Testing where"
+            , "func :: (Integer -> Integer -> Integer)"
+            , "func x y = x + y"
+            ]
+      liftIO $ expectedContentAfterAction @=? contentAfterAction
+  , testSession "local signature" $ do
+      let content = T.unlines
+            [ "module Testing where"
+            , "func :: Int -> Int"
+            , "func x ="
+            , "  let y :: _"
+            , "      y = x * 2"
+            , "  in y"
+            ]
+      doc <- openDoc' "Testing.hs" "haskell" content
+      _ <- waitForDiagnostics
+      actionsOrCommands <- getCodeActions doc (Range (Position 4 1) (Position 4 10))
+      let [addSignature] = [action | CACodeAction action@(CodeAction { _title = actionTitle }) <- actionsOrCommands
+                                    , "Use type signature" `T.isInfixOf` actionTitle
+                              ]
+      executeCodeAction addSignature
+      contentAfterAction <- documentContents doc
+      let expectedContentAfterAction = T.unlines
+            [ "module Testing where"
+            , "func :: Int -> Int"
+            , "func x ="
+            , "  let y :: (Int)"
+            , "      y = x * 2"
+            , "  in y"
             ]
       liftIO $ expectedContentAfterAction @=? contentAfterAction
   ]


### PR DESCRIPTION
This is for an initial discussion for now as it depends on other in-flight changes, and to let others
know that I'm working on it. Only the final commit d277b7c is actually relevant.

It makes it possible to fill in type signatures interactively by typing _ and then using the code action to fill in what GHC inferred.

It doesn't always produce a valid type signature as the one GHC mentions might use unavailable type variables or be missing constraints, but it at least gets the user started. It also always adds parentheses around the inserted signature as it's hard to know when they are really needed or not.

We also need consistent treatment of smart quotes (being discussed in #2809). 

We might want to think about how to organise code actions, as their number is likely to increase quite rapidly:

- Do we want the current fall through behaviour of `suggestAction` or to replace it with something that's more explicitly composed? For example my change will remove the existing code action that would add `PartialTypeSignatures` to the module. I think that's reasonable in this case as mostly people wouldn't want that, but there will likely be cases in future where we want both.

- Should we organise all the ad-hoc text recognition better? I understand it'll be replaced by an ADT exposed from GHC at some point in the future.

- Should we abstract the way we write code action test cases to reduce the boilerplate?

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
