### PR TITLE
Explicitly run schema migration/validation

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -86,7 +86,9 @@ conformance_test(
     server = ":reference-v2",
     server_args = [
         "--port 6865",
-        "--jdbc-url jdbc:h2:mem:daml_on_x;db_close_on_exit=false",
+        # db_close_delay=-1 is needed so that the in-memory database is not closed (and therefore lost)
+        # after the flyway migration
+        "--jdbc-url jdbc:h2:mem:daml_on_x;db_close_delay=-1;db_close_on_exit=false",
     ],
     test_tool_args = [
         "--all-tests",

--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -106,8 +106,10 @@ conformance_test(
     server = ":reference-v2",
     server_args = [
         "--port 6865",
-        "--jdbc-url jdbc:h2:mem:daml_on_x;db_close_on_exit=false",
-        "--extra-participant second-participant,6866,jdbc:h2:mem:daml_on_x2;db_close_on_exit=false",
+        # db_close_delay=-1 is needed so that the in-memory database is not closed (and therefore lost)
+        # after the flyway migration
+        "--jdbc-url jdbc:h2:mem:daml_on_x;db_close_delay=-1;db_close_on_exit=false",
+        "--extra-participant second-participant,6866,jdbc:h2:mem:daml_on_x2;db_close_delay=-1;db_close_on_exit=false",
     ],
     test_tool_args = [
         "--include=SemanticTests",

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -7,11 +7,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
+import com.daml.ledger.api.server.damlonx.reference.v2.cli.Cli
 import com.daml.ledger.participant.state.kvutils.InMemoryKVParticipantState
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf.DamlLf.Archive
-import com.digitalasset.platform.index.cli.Cli
 import com.digitalasset.platform.index.{StandaloneIndexServer, StandaloneIndexerServer}
 import org.slf4j.LoggerFactory
 
@@ -54,14 +54,14 @@ object ReferenceServer extends App {
     } yield ledger.uploadPackages(dar.all, None)
   }
 
-  val indexerServer = StandaloneIndexerServer(readService, config.jdbcUrl)
+  val indexerServer = StandaloneIndexerServer(readService, config)
   val indexServer = StandaloneIndexServer(config, readService, writeService).start()
 
   val extraParticipants =
     for {
       (participantId, port, jdbcUrl) <- config.extraPartipants
     } yield {
-      val extraIndexer = StandaloneIndexerServer(readService, jdbcUrl)
+      val extraIndexer = StandaloneIndexerServer(readService, config)
       val extraLedgerApiServer = StandaloneIndexServer(
         config.copy(
           port = port,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -61,13 +61,14 @@ object ReferenceServer extends App {
     for {
       (participantId, port, jdbcUrl) <- config.extraPartipants
     } yield {
-      val extraIndexer = StandaloneIndexerServer(readService, config)
+      val participantConfig = config.copy(
+        port = port,
+        participantId = participantId,
+        jdbcUrl = jdbcUrl
+      )
+      val extraIndexer = StandaloneIndexerServer(readService, participantConfig)
       val extraLedgerApiServer = StandaloneIndexServer(
-        config.copy(
-          port = port,
-          participantId = participantId,
-          jdbcUrl = jdbcUrl
-        ),
+        participantConfig,
         readService,
         writeService
       )

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
@@ -1,7 +1,6 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-package com.digitalasset.platform.index.cli
+package com.daml.ledger.api.server.damlonx.reference.v2.cli
 
 import java.io.File
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -54,6 +54,7 @@ compileDependencies = [
     "//3rdparty/jvm/com/typesafe/akka:akka_actor",
     "//3rdparty/jvm/com/google/guava:guava",
     "//3rdparty/jvm/org/postgresql:postgresql",
+    "//3rdparty/jvm/com/h2database:h2",
     "//3rdparty/jvm/com/zaxxer:HikariCP",
     "//3rdparty/jvm/org/flywaydb:flyway_core",
     "//3rdparty/jvm/com/typesafe/play:anorm",
@@ -93,7 +94,6 @@ da_scala_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":sandbox",
-        "//3rdparty/jvm/com/h2database:h2",
     ],
 )
 
@@ -142,7 +142,6 @@ testDependencies = [
     "//3rdparty/jvm/org/scalacheck:scalacheck",
     "//3rdparty/jvm/org/awaitility:awaitility",
     "//3rdparty/jvm/commons_io:commons_io",
-    "//3rdparty/jvm/com/h2database:h2",
     "//bazel_tools/runfiles:scala_runfiles",
 ] + compileDependencies
 
@@ -243,18 +242,14 @@ conformance_test(
 
 conformance_test(
     name = "conformance-test-static-time-h2database",
-    extra_data = [
-        "@postgresql_dev_env//:all",
-        "@postgresql_dev_env//:createdb",
-        "@postgresql_dev_env//:initdb",
-        "@postgresql_dev_env//:pg_ctl",
-    ],
     server = ":sandbox-binary",
     server_args = [
         "--port 6865",
         "--static-time",
         "--eager-package-loading",
-        "--sql-backend-jdbcurl jdbc:h2:mem:static_time",
+        # db_close_delay=-1 is needed so that the in-memory database is not closed (and therefore lost)
+        # after the flyway migration
+        "--sql-backend-jdbcurl jdbc:h2:mem:static_time;db_close_delay=-1",
     ],
     test_tool_args = [
         "--all-tests",
@@ -264,18 +259,14 @@ conformance_test(
 
 conformance_test(
     name = "conformance-test-wall-clock-h2database",
-    extra_data = [
-        "@postgresql_dev_env//:all",
-        "@postgresql_dev_env//:createdb",
-        "@postgresql_dev_env//:initdb",
-        "@postgresql_dev_env//:pg_ctl",
-    ],
     server = ":sandbox-binary",
     server_args = [
         "--port 6865",
         "--wall-clock-time",
         "--eager-package-loading",
-        "--sql-backend-jdbcurl jdbc:h2:mem:wall_clock_time",
+        # db_close_delay=-1 is needed so that the in-memory database is not closed (and therefore lost)
+        # after the flyway migration
+        "--sql-backend-jdbcurl jdbc:h2:mem:wall_clock_time;db_close_delay=-1",
     ],
     test_tool_args = [
         "--all-tests",

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -28,10 +28,12 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlLedger.{
   noOfStreamingConnections
 }
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{
+  DbType,
+  JdbcLedgerDao,
   LedgerDao,
-  PersistenceEntry,
-  JdbcLedgerDao
+  PersistenceEntry
 }
+import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   ContractSerializer,
   KeyHasher,
@@ -45,14 +47,32 @@ import scalaz.syntax.tag._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-object JdbcIndexer {
+sealed trait InitStatus
+final abstract class Initialized extends InitStatus
+final abstract class Uninitialized extends InitStatus
+
+object JdbcIndexerFactory {
+  def apply(): JdbcIndexerFactory[Uninitialized] = new JdbcIndexerFactory[Uninitialized]()
+}
+
+class JdbcIndexerFactory[Status <: InitStatus] private () {
   private val logger = LoggerFactory.getLogger(classOf[JdbcIndexer])
   private[index] val asyncTolerance = 30.seconds
 
-  def create(
-      actorSystem: ActorSystem,
-      readService: ReadService,
-      jdbcUrl: String): Future[JdbcIndexer] = {
+  def validateSchema(jdbcUrl: String)(
+      implicit x: Status =:= Uninitialized): JdbcIndexerFactory[Initialized] = {
+    FlywayMigrations(jdbcUrl).validate()
+    this.asInstanceOf[JdbcIndexerFactory[Initialized]]
+  }
+
+  def migrateSchema(jdbcUrl: String)(
+      implicit x: Status =:= Uninitialized): JdbcIndexerFactory[Initialized] = {
+    FlywayMigrations(jdbcUrl).migrate()
+    this.asInstanceOf[JdbcIndexerFactory[Initialized]]
+  }
+
+  def create(actorSystem: ActorSystem, readService: ReadService, jdbcUrl: String)(
+      implicit x: Status =:= Initialized): Future[JdbcIndexer] = {
     val materializer: ActorMaterializer = ActorMaterializer()(actorSystem)
     val metricsManager = MetricsManager(false)
 
@@ -82,11 +102,10 @@ object JdbcIndexer {
   }
 
   private def initializeDao(jdbcUrl: String, mm: MetricsManager) = {
-    val dbType = JdbcLedgerDao.jdbcType(jdbcUrl)
+    val dbType = DbType.jdbcType(jdbcUrl)
     val dbDispatcher =
       DbDispatcher(
         jdbcUrl,
-        dbType,
         if (dbType.supportsParallelWrites) noOfShortLivedConnections else 1,
         noOfStreamingConnections)
     val ledgerDao = LedgerDao.metered(
@@ -130,7 +149,7 @@ object JdbcIndexer {
   * @param beginAfterExternalOffset The last offset received from the read service.
   *                                 This offset has inclusive semantics,
   */
-class JdbcIndexer private (
+class JdbcIndexer private[index] (
     initialInternalOffset: Long,
     beginAfterExternalOffset: Option[LedgerString],
     ledgerDao: LedgerDao)(implicit mat: Materializer)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -42,7 +42,7 @@ object StandaloneIndexServer {
       readService: ReadService,
       writeService: WriteService): StandaloneIndexServer =
     new StandaloneIndexServer(
-      "sandbox",
+      "index",
       config,
       readService,
       writeService

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/config/Config.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/config/Config.scala
@@ -5,9 +5,17 @@ package com.digitalasset.platform.index.config
 
 import java.io.File
 
+import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref.LedgerString
 import com.digitalasset.ledger.api.tls.TlsConfiguration
+
+sealed trait StartupMode
+object StartupMode {
+  case object ValidateAndStart extends StartupMode
+  case object MigrateAndStart extends StartupMode
+  case object MigrateOnly extends StartupMode
+}
 
 final case class Config(
     port: Int,
@@ -17,8 +25,9 @@ final case class Config(
     timeProvider: TimeProvider, // enables use of non-wall-clock time in tests
     jdbcUrl: String,
     tlsConfig: Option[TlsConfiguration],
-    participantId: LedgerString,
-    extraPartipants: Vector[(LedgerString, Int, String)]
+    participantId: ParticipantId,
+    extraPartipants: Vector[(ParticipantId, Int, String)],
+    startupMode: StartupMode
 )
 
 object Config {
@@ -33,6 +42,7 @@ object Config {
       "",
       None,
       LedgerString.assertFromString("standalone-participant"),
-      Vector.empty
+      Vector.empty,
+      StartupMode.MigrateAndStart
     )
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -21,14 +21,14 @@ import com.digitalasset.platform.sandbox.banner.Banner
 import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.services.SandboxResetService
+import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
+import com.digitalasset.platform.sandbox.stores.ledger._
+import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlStartMode
 import com.digitalasset.platform.sandbox.stores.{
   InMemoryActiveContracts,
   InMemoryPackageStore,
   SandboxIndexAndWriteService
 }
-import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
-import com.digitalasset.platform.sandbox.stores.ledger._
-import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlStartMode
 import com.digitalasset.platform.server.services.testing.TimeServiceBackend
 import com.digitalasset.platform.services.time.TimeProviderType
 import org.slf4j.LoggerFactory

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/ReadOnlySqlLedger.scala
@@ -11,6 +11,7 @@ import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
 import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ledger.ReadOnlyLedger
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{
+  DbType,
   JdbcLedgerDao,
   LedgerDao,
   LedgerReadDao
@@ -39,9 +40,9 @@ object ReadOnlySqlLedger {
       mm: MetricsManager): Future[ReadOnlyLedger] = {
     implicit val ec: ExecutionContext = DEC
 
-    val dbType = JdbcLedgerDao.jdbcType(jdbcUrl)
+    val dbType = DbType.jdbcType(jdbcUrl)
     val dbDispatcher =
-      DbDispatcher(jdbcUrl, dbType, noOfShortLivedConnections, noOfStreamingConnections)
+      DbDispatcher(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
     val ledgerReadDao = LedgerDao.meteredRead(
       JdbcLedgerDao(
         dbDispatcher,
@@ -90,9 +91,6 @@ private class ReadOnlySqlLedgerFactory(ledgerDao: LedgerReadDao) {
   /** *
     * Creates a DB backed Ledger implementation.
     *
-    * @param initialLedgerId a random ledger id is generated if none given, if set it's used to initialize the ledger.
-    *                        In case the ledger had already been initialized, the given ledger id must not be set or must
-    *                        be equal to the one in the database.
     * @return a compliant read-only Ledger implementation
     */
   def createReadOnlySqlLedger(initialLedgerId: Option[LedgerId])(
@@ -147,6 +145,7 @@ private class ReadOnlySqlLedgerFactory(ledgerDao: LedgerReadDao) {
     logger.info(s"Found existing ledger with id: ${foundLedgerId.unwrap}")
     Future.successful(foundLedgerId)
   }
+
 }
 
 private object ReadOnlySqlLedgerFactory {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -29,6 +29,7 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlStartMode.{
   ContinueIfExists
 }
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao._
+import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   ContractSerializer,
   KeyHasher,
@@ -77,9 +78,12 @@ object SqlLedger {
       mm: MetricsManager): Future[Ledger] = {
     implicit val ec: ExecutionContext = DEC
 
-    val dbType = JdbcLedgerDao.jdbcType(jdbcUrl)
+    new FlywayMigrations(jdbcUrl).migrate()
+
+    val dbType = DbType.jdbcType(jdbcUrl)
     val dbDispatcher =
-      DbDispatcher(jdbcUrl, dbType, noOfShortLivedConnections, noOfStreamingConnections)
+      DbDispatcher(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
+
     val ledgerDao = LedgerDao.metered(
       JdbcLedgerDao(
         dbDispatcher,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.stores.ledger.sql.dao
+
+sealed abstract class DbType(val name: String, val supportsParallelWrites: Boolean)
+
+object DbType {
+  object Postgres extends DbType("postgres", true)
+
+  // H2 does not support concurrent, conditional updates to the ledger_end at read committed isolation
+  // level: "It is possible that a transaction from one connection overtakes a transaction from a different
+  // connection. Depending on the operations, this might result in different results, for example when conditionally
+  // incrementing a value in a row." - from http://www.h2database.com/html/advanced.html
+  object H2Database extends DbType("h2database", false)
+
+  def jdbcType(jdbcUrl: String): DbType = jdbcUrl match {
+    case h2 if h2.startsWith("jdbc:h2:") => H2Database
+    case _ => Postgres
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
@@ -16,6 +16,8 @@ object DbType {
 
   def jdbcType(jdbcUrl: String): DbType = jdbcUrl match {
     case h2 if h2.startsWith("jdbc:h2:") => H2Database
-    case _ => Postgres
+    case pg if pg.startsWith("jdbc:postgresql:") => Postgres
+    case otherwise =>
+      sys.error(s"JDBC URL doesn't match any supported databases (h2, pg): $otherwise")
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrations.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrations.scala
@@ -3,19 +3,43 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql.migration
 
-import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.JdbcLedgerDao
-import javax.sql.DataSource
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{DbType, HikariConnection}
 import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.configuration.FluentConfiguration
 import org.slf4j.LoggerFactory
 
+import scala.concurrent.duration._
+import scala.util.Try
 import scala.util.control.NonFatal
 
-class FlywayMigrations(ds: DataSource, dbType: JdbcLedgerDao.DbType) {
+class FlywayMigrations(jdbcUrl: String) {
   import FlywayMigrations._
 
   private val logger = LoggerFactory.getLogger(getClass)
 
+  private val dbType = DbType.jdbcType(jdbcUrl)
+  private def newDataSource =
+    HikariConnection.createDataSource(jdbcUrl, "Flyway-Pool", 2, 2, 250.millis)
+
+  def validate(): Unit = {
+    val ds = newDataSource
+    try {
+      val flyway = configurationBase(dbType).dataSource(ds).load()
+      logger.info(s"running Flyway validation..")
+      flyway.validate()
+      logger.info(s"Flyway schema validation finished successfully")
+    } catch {
+      case NonFatal(e) =>
+        logger.error("an error occurred while running schema migration", e)
+        //there is little point in communicating this error in a typed manner, we should rather blow up
+        throw e
+    } finally {
+      val _ = Try(ds.close())
+    }
+  }
+
   def migrate(): Unit = {
+    val ds = newDataSource
     try {
       val flyway = configurationBase(dbType).dataSource(ds).load()
       logger.info(s"running Flyway migration..")
@@ -27,6 +51,8 @@ class FlywayMigrations(ds: DataSource, dbType: JdbcLedgerDao.DbType) {
         //TODO: shall we quit gracefully if something goes off track?
         //there is little point in communicating this error in a typed manner, we should rather blow up
         throw e
+    } finally {
+      val _ = Try(ds.close())
     }
   }
 
@@ -34,9 +60,9 @@ class FlywayMigrations(ds: DataSource, dbType: JdbcLedgerDao.DbType) {
 
 object FlywayMigrations {
 
-  def configurationBase(dbType: JdbcLedgerDao.DbType) =
+  def configurationBase(dbType: DbType): FluentConfiguration =
     Flyway.configure.locations("classpath:db/migration/" + dbType.name)
 
-  def apply(ds: DataSource, dbType: JdbcLedgerDao.DbType): FlywayMigrations =
-    new FlywayMigrations(ds, dbType)
+  def apply(jdbcUrl: String): FlywayMigrations =
+    new FlywayMigrations(jdbcUrl)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -9,10 +9,7 @@ import java.util.concurrent.Executors
 import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
 import com.digitalasset.platform.common.util.DirectExecutionContext
-import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{
-  HikariJdbcConnectionProvider,
-  JdbcLedgerDao
-}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.slf4j.LoggerFactory
 
@@ -45,18 +42,13 @@ trait DbDispatcher extends AutoCloseable {
 
 private class DbDispatcherImpl(
     jdbcUrl: String,
-    dbType: JdbcLedgerDao.DbType,
     val noOfShortLivedConnections: Int,
     noOfStreamingConnections: Int)
     extends DbDispatcher {
 
   private val logger = LoggerFactory.getLogger(getClass)
   private val connectionProvider =
-    HikariJdbcConnectionProvider(
-      jdbcUrl,
-      dbType,
-      noOfShortLivedConnections,
-      noOfStreamingConnections)
+    HikariJdbcConnectionProvider(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
   private val sqlExecutor = SqlExecutor(noOfShortLivedConnections)
 
   private val connectionGettingThreadPool = ExecutionContext.fromExecutorService(
@@ -99,14 +91,12 @@ object DbDispatcher {
     * * in sync with the number of JDBC connections in the pool.
     *
     * @param jdbcUrl                   the jdbc url containing the database name, user name and password
-    * @param dbType                    the jdbc database type, needed for db migrations
     * @param noOfShortLivedConnections the number of connections to be pre-allocated for regular SQL queries
     * @param noOfStreamingConnections  the max number of connections to be used for long, streaming queries
     */
   def apply(
       jdbcUrl: String,
-      dbType: JdbcLedgerDao.DbType,
       noOfShortLivedConnections: Int,
       noOfStreamingConnections: Int): DbDispatcher =
-    new DbDispatcherImpl(jdbcUrl, dbType, noOfShortLivedConnections, noOfStreamingConnections)
+    new DbDispatcherImpl(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
@@ -3,16 +3,14 @@
 
 package com.digitalasset.platform.sandbox.persistence
 
-import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.{
-  HikariJdbcConnectionProvider,
-  JdbcLedgerDao
-}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider
+import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
 import org.scalatest._
 
 class PostgresIT extends WordSpec with Matchers with PostgresAroundAll {
 
   private lazy val connectionProvider =
-    HikariJdbcConnectionProvider(postgresFixture.jdbcUrl, JdbcLedgerDao.Postgres, 4, 4)
+    HikariJdbcConnectionProvider(postgresFixture.jdbcUrl, 4, 4)
 
   "Postgres" when {
 
@@ -34,6 +32,7 @@ class PostgresIT extends WordSpec with Matchers with PostgresAroundAll {
   "Flyway" should {
 
     "execute initialisation script" in {
+      FlywayMigrations(postgresFixture.jdbcUrl).migrate()
       connectionProvider.runSQL { conn =>
         def checkTableExists(table: String) = {
           val resultSet = conn.createStatement().executeQuery(s"SELECT * from $table")

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -16,8 +16,18 @@ import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
-import com.digitalasset.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises, NodeFetch}
-import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst, ValueText, VersionedValue}
+import com.digitalasset.daml.lf.transaction.Node.{
+  KeyWithMaintainers,
+  NodeCreate,
+  NodeExercises,
+  NodeFetch
+}
+import com.digitalasset.daml.lf.value.Value.{
+  AbsoluteContractId,
+  ContractInst,
+  ValueText,
+  VersionedValue
+}
 import com.digitalasset.daml.lf.value.ValueVersions
 import com.digitalasset.daml_lf.DamlLf
 import com.digitalasset.ledger.EventId
@@ -27,7 +37,12 @@ import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao._
 import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
-import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{ContractSerializer, KeyHasher, TransactionSerializer, ValueSerializer}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
+  ContractSerializer,
+  KeyHasher,
+  TransactionSerializer,
+  ValueSerializer
+}
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher
 import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -71,14 +71,14 @@ class JdbcLedgerDaoSpec
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, JdbcLedgerDao.Postgres, 4, 4)
+    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4)
     ledgerDao = JdbcLedgerDao(
       dbDispatcher,
       ContractSerializer,
       TransactionSerializer,
       ValueSerializer,
       KeyHasher,
-      JdbcLedgerDao.Postgres)
+      DbType.Postgres)
     Await.result(ledgerDao.initializeLedger(LedgerId("test-ledger"), 0), 10.seconds)
   }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -16,18 +16,8 @@ import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
-import com.digitalasset.daml.lf.transaction.Node.{
-  KeyWithMaintainers,
-  NodeCreate,
-  NodeExercises,
-  NodeFetch
-}
-import com.digitalasset.daml.lf.value.Value.{
-  AbsoluteContractId,
-  ContractInst,
-  ValueText,
-  VersionedValue
-}
+import com.digitalasset.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises, NodeFetch}
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst, ValueText, VersionedValue}
 import com.digitalasset.daml.lf.value.ValueVersions
 import com.digitalasset.daml_lf.DamlLf
 import com.digitalasset.ledger.EventId
@@ -36,12 +26,8 @@ import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao._
-import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
-  ContractSerializer,
-  KeyHasher,
-  TransactionSerializer,
-  ValueSerializer
-}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
+import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{ContractSerializer, KeyHasher, TransactionSerializer, ValueSerializer}
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher
 import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}
 
@@ -71,6 +57,7 @@ class JdbcLedgerDaoSpec
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    FlywayMigrations(postgresFixture.jdbcUrl).migrate()
     dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4)
     ledgerDao = JdbcLedgerDao(
       dbDispatcher,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrationsSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrationsSpec.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql.migration
 import java.math.BigInteger
 import java.security.MessageDigest
 
-import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.JdbcLedgerDao
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.DbType
 import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations.configurationBase
 import org.flywaydb.core.internal.resource.LoadableResource
 import org.flywaydb.core.internal.scanner.Scanner
@@ -20,22 +20,22 @@ import scala.collection.JavaConverters._
 class FlywayMigrationsSpec extends WordSpec with Matchers {
 
   private val digester = MessageDigest.getInstance("SHA-256")
-  private def scannerOfDbType(dbType: JdbcLedgerDao.DbType) = {
+  private def scannerOfDbType(dbType: DbType) = {
     val config = configurationBase(dbType)
     new Scanner(config.getLocations.toList.asJava, getClass.getClassLoader, config.getEncoding)
   }
 
   "Postgres flyway migration files" should {
     "always have a valid SHA-256 digest file accompanied" in assertFlywayMigrationFileHashes(
-      JdbcLedgerDao.Postgres)
+      DbType.Postgres)
   }
 
   "H2 database flyway migration files" should {
     "always have a valid SHA-256 digest file accompanied" in assertFlywayMigrationFileHashes(
-      JdbcLedgerDao.H2Database)
+      DbType.H2Database)
   }
 
-  private def assertFlywayMigrationFileHashes(dbType: JdbcLedgerDao.DbType) = {
+  private def assertFlywayMigrationFileHashes(dbType: DbType) = {
     val resourceScanner = scannerOfDbType(dbType)
 
     resourceScanner


### PR DESCRIPTION
The Ledger Indexer can now be started in 3 modes:

- validate schema and start
- migrate schema and start
- migrate schema only and exit

Fixes #2660

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
