### PR TITLE
Enable {-# LANGUAGE CPP #-} for daml.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -623,6 +623,10 @@ hazel_repositories(
                 "eb2c732b3d4ab5f7b367c51eef845e597ade19da52c03ee11954d35b6cfc4128",
                 patch_args = ["-p1"],
                 patches = ["@com_github_digital_asset_daml//3rdparty/haskell:bzlib-conduit.patch"],
+            ) + hazel_hackage(
+                "hpp",
+                "0.6.1",
+                "d1a843f4383223f85de4d91759545966f33a139d0019ab30a2f766bf9a7d62bf",
             ),
         pkgs = packages,
     ),

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -28,6 +28,7 @@ da_haskell_binary(
         ghc_pkg,
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
+        "//compiler/damlc:ghcversion",
     ],
     hackage_deps = [
         "base",
@@ -37,6 +38,12 @@ da_haskell_binary(
     deps = [
         ":damlc-lib",
     ],
+)
+
+filegroup(
+    name = "ghcversion",
+    srcs = ["ghcversion.h"],
+    visibility = ["__pkg__"],
 )
 
 # damlc without runfiles. We use that to build the daml-prim and daml-stdlib
@@ -51,6 +58,7 @@ da_haskell_binary(
         "-optl-static",
         "-optl-pthread",
     ] if is_windows else [],
+    data = ["//compiler/damlc:ghcversion"],
     hackage_deps = [
         "base",
     ],

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -26,9 +26,9 @@ da_haskell_binary(
     data = [
         "//compiler/damlc/daml-ide-core:dlint.yaml",
         ghc_pkg,
+        "//compiler/damlc:ghcversion",
         "//compiler/damlc/pkg-db",
         "//compiler/scenario-service/server:scenario_service_jar",
-        "//compiler/damlc:ghcversion",
     ],
     hackage_deps = [
         "base",

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -40,9 +40,14 @@ da_haskell_binary(
     ],
 )
 
-filegroup(
+genrule(
     name = "ghcversion",
-    srcs = ["ghcversion.h"],
+    srcs = [],
+    outs = ["ghcversion.h"],
+    cmd = """
+        echo > $(OUTS)
+    """,
+    tools = [],
     visibility = ["__pkg__"],
 )
 

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -70,6 +70,8 @@ data Options = Options
     -- ^ Whether to enable linting of the generated GHC Core. (Used in testing.)
   , optHaddock :: Haddock
     -- ^ Whether to enable lexer option `Opt_Haddock` (default is `Haddock False`).
+  , optCppPath :: Maybe FilePath
+    -- ^ Enable CPP, by giving filepath to the executable.
   } deriving Show
 
 newtype Haddock = Haddock Bool
@@ -156,6 +158,7 @@ defaultOptions mbVersion =
         , optDflagCheck = True
         , optCoreLinting = False
         , optHaddock = Haddock False
+        , optCppPath = Nothing
         }
 
 getBaseDir :: IO FilePath

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -74,7 +74,7 @@ data Options = Options
     -- ^ Enable CPP, by giving filepath to the executable.
   , optGhcVersionFile :: Maybe FilePath
     -- ^ Path to "ghcversion.h". Needed for running CPP. We ship this
-    -- an part of our runfiles.
+    -- as part of our runfiles. This is set by 'mkOptions'.
   } deriving Show
 
 newtype Haddock = Haddock Bool

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -262,7 +262,7 @@ adjustDynFlags options@Options{..} dflags
             { platformArch = P.ArchUnknown
             , platformOS = P.OSUnknown
             , platformWordSize = 8
-            , platformUnregisterised = False
+            , platformUnregisterised = True
             , platformHasGnuNonexecStack = False
             , platformHasIdentDirective = False
             , platformHasSubsectionsViaSymbols = False

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -226,14 +226,19 @@ adjustDynFlags options@Options{..} dflags
   $ apply xopt_set xExtensionsSet
   $ apply xopt_unset xExtensionsUnset
   $ apply gopt_set (xFlagsSet options)
+  $ addCppFlags
   dflags{
     mainModIs = mkModule primUnitId (mkModuleName "NotAnExistingName"), -- avoid DEL-6770
     debugLevel = 1,
     ghcLink = NoLink, hscTarget = HscNothing -- avoid generating .o or .hi files
     {-, dumpFlags = Opt_D_ppr_debug `EnumSet.insert` dumpFlags dflags -- turn on debug output from GHC-}
   }
-  where apply f xs d = foldl' f d xs
-
+  where
+    apply f xs d = foldl' f d xs
+    alterSettings f d = d { settings = f (settings d) }
+    addCppFlags = case optCppPath of
+        Nothing -> id
+        Just cppPath -> alterSettings (\s -> s { sPgm_P = (cppPath, [])})
 
 setThisInstalledUnitId :: UnitId -> DynFlags -> DynFlags
 setThisInstalledUnitId unitId dflags =

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -19,6 +19,7 @@ import Data.Bifunctor
 import Data.IORef
 import Data.List
 import DynFlags (parseDynamicFilePragma)
+import qualified Platform as P
 import qualified EnumSet
 import GHC                         hiding (convertLit)
 import GHC.LanguageExtensions.Type
@@ -230,15 +231,33 @@ adjustDynFlags options@Options{..} dflags
   dflags{
     mainModIs = mkModule primUnitId (mkModuleName "NotAnExistingName"), -- avoid DEL-6770
     debugLevel = 1,
-    ghcLink = NoLink, hscTarget = HscNothing -- avoid generating .o or .hi files
+    ghcLink = NoLink, hscTarget = HscNothing, -- avoid generating .o or .hi files
     {-, dumpFlags = Opt_D_ppr_debug `EnumSet.insert` dumpFlags dflags -- turn on debug output from GHC-}
+    ghcVersionFile = optGhcVersionFile
   }
   where
     apply f xs d = foldl' f d xs
     alterSettings f d = d { settings = f (settings d) }
     addCppFlags = case optCppPath of
         Nothing -> id
-        Just cppPath -> alterSettings (\s -> s { sPgm_P = (cppPath, [])})
+        Just cppPath -> alterSettings $ \s -> s
+            { sPgm_P = (cppPath, [])
+            , sOpt_P = []
+                -- Try adding "-P" here to suppress #line pragmas from the
+                -- preprocessor (hpp, specifically), if #line pragmas become
+                -- an issue. The reason they aren't an issue right now is because
+                -- ghcversion.h is empty, so no #line pragmas are generated.
+            , sTargetPlatform = P.Platform
+                { platformArch = P.ArchUnknown
+                , platformOS = P.OSUnknown
+                , platformWordSize = 8 -- 8 bytes / 64 bits
+                , platformUnregisterised = False
+                , platformHasGnuNonexecStack = False
+                , platformHasIdentDirective = False
+                , platformHasSubsectionsViaSymbols = False
+                , platformIsCrossCompiling = False
+                }
+            }
 
 setThisInstalledUnitId :: UnitId -> DynFlags -> DynFlags
 setThisInstalledUnitId unitId dflags =

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -118,8 +118,6 @@ data KindRep = KindRepTyConApp TyCon [KindRep]
              | KindRepTypeLitS TypeLitSort Addr#
              | KindRepTypeLitD TypeLitSort [Char]
 
-#line 10
-
 -- | HIDE
 data TypeLitSort = TypeLitSymbol
                  | TypeLitNat

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -5,6 +5,7 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS -Wno-unused-binds #-} -- the opaque constructors are not exported
 daml 1.2
 
@@ -117,6 +118,8 @@ data KindRep = KindRepTyConApp TyCon [KindRep]
              | KindRepTYPE !RuntimeRep
              | KindRepTypeLitS TypeLitSort Addr#
              | KindRepTypeLitD TypeLitSort [Char]
+
+#line 10
 
 -- | HIDE
 data TypeLitSort = TypeLitSymbol

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -5,7 +5,6 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS -Wno-unused-binds #-} -- the opaque constructors are not exported
 daml 1.2
 

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -928,6 +928,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> optNoDflagCheck
     <*> pure False
     <*> pure (Haddock False)
+    <*> optCppPath
   where
     optImportPath :: Parser [FilePath]
     optImportPath =
@@ -993,7 +994,12 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
       long "no-dflags-check" <>
       internal
 
-
+    optCppPath :: Parser (Maybe FilePath)
+    optCppPath = optional . option str
+        $ metavar "PATH"
+        <> long "cpp"
+        <> help "Set path to CPP."
+        <> internal
 
 optGhcCustomOptions :: Parser [String]
 optGhcCustomOptions =

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -929,6 +929,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure False
     <*> pure (Haddock False)
     <*> optCppPath
+    <*> pure Nothing
   where
     optImportPath :: Parser [FilePath]
     optImportPath =

--- a/compiler/damlc/pkg-db/util.bzl
+++ b/compiler/damlc/pkg-db/util.bzl
@@ -102,7 +102,7 @@ def _daml_package_rule_impl(ctx):
     ctx.actions.run_shell(
         outputs = [dalf, iface_dir],
         inputs = ctx.files.srcs + [package_db_dir, pkg_name_version],
-        tools = [ctx.executable.damlc_bootstrap],
+        tools = [ctx.executable.damlc_bootstrap, ctx.executable.cpp],
         progress_message = "Compiling " + name + ".daml to daml-lf " + ctx.attr.daml_lf_version,
         command = """
       set -eou pipefail
@@ -114,6 +114,7 @@ def _daml_package_rule_impl(ctx):
         --package-db {package_db_dir} \
         --write-iface \
         --target {daml_lf_version} \
+        --cpp {cpp} \
         -o {dalf_file} \
         {main}
 
@@ -125,6 +126,7 @@ def _daml_package_rule_impl(ctx):
             package_db_dir = package_db_dir.path,
             damlc_bootstrap = ctx.executable.damlc_bootstrap.path,
             dalf_file = dalf.path,
+            cpp = ctx.executable.cpp.path,
             daml_lf_version = ctx.attr.daml_lf_version,
             iface_dir = iface_dir.path,
             pkg_root = ctx.attr.pkg_root,
@@ -160,6 +162,11 @@ daml_package_rule = rule(
         "dependencies": attr.label_list(allow_files = False),
         "damlc_bootstrap": attr.label(
             default = Label("//compiler/damlc:damlc-bootstrap"),
+            executable = True,
+            cfg = "host",
+        ),
+        "cpp": attr.label(
+            default = Label("@haskell_hpp//:bin"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
Part of #99. 

This PR enables the use of `{-# LANGUAGE CPP #-}` in daml. To use it, the user must pass the `--cpp PATH` option, where `PATH` points to the cpp executable they wish to use. The `--cpp` option is hidden, at least for now. I'm using `hpp` to build the standard library package database, but we might want to change that later.

Issues / future work:

- The daml parser doesn't accept `#line` pragmas, which `hpp` and `cpphs` emit by default. I suppresed these lines by passing `-P` option to `hpp`, but perhaps there is a better way that doesn't involve messing up line numbers.

- Because of the above, `ghcversion.h` is intentionally left blank. This is a header file that gets automatically `#include`d by ghc whenever `CPP` is enabled.

- damldocs has an issue with CPP in the standard library right now, but I'll fix this in a separate PR. I think it just means changing how IDE options get passed to damldocs.

- Right now no DAML-LF version information is being passed yet.