### PR TITLE
language: fix: missing template instances in package

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -92,9 +92,10 @@ generateUpgradeModule templateNames modName qualA qualB =
 
 upgradeTemplates :: String -> [String]
 upgradeTemplates n =
-    [ "type " <> n <> "Upgrade = Upgrade A." <> n <> " B." <> n
-    , "type " <> n <> "Rollback = Rollback A." <> n <> " B." <> n
+    [ "template instance " <> n <> "Upgrade = Upgrade A." <> n <> " B." <> n
+    , "template instance " <> n <> "Rollback = Rollback A." <> n <> " B." <> n
     , "instance Convertible A." <> n <> " B." <> n
+    , "instance Convertible B." <> n <> " A." <> n
     ]
 
 -- | Generate the full source for a daml-lf package.

--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -12,6 +12,8 @@ module DA.Upgrade
   , Convertible(..)
   , GenConvertible
   , Upgrade(..)
+  , UpgradeInstance(..)
+  , RollbackInstance(..)
   , Rollback(..)
   )
   where

--- a/docs/source/migrate/foo-upgrade-2.0.0/daml/Foo.daml
+++ b/docs/source/migrate/foo-upgrade-2.0.0/daml/Foo.daml
@@ -8,7 +8,8 @@ import FooB qualified as B
 import FooAInstances()
 import FooBInstances()
 import DA.Upgrade
-type FooUpgrade = Upgrade A.Foo B.Foo
-type FooRollback = Rollback A.Foo B.Foo
+template instance FooUpgrade = Upgrade A.Foo B.Foo
+template instance FooRollback = Rollback A.Foo B.Foo
 instance Convertible A.Foo B.Foo
+instance Convertible B.Foo A.Foo
 

--- a/docs/source/migrate/foo-upgrade-2.0.0/daml/FooManual.daml
+++ b/docs/source/migrate/foo-upgrade-2.0.0/daml/FooManual.daml
@@ -8,8 +8,8 @@ import FooB qualified as B
 import FooAInstances()
 import FooBInstances()
 import DA.Upgrade
-type FooUpgrade = Upgrade A.Foo B.Foo
-type FooRollback = Rollback A.Foo B.Foo
+template instance FooUpgrade = Upgrade A.Foo B.Foo
+template instance FooRollback = Rollback A.Foo B.Foo
 
 instance Convertible A.Foo B.Foo where
     convert d = B.Foo with a = d.a; p = d.p; t = "upgraded"


### PR DESCRIPTION
The package compiled via daml migrate was missing the actual
Upgrade/Rollback templates. This is because we used `type` instead of
`template instance` to define those templates. Also, apparently we need
to export UpgradeInstance/RollbackInstance from DA.Upgrade in the
standard library, which seems to be an issue with generic templates. I added the export for now to make the migration work.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
