### PR TITLE
Default disable "Use camelCase"

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -980,8 +980,11 @@
 # --
 # DAML specific
 
+# Not popular or useful
+- ignore: {name: Use camelCase}
+# Not relevant to DAML
 - ignore: {name: Use newtype instead of data}
-
+# Bracketing rules
 - ignore: {name: Redundant bracket}
 - ignore: {name: Redundant $}
 - ignore: {name: Move brackets to avoid $}

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -279,17 +279,18 @@ dlintSmokeTests mbScenarioService = Tasty.testGroup "Dlint smoke tests"
             setFilesOfInterest [foo]
             expectNoErrors
             expectDiagnostic DsInfo (foo, 2, 0) "Warning: Use fewer imports"
-    ,  testCase' "Suggest use camelCase" $ do
-            foo <- makeFile "Foo.daml" $ T.unlines
-                [ "daml 1.2"
-                , "module Foo where"
-                , "my_fact (n : Int) : Int"
-                , "  | n <= 1    = 1"
-                , "  | otherwise = n * my_fact (n - 1)"
-                ]
-            setFilesOfInterest [foo]
-            expectNoErrors
-            expectDiagnostic DsInfo (foo, 2, 0) "Suggestion: Use camelCase"
+    -- Now disabled by default.
+    -- ,  testCase' "Suggest use camelCase" $ do
+    --         foo <- makeFile "Foo.daml" $ T.unlines
+    --             [ "daml 1.2"
+    --             , "module Foo where"
+    --             , "my_fact (n : Int) : Int"
+    --             , "  | n <= 1    = 1"
+    --             , "  | otherwise = n * my_fact (n - 1)"
+    --             ]
+    --         setFilesOfInterest [foo]
+    --         expectNoErrors
+    --         expectDiagnostic DsInfo (foo, 2, 0) "Suggestion: Use camelCase"
     ,  testCase' "Suggest reduce duplication" $ do
             foo <- makeFile "Foo.daml" $ T.unlines
                 [ "daml 1.2"


### PR DESCRIPTION
Disable the unpopular and opinionated "Use camelCase" suggestion by default.