### PR TITLE
Specify sql database driver in connection pool (#2877)

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/DbType.scala
@@ -3,16 +3,19 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql.dao
 
-sealed abstract class DbType(val name: String, val supportsParallelWrites: Boolean)
+sealed abstract class DbType(
+    val name: String,
+    val driver: String,
+    val supportsParallelWrites: Boolean)
 
 object DbType {
-  object Postgres extends DbType("postgres", true)
+  object Postgres extends DbType("postgres", "org.postgresql.Driver", true)
 
   // H2 does not support concurrent, conditional updates to the ledger_end at read committed isolation
   // level: "It is possible that a transaction from one connection overtakes a transaction from a different
   // connection. Depending on the operations, this might result in different results, for example when conditionally
   // incrementing a value in a row." - from http://www.h2database.com/html/advanced.html
-  object H2Database extends DbType("h2database", false)
+  object H2Database extends DbType("h2database", "org.h2.Driver", false)
 
   def jdbcType(jdbcUrl: String): DbType = jdbcUrl match {
     case h2 if h2.startsWith("jdbc:h2:") => H2Database

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
@@ -33,6 +33,7 @@ object HikariConnection {
       connectionTimeout: FiniteDuration): HikariDataSource = {
     val config = new HikariConfig
     config.setJdbcUrl(jdbcUrl)
+    config.setDriverClassName(DbType.jdbcType(jdbcUrl).driver)
     config.addDataSourceProperty("cachePrepStmts", "true")
     config.addDataSourceProperty("prepStmtCacheSize", "128")
     config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048")


### PR DESCRIPTION
This is believed to prevent race conditions that yield the following error:

java.lang.RuntimeException: Failed to get driver instance for jdbcUrl=jdbc:postgresql://...

Fixes #2877 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
