### PR TITLE
Panic on interface reader error

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -8,3 +8,5 @@ This page contains release notes for the SDK.
 
 HEAD — ongoing
 --------------
+
++ [Java codegen] If the DAR source cannot be read, the application crashes and prints an error report.


### PR DESCRIPTION
Interface reader errors are no longer ignored: if the codegen process cannot interpret its input the process panics and prints an error report.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
