### PR TITLE
Allow qualified import of generic templates

### DIFF
--- a/3rdparty/haskell/BUILD.ghc-lib-parser
+++ b/3rdparty/haskell/BUILD.ghc-lib-parser
@@ -52,7 +52,7 @@ haskell_library(
     "-I/compiler", "-I/compiler/utils"
   ],
   package_name = "ghc-lib-parser",
-  version = "8.8.1.20190912",
+  version = "8.8.1.20190916",
 )
 
 cc_library(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -484,12 +484,12 @@ GRPC_HASKELL_COMMIT = "11681ec6b99add18a8d1315f202634aea343d146"
 
 GRPC_HASKELL_HASH = "c6201f4e2fd39f25ca1d47b1dac4efdf151de88a2eb58254d61abc2760e58fda"
 
-GHC_LIB_VERSION = "8.8.1.20190912"
+GHC_LIB_VERSION = "8.8.1.20190916"
 
 http_archive(
     name = "haskell_ghc__lib__parser",
     build_file = "//3rdparty/haskell:BUILD.ghc-lib-parser",
-    sha256 = "04140cbb24667d75259429c100ef49e20faa76f32441588b775c77ddf36acc44",
+    sha256 = "aad0c0ddae6575dd2c360580417e9ae68b59f97433bb75ba2356ec32605010b9",
     strip_prefix = "ghc-lib-parser-{}".format(GHC_LIB_VERSION),
     urls = ["https://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-{}.tar.gz".format(GHC_LIB_VERSION)],
 )
@@ -561,7 +561,7 @@ hazel_repositories(
 
             # Read [Working on ghc-lib] for ghc-lib update instructions at
             # https://github.com/digital-asset/daml/blob/master/ghc-lib/working-on-ghc-lib.md.
-            hazel_ghclibs(GHC_LIB_VERSION, "04140cbb24667d75259429c100ef49e20faa76f32441588b775c77ddf36acc44", "5a819b9e1a7b01cd327f8a1d11bf8d0441c4c37ab7528ddecf161fb33e596fa3") +
+            hazel_ghclibs(GHC_LIB_VERSION, "aad0c0ddae6575dd2c360580417e9ae68b59f97433bb75ba2356ec32605010b9", "083c727c854019a847b8a4d831932f4d021a17fdcecee0b31d2aff0665c6ad4f") +
             hazel_github_external("digital-asset", "hlint", "c5a1baaf05bae57dd27653fd624581cd4f811c86", "5e43b9c79da0251f8b451495e8a426386e9cbf977c0824a0034cc921e5f331b1") +
             hazel_github_external("awakesecurity", "proto3-wire", "4f355bbac895d577d8a28f567ab4380f042ccc24", "031e05d523a887fbc546096618bc11dceabae224462a6cdd6aab11c1658e17a3") +
             hazel_github_external(

--- a/compiler/damlc/tests/daml-test-files/QualGenTempl.daml
+++ b/compiler/damlc/tests/daml-test-files/QualGenTempl.daml
@@ -1,0 +1,14 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module QualGenTempl where
+
+import Proposal qualified
+
+template T with
+    p : Party
+  where
+    signatory p
+
+template instance ProposalT = Proposal.Proposal T


### PR DESCRIPTION
Currently, there's a bug which breaks `template instance` declarations when
the module containing the generic template definition is imported qualified.

This PR incorporates https://github.com/digital-asset/ghc/pull/37 to fix this problem.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/2892)
<!-- Reviewable:end -->
