### PR TITLE
Add a CPP flag for each available DAML-LF feature.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -49,6 +49,8 @@ supportedInputVersions = version1_5 : supportedOutputVersions
 data Feature = Feature
     { featureName :: !T.Text
     , featureMinVersion :: !Version
+    , featureCppFlag :: !T.Text
+        -- ^ CPP flag to test for availability of the feature.
     }
 
 -- NOTE(MH): We comment this out to leave an example how to deal with features.
@@ -59,7 +61,16 @@ featureNumeric :: Feature
 featureNumeric = Feature
     { featureName = "Numeric type"
     , featureMinVersion = version1_7
+    , featureCppFlag = "DAML_NUMERIC"
     }
+
+allFeatures :: [Feature]
+allFeatures =
+    [ featureNumeric
+    ]
+
+allFeaturesForVersion :: Version -> [Feature]
+allFeaturesForVersion version = filter (supports version) allFeatures
 
 supports :: Version -> Feature -> Bool
 supports version feature = version >= featureMinVersion feature

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -199,7 +199,7 @@ _whenRuntimeSupports version feature t e
     | otherwise = runtimeUnsupported feature t
 
 runtimeUnsupported :: Feature -> Type -> Expr
-runtimeUnsupported (Feature name version) t =
+runtimeUnsupported (Feature name version _) t =
   ETmApp
   (ETyApp (EBuiltin BEError) t)
   (EBuiltin (BEText (name <> " only supported when compiling to DAML-LF " <> T.pack (renderVersion version) <> " or later")))

--- a/compiler/damlc/daml-opts/BUILD.bazel
+++ b/compiler/damlc/daml-opts/BUILD.bazel
@@ -43,6 +43,7 @@ da_haskell_library(
         "ghc-lib-parser",
         "ghcide",
         "mtl",
+        "text",
     ],
     src_strip_prefix = "daml-opts",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Closes #99. This PR adds CPP flags for each DAML-LF feature declared in `DA.Daml.LF.Version`. The CPP flag is only passed when compiling to a DAML-LF version that supports that feature.

Right now, it only adds the `DAML_NUMERIC` CPP flag which will be used in the standard library implementation of Numeric types (see #2289). The advantage of doing things this way is that the mapping between features and versions is kept in a central location (`DA.Daml.LF.Version`), so they only need to be updated there.