### PR TITLE
Do not consider archives that are already loaded in engine

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -25,7 +25,7 @@ final class PureCompiledPackages private (
     packages: Map[PackageId, Package],
     defns: Map[SDefinitionRef, SExpr])
     extends CompiledPackages {
-  override def packageIds = packages.keySet
+  override def packageIds: Set[PackageId] = packages.keySet
   override def getPackage(pkgId: PackageId): Option[Package] = packages.get(pkgId)
   override def getDefinition(dref: SDefinitionRef): Option[SExpr] = defns.get(dref)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessPackageUpload.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessPackageUpload.scala
@@ -80,6 +80,11 @@ private[kvutils] case class ProcessPackageUpload(
 
         // Filter out archives that already exists.
         val filteredArchives = archives
+          .filterNot(
+            a =>
+              Ref.PackageId
+                .fromString(a.getHash)
+                .fold(_ => false, loadedPackages.contains))
           .filter { archive =>
             val stateKey = DamlStateKey.newBuilder
               .setPackageId(archive.getHash)


### PR DESCRIPTION
This is in preparation for allowing invocation of KeyValueCommitting without packages that are already loaded.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
