### PR TITLE
Implement AnyTemplate DAML-LF type on the Scala side

### DIFF
--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -240,7 +240,7 @@ object InterfaceReader {
           unserializableDataType(
             ctx,
             s"Unserializable primitive type: $a must be applied to one and only one TNat")
-        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow =>
+        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow | Ast.BTAnyTemplate =>
           unserializableDataType(ctx, s"Unserializable primitive type: $a")
       }
       (arity, primType) = ab

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -70,6 +70,7 @@ class TypeSpec extends WordSpec with Matchers {
             TypePrim(PrimTypeBool, ImmArraySeq(assertOneArg(args)))
           case Pkg.BTOptional => TypePrim(PrimTypeOptional, ImmArraySeq(assertOneArg(args)))
           case Pkg.BTArrow => sys.error("cannot use arrow in interface type")
+          case Pkg.BTAnyTemplate => sys.error("cannot use anytemplate in interface type")
         }
       case Pkg.TTyCon(tycon) => TypeCon(TypeConName(tycon), args.toImmArray.toSeq)
       case Pkg.TNat(_) => sys.error("cannot use nat type in interface type")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -586,6 +586,12 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
 
       case ELocation(loc, e) =>
         SELocation(loc, translate(e))
+
+      case EToAnyTemplate(e) =>
+        SEApp(SEBuiltin(SBToAnyTemplate), Array(translate(e)))
+
+      case EFromAnyTemplate(tmplId, e) =>
+        SEApp(SEBuiltin(SBFromAnyTemplate(tmplId)), Array(translate(e)))
     }
 
   @tailrec
@@ -1030,6 +1036,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         case SRecord(_, _, args) => args.forEach(goV)
         case SVariant(_, _, value) => goV(value)
         case SEnum(_, _) => ()
+        case SAnyTemplate(SRecord(_, _, args)) => args.forEach(goV)
         case _: SPAP | SToken | STuple(_, _) =>
           throw CompileError("validate: unexpected SEValue")
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1203,6 +1203,25 @@ object SBuiltin {
       throw DamlEUserError(args.get(0).asInstanceOf[SText].value)
   }
 
+  final case object SBToAnyTemplate extends SBuiltin(1) {
+    def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
+      machine.ctrl = CtrlValue(args.get(0) match {
+        case r @ SRecord(_, _, _) => SAnyTemplate(r)
+        case v => crash(s"ToAnyTemplate on non-record: $v")
+      })
+    }
+  }
+
+  final case class SBFromAnyTemplate(expectedTemplateId: TypeConName) extends SBuiltin(1) {
+    def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
+      machine.ctrl = CtrlValue(args.get(0) match {
+        case SAnyTemplate(r @ SRecord(actualTemplateId, _, _)) =>
+          SOptional(if (actualTemplateId == expectedTemplateId) Some(r) else None)
+        case v => crash(s"FromAnyTemplate applied to non-AnyTemplate: $v")
+      })
+    }
+  }
+
   // Helpers
   //
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1203,6 +1203,10 @@ object SBuiltin {
       throw DamlEUserError(args.get(0).asInstanceOf[SText].value)
   }
 
+  /** $to_any_template
+    *    :: arg (template argument)
+    *    -> AnyTemplate
+    */
   final case object SBToAnyTemplate extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
@@ -1212,6 +1216,10 @@ object SBuiltin {
     }
   }
 
+  /** $from_any_template
+    *    :: AnyTemplate
+    *    -> Optional t (where t = TTyCon(expectedTemplateId))
+    */
   final case class SBFromAnyTemplate(expectedTemplateId: TypeConName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -66,6 +66,8 @@ sealed trait SValue {
         V.ValueMap(SortedLookupList(mVal).mapValue(_.toValue))
       case SContractId(coid) =>
         V.ValueContractId(coid)
+      case SAnyTemplate(_) =>
+        throw SErrorCrash("SValue.toValue: unexpected SAnyTemplate")
       case STNat(_) =>
         throw SErrorCrash("SValue.toValue: unexpected STNat")
       case _: SPAP =>
@@ -109,7 +111,8 @@ sealed trait SValue {
       case SContractId(coid) =>
         SContractId(f(coid))
       case SEnum(_, _) | _: SPrimLit | SToken | STNat(_) => this
-
+      case SAnyTemplate(SRecord(tycon, fields, values)) =>
+        SAnyTemplate(SRecord(tycon, fields, mapArrayList(values, v => v.mapContractId(f))))
     }
 
   def equalTo(v2: SValue): Boolean = {
@@ -180,6 +183,8 @@ object SValue {
   final case class SList(list: FrontStack[SValue]) extends SValue
 
   final case class SMap(value: HashMap[String, SValue]) extends SValue
+
+  final case class SAnyTemplate(t: SRecord) extends SValue
 
   // Corresponds to a DAML-LF Nat type reified as a Speedy value.
   // It is currently used to track at runtime the scale of the

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -506,8 +506,8 @@ object Speedy {
             }
           }
         case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | STNat(_) | _: SPAP |
-            SToken =>
+            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | SAnyTemplate(_) | STNat(_) |
+            _: SPAP | SToken =>
           crash("Match on non-matchable value")
       }
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -145,6 +145,12 @@ object Ast {
 
   final case class ESome(typ: Type, body: Expr) extends Expr
 
+  /** AnyTemplate constructor **/
+  final case class EToAnyTemplate(body: Expr) extends Expr
+
+  /** Extract the underlying template if it matches the tmplId **/
+  final case class EFromAnyTemplate(tmplId: TypeConName, body: Expr) extends Expr
+
   //
   // Kinds
   //
@@ -269,6 +275,7 @@ object Ast {
   case object BTDate extends BuiltinType
   case object BTContractId extends BuiltinType
   case object BTArrow extends BuiltinType
+  case object BTAnyTemplate extends BuiltinType
 
   //
   // Primitive literals

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -48,6 +48,7 @@ object Util {
   val TTimestamp = TBuiltin(BTTimestamp)
   val TDate = TBuiltin(BTDate)
   val TParty = TBuiltin(BTParty)
+  val TAnyTemplate = TBuiltin(BTAnyTemplate)
 
   val TNumeric = new ParametricType1(BTNumeric)
   val TList = new ParametricType1(BTList)

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -121,6 +121,10 @@ private[digitalasset] class AstRewriter(
           ENone(apply(typ))
         case ESome(typ, body) =>
           ESome(apply(typ), apply(body))
+        case EToAnyTemplate(body) =>
+          EToAnyTemplate(apply(body))
+        case EFromAnyTemplate(tmplId, body) =>
+          EFromAnyTemplate(tmplId, apply(body))
       }
 
   def apply(x: TypeConApp): TypeConApp = x match {

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -32,6 +32,8 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eAbs |
       eTyAbs |
       eLet |
+      eToAnyTemplate |
+      eFromAnyTemplate |
       contractId |
       fullIdentifier ^^ EVal |
       (id ^? builtinFunctions) ^^ EBuiltin |
@@ -172,6 +174,14 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   private lazy val eLet: Parser[Expr] =
     `let` ~>! binding(`=`) ~ (`in` ~> expr) ^^ {
       case b ~ body => ELet(b, body)
+    }
+
+  private lazy val eToAnyTemplate: Parser[Expr] =
+    `to_any_template` ~>! expr0 ^^ EToAnyTemplate
+
+  private lazy val eFromAnyTemplate: Parser[Expr] =
+    `from_any_template` ~>! `@` ~> fullIdentifier ~ expr0 ^^ {
+      case tyCon ~ e => EFromAnyTemplate(tyCon, e)
     }
 
   private lazy val pattern: Parser[CasePat] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -39,7 +39,9 @@ private[parser] object Lexer extends RegexParsers {
     "fetch_by_key" -> `fetch_by_key`,
     "lookup_by_key" -> `lookup_by_key`,
     "by" -> `by`,
-    "to" -> `to`
+    "to" -> `to`,
+    "to_any_template" -> `to_any_template`,
+    "from_any_template" -> `from_any_template`
   )
 
   val token: Parser[Token] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -51,6 +51,8 @@ private[parser] object Token {
   case object `lookup_by_key` extends Token
   case object `by` extends Token
   case object `to` extends Token
+  case object `to_any_template` extends Token
+  case object `from_any_template` extends Token
 
   final case class Id(s: String) extends Token
   final case class ContractId(s: String) extends Token

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -27,6 +27,7 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
     "ContractId" -> BTContractId,
     "Arrow" -> BTArrow,
     "Map" -> BTMap,
+    "AnyTemplate" -> BTAnyTemplate,
   )
 
   private[parser] def fullIdentifier: Parser[Ref.Identifier] =

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -95,6 +95,8 @@ private[validation] object Serializability {
             unserializable(URContractId)
           case BTArrow =>
             unserializable(URFunction)
+          case BTAnyTemplate =>
+            unserializable(URAnyTemplate)
         }
       case TForall(_, _) =>
         unserializable(URForall)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -159,6 +159,11 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       ENone(apply(typ))
     case ESome(typ, body) =>
       ESome(apply(typ), apply(body))
+    case EToAnyTemplate(body) =>
+      EToAnyTemplate(apply(body))
+    case EFromAnyTemplate(tmplId, body) =>
+      EFromAnyTemplate(tmplId, apply(body))
+
   }
 
   def apply(choice: TemplateChoice): TemplateChoice = choice match {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -23,7 +23,8 @@ private[validation] object Typing {
   }
 
   private def kindOfBuiltin(bType: BuiltinType): Kind = bType match {
-    case BTInt64 | BTText | BTTimestamp | BTParty | BTBool | BTDate | BTUnit => KStar
+    case BTInt64 | BTText | BTTimestamp | BTParty | BTBool | BTDate | BTUnit | BTAnyTemplate =>
+      KStar
     case BTNumeric => KArrow(KNat, KStar)
     case BTList | BTUpdate | BTScenario | BTContractId | BTOptional | BTMap => KArrow(KStar, KStar)
     case BTArrow => KArrow(KStar, KArrow(KStar, KStar))
@@ -714,6 +715,21 @@ private[validation] object Typing {
         checkExpr(exp, TScenario(typ))
     }
 
+    private def typeOfToAnyTemplate(body: Expr): Type =
+      typeOf(body) match {
+        case TTyCon(tmplId) =>
+          lookupTemplate(ctx, tmplId)
+          TBuiltin(BTAnyTemplate)
+        case typ =>
+          throw EExpectedTemplateType(ctx, typ)
+      }
+
+    private def typeOfFromAnyTemplate(tpl: TypeConName, body: Expr): Type = {
+      lookupTemplate(ctx, tpl)
+      checkExpr(body, TBuiltin(BTAnyTemplate))
+      TOptional(TTyCon(tpl))
+    }
+
     def typeOf(expr0: Expr): Type = expr0 match {
       case EVar(name) =>
         lookupExpVar(name)
@@ -777,6 +793,10 @@ private[validation] object Typing {
         checkType(typ, KStar)
         val _ = checkExpr(body, typ)
         TOptional(typ)
+      case EToAnyTemplate(body) =>
+        typeOfToAnyTemplate(body)
+      case EFromAnyTemplate(tmplId, body) =>
+        typeOfFromAnyTemplate(tmplId, body)
     }
 
     def checkExpr(expr: Expr, typ: Type): Type = {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -719,14 +719,14 @@ private[validation] object Typing {
       typeOf(body) match {
         case TTyCon(tmplId) =>
           lookupTemplate(ctx, tmplId)
-          TBuiltin(BTAnyTemplate)
+          TAnyTemplate
         case typ =>
           throw EExpectedTemplateType(ctx, typ)
       }
 
     private def typeOfFromAnyTemplate(tpl: TypeConName, body: Expr): Type = {
       lookupTemplate(ctx, tpl)
-      checkExpr(body, TBuiltin(BTAnyTemplate))
+      checkExpr(body, TAnyTemplate)
       TOptional(TTyCon(tpl))
     }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -138,6 +138,9 @@ final case class URHigherKinded(varName: TypeVarName, kind: Kind) extends Unseri
 case object URUninhabitatedType extends UnserializabilityReason {
   def pretty: String = "variant type without constructors"
 }
+case object URAnyTemplate extends UnserializabilityReason {
+  def pretty: String = "AnyTemplate"
+}
 
 abstract class ValidationError extends java.lang.RuntimeException with Product with Serializable {
   def context: Context
@@ -284,6 +287,11 @@ final case class EExpectedTemplatableType(context: Context, conName: TypeConName
     extends ValidationError {
   protected def prettyInternal: String =
     s"expected monomorphic record type in template definition, but found: ${conName.qualifiedName}"
+
+}
+final case class EExpectedTemplateType(context: Context, typ: Type) extends ValidationError {
+  protected def prettyInternal: String =
+    s"expected template type as argument to toAnyTemplate, but found: ${typ.pretty}"
 
 }
 final case class EImportCycle(context: Context, modName: List[ModuleName]) extends ValidationError {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -58,6 +58,10 @@ private[validation] object ExprTraversable {
       case ENone(typ @ _) =>
       case ESome(typ @ _, body) =>
         f(body)
+      case EToAnyTemplate(body) =>
+        f(body)
+      case EFromAnyTemplate(tmplId @ _, body) =>
+        f(body)
     }
     ()
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -66,6 +66,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
   "Checker.typeOf" should {
 
     "infers the proper type for expression" in {
+      // The part of the expression that corresponds to the expression
+      // defined by the given rule should be wrapped in double
+      // parentheses.
       val testCases = Table(
         "expression" ->
           "expected type",
@@ -163,10 +166,10 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"Λ (τ : ⋆) (σ : ⋆). λ (e₁ : τ) (e₂: σ) → (( case e₁ of _ → e₂ ))" ->
           T"∀ (τ : ⋆) (σ : ⋆). τ → σ → (( σ ))",
         // ExpToAnyTemplate
-        E"""to_any_template (Mod:T { person = 'Alice', name = "foobar" })""" ->
-          T"AnyTemplate",
+        E"""λ (t : Mod:T) -> (( to_any_template t ))""" ->
+          T"Mod:T -> AnyTemplate",
         // ExpFromAnyTemplate
-        E"""λ (t: AnyTemplate) -> from_any_template @Mod:T t""" ->
+        E"""λ (t: AnyTemplate) -> (( from_any_template @Mod:T t ))""" ->
           T"AnyTemplate → Option Mod:T",
       )
 
@@ -336,6 +339,15 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"Λ (τ : ⋆). λ (e : τ) → (( case e of () → () ))",
         // ExpCaseOr
         E"Λ (τ : ⋆). λ (e : τ) → (( case e of  ))",
+        // ExpToAnyTemplate
+        E"Λ (τ : *). λ (r: Mod:R τ) -> to_any_template r",
+        E"Λ (τ : *). λ (t: Mod:Tree τ) -> to_any_template t",
+        E"λ (c: Color) -> to_any_template c",
+        // ExpFromAnyTemplate
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:R t",
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:Tree t",
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:Color t",
+        E"λ (t: Mod:T) -> from_any_template @Mod:T t",
         // ScnPure
         E"Λ (τ : ⋆ → ⋆). λ (e: τ) → (( spure @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e: τ) → (( spure @σ e ))",
@@ -395,15 +407,6 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ScenarioEmbedExpr
         E"Λ (τ : ⋆) (σ : ⋆). λ (e : Udpate σ) → (( uembed_expr @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e : σ) → (( uembed_expr @τ e ))",
-        // ToAnyTemplate
-        E"Λ (τ : *). λ (r: Mod:R τ) -> to_any_template r",
-        E"Λ (τ : *). λ (t: Mod:Tree τ) -> to_any_template t",
-        E"λ (c: Color) -> to_any_template c",
-        // FromAnyTemplate
-        E"λ (t: AnyTemplate) -> from_any_template @Mod:R t",
-        E"λ (t: AnyTemplate) -> from_any_template @Mod:Tree t",
-        E"λ (t: AnyTemplate) -> from_any_template @Mod:Color t",
-        E"λ (t: Mod:T) -> from_any_template @Mod:T t",
       )
 
       forEvery(testCases) { exp =>

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -32,6 +32,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         BTDate -> k"*",
         BTContractId -> k"* -> *",
         BTArrow -> k"* -> * -> *",
+        BTAnyTemplate -> k"*",
       )
 
       forEvery(testCases) { (bType: BuiltinType, expectedKind: Kind) =>
@@ -161,6 +162,12 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpDefault
         E"Λ (τ : ⋆) (σ : ⋆). λ (e₁ : τ) (e₂: σ) → (( case e₁ of _ → e₂ ))" ->
           T"∀ (τ : ⋆) (σ : ⋆). τ → σ → (( σ ))",
+        // ExpToAnyTemplate
+        E"""to_any_template (Mod:T { person = 'Alice', name = "foobar" })""" ->
+          T"AnyTemplate",
+        // ExpFromAnyTemplate
+        E"""λ (t: AnyTemplate) -> from_any_template @Mod:T t""" ->
+          T"AnyTemplate → Option Mod:T",
       )
 
       forEvery(testCases) { (exp: Expr, expectedType: Type) =>
@@ -388,6 +395,15 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ScenarioEmbedExpr
         E"Λ (τ : ⋆) (σ : ⋆). λ (e : Udpate σ) → (( uembed_expr @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e : σ) → (( uembed_expr @τ e ))",
+        // ToAnyTemplate
+        E"Λ (τ : *). λ (r: Mod:R τ) -> to_any_template r",
+        E"Λ (τ : *). λ (t: Mod:Tree τ) -> to_any_template t",
+        E"λ (c: Color) -> to_any_template c",
+        // FromAnyTemplate
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:R t",
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:Tree t",
+        E"λ (t: AnyTemplate) -> from_any_template @Mod:Color t",
+        E"λ (t: Mod:T) -> from_any_template @Mod:T t",
       )
 
       forEvery(testCases) { exp =>


### PR DESCRIPTION
This is the first part of
https://github.com/digital-asset/daml/issues/2876. The PR adds
AnyTemplate to Speedy and to the internal expression representation
and adapts all the relevant infrastructure (e.g., the typechecker) and
the tests.

It does not yet change the protobuf representation, the Haskell side
or the spec. I’ll update the spec together with changing the protobuf.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
