### PR TITLE
ledger-service: fix numGen for scale 38

### DIFF
--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -78,9 +78,13 @@ object ValueGenerators {
 
   //generate decimal values
   def numGen(scale: Int): Gen[Numeric] = {
-    val integerPart = Gen.listOfN(Numeric.maxPrecision - scale, Gen.choose(1, 9)).map(_.mkString)
+    def integerPart = Gen.listOfN(Numeric.maxPrecision - scale, Gen.choose(1, 9)).map(_.mkString)
     val decimalPart = Gen.listOfN(scale, Gen.choose(1, 9)).map(_.mkString)
-    val bd = integerPart.flatMap(i => decimalPart.map(d => Numeric.assertFromString(s"$i.$d")))
+    val bd =
+      if (scale == Numeric.maxPrecision)
+        decimalPart.map(d => Numeric.assertFromString(s"0.$d"))
+      else
+        integerPart.flatMap(i => decimalPart.map(d => Numeric.assertFromString(s"$i.$d")))
     Gen
       .frequency(
         (1, Gen.const(Numeric.assertFromBigDecimal(scale, 0))),


### PR DESCRIPTION
Quick fix for random generation  numeric values of scale 38.  
This PR is related to #2289.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
