### PR TITLE
Don't disable $ rules

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -984,7 +984,5 @@
 - ignore: {name: Use camelCase}
 # Not relevant to DAML
 - ignore: {name: Use newtype instead of data}
-# Bracketing rules
+# Don't warn on redundant parens
 - ignore: {name: Redundant bracket}
-- ignore: {name: Redundant $}
-- ignore: {name: Move brackets to avoid $}

--- a/compiler/damlc/tests/daml-test-files/Fungible.daml
+++ b/compiler/damlc/tests/daml-test-files/Fungible.daml
@@ -16,7 +16,7 @@ template Quantity t => Fungible t with
           otherAsset <- fetch other
           let newAmount = asset.amount + otherAsset.asset.amount
           archive other
-          create $ Fungible $ asset with amount = newAmount
+          create $ Fungible asset with amount = newAmount
 
       Split: (ContractId (Fungible t), ContractId (Fungible t))
         with splitAmount: Decimal


### PR DESCRIPTION
We were overly aggressive disabling redundant parens rules recently and overlooked that enabling the suggestions on  usages of `$` are ok (and I expect not contentious).