### PR TITLE
Revert "Do not consider archives that are already loaded in engine"

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -25,7 +25,7 @@ final class PureCompiledPackages private (
     packages: Map[PackageId, Package],
     defns: Map[SDefinitionRef, SExpr])
     extends CompiledPackages {
-  override def packageIds: Set[PackageId] = packages.keySet
+  override def packageIds = packages.keySet
   override def getPackage(pkgId: PackageId): Option[Package] = packages.get(pkgId)
   override def getDefinition(dref: SDefinitionRef): Option[SExpr] = defns.get(dref)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessPackageUpload.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessPackageUpload.scala
@@ -80,11 +80,6 @@ private[kvutils] case class ProcessPackageUpload(
 
         // Filter out archives that already exists.
         val filteredArchives = archives
-          .filterNot(
-            a =>
-              Ref.PackageId
-                .fromString(a.getHash)
-                .fold(_ => false, loadedPackages.contains))
           .filter { archive =>
             val stateKey = DamlStateKey.newBuilder
               .setPackageId(archive.getHash)


### PR DESCRIPTION
Reverts digital-asset/daml#2898.

This change works badly if we want to use one validator with multiple committers.
I'll need to find another way to avoid loading packages that are already loaded.