### PR TITLE
SemanticTests synchronize/wait across participants, specify error codes

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -15,3 +15,4 @@ HEAD — ongoing
   You can find more information in the `DAML Assistant documentation <https://docs.daml.com/tools/assistant.html>`_.
 + [Ledger] Upgraded ledger-api server H2 Database version to 1.4.199 with stability fixes including one to the ``merge`` statement.
 + [DAML Integration Kit] One more test case added. Transaction service tests are not multi-node aware.
++ [DAML Integration Kit] Semantic tests now ensure synchronization across participants when running in a multi-node setup.


### PR DESCRIPTION
The semantic tests were previously running without checking that referring to outputs of transactions across participants was synchronized accurately. This lead to both flaky tests and false positives. For the former, `eventually` uses a retry strategy to ensure the existence of contracts created elsewhere and for the latter `synchronize` creates a synchronization point across participants to ensure both participants can see the same updates so that non-existence checks can be performed effectively. Both helpers have been introduced by #2900.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
