### PR TITLE
Rename dummy package to prevent wrong interpretation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dummy",
-  "displayName": "dummy",
+  "name": "digital-asset_daml_dummy",
+  "displayName": "digital-asset_daml_dummy",
   "description": "package for bazel-managed nodejs dependencies",
   "private": true,
   "version": "0.0.0",


### PR DESCRIPTION
By using the `dummy` name, dependency analysis may (incorrectly) think that this repository is actually [`dummy`](https://www.npmjs.com/package/dummy) and produce an incorrect output.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
