### PR TITLE
HOTFIX damldoc: suppress instance docs when `--data-only`

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -49,7 +49,7 @@ applyTransform opts = distributeInstanceDocs . maybeDoAnnotations opts'
     processWith (ExcludeModules rs : rest) ms
       = maybeDoAnnotations rest $ filter (not . moduleMatchesAny (map withSlashes rs)) ms
 
-    processWith (DataOnly : rest) ms = maybeDoAnnotations rest $ map prune ms
+    processWith (DataOnly : rest) ms = maybeDoAnnotations rest $ map pruneNonData ms
 
     processWith (IgnoreAnnotations : rest) ms = processWith rest ms
 
@@ -74,8 +74,17 @@ applyTransform opts = distributeInstanceDocs . maybeDoAnnotations opts'
           -- went past it without finding IgnoreAnnotations, so apply them
 
 
-    prune :: ModuleDoc -> ModuleDoc
-    prune m = m{ md_functions = [], md_classes = [] }
+    -- When --data-only is chosen, remove all non-data documentation. This
+    -- includes functions, classes, and instances of all data types (but not
+    -- template instances).
+    pruneNonData :: ModuleDoc -> ModuleDoc
+    pruneNonData m = m{ md_functions = []
+                      , md_classes = []
+                      , md_instances = []
+                      , md_adts = map noInstances $ md_adts m
+                      }
+    noInstances :: ADTDoc -> ADTDoc
+    noInstances d = d{ ad_instances = Nothing }
 
     -- conversions to use file pattern matcher
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,4 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+* DAML Docs: suppress instance documentation when `--data-only` mode is requested


### PR DESCRIPTION
# Motivation
When documenting the DAML model of a large solution, data types with many fields get a (somewhat redundant) big array of `HasField` instances for all the fields.

# Rationale
Instance declarations for data types relate to _functions_ that the type supports, not the data it holds. 
In line with the intention of the `--data-only` flag (useful when documenting a large DAML model for a particular solution instead of functionality in a small package) `--data-only` omits the instances.

### Pull Request Checklist

- [:heavy_check_mark: ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [:heavy_check_mark: ] Set a descriptive title and thorough description
- [:no_entry_sign: ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [:heavy_check_mark:  ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [:heavy_check_mark:  ] Normal production system change, include purpose of change in description
