### PR TITLE
Fix contract key uniqueness check in kvutils

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeys.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeys.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTest, LedgerTestSuite}
 import com.digitalasset.ledger.test_stable.DA.Types.Tuple2
+import com.digitalasset.ledger.test_stable.Test.Delegated._
 import com.digitalasset.ledger.test_stable.Test.Delegation._
 import com.digitalasset.ledger.test_stable.Test.ShowDelegated._
 import com.digitalasset.ledger.test_stable.Test.TextKey._
@@ -162,10 +163,22 @@ final class ContractKeys(session: LedgerSession) extends LedgerTestSuite(session
       }
     }
 
+  val recreateContractKeys =
+    LedgerTest("CKRecreate", "Contract keys can be recreated in single transaction") { context =>
+      val key = s"${UUID.randomUUID.toString}-key"
+      for {
+        ledger <- context.participant()
+        Vector(owner) <- ledger.allocateParties(1)
+        delegated <- ledger.create(owner, Delegated(owner, key))
+        _ <- ledger.exercise(owner, delegated.exerciseRecreate(_))
+      } yield { () }
+    }
+
   override val tests: Vector[LedgerTest] = Vector(
     fetchDivulgedContract,
     rejectFetchingUndisclosedContract,
-    processContractKeys
+    processContractKeys,
+    recreateContractKeys
   )
 
 }

--- a/ledger/test-common/src/main/daml/Test.daml
+++ b/ledger/test-common/src/main/daml/Test.daml
@@ -422,6 +422,11 @@ template Delegated
     key (owner, k) : (Party, Text)
     maintainer key._1
 
+    controller owner can
+      Recreate: () do
+        create this
+        return ()
+
 template Delegation
   with
     owner : Party
@@ -454,6 +459,7 @@ template Delegation
         do
           actual <- lookupByKey @Delegated (p, k)
           assertMsg "lookup matches" (expected == actual)
+
 
 template ShowDelegated
   with

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,3 +13,4 @@ HEAD — ongoing
 + [DAML-LF] add CAST_NUMERIC and SHIFT_NUMERIC in DAML-LF 1.dev
 + [Sandbox] Dramatically increased performance of the ActiveContractService by only loading the contracts that the parties in the transaction filter are allowed to see.
 + [DAML-LF] change signature of MUL_NUMERIC and DIV_NUMERIC
++ [DAML Integration Kit] fix contract key uniqueness check in kvutils.


### PR DESCRIPTION
Archival of a contract with a key and recreation within the
same transaction is now allowed in kvutils.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
