### PR TITLE
check JSON formatting of build results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -295,6 +295,8 @@ jobs:
            "pr_url": "https://github.com/digital-asset/daml/pull/$(System.PullRequest.PullRequestNumber)",
            "pr_source_branch": "$(System.PullRequest.SourceBranch)"}
           END
+          # Test above JSON is well formed
+          cat $REPORT | jq '.'
           REPORT_GZ=$(mktemp)
           cat $REPORT | gzip -9 > $REPORT_GZ
           GCS_KEY=$(mktemp)


### PR DESCRIPTION
I caught a missing `}` in a PR a few days ago while reviewing, and I thought counting on human eyes for that sort of mistake is probably not a great plan moving forward.
