### PR TITLE
Daml-LF: make archive decoder more restrictive for 1.dev

### DIFF
--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -34,6 +34,8 @@
 //        2019-07-04: Transaction submitters must be in contract key maintainers when looking up. See #1866.
 // * dev (special staging area for the next version to be released)
 //        2019-07-29: Add nat kind and Nat types, Numeric types and Numeric builtins
+//        2019-09-17: Add Any type and, To_Any and From_Any builtins
+//        2019-09-17: Drop support for Decimal
 
 syntax = "proto3";
 package daml_lf_1;
@@ -335,11 +337,11 @@ enum PrimCon {
 // Builtin functions
 // Refer to DAML-LF major version 1 specification for types and behavior of those.
 enum BuiltinFunction {
-  ADD_DECIMAL = 0; // *Deprecated in versions >= 1.dev*
-  SUB_DECIMAL = 1; // *Deprecated in versions >= 1.dev*
-  MUL_DECIMAL = 2; // *Deprecated in versions >= 1.dev*
-  DIV_DECIMAL = 3; // *Deprecated in versions >= 1.dev*
-  ROUND_DECIMAL = 6; // *Deprecated in versions >= 1.dev*
+  ADD_DECIMAL = 0; // *Available in versions < 1.dev*
+  SUB_DECIMAL = 1; // *Available in versions < 1.dev*
+  MUL_DECIMAL = 2; // *Available in versions < 1.dev*
+  DIV_DECIMAL = 3; // *Available in versions < 1.dev*
+  ROUND_DECIMAL = 6; // *Available in versions < 1.dev*
 
   ADD_NUMERIC = 107;    // *Available in versions >= 1.dev*
   SUB_NUMERIC = 108;    // *Available in versions >= 1.dev*
@@ -372,7 +374,7 @@ enum BuiltinFunction {
   ERROR = 25;
 
   LEQ_INT64 = 33;
-  LEQ_DECIMAL = 34;  // *Deprecated in versions >= 1.dev*
+  LEQ_DECIMAL = 34;  // *Available in versions < 1.dev*
   LEQ_NUMERIC = 112;  // *Available in versions >= 1.dev*
   LEQ_TEXT = 36;
   LEQ_TIMESTAMP = 37;
@@ -380,7 +382,7 @@ enum BuiltinFunction {
   LEQ_PARTY = 89; // *Available in versions >= 1.1*
 
   LESS_INT64 = 39;
-  LESS_DECIMAL = 40;  // *Deprecated in versions >= 1.dev*
+  LESS_DECIMAL = 40;  // *Available in versions < 1.dev*
   LESS_NUMERIC = 113;  // *Available in versions >= 1.dev*
   LESS_TEXT = 42;
   LESS_TIMESTAMP = 43;
@@ -388,7 +390,7 @@ enum BuiltinFunction {
   LESS_PARTY = 90; // *Available in versions >= 1.1*
 
   GEQ_INT64 = 45;
-  GEQ_DECIMAL = 46;  // *Deprecated in versions >= 1.dev*
+  GEQ_DECIMAL = 46;  // *Available in versions < 1.dev*
   GEQ_NUMERIC = 114;  // *Available in versions >= 1.dev*
   GEQ_TEXT = 48;
   GEQ_TIMESTAMP = 49;
@@ -396,7 +398,7 @@ enum BuiltinFunction {
   GEQ_PARTY = 91; // *Available in versions >= 1.1*
 
   GREATER_INT64 = 51;
-  GREATER_DECIMAL = 52;  // *Deprecated in versions >= 1.dev*
+  GREATER_DECIMAL = 52;  // *Available in versions < 1.dev*
   GREATER_NUMERIC = 115;  // *Available in versions >= 1.dev*
   GREATER_TEXT = 54;
   GREATER_TIMESTAMP = 55;
@@ -404,7 +406,7 @@ enum BuiltinFunction {
   GREATER_PARTY = 92; // *Available in versions >= 1.1*
 
   TO_TEXT_INT64 = 57;
-  TO_TEXT_DECIMAL = 58;  // *Deprecated in versions >= 1.dev*
+  TO_TEXT_DECIMAL = 58;  // *Available in versions < 1.dev*
   TO_TEXT_NUMERIC = 116;  // *Available in versions >= 1.dev*
   TO_TEXT_TEXT = 60;
   TO_TEXT_TIMESTAMP = 61;
@@ -423,8 +425,8 @@ enum BuiltinFunction {
   TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
   UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
 
-  INT64_TO_DECIMAL = 76;  // *Deprecated in versions >= 1.dev*
-  DECIMAL_TO_INT64 = 77;  // *Deprecated in versions >= 1.dev*
+  INT64_TO_DECIMAL = 76;  // *Available in versions < 1.dev*
+  DECIMAL_TO_INT64 = 77;  // *Available in versions < 1.dev*
 
   INT64_TO_NUMERIC = 118;  // *Available in versions >= 1.dev*
   NUMERIC_TO_INT64 = 119;  // *Available in versions >= 1.dev*
@@ -432,7 +434,7 @@ enum BuiltinFunction {
   IMPLODE_TEXT = 78;
 
   EQUAL_INT64 = 79;
-  EQUAL_DECIMAL = 80;  // *Deprecated in versions >= 1.dev*
+  EQUAL_DECIMAL = 80;  // *Available in versions < 1.dev*
   EQUAL_NUMERIC = 120;  // *Available in versions >= 1.dev*
   EQUAL_TEXT = 81;
   EQUAL_TIMESTAMP = 82;
@@ -470,7 +472,7 @@ message PrimLit {
     // It would fit in an int128, but sadly protobuf does not have
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
-    string decimal = 2; // *Deprecated in versions >= 1.dev*
+    string decimal = 2; // *Available in versions < 1.dev*
 
     // Unicode string literal ('LitText')
     string text = 4;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -292,9 +292,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           val prim = lfType.getPrim
           val baseType =
             if (prim.getPrim == PLF.PrimType.DECIMAL) {
-              // FixMe: https://github.com/digital-asset/daml/issues/2289
-              //   enable the check once the compiler produces proper DAML-LF 1.dev
-              // assertUntil(LV.Features.numeric, "PrimType.DECIMAL")
+              assertUntil(LV.Features.numeric, "PrimType.DECIMAL")
               TDecimal
             } else {
               val info = builtinTypeInfoMap(prim.getPrim)
@@ -735,9 +733,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         case PLF.PrimLit.SumCase.INT64 =>
           PLInt64(lfPrimLit.getInt64)
         case PLF.PrimLit.SumCase.DECIMAL =>
-          // FixMe: https://github.com/digital-asset/daml/issues/2289
-          //   enable the check once the compiler produces proper DAML-LF 1.dev
-          // assertUntil(LV.Features.numeric, "PrimLit.decimal")
+          assertUntil(LV.Features.numeric, "PrimLit.decimal")
           Decimal
             .fromString(lfPrimLit.getDecimal)
             .flatMap(Numeric.fromBigDecimal(Decimal.scale, _))

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -189,9 +189,7 @@ class DecodeV1Spec
       }
     }
 
-    // FixMe: https://github.com/digital-asset/daml/issues/2289
-    //  reactive the test once the decoder is not so lenient
-    "reject Decimal types if version >= 1.dev" ignore {
+    "reject Decimal types if version >= 1.dev" in {
       forEvery(postNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
         forEvery(decimalTestCases) { (input, _) =>
@@ -360,9 +358,7 @@ class DecodeV1Spec
       }
     }
 
-    // FixMe: https://github.com/digital-asset/daml/issues/2289
-    //  reactive the test once the decoder is not so lenient
-    "reject Decimal builtins if version >= 1.dev" ignore {
+    "reject Decimal builtins if version >= 1.dev" in {
 
       forEvery(postNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
@@ -480,9 +476,7 @@ class DecodeV1Spec
       }
     }
 
-    // FixMe: https://github.com/digital-asset/daml/issues/2289
-    //  enable the test once the dev decoder is not so lenien
-    "reject numeric decimal if version >= 1.dev" ignore {
+    "reject numeric decimal if version >= 1.dev" in {
 
       forEvery(postNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -196,8 +196,6 @@ object SValue {
   // with SValue and we can remove one layer of indirection.
   sealed trait SPrimLit extends SValue with Equals
   final case class SInt64(value: Long) extends SPrimLit
-  // FixMe: https://github.com/digital-asset/daml/issues/2289
-  //   SNumeric currently hold only (Numeric 10) aka Decimal
   final case class SNumeric(value: Numeric) extends SPrimLit
   final case class SText(value: String) extends SPrimLit
   final case class STimestamp(value: Time.Timestamp) extends SPrimLit
@@ -218,7 +216,7 @@ object SValue {
       case V.ValueInt64(x) => SInt64(x)
       case V.ValueNumeric(x) =>
         // FixMe: https://github.com/digital-asset/daml/issues/2289
-        //   drop this double check
+        //   drop this when numerics can be  persisted
         assert(x.scale == Decimal.scale)
         SNumeric(x)
       case V.ValueText(t) => SText(t)

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -233,8 +233,9 @@ Version: 1.dev
 
   * **Add** Nat kind and Nat type.
 
-  * **Replace** fixed scaled 'Decimal' type by parametrically scaled
-    'Numeric' type.
+  * **Add** parametrically scaled Numeric type.
+
+  * **Drop** support for Decimal type. Use Numeric of scale 10 instead.
 
   * **Add** existential ``AnyTemplate`` type and
     ``from_any_template`` and ``to_any_template`` functions to convert from/to
@@ -2942,6 +2943,7 @@ On the one hand, in case of DAML-LF 1.6 (or earlier) archive:
   + ``LESS_EQ_DECIMAL`` message is translated to ``(LESS_EQ_NUMERIC @10)``
   + ``GREATER_EQ_DECIMAL`` message is translated to ``(GREATER_EQ_NUMERIC @10)``
   + ``LESS_DECIMAL`` message is translated to ``(LESS_NUMERIC @10)``
+  + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)``
   + ``GREATER_DECIMAL`` message is translated to ``(GREATER_NUMERIC @10)``
   + ``EQUAL_DECIMAL`` message is translated to ``(EQUAL_NUMERIC @10)``
   + ``TO_TEXT_DECIMAL`` message is translated to ``(TO_TEXT_NUMERIC @10)``

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -291,6 +291,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpLet
         E"Λ  (τ₁: ⋆) (τ₂ : ⋆) (σ: ⋆). λ (e₁ : τ₁) (e₂ : σ) → (( let x : τ₂ = e₁ in e₂ ))",
         E"Λ (τ : ⋆ → ⋆) (σ: ⋆). λ (e₁ : τ) (e₂ : τ → σ) → (( let x : τ = e₁ in e₂ x ))",
+        // ExpLitDecimal
+        E"λ (f: Numeric 0 → Unit) → f (( 3.1415926536 ))",
         // ExpListNil
         E"Λ (τ : ⋆ → ⋆). (( Nil @τ ))",
         // ExpListCons


### PR DESCRIPTION
This PR advances the Numeric implementation #2289.

As compiler is now able generate proper 1.dev, we make the Decoder more restrictive when reading 1.dev. 
We fix also the extractor to properly handle numeric.  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
