### PR TITLE
ignore ledger updates that contain commands rejected due to de-duplication

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -257,6 +257,9 @@ class JdbcIndexer private[index] (
         // TODO(JM) implement configuration rejections
         Future.successful(())
 
+      case CommandRejected(submitterInfo, RejectionReason.DuplicateCommand) =>
+        Future.successful(())
+
       case CommandRejected(submitterInfo, reason) =>
         val rejection = PersistenceEntry.Rejection(
           LedgerEntry.Rejection(


### PR DESCRIPTION
Ignore ledger updates that contain commands rejected due to de-duplication. 
Such updates should not be entered into the index database as a) they are redundant and can be confusing b) could open a DOS attack vector.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
