### PR TITLE
Generic template test

### DIFF
--- a/compiler/damlc/tests/daml-test-files/TemplateSuperClassD.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateSuperClassD.daml
@@ -1,0 +1,25 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- NOTE(MH): This test would fail if `$d` wasn't considered a super class
+-- prefix in `isSuperClassDict` in template resugaring.
+daml 1.2
+module TemplateSuperClassD where
+
+template Template t => Gen t with
+    p: Party
+  where
+    signatory p
+
+template T with
+    p: Party
+  where
+    signatory p
+
+template instance GenT = Gen T
+
+test: Scenario ()
+test = do
+  p <- getParty "operator"
+  p `submit` create T with p
+  return ()

--- a/compiler/damlc/tests/daml-test-files/TemplateSuperClassF.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateSuperClassF.daml
@@ -1,0 +1,27 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- NOTE(MH): This test would fail if `$f` wasn't considered a super class
+-- prefix in `isSuperClassDict` in template resugaring.
+daml 1.2
+module TemplateSuperClassF where
+
+import DA.Record
+
+template (HasField "p" t Party, Template (G t)) => F t with
+    x: t
+  where
+    signatory x.p
+
+template (HasField "p" t Party, Template (F t)) => G t with
+    y: F t
+  where
+    signatory y.x.p
+
+template T with
+    p: Party
+  where
+    signatory p
+
+template instance FT = F T
+template instance GT = G T

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -12,3 +12,4 @@ HEAD — ongoing
 - [DAML Assistant] ``daml start`` now supports ``--sandbox-option=opt``, ``--navigator-option=opt``
   and ``--json-api-option=opt`` to pass additional option to sandbox/navigator/json-api.
   These flags can be specified multiple times.
+- [DAML Compiler] Fix a bug where generic templates could crash the compiler.


### PR DESCRIPTION
This test fails with the error:
`Pattern match failure in do expression at compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs:347:17-87`

See comment in test. One can comment out one of 3 lines and compilation succeeds. Probably the strangest thing is that commenting out the type sig of `test` gets compilation to work, even though the inferred type is the same as in the signature.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
