### PR TITLE
Infer templateId and choiceName in daml trigger commands

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -80,8 +80,7 @@ toLedgerValue = error "toLedgerValue should be removed."
 
 data Command
   = CreateCommand
-      { templateId : TemplateId
-      , templateArg : LedgerValue
+      { templateArg : LedgerValue
       }
   | ExerciseCommand
       { templateId : TemplateId
@@ -90,9 +89,9 @@ data Command
       , choiceArg : LedgerValue
       }
 
-createCmd : Template t => TemplateId -> t -> Command
-createCmd templateId templateArg =
-  CreateCommand templateId (toLedgerValue templateArg)
+createCmd : Template t => t -> Command
+createCmd templateArg =
+  CreateCommand (toLedgerValue templateArg)
 
 exerciseCmd : Choice t c r => TemplateId -> Text -> Text -> c -> Command
 exerciseCmd templateId contractId choiceName choiceArg =

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -24,6 +24,11 @@ data Identifier = Identifier
   , entityName : Text
   } deriving (Show, Eq)
 
+data AnyContractId = AnyContractId
+  { templateId : Identifier
+  , contractId : Text
+  } deriving (Show, Eq)
+
 data Transaction = Transaction
  { transactionId : Text
  , events : [Event]
@@ -36,14 +41,12 @@ data Event
 
 data Created = Created
   { eventId : Text
-  , contractId : Text
-  , templateId : Identifier
+  , contractId : AnyContractId
   } deriving (Show, Eq)
 
 data Archived = Archived
   { eventId : Text
-  , contractId : Text
-  , templateId : Identifier
+  , contractId : AnyContractId
   } deriving (Show, Eq)
 
 data Message
@@ -83,9 +86,7 @@ data Command
       { templateArg : LedgerValue
       }
   | ExerciseCommand
-      { templateId : TemplateId
-      , contractId : Text
-      , choiceName : Text
+      { contractId : AnyContractId
       , choiceArg : LedgerValue
       }
 
@@ -93,9 +94,9 @@ createCmd : Template t => t -> Command
 createCmd templateArg =
   CreateCommand (toLedgerValue templateArg)
 
-exerciseCmd : Choice t c r => TemplateId -> Text -> Text -> c -> Command
-exerciseCmd templateId contractId choiceName choiceArg =
-  ExerciseCommand templateId contractId choiceName (toLedgerValue choiceArg)
+exerciseCmd : Choice t c r => AnyContractId -> c -> Command
+exerciseCmd contractId choiceArg =
+  ExerciseCommand contractId (toLedgerValue choiceArg)
 
 data Commands = Commands
   { commandId : Text

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -6,6 +6,7 @@ module Daml.Trigger
   ( Message(..)
   , Transaction(..)
   , Identifier(..)
+  , AnyContractId(..)
   , Event(..)
   , Created(..)
   , Archived(..)

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -240,6 +240,13 @@ object Converter {
     }
   }
 
+  private def getTemplateId(v: SValue): Either[String, Identifier] = {
+    v match {
+      case SRecord(templateId, _, _) => Right(templateId)
+      case _ => Left(s"Expected TemplateId but got $v")
+    }
+  }
+
   private def toTemplateId(triggerIds: TriggerIds, v: SValue): Either[String, Identifier] = {
     v match {
       case SRecord(_, _, vals) => {
@@ -256,10 +263,10 @@ object Converter {
   private def toCreate(triggerIds: TriggerIds, v: SValue): Either[String, CreateCommand] = {
     v match {
       case SRecord(_, _, vals) => {
-        assert(vals.size == 2)
+        assert(vals.size == 1)
         for {
-          templateId <- toTemplateId(triggerIds, vals.get(0))
-          templateArg <- toLedgerRecord(vals.get(1))
+          templateId <- getTemplateId(vals.get(0))
+          templateArg <- toLedgerRecord(vals.get(0))
         } yield CreateCommand(Some(toApiIdentifier(templateId)), Some(templateArg))
       }
       case _ => Left(s"Expected CreateCommand but got $v")

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -261,10 +261,10 @@ object Converter {
     }
   }
 
-  private def getTemplateId(v: SValue): Either[String, Identifier] = {
+  private def toTemplateId(v: SValue): Either[String, Identifier] = {
     v match {
       case SRecord(templateId, _, _) => Right(templateId)
-      case _ => Left(s"Expected TemplateId but got $v")
+      case _ => Left(s"Expected contract value but got $v")
     }
   }
 
@@ -295,7 +295,7 @@ object Converter {
       case SRecord(_, _, vals) => {
         assert(vals.size == 1)
         for {
-          templateId <- getTemplateId(vals.get(0))
+          templateId <- toTemplateId(vals.get(0))
           templateArg <- toLedgerRecord(vals.get(0))
         } yield CreateCommand(Some(toApiIdentifier(templateId)), Some(templateArg))
       }

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -139,9 +139,7 @@ object TriggerIds {
   }
 }
 
-case class AnyContractId(
-    templateId: Identifier,
-    contractId: String)
+case class AnyContractId(templateId: Identifier, contractId: String)
 
 object Converter {
   // Helper to make constructing an SRecord more convenient
@@ -181,7 +179,10 @@ object Converter {
       ("name", SText(id.entityName)))
   }
 
-  private def fromAnyContractId(triggerIds: TriggerIds, templateId: value.Identifier, contractId: String): SValue = {
+  private def fromAnyContractId(
+      triggerIds: TriggerIds,
+      templateId: value.Identifier,
+      contractId: String): SValue = {
     val contractIdTy = triggerIds.getId("AnyContractId")
     record(
       contractIdTy,

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -268,19 +268,6 @@ object Converter {
     }
   }
 
-  private def toTemplateId(triggerIds: TriggerIds, v: SValue): Either[String, Identifier] = {
-    v match {
-      case SRecord(_, _, vals) => {
-        assert(vals.size == 2)
-        for {
-          moduleName <- toText(vals.get(0)).flatMap(DottedName.fromString)
-          entityName <- toText(vals.get(1)).flatMap(DottedName.fromString)
-        } yield Identifier(triggerIds.mainPackageId, QualifiedName(moduleName, entityName))
-      }
-      case _ => Left(s"Expected TemplateId but got $v")
-    }
-  }
-
   private def toContractId(v: SValue): Either[String, (Identifier, String)] = {
     v match {
       case SRecord(_, _, vals) => {

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -266,7 +266,7 @@ object Converter {
     }
   }
 
-  private def toTemplateId(v: SValue): Either[String, Identifier] = {
+  private def extractTemplateId(v: SValue): Either[String, Identifier] = {
     v match {
       case SRecord(templateId, _, _) => Right(templateId)
       case _ => Left(s"Expected contract value but got $v")
@@ -286,7 +286,7 @@ object Converter {
     }
   }
 
-  private def toChoiceName(v: SValue): Either[String, String] = {
+  private def extractChoiceName(v: SValue): Either[String, String] = {
     v match {
       case SRecord(ty, _, _) => {
         Right(ty.qualifiedName.name.toString)
@@ -300,7 +300,7 @@ object Converter {
       case SRecord(_, _, vals) => {
         assert(vals.size == 1)
         for {
-          templateId <- toTemplateId(vals.get(0))
+          templateId <- extractTemplateId(vals.get(0))
           templateArg <- toLedgerRecord(vals.get(0))
         } yield CreateCommand(Some(toApiIdentifier(templateId)), Some(templateArg))
       }
@@ -314,7 +314,7 @@ object Converter {
         assert(vals.size == 2)
         for {
           anyContractId <- toAnyContractId(vals.get(0))
-          choiceName <- toChoiceName(vals.get(1))
+          choiceName <- extractChoiceName(vals.get(1))
           choiceArg <- toLedgerValue(vals.get(1))
         } yield {
           ExerciseCommand(

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -19,8 +19,8 @@ initState : Party -> ActiveContracts -> TriggerState
 initState party (ActiveContracts events) = TriggerState (foldl updateAcs TM.empty events) 0 party
   where
     updateAcs : TextMap Identifier -> Created -> TextMap Identifier
-    updateAcs acs (Created _ cId tId)
-      | tId.entityName == "Asset" = TM.insert cId tId acs
+    updateAcs acs (Created _ cId)
+      | cId.templateId.entityName == "Asset" = TM.insert cId.contractId cId.templateId acs
       | otherwise = acs
 
 -- | This is a very silly trigger for testing purposes:
@@ -43,12 +43,12 @@ test = Trigger
       where
         updateEvent : ([Command], TextMap Identifier) -> Event -> ([Command], TextMap Identifier)
         updateEvent (cmds, acs) ev = case ev of
-          CreatedEvent (Created _ cId tId)
-            | tId.entityName == "Asset" ->
+          CreatedEvent (Created _ cId)
+            | cId.templateId.entityName == "Asset" ->
             let createMirror : Command = createCmd (AssetMirror { issuer = party })
-            in (createMirror :: cmds, TM.insert cId tId acs)
-          ArchivedEvent (Archived _ cId tId)
-            | tId.entityName == "Asset" -> (cmds, TM.delete cId acs)
+            in (createMirror :: cmds, TM.insert cId.contractId cId.templateId acs)
+          ArchivedEvent (Archived _ cId)
+            | cId.templateId.entityName == "Asset" -> (cmds, TM.delete cId.contractId acs)
           _ -> (cmds, acs)
 
 template Asset

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -45,7 +45,7 @@ test = Trigger
         updateEvent (cmds, acs) ev = case ev of
           CreatedEvent (Created _ cId tId)
             | tId.entityName == "Asset" ->
-            let createMirror : Command = createCmd (TemplateId "ACS" "AssetMirror") (AssetMirror { issuer = party })
+            let createMirror : Command = createCmd (AssetMirror { issuer = party })
             in (createMirror :: cmds, TM.insert cId tId acs)
           ArchivedEvent (Archived _ cId tId)
             | tId.entityName == "Asset" -> (cmds, TM.delete cId acs)

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -45,8 +45,11 @@ test = Trigger
         updateEvent (cmds, acs) ev = case ev of
           CreatedEvent (Created _ cId)
             | cId.templateId.entityName == "Asset" ->
-            let createMirror : Command = createCmd (AssetMirror { issuer = party })
-            in (createMirror :: cmds, TM.insert cId.contractId cId.templateId acs)
+            let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer = party })
+            in (proposeMirror :: cmds, TM.insert cId.contractId cId.templateId acs)
+            | cId.templateId.entityName == "AssetMirrorProposal" ->
+            let accept : Command = exerciseCmd @AssetMirrorProposal cId Accept
+            in (accept :: cmds, acs)
           ArchivedEvent (Archived _ cId)
             | cId.templateId.entityName == "Asset" -> (cmds, TM.delete cId.contractId acs)
           _ -> (cmds, acs)
@@ -62,3 +65,13 @@ template AssetMirror
     issuer : Party
   where
     signatory issuer
+
+template AssetMirrorProposal
+  with
+    issuer : Party
+  where
+    signatory issuer
+
+    controller issuer can
+      Accept : ContractId AssetMirror
+        do create AssetMirror { issuer = issuer }

--- a/triggers/tests/src/test/scala/com/daml/trigger/test/AcsMain.scala
+++ b/triggers/tests/src/test/scala/com/daml/trigger/test/AcsMain.scala
@@ -292,14 +292,14 @@ object AcsMain {
 
         try {
 
-          test(NumTransactions(2), (client, party) => {
+          test(NumTransactions(3), (client, party) => {
             for {
               contractId <- create(client, party, "1.0")
             } yield (Set(contractId), ActiveAssetMirrors(1))
           })
 
           test(
-            NumTransactions(4),
+            NumTransactions(6),
             (client, party) => {
               for {
                 contractId1 <- create(client, party, "2.0")
@@ -309,7 +309,7 @@ object AcsMain {
           )
 
           test(
-            NumTransactions(6),
+            NumTransactions(8),
             (client, party) => {
               for {
                 contractId1 <- create(client, party, "3.0")


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/2914

- Infers `templateId` from `templateArg` in `createCmd`.
- Infers `choiceName` from `choiceArg` in `exerciseCmd`.
- Introduces `AnyContractId`, which carries `templateId` and `contractId`.
- Infers `templateId` from `contractId: AnyContractId` in `exerciseCmd`.
- The template type still needs to be passed explicitly in `exerciseCmd`.
    In future we may wish to pass `ContractId t` instead of `AnyContractId`. This would require something like `fromAnyContractId : AnyContractId -> Option (ContractId t)`
- Extends the `ACS` test-case to use `exerciseCmd`.
    Introduces an indirection, where the trigger first creates `AssetMirrorProposal` and then exercises the `Accept` choice that creates the actual `AssetMirror`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
