### PR TITLE
Disable redundant $ rule by default

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -984,5 +984,6 @@
 - ignore: {name: Use camelCase}
 # Not relevant to DAML
 - ignore: {name: Use newtype instead of data}
-# Don't warn on redundant parens
+# Don't warn on redundant parens or $
 - ignore: {name: Redundant bracket}
+- ignore: {name: Redundant $}


### PR DESCRIPTION
In PR https://github.com/digital-asset/daml/pull/2909/files, the DLint "redundant $" rule was enabled by default. Although @hurryabit didn't explicitly say so to do so, I believe he doesn't want this enabled at this time judging that expressions like `A $ b with x = ...` shouldn't warn. Accordingly, in this PR I'm unwinding that change.