### PR TITLE
daml-lf: reserve % for use in the JSON API query language, or anything else

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -442,6 +442,10 @@ Identifiers are standard `java identifiers
 restricted to US-ASCII while names are sequences of identifiers
 intercalated with dots.
 
+The character ``%`` is reserved for external languages built on
+DAML-LF as a "not an Ident" notation, so should not be considered for
+future addition to allowed identifier characters.
+
 In the following, we will use identifiers to represent *built-in
 functions*, term and type *variable names*, record and tuple *field
 names*, *variant constructors*, and *template choices*. On the other


### PR DESCRIPTION
#2777 uses `%` to avoid its special field from being interpreted as a #2778 field equality query. Early in the draft, `$` was used for this purpose, until we noticed that `$` is allowed for LF identifiers, so this would be ambiguous.

We want to avoid accidentally triggering this ambiguity in the future. `%` is already implicitly forbidden; this PR merely adds a non-normative note asking future editors to avoid adding `%` to the `Ident` syntax.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
