### PR TITLE
Add Eq and Show as preconditions to the Template type class

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Template.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Template.daml
@@ -11,7 +11,7 @@ module DA.Internal.Template where
 import DA.Internal.LF
 import DA.Internal.Prelude
 
-class Template t where
+class (Eq t, Show t) => Template t where
 
   -- | The signatories of a contract.
   signatory : t -> [Party]

--- a/compiler/damlc/tests/daml-test-files/Asset.daml
+++ b/compiler/damlc/tests/daml-test-files/Asset.daml
@@ -8,6 +8,6 @@ import DA.Record
 -- It would be better to write these as constraint synonyms, but DAML doesn't
 -- allow them at the moment.
 
-class (Eq t, HasField "issuer" t Party, HasField "owner" t Party) => Asset t
+class (Eq t, Show t, HasField "issuer" t Party, HasField "owner" t Party) => Asset t
 
 class (Asset t, HasField "amount" t Decimal) => Quantity t

--- a/compiler/damlc/tests/daml-test-files/GenTemplContext.daml
+++ b/compiler/damlc/tests/daml-test-files/GenTemplContext.daml
@@ -8,7 +8,7 @@
 daml 1.2
 module GenTemplContext where
 
-template A t with
+template (Eq t, Show t) => A t with
     x : t
     p : Party
   where

--- a/compiler/damlc/tests/daml-test-files/GenericChoice.daml
+++ b/compiler/damlc/tests/daml-test-files/GenericChoice.daml
@@ -6,7 +6,7 @@
 daml 1.2
 module GenericChoice where
 
-template Foo c with
+template (Eq c, Show c) => Foo c with
     p : Party
     a : c
   where

--- a/compiler/damlc/tests/daml-test-files/Locations.daml
+++ b/compiler/damlc/tests/daml-test-files/Locations.daml
@@ -8,7 +8,7 @@ template A with
   where
     signatory p
 
-template T a with
+template (Eq a, Show a) => T a with
     p : Party
     x : a
   where

--- a/compiler/damlc/tests/daml-test-files/TemplateHeaders.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateHeaders.daml
@@ -23,13 +23,11 @@ template A with
 
 template B a with
     pb : Party
-    xb : a
   where
     signatory pb
 
 template C a b c with
     pc : Party
-    xc : a
   where
     signatory pc
 

--- a/compiler/damlc/tests/daml-test-files/TemplateSuperClassF.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateSuperClassF.daml
@@ -8,7 +8,7 @@ module TemplateSuperClassF where
 
 import DA.Record
 
-template (HasField "p" t Party, Template (G t)) => F t with
+template (HasField "p" t Party, Eq t, Show t, Template (G t)) => F t with
     x: t
   where
     signatory x.p

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -28,3 +28,10 @@ HEAD — ongoing
 - [Security] Document how to verify the signature on release tarballs.
 + [DAML Ledger Integration Kit] The TTL for commands is now read from the configuration service.
 + [DAML Ledger Integration Kit] The contract key tests now live under a single test suite and are multi-node aware.
+- [DAML Compiler] **BREAKING CHANGE**
+  Require Eq and Show as preconditions to the Template type class.
+  This means that a type parameter to a generic template must satisfy the Eq and Show constraints
+  if it is used as a template or choice parameter.
+  This change catches a particular class of errors - where unserializable types are used as
+  template/choice parameters - in the template declaration instead of the later template instance.
+  This should not affect working templates in practice.


### PR DESCRIPTION
Data types desugared from the `template` syntax will have these
instances automatically. This way we can simplify typeclasses
that have to specify `Eq` or `Show` on top of the `Template`
precondition.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
