### PR TITLE
restore full has_release check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,13 +160,10 @@ jobs:
     dependsOn: [ "Linux", "macOS", "Windows", "Windows_signing", "perf"]
     pool:
       vmImage: "Ubuntu-16.04"
-    # As of 2019-09-04, Azure seems to be unable to handle more than 2
-    # references to a dependency in the `condition` field. Therefore, I have
-    # removed the check for the Windows job output, as, at the moment, it
-    # always sets its `has_released` variable to true so in effect that check
-    # is already covered by the `succeeded` call.
     condition: and(succeeded(),
                    eq( dependencies.Linux.outputs['release.has_released'], 'true' ),
+                   eq( dependencies.Windows.outputs['release.has_released'], 'true' ),
+                   eq( dependencies.Windows_signing.outputs['release.has_released'], 'true' ),
                    eq( dependencies.macOS.outputs['release.has_released'], 'true' ))
     variables:
       artifact-linux: $[ dependencies.Linux.outputs['publish.artifact'] ]


### PR DESCRIPTION
I _believe_ this "hack" is not needed anymore, as I have successfully rerun an old master commit that had failed on it.

Note: this is actually not very useful in that both the Windows and the Windows_signing jobs, in their current form, always emit that variable if they have run to completion. Logically, though, it feels cleaner.