### PR TITLE
sign releases

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -33,11 +33,6 @@ jobs:
       - checkout: self
       - bash: ci/dev-env-install.sh
         displayName: 'Build/Install the Developer Environment'
-      - bash: ci/configure-bazel.sh
-        displayName: 'Configure Bazel'
-        env:
-          IS_FORK: $(System.PullRequest.IsFork)
-          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - bash: |
           set -euo pipefail
 
@@ -252,6 +247,10 @@ jobs:
           curl https://api.github.com/repos/digital-asset/daml/releases -s | gzip -9 > $STATS
 
           GCS_KEY=$(mktemp)
+          cleanup () {
+              rm -f $GCS_KEY
+          }
+          trap cleanup EXIT
           echo "$GOOGLE_APPLICATION_CREDENTIALS_CONTENT" > $GCS_KEY
           gcloud auth activate-service-account --key-file=$GCS_KEY
           BOTO_CONFIG=/dev/null gsutil cp $STATS gs://daml-data/downloads/$(date -u +%Y%m%d_%H%M%SZ).json.gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,10 @@ jobs:
           INSTALLER=daml-sdk-$(cat VERSION)-windows.exe
           mv "$(Build.StagingDirectory)/$(unsigned-installer)" "$(Build.StagingDirectory)/$INSTALLER"
           chmod +x "$(Build.StagingDirectory)/$INSTALLER"
+          cleanup () {
+              rm -f signing_key.pfx
+          }
+          trap cleanup EXIT
           echo "$SIGNING_KEY" | base64 -d > signing_key.pfx
           MSYS_NO_PATHCONV=1 signtool.exe sign '/f' signing_key.pfx '/fd' sha256 '/tr' "http://timestamp.digicert.com" '/v' "$(Build.StagingDirectory)/$INSTALLER"
           rm signing_key.pfx
@@ -205,6 +209,24 @@ jobs:
           artifactName: $(artifact-windows-installer)
           targetPath: $(Build.StagingDirectory)/release
         condition: not(eq(variables['skip-github'], 'TRUE'))
+      - bash: |
+          set -euo pipefail
+          KEY_FILE=$(mktemp)
+          GPG_DIR=$(mktemp -d)
+          cleanup() {
+              rm -rf $KEY_FILE $GPG_DIR
+          }
+          trap cleanup EXIT
+          echo "$GPG_KEY" > $KEY_FILE
+          gpg --homedir $GPG_DIR --no-tty --quiet --import $KEY_FILE
+          cd $(Build.StagingDirectory)/release
+          # Note: relies on our release artifacts not having spaces in their
+          # names. Creates a ${f}.asc with the signature for each $f.
+          for f in *; do
+              gpg --homedir $GPG_DIR -ab $f
+          done
+        env:
+          GPG_KEY: $(gpg-code-signing)
       - task: GitHubRelease@0
         inputs:
           gitHubConnection: 'garyverhaegen-da'
@@ -307,6 +329,10 @@ jobs:
           REPORT_GZ=$(mktemp)
           cat $REPORT | gzip -9 > $REPORT_GZ
           GCS_KEY=$(mktemp)
+          cleanup() {
+              rm -rf $GCS_KEY
+          }
+          trap cleanup EXIT
           # Application credentials will not be set for forks. We give up on
           # tracking those for now. "Not set" in Azure world means set to the
           # expression Azure would otherwise substitute, i.e. the literal value

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,3 +22,4 @@ HEAD — ongoing
 - [DAML Compiler]
   ``damlc migrate`` now produces a project that can be built with ``daml build`` as opposed to
   having to use the special ``build.sh`` and ``build.cmd`` scripts.
+- [security] Starting with this one, releases are now signed on GitHub.


### PR DESCRIPTION
We have the GPG key available for signing Maven artifacts already, so this seems like a low-cost way of increasing confidence in our released artifacts.

I've also made some minor changes to the rest of the pipelines to tighten security a bit around making sure we delete credentials.