### PR TITLE
Include all daml files in dar if source points to a file

### DIFF
--- a/3rdparty/haskell/BUILD.ghcide
+++ b/3rdparty/haskell/BUILD.ghcide
@@ -43,7 +43,6 @@ depends = [
 
 hidden = [
     "Development.IDE.Core.Compile",
-    "Development.IDE.GHC.Compat",
     "Development.IDE.GHC.CPP",
     "Development.IDE.GHC.Error",
     "Development.IDE.GHC.Orphans",

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -188,7 +188,11 @@ runTestsInProjectOrFiles projectOpts Nothing color mbJUnitOutput cliOptions = Co
         case parseProjectConfig project of
             Left err -> throwIO err
             Right PackageConfigFields {..} -> do
-              files <- getDamlFiles pSrc
+              -- TODO: We set up one scenario service context per file that
+              -- we pass to execTest and scenario cnotexts are quite expensive.
+              -- Therefore we keep the behavior of only passing the root file
+              -- if source points to a specific file.
+              files <- getDamlRootFiles pSrc
               execTest files color mbJUnitOutput cliOptions
 runTestsInProjectOrFiles projectOpts (Just inFiles) color mbJUnitOutput cliOptions = Command Test effect
   where effect = withProjectRoot' projectOpts $ \relativize -> do

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,6 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [DAML Compiler]
+  Fix a bug where ``.dar`` files produced by ``daml build`` were missing
+  all ``.daml`` files except for the one that ``source`` pointed to.


### PR DESCRIPTION
Previously, we only included the source file itself but not its
dependencies which didn’t make much sense.

This fixes #2960

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
