### PR TITLE
Extractor: enable numerics for multi table data format

### DIFF
--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -303,10 +303,7 @@ object Queries {
           )
         case V.ValueInt64(value) => Fragment("?", value)
         case V.ValueNumeric(value) =>
-          // FixMe: https://github.com/digital-asset/daml/issues/2289
-          //  For now all the ValueNumeric should have scale 10
-          //  Check this code once it is possible to create Numerics with different scale
-          Fragment("?::numeric(38,10)", value: BigDecimal)
+          Fragment(s"?::numeric(38,${value.scale})", value: BigDecimal)
         case V.ValueText(value) => Fragment("?", value)
         case ts @ V.ValueTimestamp(_) => Fragment("?", ts)
         case V.ValueParty(value) => Fragment("?", value: String)

--- a/extractor/src/test/resources/damls/PrimitiveTypes.daml
+++ b/extractor/src/test/resources/damls/PrimitiveTypes.daml
@@ -6,6 +6,9 @@ daml 1.2 module PrimitiveTypes where
 import DA.Date
 import DA.TextMap as TM
 
+-- FixMe: https://github.com/digital-asset/daml/issues/2289
+-- add test for Numerics once the compiler can produce them,
+
 template BasicPrimitiveTypes
   with
     reference: Text


### PR DESCRIPTION
This PR advances the Numeric implementation #2289.

In this PR, we enable the numerics in the multi table data format when data are persisted.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
