### PR TITLE
fix build data encoding

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -250,10 +250,17 @@ jobs:
       release.machine: $[ dependencies.release.outputs['start.machine'] ]
       release.end: $[ dependencies.release.outputs['end.time'] ]
       release.status: $[ dependencies.release.result ]
+      # Using expression syntax so we get an empty string if not set, rather
+      # than the raw $(VarName) string. Expression syntax works on the
+      # variables key, but not on the env one, so we need an extra indirection.
+      # Note: These Azure variables are only set for PR builds.
+      pr.num: $[ variables['System.PullRequest.PullRequestNumber'] ]
+      pr.branch: $[ variables['System.PullRequest.SourceBranch'] ]
     steps:
       - checkout: self
       - bash: |
           set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
 
           REPORT=$(mktemp)
           cat >$REPORT <<END
@@ -289,11 +296,11 @@ jobs:
            "reason": "$(Build.Reason)",
            "branch": "$(Build.SourceBranch)",
            "commit_sha": "$(Build.SourceVersion)",
-           "commit_message": "$(Build.SourceVersionMessage)",
+           "commit_message": $(echo -n "$COMMIT_MSG" | jq -sR),
            "is_fork": "$(System.PullRequest.IsFork)",
-           "pr": "$(System.PullRequest.PullRequestNumber)",
-           "pr_url": "https://github.com/digital-asset/daml/pull/$(System.PullRequest.PullRequestNumber)",
-           "pr_source_branch": "$(System.PullRequest.SourceBranch)"}
+           "pr": "$PR_NUM",
+           "pr_url": "https://github.com/digital-asset/daml/pull/$PR_NUM",
+           "pr_source_branch": "$PR_BRANCH"}
           END
           # Test above JSON is well formed
           cat $REPORT | jq '.'
@@ -322,3 +329,10 @@ jobs:
           fi
         env:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+          # Commit message is always set
+          COMMIT_MSG: $(Build.SourceVersionMessage)
+          # Because these variables are always set (in the variables block),
+          # hopefully these should be set as expected (i.e. either correct
+          # value or empty string, but not $(Azure.Variable.Name)).
+          PR_NUM: $(pr.num)
+          PR_BRANCH: $(pr.branch)


### PR DESCRIPTION
There was an issue where multiline commit messages were not encoded at
all, yielding invalid JSON. This should fix it. This commit message is
designed to test it before it gets to master.

$(exit 1)
`exit 1`
end quote: "
invalid json input