### PR TITLE
Name collision checking within a module.

### DIFF
--- a/compiler/daml-lf-tools/BUILD.bazel
+++ b/compiler/daml-lf-tools/BUILD.bazel
@@ -17,7 +17,6 @@ da_haskell_library(
         "recursion-schemes",
         "safe",
         "text",
-        "transformers",
         "uniplate",
         "unordered-containers",
     ],

--- a/compiler/daml-lf-tools/BUILD.bazel
+++ b/compiler/daml-lf-tools/BUILD.bazel
@@ -17,6 +17,7 @@ da_haskell_library(
         "recursion-schemes",
         "safe",
         "text",
+        "transformers",
         "uniplate",
         "unordered-containers",
     ],

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker.hs
@@ -14,6 +14,7 @@ import           DA.Daml.LF.TypeChecker.Error
 import qualified DA.Daml.LF.TypeChecker.PartyLiterals as PartyLits
 import qualified DA.Daml.LF.TypeChecker.Recursion as Recursion
 import qualified DA.Daml.LF.TypeChecker.Serializability as Serializability
+import qualified DA.Daml.LF.TypeChecker.NameCollision as NameCollision
 
 checkModule ::
      World
@@ -26,3 +27,4 @@ checkModule world0 version m = do
       Recursion.checkModule m
       Serializability.checkModule m
       PartyLits.checkModule m
+      NameCollision.checkModule m

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -104,6 +104,7 @@ data Error
   | EContext               !Context !Error
   | EKeyOperationOnTemplateWithNoKey !(Qualified TypeConName)
   | EUnsupportedFeature !Feature
+  | EForbiddenNameCollision !T.Text
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -287,6 +288,8 @@ instance Pretty Error where
     EUnsupportedFeature Feature{..} ->
       "unsupported feature:" <-> pretty featureName
       <-> "only supported in DAML-LF version" <-> pretty featureMinVersion <-> "and later"
+    EForbiddenNameCollision name ->
+      "forbidden name collision for " <-> pretty name
 
 instance Pretty Context where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -104,7 +104,7 @@ data Error
   | EContext               !Context !Error
   | EKeyOperationOnTemplateWithNoKey !(Qualified TypeConName)
   | EUnsupportedFeature !Feature
-  | EForbiddenNameCollision !T.Text
+  | EForbiddenNameCollision !T.Text ![T.Text]
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -288,8 +288,8 @@ instance Pretty Error where
     EUnsupportedFeature Feature{..} ->
       "unsupported feature:" <-> pretty featureName
       <-> "only supported in DAML-LF version" <-> pretty featureMinVersion <-> "and later"
-    EForbiddenNameCollision name ->
-      "forbidden name collision for " <-> pretty name
+    EForbiddenNameCollision name names ->
+      "name collision between " <-> pretty name <-> " and " <-> pretty (T.intercalate ", " names)
 
 instance Pretty Context where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Daml.LF.TypeChecker.NameCollision
     ( checkModule
     ) where
@@ -156,3 +159,4 @@ checkModule mod0 =
         forM_ (moduleTemplates mod0) $ \tpl ->
             withContext (ContextTemplate mod0 tpl TPWhole) $
                 checkTemplate (moduleName mod0) tpl
+

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -5,132 +5,151 @@ module DA.Daml.LF.TypeChecker.NameCollision
 import DA.Daml.LF.Ast
 import DA.Daml.LF.TypeChecker.Env
 import DA.Daml.LF.TypeChecker.Error
+import Data.Maybe
 import Control.Monad.Extra
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Control.Monad.Trans.State as S
 
+-- | The various names we wish to track within a package.
+-- This type separates all the different kinds of names
+-- out nicely, and preserves case sensitivity, so the
+-- names are easy to display in error messages. To get
+-- the corresponding case insensitive fully resolved name,
+-- see 'FRName'.
+data Name
+    = NModule ModuleName
+    | NRecordType ModuleName TypeConName
+    | NVariantType ModuleName TypeConName
+    | NEnumType ModuleName TypeConName
+    | NVariantCon ModuleName TypeConName VariantConName
+    | NEnumCon ModuleName TypeConName VariantConName
+    | NField ModuleName TypeConName FieldName
+    | NChoice ModuleName TypeConName ChoiceName
+
+-- | Display a name in a super unambiguous way.
+displayName :: Name -> T.Text
+displayName = \case
+    NModule (ModuleName m) ->
+        T.concat ["module ", dot m]
+    NRecordType (ModuleName m) (TypeConName t) ->
+        T.concat ["record ", dot m, ":", dot t]
+    NVariantType (ModuleName m) (TypeConName t) ->
+        T.concat ["variant ", dot m, ":", dot t]
+    NEnumType (ModuleName m) (TypeConName t) ->
+        T.concat ["enum ", dot m, ":", dot t]
+    NVariantCon (ModuleName m) (TypeConName t) (VariantConName v) ->
+        T.concat ["variant constructor ", dot m, ":", dot t, ".", v]
+    NEnumCon (ModuleName m) (TypeConName t) (VariantConName v) ->
+        T.concat ["enum constructor ", dot m, ":", dot t, ".", v]
+    NField (ModuleName m) (TypeConName t) (FieldName f) ->
+        T.concat ["field ", dot m, ":", dot t, ".", f]
+    NChoice (ModuleName m) (TypeConName t) (ChoiceName c) ->
+        T.concat ["choice ", dot m, ":", dot t, ".", c]
+  where
+    dot = T.intercalate "."
+
+-- | Asks whether a name collision is permitted. According to the
+-- LF Spec, a name collision is only permitted when it occurs
+-- between a record type and a variant constructor defined in
+-- the same module.
+nameCollisionPermitted :: Name -> Name -> Bool
+nameCollisionPermitted a b =
+    case (a,b) of
+        (NRecordType m1 _, NVariantCon m2 _ _) -> m1 == m2
+        (NVariantCon m1 _ _, NRecordType m2 _) -> m1 == m2
+        _ -> False
+
+-- | Asks whether a name collision is forbidden.
+nameCollisionForbidden :: Name -> Name -> Bool
+nameCollisionForbidden a b = not (nameCollisionPermitted a b)
+
 -- | Fully resolved name within a package. We don't use
 -- Qualified from DA.Daml.LF.Ast because that hides collisions
--- between module names and type names. Also, we implement
--- case-insensitive Eq and Ord instances for FRName.
+-- between module names and type names. This should only be
+-- constructed lower case in order to have case-insensitivity.
 --
 -- This corresponds to the following section of the LF spec:
 -- https://github.com/digital-asset/daml/blob/master/daml-lf/spec/daml-lf-1.rst#fully-resolved-name
 newtype FRName = FRName [T.Text]
+    deriving (Eq, Ord)
 
-instance Eq FRName where
-    (==) (FRName xs) (FRName ys) =
-        map T.toLower xs == map T.toLower ys
-
-instance Ord FRName where
-    compare (FRName xs) (FRName ys) =
-        compare (map T.toLower xs) (map T.toLower ys)
-
-frModuleName :: ModuleName -> FRName
-frModuleName =
-    FRName . unModuleName
-
-frTypeConName :: ModuleName -> TypeConName -> FRName
-frTypeConName (ModuleName m) (TypeConName t) =
-    FRName (m ++ t)
-
-frVariantConName :: ModuleName -> TypeConName -> VariantConName -> FRName
-frVariantConName (ModuleName m) (TypeConName t) (VariantConName v) =
-    FRName (m ++ t ++ [v])
-
-frFieldName :: ModuleName -> TypeConName -> FieldName -> FRName
-frFieldName (ModuleName m) (TypeConName t) (FieldName f) =
-    FRName (m ++ t ++ [f])
-
-frChoiceName :: ModuleName -> TypeConName -> ChoiceName -> FRName
-frChoiceName (ModuleName m) (TypeConName t) (ChoiceName c) =
-    FRName (m ++ t ++ [c])
-
--- | Pack a fully resolved name into a single Text value
--- for the purposes of displaying / error messages.
-packFRName :: FRName -> T.Text
-packFRName (FRName parts) = T.intercalate "." parts
+-- | Turn a name into a fully resolved name.
+fullyResolve :: Name -> FRName
+fullyResolve = FRName . map T.toLower . \case
+    NModule (ModuleName m) ->
+        m
+    NRecordType (ModuleName m) (TypeConName t) ->
+        m ++ t
+    NVariantType (ModuleName m) (TypeConName t) ->
+        m ++ t
+    NEnumType (ModuleName m) (TypeConName t) ->
+        m ++ t
+    NVariantCon (ModuleName m) (TypeConName t) (VariantConName v) ->
+        m ++ t ++ [v]
+    NEnumCon (ModuleName m) (TypeConName t) (VariantConName v) ->
+        m ++ t ++ [v]
+    NField (ModuleName m) (TypeConName t) (FieldName f) ->
+        m ++ t ++ [f]
+    NChoice (ModuleName m) (TypeConName t) (ChoiceName c) ->
+        m ++ t ++ [c]
 
 -- | State of the name collision checker. This is a
--- map from fully resolved names within a package
--- to their name sources. We update the map as we
--- go along.
-newtype NCState = NCState (M.Map FRName NameSource)
-
--- | Where a name comes from, for the purposes of
--- the name collision check.
-data NameSource
-    = VariantCon ModuleName
-    | RecordType ModuleName
-    | Other
-
--- | Combine two name sources only if the respective name
--- collision is permitted. The only permitted collision
--- is a single collision between a variant constructor
--- name and a record type name defined in the same module.
-combineNameSource :: NameSource -> NameSource -> Maybe NameSource
-combineNameSource a b =
-    case (a,b) of
-        (VariantCon m1, RecordType m2) | m1 == m2 -> Just Other
-        (RecordType m1, VariantCon m2) | m1 == m2 -> Just Other
-        _ -> Nothing
+-- map from fully resolved names within a package to their
+-- original names. We update this map as we go along.
+newtype NCState = NCState (M.Map FRName [Name])
 
 -- | Initial name collision checker state.
 initialState :: NCState
 initialState = NCState M.empty
 
--- | Try to add a name to the NCState. Returns Nothing only
+-- | Try to add a name to the NCState. Returns Error only
 -- if the name results in a forbidden name collision.
-addName :: FRName -> NameSource -> NCState -> Maybe NCState
-addName name source (NCState map) =
-    case M.lookup name map of
-        Nothing -> Just (NCState (M.insert name source map))
-        Just oldSource -> do
-            newSource <- combineNameSource oldSource source
-            Just (NCState (M.insert name newSource map))
+addName :: Name -> NCState -> Either Error NCState
+addName name (NCState nameMap) = do
+    let frName = fullyResolve name
+        oldNames = fromMaybe [] (M.lookup frName nameMap)
+        badNames = filter (nameCollisionForbidden name) oldNames
+    if null badNames then do
+        Right . NCState $ M.insert frName (oldNames ++ [name]) nameMap
+    else do
+        Left $ EForbiddenNameCollision
+            (displayName name)
+            (map displayName badNames)
 
-checkName :: MonadGamma m => FRName -> NameSource -> S.StateT NCState m ()
-checkName name source = do
+checkName :: MonadGamma m => Name -> S.StateT NCState m ()
+checkName name = do
     ncState <- S.get
-    case addName name source ncState of
-        Nothing ->
-            throwWithContext (EForbiddenNameCollision (packFRName name))
-        Just ncState' ->
-            S.put ncState'
+    either throwWithContext S.put (addName name ncState)
 
 checkDataType :: MonadGamma m => ModuleName -> DefDataType -> S.StateT NCState m ()
 checkDataType moduleName DefDataType{..} =
     case dataCons of
         DataRecord fields -> do
-            checkName (frTypeConName moduleName dataTypeCon)
-                (RecordType moduleName)
+            checkName (NRecordType moduleName dataTypeCon)
             forM_ fields $ \(fieldName, _) -> do
-                checkName (frFieldName moduleName dataTypeCon fieldName) Other
+                checkName (NField moduleName dataTypeCon fieldName)
 
         DataVariant constrs -> do
-            checkName (frTypeConName moduleName dataTypeCon) Other
+            checkName (NVariantType moduleName dataTypeCon)
             forM_ constrs $ \(vconName, _) -> do
-                checkName (frVariantConName moduleName dataTypeCon vconName)
-                    (VariantCon moduleName)
+                checkName (NVariantCon moduleName dataTypeCon vconName)
 
         DataEnum constrs -> do
-            checkName (frTypeConName moduleName dataTypeCon) Other
+            checkName (NEnumType moduleName dataTypeCon)
             forM_ constrs $ \vconName -> do
-                checkName (frVariantConName moduleName dataTypeCon vconName)
-                    Other
+                checkName (NEnumCon moduleName dataTypeCon vconName)
 
 checkTemplate :: MonadGamma m => ModuleName -> Template -> S.StateT NCState m ()
 checkTemplate moduleName Template{..} = do
     forM_ tplChoices $ \TemplateChoice{..} ->
-        checkName (frChoiceName moduleName tplTypeCon chcName) Other
+        checkName (NChoice moduleName tplTypeCon chcName)
 
--- | Check whether a module satisfies the name collision condition
--- as specified in the DAML-LF spec.
+-- | Check whether a module satisfies the name collision condition.
 checkModule :: MonadGamma m => Module -> m ()
 checkModule mod0 =
     void . flip S.runStateT initialState $ do
-        checkName (frModuleName (moduleName mod0)) Other
+        checkName (NModule (moduleName mod0))
         forM_ (moduleDataTypes mod0) $ \dataType ->
             withContext (ContextDefDataType mod0 dataType) $
                 checkDataType (moduleName mod0) dataType

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -1,0 +1,139 @@
+module DA.Daml.LF.TypeChecker.NameCollision
+    ( checkModule
+    ) where
+
+import DA.Daml.LF.Ast
+import DA.Daml.LF.TypeChecker.Env
+import DA.Daml.LF.TypeChecker.Error
+import Control.Monad.Extra
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Control.Monad.Trans.State as S
+
+-- | Fully resolved name within a package. We don't use
+-- Qualified from DA.Daml.LF.Ast because that hides collisions
+-- between module names and type names. Also, we implement
+-- case-insensitive Eq and Ord instances for FRName.
+--
+-- This corresponds to the following section of the LF spec:
+-- https://github.com/digital-asset/daml/blob/master/daml-lf/spec/daml-lf-1.rst#fully-resolved-name
+newtype FRName = FRName [T.Text]
+
+instance Eq FRName where
+    (==) (FRName xs) (FRName ys) =
+        map T.toLower xs == map T.toLower ys
+
+instance Ord FRName where
+    compare (FRName xs) (FRName ys) =
+        compare (map T.toLower xs) (map T.toLower ys)
+
+frModuleName :: ModuleName -> FRName
+frModuleName =
+    FRName . unModuleName
+
+frTypeConName :: ModuleName -> TypeConName -> FRName
+frTypeConName (ModuleName m) (TypeConName t) =
+    FRName (m ++ t)
+
+frVariantConName :: ModuleName -> TypeConName -> VariantConName -> FRName
+frVariantConName (ModuleName m) (TypeConName t) (VariantConName v) =
+    FRName (m ++ t ++ [v])
+
+frFieldName :: ModuleName -> TypeConName -> FieldName -> FRName
+frFieldName (ModuleName m) (TypeConName t) (FieldName f) =
+    FRName (m ++ t ++ [f])
+
+frChoiceName :: ModuleName -> TypeConName -> ChoiceName -> FRName
+frChoiceName (ModuleName m) (TypeConName t) (ChoiceName c) =
+    FRName (m ++ t ++ [c])
+
+-- | Pack a fully resolved name into a single Text value
+-- for the purposes of displaying / error messages.
+packFRName :: FRName -> T.Text
+packFRName (FRName parts) = T.intercalate "." parts
+
+-- | State of the name collision checker. This is a
+-- map from fully resolved names within a package
+-- to their name sources. We update the map as we
+-- go along.
+newtype NCState = NCState (M.Map FRName NameSource)
+
+-- | Where a name comes from, for the purposes of
+-- the name collision check.
+data NameSource
+    = VariantCon ModuleName
+    | RecordType ModuleName
+    | Other
+
+-- | Combine two name sources only if the respective name
+-- collision is permitted. The only permitted collision
+-- is a single collision between a variant constructor
+-- name and a record type name defined in the same module.
+combineNameSource :: NameSource -> NameSource -> Maybe NameSource
+combineNameSource a b =
+    case (a,b) of
+        (VariantCon m1, RecordType m2) | m1 == m2 -> Just Other
+        (RecordType m1, VariantCon m2) | m1 == m2 -> Just Other
+        _ -> Nothing
+
+-- | Initial name collision checker state.
+initialState :: NCState
+initialState = NCState M.empty
+
+-- | Try to add a name to the NCState. Returns Nothing only
+-- if the name results in a forbidden name collision.
+addName :: FRName -> NameSource -> NCState -> Maybe NCState
+addName name source (NCState map) =
+    case M.lookup name map of
+        Nothing -> Just (NCState (M.insert name source map))
+        Just oldSource -> do
+            newSource <- combineNameSource oldSource source
+            Just (NCState (M.insert name newSource map))
+
+checkName :: MonadGamma m => FRName -> NameSource -> S.StateT NCState m ()
+checkName name source = do
+    ncState <- S.get
+    case addName name source ncState of
+        Nothing ->
+            throwWithContext (EForbiddenNameCollision (packFRName name))
+        Just ncState' ->
+            S.put ncState'
+
+checkDataType :: MonadGamma m => ModuleName -> DefDataType -> S.StateT NCState m ()
+checkDataType moduleName DefDataType{..} =
+    case dataCons of
+        DataRecord fields -> do
+            checkName (frTypeConName moduleName dataTypeCon)
+                (RecordType moduleName)
+            forM_ fields $ \(fieldName, _) -> do
+                checkName (frFieldName moduleName dataTypeCon fieldName) Other
+
+        DataVariant constrs -> do
+            checkName (frTypeConName moduleName dataTypeCon) Other
+            forM_ constrs $ \(vconName, _) -> do
+                checkName (frVariantConName moduleName dataTypeCon vconName)
+                    (VariantCon moduleName)
+
+        DataEnum constrs -> do
+            checkName (frTypeConName moduleName dataTypeCon) Other
+            forM_ constrs $ \vconName -> do
+                checkName (frVariantConName moduleName dataTypeCon vconName)
+                    Other
+
+checkTemplate :: MonadGamma m => ModuleName -> Template -> S.StateT NCState m ()
+checkTemplate moduleName Template{..} = do
+    forM_ tplChoices $ \TemplateChoice{..} ->
+        checkName (frChoiceName moduleName tplTypeCon chcName) Other
+
+-- | Check whether a module satisfies the name collision condition
+-- as specified in the DAML-LF spec.
+checkModule :: MonadGamma m => Module -> m ()
+checkModule mod0 =
+    void . flip S.runStateT initialState $ do
+        checkName (frModuleName (moduleName mod0)) Other
+        forM_ (moduleDataTypes mod0) $ \dataType ->
+            withContext (ContextDefDataType mod0 dataType) $
+                checkDataType (moduleName mod0) dataType
+        forM_ (moduleTemplates mod0) $ \tpl ->
+            withContext (ContextTemplate mod0 tpl TPWhole) $
+                checkTemplate (moduleName mod0) tpl

--- a/compiler/damlc/tests/daml-test-files/Collision.daml
+++ b/compiler/damlc/tests/daml-test-files/Collision.daml
@@ -1,4 +1,4 @@
--- @ERROR name collision between record Collision:RECORD and record Collision:Record
+-- @ERROR name collision between record Collision:Record and record Collision:RECORD
 daml 1.2
 module Collision where
 

--- a/compiler/damlc/tests/daml-test-files/Collision.daml
+++ b/compiler/damlc/tests/daml-test-files/Collision.daml
@@ -1,4 +1,4 @@
--- @ERROR collision between record Collision:RECORD and record Collision:Record
+-- @ERROR name collision between record Collision:RECORD and record Collision:Record
 daml 1.2
 module Collision where
 


### PR DESCRIPTION
This PR implements name collision checking in the DAML-LF typechecker. Name collision checking should be done at the package level (to prevent, e.g., collision between types `A.B:C` and `A:B.C` in different modules, or module name to type collision `A.B` versus `A:B`). But this PR is a first step by checking for collision within a module.

Part of this is checking the "name collision condition", which says that a name collision is permitted iff it happens between a record type name and a variant constructor name in the same module.

Fixes #2768.