### PR TITLE
Get rid of ./build.sh scripts for damlc migrate

### DIFF
--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -354,15 +354,11 @@ packagingTests tmpDir = testGroup "packaging"
         callCommandQuiet $ unwords ["daml", "migrate", projectRollback, bDar, aDar]
         step "Build migration project"
         withCurrentDirectory projectUpgrade $
-            if isWindows
-                then callCommandQuiet ".\\build.cmd"
-                else callCommandQuiet "./build.sh"
+            callCommand "daml build"
         assertBool "upgrade-0.0.1.dar was not created" =<< doesFileExist upgradeDar
         step "Build rollback project"
         withCurrentDirectory projectRollback $
-            if isWindows
-                then callCommandQuiet ".\\build.cmd"
-                else callCommandQuiet "./build.sh"
+            callCommand "daml build"
         assertBool "rollback-0.0.1.dar was not created" =<< doesFileExist rollbackDar
         step "Merging upgrade dar"
         callCommandQuiet $

--- a/docs/source/migrate/index.rst
+++ b/docs/source/migrate/index.rst
@@ -38,11 +38,7 @@ directory to ``foo-upgrade-2.0.0`` and run
 
 .. code-block:: none
 
-  ./build.sh
-
-respectively ``.\build.cmd`` if your on a Windows system.  Note that you can **not** use the usual
-``daml build`` command to build the migration project. The `migrate` command will setup the project
-and initializes a suitable package database, while ``daml build`` would overwrite this setup again.
+  daml build
 
 How migrations work and when it is necessary to write code manually
 -------------------------------------------------------------------
@@ -129,7 +125,7 @@ package has been extended to
   :language: daml
   :lines: 6-15
 
-Here is typical error message in this case of an invocation of ``build.sh``:
+Here is typical error message in this case of an invocation of ``daml build``:
 
 .. code-block:: none
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -16,3 +16,6 @@ HEAD — ongoing
 - [DAML Compiler]
   Fix a bug where importing the same module from different directories
   resulted in an error in ``daml build``.
+- [DAML Compiler]
+  ``damlc migrate`` now produces a project that can be built with ``daml build`` as opposed to
+  having to use the special ``build.sh`` and ``build.cmd`` scripts.


### PR DESCRIPTION
Now that we have the build-options fields that makes for a much nicer
interface.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
