### PR TITLE
Fix getSrcRoot for A/B.daml

### DIFF
--- a/libs-haskell/da-hs-base/src/Data/Conduit/Tar/Extra.hs
+++ b/libs-haskell/da-hs-base/src/Data/Conduit/Tar/Extra.hs
@@ -4,6 +4,7 @@
 module Data.Conduit.Tar.Extra
     ( module Data.Conduit.Tar
     , restoreFile
+    , dropDirectory1
     ) where
 
 import Conduit


### PR DESCRIPTION
Previuosly we would return A for module A.B in A/B.daml which resulted
in us including /B.daml in the DAR instead of /A/B.daml.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
