### PR TITLE
Improve ledger sql backend performance

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
@@ -29,8 +29,13 @@ import com.digitalasset.platform.sandbox.stores.ActiveLedgerState._
   */
 trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
 
-  /** Callback to query an active or divulged contract, used for transaction validation */
-  def lookupContract(cid: AbsoluteContractId): Option[Contract]
+  /** Callback to query an active or divulged contract, used for transaction validation
+    * Returns:
+    * - None if the contract does not exist
+    * - Some(None) if the contract exists, but its LET is unknown (i.e., a divulged contract)
+    * - Some(Some(_)) if the contract exists and its LET is known
+    * */
+  def lookupContractLet(cid: AbsoluteContractId): Option[Option[Instant]]
 
   /** Callback to query a contract key, used for transaction validation */
   def keyExists(key: GlobalKey): Boolean

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
@@ -39,7 +39,7 @@ trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
   def addContract(c: ActiveContract, keyO: Option[GlobalKey]): Self
 
   /** Called when the given contract is archived */
-  def removeContract(cid: AbsoluteContractId, keyO: Option[GlobalKey]): Self
+  def removeContract(cid: AbsoluteContractId): Self
 
   /** Called once for each transaction with the set of parties found in that transaction.
     * As the sandbox has an open world of parties, any party name mentioned in a transaction

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
@@ -14,6 +14,14 @@ import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst, V
 import com.digitalasset.ledger.WorkflowId
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState._
 
+sealed abstract class LetLookup
+
+/** Contract exists, but contract LET is unknown (e.g., a divulged contract) */
+case object LetUnknown extends LetLookup
+
+/** Contract exists with the given LET */
+final case class Let(instant: Instant) extends LetLookup
+
 /**
   * An abstract representation of the active ledger state:
   * - Active contracts
@@ -32,10 +40,10 @@ trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
   /** Callback to query an active or divulged contract, used for transaction validation
     * Returns:
     * - None if the contract does not exist
-    * - Some(None) if the contract exists, but its LET is unknown (i.e., a divulged contract)
-    * - Some(Some(_)) if the contract exists and its LET is known
+    * - Some(LetUnknown) if the contract exists, but its LET is unknown (i.e., a divulged contract)
+    * - Some(Let(_)) if the contract exists and its LET is known
     * */
-  def lookupContractLet(cid: AbsoluteContractId): Option[Option[Instant]]
+  def lookupContractLet(cid: AbsoluteContractId): Option[LetLookup]
 
   /** Callback to query a contract key, used for transaction validation */
   def keyExists(key: GlobalKey): Boolean

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
@@ -101,14 +101,14 @@ class ActiveLedgerStateManager[ALS](initialState: => ALS)(
                 cid: AbsoluteContractId,
                 predType: PredicateType): Option[SequencingError] =
               acc lookupContractLet cid match {
-                case Some(Some(otherContractLet)) =>
+                case Some(Let(otherContractLet)) =>
                   // Existing active contract, check its LET
                   if (otherContractLet.isAfter(let)) {
                     Some(TimeBeforeError(cid, otherContractLet, let, predType))
                   } else {
                     None
                   }
-                case Some(None) =>
+                case Some(LetUnknown) =>
                   // Contract divulged in the past
                   None
                 case None if divulgedContracts.exists(_._1 == cid) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
@@ -188,11 +188,7 @@ class ActiveLedgerStateManager[ALS](initialState: => ALS)(
                 ats.copy(
                   errs = contractCheck(absCoid, Exercise).fold(errs)(errs + _),
                   acc = Some(if (ne.consuming) {
-                    val keyO = (acc lookupContract absCoid)
-                      .collect({ case c: ActiveContract => c })
-                      .flatMap(_.key)
-                      .map(key => GlobalKey(ne.templateId, key.key))
-                    acc.removeContract(absCoid, keyO)
+                    acc.removeContract(absCoid)
                   } else {
                     acc
                   }),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
@@ -100,15 +100,15 @@ class ActiveLedgerStateManager[ALS](initialState: => ALS)(
             def contractCheck(
                 cid: AbsoluteContractId,
                 predType: PredicateType): Option[SequencingError] =
-              acc lookupContract cid match {
-                case Some(otherContract: ActiveContract) =>
+              acc lookupContractLet cid match {
+                case Some(Some(otherContractLet)) =>
                   // Existing active contract, check its LET
-                  if (otherContract.let.isAfter(let)) {
-                    Some(TimeBeforeError(cid, otherContract.let, let, predType))
+                  if (otherContractLet.isAfter(let)) {
+                    Some(TimeBeforeError(cid, otherContractLet, let, predType))
                   } else {
                     None
                   }
-                case Some(_: DivulgedContract) =>
+                case Some(None) =>
                   // Contract divulged in the past
                   None
                 case None if divulgedContracts.exists(_._1 == cid) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -29,11 +29,11 @@ case class InMemoryActiveLedgerState(
   def lookupContract(cid: AbsoluteContractId): Option[Contract] =
     activeContracts.get(cid).orElse[Contract](divulgedContracts.get(cid))
 
-  override def lookupContractLet(cid: AbsoluteContractId): Option[Option[Instant]] =
+  override def lookupContractLet(cid: AbsoluteContractId): Option[LetLookup] =
     activeContracts
       .get(cid)
-      .map(c => Some(c.let))
-      .orElse[Option[Instant]](divulgedContracts.get(cid).map(_ => None))
+      .map(c => Let(c.let))
+      .orElse[LetLookup](divulgedContracts.get(cid).map(_ => LetUnknown))
 
   override def keyExists(key: GlobalKey) = keys.contains(key)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -26,8 +26,14 @@ case class InMemoryActiveLedgerState(
     parties: Map[Party, PartyDetails])
     extends ActiveLedgerState[InMemoryActiveLedgerState] {
 
-  override def lookupContract(cid: AbsoluteContractId): Option[Contract] =
+  def lookupContract(cid: AbsoluteContractId): Option[Contract] =
     activeContracts.get(cid).orElse[Contract](divulgedContracts.get(cid))
+
+  override def lookupContractLet(cid: AbsoluteContractId): Option[Option[Instant]] =
+    activeContracts
+      .get(cid)
+      .map(c => Some(c.let))
+      .orElse[Option[Instant]](divulgedContracts.get(cid).map(_ => None))
 
   override def keyExists(key: GlobalKey) = keys.contains(key)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -6,7 +6,6 @@
 package db.migration.postgres
 
 import java.sql.Connection
-import java.time.Instant
 import java.util.Date
 
 import akka.stream.scaladsl.Source
@@ -623,12 +622,12 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
     * This method therefore treats all contracts as active contracts.
     */
   private def lookupActiveContractLetSync(contractId: AbsoluteContractId)(
-      implicit conn: Connection): Option[Option[Instant]] =
+      implicit conn: Connection): Option[LetLookup] =
     SQL_SELECT_CONTRACT_LET
       .on("contract_id" -> contractId.coid)
       .as(ContractDataParser.singleOpt)
       .map {
-        case (_, _, _, let, _, _, _) => Some(let.toInstant)
+        case (_, _, _, let, _, _, _) => Let(let.toInstant)
       }
 
   private val SQL_GET_LEDGER_ENTRIES = SQL(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -5,8 +5,8 @@
 // 'db.migration.postgres' for postgres migrations
 package db.migration.postgres
 
-import java.io.InputStream
 import java.sql.Connection
+import java.time.Instant
 import java.util.Date
 
 import akka.stream.scaladsl.Source
@@ -14,19 +14,18 @@ import akka.NotUsed
 import anorm.SqlParser._
 import anorm.{BatchSql, Macro, NamedParameter, RowParser, SQL, SqlParser}
 import com.daml.ledger.participant.state.v1.AbsoluteContractInst
-import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.transaction.Transaction
-import com.digitalasset.daml.lf.transaction.Node.{GlobalKey, KeyWithMaintainers, NodeCreate}
+import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId}
 import com.digitalasset.ledger._
 import com.digitalasset.ledger.api.domain.RejectionReason
 import com.digitalasset.ledger.api.domain.RejectionReason._
 import com.digitalasset.platform.sandbox.services.transaction.SandboxEventIdFormatter
-import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.{ActiveContract, Contract}
+import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.ActiveContract
 import com.digitalasset.platform.sandbox.stores._
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
 import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
@@ -36,7 +35,6 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
   ValueSerializer
 }
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.Conversions._
-import com.google.common.io.ByteStreams
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 import org.slf4j.LoggerFactory
 
@@ -346,8 +344,8 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
 
       final class AcsStoreAcc extends ActiveLedgerState[AcsStoreAcc] {
 
-        override def lookupContract(cid: AbsoluteContractId) =
-          lookupActiveContractSync(cid)
+        override def lookupContractLet(cid: AbsoluteContractId) =
+          lookupActiveContractLetSync(cid)
 
         override def keyExists(key: GlobalKey): Boolean = selectContractKey(key).isDefined
 
@@ -603,7 +601,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
     ~ binaryStream("key").?
     ~ binaryStream("transaction") map (flatten))
 
-  private val SQL_SELECT_CONTRACT =
+  private val SQL_SELECT_CONTRACT_LET =
     SQL(
       "select c.*, le.recorded_at, le.transaction from contracts c inner join ledger_entries le on c.transaction_id = le.transaction_id where id={contract_id} and archive_offset is null ")
 
@@ -621,90 +619,17 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
   private val SQL_SELECT_KEY_MAINTAINERS =
     SQL("select maintainer from contract_key_maintainers where contract_id={contract_id}")
 
-  private def lookupActiveContractSync(contractId: AbsoluteContractId)(
-      implicit conn: Connection): Option[Contract] =
-    SQL_SELECT_CONTRACT
+  /** Note: at the time this migration was written, divulged contracts were not stored separately from active contracts.
+    * This method therefore treats all contracts as active contracts.
+    */
+  private def lookupActiveContractLetSync(contractId: AbsoluteContractId)(
+      implicit conn: Connection): Option[Option[Instant]] =
+    SQL_SELECT_CONTRACT_LET
       .on("contract_id" -> contractId.coid)
       .as(ContractDataParser.singleOpt)
-      .map(mapContractDetails)
-
-  /** Note: at the time this migration was written, divulged contracts were not stored separately from active contracts.
-    * This method therefore always returns an ActiveContract.
-    */
-  private def mapContractDetails(
-      contractResult: (
-          ContractIdString,
-          TransactionIdString,
-          WorkflowId,
-          Date,
-          InputStream,
-          Option[InputStream],
-          InputStream))(implicit conn: Connection): ActiveContract =
-    contractResult match {
-      case (coid, transactionId, workflowId, createdAt, contractStream, keyStreamO, tx) =>
-        val witnesses = lookupWitnesses(coid)
-        val divulgences = lookupDivulgences(coid)
-        val absoluteCoid = AbsoluteContractId(coid)
-        val contractInstance = contractSerializer
-          .deserializeContractInstance(ByteStreams.toByteArray(contractStream))
-          .getOrElse(sys.error(s"failed to deserialize contract! cid:$coid"))
-
-        val (signatories: Set[Ref.Party], observers: Set[Ref.Party]) =
-          transactionSerializer
-            .deserializeTransaction(ByteStreams.toByteArray(tx))
-            .getOrElse(sys.error(s"failed to deserialize transaction! cid:$coid"))
-            .nodes
-            .collectFirst {
-              case (_, NodeCreate(coid, _, _, signatories, stakeholders, _))
-                  if coid == absoluteCoid =>
-                (signatories, stakeholders diff signatories)
-            } getOrElse {
-            logger.warn(s"Unable to read stakeholders for contract $coid, returning empty result")
-            (Set.empty, Set.empty)
-          }
-
-        ActiveContract(
-          absoluteCoid,
-          createdAt.toInstant,
-          transactionId,
-          Some(workflowId),
-          contractInstance,
-          witnesses,
-          divulgences,
-          keyStreamO.map(keyStream => {
-            val keyMaintainers = lookupKeyMaintainers(coid)
-            val keyValue = valueSerializer
-              .deserializeValue(ByteStreams.toByteArray(keyStream))
-              .getOrElse(sys.error(s"failed to deserialize key value! cid:$coid"))
-            KeyWithMaintainers(keyValue, keyMaintainers)
-          }),
-          signatories,
-          observers,
-          contractInstance.agreementText
-        )
-    }
-
-  private def lookupWitnesses(coid: String)(implicit conn: Connection): Set[Party] =
-    SQL_SELECT_WITNESS
-      .on("contract_id" -> coid)
-      .as(party("witness").*)
-      .toSet
-
-  private def lookupDivulgences(coid: String)(
-      implicit conn: Connection): Map[Party, TransactionIdString] =
-    SQL_SELECT_DIVULGENCE
-      .on("contract_id" -> coid)
-      .as(DivulgenceParser.*)
       .map {
-        case (party, _, transaction_id) => party -> transaction_id
+        case (_, _, _, let, _, _, _) => Some(let.toInstant)
       }
-      .toMap
-
-  private def lookupKeyMaintainers(coid: String)(implicit conn: Connection) =
-    SQL_SELECT_KEY_MAINTAINERS
-      .on("contract_id" -> coid)
-      .as(party("maintainer").*)
-      .toSet
 
   private val SQL_GET_LEDGER_ENTRIES = SQL(
     "select * from ledger_entries where ledger_offset>={startInclusive} and ledger_offset<{endExclusive} order by ledger_offset asc")

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -11,3 +11,5 @@ HEAD — ongoing
 
 - [DAML Studio] ``damlc ide`` now also supports a ``--target`` option.
   The easiest way to specify this is the ``build-options`` field in ``daml.yaml``.
+- [Ledger] 
+  Improve SQL backend performance by eliminating extra queries to the database.


### PR DESCRIPTION
Improves SQL backend performance by eliminating extra database queries.

- Instead of loading the whole contract, only the LET is loaded for the contract check in `ActiveLedgerStateManager`
- Instead of loading the whole contract only to get the key so that it can be removed, the contract key is removed by matching the contract id.

Fixes #2888. 
