### PR TITLE
Deduce pkgname in damlc migrate from dalf not dar

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -786,10 +786,10 @@ execMigrate projectOpts opts0 inFile1_ inFile2_ mbDir =
           [(pkgName1, pkgId1, lfPkg1), (pkgName2, pkgId2, lfPkg2)] <-
               forM [inFile1, inFile2] $ \inFile -> do
                   bytes <- B.readFile inFile
-                  let pkgName = takeBaseName inFile
                   let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
                   -- get the main pkg
                   dalfManifest <- either fail pure $ readDalfManifest dar
+                  let pkgName = takeBaseName $ mainDalfPath dalfManifest
                   mainDalfEntry <- getEntry (mainDalfPath dalfManifest) dar
                   (mainPkgId, mainLfPkg) <- decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
                   pure (pkgName, mainPkgId, mainLfPkg)

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -326,8 +326,8 @@ packagingTests tmpDir = testGroup "packaging"
         let projectB = tmpDir </> "a-2.0"
         let projectUpgrade = tmpDir </> "upgrade"
         let projectRollback = tmpDir </> "rollback"
-        let aDar = projectA </> distDir </> "a-1.0.dar"
-        let bDar = projectB </> distDir </> "a-2.0.dar"
+        let aDar = projectA </> "projecta.dar"
+        let bDar = projectB </> "projectb.dar"
         let upgradeDar = projectUpgrade </> distDir </> "upgrade-0.0.1.dar"
         let rollbackDar= projectRollback </> distDir </> "rollback-0.0.1.dar"
         let bWithUpgradesDar = "a-2.0-with-upgrades.dar"
@@ -356,7 +356,8 @@ packagingTests tmpDir = testGroup "packaging"
             , "  - daml-prim"
             , "  - daml-stdlib"
             ]
-        withCurrentDirectory projectA $ callCommandQuiet "daml build"
+        -- We use -o to test that we do not depend on the name of the dar
+        withCurrentDirectory projectA $ callCommandQuiet $ "daml build -o " <> aDar
         assertBool "a-1.0.dar was not created." =<< doesFileExist aDar
         step "Creating project a-2.0 ..."
         createDirectoryIfMissing True (projectB </> "daml")
@@ -383,9 +384,11 @@ packagingTests tmpDir = testGroup "packaging"
             , "  - daml-prim"
             , "  - daml-stdlib"
             ]
-        withCurrentDirectory projectB $ callCommandQuiet "daml build"
+        -- We use -o to test that we do not depend on the name of the dar
+        withCurrentDirectory projectB $ callCommandQuiet $ "daml build -o " <> bDar
         assertBool "a-2.0.dar was not created." =<< doesFileExist bDar
         step "Creating upgrade/rollback project"
+        -- We use -o to verify that we do not depend on the
         callCommandQuiet $ unwords ["daml", "migrate", projectUpgrade, aDar, bDar]
         callCommandQuiet $ unwords ["daml", "migrate", projectRollback, bDar, aDar]
         step "Build migration project"


### PR DESCRIPTION
The filename of the dar is not something that you should rely on as
evidenced by the fact that we have a -o option to change it to
something completely different.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
