### PR TITLE
Support passing additional options to sandbox/navigator/json-api in d…

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -44,6 +44,9 @@ data Command
       , jsonApiCfg :: JsonApiConfig
       , onStartM :: Maybe String
       , waitForSignal :: WaitForSignal
+      , sandboxOptions :: SandboxOptions
+      , navigatorOptions :: NavigatorOptions
+      , jsonApiOptions :: JsonApiOptions
       }
     | Deploy { flags :: HostAndPortFlags }
     | LedgerListParties { flags :: HostAndPortFlags, json :: JsonFlag }
@@ -106,6 +109,9 @@ commandParser = subparser $ fold
         <*> jsonApiCfg
         <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
         <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
+        <*> (SandboxOptions <$> many (strOption (long "sandbox-option" <> metavar "SANDBOX_OPTION" <> help "Pass option to sandbox")))
+        <*> (NavigatorOptions <$> many (strOption (long "navigator-option" <> metavar "NAVIGATOR_OPTION" <> help "Pass option to navigator")))
+        <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
 
     deployCmdInfo = mconcat
         [ progDesc $ concat
@@ -215,7 +221,17 @@ runCommand New {..} = runNew targetFolder templateNameM []
 runCommand Migrate {..} = runMigrate targetFolder pkgPathFrom pkgPathTo
 runCommand Init {..} = runInit targetFolderM
 runCommand ListTemplates = runListTemplates
-runCommand Start {..} = runStart sandboxPortM startNavigator jsonApiCfg openBrowser onStartM waitForSignal
+runCommand Start {..} =
+    runStart
+        sandboxPortM
+        startNavigator
+        jsonApiCfg
+        openBrowser
+        onStartM
+        waitForSignal
+        sandboxOptions
+        navigatorOptions
+        jsonApiOptions
 runCommand Deploy {..} = runDeploy flags
 runCommand LedgerListParties {..} = runLedgerListParties flags json
 runCommand LedgerAllocateParties {..} = runLedgerAllocateParties flags parties

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -19,6 +19,8 @@ DAML Assistant (``daml``)
   - Launch :doc:`DAML Studio </daml/daml-studio>`: ``daml studio``
   - Launch :doc:`Sandbox </tools/sandbox>`, :doc:`Navigator </tools/navigator/index>` and the HTTP JSON API: ``daml start``
     You can disable the HTTP JSON API by passing ``--json-api-port none`` to ``daml start``.
+    To specify additional options for sandbox/navigator/the HTTP JSON API you can use
+    ``--sandbox-option=opt``, ``--navigator-option=opt`` and ``--json-api-option=opt``.
   - Launch Sandbox: ``daml sandbox``
   - Launch Navigator: ``daml navigator``
   - Launch :doc:`Extractor </tools/extractor>`: ``daml extractor``

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,6 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [DAML Assistant] ``daml start`` now supports ``--sandbox-option=opt``, ``--navigator-option=opt``
+  and ``--json-api-option=opt`` to pass additional option to sandbox/navigator/json-api.
+  These flags can be specified multiple times.


### PR DESCRIPTION
…aml start

This should make `daml start` a bit more useful since you don’t have
to switch to starting all processes separately once you start
deviating from the defaults, e.g., I found myself wanting to specify a
custom ledger id during the hackathon. This is part 1 of ##2993.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
