### PR TITLE
scenario-service: run no validation, when called from ide

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -286,7 +286,7 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(dalfPackageId pkg, dalfPackageBytes pkg) | pkg <- Map.elems pkgMap]
         , ctxDamlLfVersion = lfVersion
-        , ctxSkipValidation = SS.SkipValidation (getFlag envScenarioSkipValidation)
+        , ctxSkipValidation = SS.SkipValidation (getSkipScenarioValidation envSkipScenarioValidation)
         }
 
 worldForFile :: NormalizedFilePath -> Action LF.World
@@ -326,7 +326,7 @@ createScenarioContextRule =
 dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
-    if getSkipScenarioValidation envScenarioSkipValidation then
+    if getSkipScenarioValidation envSkipScenarioValidation then
         use_ GenerateRawDalf file
     else
         use_ GenerateDalf file

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -286,9 +286,7 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(dalfPackageId pkg, dalfPackageBytes pkg) | pkg <- Map.elems pkgMap]
         , ctxDamlLfVersion = lfVersion
-        , ctxNoValidation = case envScenarioValidation of
-              ScenarioValidationEnable -> SS.LightValidation False
-              ScenarioValidationDisable -> SS.LightValidation True
+        , ctxValidation = envScenarioValidation
         }
 
 worldForFile :: NormalizedFilePath -> Action LF.World
@@ -328,9 +326,10 @@ createScenarioContextRule =
 dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
-    case envScenarioValidation of
-        ScenarioValidationDisable -> use_ GenerateRawDalf file
-        ScenarioValidationEnable -> use_ GenerateDalf file
+    if envScenarioValidation then
+      use_ GenerateRawDalf file
+    else
+      use_ GenerateDalf file
 
 runScenariosRule :: Rules ()
 runScenariosRule =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -326,7 +326,7 @@ createScenarioContextRule =
 dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
-    if getFlag envScenarioSkipValidation then
+    if getSkipScenarioValidation envScenarioSkipValidation then
         use_ GenerateRawDalf file
     else
         use_ GenerateDalf file

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -286,7 +286,9 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(dalfPackageId pkg, dalfPackageBytes pkg) | pkg <- Map.elems pkgMap]
         , ctxDamlLfVersion = lfVersion
-        , ctxValidation = envScenarioValidation
+        , ctxSkipValidation = case envScenarioValidation of
+            ScenarioValidation True -> SS.SkipValidation False
+            ScenarioValidation False -> SS.SkipValidation True
         }
 
 worldForFile :: NormalizedFilePath -> Action LF.World
@@ -326,10 +328,9 @@ createScenarioContextRule =
 dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
-    if envScenarioValidation then
-      use_ GenerateRawDalf file
-    else
-      use_ GenerateDalf file
+    case envScenarioValidation of
+        ScenarioValidation False -> use_ GenerateRawDalf file
+        ScenarioValidation True -> use_ GenerateDalf file
 
 runScenariosRule :: Rules ()
 runScenariosRule =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -286,9 +286,9 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(dalfPackageId pkg, dalfPackageBytes pkg) | pkg <- Map.elems pkgMap]
         , ctxDamlLfVersion = lfVersion
-        , ctxLightValidation = case envScenarioValidation of
-              ScenarioValidationFull -> SS.LightValidation False
-              ScenarioValidationLight -> SS.LightValidation True
+        , ctxNoValidation = case envScenarioValidation of
+              ScenarioValidationEnable -> SS.LightValidation False
+              ScenarioValidationDisable -> SS.LightValidation True
         }
 
 worldForFile :: NormalizedFilePath -> Action LF.World
@@ -329,8 +329,8 @@ dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
     case envScenarioValidation of
-        ScenarioValidationLight -> use_ GenerateRawDalf file
-        ScenarioValidationFull -> use_ GenerateDalf file
+        ScenarioValidationDisable -> use_ GenerateRawDalf file
+        ScenarioValidationEnable -> use_ GenerateDalf file
 
 runScenariosRule :: Rules ()
 runScenariosRule =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -286,9 +286,7 @@ contextForFile file = do
         { ctxModules = Map.fromList encodedModules
         , ctxPackages = [(dalfPackageId pkg, dalfPackageBytes pkg) | pkg <- Map.elems pkgMap]
         , ctxDamlLfVersion = lfVersion
-        , ctxSkipValidation = case envScenarioValidation of
-            ScenarioValidation True -> SS.SkipValidation False
-            ScenarioValidation False -> SS.SkipValidation True
+        , ctxSkipValidation = SS.SkipValidation (getFlag envScenarioSkipValidation)
         }
 
 worldForFile :: NormalizedFilePath -> Action LF.World
@@ -328,9 +326,10 @@ createScenarioContextRule =
 dalfForScenario :: NormalizedFilePath -> Action LF.Module
 dalfForScenario file = do
     DamlEnv{..} <- getDamlServiceEnv
-    case envScenarioValidation of
-        ScenarioValidation False -> use_ GenerateRawDalf file
-        ScenarioValidation True -> use_ GenerateDalf file
+    if getFlag envScenarioSkipValidation then
+        use_ GenerateRawDalf file
+    else
+        use_ GenerateDalf file
 
 runScenariosRule :: Rules ()
 runScenariosRule =

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -66,7 +66,7 @@ data DamlEnv = DamlEnv
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
-  , envScenarioValidation :: Bool
+  , envScenarioValidation :: ScenarioValidation
   }
 
 instance IsIdeGlobal DamlEnv

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -66,7 +66,7 @@ data DamlEnv = DamlEnv
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
-  , envScenarioValidation :: ScenarioValidation
+  , envScenarioSkipValidation :: ScenarioSkipValidation
   }
 
 instance IsIdeGlobal DamlEnv
@@ -82,7 +82,7 @@ mkDamlEnv opts scenarioService = do
         , envScenarioContexts = scenarioContextsVar
         , envPreviousScenarioContexts = previousScenarioContextsVar
         , envDamlLfVersion = optDamlLfVersion opts
-        , envScenarioValidation = optScenarioValidation opts
+        , envScenarioSkipValidation = optScenarioSkipValidation opts
         }
 
 getDamlServiceEnv :: Action DamlEnv

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -66,7 +66,7 @@ data DamlEnv = DamlEnv
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
-  , envScenarioValidation :: ScenarioValidation
+  , envScenarioValidation :: Bool
   }
 
 instance IsIdeGlobal DamlEnv

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -66,7 +66,7 @@ data DamlEnv = DamlEnv
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
-  , envScenarioSkipValidation :: ScenarioSkipValidation
+  , envSkipScenarioValidation :: SkipScenarioValidation
   }
 
 instance IsIdeGlobal DamlEnv
@@ -82,7 +82,7 @@ mkDamlEnv opts scenarioService = do
         , envScenarioContexts = scenarioContextsVar
         , envPreviousScenarioContexts = previousScenarioContextsVar
         , envDamlLfVersion = optDamlLfVersion opts
-        , envScenarioSkipValidation = optScenarioSkipValidation opts
+        , envSkipScenarioValidation = optSkipScenarioValidation opts
         }
 
 getDamlServiceEnv :: Action DamlEnv

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -84,7 +84,7 @@ data DlintUsage
   | DlintDisabled
   deriving Show
 
-data ScenarioSkipValidation = ScenarioSkipValidation { getFlag :: Bool }
+data ScenarioSkipValidation = ScenarioSkipValidation { getSkipScenarioValidation :: Bool }
   deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -4,6 +4,7 @@
 module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
+    , ScenarioValidation(..)
     , DlintUsage(..)
     , Haddock(..)
     , defaultOptionsIO
@@ -54,9 +55,9 @@ data Options = Options
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: EnableScenarioService
     -- ^ Controls whether the scenario service is started.
-  , optScenarioValidation :: Bool
-    -- ^ Controls whether the scenario service server skip the validation.
-    --  This is mostly used to run additional checks on CI while keeping the IDE fast.
+  , optScenarioValidation :: ScenarioValidation
+    -- ^ Controls whether the scenario service server run package validations.
+    -- This is mostly used to run additional checks on CI while keeping the IDE fast.
   , optDlintUsage :: DlintUsage
   -- ^ Information about dlint usage.
   , optIsGenerated :: Bool
@@ -81,6 +82,9 @@ newtype Haddock = Haddock Bool
 data DlintUsage
   = DlintEnabled { dlintUseDataDir :: FilePath, dlintAllowOverrides :: Bool }
   | DlintDisabled
+  deriving Show
+
+data ScenarioValidation = ScenarioValidation Bool
   deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }
@@ -154,7 +158,7 @@ defaultOptions mbVersion =
         , optDebug = False
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
-        , optScenarioValidation = True
+        , optScenarioValidation = ScenarioValidation True
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optDflagCheck = True

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -84,7 +84,7 @@ data DlintUsage
   | DlintDisabled
   deriving Show
 
-data SkipScenarioValidation = SkipScenarioValidation { getSkipScenarioValidation :: Bool }
+newtype SkipScenarioValidation = SkipScenarioValidation { getSkipScenarioValidation :: Bool }
   deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -86,8 +86,8 @@ data DlintUsage
   deriving Show
 
 data ScenarioValidation
-    = ScenarioValidationLight
-    | ScenarioValidationFull
+    = ScenarioValidationDisable
+    | ScenarioValidationEnable
     deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }
@@ -161,7 +161,7 @@ defaultOptions mbVersion =
         , optDebug = False
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
-        , optScenarioValidation = ScenarioValidationFull
+        , optScenarioValidation = ScenarioValidationEnable
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optDflagCheck = True

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -4,7 +4,7 @@
 module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
-    , ScenarioSkipValidation(..)
+    , SkipScenarioValidation(..)
     , DlintUsage(..)
     , Haddock(..)
     , defaultOptionsIO
@@ -55,7 +55,7 @@ data Options = Options
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: EnableScenarioService
     -- ^ Controls whether the scenario service is started.
-  , optScenarioSkipValidation :: ScenarioSkipValidation
+  , optSkipScenarioValidation :: SkipScenarioValidation
     -- ^ Controls whether the scenario service server run package validations.
     -- This is mostly used to run additional checks on CI while keeping the IDE fast.
   , optDlintUsage :: DlintUsage
@@ -84,7 +84,7 @@ data DlintUsage
   | DlintDisabled
   deriving Show
 
-data ScenarioSkipValidation = ScenarioSkipValidation { getSkipScenarioValidation :: Bool }
+data SkipScenarioValidation = SkipScenarioValidation { getSkipScenarioValidation :: Bool }
   deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }
@@ -158,7 +158,7 @@ defaultOptions mbVersion =
         , optDebug = False
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
-        , optScenarioSkipValidation = ScenarioSkipValidation False
+        , optSkipScenarioValidation = SkipScenarioValidation False
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optDflagCheck = True

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -4,7 +4,6 @@
 module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
-    , ScenarioValidation(..)
     , DlintUsage(..)
     , Haddock(..)
     , defaultOptionsIO
@@ -55,10 +54,9 @@ data Options = Options
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: EnableScenarioService
     -- ^ Controls whether the scenario service is started.
-  , optScenarioValidation :: ScenarioValidation
-    -- ^ Controls whether the scenario service server runs all checks
-    -- or only a subset of them. This is mostly used to run additional
-    -- checks on CI while keeping the IDE fast.
+  , optScenarioValidation :: Bool
+    -- ^ Controls whether the scenario service server skip the validation.
+    --  This is mostly used to run additional checks on CI while keeping the IDE fast.
   , optDlintUsage :: DlintUsage
   -- ^ Information about dlint usage.
   , optIsGenerated :: Bool
@@ -84,11 +82,6 @@ data DlintUsage
   = DlintEnabled { dlintUseDataDir :: FilePath, dlintAllowOverrides :: Bool }
   | DlintDisabled
   deriving Show
-
-data ScenarioValidation
-    = ScenarioValidationDisable
-    | ScenarioValidationEnable
-    deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }
     deriving Show
@@ -161,7 +154,7 @@ defaultOptions mbVersion =
         , optDebug = False
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
-        , optScenarioValidation = ScenarioValidationEnable
+        , optScenarioValidation = True
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optDflagCheck = True

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -4,7 +4,7 @@
 module DA.Daml.Options.Types
     ( Options(..)
     , EnableScenarioService(..)
-    , ScenarioValidation(..)
+    , ScenarioSkipValidation(..)
     , DlintUsage(..)
     , Haddock(..)
     , defaultOptionsIO
@@ -55,7 +55,7 @@ data Options = Options
     -- ^ custom options, parsed by GHC option parser, overriding DynFlags
   , optScenarioService :: EnableScenarioService
     -- ^ Controls whether the scenario service is started.
-  , optScenarioValidation :: ScenarioValidation
+  , optScenarioSkipValidation :: ScenarioSkipValidation
     -- ^ Controls whether the scenario service server run package validations.
     -- This is mostly used to run additional checks on CI while keeping the IDE fast.
   , optDlintUsage :: DlintUsage
@@ -84,7 +84,7 @@ data DlintUsage
   | DlintDisabled
   deriving Show
 
-data ScenarioValidation = ScenarioValidation Bool
+data ScenarioSkipValidation = ScenarioSkipValidation { getFlag :: Bool }
   deriving Show
 
 newtype EnableScenarioService = EnableScenarioService { getEnableScenarioService :: Bool }
@@ -158,7 +158,7 @@ defaultOptions mbVersion =
         , optDebug = False
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
-        , optScenarioValidation = ScenarioValidation True
+        , optScenarioSkipValidation = ScenarioSkipValidation False
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
         , optDflagCheck = True

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -353,7 +353,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Com
           opts <- defaultOptionsIO Nothing
           opts <- pure $ opts
               { optScenarioService = enableScenarioService
-              , optScenarioValidation = ScenarioValidationDisable
+              , optScenarioValidation = False
               , optShakeProfiling = mbProfileDir
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -353,7 +353,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Com
           opts <- defaultOptionsIO Nothing
           opts <- pure $ opts
               { optScenarioService = enableScenarioService
-              , optScenarioSkipValidation = ScenarioSkipValidation True
+              , optSkipScenarioValidation = SkipScenarioValidation True
               , optShakeProfiling = mbProfileDir
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -353,7 +353,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Com
           opts <- defaultOptionsIO Nothing
           opts <- pure $ opts
               { optScenarioService = enableScenarioService
-              , optScenarioValidation = ScenarioValidation False
+              , optScenarioSkipValidation = ScenarioSkipValidation True
               , optShakeProfiling = mbProfileDir
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -353,7 +353,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Com
           opts <- defaultOptionsIO Nothing
           opts <- pure $ opts
               { optScenarioService = enableScenarioService
-              , optScenarioValidation = False
+              , optScenarioValidation = ScenarioValidation False
               , optShakeProfiling = mbProfileDir
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -353,7 +353,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir = Com
           opts <- defaultOptionsIO Nothing
           opts <- pure $ opts
               { optScenarioService = enableScenarioService
-              , optScenarioValidation = ScenarioValidationLight
+              , optScenarioValidation = ScenarioValidationDisable
               , optShakeProfiling = mbProfileDir
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -386,7 +386,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> optDebugLog
     <*> optGhcCustomOptions
     <*> pure enableScenarioService
-    <*> pure (optScenarioSkipValidation $ defaultOptions Nothing)
+    <*> pure (optSkipScenarioValidation $ defaultOptions Nothing)
     <*> dlintUsageOpt
     <*> pure False
     <*> optNoDflagCheck

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -386,7 +386,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> optDebugLog
     <*> optGhcCustomOptions
     <*> pure enableScenarioService
-    <*> pure (optScenarioValidation $ defaultOptions Nothing)
+    <*> pure (optScenarioSkipValidation $ defaultOptions Nothing)
     <*> dlintUsageOpt
     <*> pure False
     <*> optNoDflagCheck

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- defaultOptionsIO (Just version)
     opts <- pure $ opts
         { optThreads = 0
-        , optScenarioValidation = ScenarioValidationFull
+        , optScenarioValidation = ScenarioValidationEnable
         , optCoreLinting = True
         }
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- defaultOptionsIO (Just version)
     opts <- pure $ opts
         { optThreads = 0
-        , optScenarioValidation = True
+        , optScenarioValidation = ScenarioValidation True
         , optCoreLinting = True
         }
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- defaultOptionsIO (Just version)
     opts <- pure $ opts
         { optThreads = 0
-        , optScenarioSkipValidation = ScenarioSkipValidation False
+        , optSkipScenarioValidation = SkipScenarioValidation False
         , optCoreLinting = True
         }
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- defaultOptionsIO (Just version)
     opts <- pure $ opts
         { optThreads = 0
-        , optScenarioValidation = ScenarioValidationEnable
+        , optScenarioValidation = True
         , optCoreLinting = True
         }
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,7 +126,7 @@ getIntegrationTests registerTODO scenarioService version = do
     opts <- defaultOptionsIO (Just version)
     opts <- pure $ opts
         { optThreads = 0
-        , optScenarioValidation = ScenarioValidation True
+        , optScenarioSkipValidation = ScenarioSkipValidation False
         , optCoreLinting = True
         }
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -11,6 +11,7 @@ module DA.Daml.LF.ScenarioServiceClient
   , Handle
   , withScenarioService
   , Context(..)
+  , LowLevel.SkipValidation(..)
   , LowLevel.ContextId
   , getNewCtx
   , deleteCtx
@@ -117,7 +118,7 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxDamlLfVersion :: LF.Version
-  , ctxValidation :: Bool
+  , ctxSkipValidation :: LowLevel.SkipValidation
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -140,7 +141,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxDamlLfVersion
-      ctxValidation
+      ctxSkipValidation
   writeIORef hLoadedPackages newLoadedPackages
   writeIORef hLoadedModules ctxModules
   res <- LowLevel.updateCtx hLowLevelHandle hContextId ctxUpdate

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -118,7 +118,7 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxDamlLfVersion :: LF.Version
-  , ctxLightValidation :: LowLevel.LightValidation
+  , ctxNoValidation :: LowLevel.LightValidation
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -141,7 +141,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxDamlLfVersion
-      ctxLightValidation
+      ctxNoValidation
   writeIORef hLoadedPackages newLoadedPackages
   writeIORef hLoadedModules ctxModules
   res <- LowLevel.updateCtx hLowLevelHandle hContextId ctxUpdate

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -11,7 +11,6 @@ module DA.Daml.LF.ScenarioServiceClient
   , Handle
   , withScenarioService
   , Context(..)
-  , LowLevel.LightValidation(..)
   , LowLevel.ContextId
   , getNewCtx
   , deleteCtx
@@ -118,7 +117,7 @@ data Context = Context
   { ctxModules :: MS.Map Hash (LF.ModuleName, BS.ByteString)
   , ctxPackages :: [(LF.PackageId, BS.ByteString)]
   , ctxDamlLfVersion :: LF.Version
-  , ctxNoValidation :: LowLevel.LightValidation
+  , ctxValidation :: Bool
   }
 
 getNewCtx :: Handle -> Context -> IO (Either LowLevel.BackendError LowLevel.ContextId)
@@ -141,7 +140,7 @@ getNewCtx Handle{..} Context{..} = withLock hContextLock $ withSem hConcurrencyS
       loadPackages
       (S.toList unloadPackages)
       ctxDamlLfVersion
-      ctxNoValidation
+      ctxValidation
   writeIORef hLoadedPackages newLoadedPackages
   writeIORef hLoadedModules ctxModules
   res <- LowLevel.updateCtx hLowLevelHandle hContextId ctxUpdate

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -18,6 +18,7 @@ module DA.Daml.LF.ScenarioServiceClient.LowLevel
   , deleteCtx
   , gcCtxs
   , ContextUpdate(..)
+  , SkipValidation(..)
   , updateCtx
   , runScenario
   , SS.ScenarioResult(..)
@@ -80,13 +81,17 @@ data Handle = Handle
 newtype ContextId = ContextId { getContextId :: Int64 }
   deriving (NFData, Eq, Show)
 
+-- | If true, the scenario service server do not run package validations.
+data SkipValidation = SkipValidation { getFlag :: Bool }
+  deriving Show
+
 data ContextUpdate = ContextUpdate
   { updLoadModules :: ![(LF.ModuleName, BS.ByteString)]
   , updUnloadModules :: ![LF.ModuleName]
   , updLoadPackages :: ![(LF.PackageId, BS.ByteString)]
   , updUnloadPackages :: ![LF.PackageId]
   , updDamlLfVersion :: LF.Version
-  , updValidation :: Bool
+  , updSkipValidation :: SkipValidation
   }
 
 encodeModule :: LF.Version -> LF.Module -> BS.ByteString
@@ -289,7 +294,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           ctxId
           (Just updModules)
           (Just updPackages)
-          (not updValidation)
+          (getFlag updSkipValidation)
   pure (void res)
   where
     updModules =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -18,7 +18,6 @@ module DA.Daml.LF.ScenarioServiceClient.LowLevel
   , deleteCtx
   , gcCtxs
   , ContextUpdate(..)
-  , LightValidation(..)
   , updateCtx
   , runScenario
   , SS.ScenarioResult(..)
@@ -81,16 +80,13 @@ data Handle = Handle
 newtype ContextId = ContextId { getContextId :: Int64 }
   deriving (NFData, Eq, Show)
 
--- | If true, the scenario service server only runs a subset of validations.
-newtype LightValidation = LightValidation { getLightValidation :: Bool }
-
 data ContextUpdate = ContextUpdate
   { updLoadModules :: ![(LF.ModuleName, BS.ByteString)]
   , updUnloadModules :: ![LF.ModuleName]
   , updLoadPackages :: ![(LF.PackageId, BS.ByteString)]
   , updUnloadPackages :: ![LF.PackageId]
   , updDamlLfVersion :: LF.Version
-  , updLightValidation :: LightValidation
+  , updValidation :: Bool
   }
 
 encodeModule :: LF.Version -> LF.Module -> BS.ByteString
@@ -293,7 +289,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           ctxId
           (Just updModules)
           (Just updPackages)
-          (getLightValidation updLightValidation)
+          (not updValidation)
   pure (void res)
   where
     updModules =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -82,7 +82,7 @@ newtype ContextId = ContextId { getContextId :: Int64 }
   deriving (NFData, Eq, Show)
 
 -- | If true, the scenario service server do not run package validations.
-data SkipValidation = SkipValidation { getFlag :: Bool }
+data SkipValidation = SkipValidation { getSkipValidation :: Bool }
   deriving Show
 
 data ContextUpdate = ContextUpdate
@@ -294,7 +294,7 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
           ctxId
           (Just updModules)
           (Just updPackages)
-          (getFlag updSkipValidation)
+          (getSkipValidation updSkipValidation)
   pure (void res)
   where
     updModules =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -82,7 +82,7 @@ newtype ContextId = ContextId { getContextId :: Int64 }
   deriving (NFData, Eq, Show)
 
 -- | If true, the scenario service server do not run package validations.
-data SkipValidation = SkipValidation { getSkipValidation :: Bool }
+newtype SkipValidation = SkipValidation { getSkipValidation :: Bool }
   deriving Show
 
 data ContextUpdate = ContextUpdate

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -98,7 +98,7 @@ message UpdateContextRequest {
   int64 context_id = 1;
   UpdateModules update_modules = 2;
   UpdatePackages update_packages = 3;
-  bool lightValidation = 4; // if true runs only a subset of the validations
+  bool noValidation = 4; // if true, does not run the package validations
 }
 
 message UpdateContextResponse {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -201,7 +201,7 @@ class ScenarioService extends ScenarioServiceGrpc.ScenarioServiceImplBase {
             loadModules,
             unloadPackages,
             loadPackages,
-            req.getLightValidation
+            req.getNoValidation
           )
 
           resp.addAllLoadedModules(ctx.loadedModules().map(_.toString).asJava)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Validation.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Validation.scala
@@ -35,23 +35,4 @@ object Validation {
     Serializability.checkModule(world, pkgId, mod)
     PartyLiterals.checkModule(world, pkgId, mod)
   }
-
-  /*
-    checkPackageForScenarioService runs a subset of the validation for the scenario service.
-
-    We do not want type check because it is slow and duplicated in Haskell side
-    We do not want serializability check because the inference is not properly propagate to the engine (in case of scenario)
-    We want collision check because it is not done on Haskell side.
-   */
-  def checkPackageForScenarioService(
-      pkgs: PartialFunction[PackageId, Package],
-      pkgId: PackageId
-  ): Either[ValidationError, Unit] =
-    try {
-      val world = new World(pkgs)
-      Right(Collision.checkPackage(pkgId, world.lookupPackage(NoContext, pkgId).modules))
-    } catch {
-      case e: ValidationError =>
-        Left(e)
-    }
 }


### PR DESCRIPTION
Now that #2768 is fixed, the compiler run all the package validations before generating a dar.
Therefore we can drop the collision validations when the scenario service is run from the IDE.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
