### PR TITLE
release signing: decode gpg credentials

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,7 @@ jobs:
               rm -rf $KEY_FILE $GPG_DIR
           }
           trap cleanup EXIT
-          echo "$GPG_KEY" > $KEY_FILE
+          echo "$GPG_KEY" | base64 -d > $KEY_FILE
           gpg --homedir $GPG_DIR --no-tty --quiet --import $KEY_FILE
           cd $(Build.StagingDirectory)/release
           # Note: relies on our release artifacts not having spaces in their


### PR DESCRIPTION
After the 0.13.26 release failed, I looked more closely at the Haskell release code and it looks like I had missed the fact that [the gpg key provided by CI is base64-encoded](https://github.com/digital-asset/daml/blob/8ad74da20be3dbeca3901882bfddcf100b429ec2/release/src/Upload.hs#L293).

Apologies for the failed release.