### PR TITLE
Fix issue with template instance constraint rewriting

### DIFF
--- a/compiler/damlc/tests/daml-test-files/GenericChoice.daml
+++ b/compiler/damlc/tests/daml-test-files/GenericChoice.daml
@@ -35,3 +35,8 @@ deleteFooByKey : forall c. Template (Foo c) => Party -> Update ()
 deleteFooByKey fooKey = do
     (fooCid, _) <- fetchByKey @(Foo c) fooKey
     exercise fooCid Delete
+
+-- NOTE(MH): The superfluous parentheses around the constraint caused the
+-- rewriting to fail in the past.
+deleteFoo' : (Template (Foo c)) => ContractId (Foo c) -> Update ()
+deleteFoo' fooCid = exercise fooCid Delete

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,3 +20,4 @@ HEAD — ongoing
 - [Ledger] 
   Improve SQL backend performance by eliminating extra queries to the database.
 + [DAML Ledger Integration Kit] The transaction service is now fully tested.
+- [DAML Compiler] Fix a problem where constraints of the form `Template (Foo t)` caused the compiler to suggest enabling the `UndecidableInstances` language extension.


### PR DESCRIPTION
The compiler rewrites constraints like `Template (Foo t) => ...` into
`FooInstance t => ...`. Unfortunately, this rewriting does not yet kick in
when the constraint contains superfluous parentheses as in
`(Template (Foo t)) => ...`.

This PR fixes the problem.

Fixes #2994.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3010)
<!-- Reviewable:end -->
