### PR TITLE
Add a --target flag to the IDE

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,3 +9,5 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [DAML Studio] ``damlc ide`` now also supports a ``--target`` option.
+  The easiest way to specify this is the ``build-options`` field in ``daml.yaml``.


### PR DESCRIPTION
It is really annoying to not be able to load code that requires 1.dev
in the IDE.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
