### PR TITLE
Wait for lints in damlc integration tests

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -321,6 +321,7 @@ mainProj TestArguments{..} service outdir log file = do
     runActionSync service $ do
             cores <- ghcCompile log file
             corePrettyPrint cores
+            getDlintIdeas file
             lf <- lfConvert log file
             lfPrettyPrint lf
             lf <- lfTypeCheck log file


### PR DESCRIPTION
Currently, the integration tests fail sometimes because of missing lints.
Our suspicion is that the linter gets killed when the type checker fails
before it managed to produce the lints. This change makes sure we wait for
the linter.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3020)
<!-- Reviewable:end -->
