### PR TITLE
Merge package reference detection into package id encoding

### DIFF
--- a/compiler/daml-lf-proto/BUILD.bazel
+++ b/compiler/daml-lf-proto/BUILD.bazel
@@ -20,6 +20,7 @@ da_haskell_library(
         "template-haskell",
         "text",
         "transformers",
+        "unordered-containers",
         "vector",
     ],
     src_strip_prefix = "src",

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -8,19 +8,20 @@ module DA.Daml.LF.Proto3.EncodeV1
   , encodePackage
   ) where
 
-import           Control.Lens ((^.), (^..), matching)
+import           Control.Lens ((^.), matching)
 import           Control.Lens.Ast (rightSpine)
-import           Control.Monad.Reader.Class
+import           Control.Monad.State
 
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.List as L
 import qualified Data.NameMap as NM
-import qualified Data.Set as S
 import qualified Data.Text           as T
 import qualified Data.Text.Lazy      as TL
 import qualified Data.Vector         as V
+import           Data.Word
 
 import           DA.Pretty
 import           DA.Daml.LF.Ast
-import           DA.Daml.LF.Ast.Optics (packageRefs)
 import           DA.Daml.LF.Mangling
 import qualified Da.DamlLf1 as P
 
@@ -31,13 +32,28 @@ import qualified Proto3.Suite as P (Enumerated (..))
 -- otherwise always be wrapped in `Just` at their call sites.
 type Just a = Maybe a
 
-newtype Encode a = Encode{runEncode :: EncodeEnv -> a}
-    deriving (Functor, Applicative, Monad, MonadReader EncodeEnv)
+type Encode a = State EncodeEnv a
+
+data InternMode = InternNothing | InternPackageIdsOnly
 
 data EncodeEnv = EncodeEnv
     { _version :: Version
-    , internedPackageIds :: S.Set PackageId
+    , internMode :: InternMode
+    , internedStrings :: HMS.HashMap T.Text Word64
     }
+
+initEncodeEnv :: Version -> InternMode -> EncodeEnv
+initEncodeEnv version mode = EncodeEnv version mode HMS.empty
+
+allocString :: T.Text -> Encode Word64
+allocString t = do
+    env@EncodeEnv{internedStrings} <- get
+    case t `HMS.lookup` internedStrings of
+        Just n -> pure n
+        Nothing -> do
+            let n = fromIntegral (HMS.size internedStrings)
+            put $ env{internedStrings = HMS.insert t n internedStrings}
+            pure n
 
 ------------------------------------------------------------------------
 -- Simple encodings
@@ -92,10 +108,10 @@ encodePackageRef :: PackageRef -> Encode (Just P.PackageRef)
 encodePackageRef = fmap (Just . P.PackageRef . Just) . \case
     PRSelf -> pure $ P.PackageRefSumSelf P.Unit
     PRImport pkgId -> do
-        EncodeEnv{internedPackageIds} <- ask
-        pure $ case pkgId `S.lookupIndex` internedPackageIds of
-            Nothing -> P.PackageRefSumPackageId $ encodePackageId pkgId
-            Just n -> P.PackageRefSumInternedId $ fromIntegral n
+        EncodeEnv{internMode} <- get
+        case internMode of
+            InternNothing -> pure $ P.PackageRefSumPackageId $ encodePackageId pkgId
+            InternPackageIdsOnly -> P.PackageRefSumInternedId <$> allocString (unPackageId pkgId)
 
 encodeModuleRef :: PackageRef -> ModuleName -> Encode (Just P.ModuleRef)
 encodeModuleRef pkgRef modName = do
@@ -640,9 +656,9 @@ encodeFeatureFlags FeatureFlags{..} = Just P.FeatureFlags
 
 encodeModuleWithLargePackageIds :: Version -> Module -> P.Module
 encodeModuleWithLargePackageIds version mod =
-    let env = EncodeEnv version S.empty
+    let env = initEncodeEnv version InternNothing
     in
-    runEncode (encodeModule mod) env
+    fst $ runState (encodeModule mod) env
 
 encodeModule :: Module -> Encode P.Module
 encodeModule Module{..} = do
@@ -655,14 +671,13 @@ encodeModule Module{..} = do
 
 -- | NOTE(MH): Assumes the DAML-LF version of the 'Package' is 'V1'.
 encodePackage :: Package -> P.Package
-encodePackage pkg@(Package version mods) =
-    let pkgIds = S.fromList $ pkg ^.. packageRefs._PRImport
-        env = EncodeEnv version pkgIds
+encodePackage (Package version mods) =
+    let env = initEncodeEnv version InternPackageIdsOnly
+        (packageModules, EncodeEnv{internedStrings}) = runState (encodeNameMap encodeModule mods) env
+        packageInternedPackageIds =
+            V.fromList $ map (TL.fromStrict . fst) $ L.sortOn snd $ HMS.toList internedStrings
     in
-    P.Package
-    { packageModules = runEncode (encodeNameMap encodeModule mods) env
-    , packageInternedPackageIds = V.fromList $ map encodePackageId $ S.toAscList pkgIds
-    }
+    P.Package{..}
 
 -- | NOTE(MH): This functions is used for sanity checking. The actual checks
 -- are done in the conversion to DAML-LF.

--- a/compiler/damlc/tests/daml-test-files/InternedExternalRefs.daml
+++ b/compiler/damlc/tests/daml-test-files/InternedExternalRefs.daml
@@ -2,7 +2,14 @@
 -- All rights reserved.
 
 -- @ SINCE-LF 1.6
-daml 1.2 module InternedExternalRefs where
+-- @QUERY-LF [ .modules[] | .values[] | .expr.val.module.package_ref.interned_id ] | sort == ["0", "1"]
+-- @QUERY-LF .interned_package_ids | length == 2
 
--- @ QUERY-LF .modules[] | .values[] | select(.name_with_type.name == ["reverseCopy"]) | .expr.val.module.package_ref.interned_id >= 0
-reverseCopy = reverse
+-- We test that interning of package ids works. The two packages we reference are
+-- daml-prim and daml-stdlib.
+daml 1.2
+module InternedExternalRefs where
+
+reverseCopy = reverse  -- this is a reference to daml-stdlib
+
+errorCopy = error  -- this is a reference to daml-prim


### PR DESCRIPTION
Currently, the encoding of a DAML-LF package works in two phases:
1. We compute the set of all package ids refernced by the package to encode.
2. We use this set of package ids to form a table for interning that is then
   consulted during the encoding of package ids.

This PR changes it such that the interning table is computed while the
package is being encoded. New package ids are added to the table whenever
they are encountered for the first time.

This is in preparation for the general inlining of all strings, which will
use the same approach to building the interning table.

This PR is a pure refactoring and does not change any functionality.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3039)
<!-- Reviewable:end -->
