### PR TITLE
Unflake dlint in integration tests

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -143,8 +143,8 @@ data DalfDependency = DalfDependency
     -- ^ The absolute path to the dalf file.
   }
 
-getDlintIdeas :: NormalizedFilePath -> Action ()
-getDlintIdeas f = use_ GetDlintDiagnostics f
+getDlintIdeas :: NormalizedFilePath -> Action (Maybe ())
+getDlintIdeas f = runMaybeT $ useE GetDlintDiagnostics f
 
 ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . HughesPJPretty.prettyShow

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -319,9 +319,9 @@ mainProj TestArguments{..} service outdir log file = do
 
     setFilesOfInterest service (Set.singleton file)
     runActionSync service $ do
+            dlint log file
             cores <- ghcCompile log file
             corePrettyPrint cores
-            getDlintIdeas file
             lf <- lfConvert log file
             lfPrettyPrint lf
             lf <- lfTypeCheck log file
@@ -335,6 +335,9 @@ unjust act = do
     case res of
       Nothing -> fail "_IGNORE_"
       Just v -> return v
+
+dlint :: (String -> IO ()) -> NormalizedFilePath -> Action ()
+dlint log file = timed log "DLint" $ unjust $ getDlintIdeas file
 
 ghcCompile :: (String -> IO ()) -> NormalizedFilePath -> Action [GHC.CoreModule]
 ghcCompile log file = timed log "GHC compile" $ unjust $ getGhcCore file


### PR DESCRIPTION
Previously, we sometimes missed the dlint hints because we got killed
due to a typechecking error before they were produced. Now, we
force them to be generated which should hopefully fix that.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
