### PR TITLE
Shorten test names in //compiler/damlc:integration-dev

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -115,10 +115,12 @@ getIntegrationTests registerTODO scenarioService version = do
 
     -- test files are declared as data in BUILD.bazel
     testsLocation <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/daml-test-files"
-    damlTestFiles <- filter (".daml" `isExtensionOf`) <$> listFiles testsLocation
+    damlTestFiles <-
+        map (\f -> (makeRelative testsLocation f, f)) .
+        filter (".daml" `isExtensionOf`) <$> listFiles testsLocation
     -- only run Test.daml (see https://github.com/digital-asset/daml/issues/726)
     bondTradingLocation <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/bond-trading"
-    let allTestFiles = damlTestFiles ++ [bondTradingLocation </> "Test.daml"]
+    let allTestFiles = damlTestFiles ++ [("bond-trading/Test.daml", bondTradingLocation </> "Test.daml")]
 
     let outdir = "compiler/damlc/output"
     createDirectoryIfMissing True outdir
@@ -154,8 +156,8 @@ instance IsTest TestCase where
     pure $ res { resultDescription = desc }
   testOptions = Tagged []
 
-testCase :: TestArguments -> LF.Version -> IO IdeState -> FilePath -> (TODO -> IO ()) -> FilePath -> TestTree
-testCase args version getService outdir registerTODO file = singleTest file . TestCase $ \log -> do
+testCase :: TestArguments -> LF.Version -> IO IdeState -> FilePath -> (TODO -> IO ()) -> (String, FilePath) -> TestTree
+testCase args version getService outdir registerTODO (name, file) = singleTest name . TestCase $ \log -> do
   service <- getService
   anns <- readFileAnns file
   if any (ignoreVersion version) anns


### PR DESCRIPTION
Previously the test names consisted of the full absolute file paths
which got unreadable very quickly. Sadly the absolute file paths still
leak into the error messages since I don’t know of a nice way to get
relative paths here (just making them relative to cwd doesn’t work)
but this is still much more readable.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.