### PR TITLE
Don't trigger a lint in ErrorsWithColons test case

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
+++ b/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
@@ -1,11 +1,11 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=9:35-9:42; Use list literal
--- @ERROR range=9:35-9:42; In the expression: (1 :: [])
+-- @ERROR range=8:35-8:43; In the expression: (1 :: nil)
 -- @ERROR range=11:13-11:14; In the expression: 1 : Text
 daml 1.2 module ErrorsWithColons where
 
-badIf = if True then Some 1 else (1 :: [])
+badIf = if True then Some 1 else (1 :: nil)
+    where nil = []
 
 notString = 1 : Text


### PR DESCRIPTION
This causes some trouble right now since our integration test suite
does not work well when a test triggers both type error and lints.

It works well in the IDE tests. Fixing this is hence not critical and this
PR presents a cheap workaround.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3048)
<!-- Reviewable:end -->
