### PR TITLE
Introduce ledger API authorization

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -14,6 +14,7 @@ import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf.DamlLf.Archive
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.index.{StandaloneIndexServer, StandaloneIndexerServer}
+import com.digitalasset.platform.server.api.authorization.auth.AuthServiceWildcard
 import org.slf4j.LoggerFactory
 
 import scala.util.Try
@@ -47,6 +48,7 @@ object ReferenceServer extends App {
 
   val readService = ledger
   val writeService = ledger
+  val authService = AuthServiceWildcard()
 
   config.archiveFiles.foreach { file =>
     for {
@@ -58,7 +60,8 @@ object ReferenceServer extends App {
   val participantLoggerFactory = NamedLoggerFactory.forParticipant(participantId)
   val indexerServer = StandaloneIndexerServer(readService, config, participantLoggerFactory)
   val indexServer =
-    StandaloneIndexServer(config, readService, writeService, participantLoggerFactory).start()
+    StandaloneIndexServer(config, readService, writeService, authService, participantLoggerFactory)
+      .start()
 
   val extraParticipants =
     for {
@@ -77,6 +80,7 @@ object ReferenceServer extends App {
         participantConfig,
         readService,
         writeService,
+        authService,
         participantLoggerFactory
       )
       (extraIndexer, extraLedgerApiServer.start())

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -48,7 +48,7 @@ object ReferenceServer extends App {
 
   val readService = ledger
   val writeService = ledger
-  val authService = AuthServiceWildcard()
+  val authService = AuthServiceWildcard
 
   config.archiveFiles.foreach { file =>
     for {

--- a/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
@@ -18,6 +18,7 @@ import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml_lf.DamlLf.Archive
 import com.digitalasset.platform.common.util.DirectExecutionContext
+import com.digitalasset.platform.server.api.authorization.auth.AuthServiceWildcard
 import org.slf4j.LoggerFactory
 
 import scala.util.Try
@@ -73,11 +74,14 @@ object ReferenceServer extends App {
         participantId = participantId
       )
 
+      val authService = AuthServiceWildcard()
+
       val server = Server(
         serverPort = config.port,
         sslContext = config.tlsConfig.flatMap(_.server),
         indexService = indexService,
         writeService = ledger,
+        authService = authService
       )
 
       // If port file was provided, write out the allocated server port to it.

--- a/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference/src/main/scala/com/daml/ledger/api/server/damlonx/reference/ReferenceServer.scala
@@ -74,7 +74,7 @@ object ReferenceServer extends App {
         participantId = participantId
       )
 
-      val authService = AuthServiceWildcard()
+      val authService = AuthServiceWildcard
 
       val server = Server(
         serverPort = config.port,

--- a/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
+++ b/ledger/api-server-damlonx/src/main/scala/com/daml/ledger/api/server/damlonx/Server.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 import akka.stream.ActorMaterializer
 import com.daml.ledger.api.server.damlonx.services._
 import com.daml.ledger.participant.state.index.v1.IndexService
-import com.daml.ledger.participant.state.v1.WriteService
+import com.daml.ledger.participant.state.v1.{AuthService, WriteService}
 import com.digitalasset.daml.lf.engine.{Engine, EngineInfo}
 import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.digitalasset.ledger.api.domain
@@ -35,7 +35,8 @@ object Server {
       serverPort: Int,
       sslContext: Option[SslContext],
       indexService: IndexService,
-      writeService: WriteService)(implicit materializer: ActorMaterializer): Server = {
+      writeService: WriteService,
+      authService: AuthService)(implicit materializer: ActorMaterializer): Server = {
     implicit val serverEsf: AkkaExecutionSequencerPool =
       new AkkaExecutionSequencerPool(
         // NOTE(JM): Pick a unique pool name as we want to allow multiple ledger api server
@@ -54,7 +55,7 @@ object Server {
       serverEsf,
       serverPort,
       sslContext,
-      createServices(indexService, writeService, loggerFactory),
+      createServices(indexService, writeService, authService, loggerFactory),
       loggerFactory
     ),
   }
@@ -62,6 +63,7 @@ object Server {
   private def createServices(
       indexService: IndexService,
       writeService: WriteService,
+      authService: AuthService,
       loggerFactory: NamedLoggerFactory)(
       implicit mat: ActorMaterializer,
       serverEsf: ExecutionSequencerFactory

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/ApiServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/ApiServiceAuthorization.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization
+
+import com.daml.ledger.participant.state.v1.Claims
+import com.digitalasset.ledger.api.v1.transaction_filter.TransactionFilter
+import com.digitalasset.platform.server.api.validation.ErrorFactories._
+import io.grpc.{Context, StatusRuntimeException}
+import org.slf4j.{Logger, LoggerFactory}
+
+sealed abstract class Authorization
+case object Authorized extends Authorization
+final case class NotAuthorized(reason: String = "You are not authorized to use this resource")
+    extends Authorization
+
+/** A simple helper that allows services to use authorization claims
+  * that have been stored by [[AuthorizationInterceptor]].
+  */
+object ApiServiceAuthorization {
+
+  protected val logger: Logger = LoggerFactory.getLogger(ApiServiceAuthorization.getClass)
+
+  private[this] def getStackTrace(t: Throwable): String = {
+    import java.io.PrintWriter
+    import java.io.StringWriter
+    val sw = new StringWriter
+    val pw = new PrintWriter(sw, true)
+    t.printStackTrace(pw)
+    pw.flush()
+    sw.flush()
+    sw.toString
+  }
+
+  /** Checks whether the given claims give access to the request.
+    *
+    * @param check Given a set of [[Claims]], returns whether the current method is authorized.
+    *              Typically, the caller compares the request parameters with the given claims.
+    *
+    * @return   A [[StatusRuntimeException]] with code `PERMISSION_DENIED` if the request is not authorized,
+    *           or Unit if the request is authorized.
+    */
+  def requireClaims(check: Claims => Authorization): Either[StatusRuntimeException, Unit] = {
+    val claims = AuthorizationInterceptor.contextKeyClaim.get()
+    if (claims == null) {
+      // The current context does not contain any claims.
+      // Most likely causes:
+      // - The API server does not use the [[AuthorizationInterceptor]] which is responsible for creating the context
+      // - This function is called from a thread different from the one used to handle the gRPC call,
+      //   such as during a `Future.map`. See also [[ApiServiceAuthorization.withContext]].
+      logger.error(s"No context key at: ${getStackTrace(new Exception)}")
+      Left(internal("Context.key.get returned no valid Claims."))
+    } else {
+      check(claims) match {
+        case Authorized =>
+          Right(())
+        case NotAuthorized(reason) =>
+          // Be careful with logging errors in order to not leak secrets through log messages
+          // logger.warn(s"Rejecting authorization with claims $claims")
+          Left(permissionDenied(reason))
+      }
+    }
+  }
+
+  /** Executes the given block with the given gRPC context as the current context.
+    *
+    * Usage:
+    * ```
+    * // Capture the gRPC context in a gRPC thread
+    * val ctx = Context.current
+    *
+    * // Function bar uses ApiServiceAuthorization.requireClaims,
+    * // but is called from a non-gRPC thread.
+    * // Wrap it in withContext, so that the gRPC context is available in bar()
+    * val asyncResult: Future[T] = foo()
+    *   .flatMap(ApiServiceAuthorization.withContext(ctx)(bar))
+    * ```
+    */
+  def withContext[T](context: Context)(block: => T): T = {
+    val previous = context.attach()
+    try block
+    finally context.detach(previous)
+  }
+
+  def requirePublicClaims(): Either[StatusRuntimeException, Unit] = {
+    requireClaims(claims => if (claims.isPublic) Authorized else NotAuthorized())
+  }
+
+  def requireAdminClaims(): Either[StatusRuntimeException, Unit] = {
+    requireClaims(claims => if (claims.isAdmin) Authorized else NotAuthorized())
+  }
+
+  def requireClaimsForAllParties(parties: Set[String]): Either[StatusRuntimeException, Unit] = {
+    requireClaims(
+      claims => if (parties.forall(p => claims.canActAs(p))) Authorized else NotAuthorized())
+  }
+
+  def requireClaimsForParty(party: Option[String]): Either[StatusRuntimeException, Unit] = {
+    requireClaims(
+      claims => if (party.forall(p => claims.canActAs(p))) Authorized else NotAuthorized())
+  }
+
+  /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
+  def requireClaimsForTransactionFilter(
+      filter: Option[TransactionFilter]): Either[StatusRuntimeException, Unit] = {
+    val filterPartyNames = filter
+      .map(_.filtersByParty.keySet)
+      .getOrElse(Set.empty)
+    requireClaimsForAllParties(filterPartyNames)
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/AsyncForwardingListener.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/AsyncForwardingListener.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization
+
+import io.grpc.ServerCall
+
+import scala.collection.mutable
+
+/** This listener buffers all messages until `setNextListener` is called,
+  * at which point all buffered messages are sent to the given listener.
+  * From then on, all future messages are sent directly to the given listener.
+  *
+  * The target listener is usually created through `Contexts.interceptCall` or `ServerCallHandler.startCall`.
+  * */
+abstract class AsyncForwardingListener[ReqT] extends ServerCall.Listener[ReqT] {
+  protected type Listener = ServerCall.Listener[ReqT]
+  private[this] val lock = new Object
+  private[this] val stash: mutable.ListBuffer[Listener => Unit] = new mutable.ListBuffer
+  private[this] var nextListener: Option[Listener] = None
+
+  private def enqueueOrProcess(msg: Listener => Unit): Unit = lock.synchronized {
+    if (nextListener.isDefined) {
+      msg(nextListener.get)
+    } else {
+      stash.append(msg)
+    }
+  }
+
+  protected def setNextListener(listener: Listener): Unit = lock.synchronized {
+    nextListener = Some(listener)
+    stash.foreach(msg => msg(listener))
+  }
+
+  // All methods that need to be forwarded
+  override def onHalfClose(): Unit = enqueueOrProcess(i => i.onHalfClose())
+  override def onCancel(): Unit = enqueueOrProcess(i => i.onCancel())
+  override def onComplete(): Unit = enqueueOrProcess(i => i.onComplete())
+  override def onReady(): Unit = enqueueOrProcess(i => i.onReady())
+  override def onMessage(message: ReqT): Unit = enqueueOrProcess(i => i.onMessage(message))
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/AuthorizationInterceptor.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/AuthorizationInterceptor.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization
+
+import com.daml.ledger.participant.state.v1.{AuthService, Claims}
+import io.grpc.{
+  Context,
+  Contexts,
+  Metadata,
+  ServerCall,
+  ServerCallHandler,
+  ServerInterceptor,
+  Status
+}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.compat.java8.FutureConverters
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+/**
+  * This interceptor uses the given [[AuthService]] to get [[Claims]] for the current request,
+  * and then stores them in the current [[Context]].
+  *
+  * Use [[ApiServiceAuthorization]] to read the claims from the context.
+  * */
+class AuthorizationInterceptor(protected val authService: AuthService, ec: ExecutionContext)
+    extends ServerInterceptor {
+
+  protected val logger: Logger = LoggerFactory.getLogger(AuthorizationInterceptor.getClass)
+
+  override def interceptCall[ReqT, RespT](
+      call: ServerCall[ReqT, RespT],
+      headers: Metadata,
+      nextListener: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    // Note: Context uses ThreadLocal storage, we need to capture it outside of the async block below.
+    // Contexts are immutable and safe to pass around.
+    val prevCtx = Context.current
+
+    // The method interceptCall() must return a Listener.
+    // The target listener is created by calling `Contexts.interceptCall()`.
+    // However, this is only done after we have asynchronously received the claims.
+    // Therefore, we need to return a listener that buffers all messages until the target listener is available.
+    new AsyncForwardingListener[ReqT] {
+      FutureConverters
+        .toScala(authService.decodeMetadata(headers))
+        .onComplete {
+          case Success(claims) =>
+            val nextCtx = prevCtx.withValue(AuthorizationInterceptor.contextKeyClaim, claims)
+            // Contexts.interceptCall() creates a listener that wraps all methods of `nextListener`
+            // such that `Context.current` returns `nextCtx`.
+            val nextListenerWithContext =
+              Contexts.interceptCall(nextCtx, call, headers, nextListener)
+            setNextListener(nextListenerWithContext)
+            nextListenerWithContext
+          case Failure(exception) =>
+            logger.warn(s"Failed to get claims from request metadata: ${exception.getMessage}")
+            call.close(
+              Status.INTERNAL.withDescription("Failed to get claims from request metadata"),
+              new Metadata())
+            new ServerCall.Listener[Nothing]() {}
+        }(ec)
+    }
+  }
+}
+
+object AuthorizationInterceptor {
+  val contextKeyClaim: Context.Key[Claims] = Context.key("AuthServiceDecodedClaim")
+
+  def apply(authService: AuthService, ec: ExecutionContext): AuthorizationInterceptor = {
+    new AuthorizationInterceptor(authService, ec)
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceNone.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceNone.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.v1.{AuthService, Claims}
 import io.grpc.Metadata
 
 /** An AuthService that rejects all calls by always returning an empty set of [[Claims]] */
-case class AuthServiceNone() extends AuthService {
+case object AuthServiceNone extends AuthService {
   override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
     CompletableFuture.completedFuture(Claims.empty)
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceNone.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceNone.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.auth
+
+import java.util.concurrent.{CompletableFuture, CompletionStage}
+
+import com.daml.ledger.participant.state.v1.{AuthService, Claims}
+import io.grpc.Metadata
+
+/** An AuthService that rejects all calls by always returning an empty set of [[Claims]] */
+case class AuthServiceNone() extends AuthService {
+  override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
+    CompletableFuture.completedFuture(Claims.empty)
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceWildcard.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceWildcard.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.auth
+
+import java.util.concurrent.{CompletableFuture, CompletionStage}
+
+import com.daml.ledger.participant.state.v1.{AuthService, Claims}
+import io.grpc.Metadata
+
+/** An AuthService that authorizes all calls by always returning a wildcard [[Claims]] */
+case class AuthServiceWildcard() extends AuthService {
+  override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
+    CompletableFuture.completedFuture(Claims.wildcard)
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceWildcard.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/auth/AuthServiceWildcard.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.v1.{AuthService, Claims}
 import io.grpc.Metadata
 
 /** An AuthService that authorizes all calls by always returning a wildcard [[Claims]] */
-case class AuthServiceWildcard() extends AuthService {
+case object AuthServiceWildcard extends AuthService {
   override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
     CompletableFuture.completedFuture(Claims.wildcard)
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/ActiveContractsServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/ActiveContractsServiceAuthorization.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService
+import com.digitalasset.ledger.api.v1.active_contracts_service.{
+  ActiveContractsServiceGrpc,
+  GetActiveContractsRequest,
+  GetActiveContractsResponse
+}
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+import org.slf4j.{Logger, LoggerFactory}
+
+class ActiveContractsServiceAuthorization(
+    protected val service: ActiveContractsService with AutoCloseable,
+    protected val authService: AuthService)
+    extends ActiveContractsService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(ActiveContractsService.getClass)
+
+  override def getActiveContracts(
+      request: GetActiveContractsRequest,
+      responseObserver: StreamObserver[GetActiveContractsResponse]): Unit =
+    ApiServiceAuthorization
+      .requireClaimsForTransactionFilter(request.filter)
+      .fold(responseObserver.onError(_), _ => service.getActiveContracts(request, responseObserver))
+
+  override def bindService(): ServerServiceDefinition =
+    ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandCompletionServiceAuthorization.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import akka.stream.scaladsl.Source
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionService
+import com.digitalasset.ledger.api.v1.command_completion_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import com.digitalasset.platform.server.api.services.grpc.GrpcCommandCompletionService
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class CommandCompletionServiceAuthorization(
+    protected val service: GrpcCommandCompletionService with AutoCloseable,
+    protected val authService: AuthService)
+    extends CommandCompletionService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(CommandCompletionService.getClass)
+
+  override def completionEnd(request: CompletionEndRequest): Future[CompletionEndResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.completionEnd(request))
+
+  override def completionStream(
+      request: CompletionStreamRequest,
+      responseObserver: StreamObserver[CompletionStreamResponse]): Unit =
+    ApiServiceAuthorization
+      .requireClaimsForAllParties(request.parties.toSet)
+      .fold(responseObserver.onError, _ => service.completionStream(request, responseObserver))
+
+  override def bindService(): ServerServiceDefinition =
+    CommandCompletionServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+
+  def completionStreamSource(
+      request: CompletionStreamRequest): Source[CompletionStreamResponse, akka.NotUsed] =
+    service.completionStreamSource(request)
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandServiceAuthorization.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
+import com.digitalasset.ledger.api.v1.command_service.{
+  CommandServiceGrpc,
+  SubmitAndWaitForTransactionIdResponse,
+  SubmitAndWaitForTransactionResponse,
+  SubmitAndWaitForTransactionTreeResponse,
+  SubmitAndWaitRequest
+}
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import com.google.protobuf.empty.Empty
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+/** Note: the command service internally uses calls to the CommandSubmissionService and CommandCompletionService.
+  * These calls already require authentication, but it is better to check authorization here as well.
+  */
+class CommandServiceAuthorization(
+    protected val service: CommandService with AutoCloseable,
+    protected val authService: AuthService)
+    extends CommandService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(CommandService.getClass)
+
+  override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
+    ApiServiceAuthorization
+      .requireClaimsForParty(request.commands.map(_.party))
+      .fold(Future.failed(_), _ => service.submitAndWait(request))
+
+  override def submitAndWaitForTransaction(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForParty(request.commands.map(_.party))
+      .fold(Future.failed(_), _ => service.submitAndWaitForTransaction(request))
+
+  override def submitAndWaitForTransactionId(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionIdResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForParty(request.commands.map(_.party))
+      .fold(Future.failed(_), _ => service.submitAndWaitForTransactionId(request))
+
+  override def submitAndWaitForTransactionTree(
+      request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForParty(request.commands.map(_.party))
+      .fold(Future.failed(_), _ => service.submitAndWaitForTransactionTree(request))
+
+  override def bindService(): ServerServiceDefinition =
+    CommandServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/CommandSubmissionServiceAuthorization.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
+import com.digitalasset.ledger.api.v1.command_submission_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import com.google.protobuf.empty.Empty
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class CommandSubmissionServiceAuthorization(
+    protected val service: CommandSubmissionService with AutoCloseable,
+    protected val authService: AuthService)
+    extends CommandSubmissionService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(CommandSubmissionService.getClass)
+
+  override def submit(request: SubmitRequest): Future[Empty] =
+    ApiServiceAuthorization
+      .requireClaimsForParty(request.commands.map(_.party))
+      .fold(Future.failed(_), _ => service.submit(request))
+
+  override def bindService(): ServerServiceDefinition =
+    CommandSubmissionServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/LedgerConfigurationServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/LedgerConfigurationServiceAuthorization.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.ledger_configuration_service.LedgerConfigurationServiceGrpc.LedgerConfigurationService
+import com.digitalasset.ledger.api.v1.ledger_configuration_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+import org.slf4j.{Logger, LoggerFactory}
+
+class LedgerConfigurationServiceAuthorization(
+    protected val service: LedgerConfigurationService with AutoCloseable,
+    protected val authService: AuthService)
+    extends LedgerConfigurationService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(LedgerConfigurationService.getClass)
+
+  override def getLedgerConfiguration(
+      request: GetLedgerConfigurationRequest,
+      responseObserver: StreamObserver[GetLedgerConfigurationResponse]): Unit =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(
+        responseObserver.onError,
+        _ => service.getLedgerConfiguration(request, responseObserver))
+
+  override def bindService(): ServerServiceDefinition =
+    LedgerConfigurationServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/LedgerIdentityServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/LedgerIdentityServiceAuthorization.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  GetLedgerIdentityResponse,
+  LedgerIdentityServiceGrpc
+}
+import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class LedgerIdentityServiceAuthorization(
+    protected val service: LedgerIdentityServiceGrpc.LedgerIdentityService with AutoCloseable,
+    protected val authService: AuthService)
+    extends LedgerIdentityServiceGrpc.LedgerIdentityService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(LedgerIdentityService.getClass)
+
+  override def getLedgerIdentity(
+      request: GetLedgerIdentityRequest): Future[GetLedgerIdentityResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.getLedgerIdentity(request))
+
+  override def bindService(): ServerServiceDefinition =
+    LedgerIdentityServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PackageManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PackageManagementServiceAuthorization.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc.PackageManagementService
+import com.digitalasset.ledger.api.v1.admin.package_management_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class PackageManagementServiceAuthorization(
+    protected val service: PackageManagementService with AutoCloseable,
+    protected val authService: AuthService)
+    extends PackageManagementService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(PackageManagementService.getClass)
+
+  override def listKnownPackages(
+      request: ListKnownPackagesRequest): Future[ListKnownPackagesResponse] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.listKnownPackages(request))
+
+  override def uploadDarFile(request: UploadDarFileRequest): Future[UploadDarFileResponse] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.uploadDarFile(request))
+
+  override def bindService(): ServerServiceDefinition =
+    PackageManagementServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PackageServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PackageServiceAuthorization.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc.PackageService
+import com.digitalasset.ledger.api.v1.package_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class PackageServiceAuthorization(
+    protected val service: PackageService with AutoCloseable,
+    protected val authService: AuthService)
+    extends PackageService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(PackageService.getClass)
+
+  override def listPackages(request: ListPackagesRequest): Future[ListPackagesResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.listPackages(request))
+
+  override def getPackage(request: GetPackageRequest): Future[GetPackageResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.getPackage(request))
+
+  override def getPackageStatus(
+      request: GetPackageStatusRequest): Future[GetPackageStatusResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.getPackageStatus(request))
+
+  override def bindService(): ServerServiceDefinition =
+    PackageServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/PartyManagementServiceAuthorization.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.admin.party_management_service.{
+  AllocatePartyRequest,
+  AllocatePartyResponse,
+  GetParticipantIdRequest,
+  GetParticipantIdResponse,
+  ListKnownPartiesRequest,
+  ListKnownPartiesResponse,
+  PartyManagementServiceGrpc
+}
+import com.digitalasset.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc.PartyManagementService
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class PartyManagementServiceAuthorization(
+    protected val service: PartyManagementService with AutoCloseable,
+    protected val authService: AuthService)
+    extends PartyManagementService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(PartyManagementService.getClass)
+
+  override def getParticipantId(
+      request: GetParticipantIdRequest): Future[GetParticipantIdResponse] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.getParticipantId(request))
+
+  override def allocateParty(request: AllocatePartyRequest): Future[AllocatePartyResponse] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.allocateParty(request))
+
+  override def listKnownParties(
+      request: ListKnownPartiesRequest): Future[ListKnownPartiesResponse] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.listKnownParties(request))
+
+  override def bindService(): ServerServiceDefinition =
+    PartyManagementServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TimeServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TimeServiceAuthorization.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService
+import com.digitalasset.ledger.api.v1.testing.time_service._
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import com.google.protobuf.empty.Empty
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class TimeServiceAuthorization(
+    protected val service: TimeService with AutoCloseable,
+    protected val authService: AuthService)
+    extends TimeService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(TimeService.getClass)
+
+  override def getTime(
+      request: GetTimeRequest,
+      responseObserver: StreamObserver[GetTimeResponse]): Unit =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(responseObserver.onError, _ => service.getTime(request, responseObserver))
+
+  override def setTime(request: SetTimeRequest): Future[Empty] =
+    ApiServiceAuthorization
+      .requireAdminClaims()
+      .fold(Future.failed(_), _ => service.setTime(request))
+
+  override def bindService(): ServerServiceDefinition =
+    TimeServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TransactionServiceAuthorization.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.server.api.authorization.services
+
+import com.daml.ledger.participant.state.v1.AuthService
+import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
+import com.digitalasset.ledger.api.v1.transaction_service
+import com.digitalasset.ledger.api.v1.transaction_service.{
+  GetFlatTransactionResponse,
+  GetLedgerEndRequest,
+  GetLedgerEndResponse,
+  GetTransactionResponse,
+  GetTransactionTreesResponse,
+  GetTransactionsResponse,
+  TransactionServiceGrpc
+}
+import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionService
+import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.server.api.ProxyCloseable
+import com.digitalasset.platform.server.api.authorization.ApiServiceAuthorization
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Future
+
+class TransactionServiceAuthorization(
+    protected val service: TransactionService with AutoCloseable,
+    protected val authService: AuthService)
+    extends TransactionService
+    with ProxyCloseable
+    with GrpcApiService {
+
+  protected val logger: Logger = LoggerFactory.getLogger(TransactionService.getClass)
+
+  override def getTransactions(
+      request: transaction_service.GetTransactionsRequest,
+      responseObserver: StreamObserver[GetTransactionsResponse]): Unit =
+    // TODO(RC): To implement claims expiration, get the expiration date here and create a
+    // wrapping StreamObserver that checks the expiration date on each callback.
+    // OR: overwrite getTransactionsSource from [[GrpcTransactionService]] and kill the source
+    // as soon as the claims expire.
+    ApiServiceAuthorization
+      .requireClaimsForTransactionFilter(request.filter)
+      .fold(responseObserver.onError(_), _ => service.getTransactions(request, responseObserver))
+
+  override def getTransactionTrees(
+      request: transaction_service.GetTransactionsRequest,
+      responseObserver: StreamObserver[GetTransactionTreesResponse]): Unit =
+    ApiServiceAuthorization
+      .requireClaimsForTransactionFilter(request.filter)
+      .fold(
+        responseObserver.onError(_),
+        _ => service.getTransactionTrees(request, responseObserver))
+
+  override def getTransactionByEventId(
+      request: transaction_service.GetTransactionByEventIdRequest): Future[GetTransactionResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForAllParties(request.requestingParties.toSet)
+      .fold(Future.failed(_), _ => service.getTransactionByEventId(request))
+
+  override def getTransactionById(
+      request: transaction_service.GetTransactionByIdRequest): Future[GetTransactionResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForAllParties(request.requestingParties.toSet)
+      .fold(Future.failed(_), _ => service.getTransactionById(request))
+
+  override def getFlatTransactionByEventId(
+      request: transaction_service.GetTransactionByEventIdRequest)
+    : Future[GetFlatTransactionResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForAllParties(request.requestingParties.toSet)
+      .fold(Future.failed(_), _ => service.getFlatTransactionByEventId(request))
+
+  override def getFlatTransactionById(
+      request: transaction_service.GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
+    ApiServiceAuthorization
+      .requireClaimsForAllParties(request.requestingParties.toSet)
+      .fold(Future.failed(_), _ => service.getFlatTransactionById(request))
+
+  override def getLedgerEnd(request: GetLedgerEndRequest): Future[GetLedgerEndResponse] =
+    ApiServiceAuthorization
+      .requirePublicClaims()
+      .fold(Future.failed(_), _ => service.getLedgerEnd(request))
+
+  override def bindService(): ServerServiceDefinition =
+    TransactionServiceGrpc.bindService(this, DirectExecutionContext)
+
+  override def close(): Unit = service.close()
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/authorization/services/TransactionServiceAuthorization.scala
@@ -37,7 +37,7 @@ class TransactionServiceAuthorization(
   override def getTransactions(
       request: transaction_service.GetTransactionsRequest,
       responseObserver: StreamObserver[GetTransactionsResponse]): Unit =
-    // TODO(RC): To implement claims expiration, get the expiration date here and create a
+    // TODO(RA): To implement claims expiration, get the expiration date here and create a
     // wrapping StreamObserver that checks the expiration date on each callback.
     // OR: overwrite getTransactionsSource from [[GrpcTransactionService]] and kill the source
     // as soon as the claims expire.

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ApiCommandService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/command/ApiCommandService.scala
@@ -27,6 +27,7 @@ import com.digitalasset.ledger.client.services.commands.{
   CommandTrackerFlow
 }
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
+import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.server.api.ApiException
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandService
 import com.digitalasset.platform.server.services.command.ApiCommandService.LowLevelCommandServiceAccess
@@ -185,7 +186,7 @@ object ApiCommandService {
       implicit grpcExecutionContext: ExecutionContext,
       actorMaterializer: ActorMaterializer,
       esf: ExecutionSequencerFactory
-  ): CommandServiceGrpc.CommandService with BindableService with CommandServiceLogging =
+  ): CommandServiceGrpc.CommandService with GrpcApiService with CommandServiceLogging =
     new GrpcCommandService(
       new ApiCommandService(svcAccess, configuration, loggerFactory),
       configuration.ledgerId

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ApiTimeService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ApiTimeService.scala
@@ -20,7 +20,7 @@ import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.server.api.validation.FieldValidations
 import com.google.protobuf.empty.Empty
 
-import io.grpc.{BindableService, ServerServiceDefinition, Status, StatusRuntimeException}
+import io.grpc.{ServerServiceDefinition, Status, StatusRuntimeException}
 import org.slf4j.Logger
 import scalaz.syntax.tag._
 
@@ -132,7 +132,7 @@ object ApiTimeService {
   def create(ledgerId: LedgerId, backend: TimeServiceBackend, loggerFactory: NamedLoggerFactory)(
       implicit grpcExecutionContext: ExecutionContext,
       mat: Materializer,
-      esf: ExecutionSequencerFactory): TimeService with BindableService with TimeServiceLogging = {
+      esf: ExecutionSequencerFactory): TimeService with GrpcApiService with TimeServiceLogging = {
     val loggerOverride = loggerFactory.getLogger(TimeServiceGrpc.TimeService.getClass)
     new ApiTimeService(ledgerId, backend, loggerOverride) with TimeServiceLogging {
       override protected val logger = loggerOverride

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -19,6 +19,7 @@ da_scala_library(
     deps = [
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/typesafe/akka:akka_stream",
+        "//3rdparty/jvm/io/grpc:grpc_services",
         "//daml-lf/archive:daml_lf_java_proto",
         "//daml-lf/data",
         "//daml-lf/transaction",

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/AuthService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/AuthService.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import java.util.concurrent.CompletionStage
+
+/** An interface for authorizing the ledger API access to a participant.
+  *
+  * The AuthService is responsible for converting request metadata (such as
+  * the HTTP headers) into a set of [[Claims]].
+  * These claims are then used by the ledger API server to check whether the
+  * request is authorized.
+  *
+  * For example, a participant could:
+  * - Ask all ledger API users to attach an `Authorization` header
+  *   with a JWT token as the header value.
+  * - Implement `decodeMetadata()` such that it reads the JWT token
+  *   from the corresponding HTTP header, validates the token,
+  *   and converts the token payload to [[Claims]].
+  */
+trait AuthService {
+
+  /** Converts gRPC request metadata into a set of [[Claims]].
+    *
+    *  @param headers All HTTP headers attached to the request.
+    *
+    */
+  def decodeMetadata(headers: io.grpc.Metadata): CompletionStage[Claims]
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Claims.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Claims.scala
@@ -58,7 +58,7 @@ final case class ClaimActAsParty(name: Ref.Party) extends Claim
   * | PackageManagementService            | *                          | isAdmin                                  |
   * | PartyManagementService              | *                          | isAdmin                                  |
   * | ResetService                        | *                          | isAdmin                                  |
-  * | TimeService                         | *                          | ???                                      |
+  * | TimeService                         | *                          | isAdmin                                  |
   * | TransactionService                  | LedgerEnd                  | isPublic                                 |
   * | TransactionService                  | *                          | for each requested party p: canActAs(p)  |
   * +-------------------------------------+----------------------------+------------------------------------------+

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Claims.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Claims.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.daml.lf.data.Ref
+
+/**
+  * A claim is a single statement about what an authenticated user can do with the ledger API.
+  *
+  * Note: this ADT is expected to evolve in the future by adding new cases for more fine grained claims.
+  * The existing cases should be treated as immutable in order to guarantee backwards compatibility for
+  * [[AuthService]] implementations.
+  */
+sealed abstract class Claim
+
+/** Authorized to use all admin services.
+  * Does not authorize to use non-admin services.
+  */
+case object ClaimAdmin extends Claim
+
+/** Authorized to use all "public" services, i.e.,
+  * those that do not require admin rights and do not depend on any DAML party.
+  * Examples include the LedgerIdentityService or the PackageService.
+  */
+case object ClaimPublic extends Claim
+
+/** Authorized to act as any party, including:
+  * - Reading all data for all parties
+  * - Creating contract on behalf of any party
+  * - Exercising choices on behalf of any party
+  */
+case object ClaimActAsAnyParty extends Claim
+
+/** Authorized to act as the given party, including:
+  * - Reading all data for the given party
+  * - Creating contracts on behalf of the given party
+  * - Exercising choices on behalf of the given party
+  */
+final case class ClaimActAsParty(name: Ref.Party) extends Claim
+
+/**
+  * [[Claims]] define what actions an authenticated user can perform on the ledger API.
+  *
+  *
+  * The following is a full list of services and the corresponding required claims:
+  * +-------------------------------------+----------------------------+------------------------------------------+
+  * | Ledger API service                  | Method                     | Access with                              |
+  * +-------------------------------------+----------------------------+------------------------------------------+
+  * | LedgerIdentityService               | GetLedgerIdentity          | isPublic                                 |
+  * | ActiveContractsService              | GetActiveContracts         | for each requested party p: canActAs(p)  |
+  * | CommandSubmissionService            | Submit                     | for submitting party p: canActAs(p)      |
+  * | CommandCompletionService            | CompletionEnd              | isPublic                                 |
+  * | CommandCompletionService            | CompletionStream           | for each requested party p: canActAs(p)  |
+  * | CommandService                      | *                          | for submitting party p: canActAs(p)      |
+  * | LedgerConfigurationService          | GetLedgerConfiguration     | isPublic                                 |
+  * | PackageService                      | *                          | isPublic                                 |
+  * | PackageManagementService            | *                          | isAdmin                                  |
+  * | PartyManagementService              | *                          | isAdmin                                  |
+  * | ResetService                        | *                          | isAdmin                                  |
+  * | TimeService                         | *                          | ???                                      |
+  * | TransactionService                  | LedgerEnd                  | isPublic                                 |
+  * | TransactionService                  | *                          | for each requested party p: canActAs(p)  |
+  * +-------------------------------------+----------------------------+------------------------------------------+
+  */
+case class Claims(claims: Seq[Claim]) {
+
+  /** Returns true if the set of claims authorizes the user to use admin services */
+  def isAdmin: Boolean = claims.exists {
+    case ClaimAdmin => true
+    case _ => false
+  }
+
+  /** Returns true if the set of claims authorizes the user to use public services */
+  def isPublic: Boolean = claims.exists {
+    case ClaimPublic => true
+    case _ => false
+  }
+
+  /** Returns true if the set of claims authorizes the user to act as the given party */
+  def canActAs(party: String): Boolean = claims.exists {
+    case ClaimActAsAnyParty => true
+    case ClaimActAsParty(p) => p == party
+    case _ => false
+  }
+}
+
+object Claims {
+
+  /** A set of [[Claims]] that does not have any authorization */
+  def empty: Claims = Claims(List.empty[Claim])
+
+  /** A set of [[Claims]] that has all possible authorizations */
+  def wildcard: Claims = Claims(List[Claim](ClaimPublic, ClaimAdmin, ClaimActAsAnyParty))
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
@@ -139,10 +139,13 @@ object ApiServices {
 
       val apiTimeServiceOpt =
         optTimeServiceBackend.map { tsb =>
-          ApiTimeService.create(
-            ledgerId,
-            tsb,
-            loggerFactory
+          new TimeServiceAuthorization(
+            ApiTimeService.create(
+              ledgerId,
+              tsb,
+              loggerFactory
+            ),
+            authService
           )
         }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -90,7 +90,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
   // TODO: Pass this info in command-line (See issue #2025)
   val participantId: ParticipantId = Ref.LedgerString.assertFromString("sandbox-participant")
 
-  private val authService: AuthService = AuthServiceWildcard()
+  private val authService: AuthService = AuthServiceWildcard
 
   case class ApiServerState(
       ledgerId: LedgerId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiActiveContractsService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiActiveContractsService.scala
@@ -102,7 +102,7 @@ object ApiActiveContractsService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory)
-    : ActiveContractsService with BindableService with ActiveContractsServiceLogging =
+    : ActiveContractsService with GrpcApiService with ActiveContractsServiceLogging =
     new ActiveContractsServiceValidation(
       new ApiActiveContractsService(backend, loggerFactory = loggerFactory)(ec, mat, esf),
       ledgerId

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiCommandCompletionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiCommandCompletionService.scala
@@ -16,11 +16,12 @@ import com.digitalasset.ledger.api.messages.command.completion.CompletionStreamR
 import com.digitalasset.ledger.api.v1.command_completion_service._
 import com.digitalasset.ledger.api.validation.PartyNameChecker
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
+import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.participant.util.Slf4JLog
 import com.digitalasset.platform.server.api.services.domain.CommandCompletionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandCompletionService
-import io.grpc.{BindableService, ServerServiceDefinition}
+import io.grpc.ServerServiceDefinition
 import org.slf4j.Logger
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -65,15 +66,13 @@ object ApiCommandCompletionService {
       loggerFactory: NamedLoggerFactory)(
       implicit ec: ExecutionContext,
       mat: Materializer,
-      esf: ExecutionSequencerFactory): GrpcCommandCompletionService
-    with BindableService
-    with AutoCloseable
-    with CommandCompletionServiceLogging = {
+      esf: ExecutionSequencerFactory)
+    : GrpcCommandCompletionService with GrpcApiService with CommandCompletionServiceLogging = {
     val impl: CommandCompletionService =
       new ApiCommandCompletionService(completionsService, loggerFactory)
 
     new GrpcCommandCompletionService(ledgerId, impl, PartyNameChecker.AllowAllParties)
-    with BindableService with CommandCompletionServiceLogging {
+    with GrpcApiService with CommandCompletionServiceLogging {
       override val logger: Logger = loggerFactory.getLogger(impl.getClass)
       override def bindService(): ServerServiceDefinition =
         CommandCompletionServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiLedgerConfigurationService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiLedgerConfigurationService.scala
@@ -50,8 +50,9 @@ object ApiLedgerConfigurationService {
       loggerFactory: NamedLoggerFactory)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
-      mat: Materializer)
-    : GrpcApiService with BindableService with LedgerConfigurationServiceLogging =
+      mat: Materializer): LedgerConfigurationServiceGrpc.LedgerConfigurationService
+    with GrpcApiService
+    with LedgerConfigurationServiceLogging =
     new LedgerConfigurationServiceValidation(
       new ApiLedgerConfigurationService(configurationService),
       ledgerId) with BindableService with LedgerConfigurationServiceLogging {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiPackageService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiPackageService.scala
@@ -89,7 +89,7 @@ class ApiPackageService private (backend: IndexPackagesService)
 object ApiPackageService {
   def create(ledgerId: LedgerId, backend: IndexPackagesService, loggerFactory: NamedLoggerFactory)(
       implicit ec: ExecutionContext)
-    : PackageService with BindableService with PackageServiceLogging =
+    : PackageService with GrpcApiService with PackageServiceLogging =
     new PackageServiceValidation(new ApiPackageService(backend), ledgerId) with BindableService
     with PackageServiceLogging {
       override protected val logger = loggerFactory.getLogger(PackageService.getClass)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
@@ -25,13 +25,14 @@ import com.digitalasset.grpc.adapter.utils.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.digitalasset.ledger.api.messages.command.submission.SubmitRequest
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
+import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.sandbox.stores.ledger.{CommandExecutor, ErrorCause}
 import com.digitalasset.platform.server.api.services.domain.CommandSubmissionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandSubmissionService
 import com.digitalasset.platform.server.api.validation.ErrorFactories
 import com.digitalasset.platform.server.services.command.time.TimeModelValidator
 
-import io.grpc.{BindableService, Status}
+import io.grpc.Status
 import scalaz.syntax.tag._
 
 import scala.compat.java8.FutureConverters
@@ -50,7 +51,7 @@ object ApiSubmissionService {
       timeProvider: TimeProvider,
       commandExecutor: CommandExecutor,
       loggerFactory: NamedLoggerFactory)(implicit ec: ExecutionContext, mat: ActorMaterializer)
-    : GrpcCommandSubmissionService with BindableService with CommandSubmissionServiceLogging =
+    : GrpcCommandSubmissionService with GrpcApiService with CommandSubmissionServiceLogging =
     new GrpcCommandSubmissionService(
       new ApiSubmissionService(
         contractStore,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -122,7 +122,8 @@ object ApiPackageManagementService {
   def createApiService(
       readBackend: IndexPackagesService,
       writeBackend: WritePackagesService,
-      loggerFactory: NamedLoggerFactory)(implicit mat: ActorMaterializer): GrpcApiService =
+      loggerFactory: NamedLoggerFactory)(implicit mat: ActorMaterializer)
+    : PackageManagementServiceGrpc.PackageManagementService with GrpcApiService =
     new ApiPackageManagementService(readBackend, writeBackend, mat.system.scheduler, loggerFactory)
     with PackageManagementServiceLogging
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -111,7 +111,8 @@ object ApiPartyManagementService {
       loggerFactory: NamedLoggerFactory)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
-      mat: ActorMaterializer): GrpcApiService =
+      mat: ActorMaterializer)
+    : PartyManagementServiceGrpc.PartyManagementService with GrpcApiService =
     new ApiPartyManagementService(readBackend, writeBackend, mat.system.scheduler, loggerFactory)
     with PartyManagementServiceLogging
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.time.Instant
 
 import akka.stream.ActorMaterializer
-import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.participant.state.v1.{AuthService, ParticipantId}
 import com.digitalasset.api.util.{TimeProvider, ToleranceWindow}
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
@@ -46,9 +46,10 @@ trait TestHelpers {
   }
 
   // TODO: change damle flag to LF once finished implementation
-  protected def submissionService(timeProvider: TimeProvider, toleranceWindow: ToleranceWindow)(
-      implicit ec: ExecutionContext,
-      mat: ActorMaterializer) = {
+  protected def submissionService(
+      timeProvider: TimeProvider,
+      toleranceWindow: ToleranceWindow,
+      authService: AuthService)(implicit ec: ExecutionContext, mat: ActorMaterializer) = {
 
     implicit val mm: MetricsManager = MetricsManager()
 


### PR DESCRIPTION
This PR introduces ledger API authorization.

## Overview
- Introduce an `AuthService`, to be implemented by ledger operators.
- Add a `AuthorizationInterceptor` that decodes HTTP headers into `Claims` using the above `AuthService`.
- Check claims in all ledger API services
- Currently, the sandbox and all DAML-on-X servers use the hardcoded `AuthServiceWildcard`, which blindly authorizes all requests.

Documentation and tests will follow in future PRs.

## References

Fixes #3021.
Fixes #3022.
Fixes #3024.
Fixes #3025.
Fixes #3026.
Fixes #3027.
Fixes #3028.
Fixes #3029.
Fixes #3030.
Fixes #3031.
Fixes #3032.
Fixes #3033.
Fixes #3034.
Fixes #3035.
