### PR TITLE
Simplify the Haskell implementation of the DAML-LF decoder

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
@@ -8,10 +8,10 @@ module DA.Daml.LF.Proto3.Decode
 
 import Da.DamlLf (ArchivePayload(..), ArchivePayloadSum(..))
 import DA.Daml.LF.Ast (Package)
-import DA.Daml.LF.Proto3.Error (Error(ParseError), Decode)
+import DA.Daml.LF.Proto3.Error
 import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
 
-decodePayload :: ArchivePayload -> Decode Package
+decodePayload :: ArchivePayload -> Either Error Package
 decodePayload payload = case archivePayloadSum payload of
     Just ArchivePayloadSumDamlLf0{} -> Left $ ParseError "Payload is DamlLf0"
     Just (ArchivePayloadSumDamlLf1 package) -> DecodeV1.decodePackage minor package

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -2,8 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module DA.Daml.LF.Proto3.Error
-    ( Decode
-    , Error(..)
+    ( Error(..)
     ) where
 
 import qualified Data.Text as T
@@ -25,5 +24,3 @@ data Error
   | MissingPackageRefId Word64
   | ExpectedTCon Type
   deriving (Show, Eq)
-
-type Decode = Either Error


### PR DESCRIPTION
Right now, some functions are polymorphic in the monad we use. This is
absolutely unnecessary.

This PR fixes one monad and uses it all over the place. This is a pure
refactoring which doesn't change any functionality.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3053)
<!-- Reviewable:end -->
