### PR TITLE
Bundle packages with SDK releases

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -11,7 +11,7 @@ module DA.Cli.Damlc (main) where
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
 import qualified "zip" Codec.Archive.Zip as Zip
 import Control.Exception
-import Control.Exception.Safe (catchIO)
+import Control.Exception.Safe (catchIO, handleIO)
 import Control.Monad.Except
 import Control.Monad.Extra (whenM)
 import DA.Bazel.Runfiles
@@ -486,7 +486,28 @@ createProjectPackageDb ::
 createProjectPackageDb (AllowDifferentSdkVersions allowDiffSdkVersions) lfVersion fps = do
     let dbPath = projectPackageDatabase </> lfVersionString lfVersion
     createDirectoryIfMissing True $ dbPath </> "package.conf.d"
-    let fps0 = filter (`notElem` basePackages) fps
+    -- Expand SDK package dependencies using the SDK root path.
+    -- E.g. `daml-trigger` --> `$DAML_SDK/daml-libs/daml-trigger.dar`
+    -- Or, fail if not run from DAML assistant.
+    mbSdkPath <- handleIO (\_ -> pure Nothing) $ Just <$> getSdkPath
+    let isSdkPackage fp = takeExtension fp /= ".dar"
+        handleSdkPackages :: [FilePath] -> IO [FilePath]
+        handleSdkPackages = case mbSdkPath of
+          Just sdkPath ->
+            let expand fp
+                  | isSdkPackage fp
+                  = sdkPath </> "daml-libs" </> fp <.> "dar"
+                  | otherwise
+                  = fp
+            in pure . map expand
+          Nothing ->
+            let expand fp
+                  | isSdkPackage fp
+                  = fail $ "Cannot resolve SDK dependency '" ++ fp ++ "'. Use daml-assistant."
+                  | otherwise
+                  = pure fp
+            in mapM expand
+    fps0 <- handleSdkPackages $ filter (`notElem` basePackages) fps
     sdkVersions <-
         forM fps0 $ \fp -> do
             bs <- BSL.readFile fp

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -73,6 +73,7 @@ genrule(
         "//ledger-service/http-json:http-json-binary_deploy.jar",
         "//language-support/codegen-main:codegen-main_deploy.jar",
         "//templates:templates-tarball.tar.gz",
+        "//triggers/daml:daml-trigger.dar",
     ],
     outs = ["sdk-release-tarball.tar.gz"],
     cmd = """
@@ -94,6 +95,9 @@ genrule(
 
       mkdir -p $$OUT/damlc
       tar xf $(location //compiler/damlc:damlc-dist) --strip-components=1 -C $$OUT/damlc
+
+      mkdir -p $$OUT/daml-libs
+      cp -t $$OUT/daml-libs $(location //triggers/daml:daml-trigger.dar)
 
       mkdir -p $$OUT/daml-helper
       tar xf $(location //daml-assistant/daml-helper:daml-helper-dist) --strip-components=1 -C $$OUT/daml-helper

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -5,9 +5,9 @@
 # daml_compile instead of a genrule.
 
 genrule(
-    name = "trigger",
+    name = "daml-trigger",
     srcs = glob(["**/*.daml"]),
-    outs = ["trigger.dar"],
+    outs = ["daml-trigger.dar"],
     cmd = """
       set -eou pipefail
       TMP_DIR=$$(mktemp -d)
@@ -15,14 +15,14 @@ genrule(
       cp -L $(location Daml/Trigger.daml) $$TMP_DIR/daml/Daml
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: 0.0.0
-name: trigger
+name: daml-trigger
 source: daml
 version: 0.0.1
 dependencies:
   - daml-stdlib
   - daml-prim
 EOF
-      $(location //compiler/damlc) build --target=1.dev --project-root=$$TMP_DIR -o $$PWD/$(location trigger.dar)
+      $(location //compiler/damlc) build --target=1.dev --project-root=$$TMP_DIR -o $$PWD/$(location daml-trigger.dar)
       rm -rf $$TMP_DIR
     """,
     tools = ["//compiler/damlc"],

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -14,7 +14,7 @@ genrule(
     name = "acs",
     srcs =
         glob(["**/*.daml"]) + [
-            "//triggers/daml:trigger.dar",
+            "//triggers/daml:daml-trigger.dar",
         ],
     outs = ["acs.dar"],
     cmd = """
@@ -22,7 +22,7 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location :daml/ACS.daml) $$TMP_DIR/daml
-      cp -L $(location //triggers/daml:trigger.dar) $$TMP_DIR/
+      cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: 0.0.0
 name: acs
@@ -31,7 +31,7 @@ version: 0.0.1
 dependencies:
   - daml-stdlib
   - daml-prim
-  - trigger.dar
+  - daml-trigger.dar
 EOF
       $(location //compiler/damlc) build --target=1.dev --project-root=$$TMP_DIR -o $$PWD/$(location acs.dar)
       rm -rf $$TMP_DIR

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,6 +10,11 @@ HEAD — ongoing
 --------------
 
 + [JSON API - Experimental] Returning archived and active/created contracts from ``/command/exercise``
++ [SDK] Bundle the ``daml-trigger`` package. Note, this package is experimental and will change.
++ [SDK] Releases can now bundle additional libraries with the SDK in ``$DAML_SDK/daml-libs``. You
+  can refer to them in your ``daml.yaml`` file by listing the package name without ``.dar``
+  extension. See `issue #2979 <https://github.com/digital-asset/daml/issues/2979>`_.
++ [JSON API - Experimental] Returning archived and active contracts from ``/command/exercise``
   enpoint. See `issue #2925 <https://github.com/digital-asset/daml/issues/2925>`_.
 + [JSON API - Experimental] Flattening the output of the ``/contracts/search`` endpoint.
   The endpoint returns ``ActiveContract`` objects without ``GetActiveContractsResponse`` wrappers.


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/2979

- Packages can be bundled with the SDK in `$DAML_SDK/daml-libs`.
- Bundled packages can be referenced in `daml.yaml`'s `dependencies` by package name without `.dar` extension.
- Bundle the `daml-trigger` package. (Package will change in the future)
- Add to daml-assistant integration tests.
- Update changelog.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
