### PR TITLE
Refactor DAML-LF encoder/decoder in prep for string interning

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -9,7 +9,6 @@ import Data.Char
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Internal as T (text)
-import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Array as TA
 import Data.Word
 
@@ -37,7 +36,7 @@ import Data.Word
 -- and, value reference names are non-empty sequences of
 -- identifiers. Such sequence of identifier are called *dotted name*
 -- in the proto encoding/decoding code.
--- 
+--
 -- IMPORTANT: keep in sync with
 -- `com.digitalasset.daml.lf.data.Ref.DottedName.fromSegments`
 
@@ -64,12 +63,12 @@ ord' = fromIntegral . ord
 -- can avoid allocating new `Text`s and we optimize the case where we do have to
 -- mangle by preallocating the array of the right size and writing the characters
 -- directly to that.
-mangleIdentifier :: T.Text -> Either String TL.Text
+mangleIdentifier :: T.Text -> Either String T.Text
 mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
     MangledSize 0 _ -> Left "Empty identifier"
     MangledSize chars word16s
-      | chars == word16s -> Right $! TL.fromStrict txt
-      | otherwise -> Right $! TL.fromStrict $
+      | chars == word16s -> Right txt
+      | otherwise -> Right $!
         let !arr = TA.run $ do
             a <- TA.new word16s
             let poke !j !minj !x

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -50,12 +50,12 @@ lookupString strIdW = do
 -- Decodings of things related to string interning
 ------------------------------------------------------------------------
 
--- | Encode of a string that cannot be interned, e.g, the entries of the
+-- | Decode of a string that cannot be interned, e.g, the entries of the
 -- interning table itself.
 decodeString :: TL.Text -> T.Text
 decodeString = TL.toStrict
 
--- | Encode a string that will be interned in DAML-LF 1.7 and onwards.
+-- | Decode a string that will be interned in DAML-LF 1.7 and onwards.
 decodeInternableString :: TL.Text -> Decode T.Text
 decodeInternableString = pure . decodeString
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -96,7 +96,7 @@ data ContextUpdate = ContextUpdate
 
 encodeModule :: LF.Version -> LF.Module -> BS.ByteString
 encodeModule version m = case version of
-    LF.V1{} -> BSL.toStrict (Proto.toLazyByteString (EncodeV1.encodeModuleWithLargePackageIds version m))
+    LF.V1{} -> BSL.toStrict (Proto.toLazyByteString (EncodeV1.encodeModuleWithoutInterning version m))
 
 data BackendError
   = BErrorClient ClientError


### PR DESCRIPTION
Refactor the encoder/decoder such that all the functions concerned with
interning live next to each other and code will break once the types of
the protobuf messages change.

This PR is a pure refactoring and does not change any functionality.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3060)
<!-- Reviewable:end -->
