### PR TITLE
Fix automatic retry mechanism in scala bindings.

### DIFF
--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
@@ -97,7 +97,8 @@ object CommandRetryFlow {
         FlowShape(merge.in(PROPAGATE_PORT), retryDecider.out(PROPAGATE_PORT))
       })
 
-  private val RETRYABLE_ERROR_CODES = Set(Code.RESOURCE_EXHAUSTED_VALUE)
+  private[retrying] val RETRYABLE_ERROR_CODES =
+    Set(Code.RESOURCE_EXHAUSTED_VALUE, Code.UNAVAILABLE_VALUE)
 
   private def statusNotFoundError(commandId: String): Int =
     throw new RuntimeException(s"Status for command $commandId is missing.")

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -45,4 +45,4 @@ HEAD — ongoing
   This type definition is easier to use in the surface DAML and consistent with the types translated to DAML LF.
   The only change to user DAML is that uses of the ``TI`` ``newtype`` generated from
   ``template instance TI = T A1 .. AN`` should be simplified to use the type synonym ``type TI = T A1 .. AN``.
-+ [Scala Bindings] Fixed a bug in the retry logic of ``LedgerClientBinding#retryingConfirmedCommands``. Commands are now only retried when the server responds with status RESOURCE_EXHAUSTED.
++ [Scala Bindings] Fixed a bug in the retry logic of ``LedgerClientBinding#retryingConfirmedCommands``. Commands are now only retried when the server responds with status ``RESOURCE_EXHAUSTED`` or ``UNAVAILABLE``.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,3 +22,27 @@ HEAD — ongoing
   as JSON has been replaced with :doc:`/json-api/lf-value-specification`.  See `issue
   #3066 <https://github.com/digital-asset/daml/issues/3066>`_ for specifics.
 + [Scala Codegen] Fixes for StackOverflowErrors in reading large LF archives. See `issue #3104 <https://github.com/digital-asset/daml/issues/3104>`_.
++ [JSON API - Experimental] Returning archived and active/created contracts from ``/command/exercise``
+  enpoint. See `issue #2925 <https://github.com/digital-asset/daml/issues/2925>`_.
++ [JSON API - Experimental] Flattening the output of the ``/contracts/search`` endpoint.
+  The endpoint returns ``ActiveContract`` objects without ``GetActiveContractsResponse`` wrappers.
+  See `issue #2987 <https://github.com/digital-asset/daml/pull/2987>`_.
+- [DAML Assistant] ``daml start`` now supports ``--sandbox-option=opt``, ``--navigator-option=opt``
+  and ``--json-api-option=opt`` to pass additional option to sandbox/navigator/json-api.
+  These flags can be specified multiple times.
+- [DAML Studio] ``damlc ide`` now also supports a ``--target`` option.
+  The easiest way to specify this is the ``build-options`` field in ``daml.yaml``.
+- [Ledger]
+  Improve SQL backend performance by eliminating extra queries to the database.
+- [DAML Tool - Visual]
+  Adding `daml damlc visual-web` command. visual-command generates webpage with `d3 <https://d3js.org>`_ network.
++ [DAML Ledger Integration Kit] The transaction service is now fully tested.
+- [DAML Compiler] Fix a problem where constraints of the form ``Template (Foo t)`` caused the compiler to suggest enabling the ``UndecidableInstances`` language extension.
+- [Security] Document how to verify the signature on release tarballs.
++ [DAML Ledger Integration Kit] The TTL for commands is now read from the configuration service.
++ [DAML Ledger Integration Kit] The contract key tests now live under a single test suite and are multi-node aware.
+- [DAML Compiler] **BREAKING CHANGE** Desugar template instances to ``type`` synonyms instead of ``newtype``s.
+  This type definition is easier to use in the surface DAML and consistent with the types translated to DAML LF.
+  The only change to user DAML is that uses of the ``TI`` ``newtype`` generated from
+  ``template instance TI = T A1 .. AN`` should be simplified to use the type synonym ``type TI = T A1 .. AN``.
++ [Scala Bindings] Fixed a bug in the retry logic of ``LedgerClientBinding#retryingConfirmedCommands``. Commands are now only retried when the server responds with status RESOURCE_EXHAUSTED.

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,27 +22,5 @@ HEAD — ongoing
   as JSON has been replaced with :doc:`/json-api/lf-value-specification`.  See `issue
   #3066 <https://github.com/digital-asset/daml/issues/3066>`_ for specifics.
 + [Scala Codegen] Fixes for StackOverflowErrors in reading large LF archives. See `issue #3104 <https://github.com/digital-asset/daml/issues/3104>`_.
-+ [JSON API - Experimental] Returning archived and active/created contracts from ``/command/exercise``
-  enpoint. See `issue #2925 <https://github.com/digital-asset/daml/issues/2925>`_.
-+ [JSON API - Experimental] Flattening the output of the ``/contracts/search`` endpoint.
-  The endpoint returns ``ActiveContract`` objects without ``GetActiveContractsResponse`` wrappers.
-  See `issue #2987 <https://github.com/digital-asset/daml/pull/2987>`_.
-- [DAML Assistant] ``daml start`` now supports ``--sandbox-option=opt``, ``--navigator-option=opt``
-  and ``--json-api-option=opt`` to pass additional option to sandbox/navigator/json-api.
-  These flags can be specified multiple times.
-- [DAML Studio] ``damlc ide`` now also supports a ``--target`` option.
-  The easiest way to specify this is the ``build-options`` field in ``daml.yaml``.
-- [Ledger]
-  Improve SQL backend performance by eliminating extra queries to the database.
-- [DAML Tool - Visual]
-  Adding `daml damlc visual-web` command. visual-command generates webpage with `d3 <https://d3js.org>`_ network.
-+ [DAML Ledger Integration Kit] The transaction service is now fully tested.
-- [DAML Compiler] Fix a problem where constraints of the form ``Template (Foo t)`` caused the compiler to suggest enabling the ``UndecidableInstances`` language extension.
-- [Security] Document how to verify the signature on release tarballs.
-+ [DAML Ledger Integration Kit] The TTL for commands is now read from the configuration service.
-+ [DAML Ledger Integration Kit] The contract key tests now live under a single test suite and are multi-node aware.
-- [DAML Compiler] **BREAKING CHANGE** Desugar template instances to ``type`` synonyms instead of ``newtype``s.
-  This type definition is easier to use in the surface DAML and consistent with the types translated to DAML LF.
-  The only change to user DAML is that uses of the ``TI`` ``newtype`` generated from
-  ``template instance TI = T A1 .. AN`` should be simplified to use the type synonym ``type TI = T A1 .. AN``.
 + [Scala Bindings] Fixed a bug in the retry logic of ``LedgerClientBinding#retryingConfirmedCommands``. Commands are now only retried when the server responds with status ``RESOURCE_EXHAUSTED`` or ``UNAVAILABLE``.
+


### PR DESCRIPTION
This fix only affects the usage of
com.digitalasset.ledger.client.binding.LedgerClientBinding#retryingConfirmedCommands

The retry mechanism didn't distinguish between submission failures and
final completion failures. Retrying completion failures with the same
commandId doesn't make sense, as the deduplication mechanism will kick
in.
The new mechanism now only retries commands with an updated LET and MRT
in case the server responds with a RESOURCE_EXHAUSTED status code (i.e.
backpressure).

Fixes #3057.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
