### PR TITLE
fix hoogle; revert cache buckets ACL changes

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -29,13 +29,6 @@ resource "google_storage_bucket_object" "index_bazel_cache" {
   depends_on   = ["module.nix_cache"]
 }
 
-// Set ACL for ./index.html
-resource "google_storage_object_acl" "index_bazel_cache-acl" {
-  bucket         = "${module.bazel_cache.bucket_name}"
-  object         = "${google_storage_bucket_object.index_bazel_cache.name}"
-  predefined_acl = "publicRead"
-}
-
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
   bucket = "${module.bazel_cache.bucket_name}"

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -32,6 +32,7 @@ resource "google_compute_instance_template" "hoogle" {
 
   metadata_startup_script = <<STARTUP
 #! /bin/bash
+set -euo pipefail
 apt-get update
 apt-get -y upgrade
 ### stackdriver
@@ -73,7 +74,7 @@ curl -sSL https://get.haskellstack.org/ | sh
 runuser -u hoogle bash <<HOOGLE_SETUP
 git clone https://github.com/ndmitchell/hoogle.git
 cd hoogle
-stack init --resolver=nightly
+stack init --resolver=lts-14.7
 stack build
 stack install
 export PATH=/home/hoogle/.local/bin:$PATH

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -59,7 +59,7 @@ http {
   server {
     listen 8081 default_server;
     server_name _;
-    return 307 https://hoogle.daml.com$request_uri;
+    return 307 https://hoogle.daml.com\$request_uri;
   }
 }
 NGINX

--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -38,13 +38,6 @@ resource "google_storage_bucket_object" "index_nix_cache" {
   depends_on   = ["module.nix_cache"]
 }
 
-// Set ACL for ./index.html
-resource "google_storage_object_acl" "index_nix_cache-acl" {
-  bucket         = "${module.nix_cache.bucket_name}"
-  object         = "${google_storage_bucket_object.index_nix_cache.name}"
-  predefined_acl = "publicRead"
-}
-
 // provide a nix-cache-info file setting a higher priority
 // than cache.nixos.org, so we prefer it
 resource "google_storage_bucket_object" "nix-cache-info" {
@@ -58,13 +51,6 @@ Priority: 10
   EOF
 
   content_type = "text/plain"
-}
-
-// Set ACL for ./nix-cache-info
-resource "google_storage_object_acl" "nix-cache-info-acl" {
-  bucket         = "${module.nix_cache.bucket_name}"
-  object         = "${google_storage_bucket_object.nix-cache-info.name}"
-  predefined_acl = "publicRead"
 }
 
 output "nix_cache_ip" {


### PR DESCRIPTION
This has already been (successfully) applied. I will post the full transcript of the Terraform run as a comment below. There are two parts to this PR: undoing #2460 and fixing [Hoogle](https://hoogle.daml.com).

# Undoing ACL changes

Why? Simply put, because it broke Terraform. I have not been able to fully understand what is happening there, but somehow these three ACL instructions, although perfectly valid as per the documentation, seemed to hit a weird code path in Terraform, resulting in random error messages. Every time I ran `terraform plan` I got a different set of resource errors at the "refreshing state" step.

I have tried to investigate, commenting either some of the three blocks or some lines within the blocks, and it has just resulted in errors that seemed even more random, where the errors I got for a given set of files would depend on how I got there (i.e. in which order I uncommented specific lines).

Given that Hoogle is broken right now and that #2460 was, to begin with, a change we were not sure we would need, and then again even if we did it would only be if and when we ever had to recreate the Bazel and Nix caches from scratch, I've decided to go for the easy path of just reverting it.

# Fixing Hoogle

I am not familiar enough with the Haskell ecosystem to be positive here, but it seems to me more likely to be a stack snapshot issue than a Hoogle bug. Nonetheless, I have [reported the breakage to Hoogle](https://github.com/ndmitchell/hoogle/issues/321).

The fix is simple: I've just pinned the stack resolver to the last known-good version, rather than a floating nightly.