### PR TITLE
Update rest of standard library for Numeric

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Math.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Math.daml
@@ -1,10 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
-
 {-# LANGUAGE CPP #-}
 
+daml 1.2
 -- | Math - Utility Math functions for `Decimal`
 -- The this library is designed to give good precision, typically giving 9 correct decimal places.
 -- The numerical algorithms run with many iterations to achieve that precision and are interpreted

--- a/compiler/damlc/daml-stdlib-src/DA/Math.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Math.daml
@@ -2,6 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 daml 1.2
+
+{-# LANGUAGE CPP #-}
+
 -- | Math - Utility Math functions for `Decimal`
 -- The this library is designed to give good precision, typically giving 9 correct decimal places.
 -- The numerical algorithms run with many iterations to achieve that precision and are interpreted
@@ -125,7 +128,13 @@ tan x = s / c
     (c, s) = cordic 34 x
 
 -- | The number Pi
-pi = 3.1415926536
+#ifdef DAML_NUMERIC
+pi : Numeric n
+pi = 3.14159_26535_89793_23846_26433_83279_50288_41
+#else
+pi : Decimal
+pi = 3.14159_26536
+#endif
 
 -- | `cordic` is an implementation of the CORDIC algorithm.
 -- See https://en.wikipedia.org/wiki/CORDIC

--- a/compiler/damlc/daml-stdlib-src/DA/Text.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Text.daml
@@ -2,6 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 daml 1.2
+
+{-# LANGUAGE CPP #-}
+
 -- | Functions for working with Text.
 module DA.Text
   ( Text
@@ -44,6 +47,9 @@ module DA.Text
   , DA.Text.isAlpha
   , DA.Text.isAlphaNum
   , DA.Text.parseInt
+#ifdef DAML_NUMERIC
+  , DA.Text.parseNumeric
+#endif
   , DA.Text.parseDecimal
   , DA.Text.sha256
   , DA.Text.toCodePoints
@@ -257,6 +263,22 @@ isAlphaNum = isPred (\t -> t >= "0" && t <= "9" || t >= "a" && t <= "z" || t >= 
 parseInt : Text -> Optional Int
 parseInt = primitive @"BEInt64FromText"
 
+#ifdef DAML_NUMERIC
+-- | Attempt to parse a `Numeric` value from a given `Text`.
+-- To get `Some` value, the text must follow the regex
+-- `(-|\+)?[0-9]+(\.[0-9]+)?`
+-- In particular, the shorthands `".12"` and `"12."` do not work,
+-- but the value can be prefixed with `+`.
+-- Leading and trailing zeros are fine, however spaces are not.
+-- Examples:
+-- ```
+--   parseNumeric "3.14" == Some 3.14
+--   parseNumeric "+12.0" == Some 12
+-- ```
+parseNumeric : Text -> Optional (Numeric n)
+parseNumeric = primitive @"BENumericFromText"
+#endif
+
 -- | Attempt to parse a `Decimal` value from a given `Text`.
 -- To get `Some` value, the text must follow the regex
 -- `(-|\+)?[0-9]+(\.[0-9]+)?`
@@ -269,7 +291,11 @@ parseInt = primitive @"BEInt64FromText"
 --   parseDecimal "+12.0" == Some 12
 -- ```
 parseDecimal : Text -> Optional Decimal
+#ifdef DAML_NUMERIC
+parseDecimal = parseNumeric
+#else
 parseDecimal = primitive @"BEDecimalFromText"
+#endif
 
 -- | Computes the SHA256 of the UTF8 bytes of the `Text`, and returns it in its hex-encoded
 -- form. The hex encoding uses lowercase letters.

--- a/compiler/damlc/daml-stdlib-src/DA/Text.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Text.daml
@@ -1,10 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
-
 {-# LANGUAGE CPP #-}
 
+daml 1.2
 -- | Functions for working with Text.
 module DA.Text
   ( Text


### PR DESCRIPTION
Except for the `DA.Math` functions (`(**), exp, log, sin, cos, tan`) which are fixed at scale 10 for now, following a discussion about adding them as primitives (see #1066).