### PR TITLE
Intern all strings and dotted names in the DAML-LF protobuf encoding

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -71,7 +71,6 @@ featureStringInterning :: Feature
 featureStringInterning = Feature
     { featureName = "String interning"
     , featureMinVersion = version1_7
-      -- TODO(MH): Make CPP flags optional.
     , featureCppFlag = "DAML_STRING_INTERNING"
     }
 
@@ -79,6 +78,7 @@ allFeatures :: [Feature]
 allFeatures =
     [ featureNumeric
     , featureAnyTemplate
+    , featureStringInterning
     ]
 
 allFeaturesForVersion :: Version -> [Feature]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -67,6 +67,14 @@ featureAnyTemplate = Feature
    , featureCppFlag = "DAML_ANY_TEMPLATE"
    }
 
+featureStringInterning :: Feature
+featureStringInterning = Feature
+    { featureName = "String interning"
+    , featureMinVersion = version1_7
+      -- TODO(MH): Make CPP flags optional.
+    , featureCppFlag = "DAML_STRING_INTERNING"
+    }
+
 allFeatures :: [Feature]
 allFeatures =
     [ featureNumeric

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -72,7 +72,7 @@ decodeInternableStrings :: V.Vector TL.Text -> Word64 -> Decode [T.Text]
 decodeInternableStrings strs id
     | V.null strs = lookupStringList id
     | id == 0 = pure $ map decodeString (V.toList strs)
-    | otherwise = throwError $ ParseError $ "items and interned id both set for string list"
+    | otherwise = throwError $ ParseError "items and interned id both set for string list"
 
 -- | Decode the name of a syntactic object, e.g., a variable or a data
 -- constructor. These strings are mangled to escape special characters. All
@@ -204,7 +204,7 @@ decodeDataCons = \case
     mangled <- if
       | V.null cIds -> pure $ map decodeString (V.toList cs)
       | V.null cs -> mapM lookupString (V.toList cIds)
-      | otherwise -> throwError $ ParseError $ "strings and interned string ids both set for enum constructor"
+      | otherwise -> throwError $ ParseError "strings and interned string ids both set for enum constructor"
     DataEnum <$> mapM (decodeNameString VariantConName) mangled
 
 decodeDefValueNameWithType :: LF1.DefValue_NameWithType -> Decode (ExprValName, Type)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -21,6 +21,7 @@ data Error
   | EDuplicateTemplate TypeConName
   | DuplicateChoice ChoiceName
   | UnsupportedMinorVersion T.Text
-  | MissingPackageRefId Word64
+  | BadStringId Word64
+  | BadDottedNameId Word64
   | ExpectedTCon Type
   deriving (Show, Eq)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -7,7 +7,6 @@ module DA.Daml.LF.Proto3.Error
 
 import qualified Data.Text as T
 import Data.Int (Int32)
-import Data.Word (Word64)
 
 import DA.Daml.LF.Ast
 
@@ -21,7 +20,7 @@ data Error
   | EDuplicateTemplate TypeConName
   | DuplicateChoice ChoiceName
   | UnsupportedMinorVersion T.Text
-  | BadStringId Word64
-  | BadDottedNameId Word64
+  | BadStringId Int32
+  | BadDottedNameId Int32
   | ExpectedTCon Type
   deriving (Show, Eq)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
@@ -1,0 +1,25 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module DA.Daml.LF.Proto3.Util (
+    EitherLike,
+    toEither,
+    fromEither,
+    ) where
+
+import GHC.Generics
+
+type EitherLike m1 m2 m3 m4 m5 a b e =
+    (Generic e, Rep e ~ D1 m1 (C1 m2 (S1 m3 (Rec0 a)) :+: C1 m4 (S1 m5 (Rec0 b))))
+
+toEither :: EitherLike m1 m2 m3 m4 m5 a b e => e -> Either a b
+toEither e =
+    case unM1 $ from e of
+        L1 x -> Left $ unK1 $ unM1 $ unM1 x
+        R1 y -> Right $ unK1 $ unM1 $ unM1 y
+
+fromEither :: EitherLike m1 m2 m3 m4 m5 a b e => Either a b -> e
+fromEither = to . M1 . either (L1 . M1 . M1 . K1) (R1 . M1 . M1 . K1)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
@@ -1,7 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 module DA.Daml.LF.Proto3.Util (
@@ -10,16 +12,52 @@ module DA.Daml.LF.Proto3.Util (
     fromEither,
     ) where
 
-import GHC.Generics
+import           Data.Int
+import qualified Data.Text.Lazy as TL
+import           GHC.Generics
 
-type EitherLike m1 m2 m3 m4 m5 a b e =
-    (Generic e, Rep e ~ D1 m1 (C1 m2 (S1 m3 (Rec0 a)) :+: C1 m4 (S1 m5 (Rec0 b))))
+import qualified Da.DamlLf1 as P
 
-toEither :: EitherLike m1 m2 m3 m4 m5 a b e => e -> Either a b
-toEither e =
-    case unM1 $ from e of
-        L1 x -> Left $ unK1 $ unM1 $ unM1 x
-        R1 y -> Right $ unK1 $ unM1 $ unM1 y
+class EitherLike a b e where
+    toEither :: e -> Either a b
+    fromEither :: Either a b -> e
 
-fromEither :: EitherLike m1 m2 m3 m4 m5 a b e => Either a b -> e
-fromEither = to . M1 . either (L1 . M1 . M1 . K1) (R1 . M1 . M1 . K1)
+    default toEither
+        :: (Generic e, Rep e ~ D1 m1 (C1 m2 (S1 m3 (Rec0 a)) :+: C1 m4 (S1 m5 (Rec0 b))))
+        => e -> Either a b
+    toEither e =
+        case unM1 $ from e of
+            L1 x -> Left $ unK1 $ unM1 $ unM1 x
+            R1 y -> Right $ unK1 $ unM1 $ unM1 y
+    default fromEither
+        :: (Generic e, Rep e ~ D1 m1 (C1 m2 (S1 m3 (Rec0 a)) :+: C1 m4 (S1 m5 (Rec0 b))))
+        => Either a b -> e
+    fromEither = to . M1 . either (L1 . M1 . M1 . K1) (R1 . M1 . M1 . K1)
+
+instance EitherLike a b (Either a b) where
+    toEither = id
+    fromEither = id
+
+instance EitherLike TL.Text Int32 P.CaseAlt_ConsVarHead
+instance EitherLike TL.Text Int32 P.CaseAlt_ConsVarTail
+instance EitherLike TL.Text Int32 P.CaseAlt_EnumConstructor
+instance EitherLike TL.Text Int32 P.CaseAlt_OptionalSomeVarBody
+instance EitherLike TL.Text Int32 P.CaseAlt_VariantBinder
+instance EitherLike TL.Text Int32 P.CaseAlt_VariantVariant
+instance EitherLike TL.Text Int32 P.DefTemplateParam
+instance EitherLike TL.Text Int32 P.Expr_EnumConEnumCon
+instance EitherLike TL.Text Int32 P.Expr_RecProjField
+instance EitherLike TL.Text Int32 P.Expr_RecUpdField
+instance EitherLike TL.Text Int32 P.Expr_TupleProjField
+instance EitherLike TL.Text Int32 P.Expr_TupleUpdField
+instance EitherLike TL.Text Int32 P.Expr_VariantConVariantCon
+instance EitherLike TL.Text Int32 P.FieldWithExprField
+instance EitherLike TL.Text Int32 P.FieldWithTypeField
+instance EitherLike TL.Text Int32 P.KeyExpr_ProjectionField
+instance EitherLike TL.Text Int32 P.KeyExpr_RecordFieldField
+instance EitherLike TL.Text Int32 P.TemplateChoiceName
+instance EitherLike TL.Text Int32 P.TemplateChoiceSelfBinder
+instance EitherLike TL.Text Int32 P.Type_VarVar
+instance EitherLike TL.Text Int32 P.TypeVarWithKindVar
+instance EitherLike TL.Text Int32 P.Update_ExerciseChoice
+instance EitherLike TL.Text Int32 P.VarWithTypeVar

--- a/compiler/damlc/tests/bond-trading/Test.daml
+++ b/compiler/damlc/tests/bond-trading/Test.daml
@@ -1,6 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- Check that the interning tables don't contain duplicates:
+-- @QUERY-LF .interned_strings | (unique | length == length)
+-- @QUERY-LF .interned_dotted_names | (unique | length == length)
 daml 1.2
 module Test where
 

--- a/compiler/damlc/tests/bond-trading/Test.daml
+++ b/compiler/damlc/tests/bond-trading/Test.daml
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- Check that the interning tables don't contain duplicates:
--- @QUERY-LF .interned_strings | (unique | length == length)
--- @QUERY-LF .interned_dotted_names | (unique | length == length)
+-- @QUERY-LF .interned_strings // [] | (unique | length == length)
+-- @QUERY-LF .interned_dotted_names // [] | (unique | length == length)
 daml 1.2
 module Test where
 

--- a/compiler/damlc/tests/daml-test-files/EnumLF.daml
+++ b/compiler/damlc/tests/daml-test-files/EnumLF.daml
@@ -4,8 +4,8 @@
 -- Check that enum types get translated to DAML-LF's enum types.
 -- @SINCE-LF 1.6
 -- @QUERY-LF .modules[] | .data_types[] | select(.name | lf::get_dotted_name($pkg) == ["Color"]) | has("enum")
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_name($pkg) == ["red"]) | .expr | has("enum_con")
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_name($pkg) == ["isRed"]) | .expr.abs.body.case.alts | .[0] | has("enum")
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["red"]) | .expr | has("enum_con")
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["isRed"]) | .expr.abs.body.case.alts | .[0] | has("enum")
 -- @QUERY-LF .modules[] | .data_types[] | select(.name | lf::get_dotted_name($pkg) == ["Tag"]) | (has("enum") | not)
 daml 1.2
 module EnumLF where

--- a/compiler/damlc/tests/daml-test-files/ExerciseWithoutActors.daml
+++ b/compiler/damlc/tests/daml-test-files/ExerciseWithoutActors.daml
@@ -6,7 +6,7 @@
 -- uses actors as a sanity check.
 
 -- @SINCE-LF 1.5
--- @QUERY-LF [.modules[] | .values[] | select(.name_with_type | lf::get_name($pkg) == ["$$fFooInstance"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor") | not] | all
+-- @QUERY-LF [.modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$fFooInstance"]) | .expr | .. | objects | select(has("exercise")) | .exercise | has("actor") | not] | (length > 0 and all)
 daml 1.2
 module ExerciseWithoutActors where
 

--- a/compiler/damlc/tests/daml-test-files/InternedExternalRefs.daml
+++ b/compiler/damlc/tests/daml-test-files/InternedExternalRefs.daml
@@ -2,8 +2,8 @@
 -- All rights reserved.
 
 -- @ SINCE-LF 1.6
--- @QUERY-LF [ .modules[] | .values[] | .expr.val.module.package_ref.interned_id ] | sort == ["0", "1"]
--- @QUERY-LF .interned_package_ids | length == 2
+-- @QUERY-LF [.modules[] | .values[] | .expr.val.module.package_ref | select(has("interned_id"))] | length == 2
+-- @QUERY-LF .interned_strings | length >= 2
 
 -- We test that interning of package ids works. The two packages we reference are
 -- daml-prim and daml-stdlib.

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -173,7 +173,7 @@ testCase args version getService outdir registerTODO (name, file) = singleTest n
       for_ [file ++ ", " ++ x | Todo x <- anns] (registerTODO . TODO)
       resDiag <- checkDiagnostics log [fields | DiagnosticFields fields <- anns] $
         [ideErrorText "" $ T.pack $ show e | Left e <- [ex], not $ "_IGNORE_" `isInfixOf` show e] ++ diags
-      resQueries <- runJqQuery log outdir file [q | QueryLF q <- anns]
+      resQueries <- runJqQuery log version outdir file [q | QueryLF q <- anns]
       let failures = catMaybes $ resDiag : resQueries
       case failures of
         err : _others -> pure $ testFailed err
@@ -185,15 +185,19 @@ testCase args version getService outdir registerTODO (name, file) = singleTest n
       UntilLF maxVersion -> version > maxVersion
       _ -> False
 
-runJqQuery :: (String -> IO ()) -> FilePath -> FilePath -> [String] -> IO [Maybe String]
-runJqQuery log outdir file qs = do
+runJqQuery :: (String -> IO ()) -> LF.Version -> FilePath -> FilePath -> [String] -> IO [Maybe String]
+runJqQuery log version outdir file qs = do
   let proj = takeBaseName file
   forM qs $ \q -> do
     log $ "running jq query: " ++ q
     let jqKey = "external" </> "jq_dev_env" </> "bin" </> if isWindows then "jq.exe" else "jq"
     jq <- locateRunfiles $ mainWorkspace </> jqKey
-    queryLfLib <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/src"
-    out <- readProcess jq ["-L", queryLfLib, "import \"./query-lf-non-interned\" as lf; . as $pkg | " ++ q, outdir </> proj <.> "json"] ""
+    queryLfDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/src"
+    let queryLfMod
+            | version `supports` featureStringInterning = "query-lf-interned"
+            | otherwise = "query-lf-non-interned"
+    let fullQuery = "import \"./" ++ queryLfMod ++ "\" as lf; . as $pkg | " ++ q
+    out <- readProcess jq ["-L", queryLfDir, fullQuery, outdir </> proj <.> "json"] ""
     case trim out of
       "true" -> pure Nothing
       other -> pure $ Just $ "jq query failed: got " ++ other

--- a/compiler/damlc/tests/src/query-lf-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-interned.jq
@@ -4,6 +4,6 @@ def get_int64(pkg): .int64;
 
 def get_dotted_name(pkg): pkg.interned_dotted_names[.segments_interned_id // 0] | .segment_ids | map(pkg.interned_strings[.]);
 
-def get_field(pkg): pkg.interned_strings[.field_interned_id];
+def get_field(pkg): pkg.interned_strings[.interned_id];
 
 def get_name(pkg): .name;

--- a/compiler/damlc/tests/src/query-lf-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-interned.jq
@@ -1,0 +1,9 @@
+def get_value_name(pkg): pkg.interned_dotted_names[.name_interned_id] | .segment_ids | map(pkg.interned_strings[.]);
+
+def get_int64(pkg): .int64;
+
+def get_dotted_name(pkg): pkg.interned_dotted_names[.segments_interned_id // 0] | .segment_ids | map(pkg.interned_strings[.]);
+
+def get_field(pkg): pkg.interned_strings[.field_interned_id];
+
+def get_name(pkg): .name;

--- a/compiler/damlc/tests/src/query-lf-non-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-non-interned.jq
@@ -4,6 +4,6 @@ def get_int64(pkg): .int64;
 
 def get_dotted_name(pkg): .segments;
 
-def get_field(pkg): .field;
+def get_field(pkg): .field_name;
 
 def get_name(pkg): .name;

--- a/compiler/damlc/tests/src/query-lf-non-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-non-interned.jq
@@ -4,6 +4,6 @@ def get_int64(pkg): .int64;
 
 def get_dotted_name(pkg): .segments;
 
-def get_field(pkg): .field_name;
+def get_field(pkg): .name;
 
 def get_name(pkg): .name;

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -228,8 +228,9 @@ pkg_tar(
     visibility = ["//visibility:public"],
 )
 
+# An ad-hoc tool for testing, benchmarking and profiling package decoding performance in isolation.
 da_scala_binary(
-    name = "decode-test",
+    name = "decode-tester",
     srcs = ["src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala"],
     main_class = "com.digitalasset.daml.lf.archive.DecodeMain",
     deps = [

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -6,6 +6,7 @@ load("//bazel_tools:pkg.bzl", "pkg_tar")
 load("//bazel_tools:proto.bzl", "proto_gen")
 load(
     "//bazel_tools:scala.bzl",
+    "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
     "lf_scalacopts",
@@ -225,4 +226,16 @@ pkg_tar(
     extension = "tar.gz",
     package_dir = "daml-lf-archive-protos/protobuf/da",
     visibility = ["//visibility:public"],
+)
+
+da_scala_binary(
+    name = "decode-test",
+    srcs = ["src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala"],
+    main_class = "com.digitalasset.daml.lf.archive.DecodeMain",
+    deps = [
+        ":daml_lf_archive_scala",
+        ":daml_lf_java_proto",
+        "//daml-lf/data",
+        "//daml-lf/language",
+    ],
 )

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -63,7 +63,7 @@ message PackageRef {
 
     // An index into `interned_package_ids` of the Package containing
     // this reference.
-    uint64 interned_id = 3; // *Available in versions >= 1.6*
+    int32 interned_id = 3; // *Available in versions >= 1.6*
   }
 }
 
@@ -73,7 +73,7 @@ message DottedName {
   repeated string segments = 1;
 
   // *Must be set if and only if `segments` is an empty list.*
-  uint64 segments_interned_id = 2; // *Available in versions >= 1.dev*
+  int32 segments_interned_id = 2; // *Available in versions >= 1.dev*
 }
 
 // A fully qualified module reference
@@ -108,7 +108,7 @@ message ValName {
   repeated string name = 2;
 
   // *Must be set if and only if `segments` is an empty list.*
-  uint64 name_interned_id = 3; // *Available in versions >= 1.dev*
+  int32 name_interned_id = 3; // *Available in versions >= 1.dev*
 }
 
 // A field name definition in a record or a variant associated with a type.
@@ -118,7 +118,7 @@ message FieldWithType {
   // *Must be a valid identifier*
   oneof field {
     string field_name = 1;
-    uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
+    int32 field_interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Type associated
@@ -132,7 +132,7 @@ message VarWithType {
   // *Must be a valid identifier*
   oneof var {
     string name = 1;
-    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    int32 interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Type of the bound variable
@@ -145,7 +145,7 @@ message TypeVarWithKind {
   // *Must be a valid identifier*
   oneof var {
     string name = 1;
-    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    int32 interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Kind of the bound variable
@@ -158,7 +158,7 @@ message FieldWithExpr {
   // *Must be a valid identifier*
   oneof field {
     string field_name = 1;
-    uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
+    int32 field_interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Value of the field
@@ -270,7 +270,7 @@ message Type {
     // *Must be a valid identifier*
     oneof var {
       string var_name = 1;
-      uint64 var_interned_id = 3; // *Available in versions >= 1.dev*
+      int32 var_interned_id = 3; // *Available in versions >= 1.dev*
     }
 
     // Types to which the variable is applied
@@ -495,11 +495,11 @@ message PrimLit {
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
     string decimal = 2; // *Available in versions < 1.dev*
-    uint64 decimal_interned_id = 10; // *Available in versions >= 1.dev*
+    int32 decimal_interned_id = 10; // *Available in versions >= 1.dev*
 
     // Unicode string literal ('LitText')
     string text = 4;
-    uint64 text_interned_id = 11; // *Available in versions >= 1.dev*
+    int32 text_interned_id = 11; // *Available in versions >= 1.dev*
 
     // UTC timestamp literal ('LitTimestamp')
     //
@@ -516,7 +516,7 @@ message PrimLit {
     // Party literal ('LitParty')
     // *Must be a PartyId string*
     string party = 7;
-    uint64 party_interned_id = 12; // *Available in versions >= 1.dev*
+    int32 party_interned_id = 12; // *Available in versions >= 1.dev*
 
     // Date literal ('Date')
     // Serialization of the number of days since the unix epoch. can go backwards.
@@ -533,7 +533,7 @@ message PrimLit {
     //
     // The number of decimal digits indicate the scale of the number.
     string numeric = 9; // *Available in versions >= 1.dev*
-    uint64 numeric_interned_id = 13; // *Available in versions >= 1.dev*
+    int32 numeric_interned_id = 13; // *Available in versions >= 1.dev*
   }
 
   reserved 3; // This was char.
@@ -579,7 +579,7 @@ message Expr {
     // *must be a valid Identifier*
     oneof field {
       string name = 2;
-      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+      int32 interned_id = 4; // *Available in versions >= 1.dev*
     }
 
     // projected expression
@@ -596,7 +596,7 @@ message Expr {
     // *must be a valid identifier*
     oneof field {
       string name = 2;
-      uint64 interned_id = 5; // *Available in versions >= 1.dev*
+      int32 interned_id = 5; // *Available in versions >= 1.dev*
     }
 
     // Actual record being updated
@@ -616,7 +616,7 @@ message Expr {
     // *Must be a valid identifier*
     oneof variant_con {
       string name = 2;
-      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+      int32 interned_id = 4; // *Available in versions >= 1.dev*
     }
 
     // Argument of the variant.
@@ -634,7 +634,7 @@ message Expr {
      // *Must be a valid identifier*
      oneof enum_con {
        string name = 2;
-       uint64 interned_id = 3; // *Available in versions >= 1.dev*
+       int32 interned_id = 3; // *Available in versions >= 1.dev*
      }
    }
 
@@ -651,7 +651,7 @@ message Expr {
     // *Must be a valid Identifier*
     oneof field {
       string name = 1;
-      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+      int32 interned_id = 3; // *Available in versions >= 1.dev*
     }
 
     // tuple to be projected.
@@ -665,7 +665,7 @@ message Expr {
     // *must be a valid identifier*.
     oneof field {
       string name = 1;
-      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+      int32 interned_id = 4; // *Available in versions >= 1.dev*
     }
 
     // Actual tuple being updated.
@@ -787,7 +787,7 @@ message Expr {
     // Expression variable ('ExpVar')
     // *must be a valid identifier*
     string var = 1;
-    uint64 var_interned_id = 31; // *Available in versions >= 1.dev*
+    int32 var_interned_id = 31; // *Available in versions >= 1.dev*
 
     // Defined value ('ExpVal')
     ValName val = 2;
@@ -889,14 +889,14 @@ message CaseAlt {
     // *Must be a valid identifier*
     oneof variant {
       string variant_name = 2;
-      uint64 variant_interned_id = 4; // *Available in versions >= 1.dev*
+      int32 variant_interned_id = 4; // *Available in versions >= 1.dev*
     }
 
     // name of the variant binder
     // *Must be a valid identifier*
     oneof binder {
       string binder_name = 3;
-      uint64 binder_interned_id = 5; // *Available in versions >= 1.dev*
+      int32 binder_interned_id = 5; // *Available in versions >= 1.dev*
     }
   }
 
@@ -911,7 +911,7 @@ message CaseAlt {
     // *Must be a valid identifier*
     oneof constructor {
       string name = 2;
-      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+      int32 interned_id = 3; // *Available in versions >= 1.dev*
     }
   }
 
@@ -921,14 +921,14 @@ message CaseAlt {
     // *Must be a valid identifier*
     oneof var_head {
       string var_head_name = 1;
-      uint64 var_head_interned_id = 3; // *Available in versions >= 1.dev*
+      int32 var_head_interned_id = 3; // *Available in versions >= 1.dev*
     }
 
     // name of the binder for the tail
     // *Must be a valid identifier*
     oneof var_tail {
       string var_tail_name = 2;
-      uint64 var_tail_interned_id = 4; // *Available in versions >= 1.dev*
+      int32 var_tail_interned_id = 4; // *Available in versions >= 1.dev*
     }
   }
 
@@ -937,7 +937,7 @@ message CaseAlt {
   message OptionalSome {
     oneof var_body {
       string name = 1;
-      uint64 interned_id = 2; // *Available in versions >= 1.dev*
+      int32 interned_id = 2; // *Available in versions >= 1.dev*
     }
   }
 
@@ -992,7 +992,7 @@ message Update {
     // name of the exercised template choice
     oneof choice {
       string name = 2;
-      uint64 interned_id = 6; // *Available in versions >= 1.dev*
+      int32 interned_id = 6; // *Available in versions >= 1.dev*
     }
     // contract id
     Expr cid = 3;
@@ -1086,7 +1086,7 @@ message TemplateChoice {
   // *Must be a valid identifier*
   oneof name {
     string choice_name = 1;
-    uint64 choice_interned_id = 9; // *Available in versions >= 1.dev*
+    int32 choice_interned_id = 9; // *Available in versions >= 1.dev*
   }
 
   // Choice type
@@ -1111,7 +1111,7 @@ message TemplateChoice {
   // Name to bind the ContractId of the contract this choice is exercised on to.
   oneof self_binder {
     string self_binder_name = 7;
-    uint64 self_binder_interned_id = 10; // *Available in versions >= 1.dev*
+    int32 self_binder_interned_id = 10; // *Available in versions >= 1.dev*
   }
 
   Location location = 8;
@@ -1123,7 +1123,7 @@ message KeyExpr {
         Type.Con tycon = 1; // Always fully applied
         oneof field {
             string field_name = 2;
-            uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
+            int32 field_interned_id = 3; // *Available in versions >= 1.dev*
         }
     }
 
@@ -1135,7 +1135,7 @@ message KeyExpr {
     message RecordField {
         oneof field {
             string field_name = 1;
-            uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
+            int32 field_interned_id = 3; // *Available in versions >= 1.dev*
         }
         KeyExpr expr = 2;
     }
@@ -1173,7 +1173,7 @@ message DefTemplate {
   // Name to which the template argument is bound.
   oneof param {
     string param_name = 2;
-    uint64 param_interned_id = 11; // *Available in versions >= 1.dev*
+    int32 param_interned_id = 11; // *Available in versions >= 1.dev*
   }
 
   // NOTE(MH): The new runtime authorization check for DAML 1.0 does not rely
@@ -1218,7 +1218,7 @@ message DefDataType {
   // *Available in versions >= 1.6*
   message EnumConstructors {
     repeated string constructors = 1;
-    repeated uint64 constructors_interned_ids = 2; // *Available in versions >= 1.dev*
+    repeated int32 constructors_interned_ids = 2; // *Available in versions >= 1.dev*
   }
 
   // name of the defined data type
@@ -1257,7 +1257,7 @@ message DefValue {
     // *each element of name must be a valid identifier*
     // `name` can be empty if and only if `name_interned_id` is set.
     repeated string name = 1;
-    uint64 name_interned_id = 6; // *Available in versions >= 1.dev*
+    int32 name_interned_id = 6; // *Available in versions >= 1.dev*
 
     // Type of the value
     Type type = 2;
@@ -1299,7 +1299,7 @@ message Module {
 }
 
 message InternedDottedName {
-  repeated uint64 segment_ids = 1; // *Available in versions >= 1.dev*
+  repeated int32 segment_ids = 1; // *Available in versions >= 1.dev*
 }
 
 message Package {

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -117,8 +117,8 @@ message FieldWithType {
   // Name of the field .
   // *Must be a valid identifier*
   oneof field {
-    string field_name = 1;
-    int32 field_interned_id = 3; // *Available in versions >= 1.dev*
+    string name = 1;
+    int32 interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Type associated
@@ -157,8 +157,8 @@ message FieldWithExpr {
   // Name of the field
   // *Must be a valid identifier*
   oneof field {
-    string field_name = 1;
-    int32 field_interned_id = 3; // *Available in versions >= 1.dev*
+    string name = 1;
+    int32 interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Value of the field
@@ -1122,8 +1122,8 @@ message KeyExpr {
     message Projection {
         Type.Con tycon = 1; // Always fully applied
         oneof field {
-            string field_name = 2;
-            int32 field_interned_id = 3; // *Available in versions >= 1.dev*
+            string name = 2;
+            int32 interned_id = 3; // *Available in versions >= 1.dev*
         }
     }
 
@@ -1134,8 +1134,8 @@ message KeyExpr {
 
     message RecordField {
         oneof field {
-            string field_name = 1;
-            int32 field_interned_id = 3; // *Available in versions >= 1.dev*
+            string name = 1;
+            int32 interned_id = 3; // *Available in versions >= 1.dev*
         }
         KeyExpr expr = 2;
     }

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -36,6 +36,7 @@
 //        2019-07-29: Add nat kind and Nat types, Numeric types and Numeric builtins
 //        2019-09-17: Add Any type and, To_Any and From_Any builtins
 //        2019-09-17: Drop support for Decimal
+//        2019-09-30: Add interning of strings and dotted names
 
 syntax = "proto3";
 package daml_lf_1;
@@ -116,8 +117,8 @@ message FieldWithType {
   // Name of the field .
   // *Must be a valid identifier*
   oneof field {
-    string name = 1;
-    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    string field_name = 1;
+    uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Type associated
@@ -156,8 +157,8 @@ message FieldWithExpr {
   // Name of the field
   // *Must be a valid identifier*
   oneof field {
-    string name = 1;
-    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    string field_name = 1;
+    uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
   }
 
   // Value of the field
@@ -268,8 +269,8 @@ message Type {
     // Name of the variable.
     // *Must be a valid identifier*
     oneof var {
-      string name = 1;
-      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+      string var_name = 1;
+      uint64 var_interned_id = 3; // *Available in versions >= 1.dev*
     }
 
     // Types to which the variable is applied
@@ -887,15 +888,15 @@ message CaseAlt {
     // name of the variant constructor
     // *Must be a valid identifier*
     oneof variant {
-      string name = 2;
-      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+      string variant_name = 2;
+      uint64 variant_interned_id = 4; // *Available in versions >= 1.dev*
     }
 
     // name of the variant binder
     // *Must be a valid identifier*
     oneof binder {
-      string name = 3;
-      uint64 interned_id = 5; // *Available in versions >= 1.dev*
+      string binder_name = 3;
+      uint64 binder_interned_id = 5; // *Available in versions >= 1.dev*
     }
   }
 
@@ -919,15 +920,15 @@ message CaseAlt {
     // name of the binder for the head
     // *Must be a valid identifier*
     oneof var_head {
-      string name = 1;
-      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+      string var_head_name = 1;
+      uint64 var_head_interned_id = 3; // *Available in versions >= 1.dev*
     }
 
     // name of the binder for the tail
     // *Must be a valid identifier*
     oneof var_tail {
-      string name = 2;
-      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+      string var_tail_name = 2;
+      uint64 var_tail_interned_id = 4; // *Available in versions >= 1.dev*
     }
   }
 
@@ -1011,7 +1012,7 @@ message Update {
     reserved 3; // was actor, we thought we'd need this, but we don't
   }
 
-  // Embeded Exression Update
+  // Embedded Expression Update
   message EmbedExpr {
     // Expression type
     Type type = 1;
@@ -1084,8 +1085,8 @@ message TemplateChoice {
 
   // *Must be a valid identifier*
   oneof name {
-    string name = 1;
-    uint64 interned_id = 9; // *Available in versions >= 1.dev*
+    string choice_name = 1;
+    uint64 choice_interned_id = 9; // *Available in versions >= 1.dev*
   }
 
   // Choice type
@@ -1109,8 +1110,8 @@ message TemplateChoice {
 
   // Name to bind the ContractId of the contract this choice is exercised on to.
   oneof self_binder {
-    string name = 7;
-    uint64 interned_id = 10; // *Available in versions >= 1.dev*
+    string self_binder_name = 7;
+    uint64 self_binder_interned_id = 10; // *Available in versions >= 1.dev*
   }
 
   Location location = 8;
@@ -1121,8 +1122,8 @@ message KeyExpr {
     message Projection {
         Type.Con tycon = 1; // Always fully applied
         oneof field {
-            string name = 2;
-            uint64 interned_id = 3; // *Available in versions >= 1.dev*
+            string field_name = 2;
+            uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
         }
     }
 
@@ -1133,8 +1134,8 @@ message KeyExpr {
 
     message RecordField {
         oneof field {
-            string name = 1;
-            uint64 interned_id = 3; // *Available in versions >= 1.dev*
+            string field_name = 1;
+            uint64 field_interned_id = 3; // *Available in versions >= 1.dev*
         }
         KeyExpr expr = 2;
     }
@@ -1171,8 +1172,8 @@ message DefTemplate {
 
   // Name to which the template argument is bound.
   oneof param {
-    string name = 2;
-    uint64 interned_id = 11; // *Available in versions >= 1.dev*
+    string param_name = 2;
+    uint64 param_interned_id = 11; // *Available in versions >= 1.dev*
   }
 
   // NOTE(MH): The new runtime authorization check for DAML 1.0 does not rely

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -68,10 +68,11 @@ message PackageRef {
 
 // A `name`, e.g. Util.Either.isLeft
 message DottedName {
-
-  // *Must be a non-empty list of a valid identifiers*
+  // *Must be a non-empty list of a valid identifiers unless `segments_interned_id` is set.*
   repeated string segments = 1;
 
+  // *Must be set if and only if `segments` is an empty list.*
+  uint64 segments_interned_id = 2; // *Available in versions >= 1.dev*
 }
 
 // A fully qualified module reference
@@ -102,8 +103,11 @@ message ValName {
   // Module where the value is defined
   ModuleRef module = 1;
 
-  // value name.
+  // *Must be a non-empty list of a valid identifiers unless `interned_id` is set.*
   repeated string name = 2;
+
+  // *Must be set if and only if `segments` is an empty list.*
+  uint64 name_interned_id = 3; // *Available in versions >= 1.dev*
 }
 
 // A field name definition in a record or a variant associated with a type.
@@ -111,7 +115,10 @@ message FieldWithType {
 
   // Name of the field .
   // *Must be a valid identifier*
-  string field = 1;
+  oneof field {
+    string name = 1;
+    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+  }
 
   // Type associated
   Type type = 2;
@@ -122,7 +129,10 @@ message VarWithType {
 
   // Name of the bound expression variable.
   // *Must be a valid identifier*
-  string var = 1;
+  oneof var {
+    string name = 1;
+    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+  }
 
   // Type of the bound variable
   Type type = 2;
@@ -132,7 +142,11 @@ message VarWithType {
 message TypeVarWithKind {
   // Name of the bound expression variable
   // *Must be a valid identifier*
-  string var = 1;
+  oneof var {
+    string name = 1;
+    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+  }
+
   // Kind of the bound variable
   Kind kind = 2;
 }
@@ -141,7 +155,11 @@ message TypeVarWithKind {
 message FieldWithExpr {
   // Name of the field
   // *Must be a valid identifier*
-  string field = 1;
+  oneof field {
+    string name = 1;
+    uint64 interned_id = 3; // *Available in versions >= 1.dev*
+  }
+
   // Value of the field
   Expr expr  = 2;
 }
@@ -249,7 +267,10 @@ message Type {
 
     // Name of the variable.
     // *Must be a valid identifier*
-    string var = 1;
+    oneof var {
+      string name = 1;
+      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    }
 
     // Types to which the variable is applied
     repeated Type args = 2;
@@ -473,9 +494,11 @@ message PrimLit {
     // one. so, string it is. note that we can't store the whole and
     // decimal part in two numbers either, because 10^28 > 2^63.
     string decimal = 2; // *Available in versions < 1.dev*
+    uint64 decimal_interned_id = 10; // *Available in versions >= 1.dev*
 
     // Unicode string literal ('LitText')
     string text = 4;
+    uint64 text_interned_id = 11; // *Available in versions >= 1.dev*
 
     // UTC timestamp literal ('LitTimestamp')
     //
@@ -492,6 +515,7 @@ message PrimLit {
     // Party literal ('LitParty')
     // *Must be a PartyId string*
     string party = 7;
+    uint64 party_interned_id = 12; // *Available in versions >= 1.dev*
 
     // Date literal ('Date')
     // Serialization of the number of days since the unix epoch. can go backwards.
@@ -508,6 +532,7 @@ message PrimLit {
     //
     // The number of decimal digits indicate the scale of the number.
     string numeric = 9; // *Available in versions >= 1.dev*
+    uint64 numeric_interned_id = 13; // *Available in versions >= 1.dev*
   }
 
   reserved 3; // This was char.
@@ -551,7 +576,10 @@ message Expr {
 
     // Name of the record field to be projected on.
     // *must be a valid Identifier*
-    string field = 2;
+    oneof field {
+      string name = 2;
+      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+    }
 
     // projected expression
     Expr record = 3;
@@ -565,7 +593,10 @@ message Expr {
 
     // Name of the updated field.
     // *must be a valid identifier*
-    string field = 2;
+    oneof field {
+      string name = 2;
+      uint64 interned_id = 5; // *Available in versions >= 1.dev*
+    }
 
     // Actual record being updated
     Expr record = 3;
@@ -582,7 +613,10 @@ message Expr {
 
     // name of the variant constructor
     // *Must be a valid identifier*
-    string variant_con = 2;
+    oneof variant_con {
+      string name = 2;
+      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+    }
 
     // Argument of the variant.
     Expr variant_arg = 3;
@@ -597,7 +631,10 @@ message Expr {
 
      // name of the enum constructor
      // *Must be a valid identifier*
-     string enum_con = 2;
+     oneof enum_con {
+       string name = 2;
+       uint64 interned_id = 3; // *Available in versions >= 1.dev*
+     }
    }
 
   // Tuple Construction ('ExpTupleCon')
@@ -611,7 +648,10 @@ message Expr {
 
     // Name of the field to be projected on.
     // *Must be a valid Identifier*
-    string field = 1;
+    oneof field {
+      string name = 1;
+      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    }
 
     // tuple to be projected.
     Expr tuple = 2;
@@ -622,7 +662,10 @@ message Expr {
 
     // Name of the updated field.
     // *must be a valid identifier*.
-    string field = 1;
+    oneof field {
+      string name = 1;
+      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+    }
 
     // Actual tuple being updated.
     Expr tuple = 2;
@@ -743,6 +786,7 @@ message Expr {
     // Expression variable ('ExpVar')
     // *must be a valid identifier*
     string var = 1;
+    uint64 var_interned_id = 31; // *Available in versions >= 1.dev*
 
     // Defined value ('ExpVal')
     ValName val = 2;
@@ -842,11 +886,17 @@ message CaseAlt {
 
     // name of the variant constructor
     // *Must be a valid identifier*
-    string variant = 2;
+    oneof variant {
+      string name = 2;
+      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+    }
 
     // name of the variant binder
     // *Must be a valid identifier*
-    string binder = 3;
+    oneof binder {
+      string name = 3;
+      uint64 interned_id = 5; // *Available in versions >= 1.dev*
+    }
   }
 
   // Enum pattern
@@ -858,24 +908,36 @@ message CaseAlt {
 
     // name of the variant constructor
     // *Must be a valid identifier*
-    string constructor = 2;
+    oneof constructor {
+      string name = 2;
+      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    }
   }
 
   // Non empty list pattern
   message Cons {
     // name of the binder for the head
     // *Must be a valid identifier*
-    string var_head = 1;
+    oneof var_head {
+      string name = 1;
+      uint64 interned_id = 3; // *Available in versions >= 1.dev*
+    }
 
     // name of the binder for the tail
     // *Must be a valid identifier*
-    string var_tail = 2;
+    oneof var_tail {
+      string name = 2;
+      uint64 interned_id = 4; // *Available in versions >= 1.dev*
+    }
   }
 
   // Non empty option patterm
   // *Available in versions >= 1.1*
   message OptionalSome {
-    string var_body = 1;
+    oneof var_body {
+      string name = 1;
+      uint64 interned_id = 2; // *Available in versions >= 1.dev*
+    }
   }
 
   oneof Sum {
@@ -927,7 +989,10 @@ message Update {
     // Template type
     TypeConName template = 1;
     // name of the exercised template choice
-    string choice = 2;
+    oneof choice {
+      string name = 2;
+      uint64 interned_id = 6; // *Available in versions >= 1.dev*
+    }
     // contract id
     Expr cid = 3;
     // actors
@@ -1018,7 +1083,10 @@ message Scenario {
 message TemplateChoice {
 
   // *Must be a valid identifier*
-  string name = 1;
+  oneof name {
+    string name = 1;
+    uint64 interned_id = 9; // *Available in versions >= 1.dev*
+  }
 
   // Choice type
   bool consuming = 2;
@@ -1040,7 +1108,10 @@ message TemplateChoice {
   Expr update = 6;
 
   // Name to bind the ContractId of the contract this choice is exercised on to.
-  string self_binder = 7;
+  oneof self_binder {
+    string name = 7;
+    uint64 interned_id = 10; // *Available in versions >= 1.dev*
+  }
 
   Location location = 8;
 }
@@ -1049,7 +1120,10 @@ message TemplateChoice {
 message KeyExpr {
     message Projection {
         Type.Con tycon = 1; // Always fully applied
-        string field = 2;
+        oneof field {
+            string name = 2;
+            uint64 interned_id = 3; // *Available in versions >= 1.dev*
+        }
     }
 
     // note that the projection is always referring to the template parameter.
@@ -1058,7 +1132,10 @@ message KeyExpr {
     }
 
     message RecordField {
-        string field = 1;
+        oneof field {
+            string name = 1;
+            uint64 interned_id = 3; // *Available in versions >= 1.dev*
+        }
         KeyExpr expr = 2;
     }
 
@@ -1093,7 +1170,10 @@ message DefTemplate {
   DottedName tycon = 1;
 
   // Name to which the template argument is bound.
-  string param = 2;
+  oneof param {
+    string name = 2;
+    uint64 interned_id = 11; // *Available in versions >= 1.dev*
+  }
 
   // NOTE(MH): The new runtime authorization check for DAML 1.0 does not rely
   // on the stakeholder signatures produced by the obligables computation
@@ -1137,6 +1217,7 @@ message DefDataType {
   // *Available in versions >= 1.6*
   message EnumConstructors {
     repeated string constructors = 1;
+    repeated uint64 constructors_interned_ids = 2; // *Available in versions >= 1.dev*
   }
 
   // name of the defined data type
@@ -1173,7 +1254,9 @@ message DefValue {
 
     // Name of the value
     // *each element of name must be a valid identifier*
+    // `name` can be empty if and only if `name_interned_id` is set.
     repeated string name = 1;
+    uint64 name_interned_id = 6; // *Available in versions >= 1.dev*
 
     // Type of the value
     Type type = 2;
@@ -1214,7 +1297,12 @@ message Module {
   repeated DefTemplate templates = 7;
 }
 
+message InternedDottedName {
+  repeated uint64 segment_ids = 1; // *Available in versions >= 1.dev*
+}
+
 message Package {
   repeated Module modules = 1;
-  repeated string interned_package_ids = 2; // *Available in versions >= 1.6*
+  repeated string interned_strings = 2; // *Available in versions >= 1.6*
+  repeated InternedDottedName interned_dotted_names = 3; // *Available in versions >= 1.dev*
 }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -72,7 +72,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
     if (internedList.nonEmpty)
       assertSince(LV.Features.internedDottedNames, "interned dotted names table")
 
-    def outOfRange(id: Long) =
+    def outOfRange(id: Int) =
       ParseError(s"invalid string table index $id")
 
     internedList
@@ -80,7 +80,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         idn =>
           decodeSegments(
             idn.getSegmentIdsList.asScala
-              .map(id => internedStrings.lift(id.toInt).getOrElse(throw outOfRange(id)))(breakOut))
+              .map(id => internedStrings.lift(id).getOrElse(throw outOfRange(id)))(breakOut))
       )(breakOut)
   }
 
@@ -146,18 +146,14 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
 
     // -----------------------------------------------------------------------
 
-    private[this] def getInternedString(id: Long): String = {
+    private[this] def getInternedString(id: Int): String = {
       def outOfRange = ParseError(s"invalid string table index $id")
-      val iid = id.toInt
-      if (iid != iid.toLong) throw outOfRange
-      internedStrings.lift(iid).getOrElse(throw outOfRange)
+      internedStrings.lift(id).getOrElse(throw outOfRange)
     }
 
-    private[this] def getInternedDottedName(id: Long): DottedName = {
+    private[this] def getInternedDottedName(id: Int): DottedName = {
       def outOfRange = ParseError(s"invalid dotted name table index $id")
-      val iid = id.toInt
-      if (iid != iid.toLong) throw outOfRange
-      internedDottedNames.lift(iid).getOrElse(throw outOfRange)
+      internedDottedNames.lift(id).getOrElse(throw outOfRange)
     }
 
     private[this] def decodeDottedName(name: PLF.DottedName): DottedName =

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -197,9 +197,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
 
     private[this] def decodeFieldWithType(lfFieldWithType: PLF.FieldWithType): (Name, Type) =
       name(lfFieldWithType.getFieldCase match {
-        case PLF.FieldWithType.FieldCase.FIELD_NAME => lfFieldWithType.getFieldName
-        case PLF.FieldWithType.FieldCase.FIELD_INTERNED_ID =>
-          getInternedString(lfFieldWithType.getFieldInternedId)
+        case PLF.FieldWithType.FieldCase.NAME => lfFieldWithType.getName
+        case PLF.FieldWithType.FieldCase.INTERNED_ID =>
+          getInternedString(lfFieldWithType.getInternedId)
         case PLF.FieldWithType.FieldCase.FIELD_NOT_SET =>
           throw ParseError("FieldWithType.FIELD_NOT_SET")
       }) -> decodeType(lfFieldWithType.getType)
@@ -211,9 +211,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         lfFieldWithExpr: PLF.FieldWithExpr,
         definition: String): (Name, Expr) =
       name(lfFieldWithExpr.getFieldCase match {
-        case PLF.FieldWithExpr.FieldCase.FIELD_NAME => lfFieldWithExpr.getFieldName
-        case PLF.FieldWithExpr.FieldCase.FIELD_INTERNED_ID =>
-          getInternedString(lfFieldWithExpr.getFieldInternedId)
+        case PLF.FieldWithExpr.FieldCase.NAME => lfFieldWithExpr.getName
+        case PLF.FieldWithExpr.FieldCase.INTERNED_ID =>
+          getInternedString(lfFieldWithExpr.getInternedId)
         case PLF.FieldWithExpr.FieldCase.FIELD_NOT_SET =>
           throw ParseError("FieldWithExpr.FIELD_NOT_SET")
       }) -> decodeExpr(lfFieldWithExpr.getExpr, definition)
@@ -292,10 +292,10 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             tycon = decodeTypeConApp(recCon.getTycon),
             fields = ImmArray(recCon.getFieldsList.asScala).map(field =>
               name(field.getFieldCase match {
-                case PLF.KeyExpr.RecordField.FieldCase.FIELD_NAME =>
-                  field.getFieldName
-                case PLF.KeyExpr.RecordField.FieldCase.FIELD_INTERNED_ID =>
-                  getInternedString(field.getFieldInternedId)
+                case PLF.KeyExpr.RecordField.FieldCase.NAME =>
+                  field.getName
+                case PLF.KeyExpr.RecordField.FieldCase.INTERNED_ID =>
+                  getInternedString(field.getInternedId)
                 case PLF.KeyExpr.RecordField.FieldCase.FIELD_NOT_SET =>
                   throw ParseError("KeyExpr.Record.Field.FIELD_NOT_SET")
 
@@ -309,9 +309,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
               ERecProj(
                 decodeTypeConApp(lfProj.getTycon),
                 name(lfProj.getFieldCase match {
-                  case PLF.KeyExpr.Projection.FieldCase.FIELD_NAME => lfProj.getFieldName
-                  case PLF.KeyExpr.Projection.FieldCase.FIELD_INTERNED_ID =>
-                    getInternedString(lfProj.getFieldInternedId)
+                  case PLF.KeyExpr.Projection.FieldCase.NAME => lfProj.getName
+                  case PLF.KeyExpr.Projection.FieldCase.INTERNED_ID =>
+                    getInternedString(lfProj.getInternedId)
                   case PLF.KeyExpr.Projection.FieldCase.FIELD_NOT_SET =>
                     throw ParseError("KeyExpr.Projection.Field.FIELD_NOT_SET")
                 }),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.archive
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import com.digitalasset.daml_lf.DamlLf.Archive
+
+import scala.util.Try
+
+/**
+  * Test application for decoding DARs. Useful for testing decoder performance and memory usage.
+  */
+object DecodeMain extends App {
+  /*if (args.length != 1) {
+    println("usage: decode <dar file>")
+    System.exit(1)
+  }*/
+
+  println("waiting 10s")
+  Thread.sleep(10000)
+
+  val file = new File("/tmp/spider-dev.dar")
+
+  //(1 to 3).foreach { _ =>
+  val t0 = System.nanoTime()
+
+  val archives =
+    DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
+      .readArchiveFromFile(file) // new File(args(0)))
+      .get
+  val t1 = System.nanoTime()
+
+  val _ = Decode.decodeArchive(archives.main)
+  val t2 = System.nanoTime()
+
+  def toMillis(a: Long, b: Long) = TimeUnit.NANOSECONDS.toMillis(b - a)
+
+  println(s"parseFrom in ${toMillis(t0, t1)}ms, decoded in ${toMillis(t1, t2)}ms.")
+
+  //  System.gc()
+  //}
+
+  val pid = Integer.parseInt(new File("/proc/self").getCanonicalFile.getName)
+  println(s"waiting 5s to exit. pid is $pid.")
+
+  Thread.sleep(5000)
+}

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
@@ -6,45 +6,38 @@ package com.digitalasset.daml.lf.archive
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import com.digitalasset.daml_lf.DamlLf.Archive
-
-import scala.util.Try
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.language.Ast
 
 /**
   * Test application for decoding DARs. Useful for testing decoder performance and memory usage.
   */
 object DecodeMain extends App {
-  /*if (args.length != 1) {
+  if (args.length != 1) {
     println("usage: decode <dar file>")
     System.exit(1)
-  }*/
-
-  println("waiting 10s")
-  Thread.sleep(10000)
-
-  val file = new File("/tmp/spider-dev.dar")
-
-  //(1 to 3).foreach { _ =>
-  val t0 = System.nanoTime()
-
-  val archives =
-    DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
-      .readArchiveFromFile(file) // new File(args(0)))
-      .get
-  val t1 = System.nanoTime()
-
-  val _ = Decode.decodeArchive(archives.main)
-  val t2 = System.nanoTime()
+  }
 
   def toMillis(a: Long, b: Long) = TimeUnit.NANOSECONDS.toMillis(b - a)
 
-  println(s"parseFrom in ${toMillis(t0, t1)}ms, decoded in ${toMillis(t1, t2)}ms.")
+  (1 to 3).foreach { _ =>
+    val t0 = System.nanoTime()
 
-  //  System.gc()
-  //}
+    val archives =
+      DarReader().readArchiveFromFile(new File(args(0))).get
+    val t1 = System.nanoTime()
 
-  val pid = Integer.parseInt(new File("/proc/self").getCanonicalFile.getName)
-  println(s"waiting 5s to exit. pid is $pid.")
+    val _: (Ref.PackageId, Ast.Package) =
+      Decode.readArchivePayload(archives.main._1, archives.main._2)
+    val t2 = System.nanoTime()
 
-  Thread.sleep(5000)
+    println(s"parseFrom in ${toMillis(t0, t1)}ms, decoded in ${toMillis(t1, t2)}ms.")
+
+    // Wait a while to allow for running e.g. jmap -heap etc.
+    //val pid = Integer.parseInt(new File("/proc/self").getCanonicalFile.getName)
+    //println(s"sleeping 5s, pid is $pid.")
+    //Thread.sleep(5000)
+
+    System.gc()
+  }
 }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -49,6 +49,7 @@ class DecodeV1Spec
       .ModuleDecoder(
         Ref.PackageId.assertFromString("noPkgId"),
         ImmArray.empty.toSeq,
+        ImmArray.empty.toSeq,
         dummyModule,
         onlySerializableDataDefs = false)
 
@@ -508,7 +509,7 @@ class DecodeV1Spec
             pr.getInternedId
         }
         .value
-      dalf1.getInternedPackageIdsList.asScala.lift(iix.toInt).value
+      dalf1.getInternedStringsList.asScala.lift(iix.toInt).value
     }
 
     "take a dalf with interned IDs" in {

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -151,7 +151,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
     @inline
     private implicit def encodeFieldWithType(nameWithType: (String, Type)): PLF.FieldWithType = {
       val (name, typ) = nameWithType
-      PLF.FieldWithType.newBuilder().setFieldName(name).setType(typ).build()
+      PLF.FieldWithType.newBuilder().setName(name).setType(typ).build()
     }
 
     private val TForalls = RightRecMatcher[(TypeVarName, Kind), Type]({
@@ -240,7 +240,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
     @inline
     private implicit def encodeFieldWithExpr(fieldWithExpr: (Name, Expr)): PLF.FieldWithExpr = {
       val (name, expr) = fieldWithExpr
-      PLF.FieldWithExpr.newBuilder().setFieldName(name).setExpr(expr).build()
+      PLF.FieldWithExpr.newBuilder().setName(name).setExpr(expr).build()
     }
 
     @inline

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -141,13 +141,17 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
     @inline
     private implicit def encodeTypeBinder(binder: (String, Kind)): PLF.TypeVarWithKind = {
       val (varName, kind) = binder
-      PLF.TypeVarWithKind.newBuilder().setVar(varName).setKind(kind).build()
+      PLF.TypeVarWithKind
+        .newBuilder()
+        .setName(varName)
+        .setKind(kind)
+        .build()
     }
 
     @inline
     private implicit def encodeFieldWithType(nameWithType: (String, Type)): PLF.FieldWithType = {
       val (name, typ) = nameWithType
-      PLF.FieldWithType.newBuilder().setField(name).setType(typ).build()
+      PLF.FieldWithType.newBuilder().setFieldName(name).setType(typ).build()
     }
 
     private val TForalls = RightRecMatcher[(TypeVarName, Kind), Type]({
@@ -177,7 +181,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       typ match {
         case TVar(varName) =>
           builder.setVar(
-            PLF.Type.Var.newBuilder().setVar(varName).accumulateLeft(args)(_ addArgs _))
+            PLF.Type.Var.newBuilder().setVarName(varName).accumulateLeft(args)(_ addArgs _))
         case TNat(n) =>
           assertSince(LV.Features.numeric, "Type.TNat")
           builder.setNat(n.toLong)
@@ -236,13 +240,13 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
     @inline
     private implicit def encodeFieldWithExpr(fieldWithExpr: (Name, Expr)): PLF.FieldWithExpr = {
       val (name, expr) = fieldWithExpr
-      PLF.FieldWithExpr.newBuilder().setField(name).setExpr(expr).build()
+      PLF.FieldWithExpr.newBuilder().setFieldName(name).setExpr(expr).build()
     }
 
     @inline
     private implicit def encodeExprBinder(binder: (String, Type)): PLF.VarWithType = {
       val (varName, typ) = binder
-      PLF.VarWithType.newBuilder().setVar(varName).setType(typ).build()
+      PLF.VarWithType.newBuilder().setName(varName).setType(typ).build()
     }
 
     private implicit def encodeLocation(loc: Location): PLF.Location = {
@@ -294,7 +298,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
             PLF.Update.Exercise
               .newBuilder()
               .setTemplate(templateId)
-              .setChoice(choice)
+              .setName(choice)
               .setCid(cid)
               .accumulateLeft(actors)(_ setActor _)
               .setArg(arg)
@@ -369,22 +373,26 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       alt.pattern match {
         case CPVariant(tyCon, variant, binder) =>
           builder.setVariant(
-            PLF.CaseAlt.Variant.newBuilder().setCon(tyCon).setVariant(variant).setBinder(binder))
+            PLF.CaseAlt.Variant
+              .newBuilder()
+              .setCon(tyCon)
+              .setVariantName(variant)
+              .setBinderName(binder))
         case CPEnum(tyCon, con) =>
           assertSince(LV.Features.enum, "CaseAlt.Enum")
-          builder.setEnum(PLF.CaseAlt.Enum.newBuilder().setCon(tyCon).setConstructor(con))
+          builder.setEnum(PLF.CaseAlt.Enum.newBuilder().setCon(tyCon).setName(con))
         case CPPrimCon(primCon) =>
           builder.setPrimCon(primCon)
         case CPNil =>
           builder.setNil(unit)
         case CPCons(head, tail) =>
-          builder.setCons(PLF.CaseAlt.Cons.newBuilder().setVarHead(head).setVarTail(tail))
+          builder.setCons(PLF.CaseAlt.Cons.newBuilder().setVarHeadName(head).setVarTailName(tail))
         case CPNone =>
           assertSince(LV.Features.optional, "CaseAlt.OptionalNone")
           builder.setOptionalNone(unit)
         case CPSome(x) =>
           assertSince(LV.Features.optional, "CaseAlt.OptionalSome")
-          builder.setOptionalSome(PLF.CaseAlt.OptionalSome.newBuilder().setVarBody(x))
+          builder.setOptionalSome(PLF.CaseAlt.OptionalSome.newBuilder().setName(x))
         case CPDefault =>
           builder.setDefault(unit)
       }
@@ -429,13 +437,13 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
             PLF.Expr.RecCon.newBuilder().setTycon(tyCon).accumulateLeft(fields)(_ addFields _))
         case ERecProj(tycon, field, expr) =>
           newBuilder.setRecProj(
-            PLF.Expr.RecProj.newBuilder().setTycon(tycon).setField(field).setRecord(expr))
+            PLF.Expr.RecProj.newBuilder().setTycon(tycon).setName(field).setRecord(expr))
         case ERecUpd(tyCon, field, expr, update) =>
           newBuilder.setRecUpd(
             PLF.Expr.RecUpd
               .newBuilder()
               .setTycon(tyCon)
-              .setField(field)
+              .setName(field)
               .setRecord(expr)
               .setUpdate(update))
         case EVariantCon(tycon, variant, arg) =>
@@ -443,19 +451,19 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
             PLF.Expr.VariantCon
               .newBuilder()
               .setTycon(tycon)
-              .setVariantCon(variant)
+              .setName(variant)
               .setVariantArg(arg))
         case EEnumCon(tyCon, con) =>
           assertSince(LV.Features.enum, "Expr.Enum")
-          newBuilder.setEnumCon(PLF.Expr.EnumCon.newBuilder().setTycon(tyCon).setEnumCon(con))
+          newBuilder.setEnumCon(PLF.Expr.EnumCon.newBuilder().setTycon(tyCon).setName(con))
         case ETupleCon(fields) =>
           newBuilder.setTupleCon(
             PLF.Expr.TupleCon.newBuilder().accumulateLeft(fields)(_ addFields _))
         case ETupleProj(field, expr) =>
-          newBuilder.setTupleProj(PLF.Expr.TupleProj.newBuilder().setField(field).setTuple(expr))
+          newBuilder.setTupleProj(PLF.Expr.TupleProj.newBuilder().setName(field).setTuple(expr))
         case ETupleUpd(field, tuple, update) =>
           newBuilder.setTupleUpd(
-            PLF.Expr.TupleUpd.newBuilder().setField(field).setTuple(tuple).setUpdate(update))
+            PLF.Expr.TupleUpd.newBuilder().setName(field).setTuple(tuple).setUpdate(update))
         case EApps(fun, args) =>
           newBuilder.setApp(PLF.Expr.App.newBuilder().setFun(fun).accumulateLeft(args)(_ addArgs _))
         case ETyApps(expr, typs1) =>
@@ -551,13 +559,13 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       val (name, choice) = nameWithChoice
       PLF.TemplateChoice
         .newBuilder()
-        .setName(name)
+        .setChoiceName(name)
         .setConsuming(choice.consuming)
         .setControllers(choice.controllers)
         .setArgBinder(choice.argBinder._1.getOrElse("") -> choice.argBinder._2)
         .setRetType(choice.returnType)
         .setUpdate(choice.update)
-        .setSelfBinder(choice.selfBinder)
+        .setSelfBinderName(choice.selfBinder)
         .build()
     }
 
@@ -575,7 +583,7 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
       PLF.DefTemplate
         .newBuilder()
         .setTycon(name)
-        .setParam(template.param)
+        .setParamName(template.param)
         .setPrecond(template.precond)
         .setSignatories(template.signatories)
         .setAgreement(template.agreementText)

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -17,15 +17,15 @@ sealed abstract class LanguageMajorVersion(
     with Product
     with Serializable {
 
-  val maxSupportedStableMinorVersion: LanguageMinorVersion.Stable =
+  final val maxSupportedStableMinorVersion: LanguageMinorVersion.Stable =
     LanguageMinorVersion.Stable(stableAscending.last)
 
   // do *not* use implicitly unless type `LanguageMinorVersion` becomes
   // indexed by the enclosing major version's singleton type --SC
-  final def minorVersionOrdering: Ordering[LanguageMinorVersion] =
+  final val minorVersionOrdering: Ordering[LanguageMinorVersion] =
     Ordering.by(acceptedVersions.zipWithIndex.toMap)
 
-  val supportedMinorVersions: List[LanguageMinorVersion] =
+  final val supportedMinorVersions: List[LanguageMinorVersion] =
     acceptedVersions
 
   final def supportsMinorVersion(fromLFFile: String): Boolean =

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -54,7 +54,8 @@ object LanguageVersion {
     val coerceContractId = v1_5
     val textPacking = v1_6
     val enum = v1_6
-    val internedStrings = v1_6
+    val internedPackageId = v1_6
+    val internedStrings = v1_dev
     val internedDottedNames = v1_dev
     val numeric = v1_dev
     val anyTemplate = v1_dev

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -23,10 +23,10 @@ object LanguageVersion {
   private[lf] def apply(major: LanguageMajorVersion, minor: String): LanguageVersion =
     apply(major, Minor fromProtoIdentifier minor)
 
-  def default: LanguageVersion =
+  val default: LanguageVersion =
     defaultV1
 
-  def ordering: Ordering[LanguageVersion] =
+  final val ordering: Ordering[LanguageVersion] =
     (left, right) =>
       (left, right) match {
         case (LanguageVersion(leftMajor, leftMinor), LanguageVersion(rightMajor, rightMinor))

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -54,7 +54,8 @@ object LanguageVersion {
     val coerceContractId = v1_5
     val textPacking = v1_6
     val enum = v1_6
-    val internedIds = v1_6
+    val internedStrings = v1_6
+    val internedDottedNames = v1_dev
     val numeric = v1_dev
     val anyTemplate = v1_dev
 


### PR DESCRIPTION
On one of our huge DAML code bases this has brought down the size of the
DALF by 60% and cut the memory usage during decoding by 50%.

The `@QUERY-LF` tests in the damlc integration tests check that the
interning actually works.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3067)
<!-- Reviewable:end -->
