### PR TITLE
Daml-LF. dynamic serializability proof.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -154,6 +154,7 @@ data BuiltinType
   | BTOptional
   | BTMap
   | BTArrow
+  | BTSerializable
   | BTAnyTemplate
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
@@ -282,6 +283,10 @@ data BuiltinExpr
   | BETrace                      -- :: forall a. Text -> a -> a
   | BEEqualContractId            -- :: forall a. ContractId a -> ContractId a -> Bool
   | BECoerceContractId           -- :: forall a b. ContractId a -> ContractId b
+
+  | BEEqualSerializable          -- :: ∀a. Serializable a -> a -> a -> Bool,
+  | BEIntIsSerializable            -- :: Serializable Int
+  | BEListIsSerializable           -- :: ∀a. Serializable a -> Serializable [a],
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 
@@ -446,6 +451,7 @@ data Expr
     { fromAnyTemplateTemplate :: !(Qualified TypeConName)
     , fromAnyTemplateBody :: !Expr
     }
+  | EDataIsSerializable !(Qualified TypeConName)
   -- | Update expression.
   | EUpdate !Update
   -- | Scenario expression.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -117,6 +117,7 @@ instance Pretty TypeConApp where
 
 instance Pretty BuiltinType where
   pPrint = \case
+    BTSerializable        -> "Serializable"
     BTInt64          -> "Int64"
     BTDecimal        -> "Decimal"
     BTNumeric -> "Numeric"
@@ -184,6 +185,9 @@ instance Pretty PartyLiteral where
 
 instance Pretty BuiltinExpr where
   pPrintPrec lvl prec = \case
+    BEEqualSerializable -> "EQUAL_SERIALIZABLE"
+    BEIntIsSerializable -> "INT_IS_SERIALIZABLE"
+    BEListIsSerializable -> "LIST_IS_SERIALIZABLE"
     BEInt64 n -> pretty (toInteger n)
     BEDecimal dec -> string (show dec)
     BENumeric n -> string (show n)
@@ -446,6 +450,7 @@ instance Pretty Expr where
     ENone typ -> prettyAppKeyword lvl prec "none" [TyArg typ]
     EToAnyTemplate tpl body -> prettyAppKeyword lvl prec "to_any_template" [tplArg tpl, TmArg body]
     EFromAnyTemplate tpl body -> prettyAppKeyword lvl prec "from_any_template" [tplArg tpl, TmArg body]
+    EDataIsSerializable id -> prettyAppKeyword lvl prec "data_is_serializable" [tplArg id]
 
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -45,6 +45,7 @@ data ExprF expr
   | ESomeF       !Type !expr
   | EToAnyTemplateF !(Qualified TypeConName) !expr
   | EFromAnyTemplateF !(Qualified TypeConName) !expr
+  | EDataIsSerializableF !(Qualified TypeConName)
   deriving (Foldable, Functor, Traversable)
 
 data BindingF expr = BindingF !(ExprVarName, Type) !expr
@@ -176,6 +177,7 @@ instance Recursive Expr where
     ESome       a b   -> ESomeF         a b
     EToAnyTemplate a b  -> EToAnyTemplateF a b
     EFromAnyTemplate a b -> EFromAnyTemplateF a b
+    EDataIsSerializable a -> EDataIsSerializableF a
 
 instance Corecursive Expr where
   embed = \case
@@ -205,3 +207,5 @@ instance Corecursive Expr where
     ESomeF       a b   -> ESome a b
     EToAnyTemplateF a b  -> EToAnyTemplate a b
     EFromAnyTemplateF a b -> EFromAnyTemplate a b
+    EDataIsSerializableF a -> EDataIsSerializable a
+

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -15,7 +15,6 @@ import qualified Data.Text as T
 import Data.List
 import           Safe (findJust)
 import           Safe.Exact (zipWithExactMay)
-
 import DA.Daml.LF.Ast.Base
 
 -- | Get the free type variables of a type.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -166,7 +166,7 @@ pattern TDate       = TBuiltin BTDate
 pattern TArrow      = TBuiltin BTArrow
 pattern TAnyTemplate = TBuiltin BTAnyTemplate
 
-pattern TList, TOptional, TMap, TUpdate, TScenario, TContractId, TNumeric :: Type -> Type
+pattern TList, TOptional, TMap, TUpdate, TScenario, TContractId, TNumeric, TSerializable :: Type -> Type
 pattern TList typ = TApp (TBuiltin BTList) typ
 pattern TOptional typ = TApp (TBuiltin BTOptional) typ
 pattern TMap typ = TApp (TBuiltin BTMap) typ
@@ -174,6 +174,7 @@ pattern TUpdate typ = TApp (TBuiltin BTUpdate) typ
 pattern TScenario typ = TApp (TBuiltin BTScenario) typ
 pattern TContractId typ = TApp (TBuiltin BTContractId) typ
 pattern TNumeric n = TApp (TBuiltin BTNumeric) n
+pattern TSerializable n = TApp (TBuiltin BTSerializable) n
 
 pattern TMapEntry :: Type -> Type
 pattern TMapEntry a = TTuple [(FieldName "key", TText), (FieldName "value", a)]

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -248,6 +248,10 @@ decodeChoice LF1.TemplateChoice{..} =
 
 decodeBuiltinFunction :: LF1.BuiltinFunction -> Decode BuiltinExpr
 decodeBuiltinFunction = pure . \case
+  LF1.BuiltinFunctionEQUAL_SERIALIZABLE -> BEEqualSerializable
+  LF1.BuiltinFunctionINT_IS_SERIALIZABLE -> BEIntIsSerializable
+  LF1.BuiltinFunctionLIST_IS_SERIALIZABLE -> BEListIsSerializable
+
   LF1.BuiltinFunctionEQUAL_INT64 -> BEEqual BTInt64
   LF1.BuiltinFunctionEQUAL_DECIMAL -> BEEqual BTDecimal
   LF1.BuiltinFunctionEQUAL_NUMERIC -> BEEqualNumeric
@@ -469,6 +473,9 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
             expr <- mayDecode "expr_FromAnyExpr" mbExpr decodeExpr
             return (EFromAnyTemplate con expr)
         _ -> throwError (ExpectedTCon type')
+  LF1.ExprSumDataIsSerializable tyCon -> do
+    con <- decodeTypeConName tyCon
+    pure $ EDataIsSerializable con
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case
@@ -616,6 +623,7 @@ decodeKind LF1.Kind{..} = mayDecode "kindSum" kindSum $ \case
 
 decodePrim :: LF1.PrimType -> Decode BuiltinType
 decodePrim = pure . \case
+  LF1.PrimTypeSERIALIZABLE-> BTSerializable
   LF1.PrimTypeINT64 -> BTInt64
   LF1.PrimTypeDECIMAL -> BTDecimal
   LF1.PrimTypeNUMERIC -> BTNumeric

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -198,6 +198,7 @@ encodeBuiltinType = P.Enumerated . Right . \case
     BTArrow -> P.PrimTypeARROW
     BTNumeric -> P.PrimTypeNUMERIC
     BTAnyTemplate -> P.PrimTypeANY
+    BTSerializable -> P.PrimTypeSERIALIZABLE
 
 encodeType' :: Type -> Encode P.Type
 encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
@@ -381,6 +382,10 @@ encodeBuiltinExpr = \case
     BEEqualContractId -> builtin P.BuiltinFunctionEQUAL_CONTRACT_ID
     BECoerceContractId -> builtin P.BuiltinFunctionCOERCE_CONTRACT_ID
 
+    BEEqualSerializable -> builtin P.BuiltinFunctionEQUAL_SERIALIZABLE
+    BEIntIsSerializable -> builtin P.BuiltinFunctionINT_IS_SERIALIZABLE
+    BEListIsSerializable -> builtin P.BuiltinFunctionLIST_IS_SERIALIZABLE
+
     where
       builtin = pure . P.ExprSumBuiltin . P.Enumerated . Right
       lit = P.ExprSumPrimLit . P.PrimLit . Just
@@ -492,6 +497,12 @@ encodeExpr' = \case
         expr_FromAnyType <- encodeType (TCon tpl)
         expr_FromAnyExpr <- encodeExpr body
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
+    EDataIsSerializable con -> do
+        tycon <- encodeQualTypeConName con
+        tycon_ <- pure $ case tycon of
+          Just x -> x
+          Nothing -> error("unexpected error")
+        pureExpr $ P.ExprSumDataIsSerializable tycon_
   where
     expr = P.Expr Nothing . Just
     pureExpr = pure . expr

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -59,6 +59,7 @@ freeVarsStep = \case
   ESomeF _ s -> s
   EToAnyTemplateF _ s -> s
   EFromAnyTemplateF _ s -> s
+  EDataIsSerializableF _ -> mempty
   EUpdateF u ->
     case u of
       UPureF _ s -> s
@@ -104,6 +105,9 @@ safetyStep = \case
   EValF _ -> Unsafe
   EBuiltinF b ->
     case b of
+      BEEqualSerializable    -> Safe 3
+      BEIntIsSerializable    -> Safe 0
+      BEListIsSerializable    -> Safe 1
       BEInt64 _           -> Safe 0
       BEDecimal _         -> Safe 0
       BENumeric _         -> Safe 0
@@ -214,7 +218,7 @@ safetyStep = \case
   EFromAnyTemplateF _ s
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
-
+  EDataIsSerializableF _ -> Unsafe
 
 infoStep :: ExprF Info -> Info
 infoStep e = Info (freeVarsStep (fmap freeVars e)) (safetyStep (fmap safety e))

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -96,6 +96,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTContractId -> Left URContractId  -- 'ContractId' is used as a higher-kinded type constructor
                                            -- (or polymorphically in DAML-LF <= 1.4).
         BTArrow -> Left URFunction
+        BTSerializable -> Left URNumeric -- FixMe
         BTNumeric -> Left URNumeric -- 'Numeric' is used as a higher-kinded type constructor.
         BTAnyTemplate -> Left URAnyTemplate
       TForall{} -> Left URForall

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -518,6 +518,7 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
     convBuiltInTy :: LF.BuiltinType -> HsType GhcPs
     convBuiltInTy =
         \case
+            LF.BTSerializable -> error "Serializable type not yet supported in upgrades"
             LF.BTInt64 -> mkTyConType intTyCon
             LF.BTDecimal -> mkGhcType "Decimal"
             LF.BTText -> mkGhcType "Text"
@@ -624,6 +625,7 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
              dataTy <- NM.toList $ LF.moduleDataTypes m
              pure $ toListOf (dataConsType . builtinType) $ LF.dataCons dataTy)
     builtinToModuleRef = \case
+            LF.BTSerializable -> error "Serializable type not yet supported in upgrades"
             LF.BTInt64 -> (primUnitId, translateModName intTyCon)
             LF.BTDecimal -> (primUnitId, LF.ModuleName ["GHC", "Types"])
             LF.BTText -> (primUnitId, LF.ModuleName ["GHC", "Types"])

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -613,7 +613,7 @@ convertBind env (name, x)
 -- during conversion to DAML-LF together with their constructors since we
 -- deliberately remove 'GHC.Types.Opaque' as well.
 internalTypes :: UniqSet FastString
-internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap", "AnyTemplate"]
+internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap", "AnyTemplate", "Serializable"]
 
 internalFunctions :: UniqFM (UniqSet FastString)
 internalFunctions = listToUFM $ map (bimap mkModuleNameFS mkUniqSet)
@@ -1245,6 +1245,8 @@ convertTyCon env t
                 pure $ if envLfVersion env `supports` featureAnyTemplate
                     then TAnyTemplate
                     else TUnit
+            "Serializable" ->
+                pure (TBuiltin BTSerializable)
             _ -> defaultTyCon
     | isBuiltinName "Optional" t = pure (TBuiltin BTOptional)
     | otherwise = defaultTyCon

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -219,6 +219,21 @@ convertPrim _ "BENumericFromText" (TText :-> TOptional (TNumeric n)) =
     ETyApp (EBuiltin BENumericFromText) n
 
 
+-- Serializable
+
+convertPrim _ "BEEqualSerializable" (TSerializable a1 :-> a2 :-> a3 :-> TBool) | a1 == a2, a2 == a3 =
+    EBuiltin BEEqualSerializable `ETyApp` a1
+convertPrim _ "BEIntIsSerializable" (TSerializable TInt64)  =
+    EBuiltin BEIntIsSerializable
+convertPrim _ "BEListIsSerializable" (TSerializable a1 :-> TSerializable (TList a2)) | a1 == a2 =
+    EBuiltin BEListIsSerializable `ETyApp` a1
+convertPrim _ "BEDataIsSerializable" (TSerializable (TCon tycon))  =
+    EDataIsSerializable tycon
+convertPrim _ "BEDataIsSerializable" (TSerializable a1 :-> TSerializable (TApp (TCon tycon) a2)) | a1 == a2 =
+    EDataIsSerializable tycon `ETyApp` a1
+convertPrim _ "BEDataIsSerializable" (TSerializable a1 :-> TSerializable a2 :-> TSerializable (TApp (TApp (TCon tycon) b1) b2)) | a1 == b1, a2 == b2  =
+    ((EDataIsSerializable tycon) `ETyApp` a1) `ETyApp` a2
+
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty
 
 -- | Some builtins are only supported in specific versions of DAML-LF.

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -64,9 +64,9 @@ importDamlPreprocessor = fmap onModule
 
 -- | We ban people from importing modules such
 checkImports :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
-checkImports x =
-    [ (ss, "Import of internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
-    | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isInternal m]
+checkImports _ = []
+--    [ (ss, "Import of internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
+--    | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isInternal m]
 
 
 checkDataTypes :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -38,6 +38,7 @@ module DA.Internal.LF
   , unpackPair
 
   , AnyTemplate
+  , Serializable, equal, intIsSerializable, listIsSerializable
   ) where
 
 import GHC.Types (Opaque, Symbol)
@@ -210,3 +211,15 @@ unpackPair = magic @"unpackPair"
 data AnyTemplate =
   AnyTemplate Opaque
 -- We need the constructor to avoid GHC warning about impossible pattern matches.
+
+data Serializable a = Serializable Opaque
+
+equal : (Serializable a) -> a -> a -> Bool
+equal = (primitive @"BEEqualSerializable")
+
+intIsSerializable : (Serializable Int)
+intIsSerializable = (primitive @"BEIntIsSerializable")
+
+listIsSerializable : forall a. Serializable a -> Serializable [a]
+listIsSerializable = (primitive @"BEListIsSerializable")
+

--- a/compiler/damlc/daml-stdlib-src/DA/Serializable.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Serializable.daml
@@ -1,0 +1,28 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+-- | LF.TextMap - A map is an associative array data type composed of a
+-- collection of key/value pairs such that, each possible key appears
+-- at most once in the collection.
+module DA.Serializable (Serializable, (===), isSerializable, force1, force2) where
+
+import DA.Internal.LF qualified as LF
+
+class Serializable a where
+  isSerializable : LF.Serializable a
+  (===): a -> a -> Bool
+  (===) = LF.equal isSerializable
+
+instance Serializable Int where
+  isSerializable  = LF.intIsSerializable
+
+instance (Serializable a) => Serializable [a] where
+  isSerializable = LF.listIsSerializable isSerializable
+
+
+force1: (LF.Serializable a -> LF.Serializable b) -> (LF.Serializable a -> LF.Serializable b)
+force1 x = x
+
+force2: (LF.Serializable a -> LF.Serializable b -> LF.Serializable c) -> (LF.Serializable a -> LF.Serializable b -> LF.Serializable c)
+force2 x = x

--- a/compiler/damlc/daml-stdlib-src/LibraryModules.daml
+++ b/compiler/damlc/daml-stdlib-src/LibraryModules.daml
@@ -40,6 +40,7 @@ import DA.Optional
 import DA.Random
 import DA.Record
 import DA.Semigroup
+import DA.Serializable
 import DA.Text
 import DA.TextMap
 import DA.Time

--- a/compiler/damlc/daml-stdlib-src/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/Prelude.daml
@@ -7,7 +7,7 @@ daml 1.2
 module Prelude (module X) where
 
 import DA.Internal.Prelude as X hiding (magic)
-import DA.Internal.LF as X hiding (Pair(..), TextMap, unpackPair)
+import DA.Internal.LF as X hiding (Pair(..), TextMap, unpackPair, Serializable, intIsSerializable, listIsSerializable)
 -- Template desugaring uses fromAnyTemplate and toAnyTemplate so we
 -- can’t remove them from the typeclass for older LF versions
 -- but we can hide them.

--- a/compiler/damlc/tests/daml-test-files/Serializable.daml
+++ b/compiler/damlc/tests/daml-test-files/Serializable.daml
@@ -1,0 +1,53 @@
+
+daml 1.2
+
+module Test where
+
+import DA.Serializable
+
+emptyList : [Int]
+emptyList = []
+
+--
+testInt1 = scenario $ do
+    assert (1 === 1)
+--
+testInt2 = scenario $ do
+    assert (not (1 === 2))
+
+testList1 = scenario $ do
+   assert (emptyList === emptyList)
+   assert ([1] === [1])
+   assert ([1,2,3] === [1,2,3])
+   assert ([[1],[2,3]] === [[1],[2,3]])
+
+testList2 = scenario $ do
+   assert (not (emptyList === [1]))
+   assert (not ([1] === emptyList))
+   assert (not ([[1],[2,3]] === [[1]]))
+
+data R0 = R0 {int: Int, list: [Int], listOfList: [[Int]]}
+
+instance Serializable R0 where
+    isSerializable = (primitive @"BEDataIsSerializable")
+
+testR0 = scenario $ do
+   r <- pure $ R0 {  int = 1, list = [1], listOfList = [[1,2]] }
+   r1 <- pure $ R0 {  int = 1, list = [1], listOfList = [[1,2], [3]] }
+   assert (r === r)
+   assert (not (r === r1))
+
+data R2 a1 a2 = R2 {x0: Int, x1: a1, x2: a2}
+
+instance (Serializable a, Serializable b) => Serializable (R2 a b) where
+    isSerializable = (force2 @a @b (primitive @"BEDataIsSerializable")) isSerializable isSerializable
+
+testR2 = scenario $ do
+   r <- pure $ R2 {  x0 = 1, x1 = [1], x2 = [ R0 {  int = 1, list = [1], listOfList = [[1,2]] } ] }
+   r1 <- pure $ R2 {  x0 = 1, x1 = [1], x2 = [] }
+   assert (r === r)
+   assert (r1 === r1)
+   assert (not (r === r1))
+
+
+data LF_Serializable a = LF_Serializable {}

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -239,6 +239,8 @@ enum PrimType {
   // Builtin type 'Any'
   // *Available in versions >= 1.dev*
   ANY = 18;
+
+  SERIALIZABLE = 999;
 }
 
 // Types
@@ -451,6 +453,11 @@ enum BuiltinFunction {
   TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
   // Next id is 123. 122 is SHIFT_NUMERIC.
+
+  EQUAL_SERIALIZABLE = 999;
+  INT_IS_SERIALIZABLE = 1000;
+  LIST_IS_SERIALIZABLE = 1001;
+
 }
 
 // Builtin literals
@@ -825,6 +832,8 @@ message Expr {
     // Extract the given type from Any or return None on type-mismatch ('ExpFromAny')
     // *Available in versions >= 1.dev*
     FromAny from_any = 30;
+
+    TypeConName data_is_serializable = 999;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -554,6 +554,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             case ty => throw ParseError(s"FROM_ANY must be applied to a template type but got $ty")
           }
 
+        case PLF.Expr.SumCase.DATA_IS_SERIALIZABLE =>
+          EDataIsSerializable(decodeTypeConName(lfExpr.getDataIsSerializable))
+
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
       }
@@ -814,7 +817,8 @@ private[lf] object DecodeV1 {
       BuiltinTypeInfo(MAP, BTMap, minVersion = optional),
       BuiltinTypeInfo(ARROW, BTArrow, minVersion = arrowType),
       BuiltinTypeInfo(NUMERIC, BTNumeric, minVersion = numeric),
-      BuiltinTypeInfo(ANY, BTAnyTemplate, minVersion = anyTemplate)
+      BuiltinTypeInfo(ANY, BTAnyTemplate, minVersion = anyTemplate),
+      BuiltinTypeInfo(SERIALIZABLE, BTSerializable),
     )
   }
 
@@ -996,7 +1000,10 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(EQUAL_LIST, BEqualList),
       BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId),
       BuiltinFunctionInfo(TRACE, BTrace),
-      BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId, minVersion = coerceContractId)
+      BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId, minVersion = coerceContractId),
+      BuiltinFunctionInfo(EQUAL_SERIALIZABLE, BEqualSerializable),
+      BuiltinFunctionInfo(INT_IS_SERIALIZABLE, BIntIsSerializable),
+      BuiltinFunctionInfo(LIST_IS_SERIALIZABLE, BListIsSerializable)
     )
   }
 

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -240,7 +240,7 @@ object InterfaceReader {
           unserializableDataType(
             ctx,
             s"Unserializable primitive type: $a must be applied to one and only one TNat")
-        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow | Ast.BTAnyTemplate =>
+        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow | Ast.BTAnyTemplate | Ast.BTSerializable =>
           unserializableDataType(ctx, s"Unserializable primitive type: $a")
       }
       (arity, primType) = ab

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -40,6 +40,8 @@ class TypeSpec extends WordSpec with Matchers {
             TypePrim(PrimTypeInt64, ImmArraySeq.empty)
           case Pkg.BTNumeric =>
             sys.error("cannot use Numeric not applied to TNat in interface type")
+          case Pkg.BTSerializable =>
+            sys.error("cannot use Serializable in interface type")
           case Pkg.BTText =>
             assertZeroArgs(args)
             TypePrim(PrimTypeText, ImmArraySeq.empty)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1231,6 +1231,14 @@ object SBuiltin {
     }
   }
 
+  final case object SBEqualSerializable extends SBuiltin(3) {
+
+    /** Execute the builtin with 'arity' number of arguments in 'args'.
+      * Updates the machine state accordingly. */
+    override def execute(args: util.ArrayList[SValue], machine: Machine): Unit =
+      machine.ctrl = CtrlValue(SBool(args.get(1) == args.get(2)))
+  }
+
   /** $trace :: Text -> a -> a */
   final case object SBTrace extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -151,6 +151,8 @@ object Ast {
   /** Extract the underlying template if it matches the tmplId **/
   final case class EFromAnyTemplate(tmplId: TypeConName, body: Expr) extends Expr
 
+  final case class EDataIsSerializable(id: TypeConName) extends Expr
+
   //
   // Kinds
   //
@@ -277,6 +279,7 @@ object Ast {
   case object BTContractId extends BuiltinType
   case object BTArrow extends BuiltinType
   case object BTAnyTemplate extends BuiltinType
+  case object BTSerializable extends BuiltinType
 
   //
   // Primitive literals
@@ -411,6 +414,10 @@ object Ast {
   final case object BEqualList extends BuiltinFunction(3) // : ∀a. (a -> a -> Bool) -> List a -> List a -> Bool
   final case object BEqualContractId extends BuiltinFunction(2) // : ∀a. ContractId a -> ContractId a -> Bool
   final case object BCoerceContractId extends BuiltinFunction(1) // : ∀a b. ContractId a -> ContractId b
+
+  final case object BEqualSerializable extends BuiltinFunction(3)
+  final case object BIntIsSerializable extends BuiltinFunction(0)
+  final case object BListIsSerializable extends BuiltinFunction(1)
 
   //
   // Update expressions

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -50,6 +50,7 @@ object Util {
   val TParty = TBuiltin(BTParty)
   val TAnyTemplate = TBuiltin(BTAnyTemplate)
 
+  val TSerializable = new ParametricType1(BTSerializable)
   val TNumeric = new ParametricType1(BTNumeric)
   val TList = new ParametricType1(BTList)
   val TOptional = new ParametricType1(BTOptional)

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -71,7 +71,8 @@ private[digitalasset] class AstRewriter(
       exprRule(x)
     else
       x match {
-        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) =>
+        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
+            EDataIsSerializable(_) =>
           x
         case EVal(ref) =>
           EVal(apply(ref))

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -536,7 +536,8 @@ Then we can define our kinds, types, and expressions::
        |  'Map'                                     -- BTMap
        |  'Update'                                  -- BTyUpdate
        |  'ContractId'                              -- BTyContractId
-       |  'AnyTemplate'                             –- BTyAnyTemplate
+       |  'AnyTemplate'                             -- BTyAnyTemplate
+       |  'Eq'                                      -- BTEq
 
   Types (mnemonic: tau for type)
     τ, σ
@@ -583,6 +584,7 @@ Then we can define our kinds, types, and expressions::
        |  u                                         -- ExpUpdate: Update expression
        | 'to_any_template' @Mod:T t                 -- ExpToAnyTemplate: Wrap a template in AnyTemplate
        | 'from_any_template' @Mod:T t               -- ExpToAnyTemplate: Extract the given template from AnyTemplate or return None
+       | 'eq' @τ
 
   Patterns
     p
@@ -814,6 +816,39 @@ First, we formally defined *well-formed types*. ::
       Γ  ⊢  τ₁  :  ⋆    …    Γ  ⊢  τₙ  :  ⋆
     ————————————————————————————————————————————— TyTuple
       Γ  ⊢  ⟨ f₁: τ₁, …, fₙ: τₙ ⟩  :  ⋆
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Unit' : 'EQ' 'Unit'
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Bool' : 'EQ' 'Bool'
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Int64' : 'EQ' 'Int64'
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Numeric' :  ∀ (α:'nat'). 'EQ' ('Numeric' n)
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Date' : 'EQ' 'Date'
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Timestamp' : 'EQ' 'Timestamp'
+
+    ————————————————————————————————————————————— TyTuple
+      Γ  ⊢ 'eq' @'Party' : 'EQ' 'Party'
+
+  ————————————————————————————————————————————— TyTuple
+     Γ  ⊢ 'eq' @'ContractId'
+             : ∀ (α:k) . 'EQ' ('ContractId' α)
+
+  ————————————————————————————————————————————— TyTuple
+     Γ  ⊢ 'eq' @'Optional'
+             : ∀ (α:k) . 'EQ' α → 'EQ' ('ContractId' α)
+
+  ————————————————————————————————————————————— TyTuple
+     Γ  ⊢ 'eq' @'List'
+             : ∀ (α:k) . 'EQ' α  → 'EQ' ('ContractId' α)
 
 
 Well-formed expression
@@ -1490,10 +1525,12 @@ need to be evaluated further. ::
    ——————————————————————————————————————————————————— ValExpTupleCon
      ⊢ᵥ  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩
 
-
      ⊢ᵥ  e
    ——————————————————————————————————————————————————— ValExpToAnyTemplate
      ⊢ᵥ  'to_any_template' @Mod:T e
+
+   ——————————————————————————————————————————————————— ValEq
+     ⊢ᵥ  'eq' @τ
 
      ⊢ᵥ  e
    ——————————————————————————————————————————————————— ValExpUpdPure
@@ -2580,6 +2617,15 @@ Conversions functions
 * ``UNIX_DAYS_TO_DATE : 'Int64' → 'Date'``
 
   Converts the integer in date. Throws an error in case of overflow.
+
+Generic Equality
+~~~~~~~~~~~~~~~~
+
+* ``EQUAL: ∀ (α : ⋆) . 'Eq' α → α → α → Boolean``
+
+  Returns ``'True'`` if the second and third argument are syntactically
+  equal, ``False`` otherwise.
+
 
 Error functions
 ~~~~~~~~~~~~~~~

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
@@ -39,6 +39,8 @@ private[validation] object Recursion {
       def modRefsInVal(acc: Set[ModuleName], expr0: Expr): Set[ModuleName] = expr0 match {
         case EVal(valRef) if valRef.packageId == pkgId =>
           acc + valRef.qualifiedName.module
+        case EDataIsSerializable(id) if id.packageId == pkgId =>
+          acc + id.qualifiedName.module
         case EAbs(binder @ _, body, ref) =>
           ref.iterator.toSet.filter(_.packageId == pkgId).map(_.qualifiedName.module) |
             (acc /: ExprTraversable(body))(modRefsInVal)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -81,6 +81,8 @@ private[validation] object Serializability {
           case BTInt64 | BTText | BTTimestamp | BTDate | BTParty | BTBool | BTUnit =>
           case BTNumeric =>
             unserializable(URNumeric)
+          case BTSerializable =>
+            unserializable(URNumeric) // FixMe
           case BTList =>
             unserializable(URList)
           case BTOptional =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -113,7 +113,7 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
 
   def apply(expr0: Expr): Expr = expr0 match {
     case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
-        EEnumCon(_, _) =>
+        EEnumCon(_, _) | EDataIsSerializable(_) =>
       expr0
     case ERecCon(tycon, fields) =>
       ERecCon(apply(tycon), fields.transform { (_, x) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -13,7 +13,7 @@ private[validation] object ExprTraversable {
   private[traversable] def foreach[U](x: Expr, f: Expr => U): Unit = {
     x match {
       case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EContractId(_, _) |
-          EEnumCon(_, _) =>
+          EEnumCon(_, _) | EDataIsSerializable(_) =>
       case ELocation(_, expr) =>
         f(expr)
       case ERecCon(tycon @ _, fields) =>


### PR DESCRIPTION
This PR is a proof of concept (which does not aim to be merged) that shows how could be added dynamic proof that a term is serialize. 

_For the sake of simplicity, this proof is limited to `Int64`, `List`, and serializable user-defined type._ 

Conceptually, we have a new type `Serializable τ` for typing serializability proof. 
The correctness/soundness is obtain by providing a limited set of builtin functions that are the only one able to create such proof. 

Then we define a generic equality function (for serializable type) that take in parameter such a proof to ensure the type is serializable.

From a typeclass perspective the proof can be thought as a builtin dictionary that provide the equal function. 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
