### PR TITLE
Write JSON files in damlc integration test

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -36,7 +36,8 @@ import Development.IDE.Types.Location
 import Development.IDE.Types.Options(IdeReportProgress(..))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Lens as A
-import           Data.ByteString.Lazy.Char8 (unpack)
+import qualified Data.Aeson.Encode.Pretty as A
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import           Data.Char
 import qualified Data.DList as DList
 import Data.Foldable
@@ -175,7 +176,7 @@ testCase args version getService outdir registerTODO (name, file) = singleTest n
       for_ [file ++ ", " ++ x | Todo x <- anns] (registerTODO . TODO)
       resDiag <- checkDiagnostics log [fields | DiagnosticFields fields <- anns] $
         [ideErrorText "" $ T.pack $ show e | Left e <- [ex], not $ "_IGNORE_" `isInfixOf` show e] ++ diags
-      resQueries <- runJqQuery log [(pkg, q) | Right pkg <- [ex], QueryLF q <- anns]
+      resQueries <- runJqQuery log outdir file [q | QueryLF q <- anns]
       let failures = catMaybes $ resDiag : resQueries
       case failures of
         err : _others -> pure $ testFailed err
@@ -187,22 +188,17 @@ testCase args version getService outdir registerTODO (name, file) = singleTest n
       UntilLF maxVersion -> version > maxVersion
       _ -> False
 
-runJqQuery :: (String -> IO ()) -> [(LF.Package, String)] -> IO [Maybe String]
-runJqQuery log qs = do
-  forM qs $ \(pkg, q) -> do
+runJqQuery :: (String -> IO ()) -> FilePath -> FilePath -> [String] -> IO [Maybe String]
+runJqQuery log outdir file qs = do
+  let proj = takeBaseName file
+  forM qs $ \q -> do
     log $ "running jq query: " ++ q
-    let json = unpack $ A.encode $ transformOn A._Value numToString $ JSONPB.toJSONPB (encodePackage pkg) JSONPB.jsonPBOptions
     let jqKey = "external" </> "jq_dev_env" </> "bin" </> if isWindows then "jq.exe" else "jq"
     jq <- locateRunfiles $ mainWorkspace </> jqKey
-    out <- readProcess jq [q] json
+    out <- readProcess jq [q, outdir </> proj <.> "json"] ""
     case trim out of
       "true" -> pure Nothing
       other -> pure $ Just $ "jq query failed: got " ++ other
-  where
-    numToString :: A.Value -> A.Value
-    numToString = \case
-      A.Number x -> A.String $ T.pack $ show x
-      other -> other
 
 
 data DiagnosticField
@@ -312,12 +308,18 @@ parseRange s =
 
 mainProj :: TestArguments -> IdeState -> FilePath -> (String -> IO ()) -> NormalizedFilePath -> IO LF.Package
 mainProj TestArguments{..} service outdir log file = do
-    writeFile <- return $ \a b -> length b `seq` writeFile a b
     let proj = takeBaseName (fromNormalizedFilePath file)
 
     let corePrettyPrint = timed log "Core pretty-printing" . liftIO . writeFile (outdir </> proj <.> "core") . unlines . map prettyPrint
     let lfSave = timed log "LF saving" . liftIO . writeFileLf (outdir </> proj <.> "dalf")
     let lfPrettyPrint = timed log "LF pretty-printing" . liftIO . writeFile (outdir </> proj <.> "pdalf") . renderPretty
+    let jsonSave pkg =
+            let numToString :: A.Value -> A.Value
+                numToString = \case
+                  A.Number x -> A.String $ T.pack $ show x
+                  other -> other
+                json = A.encodePretty $ transformOn A._Value numToString $ JSONPB.toJSONPB (encodePackage pkg) JSONPB.jsonPBOptions
+            in timed log "JSON saving" . liftIO . BSL.writeFile (outdir </> proj <.> "json") $ json
 
     setFilesOfInterest service (Set.singleton file)
     runActionSync service $ do
@@ -329,6 +331,7 @@ mainProj TestArguments{..} service outdir log file = do
             lf <- lfTypeCheck log file
             lfSave lf
             lfRunScenarios log file
+            jsonSave lf
             pure lf
 
 unjust :: Action (Maybe b) -> Action b


### PR DESCRIPTION
There were quite a few occurences where I needed to look at the JSON
representation of the generated DALF in the past. Particularly, when
trying to come up with the `@QUERY-LF` pragmas for new tests.

This PR writes the JSON files to disk next to the (pretty printed)
DALF files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
