### PR TITLE
fix haskell export script

### DIFF
--- a/language-support/hs/bindings/export-package.sh
+++ b/language-support/hs/bindings/export-package.sh
@@ -10,9 +10,9 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-cd "$(dirname ${BASH_SOURCE[0]})"
+TARGET_DIR=$(realpath $1)
 
-TARGET_DIR=$1
+cd "$(dirname ${BASH_SOURCE[0]})"
 
 bazel build //ledger-api/grpc-definitions:all-ledger-api-haskellpb-sources
 


### PR DESCRIPTION
At the moment, if the script is not invoked from its own directory and given a relative path as first argument, the path given to stack ends up being relative to the script directory anyway.

So if I'm at the root of the daml repo and type:
```
language-support/hs/bindings/export-package.sh ../davl/cli/
```
and then try to do
```
cd ../davl/cli
stack run
```
it _does_ work, because stack seems to register the sdist internally, but it does not, as expected, put the tar file at the expected place (my cwd in the last step), which is now breaking my attempts at caching the sdist.

It's a bit weird that in that case stack seems to just silently ignore the fact that its argument points to a directory that does not exist. It does not create it, and it does not exit with non-zero.

This fixes it by resolving the given argument to an absolute path before moving the script's cwd.