### PR TITLE
Remove flaky=True from trigger tests

### DIFF
--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -66,8 +66,6 @@ client_server_test(
     client = ":acs_test_client",
     client_files = ["$(rootpath :acs.dar)"],
     data = [":acs.dar"],
-    # See https://github.com/digital-asset/daml/issues/2881
-    flaky = True,
     server = "//ledger/sandbox:sandbox-binary",
     server_files = ["$(rootpath :acs.dar)"],
 )


### PR DESCRIPTION
I’ve run them a 100 times locally and haven’t been able to get them to
fail so it looks like the issue has been fixed since.

fixes #2881

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
