### PR TITLE
Use newtypes for id types in DAML triggers

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -9,6 +9,9 @@ module Daml.Trigger
   , Transaction(..)
   , Identifier(..)
   , AnyContractId(..)
+  , TransactionId(..)
+  , EventId(..)
+  , CommandId(..)
   , Event(..)
   , Created(..)
   , Archived(..)
@@ -32,8 +35,17 @@ data AnyContractId = AnyContractId
   , contractId : Text
   } deriving (Show, Eq)
 
+newtype TransactionId = TransactionId Text
+  deriving (Show, Eq)
+
+newtype EventId = EventId Text
+  deriving (Show, Eq)
+
+newtype CommandId = CommandId Text
+  deriving (Show, Eq)
+
 data Transaction = Transaction
- { transactionId : Text
+ { transactionId : TransactionId
  , events : [Event]
  }
 
@@ -42,13 +54,13 @@ data Event
   | ArchivedEvent Archived
 
 data Created = Created
-  { eventId : Text
+  { eventId : EventId
   , contractId : AnyContractId
   , argument : AnyTemplate
   }
 
 data Archived = Archived
-  { eventId : Text
+  { eventId : EventId
   , contractId : AnyContractId
   } deriving (Show, Eq)
 
@@ -57,13 +69,13 @@ data Message
   | MCompletion Completion
 
 data Completion = Completion
-  { commandId : Text
+  { commandId : CommandId
   , status : CompletionStatus
   } deriving Show
 
 data CompletionStatus
   = Failed { status : Int, message : Text }
-  | Succeeded { transactionId : Text }
+  | Succeeded { transactionId : TransactionId }
   deriving Show
 
 data ActiveContracts = ActiveContracts { activeContracts : [Created] }
@@ -113,6 +125,6 @@ exerciseCmd contractId choiceArg =
   ExerciseCommand contractId (toLedgerValue choiceArg)
 
 data Commands = Commands
-  { commandId : Text
+  { commandId : CommandId
   , commands : [Command]
   }

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -50,7 +50,7 @@ test = Trigger
       ([], acs) -> (state { activeAssets = acs }, [], "No command")
       (cmds, acs) ->
         ( state { activeAssets = acs, nextCommandId = state.nextCommandId + 1 }
-        , [Commands ("command_" <> show state.nextCommandId) cmds]
+        , [Commands (CommandId $ "command_" <> show state.nextCommandId) cmds]
         , "Submitted " <> show (length cmds) <> " commands"
         )
       where


### PR DESCRIPTION
This makes the API a bit safer and nicer to use. Since this is a
low-level API the constructors are exposed, for the high-level API we
probably want to hide them.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
