### PR TITLE
Log machine ids with reported errors

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -357,7 +357,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir (from
                       f loggerH
                   Undecided -> f loggerH
           initPackageDb lfVersion (InitPkgDb True) (AllowDifferentSdkVersions False)
-          dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+          dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
           opts <- defaultOptionsIO (Just lfVersion)
           opts <- pure $ opts
               { optScenarioService = enableScenarioService

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
@@ -206,7 +206,7 @@ instance ToJSON LogEntry where
 -- | this stores information about the users machine and is transmitted at the
 --   start of every session
 data MetaData = MetaData
-    { machineID :: !UUID
+    { machineId :: !UUID
     , operatingSystem :: !T.Text
     , version :: !(Maybe T.Text)
     } deriving Generic
@@ -219,14 +219,14 @@ logMetaData gcpState = do
 
 getMetaData :: GCPState -> IO MetaData
 getMetaData gcp = do
-    machineID <- fetchMachineID gcp
+    machineId <- fetchMachineID gcp
     v <- lookupEnv sdkVersionEnvVar
     let version = case v of
             Nothing -> Nothing
             Just "" -> Nothing
             Just vs -> Just $ T.pack vs
     pure MetaData
-        { machineID
+        { machineId
         , operatingSystem = T.pack os
         , version
         }

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
@@ -225,7 +225,7 @@ getMetaData gcp = do
             Just vs -> Just $ T.pack vs
     pure MetaData
         { machineID
-        , operatingSystem=T.pack os
+        , operatingSystem = T.pack os
         , version
         }
 
@@ -293,7 +293,7 @@ sendLogs gcp (unzip -> (entries, finalizers)) = unless (null entries) $ do
         Nothing -> Lgr.logJson (gcpFallbackLogger gcp) Lgr.Info ("Timeout while sending log request" :: T.Text)
         Just (HttpError e) -> logException gcp e
         Just ReachedDataLimit -> pure ()
-        Just SendSuccess -> sequence_ (map (void . tryAny) finalizers)
+        Just SendSuccess -> sequence_ $ map (void . tryAny) finalizers
 
 logsHost :: BS.ByteString
 logsHost = "logs.daml.com"
@@ -321,9 +321,9 @@ fetchMachineID :: GCPState -> IO UUID
 fetchMachineID gcp = do
     let fp = machineIDFile gcp
     let generateID = do
-        mID <- randomIO
-        T.writeFileUtf8 fp $ UUID.toText mID
-        pure mID
+            mID <- randomIO
+            T.writeFileUtf8 fp $ UUID.toText mID
+            pure mID
     exists <- doesFileExist fp
     if exists
        then do

--- a/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
+++ b/libs-haskell/da-hs-base/src/DA/Service/Logger/Impl/GCP.hs
@@ -189,7 +189,7 @@ withGcpLogger p hnd f = do
               logGCP gcp priority js (pure ())
 
 data LogEntry = LogEntry
-    { machineId :: !UUID
+    { leMachineId :: !UUID
     , severity :: !Lgr.Priority
     , timeStamp :: !UTCTime
     , message :: !(WithSession Value)
@@ -197,7 +197,7 @@ data LogEntry = LogEntry
 
 instance ToJSON LogEntry where
     toJSON LogEntry{..} = Object $ HM.fromList
-        [ ("machineId", toJSON machineId)
+        [ ("machineId", toJSON leMachineId)
         , ("severity", priorityToGCP severity)
         , ("timestamp", toJSON timeStamp)
         , ("jsonPayload", toJSON message)
@@ -243,7 +243,7 @@ instance ToJSON a => ToJSON (WithSession a) where
 
 toLogEntry :: Aeson.ToJSON a => GCPState -> Lgr.Priority -> a -> IO LogEntry
 toLogEntry gcp@GCPState{gcpSessionID} severity m = do
-    machineId <- fetchMachineID gcp
+    leMachineId <- fetchMachineID gcp
     timeStamp <- getCurrentTime
     let message = WithSession gcpSessionID $ toJSON m
     pure LogEntry{..}


### PR DESCRIPTION
Still getting familiar with this code, so open to feedback. My intention is to include machine IDs in more logged events - I noticed that at the moment we do not see machine ids for user errors (e.g. compile errors). It would be useful to have this for analytics purposes.

This PR adds the machine id to the LogEntry data type, in addition to the Metadata type which does include the machine id.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
