### PR TITLE
language: migrate: allow optional fields at any position

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Upgrade.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE IncoherentInstances #-}
 
 daml 1.2
 
@@ -89,13 +89,19 @@ instance (GenConvertible a1 a2, GenConvertible b1 b2) => GenConvertible (a1 :*: 
   cv ~(P1 a b) = P1 (cv a) (cv b)
 
 -- product embeddings
-instance (GenConvertible a1 a2) => GenConvertible a1 (a2 :*: Opt b s) where
+instance {-# OVERLAPPING #-} (GenConvertible a1 a2) => GenConvertible a1 (a2 :*: Opt b s) where
   cv a = P1 (cv a) genNone
 
+instance {-# OVERLAPPABLE #-} (GenConvertible b1 b2) => GenConvertible b1 (Opt a s :*: b2) where
+  cv b = P1 genNone (cv b)
+
 -- product projections
-instance GenConvertible a1 a2 => GenConvertible (a1 :*: Opt b1 s) a2 where
+instance {-# OVERLAPPING #-} GenConvertible a1 a2 => GenConvertible (a1 :*: Opt b1 s) a2 where
   cv ~(P1 a (M1 (K1 {unK1 = None}))) = cv a
   -- cv ~(P1 a (M1 (K1 {unK1 = Some _b}))) = error "This conversion would have introduced data loss"
+
+instance {-# OVERLAPPABLE #-} GenConvertible b1 b2 => GenConvertible (Opt a1 s :*: b1) b2 where
+  cv ~(P1 (M1 (K1 {unK1 = None})) b) = cv b
 
 -- sums
 instance (GenConvertible a1 a2, GenConvertible b1 b2) => GenConvertible (a1 :+: b1) (a2 :+: b2) where


### PR DESCRIPTION
This change makes it possible to add an optional field at an arbitrary
position and derive embeddings/projections.

To make the life of the constraint inference easier, I had to change  foldBal to foldr1 in generic instances. Not sure if this can lead to a performance problem. Opinions?

This should fix #2972 .

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
