### PR TITLE
Add a tool to generate simple DALF for plain DALF import test

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -285,3 +285,23 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+# Generate a simple DALF for plain DALF import testing
+
+da_haskell_binary(
+    name = "generate-simple-dalf",
+    srcs = ["src/DA/Test/GenerateSimpleDalf.hs"],
+    hackage_deps = [
+        "base",
+        "bytestring",
+        "text",
+    ],
+    main_function = "DA.Test.GenerateSimpleDalf.main",
+    src_strip_prefix = "src",
+    deps = [
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto",
+        "//compiler/daml-lf-tools",
+        "//libs-haskell/da-hs-base",
+    ],
+)

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -1,0 +1,83 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+module DA.Test.GenerateSimpleDalf (main) where
+
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.NameMap as NM
+import qualified Data.Text.IO as T
+import System.Environment
+
+import DA.Daml.LF.Ast.Base
+import DA.Daml.LF.Ast.Util
+import DA.Daml.LF.Ast.Version
+import DA.Daml.LF.Ast.World
+import DA.Daml.LF.Proto3.Archive
+import DA.Daml.LF.TypeChecker
+import DA.Pretty
+
+-- | This tool generates a simple DALF file and writes it to the first
+-- argument given on the command line. This DALF is intended to be used
+-- as a test case for the plain DALF import feature.
+main :: IO ()
+main = do
+    [file] <- getArgs
+    let version = V1 (PointStable 6)
+    let modName = ModuleName ["Module"]
+    let modRef = Qualified PRSelf modName
+    let tplFields = map FieldName ["this", "arg"]
+    let tplRec = DefDataType
+            { dataLocation = Nothing
+            , dataTypeCon = TypeConName ["Template"]
+            , dataSerializable = IsSerializable True
+            , dataParams = []
+            , dataCons = DataRecord $ map (, TParty) tplFields
+            }
+    let tplParam = ExprVarName "arg"
+    let tplParties =
+            let cons f = ECons TParty (ERecProj (TypeConApp (modRef (dataTypeCon tplRec)) []) f (EVar tplParam))
+            in foldr cons (ENil TParty) tplFields
+    let chcArg = DefDataType
+            { dataLocation = Nothing
+            , dataTypeCon = TypeConName ["Choice"]
+            , dataSerializable = IsSerializable True
+            , dataParams = []
+            , dataCons = DataVariant [(VariantConName "Choice", TUnit)]
+            }
+    let chc = TemplateChoice
+            { chcLocation = Nothing
+            , chcName = ChoiceName "NotChoice"
+            , chcConsuming = True
+            , chcControllers = tplParties
+            , chcSelfBinder = ExprVarName "this"
+            , chcArgBinder = (ExprVarName "self", TCon (modRef (dataTypeCon chcArg)))
+            , chcReturnType = TUnit
+            , chcUpdate = EUpdate $ UPure TUnit EUnit
+            }
+    let tpl = Template
+            { tplLocation = Nothing
+            , tplTypeCon = TypeConName ["Template"]
+            , tplParam = tplParam
+            , tplPrecondition = mkBool True
+            , tplSignatories = tplParties
+            , tplObservers = ENil TParty
+            , tplAgreement = mkEmptyText
+            , tplChoices = NM.fromList [chc]
+            , tplKey = Nothing
+            }
+    let mod = Module
+            { moduleName = ModuleName ["Module"]
+            , moduleSource = Nothing
+            , moduleFeatureFlags = FeatureFlags{forbidPartyLiterals = True}
+            , moduleDataTypes = NM.fromList [tplRec, chcArg]
+            , moduleValues = NM.empty
+            , moduleTemplates = NM.fromList [tpl]
+            }
+    either (error . renderPretty) pure $ checkModule (initWorld [] version) version mod
+    let pkg = Package
+            { packageLfVersion = version
+            , packageModules = NM.fromList [mod]
+            }
+    let (bytes, hash) = encodeArchiveAndHash pkg
+    BSL.writeFile file bytes
+    T.putStrLn hash
+    pure ()


### PR DESCRIPTION
We're working on a feature to import plain DALFs without any attached
source or interface files into a DAML project. This PR provides a tool to
generate a simple DALF file for testing this feature.

Currently, the DALF looks like
```
package 6717121ea2a7792f0fe90b08da87eaf3bec54593b80c15ce842be2995d0a1450 where
  daml-lf 1.6
  +ForbidPartyLiterals
  
  module Module where
    record @serializable Template = {this : Party; arg : Party}
    variant @serializable Choice =
      | Choice Unit
    template Template arg where
      signatory cons
                  @Party
                  (Module:Template.this arg)
                  (cons @Party (Module:Template.arg arg) (nil @Party))
      observer nil @Party
      ensure true
      agreement ""
      choice consuming NotChoice (this : ContractId Module:Template) (self : Module:Choice) : Unit
        by cons
             @Party
             (Module:Template.this arg)
             (cons @Party (Module:Template.arg arg) (nil @Party))
        to upure @Unit unit
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3102)
<!-- Reviewable:end -->
