### PR TITLE
Implement ToTextTemplateId primitive on Scala side

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -594,6 +594,12 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
 
       case EFromAnyTemplate(tmplId, e) =>
         SEApp(SEBuiltin(SBFromAnyTemplate(tmplId)), Array(translate(e)))
+
+      case ETyCon(tyCon) =>
+        // Ensure that the type is known.
+        lookupDefinition(tyCon)
+          .getOrElse(throw CompileError(s"type $tyCon not found"))
+        SEBuiltin(SBTyCon(tyCon))
     }
 
   @tailrec

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -595,11 +595,8 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
       case EFromAnyTemplate(tmplId, e) =>
         SEApp(SEBuiltin(SBFromAnyTemplate(tmplId)), Array(translate(e)))
 
-      case ETyCon(tyCon) =>
-        // Ensure that the type is known.
-        lookupDefinition(tyCon)
-          .getOrElse(throw CompileError(s"type $tyCon not found"))
-        SEBuiltin(SBTyCon(tyCon))
+      case EToTextTemplateId(tmplId) =>
+        SEBuiltin(SBToTextTemplateId(tmplId))
     }
 
   @tailrec

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1277,12 +1277,12 @@ object SBuiltin {
     }
   }
 
-  /** $ty_con
+  /** $to_text_template_id
     *     :: Text
     */
-  final case class SBTyCon(tyCon: TypeConName) extends SBuiltin(0) {
+  final case class SBToTextTemplateId(tmplId: TypeConName) extends SBuiltin(0) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SText(tyCon.toString()))
+      machine.ctrl = CtrlValue(SText(tmplId.toString()))
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1277,6 +1277,15 @@ object SBuiltin {
     }
   }
 
+  /** $ty_con
+    *     :: Text
+    */
+  final case class SBTyCon(tyCon: TypeConName) extends SBuiltin(0) {
+    def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
+      machine.ctrl = CtrlValue(SText(tyCon.toString()))
+    }
+  }
+
   // Helpers
   //
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -161,6 +161,19 @@ class SpeedyTest extends WordSpec with Matchers {
     }
   }
 
+  "ty_con" should {
+
+    "equal for equal types" in {
+      eval(e"""EQUAL_TEXT (ty_con @Test:T1) (ty_con @Test:T1)""", anyTemplatePkgs) shouldBe Right(
+        SBool(true))
+    }
+
+    "different for different types" in {
+      eval(e"""EQUAL_TEXT (ty_con @Test:T1) (ty_con @Test:T2)""", anyTemplatePkgs) shouldBe Right(
+        SBool(false))
+    }
+
+  }
 }
 
 object SpeedyTest {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -161,16 +161,18 @@ class SpeedyTest extends WordSpec with Matchers {
     }
   }
 
-  "ty_con" should {
+  "to_text_template_id" should {
 
     "equal for equal types" in {
-      eval(e"""EQUAL_TEXT (ty_con @Test:T1) (ty_con @Test:T1)""", anyTemplatePkgs) shouldBe Right(
-        SBool(true))
+      eval(
+        e"""EQUAL_TEXT (to_text_template_id @Test:T1) (to_text_template_id @Test:T1)""",
+        anyTemplatePkgs) shouldBe Right(SBool(true))
     }
 
     "different for different types" in {
-      eval(e"""EQUAL_TEXT (ty_con @Test:T1) (ty_con @Test:T2)""", anyTemplatePkgs) shouldBe Right(
-        SBool(false))
+      eval(
+        e"""EQUAL_TEXT (to_text_template_id @Test:T1) (to_text_template_id @Test:T2)""",
+        anyTemplatePkgs) shouldBe Right(SBool(false))
     }
 
   }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -151,8 +151,8 @@ object Ast {
   /** Extract the underlying template if it matches the tmplId **/
   final case class EFromAnyTemplate(tmplId: TypeConName, body: Expr) extends Expr
 
-  /** Textual type representation **/
-  final case class ETyCon(tyCon: TypeConName) extends Expr
+  /** Unique textual representation of template Id **/
+  final case class EToTextTemplateId(tmplId: TypeConName) extends Expr
 
   //
   // Kinds

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -151,6 +151,9 @@ object Ast {
   /** Extract the underlying template if it matches the tmplId **/
   final case class EFromAnyTemplate(tmplId: TypeConName, body: Expr) extends Expr
 
+  /** Textual type representation **/
+  final case class ETyCon(tyCon: TypeConName) extends Expr
+
   //
   // Kinds
   //

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -125,6 +125,8 @@ private[digitalasset] class AstRewriter(
           EToAnyTemplate(tmplId, apply(body))
         case EFromAnyTemplate(tmplId, body) =>
           EFromAnyTemplate(tmplId, apply(body))
+        case ETyCon(tyCon) =>
+          ETyCon(tyCon)
       }
 
   def apply(x: TypeConApp): TypeConApp = x match {

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -125,8 +125,8 @@ private[digitalasset] class AstRewriter(
           EToAnyTemplate(tmplId, apply(body))
         case EFromAnyTemplate(tmplId, body) =>
           EFromAnyTemplate(tmplId, apply(body))
-        case ETyCon(tyCon) =>
-          ETyCon(tyCon)
+        case EToTextTemplateId(tmplId) =>
+          EToTextTemplateId(tmplId)
       }
 
   def apply(x: TypeConApp): TypeConApp = x match {

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -34,6 +34,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eLet |
       eToAnyTemplate |
       eFromAnyTemplate |
+      eTyCon |
       contractId |
       fullIdentifier ^^ EVal |
       (id ^? builtinFunctions) ^^ EBuiltin |
@@ -184,6 +185,11 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   private lazy val eFromAnyTemplate: Parser[Expr] =
     `from_any_template` ~>! `@` ~> fullIdentifier ~ expr0 ^^ {
       case tyCon ~ e => EFromAnyTemplate(tyCon, e)
+    }
+
+  private lazy val eTyCon: Parser[Expr] =
+    `ty_con` ~>! `@` ~> fullIdentifier ^^ {
+      case tyCon => ETyCon(tyCon)
     }
 
   private lazy val pattern: Parser[CasePat] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -34,7 +34,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eLet |
       eToAnyTemplate |
       eFromAnyTemplate |
-      eTyCon |
+      eToTextTemplateId |
       contractId |
       fullIdentifier ^^ EVal |
       (id ^? builtinFunctions) ^^ EBuiltin |
@@ -187,9 +187,9 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       case tyCon ~ e => EFromAnyTemplate(tyCon, e)
     }
 
-  private lazy val eTyCon: Parser[Expr] =
-    `ty_con` ~>! `@` ~> fullIdentifier ^^ {
-      case tyCon => ETyCon(tyCon)
+  private lazy val eToTextTemplateId: Parser[Expr] =
+    `to_text_template_id` ~>! `@` ~> fullIdentifier ^^ {
+      case tyCon => EToTextTemplateId(tyCon)
     }
 
   private lazy val pattern: Parser[CasePat] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -41,7 +41,8 @@ private[parser] object Lexer extends RegexParsers {
     "by" -> `by`,
     "to" -> `to`,
     "to_any_template" -> `to_any_template`,
-    "from_any_template" -> `from_any_template`
+    "from_any_template" -> `from_any_template`,
+    "ty_con" -> `ty_con`
   )
 
   val token: Parser[Token] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -42,7 +42,7 @@ private[parser] object Lexer extends RegexParsers {
     "to" -> `to`,
     "to_any_template" -> `to_any_template`,
     "from_any_template" -> `from_any_template`,
-    "ty_con" -> `ty_con`
+    "to_text_template_id" -> `to_text_template_id`
   )
 
   val token: Parser[Token] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -53,6 +53,7 @@ private[parser] object Token {
   case object `to` extends Token
   case object `to_any_template` extends Token
   case object `from_any_template` extends Token
+  case object `ty_con` extends Token
 
   final case class Id(s: String) extends Token
   final case class ContractId(s: String) extends Token

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -53,7 +53,7 @@ private[parser] object Token {
   case object `to` extends Token
   case object `to_any_template` extends Token
   case object `from_any_template` extends Token
-  case object `ty_con` extends Token
+  case object `to_text_template_id` extends Token
 
   final case class Id(s: String) extends Token
   final case class ContractId(s: String) extends Token

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -163,8 +163,8 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       EToAnyTemplate(tmplId, apply(body))
     case EFromAnyTemplate(tmplId, body) =>
       EFromAnyTemplate(tmplId, apply(body))
-    case ETyCon(tyCon) =>
-      ETyCon(tyCon)
+    case EToTextTemplateId(tmplId) =>
+      EToTextTemplateId(tmplId)
 
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -163,6 +163,8 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       EToAnyTemplate(tmplId, apply(body))
     case EFromAnyTemplate(tmplId, body) =>
       EFromAnyTemplate(tmplId, apply(body))
+    case ETyCon(tyCon) =>
+      ETyCon(tyCon)
 
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -738,8 +738,8 @@ private[validation] object Typing {
       TOptional(TTyCon(tpl))
     }
 
-    private def typeOfTyCon(tyCon: TypeConName): Type = {
-      lookupDataType(ctx, tyCon)
+    private def typeOfToTextTemplateId(tpl: TypeConName): Type = {
+      lookupTemplate(ctx, tpl)
       TText
     }
 
@@ -810,8 +810,8 @@ private[validation] object Typing {
         typeOfToAnyTemplate(tmplId, body)
       case EFromAnyTemplate(tmplId, body) =>
         typeOfFromAnyTemplate(tmplId, body)
-      case ETyCon(tyCon) =>
-        typeOfTyCon(tyCon)
+      case EToTextTemplateId(tmplId) =>
+        typeOfToTextTemplateId(tmplId)
     }
 
     def checkExpr(expr: Expr, typ: Type): Type = {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -738,6 +738,11 @@ private[validation] object Typing {
       TOptional(TTyCon(tpl))
     }
 
+    private def typeOfTyCon(tyCon: TypeConName): Type = {
+      lookupDataType(ctx, tyCon)
+      TText
+    }
+
     def typeOf(expr0: Expr): Type = expr0 match {
       case EVar(name) =>
         lookupExpVar(name)
@@ -805,6 +810,8 @@ private[validation] object Typing {
         typeOfToAnyTemplate(tmplId, body)
       case EFromAnyTemplate(tmplId, body) =>
         typeOfFromAnyTemplate(tmplId, body)
+      case ETyCon(tyCon) =>
+        typeOfTyCon(tyCon)
     }
 
     def checkExpr(expr: Expr, typ: Type): Type = {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -62,6 +62,7 @@ private[validation] object ExprTraversable {
         f(body)
       case EFromAnyTemplate(tmplId @ _, body) =>
         f(body)
+      case ETyCon(tyCon @ _) =>
     }
     ()
   }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -62,7 +62,7 @@ private[validation] object ExprTraversable {
         f(body)
       case EFromAnyTemplate(tmplId @ _, body) =>
         f(body)
-      case ETyCon(tyCon @ _) =>
+      case EToTextTemplateId(tmplId @ _) =>
     }
     ()
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -171,6 +171,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpFromAnyTemplate
         E"""λ (t: AnyTemplate) -> (( from_any_template @Mod:T t ))""" ->
           T"AnyTemplate → Option Mod:T",
+        // ExpTyCon
+        E"""(( ty_con @Mod:T ))""" ->
+          T"Text",
       )
 
       forEvery(testCases) { (exp: Expr, expectedType: Type) =>
@@ -350,6 +353,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"λ (t: AnyTemplate) -> from_any_template @Mod:Tree t",
         E"λ (t: AnyTemplate) -> from_any_template @Mod:Color t",
         E"λ (t: Mod:T) -> from_any_template @Mod:T t",
+        // ExpTyCon
+        E"ty_con @Mod:NoSuchType",
         // ScnPure
         E"Λ (τ : ⋆ → ⋆). λ (e: τ) → (( spure @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e: τ) → (( spure @σ e ))",

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -171,8 +171,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         // ExpFromAnyTemplate
         E"""λ (t: AnyTemplate) -> (( from_any_template @Mod:T t ))""" ->
           T"AnyTemplate → Option Mod:T",
-        // ExpTyCon
-        E"""(( ty_con @Mod:T ))""" ->
+        // ExpToTextTemplateId
+        E"""(( to_text_template_id @Mod:T ))""" ->
           T"Text",
       )
 
@@ -353,8 +353,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"λ (t: AnyTemplate) -> from_any_template @Mod:Tree t",
         E"λ (t: AnyTemplate) -> from_any_template @Mod:Color t",
         E"λ (t: Mod:T) -> from_any_template @Mod:T t",
-        // ExpTyCon
-        E"ty_con @Mod:NoSuchType",
+        // ExpToTextTemplateId
+        E"to_text_template_id @Mod:NoSuchType",
         // ScnPure
         E"Λ (τ : ⋆ → ⋆). λ (e: τ) → (( spure @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e: τ) → (( spure @σ e ))",


### PR DESCRIPTION
Implements the Scala side of https://github.com/digital-asset/daml/issues/3072. I.e.
> a builtin expression `tyCon @Mod:T` of type `Text` that produces for any type Constructor a unique textual representation.

As proposed in https://github.com/digital-asset/daml/issues/3072#issuecomment-536910941

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
