### PR TITLE
Add to_text_template_id primitive to protobuf

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -448,6 +448,9 @@ data Expr
     { fromAnyTemplateTemplate :: !(Qualified TypeConName)
     , fromAnyTemplateBody :: !Expr
     }
+  | EToTextTemplateId
+    { toTextTemplateIdTemplate :: !(Qualified TypeConName)
+    }
   -- | Update expression.
   | EUpdate !Update
   -- | Scenario expression.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -448,6 +448,7 @@ instance Pretty Expr where
     ENone typ -> prettyAppKeyword lvl prec "none" [TyArg typ]
     EToAnyTemplate tpl body -> prettyAppKeyword lvl prec "to_any_template" [tplArg tpl, TmArg body]
     EFromAnyTemplate tpl body -> prettyAppKeyword lvl prec "from_any_template" [tplArg tpl, TmArg body]
+    EToTextTemplateId tpl -> prettyAppKeyword lvl prec "to_text_template_id" [tplArg tpl]
 
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -45,6 +45,7 @@ data ExprF expr
   | ESomeF       !Type !expr
   | EToAnyTemplateF !(Qualified TypeConName) !expr
   | EFromAnyTemplateF !(Qualified TypeConName) !expr
+  | EToTextTemplateIdF !(Qualified TypeConName)
   deriving (Foldable, Functor, Traversable)
 
 data BindingF expr = BindingF !(ExprVarName, Type) !expr
@@ -176,6 +177,7 @@ instance Recursive Expr where
     ESome       a b   -> ESomeF         a b
     EToAnyTemplate a b  -> EToAnyTemplateF a b
     EFromAnyTemplate a b -> EFromAnyTemplateF a b
+    EToTextTemplateId a -> EToTextTemplateIdF a
 
 instance Corecursive Expr where
   embed = \case
@@ -205,3 +207,4 @@ instance Corecursive Expr where
     ESomeF       a b   -> ESome a b
     EToAnyTemplateF a b  -> EToAnyTemplate a b
     EFromAnyTemplateF a b -> EFromAnyTemplate a b
+    EToTextTemplateIdF a -> EToTextTemplateId a

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -469,6 +469,12 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
             expr <- mayDecode "expr_FromAnyExpr" mbExpr decodeExpr
             return (EFromAnyTemplate con expr)
         _ -> throwError (ExpectedTCon type')
+  LF1.ExprSumToTextTemplateId (LF1.Expr_ToTextTemplateId mbType) -> do
+    type' <- mayDecode "expr_ToTextTemplateIdType" mbType decodeType
+    case type' of
+        TCon con ->
+            return (EToTextTemplateId con)
+        _ -> throwError (ExpectedTCon type')
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -494,6 +494,9 @@ encodeExpr' = \case
         expr_FromAnyType <- encodeType (TCon tpl)
         expr_FromAnyExpr <- encodeExpr body
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
+    EToTextTemplateId tpl -> do
+        expr_ToTextTemplateIdType <- encodeType (TCon tpl)
+        pureExpr $ P.ExprSumToTextTemplateId P.Expr_ToTextTemplateId{..}
   where
     expr = P.Expr Nothing . Just
     pureExpr = pure . expr

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -59,6 +59,7 @@ freeVarsStep = \case
   ESomeF _ s -> s
   EToAnyTemplateF _ s -> s
   EFromAnyTemplateF _ s -> s
+  EToTextTemplateIdF _ -> mempty
   EUpdateF u ->
     case u of
       UPureF _ s -> s
@@ -216,6 +217,7 @@ safetyStep = \case
   EFromAnyTemplateF _ s
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
+  EToTextTemplateIdF _ -> Safe 0
 
 
 infoStep :: ExprF Info -> Info

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -508,6 +508,10 @@ typeOf = \case
     _ :: Template <- inWorld (lookupTemplate tpl)
     checkExpr bodyExpr (TBuiltin BTAnyTemplate)
     pure $ TOptional (TCon tpl)
+  EToTextTemplateId tpl -> do
+    -- Ensure that the type is known.
+    _ :: Template <- inWorld (lookupTemplate tpl)
+    pure $ TBuiltin BTText
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf expr

--- a/daml-lf/archive/da/daml_lf_1.proto
+++ b/daml-lf/archive/da/daml_lf_1.proto
@@ -734,6 +734,13 @@ message Expr {
     Expr expr = 2;
   }
 
+  // Obtain a unique textual representation of a template Id
+  // *Available in versions >= 1.dev*
+  message ToTextTemplateId {
+    // type to convert to text. Must be a TypeConName.
+    Type type = 1;
+  }
+
   // Location of the expression in the DAML code source.
   // Optional
   Location location = 25;
@@ -825,6 +832,10 @@ message Expr {
     // Extract the given type from Any or return None on type-mismatch ('ExpFromAny')
     // *Available in versions >= 1.dev*
     FromAny from_any = 30;
+
+    // Obtain a unique textual representation of a template Id
+    // *Available in versions >= 1.dev*
+    ToTextTemplateId to_text_template_id = 31;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -554,6 +554,16 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             case ty => throw ParseError(s"FROM_ANY must be applied to a template type but got $ty")
           }
 
+        case PLF.Expr.SumCase.TO_TEXT_TEMPLATE_ID =>
+          assertSince(LV.Features.toTextTemplateId, "Expr.ToTextTemplateId")
+          decodeType(lfExpr.getToTextTemplateId.getType) match {
+            case TTyCon(tmplId) =>
+              EToTextTemplateId(tmplId = tmplId)
+            case ty =>
+              throw ParseError(
+                s"TO_TEXT_TEMPLATE_ID must be applied to a template type but got $ty")
+          }
+
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
       }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -57,6 +57,7 @@ object LanguageVersion {
     val internedIds = v1_6
     val numeric = v1_dev
     val anyTemplate = v1_dev
+    val toTextTemplateId = v1_dev
 
     /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
       * compatibility, we introduce a new DAML-LF version where this restriction is in

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -241,6 +241,9 @@ Version: 1.dev
     ``from_any_template`` and ``to_any_template`` functions to convert from/to
     an arbitrary template to ``AnyTemplate``.
 
+  * **Add** ``to_text_template_id`` to generate a unique textual representation
+    of a template Id.
+
 Abstract syntax
 ^^^^^^^^^^^^^^^
 
@@ -583,6 +586,7 @@ Then we can define our kinds, types, and expressions::
        |  u                                         -- ExpUpdate: Update expression
        | 'to_any_template' @Mod:T t                 -- ExpToAnyTemplate: Wrap a template in AnyTemplate
        | 'from_any_template' @Mod:T t               -- ExpToAnyTemplate: Extract the given template from AnyTemplate or return None
+       | 'to_text_template_id' @Mod:T               -- ExpToTextTemplateId: Generate a unique textual representation of the given TypeConName
 
   Patterns
     p
@@ -882,6 +886,10 @@ Then we define *well-formed expressions*. ::
       'tpl' (x : T) ↦ …  ∈  〚Ξ〛Mod       Γ  ⊢  e  : AnyTemplate
     ——————————————————————————————————————————————————————————————— ExpFromAnyTemplate
       Γ  ⊢  'from_any_template' @Mod:T e  :  'Optional' Mod:T
+
+      'tpl' (x : T) ↦ …  ∈  〚Ξ〛Mod
+    ——————————————————————————————————————————————————————————————— ExpToTextTemplateId
+      Γ  ⊢  'to_text_template_id' @Mod:T  :  'Text'
 
     ——————————————————————————————————————————————————————————————— ExpBuiltin
       Γ  ⊢  F : 𝕋(F)
@@ -1665,6 +1673,9 @@ exact output.
     —————————————————————————————————————————————————————————————————————— EvExpFromAnyTemplateFail
       'from_any_template' @Mod₁:T₁ e ‖ E₀  ⇓  'None' ‖ E₁
 
+
+    —————————————————————————————————————————————————————————————————————— EvExpToTextTemplateId
+      'to_text_template_id' @Mod:T ‖ E₀  ⇓  "Mod:T" ‖ E₀
 
       e₁ ‖ E₀  ⇓  Ok v₁ ‖ E₁
       v 'matches' p₁  ⇝  Succ (x₁ ↦ v₁ · … · xₘ ↦ vₘ · ε)


### PR DESCRIPTION
Implements the protobuf part of #3072 

As #2930 before this implements a more general protobuf representation holding an arbitrary type to allow for later extensibility. The decoder restricts usage to type constructors.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
