### PR TITLE
Mark daml json-api as experimental

### DIFF
--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -59,7 +59,7 @@ commands:
   args: ["lax", "ide"]
 - name: json-api
   path: daml-helper/daml-helper
-  desc: "Launch the HTTP JSON API"
+  desc: "Launch the HTTP JSON API (experimental)"
   args: ["run-jar", "--logback-config=json-api/json-api-logback.xml", "json-api/json-api.jar"]
 - name: codegen
   path: daml-helper/daml-helper


### PR DESCRIPTION
Mark the `daml json-api` command as experimental, like `daml deploy` and `daml ledger`.