### PR TITLE
language: add internal command for generating source from dalf.

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -209,7 +209,7 @@ cmdInspect =
     detailOpt =
         fmap (maybe DA.Pretty.prettyNormal DA.Pretty.PrettyLevel) $
             optional $ option auto $ long "detail" <> metavar "LEVEL" <> help "Detail level of the pretty printed output (default: 0)"
-    cmd = execInspect <$> inputDalfOpt <*> outputFileOpt <*> jsonOpt <*> detailOpt
+    cmd = execInspect <$> inputFileOptWithExt ".dalf or .dar" <*> outputFileOpt <*> jsonOpt <*> detailOpt
 
 cmdVisual :: Mod CommandFields Command
 cmdVisual =

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -39,20 +39,16 @@ render s d = resolve s d
       Plain   -> Pretty.renderPlain
       Colored -> Pretty.renderColored
 
-inputFileOpt :: Parser FilePath
-inputFileOpt = argument str $
+inputFileOptWithExt :: String -> Parser FilePath
+inputFileOptWithExt extension = argument str $
        metavar "FILE"
-    <> help "Input .daml file whose contents are read"
+    <> help ("Input " <> extension <> " file whose contents are read")
 
-inputDarOpt :: Parser FilePath
-inputDarOpt = argument str $
-       metavar "FILE"
-    <> help "Input .dar file whose contents are read"
-
-inputFileRstOpt :: Parser FilePath
-inputFileRstOpt = argument str $
-       metavar "FILE"
-    <> help "Input .rst file whose contents are read"
+inputFileOpt, inputDarOpt, inputFileRstOpt, inputDalfOpt :: Parser FilePath
+inputFileOpt = inputFileOptWithExt ".daml"
+inputDarOpt = inputFileOptWithExt ".dar"
+inputDalfOpt = inputFileOptWithExt ".dalf"
+inputFileRstOpt = inputFileOptWithExt ".rst"
 
 inputDamlPackageOpt :: Parser FilePath
 inputDamlPackageOpt = argument str $
@@ -406,7 +402,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure enableScenarioService
     <*> pure (optSkipScenarioValidation $ defaultOptions Nothing)
     <*> dlintUsageOpt
-    <*> pure False
+    <*> optIsGenerated
     <*> optNoDflagCheck
     <*> pure False
     <*> pure (Haddock False)
@@ -446,6 +442,13 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
       help "hide all packages, use -package for explicit import" <>
       long "hide-all-packages" <>
       internal
+
+    optIsGenerated :: Parser Bool
+    optIsGenerated =
+        switch $
+        help "Tell the compiler that the source was generated." <>
+        long "generated-src" <>
+        internal
 
     -- optparse-applicative does not provide a nice way
     -- to make the argument for -j optional, see


### PR DESCRIPTION
We add an internal command for generating DAML source code from .dalf
packages. Also adds an internal flag to tell the compiler, that it is
compiling generated source. We will be using this mainly for testing purposes.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
