### PR TITLE
Allow emitting commands on trigger initialization

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -57,13 +57,10 @@ runTrigger userTrigger = LowLevel.Trigger
     initialState party (ActiveContracts createdEvents) =
       let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS []) createdEvents
           userState = userTrigger.initialize acs
-      in TriggerState
-           { acs = acs
-           , party = party
-           , userState = userState
-           , commandsInFlight = Map.empty
-           , nextCommandId = 0
-           }
+          (_, TriggerAState commands nextCommandId) = runTriggerA (userTrigger.rule party acs Map.empty userState) (TriggerAState [] 0)
+          commandsInFlight = foldl addCommands Map.empty commands
+          state = TriggerState {acs, party, userState, commandsInFlight, nextCommandId}
+      in (state, commands, "")
     update msg state =
       case msg of
         MCompletion completion ->

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -86,7 +86,7 @@ data ActiveContracts = ActiveContracts { activeContracts : [Created] }
 -- | Trigger is (approximately) a left-fold over `Message` with
 -- an accumulator of type `s`.
 data Trigger s = Trigger
-  { initialState : Party -> ActiveContracts -> s
+  { initialState : Party -> ActiveContracts -> (s, [Commands], Text)
   , update : Message -> s -> (s, [Commands], Text)
   }
 

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -112,10 +112,14 @@ object Converter {
 
   private def fromCommandId(triggerIds: TriggerIds, commandId: String): SValue = {
     val commandIdTy = triggerIds.getId("CommandId")
+    record(commandIdTy, ("unpack", SText(commandId)))
+  }
+
+  private def fromOptionalCommandId(triggerIds: TriggerIds, commandId: String): SValue = {
     if (commandId.isEmpty) {
       SOptional(None)
     } else {
-      SOptional(Some(record(commandIdTy, ("unpack", SText(commandId)))))
+      SOptional(Some(fromCommandId(triggerIds, commandId)))
     }
   }
 
@@ -192,7 +196,7 @@ object Converter {
       record(
         transactionTy,
         ("transactionId", fromTransactionId(triggerIds, t.transactionId)),
-        ("commandId", fromCommandId(triggerIds, t.commandId)),
+        ("commandId", fromOptionalCommandId(triggerIds, t.commandId)),
         ("events", SList(FrontStack(t.events.map(ev => fromEvent(triggerIds, ev)))))
       )
     )

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -36,7 +36,7 @@ initState party (ActiveContracts events) = TriggerState
 -- and we create a new AssetMirror contract whenever an Asset contract is created (but we do not archive them).
 test : Trigger TriggerState
 test = Trigger
-  { initialState = initState
+  { initialState = \party acs -> (initState party acs, [], "")
   , update = update
   }
   where

--- a/triggers/tests/src/test/scala/com/daml/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/daml/trigger/test/TestMain.scala
@@ -592,7 +592,7 @@ object TestMain {
           case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
         }
         val runner = new TestRunner(config.ledgerPort)
-        // AcsTests(dar, runner).runTests()
+        AcsTests(dar, runner).runTests()
         CopyTests(dar, runner).runTests()
     }
   }


### PR DESCRIPTION
fixes #3128

Also includes a small bug fix to reenable some tests that I
accidentally disabled in #3127 and fixes deserialization of command
ids in completions which I accidentaly broke when making fromCommandId
return an Optional since that’s what we need for transactions.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
