### PR TITLE
language: create the package database from dalfs

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -10,6 +10,7 @@ module DA.Daml.Compiler.Dar
     , getDamlFiles
     , getDamlRootFiles
     , writeIfacesAndHie
+    , mkConfFile
     ) where
 
 import qualified "zip" Codec.Archive.Zip as Zip

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -21,7 +21,6 @@ import qualified Data.Map.Strict as MS
 import Data.Maybe
 import qualified Data.NameMap as NM
 import qualified Data.Text as T
-import Data.Tuple
 import Development.IDE.GHC.Util
 import Development.IDE.Types.Location
 import "ghc-lib" GHC
@@ -101,7 +100,7 @@ upgradeTemplates n =
 -- | Generate the full source for a daml-lf package.
 generateSrcPkgFromLf ::
        LF.PackageId
-    -> MS.Map GHC.UnitId LF.PackageId
+    -> MS.Map LF.PackageId GHC.UnitId
     -> LF.Package
     -> [(NormalizedFilePath, String)]
 generateSrcPkgFromLf thisPkgId pkgMap pkg = do
@@ -189,18 +188,17 @@ newtype Qualify = Qualify Bool
 generateSrcFromLf ::
        Qualify
     -> LF.PackageId
-    -> MS.Map GHC.UnitId LF.PackageId
+    -> MS.Map LF.PackageId GHC.UnitId
     -> LF.Module
     -> ParsedSource
 generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
   where
-    pkgMapInv = MS.fromList $ map swap $ MS.toList pkgMap
     getUnitId :: LF.PackageRef -> UnitId
     getUnitId pkgRef =
         fromMaybe (error $ "Unknown package: " <> show pkgRef) $
         case pkgRef of
-            LF.PRSelf -> MS.lookup thisPkgId pkgMapInv
-            LF.PRImport pkgId -> MS.lookup pkgId pkgMapInv
+            LF.PRSelf -> MS.lookup thisPkgId pkgMap
+            LF.PRImport pkgId -> MS.lookup pkgId pkgMap
     -- TODO (drsk) how come those '#' appear in daml-lf names?
     sanitize = T.dropWhileEnd (== '#')
     mod =

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -62,6 +62,8 @@ data Options = Options
   -- ^ Information about dlint usage.
   , optIsGenerated :: Bool
     -- ^ Whether we're compiling generated code. Then we allow internal imports.
+  , optAllowDifferentSdks :: Bool
+    -- ^ Whether we're allowing imports from packages compiled with different SDK's.
   , optDflagCheck :: Bool
     -- ^ Whether to check dflags. In some cases we want to turn this check of. For example when
     -- migrating or running the daml doc test.
@@ -161,6 +163,7 @@ defaultOptions mbVersion =
         , optSkipScenarioValidation = SkipScenarioValidation False
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False
+        , optAllowDifferentSdks = False
         , optDflagCheck = True
         , optCoreLinting = False
         , optHaddock = Haddock False

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -403,6 +403,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure (optSkipScenarioValidation $ defaultOptions Nothing)
     <*> dlintUsageOpt
     <*> optIsGenerated
+    <*> optAllowDifferentSdks
     <*> optNoDflagCheck
     <*> pure False
     <*> pure (Haddock False)
@@ -486,6 +487,13 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
         <> long "cpp"
         <> help "Set path to CPP."
         <> internal
+
+    optAllowDifferentSdks :: Parser Bool
+    optAllowDifferentSdks =
+        switch $
+        help "Allow the import of packages compiled with different SDKs." <>
+        long "allow-different-sdks" <>
+        internal
 
 optGhcCustomOptions :: Parser [String]
 optGhcCustomOptions =

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -632,7 +632,6 @@ runMigrate targetFolder pkgPath1 pkgPath2
         , "daml"
         , "--project-root"
         , targetFolder
-        , "upgrade-pkg"
         , pkgPath1
         , pkgPath2
         ]


### PR DESCRIPTION
This moves the creation of a package database from given dalfs out of
the migrate command and into the init command. In particular, this makes
the process of creating a package database independent of the migrate
command.

It also changes the way this package database is created to be only
dependend on given dalf files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
