### PR TITLE
daml-lf proto: archive proto for daml-lf 1.6

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -17,72 +17,78 @@ load(
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//bazel_tools:javadoc_library.bzl", "javadoc_library")
+load(":archive.bzl", "mangle_for_java")
 
 LF_MAJOR_VERSIONS = [
     "0",
     "1",
 ]
 
-filegroup(
-    name = "daml_lf_dev_archive_proto_srcs",
-    srcs = glob(["src/main/protobuf/com/digitalasset/daml_lf_dev/*.proto"]),
-)
+LF_VERSIONS = [
+    "dev",
+    "1.6",
+]
 
-proto_library(
-    name = "daml_lf_dev_archive_proto",
-    srcs = [":daml_lf_dev_archive_proto_srcs"],
-    strip_import_prefix = "src/main/protobuf/",
-    visibility = ["//:__subpackages__"],
-)
-
-proto_gen(
-    name = "daml_lf_dev_archive_java_proto_srcs",
-    srcs = [":daml_lf_dev_archive_proto"],
-    plugin_name = "java",
-    visibility = ["//visibility:public"],
-)
-
-java_library(
-    name = "daml_lf_dev_archive_java_proto",
-    srcs = [":daml_lf_dev_archive_java_proto_srcs"],
-    tags = ["maven_coordinates=com.digitalasset:daml-lf-dev-archive-java-proto:__VERSION__"],
-    visibility = ["//visibility:public"],
-    deps = ["//3rdparty/jvm/com/google/protobuf:protobuf_java"],
-)
-
-pom_file(
-    name = "daml_lf_dev_archive_java_proto_pom",
-    target = "daml_lf_dev_archive_java_proto",
-    visibility = ["//visibility:public"],
-)
-
-javadoc_library(
-    name = "daml_lf_dev_archive_java_proto_javadoc",
-    srcs = ["daml_lf_dev_archive_java_proto"],
-    root_packages = ["com.digitalasset.daml_lf_dev"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "daml_lf_dev_archive_proto_zip",
-    srcs = [":daml_lf_dev_archive_proto_srcs"],
-    outs = ["daml_lf_dev_archive_proto_zip.zip"],
-    cmd = """
-            mkdir -p protobuf/com/digitalasset/daml_lf_dev
-            cp $(SRCS) protobuf/com/digitalasset/daml_lf_dev
-            $(location @zip_dev_env//:zip) \"$@\" -r protobuf
-          """,
-    tools = ["@zip_dev_env//:zip"],
-    visibility = ["//visibility:public"],
-)
-
-pkg_tar(
-    name = "daml_lf_dev_archive_proto_tarball",
-    srcs = [":daml_lf_dev_archive_proto_srcs"],
-    extension = "tar.gz",
-    package_dir = "com/digitalasset/daml_lf",
-    visibility = ["//visibility:public"],
-)
+[
+    [
+        filegroup(
+            name = "daml_lf_%s_archive_proto_srcs" % version,
+            srcs = glob(["src/main/protobuf/com/digitalasset/daml_lf_%s/*.proto" % mangle_for_java(version)]),
+        ),
+        proto_library(
+            name = "daml_lf_%s_archive_proto" % version,
+            srcs = [":daml_lf_%s_archive_proto_srcs" % version],
+            strip_import_prefix = "src/main/protobuf/",
+            visibility = ["//:__subpackages__"],
+        ),
+        proto_gen(
+            name = "daml_lf_%s_archive_java_proto_srcs" % version,
+            srcs = [":daml_lf_%s_archive_proto" % version],
+            plugin_name = "java",
+            visibility = ["//visibility:public"],
+        ),
+        java_library(
+            name = "daml_lf_%s_archive_java_proto" % version,
+            srcs = [":daml_lf_%s_archive_java_proto_srcs" % version],
+            tags = ["maven_coordinates=com.digitalasset:daml-lf-%s-archive-java-proto:__VERSION__" % version],
+            visibility = ["//visibility:public"],
+            deps = ["//3rdparty/jvm/com/google/protobuf:protobuf_java"],
+        ),
+        pom_file(
+            name = "daml_lf_%s_archive_java_proto_pom" % version,
+            target = "daml_lf_%s_archive_java_proto" % version,
+            visibility = ["//visibility:public"],
+        ),
+        javadoc_library(
+            name = "daml_lf_%s_archive_java_proto_javadoc" % version,
+            srcs = ["daml_lf_%s_archive_java_proto" % version],
+            root_packages = ["com.digitalasset.daml_lf_%s" % mangle_for_java(version)],
+            visibility = ["//visibility:public"],
+            deps = ["//3rdparty/jvm/com/google/protobuf:protobuf_java"],
+        ),
+        genrule(
+            name = "daml_lf_%s_archive_proto_zip" % version,
+            srcs = [":daml_lf_%s_archive_proto_srcs" % version],
+            outs = ["daml_lf_%s_archive_proto_zip.zip" % version],
+            cmd = """
+                     DESTDIR=protobuf/com/digitalasset/daml_lf_%s &&           \
+                     mkdir -p $$DESTDIR/ &&                                    \
+                     cp $(SRCS) $$DESTDIR/ &&                                  \
+                     $(location @zip_dev_env//:zip) \"$@\" -r $$DESTDIR/
+                   """ % (mangle_for_java(version)),
+            tools = ["@zip_dev_env//:zip"],
+            visibility = ["//visibility:public"],
+        ),
+        pkg_tar(
+            name = "daml_lf_%s_archive_proto_tarball" % version,
+            srcs = [":daml_lf_%s_archive_proto_srcs" % version],
+            extension = "tar.gz",
+            package_dir = "com/digitalasset/daml_lf",
+            visibility = ["//visibility:public"],
+        ),
+    ]
+    for version in LF_VERSIONS
+]
 
 # FIXME(JM): Clean this up
 genrule(
@@ -150,6 +156,8 @@ da_scala_test_suite(
     ],
     scalacopts = lf_scalacopts,
     deps = [
+        ":daml_lf_1.6_archive_java_proto",
+        ":daml_lf_1.6_archive_proto_srcs",
         ":daml_lf_archive_reader",
         ":daml_lf_dev_archive_java_proto",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",

--- a/daml-lf/archive/README.md
+++ b/daml-lf/archive/README.md
@@ -1,31 +1,47 @@
 # DAML-LF archive
 
 This component contains the `.proto` definitions specifying the format
-in which DAML-LF packages are stored -- the DAML-LF archive.
+in which DAML-LF packages are stored -- the DAML-LF archive. All the
+proto definitions are kept in the directory
+`src/protorotobuf/com/digitalasset/daml_lf_dev/`
 
-The entry point definition is `Archive` in `da/daml_lf.proto`. `Archive`
+The entry point definition is `Archive` in
+`src/protorotobuf/com/digitalasset/daml_lf_dev/daml_lf.proto`.  `Archive`
 contains some metadata about the actual archive (currently the hashing
-function and the hash), and then a binary blob containing the archive.
-The binary blob must be an `ArchivePayload` -- we keep it in binary form
-to facilitate hashing, signing, etc. The encoding and decoding of the
-payload is handled by Haskell and Java libraries in `daml-core-package`,
-so that consumers and producers do not really need to worry about it.
+function and the hash), and then a binary blob containing the
+archive. The binary blob must be an `ArchivePayload` -- we keep it in
+binary form to facilitate hashing, signing, etc. The encoding and
+decoding of the payload is handled by Haskell and Java libraries in
+`daml-core-package`, so that consumers and producers do not really
+need to worry about it.
 
 `ArchivePayload` is a sum type containing the various DAML-LF versions
-supported by the DAML-LF archive. Currently we have two versions:
+supported by the DAML-LF archive. Currently we have two major versions:
 
-* `DAML-LF-0`, which is the legacy DAML core;
+* `DAML-LF-0`, which is the deprecated legacy DAML core; 
 * `DAML-LF-1`, which is the first version of DAML-LF as specified by
     <https://github.com/digital-asset/daml/blob/master/daml-lf/spec/daml-lf-1.rst>.
 
+## Snapshot versions
+
+The component contains also an arbitrary number of snapshots of the
+protobuf definitions as they were as the time a particular version of
+DAML-LF was frozen. Those snapshots are kept in the directories
+`src/protorotobuf/com/digitalasset/daml_lf_x_y/`, where `x.y` is a
+already frozen DAML-LF version.  A snapshot for version `x.y` can be
+used to read any DAML-LF version from `1.0` to `x.y` without suffering
+breaking changes (at the generated code level) often introduced in the
+current version.
+
 ## Building
 
-It produces two libraries containing code to encode / decode such
-definition, a Haskell one and a Java one:
+It produces several libraries containing code to encode / decode such
+definition, a Haskell one, and several Java ones:
 
 ```
 $ bazel build //daml-lf/archive:daml_lf_archive_haskell_proto
 $ bazel build //daml-lf/archive:daml_lf_dev_archive_java_proto
+$ bazel build //daml-lf/archive:daml_lf_1_6_archive_java_proto
 ```
 
 ## Editing the `.proto` definitions

--- a/daml-lf/archive/archive.bzl
+++ b/daml-lf/archive/archive.bzl
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+def mangle_for_java(name):
+    return name.replace(".", "_")

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf.proto
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+package daml_lf_1_6;
+
+option java_package = "com.digitalasset.daml_lf_1_6";
+option csharp_namespace = "Com.DigitalAsset.Daml_Lf_1_6.DamlLf";
+
+import "com/digitalasset/daml_lf_1_6/daml_lf_0.proto";
+import "com/digitalasset/daml_lf_1_6/daml_lf_1.proto";
+
+message ArchivePayload {
+  // this is number 3 for historical reasons -- we had
+  // DAML-LF v0 and v1 before we had minor versions.
+  string minor = 3;
+  reserved 9999; // for the removed "dev" major version
+
+  oneof Sum {
+    daml_lf_0.Package daml_lf_0 = 1;
+    daml_lf_1.Package daml_lf_1 = 2;
+
+    // lf_2 = 4, lf_3 = 5, etc
+  }
+}
+
+enum HashFunction {
+  SHA256 = 0;
+}
+
+message Archive {
+  HashFunction hash_function = 1;
+
+  // deprecated field (bytes hash = 2), replaced by
+  // field 4.
+
+  // Must be an encoded ArchivePayload. We store it as `bytes` to
+  // simplify hashing and in future signing.
+  bytes payload = 3;
+  // The hash is simply the ascii7 lowercase hex-encoded hash of the bytes
+  // according to the hash_function. We store it here for convenience, code
+  // reading the Archive should verify that the hash is valid.
+  //
+  // Note that the hash is computed directly on the blob and not
+  // on the decoded structure. This means that servers implementing
+  // a DAML ledger need to store the blob as-is somewhere to be able
+  // to always offer proof that they have a DAML package matching
+  // the requested hash. We decided to go for this route rather than
+  // relying on a canonical encoding of the AST since such a scheme
+  // would be extremely hard (for example protobuf encoding is not
+  // canonical) to maintain and does not buy us much.
+  string hash = 4;
+
+}

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf_0.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf_0.proto
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DAML-LF-0 was a .proto representation of the DAML core stored in
+// the legacy sdaml format. We used it to ease transition between
+// sdaml and DAML-LF archives. This stub remains so we can
+// successfully decode LFv0 archives and then report that they are
+// unsupported.
+
+syntax = "proto3";
+package daml_lf_0;
+
+option java_package = "com.digitalasset.daml_lf_1_6";
+option csharp_namespace = "Com.DigitalAsset.Daml_Lf_1_6.DamlLf0";
+
+message Package {
+}

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/daml_lf_1.proto
@@ -1,0 +1,1146 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// .proto representation of the first version of the DAML-LF 1.6 language,
+// as specified by
+// <https://github.com/digital-asset/daml/tree/c2e2e007e78828180d73ab7280a52b21376e3189/daml-lf/spec/daml-lf-1.rst>.
+//
+// A few notes:
+//
+// * We generally "compress" structures that are often repeated, such as
+//   application, let bindings, abstractions, etc.. In the Haskell / Scala
+//   AST we probably will use the normal binary forms.
+// * We generally never "newtype" strings, even if it might be good in
+//   the actual AST. This is to keep the message structure relatively flat
+//   and light.
+
+
+// Minor version history (to be officialized in the spec):
+// * 0 (somewhen in December 2018): initial version
+// * 1 -- 2019-01-10: Add Optional type
+//     -- 2019-01-27: Add <, <=, =>, > for Party
+//     -- 2019-01-29: Add PrimType.ARROW
+// * 2 -- 2019-03-18: Add BuiltinFunction.{SHA256_TEXT, TO_TEXT_PARTY, FROM_TEXT_PARTY}
+//     -- 2019-03-18: Add flexible controllers (change scoping of controller expressions)
+// * 3 -- 2019-03-25: Add contract keys
+//     -- 2019-03-27: Add Map type
+// * 4 -- 2019-05-15: Add complex contract keys
+// * 5 -- 2019-05-22: Relax serializability constraints for contract ids
+//        2019-05-23: Add BuiltinFunction.COERCE_CONTRACT_ID
+//        2019-05-24: Make actors in exercise optional
+// * 6 -- 2019-05-27: Add enum type.
+//        2019-06-04: Add BuiltinFunction.{TEXT_FROM_CODE_POINTS, TEXT_TO_CODE_POINTS}
+//        2019-06-12: Add Package.interned_package_ids and PackageRef.interned_id
+//        2019-07-04: Transaction submitters must be in contract key maintainers when looking up. See #1866.
+
+syntax = "proto3";
+package daml_lf_1;
+
+option java_package = "com.digitalasset.daml_lf_1_6";
+option csharp_namespace = "Com.DigitalAsset.Daml_lf_1_6.DamlLf1";
+
+// Canonical encoding in one-ofs for cases that carry no meaningful
+// values.
+message Unit {}
+
+// Package reference
+message PackageRef {
+  oneof Sum {
+
+    // Reference to the package of which the package this reference
+    // belongs.
+    Unit self = 1;
+
+    // A `Package identifier` for an imported Package.
+    // A ascii7 lowercase hex-encoded package identifier. This refers
+    // to the DAML LF Archive Hash.
+    string package_id = 2;
+
+    // An index into `interned_package_ids` of the Package containing
+    // this reference.
+    uint64 interned_id = 3; /* Available since version 1.6 */
+  }
+}
+
+// A `name`, e.g. Util.Either.isLeft
+message DottedName {
+
+  // *Must be a non-empty list of a valid identifiers*
+  repeated string segments = 1;
+
+}
+
+// A fully qualified module reference
+message ModuleRef {
+
+  // package where the module is defined.
+  PackageRef package_ref = 1;
+
+  // module name
+  DottedName module_name = 2;
+
+}
+
+// A fully qualified reference to a type constructor name.
+message TypeConName {
+
+  // Module where the type is defined.
+  ModuleRef module = 1;
+
+  // type constructor name.
+  DottedName name = 2;
+
+}
+
+// A fully qualified reference to a value definition.
+message ValName {
+
+  // Module where the value is defined
+  ModuleRef module = 1;
+
+  // value name.
+  repeated string name = 2;
+}
+
+// A field name definition in a record or a variant associated with a type.
+message FieldWithType {
+
+  // Name of the field .
+  // *Must be a valid identifier*
+  string field = 1;
+
+  // Type associated
+  Type type = 2;
+}
+
+// Binder associated with a type.
+message VarWithType {
+
+  // Name of the bound expression variable.
+  // *Must be a valid identifier*
+  string var = 1;
+
+  // Type of the bound variable
+  Type type = 2;
+}
+
+// Type binder associated with a kind.
+message TypeVarWithKind {
+  // Name of the bound expression variable
+  // *Must be a valid identifier*
+  string var = 1;
+  // Kind of the bound variable
+  Kind kind = 2;
+}
+
+// A field in a record with its value.
+message FieldWithExpr {
+  // Name of the field
+  // *Must be a valid identifier*
+  string field = 1;
+  // Value of the field
+  Expr expr  = 2;
+}
+
+// A binding of a typed binder to an expression
+message Binding {
+  // The binder (expression variable and type)
+  VarWithType binder = 1;
+  // The value to which the variable is bound.
+  Expr bound = 2;
+}
+
+// Kinds
+message Kind {
+
+  // The kind of polymorphic type.
+  message Arrow {
+    // parameter of the kind
+    // *Must be non-empty*
+    repeated Kind params = 1;
+    Kind result = 2;
+  }
+
+  oneof Sum {
+    // Kind of monomorphic type.
+    Unit star = 1;
+    // Kind of polymorphic type.
+    Arrow arrow = 2;
+  }
+}
+
+// Builtin primitive types
+enum PrimType {
+  // Builtin type 'Unit'
+  UNIT = 0;
+
+  // Builtin type 'Bool'
+  BOOL = 1;
+
+  // Builtin type 'Int64'
+  INT64 = 2;
+
+  // Builtin type 'Int64'
+  DECIMAL = 3;
+
+  // CHAR = 4; // we have removed this in favor of TEXT for everything text related.
+
+  // Builtin type 'Text'
+  TEXT = 5;
+
+  // Builtin type 'Timestamp'
+  TIMESTAMP = 6;
+
+  // RELTIME = 7; // we removed this in favor of INT64.
+
+  // Builtin tpe 'Party'
+  PARTY = 8;
+
+  // Builtin type 'List'
+  LIST = 9;
+
+  // Builtin type 'Update'
+  UPDATE = 10;
+
+  // Builtin type 'Scenatrio'
+  SCENARIO = 11;
+
+  // Builtin type 'Date'
+  DATE = 12;
+
+  // Builtin type 'ContractId'
+  CONTRACT_ID = 13;
+
+  // Builtin type 'Optional'
+  // *Available since version 1.1*
+  OPTIONAL = 14;
+
+  // Builtin type `TArrow`
+  // *Available since version 1.1*
+  ARROW = 15;
+
+  // Builtin type 'TMap`
+  // *Available since version 1.3*
+  MAP = 16;
+
+}
+
+// Types
+message Type {
+
+  // Possibly applied type variable 'TyVar'
+  message Var {
+
+    // Name of the variable.
+    // *Must be a valid identifier*
+    string var = 1;
+
+    // Types to which the variable is applied
+    repeated Type args = 2;
+  }
+
+  // Possibly applied type constructor 'TyCon'
+  message Con {
+
+    // Name of the type constructor name
+    TypeConName tycon = 1;
+
+    // Type to which the constructor name is applied.
+    repeated Type args = 2;
+  }
+
+  // Possibly applied builtin types
+  message Prim {
+
+    // Builtin type
+    // FixMe: Rename
+    PrimType prim = 1;
+
+    // Types to which the builtin type is applied.
+    repeated Type args = 2;
+  }
+
+  // n-ary function type
+  // *Available until version 1.2*
+  message Fun {
+    // type of the arguments
+    // *Must be non-empty*
+    repeated Type params = 1;
+    // type of the result
+    Type result = 2;
+  }
+
+  // Universal quantification 'TyForAll'
+  message Forall {
+    // binders of the quantification
+    // *Must be non-empty*
+    repeated TypeVarWithKind vars = 1;
+    // Body of the quantification
+    Type body = 2;
+  }
+
+  // Tuple type
+  message Tuple{
+    // name of the field with their types.
+    repeated FieldWithType fields = 1;
+  }
+
+  oneof Sum {
+    Var var = 1;
+    Con con = 2;
+    Prim prim = 3; // FixMe: renamed
+    Fun fun = 4;
+    Forall forall = 5;
+    Tuple tuple = 7;
+  }
+
+  reserved 6; // This was list.  Removed in favour of PrimType.LIST
+  reserved 8; // This was contract_id. Removed in favour of PrimType.CONTRACT_ID
+  reserved 9; // This was update. Removed in favour of PrimType.UPDATE
+  reserved 10; // This was scenario. Removed in favor of PrimType.SCENARIO
+
+}
+
+// Primitive constructors
+enum PrimCon {
+
+  // Unit value '()'
+  CON_UNIT = 0;
+
+  // 'False' boolean value
+  CON_FALSE = 1;
+
+  // 'True' boolean value
+  CON_TRUE = 2;
+}
+
+// Builtin functions
+// Refer to DAML-LF major version 1 specification for types and behavior of those.
+enum BuiltinFunction {
+  ADD_DECIMAL = 0;
+  SUB_DECIMAL = 1;
+  MUL_DECIMAL = 2;
+  DIV_DECIMAL = 3;
+  ROUND_DECIMAL = 6;
+
+  ADD_INT64 = 7;
+  SUB_INT64 = 8;
+  MUL_INT64 = 9;
+  DIV_INT64 = 10;
+  MOD_INT64 = 11;
+  EXP_INT64 = 12;
+
+  FOLDL = 20;
+  FOLDR = 21;
+
+  MAP_EMPTY = 96;
+  MAP_INSERT = 97;
+  MAP_LOOKUP = 98;
+  MAP_DELETE = 99;
+  MAP_TO_LIST = 100;
+  MAP_SIZE = 101;
+
+  EXPLODE_TEXT = 23;
+  APPEND_TEXT = 24;
+
+  ERROR = 25;
+
+  LEQ_INT64 = 33;
+  LEQ_DECIMAL = 34;
+  LEQ_TEXT = 36;
+  LEQ_TIMESTAMP = 37;
+  LEQ_DATE = 67;
+  LEQ_PARTY = 89; // *Available Since version 1.1*
+
+  LESS_INT64 = 39;
+  LESS_DECIMAL = 40;
+  LESS_TEXT = 42;
+  LESS_TIMESTAMP = 43;
+  LESS_DATE = 68;
+  LESS_PARTY = 90; // *Available Since version 1.1*
+
+  GEQ_INT64 = 45;
+  GEQ_DECIMAL = 46;
+  GEQ_TEXT = 48;
+  GEQ_TIMESTAMP = 49;
+  GEQ_DATE = 69;
+  GEQ_PARTY = 91; // *Available Since version 1.1*
+
+  GREATER_INT64 = 51;
+  GREATER_DECIMAL = 52;
+  GREATER_TEXT = 54;
+  GREATER_TIMESTAMP = 55;
+  GREATER_DATE = 70;
+  GREATER_PARTY = 92; // *Available Since version 1.1*
+
+  TO_TEXT_INT64 = 57;
+  TO_TEXT_DECIMAL = 58;
+  TO_TEXT_TEXT = 60;
+  TO_TEXT_TIMESTAMP = 61;
+  TO_TEXT_DATE = 71;
+  TO_QUOTED_TEXT_PARTY = 63; // legacy, remove in next major version
+  TO_TEXT_PARTY = 94; // *Available Since version 1.2*
+  FROM_TEXT_PARTY = 95; // *Available Since version 1.2*, was named FROM_TEXT_PARTY in 1.2, 1.3 and 1.4
+  FROM_TEXT_INT64 = 103; // *Available Since version 1.5*
+  FROM_TEXT_DECIMAL = 104; // *Available Since version 1.5*
+  SHA256_TEXT = 93; // *Available Since version 1.2*
+
+  DATE_TO_UNIX_DAYS = 72; // Date -> Int64
+  UNIX_DAYS_TO_DATE = 73; // Int64 -> Date
+
+  TIMESTAMP_TO_UNIX_MICROSECONDS = 74; // Timestamp -> Int64
+  UNIX_MICROSECONDS_TO_TIMESTAMP = 75; // Int64 -> Timestamp
+
+  INT64_TO_DECIMAL = 76;
+  DECIMAL_TO_INT64 = 77;
+
+  IMPLODE_TEXT = 78;
+
+  EQUAL_INT64 = 79;
+  EQUAL_DECIMAL = 80;
+  EQUAL_TEXT = 81;
+  EQUAL_TIMESTAMP = 82;
+  EQUAL_DATE = 83;
+  EQUAL_PARTY = 84;
+  EQUAL_BOOL = 85;
+  EQUAL_CONTRACT_ID = 86;
+  EQUAL_LIST = 87;
+
+  TRACE = 88;
+
+  COERCE_CONTRACT_ID = 102;
+
+  TEXT_FROM_CODE_POINTS = 105;  // : List Int64 -> Text   *Available since version 1.6*
+  TEXT_TO_CODE_POINTS = 106; //: Text -> List Int64    *Available since version 1.6*
+  // Next id is 107. 106 is TEXT_TO_CODE_POINTS.
+}
+
+// Builtin literals
+// FixMe: Renamed
+message PrimLit {
+  oneof Sum {
+
+    //  64-bit integer literal ('LitInt64')
+    sint64 int64 = 1;
+
+    // Decimal literal ('LitDecimal')
+    //
+    // Serialization of number in ``[-1E28, 1E28]``
+    // with at most 10 digits of decimal precision.
+    //
+    // *Must be a string that matched
+    //        `[+-]*[0-9]{0,28}(\.[0-9]{0,10})*`*
+    //
+    // It would fit in an int128, but sadly protobuf does not have
+    // one. so, string it is. note that we can't store the whole and
+    // decimal part in two numbers either, because 10^28 > 2^63.
+    string decimal = 2;
+
+    // Unicode string literal ('LitText')
+    string text = 4;
+
+    // UTC timestamp literal ('LitTimestamp')
+    //
+    // Microseconds since the UNIX epoch. can go backwards.
+    //
+    // *Must be in range 001-01-01T00:00:00Z to
+    // 9999-12-31T23:59:59.999999Z
+
+    // sfixed since the vast majority of values will be greater than
+    // 2^28, since currently the number of microseconds since the
+    // epoch is greater than that.
+    sfixed64 timestamp = 5;
+
+    // Party literal ('LitParty')
+    // *Must be a PartyId string*
+    string party = 7;
+
+    // Date literal ('Date')
+    // Serialization of the number of days since the unix epoch. can go backwards.
+    //
+    // *Must be in range '0001-01-01' to '9999-12-31'*
+    int32 date = 8;
+  }
+
+  reserved 3; // This was char.
+  reserved 6; // This was reltime;
+}
+
+// Source code locations
+message Location {
+
+  // 0-indexed start and end line and column numbers.
+  message Range {
+    int32 start_line = 1;
+    int32 start_col = 2;
+    int32 end_line = 3;
+    int32 end_col = 4;
+  }
+
+  ModuleRef module = 1; // (*optional*), if missing the line is within the current module.
+  Range range = 2;
+}
+
+
+// Expressions
+message Expr {
+
+  // Record construction ('ExpRecCon')
+  message RecCon {
+
+    // type of the record being constructed
+    Type.Con tycon = 1;
+
+    // Field names and the associated values.
+    repeated FieldWithExpr fields = 2;
+  }
+
+  // Record projection (ExpRecProj)
+  message RecProj {
+
+    // type of the record being projected.
+    Type.Con tycon = 1;
+
+    // Name of the record field to be projected on.
+    // *must be a valid Identifier*
+    string field = 2;
+
+    // projected expression
+    Expr record = 3;
+  }
+
+  // Record update ('ExpRecUp')
+  message RecUpd {
+
+    // type of the record being updated
+    Type.Con tycon = 1;
+
+    // Name of the updated field.
+    // *must be a valid identifier*
+    string field = 2;
+
+    // Actual record being updated
+    Expr record = 3;
+
+    // Value to wich the record is udpated
+    Expr update = 4;
+  }
+
+  // Variant construction ('ExpVariantCon')
+  message VariantCon {
+
+    // type of the variant being constructed
+    Type.Con tycon = 1;
+
+    // name of the variant constructor
+    // *Must be a valid identifier*
+    string variant_con = 2;
+
+    // Argument of the variant.
+    Expr variant_arg = 3;
+  }
+
+   // Enum construction ('ExpEnumCon')
+   // *Available since version 1.6*
+   message EnumCon {
+
+     // Name of the type constructor name
+     TypeConName tycon = 1;
+
+     // name of the enum constructor
+     // *Must be a valid identifier*
+     string enum_con = 2;
+   }
+
+  // Tuple Construction ('ExpTupleCon')
+  message TupleCon {
+    // Field names and their associated values.
+    repeated FieldWithExpr fields = 1;
+  }
+
+  // Tuple Projection ('ExpTupleProj')
+  message TupleProj {
+
+    // Name of the field to be projected on.
+    // *Must be a valid Identifier*
+    string field = 1;
+
+    // tuple to be projected.
+    Expr tuple = 2;
+  }
+
+  // Tuple update ('ExpTuplUpdate')
+  message TupleUpd {
+
+    // Name of the updated field.
+    // *must be a valid identifier*.
+    string field = 1;
+
+    // Actual tuple being updated.
+    Expr tuple = 2;
+
+    // Value to which the record is udpated.
+    Expr update = 3;
+  }
+
+
+  // Application ('ExpApp')
+  message App {
+
+    // Function
+    Expr fun = 1;
+
+    // Arguments of the function.
+    // *Must be non-empty*
+    repeated Expr args = 2;
+  }
+
+  // Type application ('ExpTyApp')
+  message TyApp {
+
+    // Polymorphic expression
+    Expr expr = 1;
+
+    // Arguments of the function.
+    // *Must be non-empty*
+    repeated Type types = 2;
+  }
+
+  // Abstraction ('ExpAbs')
+  message Abs {
+
+    // Abstracted Variables with their kind
+    // *Must be non-empty*
+    repeated VarWithType param = 1;
+
+    // Abstracted value
+    Expr body  = 2;
+  }
+
+  message TyAbs {
+
+    // Abstracted Variables with their type
+    // *Must be non-empty*
+    repeated TypeVarWithKind param = 1;
+
+    // Abstracted value
+    Expr body = 2;
+  }
+
+  // Empty list ('ExpNil')
+  message Nil {
+
+    // type of the list elements.
+    Type type = 1;
+  }
+
+  // Non empty list
+  message Cons {
+
+    // type of the list elements.
+    Type type = 1;
+
+    // Front element of the list.
+    // *Must be non-empty*
+    repeated Expr front = 2;
+
+    // tail of the list
+    Expr tail = 3;
+  }
+
+  // (*Since version 1*)
+  // Empty optional value
+  message OptionalNone {
+
+    // type of the element
+    Type type = 1;
+  }
+
+  // (*Since version 1*)
+  // Non empty optional value
+  message OptionalSome {
+
+    // type of the element
+    Type type = 1;
+
+    // contained value
+    // FixMe: renamed to 'value'
+    Expr body = 2;
+  }
+
+  // Location of the expression in the DAML code source.
+  // Optional
+  Location location = 25;
+
+  oneof Sum {
+
+    // Expression variable ('ExpVar')
+    // *must be a valid identifier*
+    string var = 1;
+
+    // Defined value ('ExpVal')
+    ValName val = 2;
+
+    // Builtin function ('ExpBuiltin')
+    BuiltinFunction builtin = 3;
+
+    // Primitive constructor ('()', 'False' or 'True')
+    PrimCon prim_con = 4;
+
+    // Builtin literal ('ExpBuiltin')
+    PrimLit prim_lit = 5;
+
+    // Record construction ('ExpRecCon')
+    RecCon rec_con = 6;
+
+    // Record projection ('ExpRecProj')
+    RecProj rec_proj = 7;
+
+    // Record udpate ('ExpRecUpdate')
+    RecUpd rec_upd = 22;
+
+    // Variant construction ('ExpVariantCon')
+    VariantCon variant_con = 8;
+
+    // Enum construction ('ExpEnumCon')
+    EnumCon enum_con = 28;  // *Available since version 1.6*
+
+    // Tuple construction ('ExpTupleCon')
+    TupleCon tuple_con = 9;
+
+    // Tuple project ('ExpTupleProj')
+    TupleProj tuple_proj = 10;
+
+    // Tuple update ('ExpTupleUpdate')
+    TupleUpd tuple_upd = 23;
+
+    // Application ('ExpApp')
+    App app = 11;
+
+    // Type Application ('ExpTyApp')
+    TyApp ty_app =  12;
+
+    // Abstraction ('ExpAbs')
+    Abs abs = 13;
+
+    // Type Abstraction ('ExpTyAbs')
+    TyAbs ty_abs = 14;
+
+    // Pattern Matching ('ExpCase')
+    Case case = 15;
+
+    // Let block ('ExpLet')
+    Block let = 16;
+
+    // Empty List ('ExpNil')
+    Nil nil = 17;
+
+    // Non Empty list ('ExpCons')
+    Cons cons = 18;
+
+    // Update expression ('ExpUpdate')
+    Update update = 20;
+
+    // Scenario Expression ('ExpScenario')
+    Scenario scenario = 21;
+
+    // empty optional value ('ExpNone')
+    // *Available since version 1.1*
+    OptionalNone optional_none = 26;
+
+    // non empty optional value ('ExpSome')
+    // *Available since version 1.1*
+    OptionalSome optional_some = 27;
+  }
+
+  reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*
+  reserved 24; // This was equal_contract_id. Removed in favour of BuiltinFunction.EQUAL_CONTRACT_ID
+}
+
+// Case alternative
+message CaseAlt {
+
+  // Variant pattern
+  message Variant {
+
+    // name of the type constructor
+    TypeConName con = 1;
+
+    // name of the variant constructor
+    // *Must be a valid identifier*
+    string variant = 2;
+
+    // name of the variant binder
+    // *Must be a valid identifier*
+    string binder = 3;
+  }
+
+  // Enum pattern
+  // *Available since version 1.6*
+  message Enum {
+
+    // name of the type constructor
+    TypeConName con = 1;
+
+    // name of the variant constructor
+    // *Must be a valid identifier*
+    string constructor = 2;
+  }
+
+  // Non empty list pattern
+  message Cons {
+    // name of the binder for the head
+    // *Must be a valid identifier*
+    string var_head = 1;
+
+    // name of the binder for the tail
+    // *Must be a valid identifier*
+    string var_tail = 2;
+  }
+
+  // Non empty option patterm
+  // *Available since version 1.1*
+  message OptionalSome {
+    string var_body = 1;
+  }
+
+  oneof Sum {
+    Unit default = 1;
+    Variant variant = 2;
+    PrimCon prim_con = 3;
+    Unit nil = 4;
+    Cons cons = 5;
+    Unit optional_none = 7; // * Available since version 1.1*
+    OptionalSome optional_some = 8; // * Available since version 1.1*
+    Enum enum = 9; // * Available since version 1.6*
+  }
+
+  Expr body = 6;
+}
+
+message Case {
+  Expr scrut = 1;
+  repeated CaseAlt alts = 2;
+}
+
+// A block of bindings and an expression.
+// Encodes a sequence of binds in e.g. a let or update block.
+message Block {
+  // *Must be non-empty*
+  // Bindings
+  repeated Binding bindings = 1;
+  Expr body = 2;
+}
+
+// A Pure statement either scenario or update
+message Pure {
+  Type type = 1;
+  Expr expr = 2;
+}
+
+message Update {
+
+  // Create Update
+  message Create {
+    // Template type
+    TypeConName template = 1;
+    // Template argument
+    Expr expr = 2;
+  }
+
+  // Exercise Update
+  message Exercise {
+    // Template type
+    TypeConName template = 1;
+    // name of the exercised template choice
+    string choice = 2;
+    // contract id
+    Expr cid = 3;
+    // actors
+    // *optional since version 1.5*
+    Expr actor = 4;
+    // argument
+    Expr arg = 5;
+  }
+
+  // Fetch Update
+  message Fetch {
+    // Template type
+    TypeConName template = 1;
+    // contract id
+    Expr cid = 2;
+    reserved 3; // was actor, we thought we'd need this, but we don't
+  }
+
+  // Embeded Exression Update
+  message EmbedExpr {
+    // Expression type
+    Type type = 1;
+    // Expression body
+    Expr body = 2;
+  }
+
+  // Retrieve by key Update
+  // *Available since version 1.2*
+  message RetrieveByKey {
+    TypeConName template = 1;
+    Expr key = 2;
+  }
+
+  oneof Sum {
+    Pure pure = 1;
+    Block block = 2;
+    Create create = 3;
+    Exercise exercise = 4;
+    Fetch fetch = 5;
+    Unit get_time = 6;
+    RetrieveByKey lookup_by_key = 8; //*Available since version 1.2*
+    RetrieveByKey fetch_by_key = 9; //*Available since version 1.2*
+    // see similar constructor in `Scenario` on why this is useful.
+    EmbedExpr embed_expr = 7;
+  }
+}
+
+// Scenario actions
+message Scenario {
+
+  message Commit {
+    // committing party
+    Expr party = 1;
+    //
+    Expr expr = 2;
+    // type of result
+    Type ret_type = 3;
+  }
+
+  message EmbedExpr {
+    Type type = 1;
+    Expr body = 2;
+  }
+
+  oneof Sum {
+    Pure pure = 1;
+    Block block = 2;
+    Commit commit = 3;
+    Commit mustFailAt = 4;
+    Expr pass = 5;
+    Unit get_time = 6;
+    Expr get_party = 7;
+    // embed an expression of type Scenario. note that this construct is useful
+    // to explicitly mark the start of scenario execution, which is useful in
+    // top level definitions. for example if we hav
+    //
+    // def test : Scenario Unit = if <blah> then <this> else <that>
+    //
+    // this is not a value, since it's headed with an `if`, but we can turn
+    // it into a value by wrapping the `if` with this constructor. in that
+    // case, the `if` will be executed every time the scenario runs --
+    // as expected.
+    EmbedExpr embed_expr = 8;
+  }
+}
+
+// Template choice definition.
+message TemplateChoice {
+
+  // *Must be a valid identifier*
+  string name = 1;
+
+  // Choice type
+  bool consuming = 2;
+
+  // The controllers of the choice. They have type `List Party` and the
+  // template parameter in scope, but not the choice parameter. All of these
+  // controllers need to authorize the exercising of this choice (aka
+  // conjunctive choice controllers).
+  Expr controllers = 3;
+
+  // Name to which the choice argument is bound and its type.
+  VarWithType arg_binder = 4;
+
+  // Return type of the choice.
+  Type ret_type = 5;
+
+  // Follow-up update of the choice. It has type `Update <ret_type>` and both
+  // the template parameter and the choice parameter in scope.
+  Expr update = 6;
+
+  // Name to bind the ContractId of the contract this choice is exercised on to.
+  string self_binder = 7;
+
+  Location location = 8;
+}
+
+// we restrict key expressions to records of projections, much like SQL
+message KeyExpr {
+    message Projection {
+        Type.Con tycon = 1; // Always fully applied
+        string field = 2;
+    }
+
+    // note that the projection is always referring to the template parameter.
+    message Projections {
+        repeated Projection projections = 2;
+    }
+
+    message RecordField {
+        string field = 1;
+        KeyExpr expr = 2;
+    }
+
+    message Record {
+        Type.Con tycon = 1; // Always fully applied
+        repeated RecordField fields = 2;
+    }
+
+    oneof Sum {
+        Projections projections = 1;
+        Record record = 2;
+    }
+}
+
+// Contract template definition
+message DefTemplate {
+
+  message DefKey {
+      Type type = 1;
+      // NOTE(MH): The first version of contract keys had syntactic
+      // restrictions that key expression had to be "simple". We lifted these
+      // restrictions later and allowed arbitrarily complext key expressions.
+      oneof key_expr {
+          KeyExpr key = 2;
+          Expr complex_key = 4;
+      }
+      Expr maintainers = 3; // a function from the key type to [Party]
+  }
+
+    // The type constructor for the template, acting as both
+  // the name of the template and the type of the template argument.
+  DottedName tycon = 1;
+
+  // Name to which the template argument is bound.
+  string param = 2;
+
+  // NOTE(MH): The new runtime authorization check for DAML 1.0 does not rely
+  // on the stakeholder signatures produced by the obligables computation
+  // anymore but uses the interpreter to compute the signatories and
+  // stakeholders of contract instances.
+  // REMOVED: TemplateStakeholders stakeholders = 3;
+  reserved 3;
+
+  // Pre-condition that the template argument must satisfy.
+  // When present, it has type `Bool` and the template parameter in scope.
+  // *Optional*, interpreted as 'True' if undefined
+  Expr precond = 4;
+
+  // The signatories of the contract. They have type `List Party` and the
+  // template parameter in scope.
+  Expr signatories = 5;
+
+  // The agreement text associated with the contract. It has type `Text` and
+  // the template parameter in scope.
+  Expr agreement = 6;
+
+  // The choices available in the resulting contract.
+  repeated TemplateChoice choices = 7;
+
+  // The observers of the contract. They have type `List Party` and the
+  // template parameter in scope.
+  Expr observers = 8;
+
+  Location location = 9;
+
+  // They key definition for the template, if present
+  DefKey key = 10; // optional // *Available since version 1.3*
+}
+
+// Data type definition
+message DefDataType {
+  message Fields {
+    repeated FieldWithType fields = 1;
+  }
+
+  // *Available since version 1.6*
+  message EnumConstructors {
+    repeated string constructors = 1;
+  }
+
+  // name of the defined data type
+  DottedName name = 1;
+
+  // type parameters
+  // *Must be empty if enum field is set*
+  repeated TypeVarWithKind params = 2;
+
+  oneof DataCons {
+    Fields record = 3; // Records without fields are explicitly allowed.
+    Fields variant = 4; // Variants without constructors are explicitly allowed.
+    EnumConstructors enum = 7; // *Available since version 1.6*
+  }
+
+  // If true, this data type preserves serializability in the sense that when
+  // all parameters are instantiated with serializable types (of kind '*'),
+  // then the resulting type is serializable as well.
+  // This flag is used to simplify package validation by not requiring an
+  // inference but only a check. Such a check must validate that this flag is
+  // set correctly and that template and choice argument and result types
+  // have this flag set to true.
+  bool serializable = 5;
+
+  Location location = 6;
+}
+
+// Value definition
+message DefValue {
+  // The reason why we have this type instead of just flattening name
+  // and type in DefValue is that it was VarWithType before, and we
+  // want to be binary-compatible with it.
+  message NameWithType {
+
+    // Name of the value
+    // *each element of name must be a valid identifier*
+    repeated string name = 1;
+
+    // Type of the value
+    Type type = 2;
+  }
+
+  NameWithType name_with_type = 1;
+
+  Expr expr = 2;
+
+  // If true, the value must not contain any party literals and not reference
+  // values which contain party literals.
+  // This flag is used to simplify package validation by not requiring an
+  // inference but only a check. Such a check must validate that this flag is
+  // set correctly and that templates do not reference values which have this
+  // flag set to false.
+  bool no_party_literals = 3;
+
+  bool is_test = 4;
+
+  Location location = 5;
+}
+
+message FeatureFlags {
+  bool forbidPartyLiterals = 1;
+  bool dontDivulgeContractIdsInCreateArguments = 2;
+  bool dontDiscloseNonConsumingChoicesToObservers = 3;
+}
+
+message Module {
+  DottedName name = 1;
+  // repeated Definition definitions = 2; // Removed in favour of data_types, values and templates.
+  reserved 2;
+  // repeated string scenario_tests = 3; // Removed in favour of DefValue.is_test.
+  reserved 3;
+  FeatureFlags flags = 4;
+  repeated DefDataType data_types = 5;
+  repeated DefValue values = 6;
+  repeated DefTemplate templates = 7;
+}
+
+message Package {
+  repeated Module modules = 1;
+  repeated string interned_package_ids = 2; /* Available since version 1.6 */
+}

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
@@ -55,8 +55,10 @@ class ProtoTest extends WordSpec with Matchers with TableDrivenPropertyChecks {
     // Do not change thiss test.
     // The test checks the snapshot of the proto definition are not modified.
 
-    def dir =
-      resource(rlocation("daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/"))
+    val rootDir = "daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6"
+
+    def resolve(file: String) =
+      resource(rlocation(s"$rootDir/$file"))
 
     "not be modified" in {
 
@@ -69,7 +71,7 @@ class ProtoTest extends WordSpec with Matchers with TableDrivenPropertyChecks {
 
       forEvery(files) {
         case (fileName, hash) =>
-          hashFile(dir.resolve(fileName)) shouldBe hash
+          hashFile(resolve(fileName)) shouldBe hash
       }
     }
   }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
@@ -63,15 +63,24 @@ class ProtoTest extends WordSpec with Matchers with TableDrivenPropertyChecks {
     "not be modified" in {
 
       val files = Table(
-        "file" -> "hash",
-        "daml_lf_0.proto" -> "1554427a861be3fb00a2445711fffe3c54bf0e541be6e748d0a18c5fe01afc03",
-        "daml_lf_1.proto" -> "711b129f810248d20526144d2d56c85fc486b14ba1eb2ab6b13a659a710ad5d2",
-        "daml_lf.proto" -> "4064870ecefaa3b727d67f0b8fa31590c17c7b11ad9ca7c73f2925013edf410e",
+        ("file", "Linux hash", "windows hash"),
+        (
+          "daml_lf_0.proto",
+          "1554427a861be3fb00a2445711fffe3c54bf0e541be6e748d0a18c5fe01afc03",
+          "e79a319ed16dd7cd533d252c2884241759bd9af72f83a4516ff937db53cbcbf8"),
+        (
+          "daml_lf_1.proto",
+          "711b129f810248d20526144d2d56c85fc486b14ba1eb2ab6b13a659a710ad5d2",
+          "d75b661509079c12327e18296350aeffb77ca88f8ee110fd1c774ce8c0cb16f0"),
+        (
+          "daml_lf.proto",
+          "4064870ecefaa3b727d67f0b8fa31590c17c7b11ad9ca7c73f2925013edf410e",
+          "6b5990fe8ed2de64e3ec56a0d1d0d852983832c805cf1c3f931a0dae5b8e5ae2")
       )
 
       forEvery(files) {
-        case (fileName, hash) =>
-          hashFile(resolve(fileName)) shouldBe hash
+        case (fileName, linuxHash, windowsHash) =>
+          List(linuxHash, windowsHash) should contain(hashFile(resolve(fileName)))
       }
     }
   }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/ProtoTest.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+
+import java.nio.file.{Files, Path, Paths}
+import java.util.zip.ZipFile
+
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.{daml_lf_1_6, daml_lf_dev}
+import com.google.protobuf.CodedInputStream
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{Assertion, Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class ProtoTest extends WordSpec with Matchers with TableDrivenPropertyChecks {
+
+  private val darFile = resource(rlocation("daml-lf/archive/DarReaderTest.dar"))
+
+  private def resource(path: String): Path = {
+    val f = Paths.get(path)
+    require(Files.exists(f), s"File does not exist: $f")
+    f
+  }
+
+  "daml_lf_dev.DamlLf" should {
+    "read dalf" in {
+
+      decodeTestWrapper(
+        darFile, { cis =>
+          val archive = daml_lf_dev.DamlLf.Archive.parseFrom(cis)
+          val payload = daml_lf_dev.DamlLf.ArchivePayload.parseFrom(archive.getPayload)
+          payload.hasDamlLf1 shouldBe true
+        }
+      )
+
+    }
+  }
+
+  "daml_lf_1_6.DamlLf" should {
+    "read dalf" in {
+      decodeTestWrapper(
+        darFile, { cis =>
+          val archive = daml_lf_1_6.DamlLf.Archive.parseFrom(cis)
+          val payload = daml_lf_1_6.DamlLf.ArchivePayload.parseFrom(archive.getPayload)
+          payload.hasDamlLf1 shouldBe true
+        }
+      )
+    }
+  }
+
+  "daml_lf_1_6 file" should {
+
+    // Do not change thiss test.
+    // The test checks the snapshot of the proto definition are not modified.
+
+    def dir =
+      resource(rlocation("daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_1_6/"))
+
+    "not be modified" in {
+
+      val files = Table(
+        "file" -> "hash",
+        "daml_lf_0.proto" -> "1554427a861be3fb00a2445711fffe3c54bf0e541be6e748d0a18c5fe01afc03",
+        "daml_lf_1.proto" -> "711b129f810248d20526144d2d56c85fc486b14ba1eb2ab6b13a659a710ad5d2",
+        "daml_lf.proto" -> "4064870ecefaa3b727d67f0b8fa31590c17c7b11ad9ca7c73f2925013edf410e",
+      )
+
+      forEvery(files) {
+        case (fileName, hash) =>
+          hashFile(dir.resolve(fileName)) shouldBe hash
+      }
+    }
+  }
+
+  private def decodeTestWrapper(dar: Path, test: CodedInputStream => Assertion) = {
+    val zipFile = new ZipFile(dar.toFile)
+    val entries = zipFile.entries().asScala.filter(_.getName.endsWith(".dalf")).toList
+
+    assert(entries.size >= 2)
+    assert(entries.exists(_.getName.contains("daml-stdlib")))
+
+    entries.foreach { entry =>
+      val inputStream = zipFile.getInputStream(entry)
+      try {
+        val cos: CodedInputStream = com.google.protobuf.CodedInputStream.newInstance(inputStream)
+        test(cos)
+      } finally {
+        inputStream.close()
+      }
+    }
+  }
+
+  private def hashFile(file: Path) = {
+    val bytes = Files.readAllBytes(file)
+    java.security.MessageDigest.getInstance("SHA-256").digest(bytes).map("%02x" format _).mkString
+  }
+}

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -539,14 +539,19 @@ Then we can define our kinds, types, and expressions::
        |  'Map'                                     -- BTMap
        |  'Update'                                  -- BTyUpdate
        |  'ContractId'                              -- BTyContractId
-       |  'Any'                                     –- BTyAny
+       |  'Any'                                     -- BTyAny
 
+  Type csontratins
+    K ::= ε                                         -- ConstraintTrivial
+       |  Eq α, K                         
+       |  Serial α, K
+       
   Types (mnemonic: tau for type)
     τ, σ
       ::= α                                         -- TyVar: Type variable
        |  n                                         -- TyNat: Nat Type
        |  τ σ                                       -- TyApp: Type application
-       |  ∀ α : k . τ                               -- TyForall: Universal quantification
+       |  ∀ α : k . K ⇒ τ                          -- TyForall: Universal quantification
        |  BuiltinType                               -- TyBuiltin: Builtin type
        |  Mod:T                                     -- TyCon: type constructor
        |  ⟨ f₁: τ₁, …, fₘ: τₘ ⟩                     -- TyTuple: Tuple type
@@ -825,13 +830,19 @@ Well-formed expression
 
 Then we define *well-formed expressions*. ::
 
-                          ┌───────────────┐
-  Well-formed expressions │ Γ  ⊢  e  :  τ │
-                          └───────────────┘
+  Constraint store:
+
+   K ::= ε                                 -- StoreTrivial
+      |  'Eq' α, K                         -- StoreEq
+      |  'Serial' α, K                     -- StoreSerial
+
+                          ┌───────────────────┐
+  Well-formed expressions │ Γ ; K  ⊢  e  :  τ │
+                          └───────────────────┘
 
       x : τ  ∈  Γ
     ——————————————————————————————————————————————————————————————— ExpDefVar
-      Γ  ⊢  x  :  τ
+      Γ; K  ⊢  x  :  τ
 
       Γ  ⊢  e₁  :  τ₁ → τ₂      Γ  ⊢  e₂  :  τ₁
     ——————————————————————————————————————————————————————————————— ExpApp

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2617,7 +2617,7 @@ DAML-LF programs are serialized using `Protocol Buffers
 <https://developers.google.com/protocol-buffers/>`_.  The
 machine-readable definition of the serialization for DAML-LF major
 version 1 can be found in the `daml_lf_1.proto
-<../archive/src/main/protobuf/com/digitalasset/daml_lf_dev>`_ file.
+<../archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto>`_ file.
 
 For the sake of brevity, we do no exhaustively describe how DAML-LF
 programs are (un)serialized into protocol buffer. In the rest of this

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -14,6 +14,20 @@
   location:
     groupId: com.digitalasset
     artifactId: daml-lf-dev-archive-proto
+- target: //daml-lf/archive:daml_lf_1.6_archive_java_proto
+  type: jar-lib
+  javadoc-jar: daml_lf_1.6_archive_java_proto_javadoc.jar
+  mavenUpload: True
+- target: //daml-lf/archive:daml_lf_1.6_archive_proto_zip
+  type: zip
+  location:
+    groupId: com.digitalasset
+    artifactId: daml-lf-1.6-archive-proto
+- target: //daml-lf/archive:daml_lf_1.6_archive_proto_tarball
+  type: targz
+  location:
+    groupId: com.digitalasset
+    artifactId: daml-lf-1.6-archive-proto
 - target: //daml-lf/archive:daml_lf_archive_reader
   type: jar-scala
 - target: //compiler/damlc/jar:damlc_jar

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -28,10 +28,39 @@ HEAD — ongoing
   ``/home/daml/.daml/bin`` is automatically added to ``PATH``.
 + [JSON API - Experimental] Support for automatic package reload
   See `issue #2906 <https://github.com/digital-asset/daml/issues/2906>`_.
++ [Sandbox] Filter contracts or contracts keys in the database query for parties that cannot see them.
 + [DAML-LF] **Breaking** archive proto package renamed from `com.digitalasset.daml_lf` to `com.digitalasset.daml_lf_dev`
 + [DAML-LF] **Breaking** Some bintray/maven packages are renamed:
-   - `com.digitalasset.daml-lf-proto` becomes `com.digitalasset.daml-lf-dev-proto`
+   - `com.digitalasset.daml-lf-proto` becomes `com.digitalasset.daml-lf-dev-archive-proto`
    - `com.digitalasset.daml-lf-archive` becomes `com.digitalasset:daml-lf-dev-archive-java-proto`
    - `com.digitalasset.daml-lf-archive-scala` becomes `com.digitalasset.daml-lf-archive-reader`
 -[Sandbox] Filter contracts or contracts keys in the database query for parties that cannot see them.
 + [DAML Standard Library] Add ``createAndExercise``
++ [DAML-LF] Add immutable bintray/maven packages for handling DAML-LF archive up to version 1.6 in a stable way:
+   - `com.digitalasset.daml-lf-1.6-archive-proto`
+
+     This package contains the archive protobuf definitions as they
+     were introduced when 1.6 was freeze.  Those definitions can be
+     used to read DAML-LF archive up to version 1.6.
+
+
+     The main advantage of this package over the `dev` version
+     (`com.digitalasset.daml-lf-dev-archive-proto`) is its
+     immutability (it is guarantee it will never changed once
+     introduced in the SDK) in other words one can used it without
+     suffering frequent breaking change introduced in the `dev`
+     version.
+
+     Going forward the SKD will contains a similar immutable package
+     containning the proto definition for at least each DAML-LF
+     version the compiler support. 
+
+     We strongly advice anyone reading daml-lf archive directly to use
+     this package (or the under
+     `com.digitalasset:daml-lf-1.6-archive-java-proto` package), as
+     frequent breaking changes may be introduced in the `dev` without
+     futher notice in the release notes.
+     
+   - `com.digitalasset:daml-lf-1.6-archive-java-proto`
+
+     This package contains the java auto-generated from the package `com.digitalasset.daml-lf-1.6-archive-proto`


### PR DESCRIPTION
In this PR, we freeze the protobuf definition archive of daml-lf 1.6 as it was when introduced. 

Hence we can introduce changes (breaking at the level of the generated java/python) in the protobuf definition without breaking external dar reader that rely on this definition.  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
