### PR TITLE
language: fix: don't look for daml files in hidden directories

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -214,9 +214,13 @@ getDamlFiles srcRoot = do
 -- | Return all daml files in the given directory.
 damlFilesInDir :: FilePath -> IO [NormalizedFilePath]
 damlFilesInDir srcRoot = do
-    fs <- listFilesRecursive srcRoot
-    pure $
-        map toNormalizedFilePath $ filter (".daml" `isExtensionOf`) fs
+    -- don't recurse into hidden directories (for example the .daml dir).
+    fs <-
+        listFilesInside
+            (\fp ->
+                 return $ fp == "." || (not $ isPrefixOf "." $ takeFileName fp))
+            srcRoot
+    pure $ map toNormalizedFilePath $ filter (".daml" `isExtensionOf`) fs
 
 -- | Find all DAML files below a given source root. If the source root is a file we interpret it as
 -- main and return only that file. This is different from getDamlFiles which also returns

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -240,7 +240,7 @@ packagingTests = testGroup "packaging"
         assertBool "b.dar was not created." =<< doesFileExist bDar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile bDar
         assertBool "b.dar contains source file from package database" $
-            all (not . ("A.daml" `isSuffixOf`)) darFiles
+            not $ any ("A.daml" `isSuffixOf`) darFiles
     , testCase "Build package with SDK dependency" $ withTempDir $ \tmpDir -> do
         let project = tmpDir </> "project"
         let dar = project </> ".daml" </> "dist" </> "project-1.0.dar"

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -73,7 +73,7 @@ tests damlDir tmpDir = testGroup "Integration tests"
     , testCase "daml --help" $ callCommandQuiet "daml --help"
     , testCase "daml new --list" $ callCommandQuiet "daml new --list"
     , noassistantTests damlDir
-    , packagingTests tmpDir
+    , packagingTests
     , quickstartTests quickstartDir mvnDir
     , cleanTests cleanDir
     , deployTest deployDir
@@ -138,9 +138,9 @@ noassistantTests damlDir = testGroup "no assistant"
               callProcess damlcPath ["build", "--project-root", "foobar", "--init-package-db", "yes"]
     ]
 
-packagingTests :: FilePath -> TestTree
-packagingTests tmpDir = testGroup "packaging"
-    [ testCaseSteps "Build package with dependency" $ \step -> do
+packagingTests :: TestTree
+packagingTests = testGroup "packaging"
+    [ testCaseSteps "Build package with dependency" $ \step -> withTempDir $ \tmpDir -> do
         let projectA = tmpDir </> "a"
         let projectB = tmpDir </> "b"
         let aDar = projectA </> ".daml" </> "dist" </> "a-1.0.dar"
@@ -197,7 +197,7 @@ packagingTests tmpDir = testGroup "packaging"
             ]
         withCurrentDirectory projectB $ callCommandQuiet "daml build"
         assertBool "b.dar was not created." =<< doesFileExist bDar
-    , testCaseSteps "Dependency on a package with source: A.daml" $ \step -> do
+    , testCaseSteps "Dependency on a package with source: A.daml" $ \step -> withTempDir $ \tmpDir -> do
         let projectA = tmpDir </> "a"
         let projectB = tmpDir </> "b"
         let aDar = projectA </> ".daml" </> "dist" </> "a-1.0.dar"
@@ -230,7 +230,7 @@ packagingTests tmpDir = testGroup "packaging"
             [ "sdk-version: " <> sdkVersion
             , "version: \"1.0\""
             , "name: b"
-            , "source: B.daml"
+            , "source: ."
             , "dependencies:"
             , "  - daml-prim"
             , "  - daml-stdlib"
@@ -238,7 +238,10 @@ packagingTests tmpDir = testGroup "packaging"
             ]
         withCurrentDirectory projectB $ callCommandQuiet "daml build"
         assertBool "b.dar was not created." =<< doesFileExist bDar
-    , testCase "Build package with SDK dependency" $ do
+        darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile bDar
+        assertBool "b.dar contains source file from package database" $
+            all (not . ("A.daml" `isSuffixOf`)) darFiles
+    , testCase "Build package with SDK dependency" $ withTempDir $ \tmpDir -> do
         let project = tmpDir </> "project"
         let dar = project </> ".daml" </> "dist" </> "project-1.0.dar"
         createDirectoryIfMissing True (project </> "daml")
@@ -261,7 +264,7 @@ packagingTests tmpDir = testGroup "packaging"
             ]
         withCurrentDirectory project $ callCommandQuiet "daml build"
         assertBool "project-1.0.dar was not created." =<< doesFileExist dar
-    , testCase "Top-level source files" $ do
+    , testCase "Top-level source files" $ withTempDir $ \tmpDir -> do
         -- Test that a source file in the project root will be included in the
         -- DAR file. Regression test for #1048.
         let projDir = tmpDir </> "proj"
@@ -386,7 +389,7 @@ packagingTests tmpDir = testGroup "packaging"
             , "dependencies: [daml-prim, daml-stdlib]"
             ]
         withCurrentDirectory projDir $ callCommandQuiet "daml build"
-    , testCaseSteps "Build migration package" $ \step -> do
+    , testCaseSteps "Build migration package" $ \step -> withTempDir $ \tmpDir -> do
         -- it's important that we have fresh empty directories here!
         let projectA = tmpDir </> "a-1.0"
         let projectB = tmpDir </> "a-2.0"


### PR DESCRIPTION
Fixes #3134. When locating daml source files, we need to make sure we're
not recursing into the .daml directory, because it contains source files
of the dependencies.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
