### PR TITLE
Add a `daml` user to docker image and fix PATH

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:8u212-alpine
 RUN apk add curl bash
 ARG VERSION
+RUN addgroup -S daml && adduser -S daml -G daml
+USER daml
 RUN curl https://get.daml.com | sh -s $VERSION
-ENV PATH="~/.daml/bin:${PATH}"
+ENV PATH="/home/daml/.daml/bin:${PATH}"

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -24,3 +24,5 @@ HEAD — ongoing
 + [Scala Codegen] Fixes for StackOverflowErrors in reading large LF archives. See `issue #3104 <https://github.com/digital-asset/daml/issues/3104>`_.
 + [Scala Bindings] Fixed a bug in the retry logic of ``LedgerClientBinding#retryingConfirmedCommands``. Commands are now only retried when the server responds with status ``RESOURCE_EXHAUSTED`` or ``UNAVAILABLE``.
 
++ [DAML-SDK Docker Image] The image now contains a ``daml`` user and the SDK is installed to ``/home/daml/.daml``.
+  ``/home/daml/.daml/bin`` is automatically added to ``PATH``.


### PR DESCRIPTION
Previously, we were installing the SDK as root which is probably not a
good idea. This PR adds a new `daml` user and fixes PATH (`$HOME` and
`~` both don’t work in this context).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
