### PR TITLE
damldocs: Do not filter templates and choices by export set

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -2,6 +2,21 @@
 
 ## Templates
 
+<a name="type-exportlist-template0-22237"></a>**template** [Template0](#type-exportlist-template0-22237)
+
+> | Field    | Type     | Description |
+> | :------- | :------- | :---------- |
+> | tfield0  | Party    |  |
+> | tfield0' | Party    |  |
+> 
+> * **Choice External:Archive**
+>   
+>   (no fields)
+> 
+> * **Choice Choice0**
+>   
+>   (no fields)
+
 <a name="type-exportlist-template1-34256"></a>**template** [Template1](#type-exportlist-template1-34256)
 
 > | Field    | Type     | Description |

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -1,5 +1,52 @@
 # <a name="module-exportlist-81980"></a>Module ExportList
 
+## Templates
+
+<a name="type-exportlist-template1-34256"></a>**template** [Template1](#type-exportlist-template1-34256)
+
+> | Field    | Type     | Description |
+> | :------- | :------- | :---------- |
+> | tfield1  | Party    |  |
+> | tfield1' | Party    |  |
+> 
+> * **Choice External:Archive**
+>   
+>   (no fields)
+> 
+> * **Choice Choice1**
+>   
+>   (no fields)
+
+<a name="type-exportlist-template2-3915"></a>**template** [Template2](#type-exportlist-template2-3915)
+
+> | Field    | Type     | Description |
+> | :------- | :------- | :---------- |
+> | tfield2  | Party    |  |
+> | tfield2' | Party    |  |
+> 
+> * **Choice External:Archive**
+>   
+>   (no fields)
+> 
+> * **Choice Choice2**
+>   
+>   (no fields)
+
+<a name="type-exportlist-template3-57838"></a>**template** [Template3](#type-exportlist-template3-57838)
+
+> | Field    | Type     | Description |
+> | :------- | :------- | :---------- |
+> | tfield3  | Party    |  |
+> | tfield3' | Party    |  |
+> 
+> * **Choice External:Archive**
+>   
+>   (no fields)
+> 
+> * **Choice Choice3**
+>   
+>   (no fields)
+
 ## Typeclasses
 
 <a name="class-exportlist-class1-82332"></a>**class** [Class1](#class-exportlist-class1-82332) t **where**

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -6,6 +6,30 @@ Module ExportList
 Templates
 ^^^^^^^^^
 
+.. _type-exportlist-template0-22237:
+
+**template** `Template0 <type-exportlist-template0-22237_>`_
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - tfield0
+       - Party
+       - 
+     * - tfield0'
+       - Party
+       - 
+  
+  + **Choice External\:Archive**
+    
+  
+  + **Choice Choice0**
+    
+
 .. _type-exportlist-template1-34256:
 
 **template** `Template1 <type-exportlist-template1-34256_>`_

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -3,6 +3,81 @@
 Module ExportList
 -----------------
 
+Templates
+^^^^^^^^^
+
+.. _type-exportlist-template1-34256:
+
+**template** `Template1 <type-exportlist-template1-34256_>`_
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - tfield1
+       - Party
+       - 
+     * - tfield1'
+       - Party
+       - 
+  
+  + **Choice External\:Archive**
+    
+  
+  + **Choice Choice1**
+    
+
+.. _type-exportlist-template2-3915:
+
+**template** `Template2 <type-exportlist-template2-3915_>`_
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - tfield2
+       - Party
+       - 
+     * - tfield2'
+       - Party
+       - 
+  
+  + **Choice External\:Archive**
+    
+  
+  + **Choice Choice2**
+    
+
+.. _type-exportlist-template3-57838:
+
+**template** `Template3 <type-exportlist-template3-57838_>`_
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - tfield3
+       - Party
+       - 
+     * - tfield3'
+       - Party
+       - 
+  
+  + **Choice External\:Archive**
+    
+  
+  + **Choice Choice3**
+    
+
 Typeclasses
 ^^^^^^^^^^^
 

--- a/compiler/damlc/tests/daml-test-files/ExportList.daml
+++ b/compiler/damlc/tests/daml-test-files/ExportList.daml
@@ -11,6 +11,9 @@ module ExportList
     , Class2 ()
     , Class3 (member3)
     , Class4 (..)
+    , Template1
+    , Template2 (tfield2)
+    , Template3 (..)
     ) where
 
 function0 : Int
@@ -73,3 +76,36 @@ class Class3 t where
 class Class4 t where
     member4 : t
     member4' : t
+
+template Template1
+    with
+        tfield1 : Party
+        tfield1' : Party
+    where
+        signatory tfield1
+        controller tfield1 can
+            Choice1 : ()
+              do
+                pure ()
+
+template Template2
+    with
+        tfield2 : Party
+        tfield2' : Party
+    where
+        signatory tfield2
+        controller tfield2 can
+            Choice2 : ()
+              do
+                pure ()
+
+template Template3
+    with
+        tfield3 : Party
+        tfield3' : Party
+    where
+        signatory tfield3
+        controller tfield3 can
+            Choice3 : ()
+              do
+                pure ()

--- a/compiler/damlc/tests/daml-test-files/ExportList.daml
+++ b/compiler/damlc/tests/daml-test-files/ExportList.daml
@@ -77,6 +77,17 @@ class Class4 t where
     member4 : t
     member4' : t
 
+template Template0
+    with
+        tfield0 : Party
+        tfield0' : Party
+    where
+        signatory tfield0
+        controller tfield0 can
+            Choice0 : ()
+              do
+                pure ()
+
 template Template1
     with
         tfield1 : Party


### PR DESCRIPTION
Fixes #3146. Since templates and choices end up as part of the ledger, it makes sense to document them even if they aren't listed in the DAML module's export list. This PR moves the "filter types by whether they are exported or not" step to _after_ they are separated from template docs, not before, as suggested by @jberthold-da.