### PR TITLE
language: dalf imports and a test

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -84,7 +84,7 @@ data PackageConfigFields = PackageConfigFields
     { pName :: String
     , pSrc :: String
     , pExposedModules :: Maybe [String]
-    , pVersion :: String
+    , pVersion :: Maybe String
     , pDependencies :: [String]
     , pSdkVersion :: String
     , cliOpts :: Maybe [String]
@@ -233,15 +233,17 @@ getDamlRootFiles srcRoot = do
         then liftIO $ damlFilesInDir srcRoot
         else pure [toNormalizedFilePath srcRoot]
 
-fullPkgName :: String -> String -> String -> String
-fullPkgName n v h
-    | null v = n <> "-" <> h
-    | otherwise = n <> "-" <> v <> "-" <> h
+fullPkgName :: String -> Maybe String -> String -> String
+fullPkgName n mbV h =
+    case mbV of
+        Nothing -> n <> "-" <> h
+        Just v -> n <> "-" <> v <> "-" <> h
 
-pkgNameVersion :: String -> String -> String
-pkgNameVersion n v
-    | null v = n
-    | otherwise = n ++ "-" ++ v
+pkgNameVersion :: String -> Maybe String -> String
+pkgNameVersion n mbV =
+    case mbV of
+        Nothing -> n
+        Just v -> n ++ "-" ++ v
 
 mkConfFile ::
        PackageConfigFields -> [String] -> String -> (String, BS.ByteString)
@@ -254,12 +256,14 @@ mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = (confName, bs)
     bs =
         BSC.toStrict $
         BSC.pack $
-        unlines
+        unlines $
             [ "name: " ++ pName
             , "id: " ++ pkgNameVersion pName pVersion
             , "key: " ++ pkgNameVersion pName pVersion
-            , "version: " ++ pVersion
-            , "exposed: True"
+            ]
+            ++ ["version: " ++ v | Just v <- [pVersion] ]
+            ++
+            [ "exposed: True"
             , "exposed-modules: " ++
               unwords (fromMaybe pkgModuleNames pExposedModules)
             , "import-dirs: ${pkgroot}" ++ "/" ++ key -- we really want '/' here

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -234,10 +234,14 @@ getDamlRootFiles srcRoot = do
         else pure [toNormalizedFilePath srcRoot]
 
 fullPkgName :: String -> String -> String -> String
-fullPkgName n v h = intercalate "-" [n, v, h]
+fullPkgName n v h
+    | null v = n <> "-" <> h
+    | otherwise = n <> "-" <> v <> "-" <> h
 
 pkgNameVersion :: String -> String -> String
-pkgNameVersion n v = n ++ "-" ++ v
+pkgNameVersion n v
+    | null v = n
+    | otherwise = n ++ "-" ++ v
 
 mkConfFile ::
        PackageConfigFields -> [String] -> String -> (String, BS.ByteString)

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -298,6 +298,7 @@ da_haskell_binary(
     ],
     main_function = "DA.Test.GenerateSimpleDalf.main",
     src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -288,6 +288,14 @@ sh_test(
 
 # Generate a simple DALF for plain DALF import testing
 
+genrule(
+    name = "simple-dalf.dalf",
+    outs = ["simple-dalf.dalf"],
+    cmd = "$(location :generate-simple-dalf) $@",
+    tools = [":generate-simple-dalf"],
+    visibility = ["//visibility:public"],
+)
+
 da_haskell_binary(
     name = "generate-simple-dalf",
     srcs = ["src/DA/Test/GenerateSimpleDalf.hs"],

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -70,7 +70,7 @@ da_haskell_test(
         ":integration-tests-mvn",
         "//release:sdk-release-tarball",
         "@local_jdk//:bin/java.exe" if is_windows else "@local_jdk//:bin/java",
-        "//compiler/damlc/tests:generate-simple-dalf",
+        "//compiler/damlc/tests:simple-dalf.dalf",
         "@mvn_dev_env//:mvn",
         "@tar_dev_env//:tar",
     ],

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -70,6 +70,7 @@ da_haskell_test(
         ":integration-tests-mvn",
         "//release:sdk-release-tarball",
         "@local_jdk//:bin/java.exe" if is_windows else "@local_jdk//:bin/java",
+        "//compiler/damlc/tests:generate-simple-dalf",
         "@mvn_dev_env//:mvn",
         "@tar_dev_env//:tar",
     ],

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -70,7 +70,7 @@ da_haskell_test(
         ":integration-tests-mvn",
         "//release:sdk-release-tarball",
         "@local_jdk//:bin/java.exe" if is_windows else "@local_jdk//:bin/java",
-        "//compiler/damlc/tests:simple-dalf.dalf",
+        "//compiler/damlc/tests:generate-simple-dalf",
         "@mvn_dev_env//:mvn",
         "@tar_dev_env//:tar",
     ],

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -390,18 +390,15 @@ packagingTests = testGroup "packaging"
             ]
         withCurrentDirectory projDir $ callCommandQuiet "daml build"
     , testCase "Dalf imports" $ withTempDir $ \projDir -> do
-        let genSimpleDalfExe
-              | isWindows = "generate-simple-dalf.exe"
-              | otherwise = "generate-simple-dalf"
-        genSimpleDalf <-
+        simpleDalf <-
             locateRunfiles
-            (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> genSimpleDalfExe)
+            (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "simple-dalf.dalf")
         writeFileUTF8 (projDir </> "daml.yaml") $ unlines
           [ "sdk-version: " <> sdkVersion
           , "name: proj"
           , "version: 0.1.0"
           , "source: ."
-          , "dependencies: [daml-prim, daml-stdlib, simple-dalf-0.0.0.dalf]"
+          , "dependencies: [daml-prim, daml-stdlib, " ++ simpleDalf ++ "]"
           ]
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "daml 1.2"
@@ -426,7 +423,6 @@ packagingTests = testGroup "packaging"
             --, "agreementTemplate : Module.Template -> Text"
             --, "agreementTemplate = agreement"
             ]
-        withCurrentDirectory projDir $ callCommandQuiet $ genSimpleDalf <> " simple-dalf-0.0.0.dalf"
         withCurrentDirectory projDir $ callCommandQuiet "daml build"
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
         assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar

--- a/daml-assistant/integration-tests/src/Main.hs
+++ b/daml-assistant/integration-tests/src/Main.hs
@@ -390,15 +390,18 @@ packagingTests = testGroup "packaging"
             ]
         withCurrentDirectory projDir $ callCommandQuiet "daml build"
     , testCase "Dalf imports" $ withTempDir $ \projDir -> do
-        simpleDalf <-
+        let genSimpleDalfExe
+              | isWindows = "generate-simple-dalf.exe"
+              | otherwise = "generate-simple-dalf"
+        genSimpleDalf <-
             locateRunfiles
-            (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "simple-dalf.dalf")
+            (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> genSimpleDalfExe)
         writeFileUTF8 (projDir </> "daml.yaml") $ unlines
           [ "sdk-version: " <> sdkVersion
           , "name: proj"
           , "version: 0.1.0"
           , "source: ."
-          , "dependencies: [daml-prim, daml-stdlib, " ++ simpleDalf ++ "]"
+          , "dependencies: [daml-prim, daml-stdlib, simple-dalf-0.0.0.dalf]"
           ]
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "daml 1.2"
@@ -423,6 +426,7 @@ packagingTests = testGroup "packaging"
             --, "agreementTemplate : Module.Template -> Text"
             --, "agreementTemplate = agreement"
             ]
+        withCurrentDirectory projDir $ callCommandQuiet $ genSimpleDalf <> " simple-dalf-0.0.0.dalf"
         withCurrentDirectory projDir $ callCommandQuiet "daml build"
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
         assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar


### PR DESCRIPTION
This adds the possibility to directly import dalfs in a project. We test
that we can import the `simple-dalf` in the daml-assistant integation
tests. For now we only check that data type generation works, not yet
the template instance.

The following was fixed: When rewriting package self references, this
changes the hash of the package later on and leads to different package
hashes. Also we need to be careful to write the orignal binary
representation to this and not re-encode it because the encoding might
have changed with a different sdk.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
