### PR TITLE
daml-lf: fail if asked to encode unsupported features into older versions

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -274,6 +274,10 @@ object ValueCoder {
           identity
         )
 
+    def assertSince(minVersion: ValueVersion, description: => String) =
+      if (valueVersion precedes minVersion)
+        throw Err(s"$description is not supported by value version $valueVersion")
+
     def go(nesting: Int, protoValue: proto.Value): Value[Cid] = {
       if (nesting > MAXIMUM_NESTING) {
         throw Err(
@@ -331,6 +335,7 @@ object ValueCoder {
             ValueVariant(id, identifier(variant.getConstructor), go(newNesting, variant.getValue))
 
           case proto.Value.SumCase.ENUM =>
+            assertSince(ValueVersions.minEnum, "Value.SumCase.ENUM")
             val enum = protoValue.getEnum
             val id =
               if (enum.getEnumId == ValueOuterClass.Identifier.getDefaultInstance) None
@@ -365,6 +370,7 @@ object ValueCoder {
             )
 
           case proto.Value.SumCase.OPTIONAL =>
+            assertSince(ValueVersions.minOptional, "Value.SumCase.OPTIONAL")
             val option = protoValue.getOptional
             val mbV =
               if (option.getValue == ValueOuterClass.Value.getDefaultInstance) None
@@ -372,6 +378,7 @@ object ValueCoder {
             ValueOptional(mbV)
 
           case proto.Value.SumCase.MAP =>
+            assertSince(ValueVersions.minMap, "Value.SumCase.MAP")
             val entries = ImmArray(protoValue.getMap.getEntriesList.asScala.map(entry =>
               entry.getKey -> go(newNesting, entry.getValue)))
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -20,10 +20,10 @@ object ValueVersions
       _.protoValue) {
 
   private[this] val minVersion = ValueVersion("1")
-  private[this] val minOptional = ValueVersion("2")
+  private[value] val minOptional = ValueVersion("2")
   private[value] val minContractIdStruct = ValueVersion("3")
-  private[this] val minMap = ValueVersion("4")
-  private[this] val minEnum = ValueVersion("5")
+  private[value] val minMap = ValueVersion("4")
+  private[value] val minEnum = ValueVersion("5")
   private[value] val minNumeric = ValueVersion("6")
 
   def assignVersion[Cid](v0: Value[Cid]): Either[String, ValueVersion] = {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -19,7 +19,7 @@ object ValueVersions
     extends LfVersions(versionsAscending = VersionTimeline.ascendingVersions[ValueVersion])(
       _.protoValue) {
 
-  private[this] val minVersion = ValueVersion("1")
+  private[value] val minVersion = ValueVersion("1")
   private[value] val minOptional = ValueVersion("2")
   private[value] val minContractIdStruct = ValueVersion("3")
   private[value] val minMap = ValueVersion("4")

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf.transaction
 
 import com.digitalasset.daml.lf.EitherAssertions
-import com.digitalasset.daml.lf.data.{ImmArray}
+import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party, QualifiedName}
 import com.digitalasset.daml.lf.transaction.Node.{GenNode, NodeCreate, NodeExercises, NodeFetch}
 import com.digitalasset.daml.lf.transaction.{Transaction => Tx, TransactionOuterClass => proto}
@@ -42,7 +42,7 @@ class TransactionCoderSpec
     }
 
     "do NodeCreate" in {
-      forAll(malformedCreateNodeGen, valueVersionGen) {
+      forAll(malformedCreateNodeGen, valueVersionGen()) {
         (node: NodeCreate[Tx.TContractId, Tx.Value[Tx.TContractId]], valVer: ValueVersion) =>
           Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
             defaultNidDecode,
@@ -64,23 +64,24 @@ class TransactionCoderSpec
     }
 
     "do NodeFetch" in {
-      forAll(fetchNodeGen, valueVersionGen) { (node: NodeFetch[ContractId], valVer: ValueVersion) =>
-        Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
-          defaultNidDecode,
-          defaultCidDecode,
-          defaultValDecode,
-          defaultTransactionVersion,
-          TransactionCoder
-            .encodeNode(
-              defaultNidEncode,
-              defaultCidEncode,
-              defaultValEncode,
-              defaultTransactionVersion,
-              Tx.NodeId.unsafeFromIndex(0),
-              node)
-            .toOption
-            .get
-        )
+      forAll(fetchNodeGen, valueVersionGen()) {
+        (node: NodeFetch[ContractId], valVer: ValueVersion) =>
+          Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
+            defaultNidDecode,
+            defaultCidDecode,
+            defaultValDecode,
+            defaultTransactionVersion,
+            TransactionCoder
+              .encodeNode(
+                defaultNidEncode,
+                defaultCidEncode,
+                defaultValEncode,
+                defaultTransactionVersion,
+                Tx.NodeId.unsafeFromIndex(0),
+                node)
+              .toOption
+              .get
+          )
       }
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -187,9 +187,13 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
         ValueCoder.decodeIdentifier(ei) shouldEqual Right(i)
     }
 
+    import com.digitalasset.daml.lf.transaction.VersionTimeline.Implicits._
+
     "do versioned value with supported override version" in forAll(valueGen, valueVersionGen) {
       (value: Value[ContractId], version: ValueVersion) =>
-        testRoundTripWithVersion(value, version)
+        whenever(!(version precedes ValueVersions.assertAssignVersion(value))) {
+          testRoundTripWithVersion(value, version)
+        }
     }
 
     "do versioned value with assigned version" in forAll(valueGen) { v: Value[ContractId] =>

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -122,7 +122,7 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
       }
     }
 
-    "do ContractId in any ValueVersion" in forAll(coidValueGen, valueVersionGen)(
+    "do ContractId in any ValueVersion" in forAll(coidValueGen, valueVersionGen())(
       testRoundTripWithVersion)
 
     "do lists" in {
@@ -180,20 +180,15 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
       }
     }
 
-    "do identifier with supported override version" in forAll(idGen, valueVersionGen) {
+    "do identifier with supported override version" in forAll(idGen, valueVersionGen()) {
       (i, version) =>
         val (v2, ei) = ValueCoder.encodeIdentifier(i, Some(version))
         v2 shouldEqual version
         ValueCoder.decodeIdentifier(ei) shouldEqual Right(i)
     }
 
-    import com.digitalasset.daml.lf.transaction.VersionTimeline.Implicits._
-
-    "do versioned value with supported override version" in forAll(valueGen, valueVersionGen) {
-      (value: Value[ContractId], version: ValueVersion) =>
-        whenever(!(version precedes ValueVersions.assertAssignVersion(value))) {
-          testRoundTripWithVersion(value, version)
-        }
+    "do versioned value with supported override version" in forAll(versionedValueGen) {
+      case VersionedValue(version, value) => testRoundTripWithVersion(value, version)
     }
 
     "do versioned value with assigned version" in forAll(valueGen) { v: Value[ContractId] =>


### PR DESCRIPTION
This PR addresses fix the LF value encoder that should fails if ask to encode Optional/Map/Enum for a version the feature is not supported. 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
