### PR TITLE
daml-lf: fix maven coordinates of daml_lf_archive_reader

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -135,7 +135,7 @@ da_scala_library(
     name = "daml_lf_archive_reader",
     srcs = glob(["src/main/scala/**/*.scala"]),
     scalacopts = lf_scalacopts,
-    tags = ["maven_coordinates=com.digitalasset:daml-lf-archive-scala:__VERSION__"],
+    tags = ["maven_coordinates=com.digitalasset:daml-lf-archive-reader:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
         ":daml_lf_dev_archive_java_proto",

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -40,9 +40,7 @@ DAML-LF
    + `com.digitalasset.daml-lf-proto` becomes
      `com.digitalasset.daml-lf-dev-archive-proto`
    + `com.digitalasset.daml-lf-archive` becomes
-     `com.digitalasset:daml-lf-dev-archive-java-proto`
-   + `com.digitalasset.daml-lf-archive-scala` becomes
-     `com.digitalasset.daml-lf-archive-reader`
+     `com.digitalasset:daml-lf-dev-archive-java-proto``
 
 - Add immutable bintray/maven packages for handling DAML-LF archive up to version 1.6 in a stable way:
    + `com.digitalasset.daml-lf-1.6-archive-proto`

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,4 +13,4 @@ HEAD — ongoing
 - [Sandbox] Party management fix, see `issue #3177 <https://github.com/digital-asset/daml/issues/3177>`_.
 + [Ledger] Fixed a bug where ``CreatedEvent#event_id`` field is not properly filled by ``ActiveContractsService``.
   See `issue #65 <https://github.com/digital-asset/daml/issues/65>`__.
-+ [DAML-LF (Internal)] - the bintray/maven `com.digitalasset.daml-lf-archive-scala` becomes `com.digitalasset.daml-lf-archive-reader`
++ [DAML-LF (Internal)] Change the name of the bintray/maven ``com.digitalasset.daml-lf-archive-scala`` to ``com.digitalasset.daml-lf-archive-reader``

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,3 +13,4 @@ HEAD — ongoing
 - [Sandbox] Party management fix, see `issue #3177 <https://github.com/digital-asset/daml/issues/3177>`_.
 + [Ledger] Fixed a bug where ``CreatedEvent#event_id`` field is not properly filled by ``ActiveContractsService``.
   See `issue #65 <https://github.com/digital-asset/daml/issues/65>`__.
++ [DAML-LF (Internal)] - Breaking the bintray/maven `com.digitalasset.daml-lf-archive-scala` becomes `com.digitalasset.daml-lf-archive-reader`

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -13,4 +13,4 @@ HEAD — ongoing
 - [Sandbox] Party management fix, see `issue #3177 <https://github.com/digital-asset/daml/issues/3177>`_.
 + [Ledger] Fixed a bug where ``CreatedEvent#event_id`` field is not properly filled by ``ActiveContractsService``.
   See `issue #65 <https://github.com/digital-asset/daml/issues/65>`__.
-+ [DAML-LF (Internal)] - Breaking the bintray/maven `com.digitalasset.daml-lf-archive-scala` becomes `com.digitalasset.daml-lf-archive-reader`
++ [DAML-LF (Internal)] - the bintray/maven `com.digitalasset.daml-lf-archive-scala` becomes `com.digitalasset.daml-lf-archive-reader`


### PR DESCRIPTION
This PR fix the maven coordinate of the package daml_lf_archive_reader.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
