### PR TITLE
Improve logging and debugging of DAML triggers

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -61,7 +61,7 @@ runTrigger userTrigger = LowLevel.Trigger
           (_, TriggerAState commands nextCommandId) = runTriggerA (userTrigger.rule party acs Map.empty userState) (TriggerAState [] 0)
           commandsInFlight = foldl addCommands Map.empty commands
           state = TriggerState {acs, party, userState, commandsInFlight, nextCommandId}
-      in (state, commands, "")
+      in (state, commands)
     update msg state =
       case msg of
         MCompletion completion ->
@@ -72,7 +72,7 @@ runTrigger userTrigger = LowLevel.Trigger
                 -- to avoid removing a command from commandsInFlight before we have modified the ACS.
                 Succeeded {} -> state.commandsInFlight
               -- TODO:We should trigger rules on failures
-          in (state { userState, commandsInFlight }, [], "")
+          in (state { userState, commandsInFlight }, [])
         MTransaction transaction ->
           let acs = applyTransaction transaction state.acs
               userState = userTrigger.updateState acs (MTransaction transaction) state.userState
@@ -82,7 +82,7 @@ runTrigger userTrigger = LowLevel.Trigger
                 Some commandId -> Map.delete commandId state.commandsInFlight
               (_, TriggerAState commands nextCommandId) = runTriggerA (userTrigger.rule state.party acs inFlight userState) (TriggerAState [] state.nextCommandId)
               commandsInFlight = foldl addCommands state.commandsInFlight commands
-          in (state { acs, userState, nextCommandId, commandsInFlight}, commands, show ("transaction", sum $ map numCreates commands, sum $ map numExercises commands))
+          in (state { acs, userState, nextCommandId, commandsInFlight}, commands)
 
 numCreates : Commands -> Int
 numCreates (Commands _ cmds) = length $ filter (\x -> case x of CreateCommand {} -> True; _ -> False) cmds

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -87,8 +87,8 @@ data ActiveContracts = ActiveContracts { activeContracts : [Created] }
 -- | Trigger is (approximately) a left-fold over `Message` with
 -- an accumulator of type `s`.
 data Trigger s = Trigger
-  { initialState : Party -> ActiveContracts -> (s, [Commands], Text)
-  , update : Message -> s -> (s, [Commands], Text)
+  { initialState : Party -> ActiveContracts -> (s, [Commands])
+  , update : Message -> s -> (s, [Commands])
   }
 
 -- | We implicitly assume that the package id corresponds to the package the trigger is part of.

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -16,6 +16,7 @@ da_scala_library(
         "//3rdparty/jvm/com/github/scopt",
         "//3rdparty/jvm/com/typesafe/akka:akka_stream",
         "//3rdparty/jvm/org/scalaz:scalaz_core",
+        "//3rdparty/jvm/org/typelevel:paiges_core",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",

--- a/triggers/runner/src/main/resources/logback.xml
+++ b/triggers/runner/src/main/resources/logback.xml
@@ -7,6 +7,7 @@
     </appender>
 
     <logger name="io.netty" level="WARN" />
+    <logger name="io.grpc.netty" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl._
 import com.google.rpc.status.Status
+import com.typesafe.scalalogging.StrictLogging
 import io.grpc.StatusRuntimeException
 import java.time.Instant
 import java.util.UUID
@@ -20,6 +21,7 @@ import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.Compiler
+import com.digitalasset.daml.lf.speedy.Pretty
 import com.digitalasset.daml.lf.speedy.{SExpr, Speedy, SValue}
 import com.digitalasset.daml.lf.speedy.SExpr._
 import com.digitalasset.daml.lf.speedy.SResult._
@@ -46,7 +48,8 @@ class Runner(
     applicationId: ApplicationId,
     party: String,
     dar: Dar[(PackageId, Package)],
-    submit: SubmitRequest => Unit) {
+    submit: SubmitRequest => Unit)
+    extends StrictLogging {
 
   private val converter = Converter.fromDar(dar)
   private val triggerIds = TriggerIds.fromDar(dar)
@@ -70,16 +73,10 @@ class Runner(
           if recordId.qualifiedName ==
             QualifiedName(
               DottedName.assertFromString("DA.Types"),
-              DottedName.assertFromString("Tuple3")) => {
+              DottedName.assertFromString("Tuple2")) => {
         val newState = values.get(0)
         val commandVal = values.get(1)
-        val logMessage = values.get(2) match {
-          case SText(t) => t
-          case _ =>
-            throw new RuntimeException(s"Log message should be text but was ${values.get(2)}")
-        }
-        println(s"New state: $newState")
-        println(s"Emitted log message: ${logMessage}")
+        logger.debug(s"New state: $newState")
         commandVal match {
           case SList(transactions) =>
             // Each transaction is a list of commands
@@ -109,20 +106,48 @@ class Runner(
         newState
       }
       case v => {
-        throw new RuntimeException(s"Expected Tuple3 but got $v")
+        throw new RuntimeException(s"Expected Tuple2 but got $v")
       }
     }
+
+  def logTraces(machine: Speedy.Machine) = {
+    machine.traceLog.iterator.foreach {
+      case (msg, optLoc) =>
+        logger.info(s"TRACE ${Pretty.prettyLoc(optLoc).render(80)}: $msg")
+    }
+  }
+
+  def stepToValue(machine: Speedy.Machine) = {
+    while (!machine.isFinal) {
+      machine.step() match {
+        case SResultContinue => ()
+        case SResultError(err) => {
+          logTraces(machine)
+          logger.error(Pretty.prettyError(err, machine.ptx).render(80))
+          throw err
+        }
+        case res => {
+          logTraces(machine)
+          val errMsg = s"Unexpected speedy result: $res"
+          logger.error(errMsg)
+          throw new RuntimeException(errMsg)
+        }
+      }
+    }
+    logTraces(machine)
+  }
 
   def getTriggerSink(
       triggerId: Identifier,
       acs: Seq[CreatedEvent]): Sink[TriggerMsg, Future[SExpr]] = {
+    logger.info(s"Trigger is running as ${party}")
     val triggerExpr = EVal(triggerId)
     val (tyCon: TypeConName, stateTy) =
       dar.main._2.lookupIdentifier(triggerId.qualifiedName).toOption match {
         case Some(DValue(TApp(TTyCon(tcon), stateTy), _, _, _)) => (tcon, stateTy)
         case _ => {
-          throw new RuntimeException(
-            s"Identifier ${triggerId.qualifiedName} does not point to trigger")
+          val errMsg = s"Identifier ${triggerId.qualifiedName} does not point to a trigger"
+          throw new RuntimeException(errMsg)
         }
       }
     val triggerTy: TypeConApp = TypeConApp(tyCon, ImmArray(stateTy))
@@ -135,19 +160,9 @@ class Runner(
     val initialState =
       SEApp(getInitialState, Array(SEValue(SParty(Party.assertFromString(party))), createdExpr))
     machine.ctrl = Speedy.CtrlExpr(initialState)
-    while (!machine.isFinal) {
-      machine.step() match {
-        case SResultContinue => ()
-        case SResultError(err) => {
-          throw new RuntimeException(err)
-        }
-        case res => {
-          throw new RuntimeException(s"Unexpected speedy result $res")
-        }
-      }
-    }
+    stepToValue(machine)
     val evaluatedInitialState = handleStepResult(machine.toSValue)
-    println(s"Initial state: $evaluatedInitialState")
+    logger.debug(s"Initial state: $evaluatedInitialState")
     Flow[TriggerMsg]
       .mapConcat[TriggerMsg]({
         case CompletionMsg(c) =>
@@ -169,28 +184,22 @@ class Runner(
             converter.fromTransaction(transaction)
           }
           case CompletionMsg(completion) => {
+            val status = completion.getStatus
+            if (status.code != 0) {
+              logger.warn(s"Command failed: ${status.message}, code: ${status.code}")
+            }
             converter.fromCompletion(completion)
           }
         }
         machine.ctrl = Speedy.CtrlExpr(SEApp(update, Array(SEValue(messageVal), state)))
-        while (!machine.isFinal) {
-          machine.step() match {
-            case SResultContinue => ()
-            case SResultError(err) => {
-              throw new RuntimeException(err)
-            }
-            case res => {
-              throw new RuntimeException(s"Unexpected speed result $res")
-            }
-          }
-        }
+        stepToValue(machine)
         val newState = handleStepResult(machine.toSValue)
         SEValue(newState)
       }))(Keep.right[NotUsed, Future[SExpr]])
   }
 }
 
-object Runner {
+object Runner extends StrictLogging {
   def getTimeProvider(ty: TimeProviderType): TimeProvider = {
     ty match {
       case TimeProviderType.Static => TimeProvider.Constant(Instant.EPOCH)
@@ -259,7 +268,7 @@ object Runner {
         f.failed.foreach({
           case s: StatusRuntimeException =>
             postFailure(submitRequest.getCommands.commandId, s)
-          case e => println(s"ERROR: Unexpected exception: $e")
+          case e => logger.error(s"Unexpected exception: $e")
         })
       }
     )

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -36,22 +36,21 @@ initState party (ActiveContracts events) = TriggerState
 -- and we create a new AssetMirror contract whenever an Asset contract is created (but we do not archive them).
 test : Trigger TriggerState
 test = Trigger
-  { initialState = \party acs -> (initState party acs, [], "")
+  { initialState = \party acs -> (initState party acs, [])
   , update = update
   }
   where
-    update : Message -> TriggerState -> (TriggerState, [Commands],  Text)
+    update : Message -> TriggerState -> (TriggerState, [Commands])
     update (MCompletion c) state =
       let state' = case c.status of
             Failed {} -> state { failedCompletions = state.failedCompletions + 1 }
             Succeeded {} -> state { successfulCompletions = state.successfulCompletions + 1 }
-      in (state', [], show c)
+      in (state', [])
     update (MTransaction t) state = case foldl updateEvent ([], state.activeAssets) (events t) of
-      ([], acs) -> (state { activeAssets = acs }, [], "No command")
+      ([], acs) -> (state { activeAssets = acs }, [])
       (cmds, acs) ->
         ( state { activeAssets = acs, nextCommandId = state.nextCommandId + 1 }
         , [Commands (CommandId $ "command_" <> show state.nextCommandId) cmds]
-        , "Submitted " <> show (length cmds) <> " commands"
         )
       where
         updateEvent : ([Command], TextMap Identifier) -> Event -> ([Command], TextMap Identifier)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -14,3 +14,5 @@ HEAD — ongoing
 + [Ledger] Fixed a bug where ``CreatedEvent#event_id`` field is not properly filled by ``ActiveContractsService``.
   See `issue #65 <https://github.com/digital-asset/daml/issues/65>`__.
 + [DAML-LF (Internal)] Change the name of the bintray/maven ``com.digitalasset.daml-lf-archive-scala`` to ``com.digitalasset.daml-lf-archive-reader``
++ [DAML Triggers -Experimental] The trigger runner now logs output from ``trace``, ``error`` and
+  failed command completions and hides internal debugging output.


### PR DESCRIPTION
- We now display `trace` messages so they can be used for debugging.
- I’ve removed the log message from the low-level API since it is
  confusing as it is not exposed via the high-level API and somewhat
  redundant since you can use `trace` for debugging. If there is a
  demand for proper logging support we might want to add it back at
  some point.
- We now display errors from speedy properly. This is mainly important
  for calls to `error` since we previously lost the error message.
- Logging messages go through a proper logging library now and the
  internal debugging stuff is only displayed at debug level so not by default.
- We log failed completions at warning level to ease debugging.

fixes #2915 and #3201 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
