### PR TITLE
DAML LF: limit allocations for trivial constants

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
@@ -311,7 +311,7 @@ abstract class NumericModule {
 
     val MaxValue: Scale
 
-    val values: Vector[Scale] = Vector.range(MinValue, MaxValue + 1).map(cast)
+    lazy val values: Vector[Scale] = Vector.range(MinValue, MaxValue + 1).map(cast)
 
     /**
       * Cast the Int `x` to a `Scale`.

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/NumericSpec.scala
@@ -18,6 +18,12 @@ class NumericSpec
 
   private implicit def toScale(i: Int): Numeric.Scale = Numeric.Scale.assertFromInt(i)
 
+  "Numeric.Scale.values" should {
+    "be " in {
+      Numeric.Scale.values shouldBe Vector.range(0, 38)
+    }
+  }
+
   "fromBigDecimal" should {
 
     implicit def toBigDecimal(s: String): BigDecimal = new BigDecimal(s)

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
@@ -46,7 +46,7 @@ private[digitalasset] object DamlLfEncoder extends App {
       case e: EncodeError =>
         error(s"Encoding error: ${e.message}")
       case NonFatal(e) =>
-        error(s"error: ${e.getMessage}")
+        error(s"error: $e")
     }
 
   private def readSources(files: Seq[String]): String =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -11,6 +11,7 @@ import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.speedy.SValue
+import com.digitalasset.daml.lf.speedy.SValue.SValueContainer
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value._
 
@@ -87,6 +88,10 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
     go(fields, Map.empty)
   }
 
+  private object SValueResultDone extends SValueContainer[ResultDone[SValue]] {
+    override def apply(value: SValue): ResultDone[SValue] = ResultDone(value)
+  }
+
   // since we get these values from third-party users of the library, check the recursion limit
   // here, too.
   private[engine] def translateValue(ty0: Type, v0: Value[AbsoluteContractId]): Result[SValue] = {
@@ -112,9 +117,9 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
         (ty, value) match {
           // simple values
           case (TUnit, ValueUnit) =>
-            ResultDone(SUnit(()))
+            SValueResultDone.Unit
           case (TBool, ValueBool(b)) =>
-            ResultDone(SBool(b))
+            SValueResultDone.bool(b)
           case (TInt64, ValueInt64(i)) =>
             ResultDone(SInt64(i))
           case (TTimestamp, ValueTimestamp(t)) =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -45,7 +45,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
       TUnit ->
         ValueUnit,
       TBool ->
-        ValueBool(true),
+        ValueTrue,
       TInt64 ->
         ValueInt64(42),
       TTimestamp ->
@@ -65,7 +65,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
       TList(TText) ->
         ValueList(FrontStack(ValueText("a"), ValueText("b"))),
       TMap(TBool) ->
-        ValueMap(SortedLookupList(Map("0" -> ValueBool(true), "1" -> ValueBool(false)))),
+        ValueMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
       TOptional(TText) ->
         ValueOptional(Some(ValueText("text"))),
       TTyCon(recordCon) ->

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -687,7 +687,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
   "translate list value" should {
     "translate empty list" in {
-      val list = ValueList(FrontStack.empty[Value[AbsoluteContractId]])
+      val list = ValueNil
       val res = commandTranslator
         .translateValue(TList(TBuiltin(BTInt64)), list)
         .consume(lookupContract, lookupPackage, lookupKey)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -74,11 +74,7 @@ object SExpr {
     def execute(machine: Machine): Ctrl = CtrlValue(v)
   }
 
-  object SEValue {
-    val True = SEValue(SBool(true))
-    val False = SEValue(SBool(false))
-    val Unit = SEValue(SUnit(()))
-  }
+  object SEValue extends SValueContainer[SEValue]
 
   /** Function application. Apply 'args' to function 'fun', where 'fun'
     * evaluates to a builtin or a closure.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -75,7 +75,7 @@ object Speedy {
         // NOTE(MH): If the top of the continuation stack is the monadic token,
         // we push location information under it to account for the implicit
         // lambda binding the token.
-        case Some(KArg(Array(SEValue(SToken)))) => kont.add(last_index, KLocation(loc))
+        case Some(KArg(Array(SEValue.Token))) => kont.add(last_index, KLocation(loc))
         // NOTE(MH): When we use a cached top level value, we need to put the
         // stack trace it produced back on the continuation stack to get
         // complete stack trace at the use site. Thus, we store the stack traces
@@ -250,7 +250,7 @@ object Speedy {
       val compiler = Compiler(compiledPackages.packages)
       Right({ (checkSubmitterInMaintainers: Boolean, expr: Expr) =>
         fromSExpr(
-          SEApp(compiler.compile(expr), Array(SEValue(SToken))),
+          SEApp(compiler.compile(expr), Array(SEValue.Token)),
           checkSubmitterInMaintainers,
           compiledPackages)
       })
@@ -260,7 +260,7 @@ object Speedy {
         checkSubmitterInMaintainers: Boolean,
         sexpr: SExpr,
         compiledPackages: CompiledPackages): Machine =
-      fromSExpr(SEApp(sexpr, Array(SEValue(SToken))), checkSubmitterInMaintainers, compiledPackages)
+      fromSExpr(SEApp(sexpr, Array(SEValue.Token)), checkSubmitterInMaintainers, compiledPackages)
 
     // Used from repl.
     def fromExpr(
@@ -271,7 +271,7 @@ object Speedy {
       val compiler = Compiler(compiledPackages.packages)
       val sexpr =
         if (scenario)
-          SEApp(compiler.compile(expr), Array(SEValue(SToken)))
+          SEApp(compiler.compile(expr), Array(SEValue.Token))
         else
           compiler.compile(expr)
 
@@ -344,6 +344,8 @@ object Speedy {
         machine.kontPop.execute(value, machine)
     }
   }
+
+  object CtrlValue extends SValueContainer[CtrlValue]
 
   /** When we fetch a contract id from upstream we cannot crash in the
     * that upstream calls. Rather, we set the control to this and then crash
@@ -481,7 +483,7 @@ object Speedy {
               case _ => false
             }
           }
-        case _: SUnit =>
+        case SUnit =>
           alts.find { alt =>
             alt.pattern match {
               case SCPPrimCon(PCUnit) => true

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1130,7 +1130,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           "1" -> SInt64(1),
           "1.00" -> SNumeric(n(2, 1)),
           "True" -> SBool(true),
-          "()" -> SUnit(()),
+          "()" -> SUnit,
           """ "text" """ -> SText("text"),
           " 'party' " -> SParty(Ref.Party.assertFromString("party")),
           intList(1, 2, 3) -> SList(FrontStack(SInt64(1), SInt64(2), SInt64(3))),

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -244,6 +244,12 @@ object Ast {
   // for now it can contains only a Numeric Scale
   final case class TNat(n: Numeric.Scale) extends Type
 
+  object TNat {
+    // works because Numeric.Scale.MinValue = 0
+    val values = Numeric.Scale.values.map(new TNat(_))
+    def apply(n: Numeric.Scale): TNat = values(n)
+  }
+
   /** Reference to a type constructor. */
   final case class TTyCon(tycon: TypeConName) extends Type
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -58,14 +58,18 @@ object Util {
   val TScenario = new ParametricType1(BTScenario)
   val TContractId = new ParametricType1(BTContractId)
 
+  val TParties = TList(TParty)
+  val TDecimalScale = TNat(Decimal.scale)
+  val TDecimal = TNumeric(TDecimalScale)
+
   val EUnit = EPrimCon(PCUnit)
   val ETrue = EPrimCon(PCTrue)
   val EFalse = EPrimCon(PCFalse)
 
   def EBool(b: Boolean): EPrimCon = if (b) ETrue else EFalse
 
-  val TParties = TList(TParty)
-  val TDecimalScale = TNat(Decimal.scale)
-  val TDecimal = TNumeric(TDecimalScale)
+  val CPUnit = CPPrimCon(PCUnit)
+  val CPTrue = CPPrimCon(PCTrue)
+  val CPFalse = CPPrimCon(PCFalse)
 
 }

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -7,6 +7,7 @@ package testing.parser
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{ChoiceName, DottedName, Name}
 import com.digitalasset.daml.lf.language.Ast._
+import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.testing.parser.Parsers._
 import com.digitalasset.daml.lf.testing.parser.Token._
 
@@ -118,7 +119,7 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
 
   private lazy val choiceParam: Parser[(Option[Name], Type)] =
     `(` ~> id ~ `:` ~ typ <~ `)` ^^ { case name ~ _ ~ typ => Some(name) -> typ } |
-      success(None -> TBuiltin(BTUnit))
+      success(None -> TUnit)
 
   private lazy val templateChoice: Parser[ExprVarName => (ChoiceName, TemplateChoice)] =
     Id("choice") ~> tags(templateChoiceTags) ~ id ~ choiceParam ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
@@ -178,7 +178,7 @@ object TypedValueGenerators {
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   val genAddend: Gen[ValueAddend] = Gen.sized { sz =>
     val self = Gen.resize(sz / 2, Gen.lzy(genAddend))
-    val nestSize = sz / 6
+    val nestSize = sz / 3
     Gen.frequency(
       ((sz max 1) * ValueAddend.leafInstances.length, Gen.oneOf(ValueAddend.leafInstances)),
       (sz max 1, Gen.const(ValueAddend.contractId)),

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
@@ -62,7 +62,7 @@ object TypedValueGenerators {
     val unit = noCid(PT.Unit, (_: Unit) => ValueUnit) { case ValueUnit => () }
     val date = noCid(PT.Date, ValueDate) { case ValueDate(d) => d }
     val timestamp = noCid(PT.Timestamp, ValueTimestamp) { case ValueTimestamp(t) => t }
-    val bool = noCid(PT.Bool, ValueBool) { case ValueBool(b) => b }
+    val bool = noCid(PT.Bool, ValueBool(_)) { case ValueBool(b) => b }
     val party = noCid(PT.Party, ValueParty) { case ValueParty(p) => p }
 
     def numeric(scale: Numeric.Scale): NoCid[Numeric] = new ValueAddend {

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -229,7 +229,7 @@ object ValueGenerators {
         (sz + 1, timestampGen.map(ValueTimestamp)),
         (sz + 1, coidValueGen),
         (sz + 1, party.map(ValueParty)),
-        (sz + 1, Gen.oneOf(true, false).map(ValueBool))
+        (sz + 1, Gen.oneOf(ValueTrue, ValueFalse)),
       )
       val all =
         if (nesting >= MAXIMUM_NESTING) { List() } else { nested } ++

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -194,6 +194,12 @@ object Value {
   final case class ValueDate(value: Time.Date) extends ValueCidlessLeaf
   final case class ValueParty(value: Ref.Party) extends ValueCidlessLeaf
   final case class ValueBool(value: Boolean) extends ValueCidlessLeaf
+  object ValueBool {
+    val True = new ValueBool(true)
+    val Fasle = new ValueBool(false)
+    def apply(value: Boolean): ValueBool =
+      if (value) ValueTrue else ValueFalse
+  }
   case object ValueUnit extends ValueCidlessLeaf
   final case class ValueOptional[+Cid](value: Option[Value[Cid]]) extends Value[Cid]
   final case class ValueMap[+Cid](value: SortedLookupList[Value[Cid]]) extends Value[Cid]
@@ -311,4 +317,9 @@ object Value {
 
   /*** Keys cannot contain contract ids */
   type Key = Value[Nothing]
+
+  val ValueTrue: ValueBool = ValueBool.True
+  val ValueFalse: ValueBool = ValueBool.Fasle
+  val ValueNil: ValueList[Nothing] = ValueList(FrontStack.empty)
+  val ValueNone: ValueOptional[Nothing] = ValueOptional(None)
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -4,24 +4,23 @@
 package com.digitalasset.http
 package util
 
-import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.daml.lf.value.{Value => V}
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.value.TypedValueGenerators.genAddend
+import com.digitalasset.daml.lf.value.{Value => V}
 import com.digitalasset.platform.participant.util.LfEngineToApi.lfValueToApiValue
-
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
-import scalaz.\/-
 
 class ApiValueToLfValueConverterTest
     extends WordSpec
     with Matchers
     with GeneratorDrivenPropertyChecks {
-  type Cid = V.AbsoluteContractId
+
   private[this] val genCid = Gen.zip(Gen.alphaChar, Gen.alphaStr) map {
     case (h, t) => V.AbsoluteContractId(Ref.ContractIdString assertFromString (h +: t))
   }
+  import ApiValueToLfValueConverterTest._
 
   "apiValueToLfValue" should {
     import ApiValueToLfValueConverter.apiValueToLfValue
@@ -31,8 +30,63 @@ class ApiValueToLfValueConverterTest
       implicit val arbInj: Arbitrary[va.Inj[Cid]] = va.injarb(Arbitrary(genCid))
       forAll(minSuccessful(20)) { v: va.Inj[Cid] =>
         val vv = va.inj(v)
-        lfValueToApiValue(true, vv) map apiValueToLfValue should ===(Right(\/-(vv)))
+        val roundTrip = lfValueToApiValue(true, vv).right.toOption flatMap (x =>
+          apiValueToLfValue(x).toMaybe.toOption)
+        assert(roundTrip === Some(vv))
       }
     }
   }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+object ApiValueToLfValueConverterTest {
+
+  import org.scalactic.Equality
+  import org.scalactic.TripleEquals._
+
+  type Cid = V.AbsoluteContractId
+
+  private implicit def eqOption[X](implicit eq: Equality[X]): Equality[Option[X]] = {
+    case (Some(x), Some(y)) => x === y
+    case (x, y) => x == y
+  }
+
+  private implicit def eqImmArray[X](implicit eq: Equality[X]): Equality[ImmArray[X]] = {
+    case (x, y: ImmArray[_]) => x.length == y.length && x.indices().forall(i => x(i) === y(i))
+    case _ => false
+  }
+
+  private implicit def eqTuple[X, Y](
+      implicit xEq: Equality[X],
+      yEq: Equality[Y]): Equality[(X, Y)] = {
+    case ((x1, y1), (x2, y2)) => x1 === x2 && y1 === y2
+    case _ => false
+  }
+
+  // Numeric are normalized when converting from api to lf,
+  // them we have to relax numeric equality
+  private implicit def eqValue: Equality[V[Cid]] = {
+    case (
+        x @ (_: V.ValueInt64 | _: V.ValueText | _: V.ValueTimestamp | _: V.ValueParty |
+        _: V.ValueBool | _: V.ValueDate | V.ValueUnit | _: V.ValueEnum | _: V.ValueContractId[_]),
+        y) =>
+      x == y
+    case (V.ValueNumeric(m), V.ValueNumeric(n)) =>
+      m.stripTrailingZeros == n.stripTrailingZeros
+    case (V.ValueRecord(tycon1, fields1), V.ValueRecord(tycon2, fields2)) =>
+      tycon1 == tycon2 && fields1 === fields2
+    case (V.ValueVariant(tycon1, variant1, value1), V.ValueVariant(tycon2, variant2, value2)) =>
+      tycon1 == tycon2 && variant1 === variant2 && value1 === value2
+    case (V.ValueList(values), V.ValueList(values2)) =>
+      values.toImmArray === values2.toImmArray
+    case (V.ValueOptional(value1), V.ValueOptional(value2)) =>
+      value1 === value2
+    case (V.ValueTuple(fields), V.ValueTuple(fields2)) =>
+      fields === fields2
+    case (V.ValueMap(map1), V.ValueMap(map2)) =>
+      map1.toImmArray === map2.toImmArray
+    case _ =>
+      false
+  }
+
 }

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -130,10 +130,10 @@ abstract class ApiCodecCompressed[Cid](
         val typArg = prim.typArgs.head
         val useArray = nestsOptional(prim);
         {
-          case JsNull => V.ValueOptional(None)
+          case JsNull => V.ValueNone
           case JsArray(ov) if useArray =>
             ov match {
-              case Seq() => V.ValueOptional(Some(V.ValueOptional(None)))
+              case Seq() => V.ValueOptional(Some(V.ValueNone))
               case Seq(v) => V.ValueOptional(Some(jsValueToApiValue(v, typArg, defs)))
               case _ =>
                 deserializationError(s"Can't read ${value.prettyPrint} as Optional of Optional")
@@ -171,7 +171,7 @@ abstract class ApiCodecCompressed[Cid](
                   .get(fName)
                   .map(jsValueToApiValue(_, fTy, defs))
                   .getOrElse(fTy match {
-                    case iface.TypePrim(iface.PrimType.Optional, _) => V.ValueOptional(None)
+                    case iface.TypePrim(iface.PrimType.Optional, _) => V.ValueNone
                     case _ =>
                       deserializationError(
                         s"Can't read ${value.prettyPrint} as DamlLfRecord $id, missing field '$fName'")

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
@@ -98,7 +98,7 @@ object ValueValidator {
         .map(elements => Lf.ValueList(FrontStack(elements.toImmArray)))
     case _: Sum.Unit => Right(ValueUnit)
     case Sum.Optional(o) =>
-      o.value.fold[Either[StatusRuntimeException, domain.Value]](Right(Lf.ValueOptional(None)))(
+      o.value.fold[Either[StatusRuntimeException, domain.Value]](Right(Lf.ValueNone))(
         validateValue(_).map(v => Lf.ValueOptional(Some(v))))
     case Sum.Map(m) =>
       val entries = m.entries

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -342,8 +342,8 @@ class SubmitRequestValidatorTest
 
     "validating boolean values" should {
       "accept any of them" in {
-        validateValue(Value(Sum.Bool(true))) shouldEqual Right(Lf.ValueBool(true))
-        validateValue(Value(Sum.Bool(false))) shouldEqual Right(Lf.ValueBool(false))
+        validateValue(Value(Sum.Bool(true))) shouldEqual Right(Lf.ValueTrue)
+        validateValue(Value(Sum.Bool(false))) shouldEqual Right(Lf.ValueFalse)
       }
     }
 
@@ -426,7 +426,7 @@ class SubmitRequestValidatorTest
       "convert empty lists" in {
         val input = Value(Sum.List(ApiList(List.empty)))
         val expected =
-          Lf.ValueList(FrontStack.empty)
+          Lf.ValueNil
 
         validateValue(input) shouldEqual Right(expected)
       }
@@ -452,7 +452,7 @@ class SubmitRequestValidatorTest
     "validating optional values" should {
       "convert empty optionals" in {
         val input = Value(Sum.Optional(ApiOptional(None)))
-        val expected = Lf.ValueOptional(None)
+        val expected = Lf.ValueNone
 
         validateValue(input) shouldEqual Right(expected)
       }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
@@ -29,8 +29,8 @@ class KeyHasherSpec extends WordSpec with Matchers {
     builder += None -> ValueInt64(-1)
     builder += None -> ValueNumeric(decimal(0))
     builder += None -> ValueNumeric(decimal(BigDecimal("0.3333333333")))
-    builder += None -> ValueBool(true)
-    builder += None -> ValueBool(false)
+    builder += None -> ValueTrue
+    builder += None -> ValueFalse
     builder += None -> ValueDate(Time.Date.assertFromDaysSinceEpoch(0))
     builder += None -> ValueDate(Time.Date.assertFromDaysSinceEpoch(123456))
     builder += None -> ValueTimestamp(Time.Timestamp.assertFromLong(0))
@@ -39,7 +39,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     builder += None -> ValueText("abcd-äöü€")
     builder += None -> ValueParty(Party.assertFromString("Alice"))
     builder += None -> ValueUnit
-    builder += None -> ValueOptional(None)
+    builder += None -> ValueNone
     builder += None -> ValueOptional(Some(ValueText("Some")))
     builder += None -> ValueList(FrontStack(ValueText("A"), ValueText("B"), ValueText("C")))
     builder += None -> ValueVariant(None, Name.assertFromString("Variant"), ValueInt64(0))
@@ -251,8 +251,8 @@ class KeyHasherSpec extends WordSpec with Matchers {
     }
 
     "not produce collision in Bool" in {
-      val value1 = VersionedValue(ValueVersion("4"), ValueBool(true))
-      val value2 = VersionedValue(ValueVersion("4"), ValueBool(false))
+      val value1 = VersionedValue(ValueVersion("4"), ValueTrue)
+      val value2 = VersionedValue(ValueVersion("4"), ValueFalse)
 
       val tid = templateId("module", "name")
 
@@ -315,7 +315,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     }
 
     "not produce collision in Optional" in {
-      val value1 = VersionedValue(ValueVersion("4"), ValueOptional(None))
+      val value1 = VersionedValue(ValueVersion("4"), ValueNone)
       val value2 = VersionedValue(ValueVersion("4"), ValueOptional(Some(ValueUnit)))
 
       val tid = templateId("module", "name")

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
@@ -157,7 +157,7 @@ object ApiCodecVerbose {
       case `tagUnit` => V.ValueUnit
       case `tagOptional` =>
         anyField(value, propValue, "ApiOptional") match {
-          case JsNull => V.ValueOptional(None)
+          case JsNull => V.ValueNone
           case v => V.ValueOptional(Some(jsValueToApiValue(v)))
         }
       case `tagMap` =>

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -228,7 +228,7 @@ case object DamlConstants {
     Some(complexRecordId),
     ImmArray(
       ("fText", simpleTextV),
-      ("fBool", V.ValueBool(true)),
+      ("fBool", V.ValueTrue),
       ("fDecimal", simpleDecimalV),
       ("fUnit", V.ValueUnit),
       ("fInt64", simpleInt64V),
@@ -238,7 +238,7 @@ case object DamlConstants {
       ("fListOfUnit", V.ValueList(FrontStack(V.ValueUnit, V.ValueUnit))),
       ("fDate", simpleDateV),
       ("fTimestamp", simpleTimestampV),
-      ("fOptionalText", V.ValueOptional(None)),
+      ("fOptionalText", V.ValueNone),
       ("fOptionalUnit", V.ValueOptional(Some(V.ValueUnit))),
       ("fOptOptText", V.ValueOptional(Some(V.ValueOptional(Some(V.ValueText("foo")))))),
       (


### PR DESCRIPTION
In this PR we limit the allocation of trivial constants: 
 - AST Exprs and Types 
 - Speedy expressions and container of such data
 - Values 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
