### PR TITLE
fix dev-env ghcid

### DIFF
--- a/dev-env/bin/ghcid
+++ b/dev-env/bin/ghcid
@@ -1,1 +1,1 @@
-../lib/dade-exec-nix-tool
+../lib/dade-exec-nix-bin-tool


### PR DESCRIPTION
2f8708e1cf759326aebe8e37b6031e9ff82ab059 (#3093) broke `ghcid` (and therefore `da-ghcid`) in the `dev-env` in a fairly subtle way. When we (lazily) build up nix packages on demand, and more importantly, their symlinks into the `dev-env`, we use a command [along the lines](https://github.com/digital-asset/daml/blob/f64b63f7a3d1f5682bb22c3ad9b643ffe1fc1300/dev-env/lib/dade-common#L111) of:
```
nix-build /path/to/daml/nix/default.nix -A tools.ghcid -Q -o /path/to/daml/dev-env/var/gc-roots/ghcid
```
where the `--out-link/-o` option specifies the place where we want nix to create a symlink to the package we just built. However, the symlink that nix creates may or may not be named as given; in some cases nix will decide to add a suffix to that name. [This apparently counts as expected and proper, if undocumented, behaviour](https://github.com/NixOS/nix/issues/1229).

We do have provisions for that in the `dev-env`: most of the tools in `dev-env/bin/` are actually symlinks to `dev-env/lib/dade-exec-nix-tool`, which looks like:
```
DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
base=$(basename $0)
execTool $base out $base "$@"
```
As may be expected, `execTool` is defined in `dev-env/lib/dade-common`; what may be less obvious is that `out` is a special value that, to `execTool`, means "this package does not add a suffix", and lets `execTool` create the correct path on the fly to find the real executable from nix.

For packages where nix does add a suffix, that suffix can simply be passed as an argument to `execTool` instead of `out`. There is a common (and old) enough pattern where nix adds a `-bin` suffix that we already have a tool for that in `dev-env`, in `dev-env/bin/dade-exec-nix-bin-tool`:
```
DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
base=$(basename $0)
execTool $base bin $base "$@"
```
where the only difference is the `bin` instead of `out`.

Somehow, in this new version of nixpkgs we recently upgraded to, `ghcid` is now one of the packages that produces a link with a `-bin` suffix, so this PR updates the `dev-env/bin/ghcid` symlink to use the `dade-exec-nix-bin-tool` instead of the plain `dade-exec-nix-tool`.

Note: this issue is invisible to anyone who has not (manually) removed the `dev-env/var/gc-roots/ghcid` symlink since upgrading. In that case, the `ghcid` and `da-ghcid` commands would still work, though they would then use the pre-upgrade version.