### PR TITLE
Only match identifiers from DA.Internal.LF if they are in the right module

### DIFF
--- a/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
+++ b/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
@@ -1,0 +1,30 @@
+daml 1.2
+module LFNameCollisions where
+
+import DA.Record
+
+import Prelude hiding (submit, submitMustFail)
+
+-- This test checks that we only convert submit and submitMustFail
+-- to the corresponding LF primitives if they are coming from the
+-- right module.
+
+submit : a -> Int -> Int -> a
+submit x _ _ = x
+
+submitMustFail : a -> Int -> Int -> a
+submitMustFail x _ _ = x
+
+data Phantom (a : Symbol) (b : Symbol) = Phantom {}
+
+unpackPair : forall a b c d. Phantom a b -> (c,d) -> (c,d)
+unpackPair _ c = c
+
+a : ()
+a = submit () 0 0
+
+b : ()
+b = submitMustFail () 0 0
+
+c : (Int, Int)
+c = unpackPair @"abc" @"def" Phantom (42, 42)


### PR DESCRIPTION
For now, I’ve only fixed `DA.Internal.LF`. I think it probably makes sense to do this on a module-by-module basis.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
