### PR TITLE
Added Sandbox CLI parameter --max-ttl-seconds

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -147,6 +147,12 @@ object Cli {
         .text("Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come.")
         .action( (_, config) => config.copy(eagerPackageLoading = true))
 
+    opt[Long]("max-ttl-seconds")
+        .optional()
+        .validate(v => Either.cond(v > 0, (), "Max TTL must be a positive number"))
+        .text("The maximum TTL allowed for commands in seconds")
+        .action( (maxTtl, config) => config.copy(timeModel = config.timeModel.copy(maxTtl = Duration.ofSeconds(maxTtl))))
+
     help("help").text("Print the usage text")
 
     checkConfig(c => {

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -16,3 +16,4 @@ HEAD — ongoing
 + [DAML-LF (Internal)] Change the name of the bintray/maven ``com.digitalasset.daml-lf-archive-scala`` to ``com.digitalasset.daml-lf-archive-reader``
 + [DAML Triggers -Experimental] The trigger runner now logs output from ``trace``, ``error`` and
   failed command completions and hides internal debugging output.
++ [Sandbox] The maximum allowed TTL for commands is now configurable via the ``--max-ttl-seconds`` parameter, for example: ``daml sandbox --max-ttl-seconds 300``.


### PR DESCRIPTION
This CLI parameter can be used to modify the maximum allowed TTL used by
commands.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
