### PR TITLE
Shrink the docker image for the SDK by 57%

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -3,5 +3,5 @@ RUN apk add curl bash
 ARG VERSION
 RUN addgroup -S daml && adduser -S daml -G daml
 USER daml
-RUN curl https://get.daml.com | sh -s $VERSION
+RUN curl https://get.daml.com | sh -s $VERSION && rm -rf /tmp/*
 ENV PATH="/home/daml/.daml/bin:${PATH}"

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -17,3 +17,4 @@ HEAD — ongoing
 + [DAML Triggers -Experimental] The trigger runner now logs output from ``trace``, ``error`` and
   failed command completions and hides internal debugging output.
 + [Sandbox] The maximum allowed TTL for commands is now configurable via the ``--max-ttl-seconds`` parameter, for example: ``daml sandbox --max-ttl-seconds 300``.
++ [DAML SDK] Shrink docker image containing the full DAML SDK from 2.8 GB to 1.2 GB.


### PR DESCRIPTION
Wiping out the `/tmp` dir after installing the SDK does wonders.

@associahedron I wonder if we should do this in the assistant?

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3224)
<!-- Reviewable:end -->
