### PR TITLE
Add damlc test to list of commands that care about build-options

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -1074,7 +1074,7 @@ main = do
     -- Note: need to parse given args first to decide whether we need to add
     -- args from daml.yaml.
     Command cmd _ <- handleParseResult tempParseResult
-    let args = if cmd `elem` [Build, Compile, Ide]
+    let args = if cmd `elem` [Build, Compile, Ide, Test]
                then cliArgs ++ damlYamlArgs
                else cliArgs
         (errMsgs, parseResult) = parse args


### PR DESCRIPTION
Fixes #3208 .

I haven't had time to add a test case as well, but I want to.