### PR TITLE
Warn if module name mismatches file name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -685,7 +685,7 @@ hazel_custom_package_github(
     strip_prefix = "wai-app-static",
 )
 
-GHCIDE_REV = "5febbcbc48c7d7d4fdc8902718cecf0a2c49cc8e"
+GHCIDE_REV = "95201719218742b4c4729dfb7e290959c355ee44"
 
 # We need a custom build file to depend on ghc-lib and ghc-lib-parser
 hazel_custom_package_github(

--- a/compiler/damlc/tests/daml-test-files/AnyChoice.daml
+++ b/compiler/damlc/tests/daml-test-files/AnyChoice.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- @SINCE-LF 1.7
-daml 1.2 module AnyTemplate where
+daml 1.2 module AnyChoice where
 
 import DA.Assert
 

--- a/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
@@ -1,0 +1,7 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ WARN Module names should always match file names
+
+daml 1.2
+module ModuleNameMismatch where

--- a/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
@@ -6,7 +6,7 @@
 
 daml 1.2
 
-module RationalUpperBound where
+module RationalUpperBoundError where
 
 -- 10^38 / 10^10
 a : Decimal

--- a/compiler/damlc/tests/daml-test-files/RecordsMore.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordsMore.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 daml 1.2
-module Records_more where
+module RecordsMore where
 
 -- Tests for 'HasField' record preprocessor rewrites.
 

--- a/compiler/damlc/tests/daml-test-files/SubmitterInMaintainers_after_1866.daml
+++ b/compiler/damlc/tests/daml-test-files/SubmitterInMaintainers_after_1866.daml
@@ -7,7 +7,7 @@
 -- Tests that DAML-LF > 1.5 enforces "submitter
 -- must be in maintainer" rule. See https://github.com/digital-asset/daml/issues/1866
 daml 1.2
-module SubmitterInMaintainers_1866_before where
+module SubmitterInMaintainers_after_1866 where
 
 -- import DA.Assert
 

--- a/compiler/damlc/tests/daml-test-files/SubmitterInMaintainers_before_1866.daml
+++ b/compiler/damlc/tests/daml-test-files/SubmitterInMaintainers_before_1866.daml
@@ -6,7 +6,7 @@
 -- Tests that DAML-LF <= 1.5 does not enforce "submitter
 -- must be in maintainer" rule. See https://github.com/digital-asset/daml/issues/1866
 daml 1.2
-module SubmitterInMaintainers_1866_before where
+module SubmitterInMaintainers_before_1866 where
 
 -- import DA.Assert
 


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/3106

`damlc` will emit a warning of the form
```
Warning: Module names should always match file names, as per [documentation|https://docs.daml.com/daml/reference/file-structure.html]. This rule will be enforced in a future SDK version. Please change the filename to MODULE_NAME.daml in preparation.
```
if the filename of a module does not match its module name.

This PR adds a corresponding test-case to the damlc integration tests, and fixes damlc integration tests in which the module name did not match the file name.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
