### PR TITLE
Delete temp directory in get-daml.sh

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -3,5 +3,5 @@ RUN apk add curl bash
 ARG VERSION
 RUN addgroup -S daml && adduser -S daml -G daml
 USER daml
-RUN curl https://get.daml.com | sh -s $VERSION && rm -rf /tmp/*
+RUN curl https://get.daml.com | sh -s $VERSION
 ENV PATH="/home/daml/.daml/bin:${PATH}"

--- a/daml-assistant/get-daml.sh
+++ b/daml-assistant/get-daml.sh
@@ -17,13 +17,16 @@
 #
 
 set -eu
-cleanup() {
-  echo "$(tput setaf 3)FAILED TO INSTALL!$(tput sgr 0)"
-}
-trap cleanup EXIT
-
+readonly SWD="$PWD"
 readonly TMPDIR="$(mktemp -d)"
 cd $TMPDIR
+
+cleanup() {
+  echo "$(tput setaf 3)FAILED TO INSTALL!$(tput sgr 0)"
+  cd $SWD
+  rm -rf $TMPDIR
+}
+trap cleanup EXIT
 
 #
 # Check if curl and tar are available.
@@ -113,4 +116,5 @@ fi
 #
 trap - EXIT
 echo "$(tput setaf 3)Successfully installed DAML.$(tput sgr 0)"
-
+cd $SWD
+rm -rf $TMPDIR


### PR DESCRIPTION
For @hurryabit :-) 

This PR deletes the temp directory that gets created when running the `get.daml.com` script.  I tested extensively and this is where the wastefulness comes from. Not from the assistant, but from the script that installs it.
