### PR TITLE
Detect high level trigger

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -118,8 +118,7 @@ allows you to emit commands that are then sent to the ledger. Like
 ``Scenario`` or ``Update``, you can use ``do`` notation with
 ``TriggerA``.
 
-Once you have defined the trigger, you have to pass it to ``runTrigger``. For our DAML trigger,
-this looks as follows:
+For our DAML trigger, the definition looks as follows:
 
 .. literalinclude:: ./template-root/src/CopyTrigger.daml
    :language: daml

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -51,7 +51,8 @@ template Copy
 deriving instance Ord Copy
 
 -- TRIGGER_BEGIN
-copyTrigger = runTrigger $ Trigger
+copyTrigger : Trigger ()
+copyTrigger = Trigger
   { initialize = \_acs -> ()
   , updateState = \_acs _message () -> ()
   , rule = copyRule

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -40,20 +40,26 @@ case class Converter(
 case class TriggerIds(
     triggerPackageId: PackageId,
     triggerModuleName: ModuleName,
+    highlevelModuleName: ModuleName,
     stdlibPackageId: PackageId,
     mainPackageId: PackageId) {
   def getId(n: String): Identifier =
     Identifier(triggerPackageId, QualifiedName(triggerModuleName, DottedName.assertFromString(n)))
+  def getHighlevelId(n: String): Identifier =
+    Identifier(triggerPackageId, QualifiedName(highlevelModuleName, DottedName.assertFromString(n)))
 }
 
 object TriggerIds {
   def fromDar(dar: Dar[(PackageId, Package)]): TriggerIds = {
     val triggerModuleName = DottedName.assertFromString("Daml.Trigger.LowLevel")
+    val highlevelModuleName = DottedName.assertFromString("Daml.Trigger")
     // We might want to just fix this at compile time at some point
     // once we ship the trigger lib with the SDK.
     val triggerPackageId: PackageId = dar.all
       .find {
-        case (pkgId, pkg) => pkg.modules.contains(triggerModuleName)
+        case (pkgId, pkg) =>
+          pkg.modules.contains(triggerModuleName) &&
+          pkg.modules.contains(highlevelModuleName)
       }
       .get
       ._1
@@ -65,7 +71,7 @@ object TriggerIds {
         }
         .get
         ._1
-    TriggerIds(triggerPackageId, triggerModuleName, stdlibPackageId, dar.main._1)
+    TriggerIds(triggerPackageId, triggerModuleName, highlevelModuleName, stdlibPackageId, dar.main._1)
   }
 }
 

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -59,7 +59,7 @@ object TriggerIds {
       .find {
         case (pkgId, pkg) =>
           pkg.modules.contains(triggerModuleName) &&
-          pkg.modules.contains(highlevelModuleName)
+            pkg.modules.contains(highlevelModuleName)
       }
       .get
       ._1
@@ -71,7 +71,12 @@ object TriggerIds {
         }
         .get
         ._1
-    TriggerIds(triggerPackageId, triggerModuleName, highlevelModuleName, stdlibPackageId, dar.main._1)
+    TriggerIds(
+      triggerPackageId,
+      triggerModuleName,
+      highlevelModuleName,
+      stdlibPackageId,
+      dar.main._1)
   }
 }
 

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -158,7 +158,8 @@ class Runner(
       val lowTriggerTy = TypeConApp(triggerIds.getId("Trigger"), ImmArray(lowStateTy))
       (lowTriggerVal, lowTriggerTy)
     } else {
-      val errMsg = s"Identifier ${triggerId.qualifiedName} does not point to a trigger. Its type must be Daml.Trigger.Trigger or Daml.Trigger.LowLevel.Trigger."
+      val errMsg =
+        s"Identifier ${triggerId.qualifiedName} does not point to a trigger. Its type must be Daml.Trigger.Trigger or Daml.Trigger.LowLevel.Trigger."
       throw new RuntimeException(errMsg)
     }
   }

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -153,7 +153,10 @@ class Runner(
       (triggerVal, triggerTy)
     } else if (tyCon == triggerIds.getHighlevelId("Trigger")) {
       logger.debug("Running high-level trigger")
-      throw new RuntimeException("NOT IMPLEMENTED")
+      val lowTriggerVal = EApp(EVal(triggerIds.getHighlevelId("runTrigger")), EVal(triggerId))
+      val lowStateTy = TApp(TTyCon(triggerIds.getHighlevelId("TriggerState")), stateTy)
+      val lowTriggerTy = TypeConApp(triggerIds.getId("Trigger"), ImmArray(lowStateTy))
+      (lowTriggerVal, lowTriggerTy)
     } else {
       val errMsg = s"Identifier ${triggerId.qualifiedName} does not point to a trigger. Its type must be Daml.Trigger.Trigger or Daml.Trigger.LowLevel.Trigger."
       throw new RuntimeException(errMsg)

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -11,7 +11,8 @@ import DA.Optional
 
 import Daml.Trigger
 
-retryTrigger = runTrigger Trigger
+retryTrigger : Trigger Int
+retryTrigger = Trigger
   { initialize = \_acs -> 3
   , updateState = \_acs msg allowedFail -> case msg of
       MCompletion c

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -8,3 +8,4 @@ This page contains release notes for the SDK.
 
 HEAD — ongoing
 --------------
+- [DAML Triggers] The trigger runner now supports triggers using the high-level API directly. These no longer need to be converted to low-level Triggers using ``runTrigger``. Triggers using the low-level API are still supported.


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/3189

Allows to directly run triggers written using the high-level trigger API without the need for calling `runTrigger`. The trigger runner will detect whether a trigger uses the high-level or low-level trigger type, and in case of the high-level type automatically convert it to a low-lever trigger before execution.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
