### PR TITLE
fix a few links in documentation

### DIFF
--- a/docs/source/json-api/search-query-language.rst
+++ b/docs/source/json-api/search-query-language.rst
@@ -82,7 +82,7 @@ is no way that the above query could be written to match ``A`` but never
 
 For these reasons, as with LF value input via JSON, queries written in
 JSON are also always interpreted with respect to some specified LF types
-(e.g. template IDs). As #2777 implies, for example::
+(e.g. template IDs). For example::
 
   {"%templates": [{"moduleName": "Foo", "entityName": "A"},
                   {"moduleName": "Foo", "entityName": "B"},

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -7,8 +7,8 @@ DAML Triggers - Off-Ledger Automation in DAML
 **WARNING:** DAML Triggers are an experimental feature that is actively
 being designed and is *subject to breaking changes*.
 We welcome feedback about DAML triggers on
-`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
-or `on Slack <https://damldriven.slack.com/>`_.
+`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=DAML+Triggers>`_
+or `on Slack <https://hub.daml.com/slack/>`_.
 
 In addition to the actual DAML logic which is uploaded to the Ledger
 and the UI, DAML applications often need to automate certain

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -248,7 +248,7 @@ using the syntax ``ModuleName:identifier``. Finally, we need to
 specify the ledger host, port and the party that our trigger is executed
 as.
 
-Now open Navigator at `http://localhost:7500/ <http://localhost:7500/>`.
+Now open Navigator at http://localhost:7500/.
 
 First, login as ``Alice`` and create an ``Original`` contract with
 ``party`` set to ``Alice``.  Now, logout and login as ``Bob`` and


### PR DESCRIPTION
Fixes links from #3181 that should point somewhere else, including the new Slack from #3179. Also the issue reference in the json-api query spec has long since stopped making sense, and the meaning is clear with no external reference.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
