### PR TITLE
Use TemplateTypeRep in DAML Trigger API

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -39,7 +39,10 @@ module DA.Internal.LF
 
   , AnyTemplate
   , AnyChoice
+
   , TemplateTypeRep
+  , templateTypeRepToText
+  , templateTypeRepFromText
   ) where
 
 import GHC.Types (Opaque, Symbol)
@@ -221,3 +224,9 @@ newtype AnyChoice = AnyChoice { getAnyChoice : Any }
 -- | Unique textual representation of a template Id.
 newtype TemplateTypeRep = TemplateTypeRep { getTemplateTypeRep : Text }
   deriving (Eq, Ord, Show)
+
+templateTypeRepToText : TemplateTypeRep -> Text
+templateTypeRepToText = getTemplateTypeRep
+
+templateTypeRepFromText : Text -> Optional TemplateTypeRep
+templateTypeRepFromText = Some . TemplateTypeRep

--- a/compiler/damlc/daml-stdlib-src/DA/Next/Map.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Next/Map.daml
@@ -59,6 +59,10 @@ instance MapKey Party where
   keyToText = partyToText
   keyFromText = fromSome . partyFromText
 
+instance MapKey TemplateTypeRep where
+  keyToText = templateTypeRepToText
+  keyFromText = fromSome . templateTypeRepFromText
+
 instance MapKey Int where
   keyToText = show
   keyFromText = fromSome . parseInt

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -141,7 +141,23 @@ object Ref {
 
   /* A fully-qualified identifier pointing to a definition in the
    * specified package. */
-  case class Identifier(packageId: PackageId, qualifiedName: QualifiedName)
+  case class Identifier(packageId: PackageId, qualifiedName: QualifiedName) {
+    override def toString: String = packageId.toString + ":" + qualifiedName.toString
+  }
+  object Identifier {
+    type T = Identifier
+
+    def fromString(s: String): Either[String, Identifier] = {
+      val segments = split(s, ':')
+      if (segments.length != 3)
+        Left(s"Expecting three segments in $s, but got ${segments.length}")
+      else
+        for {
+          packageId <- PackageId.fromString(segments(0))
+          qualifiedName <- QualifiedName.fromString(segments(1) + ":" + segments(2))
+        } yield Identifier(packageId, qualifiedName)
+    }
+  }
 
   /* Choice name in a template. */
   val ChoiceName: Name.type = Name

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -64,9 +64,9 @@ copyRule : Party -> ACS -> Map CommandId [Command] -> () -> TriggerA ()
 copyRule party acs commandsInFlight () = do
 -- RULE_SIGNATURE_END
 -- ACS_QUERY_BEGIN
-  let subscribers : [(AnyContractId, Subscriber)] = getTemplates @Subscriber acs
-  let originals : [(AnyContractId, Original)] = getTemplates @Original acs
-  let copies : [(AnyContractId, Copy)] = getTemplates @Copy acs
+  let subscribers : [(TheContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
+  let originals : [(TheContractId Original, Original)] = getTemplates @Original acs
+  let copies : [(TheContractId Copy, Copy)] = getTemplates @Copy acs
 -- ACS_QUERY_END
 
 -- ACS_FILTER_BEGIN
@@ -80,7 +80,7 @@ copyRule party acs commandsInFlight () = do
 -- SUBSCRIBING_PARTIES_END
 
 -- GROUP_COPIES_BEGIN
-  let groupedCopies : [[(AnyContractId, Copy)]]
+  let groupedCopies : [[(TheContractId Copy, Copy)]]
       groupedCopies = groupOn snd $ sortOn snd $ ownedCopies
   let copiesToKeep = map head groupedCopies
   let archiveDuplicateCopies = concatMap tail groupedCopies

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -64,9 +64,9 @@ copyRule : Party -> ACS -> Map CommandId [Command] -> () -> TriggerA ()
 copyRule party acs commandsInFlight () = do
 -- RULE_SIGNATURE_END
 -- ACS_QUERY_BEGIN
-  let subscribers : [(TheContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
-  let originals : [(TheContractId Original, Original)] = getTemplates @Original acs
-  let copies : [(TheContractId Copy, Copy)] = getTemplates @Copy acs
+  let subscribers : [(AbsoluteContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
+  let originals : [(AbsoluteContractId Original, Original)] = getTemplates @Original acs
+  let copies : [(AbsoluteContractId Copy, Copy)] = getTemplates @Copy acs
 -- ACS_QUERY_END
 
 -- ACS_FILTER_BEGIN
@@ -80,7 +80,7 @@ copyRule party acs commandsInFlight () = do
 -- SUBSCRIBING_PARTIES_END
 
 -- GROUP_COPIES_BEGIN
-  let groupedCopies : [[(TheContractId Copy, Copy)]]
+  let groupedCopies : [[(AbsoluteContractId Copy, Copy)]]
       groupedCopies = groupOn snd $ sortOn snd $ ownedCopies
   let copiesToKeep = map head groupedCopies
   let archiveDuplicateCopies = concatMap tail groupedCopies

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -33,11 +33,12 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 
 -- public API
 
-newtype ACS = ACS [(AnyContractId, AnyTemplate)]
+newtype ACS = ACS (Map TemplateTypeRep [(AnyContractId, AnyTemplate)])
 
-getTemplates : Template a => ACS -> [(TheContractId a, a)]
-getTemplates (ACS tpls) =
-  mapOptional (\(cid, tpl) -> (,) <$> fromAnyContractId cid <*> fromAnyTemplate tpl) tpls
+getTemplates : forall a. Template a => ACS -> [(TheContractId a, a)]
+getTemplates (ACS tpls) = map fromAny $ fromOptional [] $ Map.lookup (templateTypeRep @a) tpls
+  where
+    fromAny (cid, tpl) = (fromSome (fromAnyContractId cid), fromSome (fromAnyTemplate tpl))
 
 data Trigger s = Trigger
   { initialize : ACS -> s
@@ -64,7 +65,7 @@ runTrigger userTrigger = LowLevel.Trigger
   }
   where
     initialState party (ActiveContracts createdEvents) =
-      let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS []) createdEvents
+      let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS Map.empty) createdEvents
           userState = userTrigger.initialize acs
           (_, TriggerAState commands nextCommandId) = runTriggerA (userTrigger.rule party acs Map.empty userState) (TriggerAState [] 0)
           commandsInFlight = foldl addCommands Map.empty commands
@@ -106,14 +107,21 @@ addCommands : Map CommandId [Command] -> Commands -> Map CommandId [Command]
 addCommands m (Commands cid cmds) = Map.insert cid cmds m
 
 insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
-insertTpl cid tpl (ACS acs) = ACS ((cid, tpl) :: acs)
+insertTpl cid tpl (ACS acs) =
+  case Map.lookup cid.typeRep acs of
+    None -> ACS (Map.insert cid.typeRep [(cid, tpl)] acs)
+    Some items -> ACS (Map.insert cid.typeRep ((cid, tpl) :: items) acs)
 
 deleteTpl : AnyContractId -> ACS -> ACS
-deleteTpl cid (ACS acs) = ACS (filter (\(cid', _) -> cid /= cid') acs)
+deleteTpl cid (ACS acs) =
+  case Map.lookup cid.typeRep acs of
+    None -> ACS acs
+    Some items -> ACS (Map.insert cid.typeRep (filter (\(cid', _) -> cid /= cid') items) acs)
 
 lookupTpl : Template a => AnyContractId -> ACS -> Optional a
 lookupTpl cid (ACS acs) = do
-  (_, tpl) <- find ((cid ==) . fst) acs
+  items <- Map.lookup cid.typeRep acs
+  (_, tpl) <- find ((cid ==) . fst) items
   fromAnyTemplate tpl
 
 applyEvent : Event -> ACS -> ACS

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -12,6 +12,9 @@ module Daml.Trigger
  , CommandId
  , Command(..)
  , AnyContractId(..)
+ , TheContractId(..)
+ , toAnyContractId
+ , fromAnyContractId
  , exerciseCmd
  , createCmd
  , Message(..)
@@ -32,8 +35,9 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 
 newtype ACS = ACS [(AnyContractId, AnyTemplate)]
 
-getTemplates : Template a => ACS -> [(AnyContractId, a)]
-getTemplates (ACS tpls) = mapOptional (\(cid, tpl) -> (cid,) <$> fromAnyTemplate tpl) tpls
+getTemplates : Template a => ACS -> [(TheContractId a, a)]
+getTemplates (ACS tpls) =
+  mapOptional (\(cid, tpl) -> (,) <$> fromAnyContractId cid <*> fromAnyTemplate tpl) tpls
 
 data Trigger s = Trigger
   { initialize : ACS -> s

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -108,19 +108,19 @@ addCommands m (Commands cid cmds) = Map.insert cid cmds m
 
 insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
 insertTpl cid tpl (ACS acs) =
-  case Map.lookup cid.typeRep acs of
-    None -> ACS (Map.insert cid.typeRep [(cid, tpl)] acs)
-    Some items -> ACS (Map.insert cid.typeRep ((cid, tpl) :: items) acs)
+  case Map.lookup cid.templateId acs of
+    None -> ACS (Map.insert cid.templateId [(cid, tpl)] acs)
+    Some items -> ACS (Map.insert cid.templateId ((cid, tpl) :: items) acs)
 
 deleteTpl : AnyContractId -> ACS -> ACS
 deleteTpl cid (ACS acs) =
-  case Map.lookup cid.typeRep acs of
+  case Map.lookup cid.templateId acs of
     None -> ACS acs
-    Some items -> ACS (Map.insert cid.typeRep (filter (\(cid', _) -> cid /= cid') items) acs)
+    Some items -> ACS (Map.insert cid.templateId (filter (\(cid', _) -> cid /= cid') items) acs)
 
 lookupTpl : Template a => AnyContractId -> ACS -> Optional a
 lookupTpl cid (ACS acs) = do
-  items <- Map.lookup cid.typeRep acs
+  items <- Map.lookup cid.templateId acs
   (_, tpl) <- find ((cid ==) . fst) items
   fromAnyTemplate tpl
 

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -12,7 +12,7 @@ module Daml.Trigger
  , CommandId
  , Command(..)
  , AnyContractId(..)
- , TheContractId(..)
+ , AbsoluteContractId(..)
  , toAnyContractId
  , fromAnyContractId
  , exerciseCmd
@@ -35,7 +35,7 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 
 newtype ACS = ACS (Map TemplateTypeRep [(AnyContractId, AnyTemplate)])
 
-getTemplates : forall a. Template a => ACS -> [(TheContractId a, a)]
+getTemplates : forall a. Template a => ACS -> [(AbsoluteContractId a, a)]
 getTemplates (ACS tpls) = map fromAny $ fromOptional [] $ Map.lookup (templateTypeRep @a) tpls
   where
     fromAny (cid, tpl) = (fromSome (fromAnyContractId cid), fromSome (fromAnyTemplate tpl))

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -8,7 +8,7 @@ module Daml.Trigger.LowLevel
   , CompletionStatus(..)
   , Transaction(..)
   , AnyContractId(..)
-  , TheContractId(..)
+  , AbsoluteContractId(..)
   , toAnyContractId
   , fromAnyContractId
   , TransactionId(..)
@@ -35,20 +35,18 @@ data AnyContractId = AnyContractId
   , contractId : Text
   } deriving (Show, Eq, Ord)
 
--- XXX: The name ContractId clashes with Prelude.ContractId.
---   Find a better name than TheContractId.
-newtype TheContractId t = TheContractId { contractId : Text }
+newtype AbsoluteContractId t = AbsoluteContractId { contractId : Text }
   deriving (Show, Eq, Ord)
 
-toAnyContractId : forall t. Template t => TheContractId t -> AnyContractId
-toAnyContractId (TheContractId contractId) = AnyContractId
+toAnyContractId : forall t. Template t => AbsoluteContractId t -> AnyContractId
+toAnyContractId (AbsoluteContractId contractId) = AnyContractId
   { templateId = templateTypeRep @t
   , contractId = contractId
   }
 
-fromAnyContractId : forall t. Template t => AnyContractId -> Optional (TheContractId t)
+fromAnyContractId : forall t. Template t => AnyContractId -> Optional (AbsoluteContractId t)
 fromAnyContractId cid
-  | cid.templateId == templateTypeRep @t = Some (TheContractId cid.contractId)
+  | cid.templateId == templateTypeRep @t = Some (AbsoluteContractId cid.contractId)
   | otherwise = None
 
 newtype TransactionId = TransactionId Text
@@ -76,7 +74,7 @@ data Created = Created
   , argument : AnyTemplate
   }
 
-fromCreated : Template t => Created -> Optional (EventId, TheContractId t, t)
+fromCreated : Template t => Created -> Optional (EventId, AbsoluteContractId t, t)
 fromCreated Created {eventId, contractId, argument}
   | Some contractId' <- fromAnyContractId contractId
   , Some argument' <- fromAnyTemplate argument
@@ -89,7 +87,7 @@ data Archived = Archived
   , contractId : AnyContractId
   } deriving (Show, Eq)
 
-fromArchived : Template t => Archived -> Optional (EventId, TheContractId t)
+fromArchived : Template t => Archived -> Optional (EventId, AbsoluteContractId t)
 fromArchived Archived {eventId, contractId}
   | Some contractId' <- fromAnyContractId contractId
   = Some (eventId, contractId')
@@ -140,7 +138,7 @@ createCmd : Template t => t -> Command
 createCmd templateArg =
   CreateCommand (toAnyTemplate templateArg)
 
-exerciseCmd : forall t c r. Choice t c r => TheContractId t -> c -> Command
+exerciseCmd : forall t c r. Choice t c r => AbsoluteContractId t -> c -> Command
 exerciseCmd contractId choiceArg =
   ExerciseCommand (toAnyContractId contractId) (toAnyChoice @t choiceArg)
 

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -17,7 +17,9 @@ module Daml.Trigger.LowLevel
   , CommandId(..)
   , Event(..)
   , Created(..)
+  , fromCreated
   , Archived(..)
+  , fromArchived
   , Trigger(..)
   , ActiveContracts(..)
   , Commands(..)
@@ -94,10 +96,25 @@ data Created = Created
   , argument : AnyTemplate
   }
 
+fromCreated : Template t => Created -> Optional (EventId, TheContractId t, t)
+fromCreated Created {eventId, contractId, argument}
+  | Some contractId' <- fromAnyContractId contractId
+  , Some argument' <- fromAnyTemplate argument
+  = Some (eventId, contractId', argument')
+  | otherwise
+  = None
+
 data Archived = Archived
   { eventId : EventId
   , contractId : AnyContractId
   } deriving (Show, Eq)
+
+fromArchived : Template t => Archived -> Optional (EventId, TheContractId t)
+fromArchived Archived {eventId, contractId}
+  | Some contractId' <- fromAnyContractId contractId
+  = Some (eventId, contractId')
+  | otherwise
+  = None
 
 data Message
   = MTransaction Transaction

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -9,6 +9,9 @@ module Daml.Trigger.LowLevel
   , Transaction(..)
   , Identifier(..)
   , AnyContractId(..)
+  , TheContractId(..)
+  , toAnyContractId
+  , fromAnyContractId
   , TransactionId(..)
   , EventId(..)
   , CommandId(..)
@@ -40,6 +43,31 @@ data AnyContractId = AnyContractId
   , templateId : Identifier
   , contractId : Text
   } deriving (Show, Eq, Ord)
+
+-- XXX: The name ContractId clashes with Prelude.ContractId.
+--   Find a better name than TheContractId.
+data TheContractId t = TheContractId
+  { -- XXX: Currently we need the Identifier for exercise and create commands.
+    --   This information is redundant with TemplateTypeRep, but, currently
+    --   there is no way to convert from TemplateTypeRep back to Identifier.
+    templateId : Identifier
+  , contractId : Text
+  } deriving (Show, Eq, Ord)
+
+toAnyContractId : forall t. Template t => TheContractId t -> AnyContractId
+toAnyContractId cid = AnyContractId
+  { typeRep = templateTypeRep @t
+  , templateId = cid.templateId
+  , contractId = cid.contractId
+  }
+
+fromAnyContractId : forall t. Template t => AnyContractId -> Optional (TheContractId t)
+fromAnyContractId cid
+  | cid.typeRep == templateTypeRep @t = Some TheContractId
+      { templateId = cid.templateId
+      , contractId = cid.contractId
+      }
+  | otherwise = None
 
 newtype TransactionId = TransactionId Text
   deriving (Show, Eq)

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -143,9 +143,9 @@ createCmd : Template t => t -> Command
 createCmd templateArg =
   CreateCommand (toAnyTemplate templateArg)
 
-exerciseCmd : forall t c r. Choice t c r => AnyContractId -> c -> Command
+exerciseCmd : forall t c r. Choice t c r => TheContractId t -> c -> Command
 exerciseCmd contractId choiceArg =
-  ExerciseCommand contractId (toAnyChoice @t choiceArg)
+  ExerciseCommand (toAnyContractId contractId) (toAnyChoice @t choiceArg)
 
 data Commands = Commands
   { commandId : CommandId

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -7,7 +7,6 @@ module Daml.Trigger.LowLevel
   , Completion(..)
   , CompletionStatus(..)
   , Transaction(..)
-  , Identifier(..)
   , AnyContractId(..)
   , TheContractId(..)
   , toAnyContractId
@@ -31,44 +30,25 @@ module Daml.Trigger.LowLevel
 
 import DA.Next.Map (MapKey(..))
 
-data Identifier = Identifier
-  { packageId : Text
-  , moduleName : Text
-  , entityName : Text
-  } deriving (Show, Eq, Ord)
-
 data AnyContractId = AnyContractId
-  { typeRep : TemplateTypeRep
-    -- XXX: Currently we need the Identifier for exercise and create commands.
-    --   This information is redundant with TemplateTypeRep, but, currently
-    --   there is no way to convert from TemplateTypeRep back to Identifier.
-  , templateId : Identifier
+  { templateId : TemplateTypeRep
   , contractId : Text
   } deriving (Show, Eq, Ord)
 
 -- XXX: The name ContractId clashes with Prelude.ContractId.
 --   Find a better name than TheContractId.
-data TheContractId t = TheContractId
-  { -- XXX: Currently we need the Identifier for exercise and create commands.
-    --   This information is redundant with TemplateTypeRep, but, currently
-    --   there is no way to convert from TemplateTypeRep back to Identifier.
-    templateId : Identifier
-  , contractId : Text
-  } deriving (Show, Eq, Ord)
+newtype TheContractId t = TheContractId { contractId : Text }
+  deriving (Show, Eq, Ord)
 
 toAnyContractId : forall t. Template t => TheContractId t -> AnyContractId
-toAnyContractId cid = AnyContractId
-  { typeRep = templateTypeRep @t
-  , templateId = cid.templateId
-  , contractId = cid.contractId
+toAnyContractId (TheContractId contractId) = AnyContractId
+  { templateId = templateTypeRep @t
+  , contractId = contractId
   }
 
 fromAnyContractId : forall t. Template t => AnyContractId -> Optional (TheContractId t)
 fromAnyContractId cid
-  | cid.typeRep == templateTypeRep @t = Some TheContractId
-      { templateId = cid.templateId
-      , contractId = cid.contractId
-      }
+  | cid.templateId == templateTypeRep @t = Some (TheContractId cid.contractId)
   | otherwise = None
 
 newtype TransactionId = TransactionId Text

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -33,7 +33,11 @@ data Identifier = Identifier
   } deriving (Show, Eq, Ord)
 
 data AnyContractId = AnyContractId
-  { templateId : Identifier
+  { typeRep : TemplateTypeRep
+    -- XXX: Currently we need the Identifier for exercise and create commands.
+    --   This information is redundant with TemplateTypeRep, but, currently
+    --   there is no way to convert from TemplateTypeRep back to Identifier.
+  , templateId : Identifier
   , contractId : Text
   } deriving (Show, Eq, Ord)
 

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -144,16 +144,19 @@ object Converter {
   }
 
   private def fromTemplateTypeRep(triggerIds: TriggerIds, templateId: value.Identifier): SValue = {
-    val templateTypeRepTy = Identifier(triggerIds.stdlibPackageId,
+    val templateTypeRepTy = Identifier(
+      triggerIds.stdlibPackageId,
       QualifiedName(
         DottedName.assertFromString("DA.Internal.LF"),
         DottedName.assertFromString("TemplateTypeRep")))
     // XXX: Deduplicate with SBToTextTemplateId.
-    val typeRep = SText(Identifier(
-      PackageId.assertFromString(templateId.packageId),
-      QualifiedName(
-        DottedName.assertFromString(templateId.moduleName),
-        DottedName.assertFromString(templateId.entityName))).toString())
+    val typeRep = SText(
+      Identifier(
+        PackageId.assertFromString(templateId.packageId),
+        QualifiedName(
+          DottedName.assertFromString(templateId.moduleName),
+          DottedName.assertFromString(templateId.entityName))
+      ).toString())
     record(templateTypeRepTy, ("getTemplateTypeRep", typeRep))
   }
 

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -10,7 +10,7 @@ import qualified DA.TextMap as TM
 import Daml.Trigger.LowLevel
 
 data TriggerState = TriggerState
-  { activeAssets : TextMap Identifier
+  { activeAssets : TextMap TemplateTypeRep
   , successfulCompletions : Int
   , failedCompletions : Int
   , nextCommandId : Int
@@ -26,7 +26,7 @@ initState party (ActiveContracts events) = TriggerState
   , failedCompletions = 0
   }
   where
-    updateAcs : TextMap Identifier -> Created -> TextMap Identifier
+    updateAcs : TextMap TemplateTypeRep -> Created -> TextMap TemplateTypeRep
     updateAcs acs (Created _ cId argument)
       | Some Asset{} <- fromAnyTemplate @(Asset ()) argument = TM.insert cId.contractId cId.templateId acs
       | otherwise = acs
@@ -53,11 +53,11 @@ test = Trigger
         , [Commands (CommandId $ "command_" <> show state.nextCommandId) cmds]
         )
       where
-        updateEvent : ([Command], TextMap Identifier) -> Event -> ([Command], TextMap Identifier)
+        updateEvent : ([Command], TextMap TemplateTypeRep) -> Event -> ([Command], TextMap TemplateTypeRep)
         updateEvent (cmds, acs) ev = case ev of
           CreatedEvent (fromCreated -> Some (_, assetId, Asset {issuer} : Asset ())) ->
             let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer })
-            in (proposeMirror :: cmds, TM.insert assetId.contractId assetId.templateId acs)
+            in (proposeMirror :: cmds, TM.insert assetId.contractId (templateTypeRep @(Asset ())) acs)
           CreatedEvent (fromCreated -> Some (_, proposalId, AssetMirrorProposal {})) ->
             let accept : Command = exerciseCmd proposalId Accept
             in (accept :: cmds, acs)

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -55,17 +55,14 @@ test = Trigger
       where
         updateEvent : ([Command], TextMap Identifier) -> Event -> ([Command], TextMap Identifier)
         updateEvent (cmds, acs) ev = case ev of
-          CreatedEvent (Created _ cId argument)
-            | Some assetId <- fromAnyContractId @(Asset ()) cId
-            , Some (Asset {issuer}) <- fromAnyTemplate @(Asset ()) argument ->
+          CreatedEvent (fromCreated -> Some (_, assetId, Asset {issuer} : Asset ())) ->
             let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer })
             in (proposeMirror :: cmds, TM.insert assetId.contractId assetId.templateId acs)
-            | Some proposalId <- fromAnyContractId @AssetMirrorProposal cId
-            , Some (AssetMirrorProposal {}) <- fromAnyTemplate argument ->
+          CreatedEvent (fromCreated -> Some (_, proposalId, AssetMirrorProposal {})) ->
             let accept : Command = exerciseCmd proposalId Accept
             in (accept :: cmds, acs)
-          ArchivedEvent (Archived _ cId)
-            | Some assetId <- fromAnyContractId @(Asset ()) cId -> (cmds, TM.delete assetId.contractId acs)
+          ArchivedEvent (fromArchived @(Asset ()) -> Some (_, assetId)) ->
+            (cmds, TM.delete assetId.contractId acs)
           _ -> (cmds, acs)
 
 -- This is only a generic template to test that we do the conversion properly.

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -56,14 +56,16 @@ test = Trigger
         updateEvent : ([Command], TextMap Identifier) -> Event -> ([Command], TextMap Identifier)
         updateEvent (cmds, acs) ev = case ev of
           CreatedEvent (Created _ cId argument)
-            | Some (Asset {issuer}) <- fromAnyTemplate @(Asset ()) argument ->
+            | Some assetId <- fromAnyContractId @(Asset ()) cId
+            , Some (Asset {issuer}) <- fromAnyTemplate @(Asset ()) argument ->
             let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer })
-            in (proposeMirror :: cmds, TM.insert cId.contractId cId.templateId acs)
-            | Some (AssetMirrorProposal {}) <- fromAnyTemplate argument ->
-            let accept : Command = exerciseCmd @AssetMirrorProposal cId Accept
+            in (proposeMirror :: cmds, TM.insert assetId.contractId assetId.templateId acs)
+            | Some proposalId <- fromAnyContractId @AssetMirrorProposal cId
+            , Some (AssetMirrorProposal {}) <- fromAnyTemplate argument ->
+            let accept : Command = exerciseCmd proposalId Accept
             in (accept :: cmds, acs)
           ArchivedEvent (Archived _ cId)
-            | cId.templateId.entityName == "AssetUnit" -> (cmds, TM.delete cId.contractId acs)
+            | Some assetId <- fromAnyContractId @(Asset ()) cId -> (cmds, TM.delete assetId.contractId acs)
           _ -> (cmds, acs)
 
 -- This is only a generic template to test that we do the conversion properly.

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -45,7 +45,7 @@ toCreate : Template t => Command -> Optional t
 toCreate (CreateCommand t) = fromAnyTemplate t
 toCreate ExerciseCommand {} = None
 
-toExercise : Command -> Optional (TheContractId T, C)
+toExercise : Command -> Optional (AbsoluteContractId T, C)
 toExercise CreateCommand {} = None
 toExercise (ExerciseCommand cid choice) =
   liftA2 (,) (fromAnyContractId cid) (fromAnyChoice @T choice)

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -45,9 +45,10 @@ toCreate : Template t => Command -> Optional t
 toCreate (CreateCommand t) = fromAnyTemplate t
 toCreate ExerciseCommand {} = None
 
-toExercise : Command -> Optional (AnyContractId, C)
+toExercise : Command -> Optional (TheContractId T, C)
 toExercise CreateCommand {} = None
-toExercise (ExerciseCommand cid choice) = fmap (cid,) $ fromAnyChoice @T choice
+toExercise (ExerciseCommand cid choice) =
+  liftA2 (,) (fromAnyContractId cid) (fromAnyChoice @T choice)
 
 template T
   with


### PR DESCRIPTION
Closes #3215 

- Add a template-type indexed version of `AnyContractId`.
    - Adds type-safety when handling contract Ids.
    - Avoids type parameter on `exerciseCmd`.
    - Easier matching on `ArchivedEvent`, e.g. `fromArchived` instead of `cid.templateId.entityName == "XYZ"`.
- Group contracts in `ACS` by `TemplateTypeRep`.
    - Allows more efficient lookups, e.g. in `getTemplates`.
    - Requires `MapKey` instance for `TemplateTypeRep`.
- Adds `toString` and `fromString` on `Identifier`.
    Uses format `<packageId>:<moduleName>:<entityName>`.
- Replaces `Identifier` by `TemplateTypeRep` in trigger runner.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
