### PR TITLE
Bazel 1.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,6 +67,10 @@ build:darwin --host_platform=@rules_haskell//haskell/platforms:darwin_x86_64_nix
 # and GHC's gcc on Windows
 build:windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain
 
+# Bazel 1.0 disabled the bash test-runner on Windows. However, some of our
+# test-cases are implemented as bash scripts and rely on the bash test-runner.
+build:windows --noincompatible_windows_native_test_wrapper
+
 # Caching is currently disabled on Windows.
 # See: https://github.com/tweag/rules_haskell/issues/744 for details.
 build:windows --noremote_accept_cached

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -723,7 +723,7 @@ Attributes:
 
 The output of `da_doc_package` with name `"foo"` is a bundle
 `sources.tar.gzip` in the path
-`//bazel-genfiles/daml-foundations/daml-tools/docs/foo`. The bundle for `"foo"` would be produced with the command:
+`//bazel-bin/daml-foundations/daml-tools/docs/foo`. The bundle for `"foo"` would be produced with the command:
 ```
 bazel build //daml-foundations/daml-tools/docs/foo:foo
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ On Windows:
 
 ```
 bazel build //release:sdk-release-tarball
-tar -vxf .\bazel-genfiles\release\sdk-release-tarball.tar.gz
+tar -vxf .\bazel-bin\release\sdk-release-tarball.tar.gz
 cd sdk-*
 daml\daml.exe install . --activate
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -889,6 +889,7 @@ buildifier_dependencies()
 nixpkgs_package(
     name = "python3_nix",
     attribute_path = "python3",
+    nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -642,6 +642,7 @@ hazel_repositories(
 hazel_custom_package_hackage(
     package_name = "ghc-paths",
     build_file = "@ai_formation_hazel//third_party/haskell:BUILD.ghc-paths",
+    sha256 = "afa68fb86123004c37c1dc354286af2d87a9dcfb12ddcb80e8bd0cd55bc87945",
     version = "0.1.0.9",
 )
 

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -137,4 +137,5 @@ dev_env_tool = repository_rule(
         ),
         "prefix": attr.string(),
     },
+    configure = True,
 )

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -138,4 +138,5 @@ dev_env_tool = repository_rule(
         "prefix": attr.string(),
     },
     configure = True,
+    local = True,
 )

--- a/bazel_tools/grpc-bazel-mingw.patch
+++ b/bazel_tools/grpc-bazel-mingw.patch
@@ -20,3 +20,4 @@ index 0349e31bb3..d2e7408dbf 100644
 +#define _WIN32_WINNT 0x0A00
  
  #include <windows.h>
+

--- a/bazel_tools/haskell-bazel-1.1.0.patch
+++ b/bazel_tools/haskell-bazel-1.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/haskell/private/path_utils.bzl b/haskell/private/path_utils.bzl
+index 22bd50e8..89d1b52b 100644
+--- a/haskell/private/path_utils.bzl
++++ b/haskell/private/path_utils.bzl
+@@ -580,7 +580,7 @@ def parse_pattern(ctx, pattern_str):
+         pattern_str = "//{package}{target}".format(package = ctx.label.package, target = pattern_str)
+ 
+     # Separate package and target (if present).
+-    package_target = pattern_str[2:].split(":", maxsplit = 2)
++    package_target = pattern_str[2:].split(":", 2)
+     package_str = package_target[0]
+     target_str = None
+     if len(package_target) == 2:

--- a/bazel_tools/proto.bzl
+++ b/bazel_tools/proto.bzl
@@ -36,8 +36,8 @@ def get_plugin_runfiles(tool, plugin_runfiles):
     return files
 
 def _proto_gen_impl(ctx):
-    src_descs = [src.proto.direct_descriptor_set for src in ctx.attr.srcs]
-    dep_descs = [dep.proto.direct_descriptor_set for dep in ctx.attr.deps]
+    src_descs = [src[ProtoInfo].direct_descriptor_set for src in ctx.attr.srcs]
+    dep_descs = [dep[ProtoInfo].direct_descriptor_set for dep in ctx.attr.deps]
     descriptors = src_descs + dep_descs
 
     sources_out = ctx.actions.declare_directory(ctx.attr.name + "-sources")
@@ -63,8 +63,8 @@ def _proto_gen_impl(ctx):
     inputs = []
 
     for src in ctx.attr.srcs:
-        src_root = src.proto.proto_source_root
-        for direct_source in src.proto.direct_sources:
+        src_root = src[ProtoInfo].proto_source_root
+        for direct_source in src[ProtoInfo].direct_sources:
             path = ""
 
             # in some cases the paths of src_root and direct_source are only partially

--- a/build.ps1
+++ b/build.ps1
@@ -30,6 +30,10 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+# Manually fetch a Windows dev-env tool to avoid the following error:
+#   ERROR loading ~/.scoop: The process cannot access the file 'C:\Users\VssAdministrator\.scoop' because it is being used by another process.
+bazel fetch @makensis_dev_env//...
+
 bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log //...
 
 bazel shutdown

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -60,7 +60,7 @@ steps:
   - bash: |
       set -euo pipefail
       ARTIFACT=daml-sdk-$(release_tag)-${{ parameters.name }}.tar.gz
-      cp bazel-genfiles/release/sdk-release-tarball.tar.gz $(Build.StagingDirectory)/$ARTIFACT
+      cp bazel-bin/release/sdk-release-tarball.tar.gz $(Build.StagingDirectory)/$ARTIFACT
       echo "##vso[task.setvariable variable=artifact;isOutput=true]$ARTIFACT"
     name: publish
     condition: eq(variables['release.has_released'], 'true')

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -38,10 +38,10 @@ steps:
   - bash: |
       set -euo pipefail
       ARTIFACT=daml-sdk-$(release_tag)-windows.tar.gz
-      cp bazel-genfiles/release/sdk-release-tarball.tar.gz '$(Build.StagingDirectory)'/$ARTIFACT
+      cp bazel-bin/release/sdk-release-tarball.tar.gz '$(Build.StagingDirectory)'/$ARTIFACT
       echo "##vso[task.setvariable variable=artifact;isOutput=true]$ARTIFACT"
       WINDOWS_INSTALLER=daml-sdk-$(release_tag)-windows-unsigned.exe
-      cp bazel-genfiles/release/windows-installer/daml-sdk-installer.exe "$(Build.StagingDirectory)/$WINDOWS_INSTALLER"
+      cp bazel-bin/release/windows-installer/daml-sdk-installer.exe "$(Build.StagingDirectory)/$WINDOWS_INSTALLER"
       echo "##vso[task.setvariable variable=artifact-unsigned-windows-installer;isOutput=true]$WINDOWS_INSTALLER"
     name: publish
     condition: eq(variables['release.has_released'], 'true')

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -130,7 +130,7 @@ build_docs_folder path versions = do
     shell_ $ "git checkout v" <> latest
     robustly_download_nix_packages
     shell_ "bazel build //docs:docs"
-    shell_ $ "tar xzf bazel-genfiles/docs/html.tar.gz --strip-components=1 -C " <> path
+    shell_ $ "tar xzf bazel-bin/docs/html.tar.gz --strip-components=1 -C " <> path
     -- Not going through Aeson because it represents JSON objects as unordered
     -- maps, and here order matters.
     let versions_json = versions
@@ -139,14 +139,14 @@ build_docs_folder path versions = do
                         & \s -> "{" <> s <> "}"
     writeFile (path <> "/versions.json") versions_json
     shell_ $ "mkdir -p  " <> path <> "/" <> latest
-    shell_ $ "tar xzf bazel-genfiles/docs/html.tar.gz --strip-components=1 -C " <> path <> "/" <> latest
+    shell_ $ "tar xzf bazel-bin/docs/html.tar.gz --strip-components=1 -C " <> path <> "/" <> latest
     Foldable.for_ (tail versions) $ \version -> do
         putStrLn $ "Building older docs: " <> version
         shell_ $ "git checkout v" <> version
         robustly_download_nix_packages
         shell_ "bazel build //docs:docs"
         shell_ $ "mkdir -p  " <> path <> "/" <> version
-        shell_ $ "tar xzf bazel-genfiles/docs/html.tar.gz --strip-components=1 -C" <> path <> "/" <> version
+        shell_ $ "tar xzf bazel-bin/docs/html.tar.gz --strip-components=1 -C" <> path <> "/" <> version
     shell_ $ "git checkout " <> cur_sha
 
 check_s3_versions :: Set.Set String -> IO Bool

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -95,11 +95,17 @@ genrule(
         "//:VERSION",
     ],
     outs = ["daml-bundled.vsix"],
+    # rm -rf can fail with "directory not empty" on Windows.
+    # As a workaround we add `|| return`.
     cmd = """
         set -euo pipefail
+        TMP_DIR=$$(mktemp -d)
+        cleanup () { rm -rf $$TMP_DIR || return; }
+        trap cleanup EXIT
         DIR=$$PWD
         VERSION=$$(cat $(location //:VERSION))
-        cd compiler/daml-extension
+        cp -r compiler/daml-extension $$TMP_DIR
+        cd $$TMP_DIR/daml-extension
         tar xzf $$DIR/$(location :node_deps_cache)
         sed -i "s/__VERSION__/$$VERSION/" package.json
         sed -i 's/"name": "daml"/"name": "daml-bundled"/' package.json

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -155,13 +155,13 @@ da_scala_test_suite(
     data = [
         ":DarReaderTest.dalf",
         ":DarReaderTest.dar",
+        ":daml_lf_1.6_archive_proto_srcs",
+        ":daml_lf_1.7_archive_proto_srcs",
     ],
     scalacopts = lf_scalacopts,
     deps = [
         ":daml_lf_1.6_archive_java_proto",
-        ":daml_lf_1.6_archive_proto_srcs",
         ":daml_lf_1.7_archive_java_proto",
-        ":daml_lf_1.7_archive_proto_srcs",
         ":daml_lf_archive_reader",
         ":daml_lf_dev_archive_java_proto",
         "//bazel_tools/runfiles:scala_runfiles",

--- a/deps.bzl
+++ b/deps.bzl
@@ -41,6 +41,8 @@ def daml_deps():
             strip_prefix = "rules_haskell-%s" % rules_haskell_version,
             urls = ["https://github.com/tweag/rules_haskell/archive/%s.tar.gz" % rules_haskell_version],
             patches = [
+                # Bazel 1.1.0 compatibility. Remove once rules_haskell has been updated.
+                "@com_github_digital_asset_daml//bazel_tools:haskell-bazel-1.1.0.patch",
                 # Remove once https://github.com/tweag/rules_haskell/pull/1039 is merged.
                 "@com_github_digital_asset_daml//bazel_tools:haskell-cc-wrapper.patch",
                 # Upstream once https://github.com/tweag/rules_haskell/pull/1039 is merged.

--- a/deps.bzl
+++ b/deps.bzl
@@ -32,7 +32,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 rules_scala_version = "8092d5f6165a8d9c4797d5f089c1ba4eee3326b1"
 rules_haskell_version = "74d91c116c59f0a3ad41e376d3307d85ddcc3253"
 rules_haskell_sha256 = "5f2423d4707c5601f465d7343c68ff4e8f271c1269e79af4dc2d156cb8a0c17d"
-rules_nixpkgs_version = "5ffb8a4ee9a52bc6bc12f95cd64ecbd82a79bc82"
+rules_nixpkgs_version = "2980a2f75a178bb3c521d46380a52fe72c656239"
 
 def daml_deps():
     if "rules_haskell" not in native.existing_rules():
@@ -62,7 +62,7 @@ def daml_deps():
             name = "io_tweag_rules_nixpkgs",
             strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
-            sha256 = "085d480232c0bada20c0d0b8b1b4ba8c62fcc006d9dc826aa0e4205e4dca6cb3",
+            sha256 = "a37917d9cb535466d94cbedab5a3d7365fc333843b2265cfb0a5211647769b88",
         )
 
     if "ai_formation_hazel" not in native.existing_rules():

--- a/deps.bzl
+++ b/deps.bzl
@@ -29,7 +29,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-rules_scala_version = "8092d5f6165a8d9c4797d5f089c1ba4eee3326b1"
+rules_scala_version = "0f89c210ade8f4320017daf718a61de3c1ac4773"
 rules_haskell_version = "74d91c116c59f0a3ad41e376d3307d85ddcc3253"
 rules_haskell_sha256 = "5f2423d4707c5601f465d7343c68ff4e8f271c1269e79af4dc2d156cb8a0c17d"
 rules_nixpkgs_version = "2980a2f75a178bb3c521d46380a52fe72c656239"
@@ -112,7 +112,7 @@ def daml_deps():
             url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
             type = "zip",
             strip_prefix = "rules_scala-%s" % rules_scala_version,
-            sha256 = "db536b9db36b5aa737db9d08fa05d1fa5531c9cf213b04bed4e9b9fc34cc2390",
+            sha256 = "37eb013ea3e6a940da70df43fe2dd6f423d1ac0849042aa586f9ac157321018d",
             patches = [
                 "@com_github_digital_asset_daml//bazel_tools:scala-escape-jvmflags.patch",
             ],

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -75,7 +75,7 @@ trap cleanup EXIT
 # Building here separately so the user can see the build process which could take a while
 bazel build $BAZEL_MODE_FLAG //release:sdk-head-tarball.tar.gz
 
-readonly TARBALL=$(bazel info bazel-genfiles $BAZEL_MODE_FLAG)/release/sdk-head-tarball.tar.gz
+readonly TARBALL=$(bazel info bazel-bin $BAZEL_MODE_FLAG)/release/sdk-head-tarball.tar.gz
 readonly TMPDIR=$(mktemp -d)
 mkdir -p $TMPDIR/sdk-head
 

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -1,12 +1,12 @@
 {
   "homepage": "https://bazel.build",
-  "version": "0.28.1",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-windows-x86_64.zip",
-      "hash": "2cb949887f0c8aa5039bb39f52a13a9a13cfcd019d42f65ee16dd134d41c0f72"
+      "url": "https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-windows-x86_64.zip",
+      "hash": "6ef3b5756ba9d8b26fc599884800aa9c55948478f9574540acba7112e0329db2"
     }
   },
   "depends": [

--- a/docs/scripts/live-preview.sh
+++ b/docs/scripts/live-preview.sh
@@ -29,7 +29,7 @@ ln -s ../source $BUILD_DIR
 ln -s ../configs $BUILD_DIR
 mkdir $BUILD_DIR/theme
 bazel build //docs:theme
-tar -zxf ../../bazel-genfiles/docs/da_theme.tar.gz -C $BUILD_DIR/theme
+tar -zxf ../../bazel-bin/docs/da_theme.tar.gz -C $BUILD_DIR/theme
 
 # License and Notices
 cp ../../LICENSE ../source
@@ -41,26 +41,26 @@ do
     if [ "$arg" = "--pdf" ]; then
         bazel build //docs:pdf-docs
         mkdir -p $BUILD_DIR/gen/_downloads
-        cp -L ../../bazel-genfiles/docs/DigitalAssetSDK.pdf $BUILD_DIR/gen/_downloads
+        cp -L ../../bazel-bin/docs/DigitalAssetSDK.pdf $BUILD_DIR/gen/_downloads
     fi
     if [ "$arg" = "--gen" ]; then
         # Hoogle
         bazel build //compiler/damlc:daml-base-hoogle-docs
         mkdir -p $BUILD_DIR/gen/hoogle_db
-        cp -L ../../bazel-genfiles/compiler/damlc/daml-base-hoogle.txt $BUILD_DIR/gen/hoogle_db/base.txt
+        cp -L ../../bazel-bin/compiler/damlc/daml-base-hoogle.txt $BUILD_DIR/gen/hoogle_db/base.txt
 
         # Javadoc
         bazel build //language-support/java:javadocs
         mkdir -p $BUILD_DIR/gen/app-dev/bindings-java
-        tar -zxf ../../bazel-genfiles/language-support/java/javadocs.tar.gz -C $BUILD_DIR/gen/app-dev/bindings-java
+        tar -zxf ../../bazel-bin/language-support/java/javadocs.tar.gz -C $BUILD_DIR/gen/app-dev/bindings-java
 
         # Proto-docs
         bazel build //ledger-api/grpc-definitions:docs
-        cp -L ../../bazel-genfiles/ledger-api/grpc-definitions/proto-docs.rst ../source/app-dev/grpc/
+        cp -L ../../bazel-bin/ledger-api/grpc-definitions/proto-docs.rst ../source/app-dev/grpc/
 
         #StdLib
         bazel build //compiler/damlc:daml-base-rst-docs
-        cp -L ../../bazel-genfiles/compiler/damlc/daml-base.rst ../source/daml/reference/base.rst
+        cp -L ../../bazel-bin/compiler/damlc/daml-base.rst ../source/daml/reference/base.rst
     fi
 done
 

--- a/docs/scripts/preview.sh
+++ b/docs/scripts/preview.sh
@@ -21,6 +21,6 @@ rm -rf $BUILD_DIR
 mkdir $BUILD_DIR
 
 bazel build //docs:docs
-tar -zxf ../../bazel-genfiles/docs/html.tar.gz -C $BUILD_DIR
+tar -zxf ../../bazel-bin/docs/html.tar.gz -C $BUILD_DIR
 cd $BUILD_DIR/html
 python -m http.server 8000

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -18,7 +18,7 @@ ledger_api_proto_source_root = "ledger-api/grpc-definitions"
 proto_library(
     name = "protos",
     srcs = glob(["**/*.proto"]),
-    proto_source_root = ledger_api_proto_source_root,
+    strip_import_prefix = "/" + ledger_api_proto_source_root,
     visibility = [
         "//visibility:public",
     ],

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -69,7 +69,13 @@ da_scala_test(
     name = "tests",
     size = "medium",
     srcs = glob(["src/test/scala/**/*.scala"]),
-    data = ["//docs:quickstart-model.dar"],
+    data = [
+        "//docs:quickstart-model.dar",
+        "@postgresql_dev_env//:all",
+        "@postgresql_dev_env//:createdb",
+        "@postgresql_dev_env//:initdb",
+        "@postgresql_dev_env//:pg_ctl",
+    ],
     resources = glob(["src/test/resources/**/*"]),
     scalacopts = hj_scalacopts,
     deps = [
@@ -82,10 +88,6 @@ da_scala_test(
         "//ledger/sandbox:sandbox-scala-tests-lib",
         "//ledger/participant-state",
         "//bazel_tools/runfiles:scala_runfiles",
-        "@postgresql_dev_env//:all",
-        "@postgresql_dev_env//:createdb",
-        "@postgresql_dev_env//:initdb",
-        "@postgresql_dev_env//:pg_ctl",
     ] + http_json_deps,
 )
 

--- a/nix/overrides/bazel/default.nix
+++ b/nix/overrides/bazel/default.nix
@@ -7,7 +7,7 @@
 # XXX: Modified relative to upstream Nix expression.
 , diffutils, getopt, perl, postgresql
 # updater
-, python3, writeScript
+, python27, python3, writeScript
 # Apple dependencies
 , cctools, libcxx, CoreFoundation, CoreServices, Foundation
 # Allow to independently override the jdks used to build and run respectively
@@ -24,11 +24,11 @@
 }:
 
 let
-  version = "0.28.1";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "0503fax70w7h6v00mkrrrgf1m5n0vkjqs76lyg95alhzc4yldsic";
+    sha256 = "1awm5wa4y4c37zy7d1ass83amwq5992wydkj5v9jx0zp7b4shrjb";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -48,11 +48,16 @@ let
       srcs.io_bazel_rules_sass
       srcs.platforms
       (if stdenv.hostPlatform.isDarwin
-       then srcs.${"java_tools_javac11_darwin-v2.0.zip"}
-       else srcs.${"java_tools_javac11_linux-v2.0.zip"})
-      srcs.${"coverage_output_generator-v1.0.zip"}
+       then srcs."java_tools_javac11_darwin-v6.1.zip"
+       else srcs."java_tools_javac11_linux-v6.1.zip")
+      srcs."coverage_output_generator-v2.0.zip"
       srcs.build_bazel_rules_nodejs
-      srcs.${"android_tools_pkg-0.7.tar.gz"}
+      srcs."android_tools_pkg-0.11.tar.gz"
+      srcs."0.28.3.tar.gz"
+      srcs.rules_pkg
+      srcs.rules_cc
+      srcs.rules_java
+      srcs.rules_proto
       ]);
 
   distDir = runCommand "bazel-deps" {} ''
@@ -106,7 +111,7 @@ let
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";
 
-    src = srcDepsSet."java_tools_javac11_${system}-v2.0.zip";
+    src = srcDepsSet."java_tools_javac11_${system}-v6.1.zip";
 
     nativeBuildInputs = [ autoPatchelfHook unzip ];
     buildInputs = [ gcc-unwrapped ];
@@ -125,7 +130,8 @@ let
 
 in
 stdenv.mkDerivation rec {
-  name = "bazel-${version}";
+  pname = "bazel";
+  inherit version;
 
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -221,18 +227,19 @@ stdenv.mkDerivation rec {
       };
 
     in {
-      bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest; };
-      cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples; };
-      java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples; };
-      protobuf = callPackage ./protobuf-test.nix { inherit runLocal bazelTest; };
-      pythonBinPath = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest; };
+      shebang = callPackage ./shebang-test.nix { inherit runLocal extracted bazelTest distDir; };
+      bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; };
+      cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      protobuf = callPackage ./protobuf-test.nix { inherit runLocal bazelTest distDir; };
+      pythonBinPath = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest distDir; };
 
-      bashToolsWithNixHacks = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
+      bashToolsWithNixHacks = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
 
-      cppWithNixHacks = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples; bazel = bazelWithNixHacks; };
-      javaWithNixHacks = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples; bazel = bazelWithNixHacks; };
-      protobufWithNixHacks = callPackage ./protobuf-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
-      pythonBinPathWithNixHacks = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
+      cppWithNixHacks = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      javaWithNixHacks = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      protobufWithNixHacks = callPackage ./protobuf-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
+      pythonBinPathWithNixHacks = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
 
       # downstream packages using buildBazelPackage
       # fixed-output hashes of the fetch phase need to be spot-checked manually
@@ -304,7 +311,7 @@ stdenv.mkDerivation rec {
       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${libcxx}/include/c++/v1"
 
       # don't use system installed Xcode to run clang, use Nix clang instead
-      sed -i -e "s;/usr/bin/xcrun clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $NIX_LDFLAGS -framework CoreFoundation;g" \
+      sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $NIX_LDFLAGS -framework CoreFoundation;g" \
         scripts/bootstrap/compile.sh \
         src/tools/xcode/realpath/BUILD \
         src/tools/xcode/stdredirect/BUILD \
@@ -325,10 +332,12 @@ stdenv.mkDerivation rec {
     '';
 
     genericPatches = ''
-      # Substitute python's stub shebang to plain python path. (see TODO add pr URL)
-      # See also `postFixup` where python is added to $out/nix-support
-      substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt \
-          --replace "#!/usr/bin/env python" "#!${python3}/bin/python"
+      # Substitute j2objc and objc wrapper's python shebang to plain python path.
+      # These scripts explicitly depend on Python 2.7, hence we use python27.
+      # See also `postFixup` where python27 is added to $out/nix-support
+      substituteInPlace tools/j2objc/j2objc_header_map.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/j2objc/j2objc_wrapper.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/objc/j2objc_dead_code_pruner.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
 
       # md5sum is part of coreutils
       sed -i 's|/sbin/md5|md5sum|' \
@@ -338,8 +347,12 @@ stdenv.mkDerivation rec {
       grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
         # If you add more replacements here, you must change the grep above!
         # Only files containing /bin are taken into account.
+        # We default to python3 where possible. See also `postFixup` where
+        # python3 is added to $out/nix-support
         substituteInPlace "$path" \
           --replace /bin/bash ${customBash}/bin/bash \
+          --replace "/usr/bin/env bash" ${customBash}/bin/bash \
+          --replace "/usr/bin/env python" ${python3}/bin/python \
           --replace /usr/bin/env ${coreutils}/bin/env \
           --replace /bin/true ${coreutils}/bin/true
       done
@@ -466,6 +479,7 @@ stdenv.mkDerivation rec {
     # the reference to .name
     mkdir $out/etc
     echo "build --override_repository=${remote_java_tools.name}=${remote_java_tools}" > $out/etc/bazelrc
+    echo "build --distdir=${distDir}" >> $out/etc/bazelrc
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
@@ -509,14 +523,17 @@ stdenv.mkDerivation rec {
   '';
 
   # Save paths to hardcoded dependencies so Nix can detect them.
-  # XXX: Modified relative to upstream Nix expression.
   postFixup = ''
     mkdir -p $out/nix-support
     echo "${customBash} ${defaultShellPath}" >> $out/nix-support/depends
     # The templates get tar’d up into a .jar,
     # so nix can’t detect python is needed in the runtime closure
+    # Some of the scripts explicitly depend on Python 2.7. Otherwise, we
+    # default to using python3. Therefore, both python27 and python3 are
+    # runtime dependencies.
+    echo "${python27}" >> $out/nix-support/depends
     echo "${python3}" >> $out/nix-support/depends
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     echo "${cctools}" >> $out/nix-support/depends
   '';
 

--- a/nix/overrides/bazel/nix-hacks.patch
+++ b/nix/overrides/bazel/nix-hacks.patch
@@ -1,10 +1,12 @@
-diff -Naur a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
---- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	2019-06-12 20:39:37.420705161 -0700
-+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	2019-06-12 20:44:18.894429744 -0700
-@@ -428,24 +428,7 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+index 8e772005cd..6ffa1c919c 100644
+--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
++++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+@@ -432,25 +432,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
+       String content;
        try {
          content = FileSystemUtils.readContent(markerPath, StandardCharsets.UTF_8);
-         String markerRuleKey = readMarkerFile(content, markerData);
+-        String markerRuleKey = readMarkerFile(content, markerData);
 -        boolean verified = false;
 -        if (Preconditions.checkNotNull(ruleKey).equals(markerRuleKey)
 -            && Objects.equals(
@@ -17,19 +19,21 @@ diff -Naur a/src/main/java/com/google/devtools/build/lib/rules/repository/Reposi
 -        }
 -
 -        if (verified) {
-           return new Fingerprint().addString(content).digestAndReset();
+-          return new Fingerprint().addString(content).digestAndReset();
 -        } else {
 -          // So that we are in a consistent state if something happens while fetching the repository
 -          markerPath.delete();
 -          return null;
 -        }
++        return new Fingerprint().addString(content).digestAndReset();
        } catch (IOException e) {
          throw new RepositoryFunctionException(e, Transience.TRANSIENT);
        }
-diff -Naur a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
---- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	2019-06-12 20:39:37.538708196 -0700
-+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	2019-06-12 20:44:18.863429602 -0700
-@@ -146,7 +146,6 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+index c282d57ab6..f9b0c08627 100644
+--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
++++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+@@ -146,7 +146,6 @@ public class JavaSubprocessFactory implements SubprocessFactory {
      ProcessBuilder builder = new ProcessBuilder();
      builder.command(params.getArgv());
      if (params.getEnv() != null) {

--- a/nix/overrides/bazel/src-deps.json
+++ b/nix/overrides/bazel/src-deps.json
@@ -7,12 +7,20 @@
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip"
         ]
     },
-    "1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz": {
-        "name": "1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-        "sha256": "3ca1b3d453a977aeda60dd335feb812771addfd0d0c61751b34b9681aa4d6534",
+    "0.28.3.tar.gz": {
+        "name": "0.28.3.tar.gz",
+        "sha256": "d8c2f20deb2f6143bac792d210db1a4872102d81529fe0ea3476c1696addd7ff",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz"
+        ]
+    },
+    "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": {
+        "name": "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "sha256": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
         ]
     },
     "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": {
@@ -23,6 +31,14 @@
             "https://github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip"
         ]
     },
+    "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip": {
+        "name": "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
     "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": {
         "name": "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "sha256": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
@@ -31,29 +47,28 @@
             "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz"
         ]
     },
-    "android_tools_pkg-0.7.tar.gz": {
-        "name": "android_tools_pkg-0.7.tar.gz",
-        "sha256": "a8e48f2fdee2c34b31f45bd47ce050a75ac774f19e0a1f6694fa49fc11d88718",
+    "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz": {
+        "name": "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "sha256": "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.7.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
+        ]
+    },
+    "android_tools_pkg-0.11.tar.gz": {
+        "name": "android_tools_pkg-0.11.tar.gz",
+        "sha256": "6fc50151063bffdda700038ea7df99c89d54dc066e9377a5baff60d55d482ad2",
+        "urls": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.11.tar.gz"
         ]
     },
     "bazel_j2objc": {
         "name": "bazel_j2objc",
-        "sha256": "a36bac432d0dbd8c98249e484b2b69dd5720afa4abb58711a3c3def1c0bfa21d",
-        "strip_prefix": "j2objc-2.0.3",
+        "sha256": "8d3403b5b7db57e347c943d214577f6879e5b175c2b59b7e075c0b6453330e9b",
+        "strip_prefix": "j2objc-2.5",
         "urls": [
-            "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip",
-            "https://github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip"
-        ]
-    },
-    "bazel_rbe_toolchains": {
-        "name": "bazel_rbe_toolchains",
-        "sha256": "e2b8644caa15235a488e831264e5dcb014e2cdf3b697319bc1e9d6b0fff0b4b9",
-        "strip_prefix": "bazel_rbe_toolchains-01529a65d21abdf71635ff0c2472043a567ecded",
-        "urls": [
-            "https://mirror.bazel.build/github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz",
-            "https://github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz"
+            "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
+            "https://github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip"
         ]
     },
     "bazel_skylib": {
@@ -67,11 +82,11 @@
     },
     "bazel_toolchains": {
         "name": "bazel_toolchains",
-        "sha256": "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
-        "strip_prefix": "bazel-toolchains-cddc376d428ada2927ad359211c3e356bd9c9fbb",
+        "sha256": "d8c2f20deb2f6143bac792d210db1a4872102d81529fe0ea3476c1696addd7ff",
+        "strip_prefix": "bazel-toolchains-0.28.3",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz"
         ]
     },
     "build_bazel_rules_nodejs": {
@@ -83,6 +98,14 @@
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip"
         ]
     },
+    "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz": {
+        "name": "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
+        "sha256": "e6a76586b264f30679688f65f7e71ac112d1446681010a13bf22d9ca071f34b7",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz"
+        ]
+    },
     "com_google_googletest": {
         "name": "com_google_googletest",
         "sha256": "0fb00ff413f6b9b80ccee44a374ca7a18af7315aea72a43c62f2acd1ca74e9b5",
@@ -92,11 +115,11 @@
             "https://github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz"
         ]
     },
-    "coverage_output_generator-v1.0.zip": {
-        "name": "coverage_output_generator-v1.0.zip",
-        "sha256": "cc470e529fafb6165b5be3929ff2d99b38429b386ac100878687416603a67889",
+    "coverage_output_generator-v2.0.zip": {
+        "name": "coverage_output_generator-v2.0.zip",
+        "sha256": "3a6951051272d51613ac4c77af6ce238a3db321bf06506fde1b8866eb18a89dd",
         "urls": [
-            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v1.0.zip"
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.0.zip"
         ]
     },
     "desugar_jdk_libs": {
@@ -135,46 +158,46 @@
     },
     "io_bazel_skydoc": {
         "name": "io_bazel_skydoc",
-        "sha256": "3ca1b3d453a977aeda60dd335feb812771addfd0d0c61751b34b9681aa4d6534",
-        "strip_prefix": "skydoc-1ca560df1cf6e280f987af2f8d08a5edc7ac6b54",
+        "sha256": "e6a76586b264f30679688f65f7e71ac112d1446681010a13bf22d9ca071f34b7",
+        "strip_prefix": "skydoc-c7bbde2950769aac9a99364b0926230060a3ce04",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz"
         ]
     },
-    "java_tools_javac11_darwin-v2.0.zip": {
-        "name": "java_tools_javac11_darwin-v2.0.zip",
-        "sha256": "0ceb0c9ff91256fe33508306bc9cd9e188dcca38df78e70839d426bdaef67a38",
+    "java_tools_javac11_darwin-v6.1.zip": {
+        "name": "java_tools_javac11_darwin-v6.1.zip",
+        "sha256": "f0c488dac18f18ab1a0d18bbd65288c7a128e90a24d9c16f65bd8243f79483a0",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_darwin-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v6.1/java_tools_javac11_darwin-v6.1.zip"
         ]
     },
-    "java_tools_javac11_linux-v2.0.zip": {
-        "name": "java_tools_javac11_linux-v2.0.zip",
-        "sha256": "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99",
+    "java_tools_javac11_linux-v6.1.zip": {
+        "name": "java_tools_javac11_linux-v6.1.zip",
+        "sha256": "12f7940ed0bc4c2e82238951cdf19b4179c7dcc361d16fe40fe4266538fb4ac6",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_linux-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v6.1/java_tools_javac11_linux-v6.1.zip"
         ]
     },
-    "java_tools_javac11_windows-v2.0.zip": {
-        "name": "java_tools_javac11_windows-v2.0.zip",
-        "sha256": "2c3fc0ce7d30d60e26f4b8a36e2eadcf9e6a9d5a51b667d3d13b78db53b24251",
+    "java_tools_javac11_windows-v6.1.zip": {
+        "name": "java_tools_javac11_windows-v6.1.zip",
+        "sha256": "e2deb2efff684de78787e0bdc7620f9672d13f04a12856d8e7f677369a8e286b",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_windows-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v6.1/java_tools_javac11_windows-v6.1.zip"
         ]
     },
     "java_tools_langtools_javac10": {
         "name": "java_tools_langtools_javac10",
-        "sha256": "e379c71e051eb83e3fc9a08c9b404712707d8920ffcf1e8fd59c844965f0b0dd",
+        "sha256": "0e9c9ac5ef17869de3cb8c3497c4c0d31836ef7b63efe1690506f53783adb212",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10_v2.zip"
         ]
     },
     "java_tools_langtools_javac11": {
         "name": "java_tools_langtools_javac11",
-        "sha256": "128a63f39d3f828a761f6afcfe3c6115279336a72ea77f60d7b3acf1841c9acb",
+        "sha256": "cf0814fa002ef3d794582bb086516d8c9ed0958f83f19799cdb08949019fe4c7",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11_v2.zip"
         ]
     },
     "java_tools_langtools_javac12": {
@@ -186,9 +209,9 @@
     },
     "java_tools_langtools_javac9": {
         "name": "java_tools_langtools_javac9",
-        "sha256": "3b6bbc47256acf2f61883901e2d4e3f9b292f5fe154a6912b928805de24cb864",
+        "sha256": "d94befcfb325a9a62aebc2052e631fde2322b4df5c82a19ed260b38ba12a0ad1",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk9.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk9_v2.zip"
         ]
     },
     "jdk10-server-release-1804.tar.xz": {
@@ -344,6 +367,49 @@
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
             "https://github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip"
+        ]
+    },
+    "rules_cc": {
+        "name": "rules_cc",
+        "sha256": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "strip_prefix": "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
+        ]
+    },
+    "rules_java": {
+        "name": "rules_java",
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "strip_prefix": "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
+    "rules_pkg": {
+        "name": "rules_pkg",
+        "sha256": "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz"
+        ]
+    },
+    "rules_pkg-0.2.0.tar.gz": {
+        "name": "rules_pkg-0.2.0.tar.gz",
+        "sha256": "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz"
+        ]
+    },
+    "rules_proto": {
+        "name": "rules_proto",
+        "sha256": "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+        "strip_prefix": "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
         ]
     },
     "zulu10.2+3-jdk10.0.1-linux_x64-allmodules.tar.gz": {

--- a/nix/tools/bazel-watcher/default.nix
+++ b/nix/tools/bazel-watcher/default.nix
@@ -50,9 +50,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 =
-        "151s3k2phkdb32yxdja1q0kbxgb4alz8l9wfyzgd2mbdrkq4a62q"
-    ;
+    sha256 = "151s3k2phkdb32yxdja1q0kbxgb4alz8l9wfyzgd2mbdrkq4a62q";
   };
 
   buildAttrs = {

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -197,13 +197,11 @@ resolvePomData BazelLocations{..} sdkVersion sdkComponentVersion art =
 
 data BazelLocations = BazelLocations
     { bazelBin :: !(Path Abs Dir)
-    , bazelGenfiles :: !(Path Abs Dir)
     } deriving Show
 
 getBazelLocations :: IO BazelLocations
 getBazelLocations = do
     bazelBin <- parseAbsDir . T.unpack . T.strip . T.pack =<< System.Process.readProcess "bazel" ["info", "bazel-bin"] ""
-    bazelGenfiles <- parseAbsDir . T.unpack . T.strip . T.pack =<< System.Process.readProcess "bazel" ["info", "bazel-genfiles"] ""
     pure BazelLocations{..}
 
 splitBazelTarget :: BazelTarget -> (Text, Text)
@@ -337,9 +335,7 @@ shouldRelease (AllArtifacts allArtifacts) (PlatformDependent platformDependent) 
 
 copyToReleaseDir :: (MonadLogger m, MonadIO m) => BazelLocations -> Path Abs Dir -> Path Rel File -> Path Rel File -> m ()
 copyToReleaseDir BazelLocations{..} releaseDir inp out = do
-    binExists <- doesFileExist (bazelBin </> inp)
-    let absIn | binExists = bazelBin </> inp
-              | otherwise = bazelGenfiles </> inp
+    let absIn = bazelBin </> inp
     let absOut = releaseDir </> out
     $logInfo ("Copying " <> pathToText absIn <> " to " <> pathToText absOut)
     createDirIfMissing True (parent absOut)

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -155,7 +155,7 @@ def _daml_doctest_impl(ctx):
         damlc = ctx.executable.damlc.short_path,
         # we end up with "../haskell_hpp/bin" while we want "external/haskell_hpp/bin"
         # so we just do the replacement ourselves.
-        cpp = ctx.executable.cpp.short_path.replace("..", "external", maxsplit = 1),
+        cpp = ctx.executable.cpp.short_path.replace("..", "external", 1),
         package_name = ctx.attr.package_name,
         flags = " ".join(ctx.attr.flags),
         version_file = ctx.file.version.path,


### PR DESCRIPTION
Update to the latest Bazel version 1.1.0

- The Nix expression is taken from https://github.com/NixOS/nixpkgs/pull/71612.
- The Windows dev-env is updated.
- `rules_scala` and `rules_nixpkgs` are updated for compatibility.
- `rules_haskell` is patched for compatibility. It will be updated in a separate PR.
- Some rule attributes and providers were changed.
- Some starlark functions no longer accept certain arguments in named form (i.e. as `kwargs`).
- By default Bazel no longer uses a bash test wrapper on Windows, instead uses a C wrapper which calls the test using `CreateProcessW`. Unfortunately, various tests, including `client_server_test`, are implemented as bash scripts which cannot be executed with `CreateProcessW`. Therefore, we disable this new default and use the bash test wrapper. See [`--incompatible_windows_native_test_wrapper`](https://github.com/bazelbuild/bazel/issues/6622).
- Bazel 1.1 fixes an [issue](https://github.com/bazelbuild/bazel/issues/9390) with `cc_wrapper` not working in Cabal packages on Windows for `rules_haskell`.
- Some scala targets were including proto sources in the `deps` attribute.
    This is no longer legal in Bazel 1.1, instead these need to go into the `data` attribute.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
