### PR TITLE
Warn on trigger package id mismatch

### DIFF
--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -13,6 +13,7 @@ da_scala_library(
     resources = glob(["src/main/resources/**/*"]),
     visibility = ["//visibility:public"],
     deps = [
+        ":trigger-package-id-lib",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
@@ -28,6 +29,35 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_typelevel_paiges_core_2_12",
     ],
+)
+
+da_scala_library(
+    name = "trigger-package-id-lib",
+    srcs = [":trigger-package-id"],
+    deps = ["//daml-lf/data"],
+)
+
+# This genrule generates a Scala file containing the package id of the trigger library
+# at build time. We use that to detect mismatches and warn the user about it.
+genrule(
+    name = "trigger-package-id",
+    srcs = [
+        "//triggers/daml:daml-trigger.dar",
+        "//compiler/damlc",
+    ],
+    outs = ["com/daml/trigger/TriggerPackageIds.scala"],
+    cmd = """
+      PACKAGE_ID=$$($(location //compiler/damlc) inspect-dar $(location //triggers/daml:daml-trigger.dar) | awk '/daml-trigger-0.0.1 / {print $$2}')
+      cat << EOF > $(location com/daml/trigger/TriggerPackageIds.scala)
+package com.daml
+
+import com.digitalasset.daml.lf.data.Ref.PackageId
+
+package object trigger {
+  val EXPECTED_TRIGGER_PACKAGE_ID = PackageId.assertFromString($$PACKAGE_ID)
+}
+EOF
+    """,
 )
 
 da_scala_binary(

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -53,8 +53,6 @@ object TriggerIds {
   def fromDar(dar: Dar[(PackageId, Package)]): TriggerIds = {
     val triggerModuleName = DottedName.assertFromString("Daml.Trigger.LowLevel")
     val highlevelModuleName = DottedName.assertFromString("Daml.Trigger")
-    // We might want to just fix this at compile time at some point
-    // once we ship the trigger lib with the SDK.
     val triggerPackageId: PackageId = dar.all
       .find {
         case (pkgId, pkg) =>

--- a/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Runner.scala
@@ -53,6 +53,10 @@ class Runner(
 
   private val converter = Converter.fromDar(dar)
   private val triggerIds = TriggerIds.fromDar(dar)
+  if (triggerIds.triggerPackageId != EXPECTED_TRIGGER_PACKAGE_ID) {
+    logger.warn(
+      s"Unexpected package id for daml-trigger library: ${triggerIds.triggerPackageId}, expected ${EXPECTED_TRIGGER_PACKAGE_ID.toString}. This is most likely caused by a mismatch between the SDK version used to build your trigger and the trigger runner.")
+  }
   private val darMap: Map[PackageId, Package] = dar.all.toMap
   private val compiler = Compiler(darMap)
   private val compiledPackages =


### PR DESCRIPTION
This is fairly easy to run into so it makes sense to warn about
this. Given that I expect the trigger library will be reasonably
stable in the near future, this is only a warning rather than an
error.

fixes #3244

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
