### PR TITLE
Add GenMap to DAML-LF 1.dev spec

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -242,9 +242,9 @@ Version: 1.7
     - drop decimal builtins, namely  `ADD_DECIMAL`, `SUB_DECIMAL`, `MUL_DECIMAL`, `DIV_DECIMAL`, `ROUND_DECIMAL`, `LEQ_DECIMAL`, `LESS_DECIMAL`, `GEQ_DECIMAL`, `GREATER_DECIMAL`, `FROM_TEXT_DECIMAL`, `TO_TEXT_DECIMAL`, `INT64_TO_DECIMAL`, `DECIMAL_TO_INT64`, `EQUAL_DECIMAL`
 
   * **Add** string interning in external package references.
-    
+
   * **Add** name interning in external package references.
-    
+
   * **Add** existential ``Any`` type
     - add `'Any'` primitive type
     - add `'to_an'y` and `'from_any'` expression to convert from/to
@@ -564,14 +564,6 @@ Then we can define our kinds, types, and expressions::
        |  'Any'                                     -- BTyAny
        |  'TypeRep'                                 -- BTTypeRep
 
-<<<<<<< HEAD
-=======
-  Type constraints
-    K ::= ε                                         -- ConstraintTrivial
-       |  Eq α, K
-       |  Serial α, K
-
->>>>>>> Add GenMap to DAML-LF 1.dev
   Types (mnemonic: tau for type)
     τ, σ
       ::= α                                         -- TyVar: Type variable
@@ -2589,7 +2581,6 @@ Map functions
 
   [*Available in versions >= 1.3*]
 
-<<<<<<< HEAD
 Type Representation function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2599,7 +2590,6 @@ Type Representation function
   the second one, ``'False'`` otherwise.
 
   [*Available in versions >= 1.7*]
-=======
 
 Generic Map functions
 ~~~~~~~~~~~~~~~~~~~~~
@@ -2752,7 +2742,6 @@ defined. ::
   ——————————————————————————————————————————————————— GenEqTupleCon
   ⟨ f₁ = e₁, …, fₘ = eₘ ⟩ ~ᵥ ⟨ f₁ = e₁', …, fₘ = eₘ' ⟩
 
->>>>>>> Add GenMap to DAML-LF 1.dev
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -242,9 +242,9 @@ Version: 1.7
     - drop decimal builtins, namely  `ADD_DECIMAL`, `SUB_DECIMAL`, `MUL_DECIMAL`, `DIV_DECIMAL`, `ROUND_DECIMAL`, `LEQ_DECIMAL`, `LESS_DECIMAL`, `GEQ_DECIMAL`, `GREATER_DECIMAL`, `FROM_TEXT_DECIMAL`, `TO_TEXT_DECIMAL`, `INT64_TO_DECIMAL`, `DECIMAL_TO_INT64`, `EQUAL_DECIMAL`
 
   * **Add** string interning in external package references.
-    
+
   * **Add** name interning in external package references.
-    
+
   * **Add** existential ``Any`` type
     - add `'Any'` primitive type
     - add `'to_an'y` and `'from_any'` expression to convert from/to
@@ -564,14 +564,6 @@ Then we can define our kinds, types, and expressions::
        |  'Any'                                     -- BTyAny
        |  'TypeRep'                                 -- BTTypeRep
 
-<<<<<<< HEAD
-=======
-  Type constraints
-    K ::= ε                                         -- ConstraintTrivial
-       |  Eq α, K
-       |  Serial α, K
-
->>>>>>> Add GenMap to DAML-LF 1.dev
   Types (mnemonic: tau for type)
     τ, σ
       ::= α                                         -- TyVar: Type variable
@@ -2589,7 +2581,6 @@ Map functions
 
   [*Available in versions >= 1.3*]
 
-<<<<<<< HEAD
 Type Representation function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2599,160 +2590,6 @@ Type Representation function
   the second one, ``'False'`` otherwise.
 
   [*Available in versions >= 1.7*]
-=======
-
-Generic Map functions
-~~~~~~~~~~~~~~~~~~~~~
-
-* ``GENMAP_EMPTY : ∀ α. ∀ β. 'GenMap' α β``
-
-  Returns the empty generic map.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_INSERT : ∀ α. ∀ β.  α → β → 'GenMap' α β → 'GenMap' α β``
-
-  Inserts a new key and value in the map. If the key is already
-  present in the map, the associated value is replaced with the
-  supplied value.
-
-  This raises an error if the key is not a valid map key. Keys are
-  compared according to the rules listed below.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_LOOKUP : ∀ α. ∀ β.  α → 'GenMap' α β → 'Optional' α``
-
-  Looks up the value at a key in the map.
-
-  This raises an error if the key is not a valid map key. Keys are
-  compared according to the rules listed below.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_DELETE : ∀ α. ∀ β.  α → 'GenMap' α β → 'GenMap' α β``
-
-  Deletes a key and its value from the map. When the key is not a
-  member of the map, the original map is returned.
-
-  This raises an error if the key is not a valid map key. Keys are
-  compared according to the rules listed below.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_KEYS : ∀ α. ∀ β.  'GenMap' α β → 'List' α``
-
-  Get the list of keys in the map. The keys are returned by first-insertion
-  order, so if you insert key ``x`` before key ``y``, then ``x`` will appear
-  before ``y`` in the list.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_VALUES : ∀ α. ∀ β.  'GenMap' α β → 'List' β``
-
-  Get the list of values in the map. The values are returned in the same
-  order as ``GENMAP_KEYS``, so the ith element of ``GENMAP_KEYS`` maps to
-  the ith element of ``GENMAP_VALUES``.
-
-  [*Available in versions >= 1.dev*]
-
-* ``GENMAP_SIZE : ∀ α. ∀ β.  'GenMap' α β → 'Int64'``
-
-  Return the number of elements in the map.
-
-  [*Available in versions >= 1.dev*]
-
-
-**Validity of Keys:** A key is valid if and only if it is equivalent
-to itself according to the relation ``~ᵥ`` defined below. Attempts to
-use an invalid key in the operations above always result in a runtime
-error.
-
-Of particular note, the following values are never valid keys:
-
-* Lambda expressions ``λ x : τ . e``
-* Type abstractions ``Λ α : k . e``
-* (Partially applied) built-in functions
-* Any value containing an invalid key
-
-**Comparison of Keys:** We define here the relation ``~ᵥ`` on value
-expressions that is used for key comparison. This is a partial
-equivalence relation over all values, but a (total) equivalence
-relation over valid keys.
-
-This relation is not exposed as a builtin function, but it coincides
-with the builtin equality for any given type, if that builtin is
-defined. ::
-
-                                  ┌──────────┐
-  Generic Equivalence Relation    │ e₁ ~ᵥ e₂ │
-                                  └──────────┘
-
-  LitInt64₁ and LitInt64₂ have the same value
-  ——————————————————————————————————————————————————— GenEqLitInt64
-  LitInt64₁ ~ᵥ LitInt64₂
-
-  LitNumeric₁ and LitNumeric₂ have the same scale and value
-  ——————————————————————————————————————————————————— GenEqLitNumeric
-  LitNumeric₁ ~ᵥ LitNumeric₂
-
-  LitText₁ and LitText₂ have the same value
-  ——————————————————————————————————————————————————— GenEqLitText
-  LitText₁ ~ᵥ LitText₂
-
-  LitDate₁ and LitDate₂ have the same value
-  ——————————————————————————————————————————————————— GenEqLitDate
-  LitDate₁ ~ᵥ LitDate₂
-
-  LitTimestamp₁ and LitTimestamp₂ have the same value
-  ——————————————————————————————————————————————————— GenEqLitTimestamp
-  LitTimestamp₁ ~ᵥ LitTimestamp₂
-
-  cid₁ and cid₂ are the same
-  ——————————————————————————————————————————————————— GenEqLitContractId
-  cid₁ ~ᵥ cid₂
-
-  ——————————————————————————————————————————————————— GenEqUnit
-  () ~ᵥ ()
-
-  ——————————————————————————————————————————————————— GenEqTrue
-  'True' ~ᵥ 'True'
-
-  ——————————————————————————————————————————————————— GenEqFalse
-  'False' ~ᵥ 'False'
-
-  ——————————————————————————————————————————————————— GenEqListNil
-  'Nil' @τ₁ ~ᵥ 'Nil' @τ₂
-
-  e₁ ~ᵥ e₁'
-  e₂ ~ᵥ e₂'
-  ——————————————————————————————————————————————————— GenEqListCons
-  'Cons' @τ e₁ e₂  ~ᵥ 'Cons' @τ' e₁' e₂'
-
-  ——————————————————————————————————————————————————— GenEqOptionNone
-  'None' @τ₁ ~ᵥ 'None' @τ₂
-
-  e₁ ~ᵥ e₂
-  ——————————————————————————————————————————————————— GenEqOptionSome
-  'Some' @τ₁ e₁ ~ᵥ 'Some' @τ₂ e₂
-
-  e₁ ~ᵥ e₁'     …       eₙ ~ᵥ eₙ'
-  ——————————————————————————————————————————————————— GenEqRecCon
-  Mod:T @τ₁ … @τₙ { f₁ = e₁, …, fₙ = eₙ }
-    ~ᵥ Mod:T @τ₁' … @τₙ' { f₁ = e₁', …, fₙ = eₙ' }
-
-  e ~ᵥ e'
-  ——————————————————————————————————————————————————— GenEqVariantCon
-  Mod:T:V @τ₁ … @τₙ e ~ᵥ Mod:T:V @τ₁' … @τₙ' e'
-
-  ——————————————————————————————————————————————————— GenEqEnumCon
-  Mod:T:E ~ᵥ Mod:T:E
-
-  e₁ ~ᵥ e₁'     …       eₙ ~ᵥ eₙ'
-  ——————————————————————————————————————————————————— GenEqTupleCon
-  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩ ~ᵥ ⟨ f₁ = e₁', …, fₘ = eₘ' ⟩
-
->>>>>>> Add GenMap to DAML-LF 1.dev
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2565,7 +2565,7 @@ Map functions
 
 * ``MAP_LOOKUP : ∀ α. 'Text' → 'Map' α → 'Optional' α``
 
-  Lookups the value at a key in the map.
+  Looks up the value at a key in the map.
 
   [*Available in versions >= 1.3*]
 
@@ -2623,7 +2623,7 @@ Generic Map functions
 
 * ``GENMAP_LOOKUP : ∀ α. ∀ β.  α → 'GenMap' α β → 'Optional' α``
 
-  Lookups the value at a key in the map.
+  Looks up the value at a key in the map.
 
   This raises an error if the key is not a valid map key. Keys are
   compared according to the rules listed below.
@@ -2640,10 +2640,19 @@ Generic Map functions
 
   [*Available in versions >= 1.dev*]
 
-* ``GENMAP_LIST : ∀ α. ∀ β.  'GenMap' α β → 'List' ⟨ key: α, value: β ⟩``
+* ``GENMAP_KEYS : ∀ α. ∀ β.  'GenMap' α β → 'List' α``
 
-  Converts to a list of key/value pairs. Unlike ``'MAP_LIST'``, the output
-  list is guaranteed to be in the order that the keys were first inserted.
+  Get the list of keys in the map. The keys are returned by first-insertion
+  order, so if you insert key ``x`` before key ``y``, then ``x`` will appear
+  before ``y`` in the list.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_VALUES : ∀ α. ∀ β.  'GenMap' α β → 'List' β``
+
+  Get the list of values in the map. The values are returned in the same
+  order as ``GENMAP_KEYS``, so the ith element of ``GENMAP_KEYS`` maps to
+  the ith element of ``GENMAP_VALUES``.
 
   [*Available in versions >= 1.dev*]
 
@@ -2664,7 +2673,6 @@ Of particular note, the following values are never valid keys:
 * Lambda expressions ``λ x : τ . e``
 * Type abstractions ``Λ α : k . e``
 * (Partially applied) built-in functions
-* (Un-evaluated) Update/Scenario values
 * Any value containing an invalid key
 
 **Comparison of Keys:** We define here the relation ``~ᵥ`` on value
@@ -2673,7 +2681,8 @@ equivalence relation over all values, but a (total) equivalence
 relation over valid keys.
 
 This relation is not exposed as a builtin function, but it coincides
-with the built-in equality for any given type, if that built-in isdefined. ::
+with the builtin equality for any given type, if that builtin is
+defined. ::
 
                                   ┌──────────┐
   Generic Equivalence Relation    │ e₁ ~ᵥ e₂ │

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -242,9 +242,9 @@ Version: 1.7
     - drop decimal builtins, namely  `ADD_DECIMAL`, `SUB_DECIMAL`, `MUL_DECIMAL`, `DIV_DECIMAL`, `ROUND_DECIMAL`, `LEQ_DECIMAL`, `LESS_DECIMAL`, `GEQ_DECIMAL`, `GREATER_DECIMAL`, `FROM_TEXT_DECIMAL`, `TO_TEXT_DECIMAL`, `INT64_TO_DECIMAL`, `DECIMAL_TO_INT64`, `EQUAL_DECIMAL`
 
   * **Add** string interning in external package references.
-
+    
   * **Add** name interning in external package references.
-
+    
   * **Add** existential ``Any`` type
     - add `'Any'` primitive type
     - add `'to_an'y` and `'from_any'` expression to convert from/to
@@ -564,6 +564,14 @@ Then we can define our kinds, types, and expressions::
        |  'Any'                                     -- BTyAny
        |  'TypeRep'                                 -- BTTypeRep
 
+<<<<<<< HEAD
+=======
+  Type constraints
+    K ::= ε                                         -- ConstraintTrivial
+       |  Eq α, K
+       |  Serial α, K
+
+>>>>>>> Add GenMap to DAML-LF 1.dev
   Types (mnemonic: tau for type)
     τ, σ
       ::= α                                         -- TyVar: Type variable
@@ -2581,6 +2589,7 @@ Map functions
 
   [*Available in versions >= 1.3*]
 
+<<<<<<< HEAD
 Type Representation function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2590,6 +2599,160 @@ Type Representation function
   the second one, ``'False'`` otherwise.
 
   [*Available in versions >= 1.7*]
+=======
+
+Generic Map functions
+~~~~~~~~~~~~~~~~~~~~~
+
+* ``GENMAP_EMPTY : ∀ α. ∀ β. 'GenMap' α β``
+
+  Returns the empty generic map.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_INSERT : ∀ α. ∀ β.  α → β → 'GenMap' α β → 'GenMap' α β``
+
+  Inserts a new key and value in the map. If the key is already
+  present in the map, the associated value is replaced with the
+  supplied value.
+
+  This raises an error if the key is not a valid map key. Keys are
+  compared according to the rules listed below.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_LOOKUP : ∀ α. ∀ β.  α → 'GenMap' α β → 'Optional' α``
+
+  Looks up the value at a key in the map.
+
+  This raises an error if the key is not a valid map key. Keys are
+  compared according to the rules listed below.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_DELETE : ∀ α. ∀ β.  α → 'GenMap' α β → 'GenMap' α β``
+
+  Deletes a key and its value from the map. When the key is not a
+  member of the map, the original map is returned.
+
+  This raises an error if the key is not a valid map key. Keys are
+  compared according to the rules listed below.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_KEYS : ∀ α. ∀ β.  'GenMap' α β → 'List' α``
+
+  Get the list of keys in the map. The keys are returned by first-insertion
+  order, so if you insert key ``x`` before key ``y``, then ``x`` will appear
+  before ``y`` in the list.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_VALUES : ∀ α. ∀ β.  'GenMap' α β → 'List' β``
+
+  Get the list of values in the map. The values are returned in the same
+  order as ``GENMAP_KEYS``, so the ith element of ``GENMAP_KEYS`` maps to
+  the ith element of ``GENMAP_VALUES``.
+
+  [*Available in versions >= 1.dev*]
+
+* ``GENMAP_SIZE : ∀ α. ∀ β.  'GenMap' α β → 'Int64'``
+
+  Return the number of elements in the map.
+
+  [*Available in versions >= 1.dev*]
+
+
+**Validity of Keys:** A key is valid if and only if it is equivalent
+to itself according to the relation ``~ᵥ`` defined below. Attempts to
+use an invalid key in the operations above always result in a runtime
+error.
+
+Of particular note, the following values are never valid keys:
+
+* Lambda expressions ``λ x : τ . e``
+* Type abstractions ``Λ α : k . e``
+* (Partially applied) built-in functions
+* Any value containing an invalid key
+
+**Comparison of Keys:** We define here the relation ``~ᵥ`` on value
+expressions that is used for key comparison. This is a partial
+equivalence relation over all values, but a (total) equivalence
+relation over valid keys.
+
+This relation is not exposed as a builtin function, but it coincides
+with the builtin equality for any given type, if that builtin is
+defined. ::
+
+                                  ┌──────────┐
+  Generic Equivalence Relation    │ e₁ ~ᵥ e₂ │
+                                  └──────────┘
+
+  LitInt64₁ and LitInt64₂ have the same value
+  ——————————————————————————————————————————————————— GenEqLitInt64
+  LitInt64₁ ~ᵥ LitInt64₂
+
+  LitNumeric₁ and LitNumeric₂ have the same scale and value
+  ——————————————————————————————————————————————————— GenEqLitNumeric
+  LitNumeric₁ ~ᵥ LitNumeric₂
+
+  LitText₁ and LitText₂ have the same value
+  ——————————————————————————————————————————————————— GenEqLitText
+  LitText₁ ~ᵥ LitText₂
+
+  LitDate₁ and LitDate₂ have the same value
+  ——————————————————————————————————————————————————— GenEqLitDate
+  LitDate₁ ~ᵥ LitDate₂
+
+  LitTimestamp₁ and LitTimestamp₂ have the same value
+  ——————————————————————————————————————————————————— GenEqLitTimestamp
+  LitTimestamp₁ ~ᵥ LitTimestamp₂
+
+  cid₁ and cid₂ are the same
+  ——————————————————————————————————————————————————— GenEqLitContractId
+  cid₁ ~ᵥ cid₂
+
+  ——————————————————————————————————————————————————— GenEqUnit
+  () ~ᵥ ()
+
+  ——————————————————————————————————————————————————— GenEqTrue
+  'True' ~ᵥ 'True'
+
+  ——————————————————————————————————————————————————— GenEqFalse
+  'False' ~ᵥ 'False'
+
+  ——————————————————————————————————————————————————— GenEqListNil
+  'Nil' @τ₁ ~ᵥ 'Nil' @τ₂
+
+  e₁ ~ᵥ e₁'
+  e₂ ~ᵥ e₂'
+  ——————————————————————————————————————————————————— GenEqListCons
+  'Cons' @τ e₁ e₂  ~ᵥ 'Cons' @τ' e₁' e₂'
+
+  ——————————————————————————————————————————————————— GenEqOptionNone
+  'None' @τ₁ ~ᵥ 'None' @τ₂
+
+  e₁ ~ᵥ e₂
+  ——————————————————————————————————————————————————— GenEqOptionSome
+  'Some' @τ₁ e₁ ~ᵥ 'Some' @τ₂ e₂
+
+  e₁ ~ᵥ e₁'     …       eₙ ~ᵥ eₙ'
+  ——————————————————————————————————————————————————— GenEqRecCon
+  Mod:T @τ₁ … @τₙ { f₁ = e₁, …, fₙ = eₙ }
+    ~ᵥ Mod:T @τ₁' … @τₙ' { f₁ = e₁', …, fₙ = eₙ' }
+
+  e ~ᵥ e'
+  ——————————————————————————————————————————————————— GenEqVariantCon
+  Mod:T:V @τ₁ … @τₙ e ~ᵥ Mod:T:V @τ₁' … @τₙ' e'
+
+  ——————————————————————————————————————————————————— GenEqEnumCon
+  Mod:T:E ~ᵥ Mod:T:E
+
+  e₁ ~ᵥ e₁'     …       eₙ ~ᵥ eₙ'
+  ——————————————————————————————————————————————————— GenEqTupleCon
+  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩ ~ᵥ ⟨ f₁ = e₁', …, fₘ = eₘ' ⟩
+
+>>>>>>> Add GenMap to DAML-LF 1.dev
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR advances the implementation of #2256. 

It introduces a new `'GenMap'` primitive type in DAML-LF that generalizes the `'Map'` primitive type. Here's a comprehensive summary of the differences between the two types:

* `'GenMap'` takes two type arguments: the type is `'GenMap' k v` instead of `'Map' v`. The first type argument to `'GenMap'` is the key type for the map, where the original `'Map'` type only supports `'Text'` keys.

* All the operations on `'GenMap' k v` are the same as for `'Map' v` except:

  * They are labelled `GENMAP_EMPTY`, `GENMAP_INSERT`, `GENMAP_LOOKUP`, `GENMAP_DELETE`, `GENMAP_KEYS`, `GENMAP_VALUES`, and `GENMAP_SIZE`, instead of `MAP_*`.

  * They take two type arguments (the key type and the value type) as opposed to `MAP_*` operations that only take one type argument (the value type).

  * Because we're phasing out LF tuples, we have `GENMAP_KEYS` and `GENMAP_VALUES` instead of `GENMAP_LIST`. These return a list of keys or values in the order that the items were inserted (rather than in alphabetical order by key). This is because keys can contain Contract IDs, which do not (and cannot) have a predetermined order, and we want the output of `GENMAP_KEYS`/`GENMAP_VALUES` to be deterministic regardless of the assignment of Contract IDs.

  * `GENMAP_INSERT`, `GENMAP_LOOKUP` and `GENMAP_DELETE` cause a runtime error whenever they are passed an invalid key, unlike `MAP_*` operations which can never cause a runtime error. See below for the definition of "invalid key".

  * Key comparison for `GENMAP_INSERT`, `GENMAP_LOOKUP` and `GENMAP_DELETE` is defined according to a key comparison relation `~ᵥ` that generalizes text key equivalence. See below for the definition of this relation.

* We define a generic partial equivalence relation `~ᵥ` to be used for key comparison that generalizes the equality relation for all built-in types, and extends it to lists, optionals, enums, variants, record and tuples. It doesn't rely on type information at all, so we maintain type erasure. This relation is not exposed as a built-in operator.

* We define a key to be valid iff it is equivalent to itself according to the key comparison relation `~ᵥ`. This excludes all functions, type abstractions, update/scenario monads, and any composite value that contains them, from being considered valid keys. It also guarantees that `~ᵥ` is an equivalence relation over all valid keys.