### PR TITLE
language: parse sdk version from manifest

### DIFF
--- a/compiler/damlc/tests/src/DarReaderTest.hs
+++ b/compiler/damlc/tests/src/DarReaderTest.hs
@@ -17,17 +17,27 @@ unitTests = testGroup "testing dar reader for longer manifest lines"
     [
         testCase "multiline manifest file test" $
         assertEqual "content over multiple lines"
-            (Right [("Dalfs", "stdlib.dalf, prim.dalf"), ("Main-Dalf", "testing.dalf")])
+            (Right
+                 [ ("Dalfs", "stdlib.dalf, prim.dalf")
+                 , ("Main-Dalf", "testing.dalf")
+                 , ("Sdk-Version", "0.13.30")
+                 ])
             (parseManifestFile $ BS.unlines
                  [ "Dalfs: stdlib.da"
                  , " lf, prim.dalf"
                  , "Main-Dalf: testing.dalf"
+                 , "Sdk-Version: 0.13.30"
                  ])
     , testCase "multiline manifest file test" $
         assertEqual "all content in the same line"
-            (Right [("Dalfs", "stdlib.dalf"), ("Main-Dalf", "solution.dalf")])
+            (Right
+                 [ ("Dalfs", "stdlib.dalf")
+                 , ("Main-Dalf", "solution.dalf")
+                 , ("Sdk-Version", "0.13.29")
+                 ])
             (parseManifestFile $ BS.unlines
                 [ "Dalfs: stdlib.dalf"
                 , "Main-Dalf: solution.dalf"
+                , "Sdk-Version: 0.13.29"
                 ])
     ]


### PR DESCRIPTION
This is in preparation for the support of cross sdk imports, where we
need to know whether imports have different sdk versions or not.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
