### PR TITLE
Inline the lookup of witnesses into the main query

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,3 +10,5 @@ HEAD — ongoing
 --------------
 
 - [DAML Compiler] Reduce the memory footprint of the IDE and the command line tools (ca. 18% in our experiments).
+- [Sandbox] Further performance improvements for looking up contracts from postgres.
+


### PR DESCRIPTION
This avoids an extra roundtrip to the database by fetching
the witnesses in the same way as the signatories and observers.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
