### PR TITLE
Configure maven_install to fetch srcjars

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -136,6 +136,7 @@ def install_java_deps():
             "org.xerial:sqlite-jdbc:3.25.2",
             "uk.co.datumedge:hamcrest-json:0.2",
         ],
+        fetch_sources = True,
         # Update by executing
         # $ bazel run @unpinned_maven//:pin
         # See https://github.com/bazelbuild/rules_jvm_external#updating-maven_installjson

--- a/maven_install.json
+++ b/maven_install.json
@@ -26,6 +26,29 @@
                 "sha256": "8ea03d64b9596b4646ec462e5b4e467e81c02213be7399eb8039ed5cf8b5b487"
             },
             {
+                "coord": "ai.x:diff_2.12:jar:sources:2.0.1",
+                "file": "v1/https/repo1.maven.org/maven2/ai/x/diff_2.12/2.0.1/diff_2.12-2.0.1-sources.jar",
+                "directDependencies": [
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "org.cvogt:scala-extensions_2.12:jar:sources:0.5.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalactic:scalactic_2.12:jar:sources:3.0.5"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalactic:scalactic_2.12:jar:sources:3.0.5",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "org.cvogt:scala-extensions_2.12:jar:sources:0.5.3",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/ai/x/diff_2.12/2.0.1/diff_2.12-2.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/ai/x/diff_2.12/2.0.1/diff_2.12-2.0.1-sources.jar"
+                ],
+                "sha256": "706ab984116fdcff4315449f40e388ab5018e1947162ddd3b7918bc25539281a"
+            },
+            {
                 "coord": "args4j:args4j:2.33",
                 "file": "v1/https/repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33.jar",
                 "directDependencies": [],
@@ -35,6 +58,17 @@
                     "https://repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33.jar"
                 ],
                 "sha256": "91ddeaba0b24adce72291c618c00bbdce1c884755f6c4dba9c5c46e871c69ed6"
+            },
+            {
+                "coord": "args4j:args4j:jar:sources:2.33",
+                "file": "v1/https/repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33-sources.jar"
+                ],
+                "sha256": "a337a37bc6fc9a2d81c952f4c6ebd5db12351e994d00e112d7fe87a4dd707204"
             },
             {
                 "coord": "ch.qos.logback:logback-classic:1.2.3",
@@ -54,6 +88,23 @@
                 "sha256": "fb53f8539e7fcb8f093a56e138112056ec1dc809ebb020b59d8a36a5ebac37e0"
             },
             {
+                "coord": "ch.qos.logback:logback-classic:jar:sources:1.2.3",
+                "file": "v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar",
+                "directDependencies": [
+                    "ch.qos.logback:logback-core:jar:sources:1.2.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "ch.qos.logback:logback-core:jar:sources:1.2.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+                ],
+                "sha256": "480cb5e99519271c9256716d4be1a27054047435ff72078d9deae5c6a19f63eb"
+            },
+            {
                 "coord": "ch.qos.logback:logback-core:1.2.3",
                 "file": "v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar",
                 "directDependencies": [],
@@ -63,6 +114,17 @@
                     "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
                 ],
                 "sha256": "5946d837fe6f960c02a53eda7a6926ecc3c758bbdd69aa453ee429f858217f22"
+            },
+            {
+                "coord": "ch.qos.logback:logback-core:jar:sources:1.2.3",
+                "file": "v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+                ],
+                "sha256": "1f69b6b638ec551d26b10feeade5a2b77abe347f9759da95022f0da9a63a9971"
             },
             {
                 "coord": "co.fs2:fs2-core_2.12:1.0.0",
@@ -88,6 +150,31 @@
                     "https://repo1.maven.org/maven2/co/fs2/fs2-core_2.12/1.0.0/fs2-core_2.12-1.0.0.jar"
                 ],
                 "sha256": "00854b905839d8cbf9c9ddfa15217b96e2672eed6dd5a09e5c2e65e8c0bc359c"
+            },
+            {
+                "coord": "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/co/fs2/fs2-core_2.12/1.0.0/fs2-core_2.12-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/co/fs2/fs2-core_2.12/1.0.0/fs2-core_2.12-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/co/fs2/fs2-core_2.12/1.0.0/fs2-core_2.12-1.0.0-sources.jar"
+                ],
+                "sha256": "2f739a14ab5acea0716913bde00b2b2b25c581403bedf9c875e9b3c526dae84d"
             },
             {
                 "coord": "co.fs2:fs2-io_2.12:1.0.0",
@@ -116,6 +203,32 @@
                 "sha256": "6561bdbda5c21c96abb23518c5b723f60659fe906ca5f052590a59352a23b011"
             },
             {
+                "coord": "co.fs2:fs2-io_2.12:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/co/fs2/fs2-io_2.12/1.0.0/fs2-io_2.12-1.0.0-sources.jar",
+                "directDependencies": [
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/co/fs2/fs2-io_2.12/1.0.0/fs2-io_2.12-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/co/fs2/fs2-io_2.12/1.0.0/fs2-io_2.12-1.0.0-sources.jar"
+                ],
+                "sha256": "503c9e9709c5d42891bf10c736ee406ff4481529a2f3d33a589d018148ad8361"
+            },
+            {
                 "coord": "com.auth0:java-jwt:3.8.1",
                 "file": "v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1.jar",
                 "directDependencies": [
@@ -135,6 +248,25 @@
                 "sha256": "2f50803b515174b11f8c6803d640538ea256f0b8cb815c17bf532d5a60400000"
             },
             {
+                "coord": "com.auth0:java-jwt:jar:sources:3.8.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "commons-codec:commons-codec:jar:sources:1.12"
+                ],
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                    "commons-codec:commons-codec:jar:sources:1.12"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar"
+                ],
+                "sha256": "73e99e54327508ef5ecd96b4369e1b5932f3abc96a45b13cefdac1e9c3cbb6f8"
+            },
+            {
                 "coord": "com.beust:jcommander:1.12",
                 "file": "v1/https/repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12.jar",
                 "directDependencies": [],
@@ -144,6 +276,17 @@
                     "https://repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12.jar"
                 ],
                 "sha256": "47544b2ce3a16d88bcfdc2144200de5d1a9f26dcf21a929095ae62d889c6614b"
+            },
+            {
+                "coord": "com.beust:jcommander:jar:sources:1.12",
+                "file": "v1/https/repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12-sources.jar"
+                ],
+                "sha256": "fccb2dda4d87781535459f840af24bdbfda920b6dcac815595bb821c01f213ab"
             },
             {
                 "coord": "com.chuusai:shapeless_2.12:2.3.2",
@@ -161,6 +304,23 @@
                     "https://repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
                 ],
                 "sha256": "75926d9dd4688710ca16d852b58746dcfc013a2a1a58d1e817a27f95b2d42303"
+            },
+            {
+                "coord": "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+                ],
+                "sha256": "6c00f4454ee1250fb2385e01e02d5751bdf6594e847befab5dbe417c95dbd2b9"
             },
             {
                 "coord": "com.eed3si9n:gigahorse-core_2.12:0.3.0",
@@ -184,6 +344,29 @@
                     "https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.3.0/gigahorse-core_2.12-0.3.0.jar"
                 ],
                 "sha256": "9f198e77608a915797e9d4b5c91eedae621cecc3f25f2a551a3fa5d6bc678aa4"
+            },
+            {
+                "coord": "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.3.0/gigahorse-core_2.12-0.3.0-sources.jar",
+                "directDependencies": [
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.3.0/gigahorse-core_2.12-0.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.3.0/gigahorse-core_2.12-0.3.0-sources.jar"
+                ],
+                "sha256": "31a6c5d8599e7bd4a9c1d38e56764c80695970ba045d2e9040dc98929b22f52a"
             },
             {
                 "coord": "com.eed3si9n:gigahorse-okhttp_2.12:0.3.0",
@@ -211,6 +394,31 @@
                 "sha256": "5cf8e8bb9d90a08aa851ac066f378f83710af7823d788f837dc64f22cebcbbdf"
             },
             {
+                "coord": "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-okhttp_2.12/0.3.0/gigahorse-okhttp_2.12-0.3.0-sources.jar",
+                "directDependencies": [
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-okhttp_2.12/0.3.0/gigahorse-okhttp_2.12-0.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/gigahorse-okhttp_2.12/0.3.0/gigahorse-okhttp_2.12-0.3.0-sources.jar"
+                ],
+                "sha256": "e991af1bb7150ee6341d4fbf0305b173cf6e0af81076cbccb010a6581019ea09"
+            },
+            {
                 "coord": "com.eed3si9n:shaded-scalajson_2.12:1.0.0-M4",
                 "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/shaded-scalajson_2.12/1.0.0-M4/shaded-scalajson_2.12-1.0.0-M4.jar",
                 "directDependencies": [
@@ -224,6 +432,21 @@
                     "https://repo1.maven.org/maven2/com/eed3si9n/shaded-scalajson_2.12/1.0.0-M4/shaded-scalajson_2.12-1.0.0-M4.jar"
                 ],
                 "sha256": "264051c330fca00fe57d4b4cb767c1f6b359a5603f79f63562832125c7055a40"
+            },
+            {
+                "coord": "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/shaded-scalajson_2.12/1.0.0-M4/shaded-scalajson_2.12-1.0.0-M4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/shaded-scalajson_2.12/1.0.0-M4/shaded-scalajson_2.12-1.0.0-M4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/shaded-scalajson_2.12/1.0.0-M4/shaded-scalajson_2.12-1.0.0-M4-sources.jar"
+                ],
+                "sha256": "73400e3c769019b0ea5f5f5f94e61a1ebbc3d9b6667c455524b15967a0f4e550"
             },
             {
                 "coord": "com.eed3si9n:sjson-new-core_2.12:0.8.2",
@@ -241,6 +464,21 @@
                 "sha256": "0c67aa883ff2e703559d723dbab04e6510f0f541f5629426bf199c4719295830"
             },
             {
+                "coord": "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/sjson-new-core_2.12/0.8.2/sjson-new-core_2.12-0.8.2-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-core_2.12/0.8.2/sjson-new-core_2.12-0.8.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-core_2.12/0.8.2/sjson-new-core_2.12-0.8.2-sources.jar"
+                ],
+                "sha256": "985acefd13801f50d51e3d45c999c8eab4e4cc32a371deb733e884da20ff9225"
+            },
+            {
                 "coord": "com.eed3si9n:sjson-new-murmurhash_2.12:0.8.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/sjson-new-murmurhash_2.12/0.8.2/sjson-new-murmurhash_2.12-0.8.2.jar",
                 "directDependencies": [
@@ -256,6 +494,23 @@
                     "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-murmurhash_2.12/0.8.2/sjson-new-murmurhash_2.12-0.8.2.jar"
                 ],
                 "sha256": "c8e622c56b1c48b384d95e8ebabaff80e1bed48aef50251a4abe613238593b93"
+            },
+            {
+                "coord": "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/sjson-new-murmurhash_2.12/0.8.2/sjson-new-murmurhash_2.12-0.8.2-sources.jar",
+                "directDependencies": [
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-murmurhash_2.12/0.8.2/sjson-new-murmurhash_2.12-0.8.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-murmurhash_2.12/0.8.2/sjson-new-murmurhash_2.12-0.8.2-sources.jar"
+                ],
+                "sha256": "19adc4fb08a1a59151a928eea65e4417f222618f33248295eaacb1677a906295"
             },
             {
                 "coord": "com.eed3si9n:sjson-new-scalajson_2.12:0.8.2",
@@ -279,6 +534,27 @@
                 "sha256": "a72ea3b3331d689e5aff14edab9b33319d3d0140e9512b87568e6311786c849d"
             },
             {
+                "coord": "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/eed3si9n/sjson-new-scalajson_2.12/0.8.2/sjson-new-scalajson_2.12-0.8.2-sources.jar",
+                "directDependencies": [
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-scalajson_2.12/0.8.2/sjson-new-scalajson_2.12-0.8.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/eed3si9n/sjson-new-scalajson_2.12/0.8.2/sjson-new-scalajson_2.12-0.8.2-sources.jar"
+                ],
+                "sha256": "820565cc1911a8e1d88789344229f92fe3dcfd747793f18fcf6e120fbe15dfd3"
+            },
+            {
                 "coord": "com.fasterxml.jackson.core:jackson-annotations:2.9.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.8/jackson-annotations-2.9.8.jar",
                 "directDependencies": [],
@@ -290,6 +566,17 @@
                 "sha256": "fdca896161766ca4a2c3e06f02f6a5ede22a5b3a55606541cd2838eace08ca23"
             },
             {
+                "coord": "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.8/jackson-annotations-2.9.8-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.8/jackson-annotations-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.8/jackson-annotations-2.9.8-sources.jar"
+                ],
+                "sha256": "134c1891587aab185730b3bf74224985e24ae483bdf39f9921140b702c8fc41a"
+            },
+            {
                 "coord": "com.fasterxml.jackson.core:jackson-core:2.9.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8.jar",
                 "directDependencies": [],
@@ -299,6 +586,17 @@
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8.jar"
                 ],
                 "sha256": "d934dab0bd48994eeea2c1b493cb547158a338a80b58c4fbc8e85fb0905e105f"
+            },
+            {
+                "coord": "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8-sources.jar"
+                ],
+                "sha256": "4ab3c312f46ddf259de240515c301c99c3a478a749d0ecaaf4395a157a646b33"
             },
             {
                 "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.8",
@@ -318,6 +616,23 @@
                 "sha256": "2351c3eba73a545db9079f5d6d768347ad72666537362c8220fe3e950a55a864"
             },
             {
+                "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8"
+                ],
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8-sources.jar"
+                ],
+                "sha256": "d6b099786ebb86566c44b15b09fde8ba2055f84ca7e98c63677ba8219f04d580"
+            },
+            {
                 "coord": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.9.8/jackson-dataformat-yaml-2.9.8.jar",
                 "directDependencies": [
@@ -333,6 +648,23 @@
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.9.8/jackson-dataformat-yaml-2.9.8.jar"
                 ],
                 "sha256": "ec6c80f083d9f0f5530bae59fe7ce359e07b8b562d7e3dbe548e33c284deed22"
+            },
+            {
+                "coord": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.9.8/jackson-dataformat-yaml-2.9.8-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "org.yaml:snakeyaml:jar:sources:1.24"
+                ],
+                "dependencies": [
+                    "org.yaml:snakeyaml:jar:sources:1.24",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.9.8/jackson-dataformat-yaml-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.9.8/jackson-dataformat-yaml-2.9.8-sources.jar"
+                ],
+                "sha256": "3712cebf21f28f0e34ece8cd32b6308713db775b77c2b43024dfe8f6e1878928"
             },
             {
                 "coord": "com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.8",
@@ -353,6 +685,24 @@
                 "sha256": "a7e100dddfdd82c4fb60d0b98a753bd59ce743183b18d4a017d6584f2592df37"
             },
             {
+                "coord": "com.fasterxml.jackson.module:jackson-module-parameter-names:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-parameter-names/2.9.8/jackson-module-parameter-names-2.9.8-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8"
+                ],
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-parameter-names/2.9.8/jackson-module-parameter-names-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-parameter-names/2.9.8/jackson-module-parameter-names-2.9.8-sources.jar"
+                ],
+                "sha256": "d755b3154d216043d1001c626dd9b11ca25358171d3f448c2cf7802af3164649"
+            },
+            {
                 "coord": "com.fasterxml.jackson.module:jackson-module-paranamer:2.9.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.8/jackson-module-paranamer-2.9.8.jar",
                 "directDependencies": [
@@ -370,6 +720,25 @@
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.8/jackson-module-paranamer-2.9.8.jar"
                 ],
                 "sha256": "0beb940a273a52fd1f936f257386b82d0fe7531d280e7cf2be471019a3d1b98e"
+            },
+            {
+                "coord": "com.fasterxml.jackson.module:jackson-module-paranamer:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.8/jackson-module-paranamer-2.9.8-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:jar:sources:2.8"
+                ],
+                "dependencies": [
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:jar:sources:2.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.8/jackson-module-paranamer-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.8/jackson-module-paranamer-2.9.8-sources.jar"
+                ],
+                "sha256": "7cc99d07c302f3cf350bb7153618f201583a026d041de57b510adfd6d9411ea5"
             },
             {
                 "coord": "com.fasterxml.jackson.module:jackson-module-scala_2.12:2.9.8",
@@ -396,6 +765,30 @@
                 "sha256": "3b6ca631f29397cb68b80b20cc8bd428fcd59ef6bc3a9ea7a1937e9af2455ad9"
             },
             {
+                "coord": "com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:sources:2.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.9.8/jackson-module-scala_2.12-2.9.8-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.module:jackson-module-paranamer:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.thoughtworks.paranamer:paranamer:jar:sources:2.8",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.module:jackson-module-paranamer:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.9.8/jackson-module-scala_2.12-2.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.9.8/jackson-module-scala_2.12-2.9.8-sources.jar"
+                ],
+                "sha256": "04b65a433a771698e75a05370c11f807734b9b63bdf52761922da38b82cbba3e"
+            },
+            {
                 "coord": "com.github.ben-manes.caffeine:caffeine:2.6.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.6.2/caffeine-2.6.2.jar",
                 "directDependencies": [],
@@ -405,6 +798,17 @@
                     "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.6.2/caffeine-2.6.2.jar"
                 ],
                 "sha256": "e77a4457735f075158dbd021c7661797dd485695fc4ed92dfdde34d4714d9750"
+            },
+            {
+                "coord": "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.6.2/caffeine-2.6.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.6.2/caffeine-2.6.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.6.2/caffeine-2.6.2-sources.jar"
+                ],
+                "sha256": "a4948be794cce8d0b998308fd402e73337b6b3c419c21388faf72f76ac9f7a19"
             },
             {
                 "coord": "com.github.blemale:scaffeine_2.12:2.5.0",
@@ -424,6 +828,25 @@
                     "https://repo1.maven.org/maven2/com/github/blemale/scaffeine_2.12/2.5.0/scaffeine_2.12-2.5.0.jar"
                 ],
                 "sha256": "5e728ecda98f39e682f2b86d62b79be806b458b8ee0631d2cd8a30df9e8dbd9d"
+            },
+            {
+                "coord": "com.github.blemale:scaffeine_2.12:jar:sources:2.5.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/blemale/scaffeine_2.12/2.5.0/scaffeine_2.12-2.5.0-sources.jar",
+                "directDependencies": [
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/blemale/scaffeine_2.12/2.5.0/scaffeine_2.12-2.5.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/blemale/scaffeine_2.12/2.5.0/scaffeine_2.12-2.5.0-sources.jar"
+                ],
+                "sha256": "9029056a1497c7b80ca68fbb9f1164516ba36365eb940521c0e6a16fc6ab08cd"
             },
             {
                 "coord": "com.github.cb372:scalacache-caffeine_2.12:0.20.0",
@@ -448,6 +871,28 @@
                 "sha256": "41dca753d161ab77973f16b899c2d3f729d3845f9657ec4e17d7c9e586d67f95"
             },
             {
+                "coord": "com.github.cb372:scalacache-caffeine_2.12:jar:sources:0.20.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/cb372/scalacache-caffeine_2.12/0.20.0/scalacache-caffeine_2.12-0.20.0-sources.jar",
+                "directDependencies": [
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                    "com.github.cb372:scalacache-core_2.12:jar:sources:0.20.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.github.cb372:scalacache-core_2.12:jar:sources:0.20.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/cb372/scalacache-caffeine_2.12/0.20.0/scalacache-caffeine_2.12-0.20.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/cb372/scalacache-caffeine_2.12/0.20.0/scalacache-caffeine_2.12-0.20.0-sources.jar"
+                ],
+                "sha256": "9ff8e6d9b602fd1ad7d018e8b6266ee1e5a9280a4ea11b663366b2cee175734b"
+            },
+            {
                 "coord": "com.github.cb372:scalacache-core_2.12:0.20.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/cb372/scalacache-core_2.12/0.20.0/scalacache-core_2.12-0.20.0.jar",
                 "directDependencies": [
@@ -467,6 +912,25 @@
                 "sha256": "bdb6b483063947dc59fe45449fd0fc50a2ae8fde8f709c05a7f137a4b98a17fe"
             },
             {
+                "coord": "com.github.cb372:scalacache-core_2.12:jar:sources:0.20.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/cb372/scalacache-core_2.12/0.20.0/scalacache-core_2.12-0.20.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/cb372/scalacache-core_2.12/0.20.0/scalacache-core_2.12-0.20.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/cb372/scalacache-core_2.12/0.20.0/scalacache-core_2.12-0.20.0-sources.jar"
+                ],
+                "sha256": "76e20c7a3eb5ddbd9de617440fbc3cfb87907ecb27e1f79283a7f91e0e459389"
+            },
+            {
                 "coord": "com.github.ghik:silencer-lib_2.12:1.3.1",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.12/1.3.1/silencer-lib_2.12-1.3.1.jar",
                 "directDependencies": [
@@ -480,6 +944,21 @@
                     "https://repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.12/1.3.1/silencer-lib_2.12-1.3.1.jar"
                 ],
                 "sha256": "66a5d76822d536ee261f8da2e89821f2893cf92a1d344fc3b1586debe2e7d4e7"
+            },
+            {
+                "coord": "com.github.ghik:silencer-lib_2.12:jar:sources:1.3.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.12/1.3.1/silencer-lib_2.12-1.3.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.12/1.3.1/silencer-lib_2.12-1.3.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.12/1.3.1/silencer-lib_2.12-1.3.1-sources.jar"
+                ],
+                "sha256": "9e45308c71dc3fc1a0019b152ba57f9e5c782e71d3c8a1a51dd0429d9d53fef9"
             },
             {
                 "coord": "com.github.ghik:silencer-plugin_2.12:1.3.1",
@@ -501,6 +980,27 @@
                     "https://repo1.maven.org/maven2/com/github/ghik/silencer-plugin_2.12/1.3.1/silencer-plugin_2.12-1.3.1.jar"
                 ],
                 "sha256": "082da2de307d68da58ef262a606d1f6ea49865f4383306e16a82821c2f4e3d90"
+            },
+            {
+                "coord": "com.github.ghik:silencer-plugin_2.12:jar:sources:1.3.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/ghik/silencer-plugin_2.12/1.3.1/silencer-plugin_2.12-1.3.1-sources.jar",
+                "directDependencies": [
+                    "com.github.ghik:silencer-lib_2.12:jar:sources:1.3.1",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.github.ghik:silencer-lib_2.12:jar:sources:1.3.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/ghik/silencer-plugin_2.12/1.3.1/silencer-plugin_2.12-1.3.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/ghik/silencer-plugin_2.12/1.3.1/silencer-plugin_2.12-1.3.1-sources.jar"
+                ],
+                "sha256": "d03611e559c72522ed9078940d810032b39dc1b8e86d01af4041115a1764be8e"
             },
             {
                 "coord": "com.github.jnr:jffi:1.2.15",
@@ -525,6 +1025,17 @@
                 "sha256": "c702a59929c1ad8b3b655c852492f153baeffdd251f0c68342d77df87b8ffabb"
             },
             {
+                "coord": "com.github.jnr:jffi:jar:sources:1.2.15",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jffi/1.2.15/jffi-1.2.15-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.15/jffi-1.2.15-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.15/jffi-1.2.15-sources.jar"
+                ],
+                "sha256": "c57482f4fd501f33c94a77dda3d69bb51b2d7fcbbe15a1feb6ebacbf069ac65d"
+            },
+            {
                 "coord": "com.github.jnr:jnr-constants:0.9.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.9.8/jnr-constants-0.9.8.jar",
                 "directDependencies": [],
@@ -534,6 +1045,17 @@
                     "https://repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.9.8/jnr-constants-0.9.8.jar"
                 ],
                 "sha256": "bcd68e9b3d3fb61cd1dc868897fcbd5380fa091092575c343dfd98d34715cef3"
+            },
+            {
+                "coord": "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.9.8/jnr-constants-0.9.8-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.9.8/jnr-constants-0.9.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.9.8/jnr-constants-0.9.8-sources.jar"
+                ],
+                "sha256": "a12f35c5a6bcda084eeb29fece48d4c050e94744bbfac7671479ca53264fa701"
             },
             {
                 "coord": "com.github.jnr:jnr-ffi:2.1.4",
@@ -565,6 +1087,33 @@
                 "sha256": "64745a3de74257eef1d32af7cf98c4928be0f6c5d72c11729cd500db21c5d478"
             },
             {
+                "coord": "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-ffi/2.1.4/jnr-ffi-2.1.4-sources.jar",
+                "directDependencies": [
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/jnr/jnr-ffi/2.1.4/jnr-ffi-2.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/jnr/jnr-ffi/2.1.4/jnr-ffi-2.1.4-sources.jar"
+                ],
+                "sha256": "1986559968e69c12a2327e772a8cc5ef0d985fe1cf87c10a7f0cd7da16655fc0"
+            },
+            {
                 "coord": "com.github.jnr:jnr-posix:3.0.41",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.0.41/jnr-posix-3.0.41.jar",
                 "directDependencies": [
@@ -590,6 +1139,30 @@
                 "sha256": "82a3fd116ffca4cf135c46eda3e377bb87d06f43484ba1bc2e9e1bfee5c7a881"
             },
             {
+                "coord": "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.0.41/jnr-posix-3.0.41-sources.jar",
+                "directDependencies": [
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.0.41/jnr-posix-3.0.41-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.0.41/jnr-posix-3.0.41-sources.jar"
+                ],
+                "sha256": "23f7162f72f6040215e6a184832a63bf87f3bb2efb9daec39d18b46d35f674e5"
+            },
+            {
                 "coord": "com.github.jnr:jnr-x86asm:1.0.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar",
                 "directDependencies": [],
@@ -599,6 +1172,17 @@
                     "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar"
                 ],
                 "sha256": "39f3675b910e6e9b93825f8284bec9f4ad3044cd20a6f7c8ff9e2f8695ebf21e"
+            },
+            {
+                "coord": "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2-sources.jar"
+                ],
+                "sha256": "3c983efd496f95ea5382ca014f96613786826136e0ce13d5c1cbc3097ea92ca0"
             },
             {
                 "coord": "com.github.mpilquist:simulacrum_2.12:0.10.0",
@@ -618,6 +1202,23 @@
                 "sha256": "ab973ec7cf3ac1cbe11a3d866aae7b567bb4b2a7f038b9ee21ba3ce6b177613e"
             },
             {
+                "coord": "com.github.mpilquist:simulacrum_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/mpilquist/simulacrum_2.12/0.10.0/simulacrum_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/mpilquist/simulacrum_2.12/0.10.0/simulacrum_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/mpilquist/simulacrum_2.12/0.10.0/simulacrum_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "170547db609a0764fe3ad159f3e9882579c3e2d4104db5106777859e8d607b67"
+            },
+            {
                 "coord": "com.github.nscala-time:nscala-time_2.12.0-RC1:2.14.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/nscala-time/nscala-time_2.12.0-RC1/2.14.0/nscala-time_2.12.0-RC1-2.14.0.jar",
                 "directDependencies": [
@@ -635,6 +1236,25 @@
                     "https://repo1.maven.org/maven2/com/github/nscala-time/nscala-time_2.12.0-RC1/2.14.0/nscala-time_2.12.0-RC1-2.14.0.jar"
                 ],
                 "sha256": "ea42cc054a6354fde6e685e9d9f78583bf0338cb580938a307078e7df0ea6375"
+            },
+            {
+                "coord": "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/nscala-time/nscala-time_2.12.0-RC1/2.14.0/nscala-time_2.12.0-RC1-2.14.0-sources.jar",
+                "directDependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "joda-time:joda-time:jar:sources:2.9.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/nscala-time/nscala-time_2.12.0-RC1/2.14.0/nscala-time_2.12.0-RC1-2.14.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/nscala-time/nscala-time_2.12.0-RC1/2.14.0/nscala-time_2.12.0-RC1-2.14.0-sources.jar"
+                ],
+                "sha256": "990f93ad1b513dde9fdd9c3c1b0b6b0f56c30c96d451a4cbedde9498ad634df0"
             },
             {
                 "coord": "com.github.pureconfig:pureconfig-macros_2.12:0.8.0",
@@ -657,6 +1277,28 @@
                     "https://repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
                 ],
                 "sha256": "71c2e471482e04442acb7db815c52f922ba62329faba3556328e7c82d9838f45"
+            },
+            {
+                "coord": "com.github.pureconfig:pureconfig-macros_2.12:jar:sources:0.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+                ],
+                "sha256": "dc4141afa07a781c26e06cc19f506ee018e72dcf3890052485a451b1be1affba"
             },
             {
                 "coord": "com.github.pureconfig:pureconfig_2.12:0.8.0",
@@ -684,6 +1326,31 @@
                 "sha256": "9927a69ffd57754a9e9538d87eb89cf07b70a26fec05ad53bb0ce69c90870bbb"
             },
             {
+                "coord": "com.github.pureconfig:pureconfig_2.12:jar:sources:0.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar",
+                "directDependencies": [
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "com.github.pureconfig:pureconfig-macros_2.12:jar:sources:0.8.0",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.github.pureconfig:pureconfig-macros_2.12:jar:sources:0.8.0",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+                ],
+                "sha256": "4c40b2bed48780a2b51b98a3b3c4757b872405d56a40845dc1114c7c0ca26390"
+            },
+            {
                 "coord": "com.github.scopt:scopt_2.12:3.7.1",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.7.1/scopt_2.12-3.7.1.jar",
                 "directDependencies": [
@@ -697,6 +1364,21 @@
                     "https://repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.7.1/scopt_2.12-3.7.1.jar"
                 ],
                 "sha256": "41c77bfc41a9492a9aa0760fa873cf99289595ff97fe761e28726e00b44f9e6a"
+            },
+            {
+                "coord": "com.github.scopt:scopt_2.12:jar:sources:3.7.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.7.1/scopt_2.12-3.7.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.7.1/scopt_2.12-3.7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.7.1/scopt_2.12-3.7.1-sources.jar"
+                ],
+                "sha256": "04b53da21b8d623dabcae8618075713ae01a731e201df639ab2eec279b232014"
             },
             {
                 "coord": "com.github.stefanbirkner:system-rules:1.17.2",
@@ -715,6 +1397,22 @@
                 "sha256": "83f2fe84b4c4ad8b2a2a0f4d369cb1d60817de7d29438df3c5cb175b716a936f"
             },
             {
+                "coord": "com.github.stefanbirkner:system-rules:jar:sources:1.17.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/stefanbirkner/system-rules/1.17.2/system-rules-1.17.2-sources.jar",
+                "directDependencies": [
+                    "junit:junit-dep:jar:sources:4.10"
+                ],
+                "dependencies": [
+                    "junit:junit-dep:jar:sources:4.10",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/github/stefanbirkner/system-rules/1.17.2/system-rules-1.17.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/stefanbirkner/system-rules/1.17.2/system-rules-1.17.2-sources.jar"
+                ],
+                "sha256": "c9ca9399e12ad89d298f155a21a74af5d5478ee1e8556f70a24303a72272b916"
+            },
+            {
                 "coord": "com.github.zafarkhaja:java-semver:0.9.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0.jar",
                 "directDependencies": [],
@@ -726,6 +1424,17 @@
                 "sha256": "2218c73b40f9af98b570d084420c1b4a81332297bd7fc27ddd552e903be8e93c"
             },
             {
+                "coord": "com.github.zafarkhaja:java-semver:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/github/zafarkhaja/java-semver/0.9.0/java-semver-0.9.0-sources.jar"
+                ],
+                "sha256": "9fc828d4be717d5c899ecf5a23e94c915bc6ab728dcfe261ef7f4ab338b3ff93"
+            },
+            {
                 "coord": "com.google.android:annotations:4.1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
                 "directDependencies": [],
@@ -735,6 +1444,17 @@
                     "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
                 ],
                 "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15"
+            },
+            {
+                "coord": "com.google.android:annotations:jar:sources:4.1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar"
+                ],
+                "sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40"
             },
             {
                 "coord": "com.google.api.grpc:proto-google-common-protos:1.12.0",
@@ -752,6 +1472,21 @@
                 "sha256": "bd60cd7a423b00fb824c27bdd0293aaf4781be1daba6ed256311103fb4b84108"
             },
             {
+                "coord": "com.google.api.grpc:proto-google-common-protos:jar:sources:1.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.12.0/proto-google-common-protos-1.12.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "com.google.protobuf:protobuf-java",
+                    "com.google.api:api-common"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.12.0/proto-google-common-protos-1.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.12.0/proto-google-common-protos-1.12.0-sources.jar"
+                ],
+                "sha256": "936fdc055855a956ef82afb1b408bd0bd5ea5d040fe6f6fc25c4955879db649a"
+            },
+            {
                 "coord": "com.google.code.findbugs:jsr305:3.0.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
                 "directDependencies": [],
@@ -761,6 +1496,17 @@
                     "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
                 ],
                 "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
+            },
+            {
+                "coord": "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+                ],
+                "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b"
             },
             {
                 "coord": "com.google.code.gson:gson:2.8.2",
@@ -774,6 +1520,17 @@
                 "sha256": "b7134929f7cc7c04021ec1cc27ef63ab907e410cf0588e397b8851181eb91092"
             },
             {
+                "coord": "com.google.code.gson:gson:jar:sources:2.8.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2-sources.jar"
+                ],
+                "sha256": "1c291a2fe0867d66ef86832e014889a398a5c5b8e823206324a782b212df0df3"
+            },
+            {
                 "coord": "com.google.errorprone:error_prone_annotations:2.3.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar",
                 "directDependencies": [],
@@ -783,6 +1540,17 @@
                     "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.jar"
                 ],
                 "sha256": "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d"
+            },
+            {
+                "coord": "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2-sources.jar"
+                ],
+                "sha256": "7ce688ed1582a67097228c050192b7cfd00479a81d2b921f7cd5116994f1402d"
             },
             {
                 "coord": "com.google.guava:guava:24.0-jre",
@@ -808,6 +1576,29 @@
                 "sha256": "e0274470b16ba1154e926b5f54ef8ae159197fbc356406bda9b261ba67e3e599"
             },
             {
+                "coord": "com.google.guava:guava:jar:sources:24.0-jre",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/guava/guava/24.0-jre/guava-24.0-jre-sources.jar",
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/google/guava/guava/24.0-jre/guava-24.0-jre-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/guava/guava/24.0-jre/guava-24.0-jre-sources.jar"
+                ],
+                "sha256": "21fbd6a606c140cfd09400b9b0a5524da1e1cdda11544ce733a4795bb9340e85"
+            },
+            {
                 "coord": "com.google.j2objc:j2objc-annotations:1.1",
                 "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
                 "directDependencies": [],
@@ -817,6 +1608,17 @@
                     "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
                 ],
                 "sha256": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6"
+            },
+            {
+                "coord": "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1-sources.jar"
+                ],
+                "sha256": "2cd9022a77151d0b574887635cdfcdf3b78155b602abc89d7f8e62aba55cfb4f"
             },
             {
                 "coord": "com.google.protobuf:protobuf-java-util:3.7.1",
@@ -841,6 +1643,28 @@
                 "sha256": "818608098c3b959482a6ce785e016192c25719c1c1c44971bad68180d3df3e9f"
             },
             {
+                "coord": "com.google.protobuf:protobuf-java-util:jar:sources:3.7.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.7.1/protobuf-java-util-3.7.1-sources.jar",
+                "directDependencies": [
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0"
+                ],
+                "dependencies": [
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "com.google.code.gson:gson:jar:sources:2.8.2"
+                ],
+                "exclusions": [
+                    "com.google.guava:guava"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.7.1/protobuf-java-util-3.7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.7.1/protobuf-java-util-3.7.1-sources.jar"
+                ],
+                "sha256": "7407fca0162b7bb22e02af5578fe9517f9e0d5e011d10add83485fda89f6b43b"
+            },
+            {
                 "coord": "com.google.protobuf:protobuf-java:3.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0.jar",
                 "directDependencies": [],
@@ -850,6 +1674,17 @@
                     "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0.jar"
                 ],
                 "sha256": "94ba90a869ddad07eb49afaa8f39e676c2554b5b1c417ad9e1188257e79be60f"
+            },
+            {
+                "coord": "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0-sources.jar"
+                ],
+                "sha256": "1982b2a96f752cf0d64c3066b5e9e4016f9cc825591f3d1a9c40a017203fcb2f"
             },
             {
                 "coord": "com.h2database:h2:1.4.199",
@@ -863,6 +1698,17 @@
                 "sha256": "3125a16743bc6b4cfbb61abba783203f1fb68230aa0fdc97898f796f99a5d42e"
             },
             {
+                "coord": "com.h2database:h2:jar:sources:1.4.199",
+                "file": "v1/https/repo1.maven.org/maven2/com/h2database/h2/1.4.199/h2-1.4.199-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/h2database/h2/1.4.199/h2-1.4.199-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/h2database/h2/1.4.199/h2-1.4.199-sources.jar"
+                ],
+                "sha256": "88b730bd05e6be6186e814e04aeafc08b119ce0c394cea9e7ed3cec5e7330ac5"
+            },
+            {
                 "coord": "com.jcraft:jsch:0.1.54",
                 "file": "v1/https/repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54.jar",
                 "directDependencies": [],
@@ -872,6 +1718,17 @@
                     "https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54.jar"
                 ],
                 "sha256": "92eb273a3316762478fdd4fe03a0ce1842c56f496c9c12fe1235db80450e1fdb"
+            },
+            {
+                "coord": "com.jcraft:jsch:jar:sources:0.1.54",
+                "file": "v1/https/repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.54/jsch-0.1.54-sources.jar"
+                ],
+                "sha256": "49d021dd58f6b455046a07331a68a5e647df354d7f6961b73df298203c43f44a"
             },
             {
                 "coord": "com.jsuereth:scala-arm_2.12:2.0",
@@ -887,6 +1744,21 @@
                     "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0.jar"
                 ],
                 "sha256": "da57db2ca312fed028689764de75dc28dbabe76e211af4cda86b567593713f10"
+            },
+            {
+                "coord": "com.jsuereth:scala-arm_2.12:jar:sources:2.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/jsuereth/scala-arm_2.12/2.0/scala-arm_2.12-2.0-sources.jar"
+                ],
+                "sha256": "2f41c0e6ac265026c0630ab413b40848da7c30c8f2deb54b75393215e2219d27"
             },
             {
                 "coord": "com.kohlschutter.junixsocket:junixsocket-common:2.0.4",
@@ -916,6 +1788,35 @@
                     "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4.jar"
                 ],
                 "sha256": "afc37615ecf7fadff74d29afb443fe4f633d396646d89d825e8224a277839f60"
+            },
+            {
+                "coord": "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar",
+                "directDependencies": [
+                    "log4j:log4j:jar:sources:1.2.17"
+                ],
+                "dependencies": [
+                    "log4j:log4j:jar:sources:1.2.17"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar"
+                ],
+                "sha256": "77a47cc4685c93df44b00679fbf9bcf1ca0c8ff642125694f2e02ab93081d23c"
+            },
+            {
+                "coord": "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "log4j:log4j"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.0.4/junixsocket-common-2.0.4-sources.jar"
+                ],
+                "sha256": "77a47cc4685c93df44b00679fbf9bcf1ca0c8ff642125694f2e02ab93081d23c"
             },
             {
                 "coord": "com.kohlschutter.junixsocket:junixsocket-native-common:2.0.4",
@@ -957,6 +1858,45 @@
                 "sha256": "f763b85ec153d9530907474e7f206ca52b287037d704bacedda38dd5c4d0f60c"
             },
             {
+                "coord": "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar",
+                "directDependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2"
+                ],
+                "dependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2"
+                ],
+                "exclusions": [
+                    "log4j:log4j"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar"
+                ],
+                "sha256": "879e7f3dbceafe8fb77f779d3373952fec32f399faf3ee8134719be05f0dfae7"
+            },
+            {
+                "coord": "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar",
+                "directDependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "log4j:log4j:jar:sources:1.2.17",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2"
+                ],
+                "dependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "log4j:log4j:jar:sources:1.2.17"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.0.4/junixsocket-native-common-2.0.4-sources.jar"
+                ],
+                "sha256": "879e7f3dbceafe8fb77f779d3373952fec32f399faf3ee8134719be05f0dfae7"
+            },
+            {
                 "coord": "com.lihaoyi:fansi_2.12:0.2.5",
                 "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.12/0.2.5/fansi_2.12-0.2.5.jar",
                 "directDependencies": [
@@ -974,6 +1914,23 @@
                 "sha256": "7d752240ec724e7370903c25b69088922fa3fb6831365db845cd72498f826eca"
             },
             {
+                "coord": "com.lihaoyi:fansi_2.12:jar:sources:0.2.5",
+                "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.12/0.2.5/fansi_2.12-0.2.5-sources.jar",
+                "directDependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/lihaoyi/fansi_2.12/0.2.5/fansi_2.12-0.2.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/lihaoyi/fansi_2.12/0.2.5/fansi_2.12-0.2.5-sources.jar"
+                ],
+                "sha256": "15ba86e9c7bb83bddab0470a48a349c0f1b90bb2cd1c7d16f09cee6ba40ca95f"
+            },
+            {
                 "coord": "com.lihaoyi:fastparse_2.12:2.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/2.1.3/fastparse_2.12-2.1.3.jar",
                 "directDependencies": [
@@ -988,6 +1945,22 @@
                     "https://repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/2.1.3/fastparse_2.12-2.1.3.jar"
                 ],
                 "sha256": "e8b831a843c0eb5105d42e4b6febfc772b3aed3a853a899e6c8196e9ecc057df"
+            },
+            {
+                "coord": "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/2.1.3/fastparse_2.12-2.1.3-sources.jar",
+                "directDependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/2.1.3/fastparse_2.12-2.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/2.1.3/fastparse_2.12-2.1.3-sources.jar"
+                ],
+                "sha256": "d7d33157d9dc83d3dd2cec6b4835bede4ce7b7d5e0bef6a08ff6c9e0efe78dd9"
             },
             {
                 "coord": "com.lihaoyi:pprint_2.12:0.5.3",
@@ -1009,6 +1982,25 @@
                 "sha256": "2e18aa0884870537bf5c562255fc759d4ebe360882b5cb2141b30eda4034c71d"
             },
             {
+                "coord": "com.lihaoyi:pprint_2.12:jar:sources:0.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.12/0.5.3/pprint_2.12-0.5.3-sources.jar",
+                "directDependencies": [
+                    "com.lihaoyi:fansi_2.12:jar:sources:0.2.5",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.lihaoyi:fansi_2.12:jar:sources:0.2.5"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/lihaoyi/pprint_2.12/0.5.3/pprint_2.12-0.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/lihaoyi/pprint_2.12/0.5.3/pprint_2.12-0.5.3-sources.jar"
+                ],
+                "sha256": "41898c25987f7023fe1dafed7639eebd1653f1bf82ba4f4381bc7ef6c50e6084"
+            },
+            {
                 "coord": "com.lihaoyi:sourcecode_2.12:0.1.7",
                 "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.12/0.1.7/sourcecode_2.12-0.1.7.jar",
                 "directDependencies": [
@@ -1024,6 +2016,21 @@
                 "sha256": "f07d79f0751ac275cc09b92caf3618f0118d153da7868b8f0c9397ce93c5f926"
             },
             {
+                "coord": "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                "file": "v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.12/0.1.7/sourcecode_2.12-0.1.7-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.12/0.1.7/sourcecode_2.12-0.1.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.12/0.1.7/sourcecode_2.12-0.1.7-sources.jar"
+                ],
+                "sha256": "7d0bb8c2de326485ffb02da7fca2fedd814b1ece6a86e1325594d593e5eaba63"
+            },
+            {
                 "coord": "com.lmax:disruptor:3.3.6",
                 "file": "v1/https/repo1.maven.org/maven2/com/lmax/disruptor/3.3.6/disruptor-3.3.6.jar",
                 "directDependencies": [],
@@ -1033,6 +2040,17 @@
                     "https://repo1.maven.org/maven2/com/lmax/disruptor/3.3.6/disruptor-3.3.6.jar"
                 ],
                 "sha256": "8c5df12a17f614464ccacc9b7c4935e5f16e694b7788e714cde4b7587d5dd266"
+            },
+            {
+                "coord": "com.lmax:disruptor:jar:sources:3.3.6",
+                "file": "v1/https/repo1.maven.org/maven2/com/lmax/disruptor/3.3.6/disruptor-3.3.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/lmax/disruptor/3.3.6/disruptor-3.3.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/lmax/disruptor/3.3.6/disruptor-3.3.6-sources.jar"
+                ],
+                "sha256": "4b0640f3a400e434419ed772339eb8f0578a571132f1cda7bbe3eb910356e1a0"
             },
             {
                 "coord": "com.sparkjava:spark-core:2.7.2",
@@ -1069,6 +2087,40 @@
                 "sha256": "d655bf54621ce406478b7ee513c469796fb540893b67148661320385639604a7"
             },
             {
+                "coord": "com.sparkjava:spark-core:jar:sources:2.7.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/sparkjava/spark-core/2.7.2/spark-core-2.7.2-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.eclipse.jetty.websocket:websocket-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-webapp:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-client:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-client:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-webapp:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/sparkjava/spark-core/2.7.2/spark-core-2.7.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/sparkjava/spark-core/2.7.2/spark-core-2.7.2-sources.jar"
+                ],
+                "sha256": "10bcbf3afdb0e68fa90b5ecd6ab0784ca7374e83298cc764692d7c04b3a05194"
+            },
+            {
                 "coord": "com.squareup.okhttp3:okhttp-urlconnection:3.7.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-urlconnection/3.7.0/okhttp-urlconnection-3.7.0.jar",
                 "directDependencies": [
@@ -1083,6 +2135,22 @@
                     "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-urlconnection/3.7.0/okhttp-urlconnection-3.7.0.jar"
                 ],
                 "sha256": "4631582b6818b6c8bdb0bca13b3ba126d2787969d33693d0f3912f1225fde3ec"
+            },
+            {
+                "coord": "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-urlconnection/3.7.0/okhttp-urlconnection-3.7.0-sources.jar",
+                "directDependencies": [
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1"
+                ],
+                "dependencies": [
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-urlconnection/3.7.0/okhttp-urlconnection-3.7.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-urlconnection/3.7.0/okhttp-urlconnection-3.7.0-sources.jar"
+                ],
+                "sha256": "f9526df9ab982e83fd184ad55d3c1b46a027d840108de9c55811d973c33013dc"
             },
             {
                 "coord": "com.squareup.okhttp3:okhttp:3.9.1",
@@ -1100,6 +2168,21 @@
                 "sha256": "a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e"
             },
             {
+                "coord": "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1-sources.jar",
+                "directDependencies": [
+                    "com.squareup.okio:okio:jar:sources:1.13.0"
+                ],
+                "dependencies": [
+                    "com.squareup.okio:okio:jar:sources:1.13.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1-sources.jar"
+                ],
+                "sha256": "bc484ee6aa958ebe683ae90e0f25484ac8bb626b769805ee4d5575dd06339f12"
+            },
+            {
                 "coord": "com.squareup.okio:okio:1.13.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0.jar",
                 "directDependencies": [],
@@ -1111,6 +2194,17 @@
                 "sha256": "734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850"
             },
             {
+                "coord": "com.squareup.okio:okio:jar:sources:1.13.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0-sources.jar"
+                ],
+                "sha256": "b0305445ad4001639413951837a2248c5e9ca28386fbae2e31e1556f7710c5a8"
+            },
+            {
                 "coord": "com.squareup:javapoet:1.11.1",
                 "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar",
                 "directDependencies": [],
@@ -1120,6 +2214,17 @@
                     "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"
                 ],
                 "sha256": "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90"
+            },
+            {
+                "coord": "com.squareup:javapoet:jar:sources:1.11.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1-sources.jar"
+                ],
+                "sha256": "63d3187d924582b1afe9eb171e725d27a7e15603513890de0f8804a7fc07e9ac"
             },
             {
                 "coord": "com.storm-enroute:scalameter-core_2.12:0.10.1",
@@ -1145,6 +2250,31 @@
                     "https://repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.12/0.10.1/scalameter-core_2.12-0.10.1.jar"
                 ],
                 "sha256": "c78b91b5089622e2ae5b73f73eaafb8e9bd9cd250b80e42574e13dbce0c4cab8"
+            },
+            {
+                "coord": "com.storm-enroute:scalameter-core_2.12:jar:sources:0.10.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.12/0.10.1/scalameter-core_2.12-0.10.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "org.apache.commons:commons-math3:jar:sources:3.2",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "org.apache.commons:commons-math3:jar:sources:3.2",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.12/0.10.1/scalameter-core_2.12-0.10.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.12/0.10.1/scalameter-core_2.12-0.10.1-sources.jar"
+                ],
+                "sha256": "9dc1154586774a01b0496f083a2587312a28522177d92d7c181711298232ae48"
             },
             {
                 "coord": "com.storm-enroute:scalameter_2.12:0.10.1",
@@ -1192,6 +2322,51 @@
                 "sha256": "4d9b63e10f822b6acc0a441a326959df0cfcf4869276a3b8d921d6b66196565d"
             },
             {
+                "coord": "com.storm-enroute:scalameter_2.12:jar:sources:0.10.1",
+                "file": "v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter_2.12/0.10.1/scalameter_2.12-0.10.1-sources.jar",
+                "directDependencies": [
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-tools.testing:test-interface:jar:sources:0.5",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.apache.commons:commons-math3:jar:sources:3.2",
+                    "org.mongodb.scala:mongo-scala-driver_2.12:jar:sources:2.2.0",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.storm-enroute:scalameter-core_2.12:jar:sources:0.10.1",
+                    "com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:sources:2.9.8"
+                ],
+                "dependencies": [
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "org.scala-tools.testing:test-interface:jar:sources:0.5",
+                    "org.apache.commons:commons-lang3:jar:sources:3.9",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.thoughtworks.paranamer:paranamer:jar:sources:2.8",
+                    "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.mongodb:mongodb-driver-core:jar:sources:3.6.4",
+                    "org.apache.commons:commons-math3:jar:sources:3.2",
+                    "org.mongodb.scala:mongo-scala-driver_2.12:jar:sources:2.2.0",
+                    "org.mongodb.scala:mongo-scala-bson_2.12:jar:sources:2.2.0",
+                    "org.mongodb:bson:jar:sources:3.6.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.storm-enroute:scalameter-core_2.12:jar:sources:0.10.1",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.module:jackson-module-paranamer:jar:sources:2.9.8",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                    "com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:sources:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/storm-enroute/scalameter_2.12/0.10.1/scalameter_2.12-0.10.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/storm-enroute/scalameter_2.12/0.10.1/scalameter_2.12-0.10.1-sources.jar"
+                ],
+                "sha256": "cb5278c8f5b12e3f230587d5fe20cd2bba6015078483d5a4e779ac0aeada5a91"
+            },
+            {
                 "coord": "com.swoval:apple-file-events:1.3.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/swoval/apple-file-events/1.3.0/apple-file-events-1.3.0.jar",
                 "directDependencies": [],
@@ -1201,6 +2376,17 @@
                     "https://repo1.maven.org/maven2/com/swoval/apple-file-events/1.3.0/apple-file-events-1.3.0.jar"
                 ],
                 "sha256": "32c513766b00977c01a41614dee25846a2705b7c8cab295306e0b472e12e46cf"
+            },
+            {
+                "coord": "com.swoval:apple-file-events:jar:sources:1.3.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/swoval/apple-file-events/1.3.0/apple-file-events-1.3.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/swoval/apple-file-events/1.3.0/apple-file-events-1.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/swoval/apple-file-events/1.3.0/apple-file-events-1.3.0-sources.jar"
+                ],
+                "sha256": "42a02324152cc04c35676887555d032056dfb42d88b8697da94ea0db3e387a84"
             },
             {
                 "coord": "com.thesamet.scalapb:compilerplugin_2.12:0.9.0",
@@ -1222,6 +2408,25 @@
                 "sha256": "dce6277e9c618d0cee1dd5141f5bd4155eccd221588c7f1658eaa915f3eb8d33"
             },
             {
+                "coord": "com.thesamet.scalapb:compilerplugin_2.12:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/compilerplugin_2.12/0.9.0/compilerplugin_2.12-0.9.0-sources.jar",
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "com.thesamet.scalapb:protoc-bridge_2.12:jar:sources:0.7.8",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.thesamet.scalapb:protoc-bridge_2.12:jar:sources:0.7.8",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/thesamet/scalapb/compilerplugin_2.12/0.9.0/compilerplugin_2.12-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thesamet/scalapb/compilerplugin_2.12/0.9.0/compilerplugin_2.12-0.9.0-sources.jar"
+                ],
+                "sha256": "caae59883dca861619ce88b6b53f4d2dac88af32ed27eaec5424c3054f3eca21"
+            },
+            {
                 "coord": "com.thesamet.scalapb:lenses_2.12:0.9.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.12/0.9.0/lenses_2.12-0.9.0.jar",
                 "directDependencies": [
@@ -1237,6 +2442,21 @@
                 "sha256": "0a2fff4de17d270cea561618090c21d50bc891d82c6f9dfccdc20568f18d0260"
             },
             {
+                "coord": "com.thesamet.scalapb:lenses_2.12:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.12/0.9.0/lenses_2.12-0.9.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.12/0.9.0/lenses_2.12-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.12/0.9.0/lenses_2.12-0.9.0-sources.jar"
+                ],
+                "sha256": "107cb837f35186db75d4a1e343fcd809591daaf08459d6d328f0ad47f4ec968e"
+            },
+            {
                 "coord": "com.thesamet.scalapb:protoc-bridge_2.12:0.7.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.12/0.7.8/protoc-bridge_2.12-0.7.8.jar",
                 "directDependencies": [
@@ -1250,6 +2470,21 @@
                     "https://repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.12/0.7.8/protoc-bridge_2.12-0.7.8.jar"
                 ],
                 "sha256": "04116b52f76adc9fac1e83e1a18321c79e332e170e6542953199e3933e5ff375"
+            },
+            {
+                "coord": "com.thesamet.scalapb:protoc-bridge_2.12:jar:sources:0.7.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.12/0.7.8/protoc-bridge_2.12-0.7.8-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.12/0.7.8/protoc-bridge_2.12-0.7.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.12/0.7.8/protoc-bridge_2.12-0.7.8-sources.jar"
+                ],
+                "sha256": "bfa5e40b1bb1e76fc8bbbf7fc2956a70483c20573f76e0380c5f66f55c526b8c"
             },
             {
                 "coord": "com.thesamet.scalapb:scalapb-runtime-grpc_2.12:0.9.0",
@@ -1287,6 +2522,41 @@
                 "sha256": "925d8d86050991da6e024138fc21a1f2ff4f8aa49c1c5f76c71b330dbaec18d1"
             },
             {
+                "coord": "com.thesamet.scalapb:scalapb-runtime-grpc_2.12:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime-grpc_2.12/0.9.0/scalapb-runtime-grpc_2.12-0.9.0-sources.jar",
+                "directDependencies": [
+                    "com.thesamet.scalapb:scalapb-runtime_2.12:jar:sources:0.9.0",
+                    "io.grpc:grpc-protobuf:jar:sources:1.22.1",
+                    "io.grpc:grpc-stub:jar:sources:1.22.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "io.grpc:grpc-stub:jar:sources:1.22.1",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.thesamet.scalapb:lenses_2.12:jar:sources:0.9.0",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-protobuf:jar:sources:1.22.1",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.api.grpc:proto-google-common-protos:jar:sources:1.12.0",
+                    "io.grpc:grpc-protobuf-lite:jar:sources:1.22.1",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "com.thesamet.scalapb:scalapb-runtime_2.12:jar:sources:0.9.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime-grpc_2.12/0.9.0/scalapb-runtime-grpc_2.12-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime-grpc_2.12/0.9.0/scalapb-runtime-grpc_2.12-0.9.0-sources.jar"
+                ],
+                "sha256": "2aeb221edcd64b059587ba8462ff45ca3e45e46f35465bc6015c0f8b1d3b9cb0"
+            },
+            {
                 "coord": "com.thesamet.scalapb:scalapb-runtime_2.12:0.9.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.12/0.9.0/scalapb-runtime_2.12-0.9.0.jar",
                 "directDependencies": [
@@ -1309,6 +2579,28 @@
                 "sha256": "b905fa66b3fd0fabf3114105cd73ae2bdddbb6e13188a6538a92ae695e7ad6ed"
             },
             {
+                "coord": "com.thesamet.scalapb:scalapb-runtime_2.12:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.12/0.9.0/scalapb-runtime_2.12-0.9.0-sources.jar",
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.thesamet.scalapb:lenses_2.12:jar:sources:0.9.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.thesamet.scalapb:lenses_2.12:jar:sources:0.9.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.12/0.9.0/scalapb-runtime_2.12-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.12/0.9.0/scalapb-runtime_2.12-0.9.0-sources.jar"
+                ],
+                "sha256": "2e1c8072c7b536e3599afabe6c60cd29ac3918640436c177224b3102e7ba007b"
+            },
+            {
                 "coord": "com.thoughtworks.paranamer:paranamer:2.8",
                 "file": "v1/https/repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8.jar",
                 "directDependencies": [],
@@ -1318,6 +2610,17 @@
                     "https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8.jar"
                 ],
                 "sha256": "688cb118a6021d819138e855208c956031688be4b47a24bb615becc63acedf07"
+            },
+            {
+                "coord": "com.thoughtworks.paranamer:paranamer:jar:sources:2.8",
+                "file": "v1/https/repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8-sources.jar"
+                ],
+                "sha256": "8a4bfc21755c36ccdd70f96d7ab891d842d5aebd6afa1b74e0efc6441e3df39c"
             },
             {
                 "coord": "com.trueaccord.lenses:lenses_2.12:0.4.10",
@@ -1333,6 +2636,21 @@
                     "https://repo1.maven.org/maven2/com/trueaccord/lenses/lenses_2.12/0.4.10/lenses_2.12-0.4.10.jar"
                 ],
                 "sha256": "2c4d6218d81eb682927ddccb386c8c3577e4cdf098130fc25bae4c9f9d312e16"
+            },
+            {
+                "coord": "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                "file": "v1/https/repo1.maven.org/maven2/com/trueaccord/lenses/lenses_2.12/0.4.10/lenses_2.12-0.4.10-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/trueaccord/lenses/lenses_2.12/0.4.10/lenses_2.12-0.4.10-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/trueaccord/lenses/lenses_2.12/0.4.10/lenses_2.12-0.4.10-sources.jar"
+                ],
+                "sha256": "ee3896f145d5ac5ea9966a702fe30641caa1670bf6a5f74376ba75fd2273c558"
             },
             {
                 "coord": "com.trueaccord.scalapb:scalapb-runtime_2.12:0.6.0-pre2",
@@ -1357,6 +2675,28 @@
                 "sha256": "07bc456f05bb654db0cae9361bd6240d5892f3066534fd5e46b6922f2cbdb1c7"
             },
             {
+                "coord": "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                "file": "v1/https/repo1.maven.org/maven2/com/trueaccord/scalapb/scalapb-runtime_2.12/0.6.0-pre2/scalapb-runtime_2.12-0.6.0-pre2-sources.jar",
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/trueaccord/scalapb/scalapb-runtime_2.12/0.6.0-pre2/scalapb-runtime_2.12-0.6.0-pre2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/trueaccord/scalapb/scalapb-runtime_2.12/0.6.0-pre2/scalapb-runtime_2.12-0.6.0-pre2-sources.jar"
+                ],
+                "sha256": "d14e202e4583e9c5b8808e090284a7bf362feab80918846f039b744d169a7ecc"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-actor_2.12:2.5.23",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.23/akka-actor_2.12-2.5.23.jar",
                 "directDependencies": [
@@ -1376,6 +2716,25 @@
                 "sha256": "e7f3969f762bffce10cf56c7a65c784d4c0f0b23853b88a88c55546db02b2817"
             },
             {
+                "coord": "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.23/akka-actor_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe:config:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.23/akka-actor_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.23/akka-actor_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "b20c9e3c9fc900df042b2d3f2e120ab7364a7066ebe96dfe14408d3baa0ce777"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-http-core_2.12:10.1.9",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.12/10.1.9/akka-http-core_2.12-10.1.9.jar",
                 "directDependencies": [
@@ -1391,6 +2750,23 @@
                     "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.12/10.1.9/akka-http-core_2.12-10.1.9.jar"
                 ],
                 "sha256": "c78ee93da277b9959e90278fafccd0aaceb10dc0b9a475a005f528988cc92498"
+            },
+            {
+                "coord": "com.typesafe.akka:akka-http-core_2.12:jar:sources:10.1.9",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.12/10.1.9/akka-http-core_2.12-10.1.9-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.12/10.1.9/akka-http-core_2.12-10.1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.12/10.1.9/akka-http-core_2.12-10.1.9-sources.jar"
+                ],
+                "sha256": "123f122d8b8539ac178932a2db994d3135e004fb4eae87048a0f620d28fdfde2"
             },
             {
                 "coord": "com.typesafe.akka:akka-http-spray-json_2.12:10.1.9",
@@ -1414,6 +2790,27 @@
                 "sha256": "7de6a706ab335129a737d0c69c819197c4280905568d0540bec924432e9c511a"
             },
             {
+                "coord": "com.typesafe.akka:akka-http-spray-json_2.12:jar:sources:10.1.9",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-spray-json_2.12/10.1.9/akka-http-spray-json_2.12-10.1.9-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-http_2.12:jar:sources:10.1.9",
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9",
+                    "com.typesafe.akka:akka-http_2.12:jar:sources:10.1.9",
+                    "com.typesafe.akka:akka-http-core_2.12:jar:sources:10.1.9"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-spray-json_2.12/10.1.9/akka-http-spray-json_2.12-10.1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-spray-json_2.12/10.1.9/akka-http-spray-json_2.12-10.1.9-sources.jar"
+                ],
+                "sha256": "a512a5b00f1fd1a61c0b6517da2cd1965ce42ad527328417735884dbc47477df"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-http-testkit_2.12:10.1.9",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.12/10.1.9/akka-http-testkit_2.12-10.1.9.jar",
                 "directDependencies": [
@@ -1431,6 +2828,25 @@
                     "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.12/10.1.9/akka-http-testkit_2.12-10.1.9.jar"
                 ],
                 "sha256": "ab165fee9887462a3ae0c409853a43f78e8b7fcf442cd550f129b28dfc9e42b0"
+            },
+            {
+                "coord": "com.typesafe.akka:akka-http-testkit_2.12:jar:sources:10.1.9",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.12/10.1.9/akka-http-testkit_2.12-10.1.9-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-http_2.12:jar:sources:10.1.9",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-http-core_2.12:jar:sources:10.1.9",
+                    "com.typesafe.akka:akka-http_2.12:jar:sources:10.1.9",
+                    "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.12/10.1.9/akka-http-testkit_2.12-10.1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.12/10.1.9/akka-http-testkit_2.12-10.1.9-sources.jar"
+                ],
+                "sha256": "67e7f773c9c4f4654db2ee245b5857a4026dc2c35d4e97fc4171176f1b022e8b"
             },
             {
                 "coord": "com.typesafe.akka:akka-http_2.12:10.1.9",
@@ -1451,6 +2867,24 @@
                 "sha256": "440315a4866e5b627da8d6d8d932c68f35496111bcfec59169e586e27a1edc9a"
             },
             {
+                "coord": "com.typesafe.akka:akka-http_2.12:jar:sources:10.1.9",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.12/10.1.9/akka-http_2.12-10.1.9-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-http-core_2.12:jar:sources:10.1.9",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-http-core_2.12:jar:sources:10.1.9",
+                    "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.12/10.1.9/akka-http_2.12-10.1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.12/10.1.9/akka-http_2.12-10.1.9-sources.jar"
+                ],
+                "sha256": "dffc3384d7953fb3d6b8a6cd928a0e8def5cee0ea71c300316bd4077098b1751"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-parsing_2.12:10.1.9",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.12/10.1.9/akka-parsing_2.12-10.1.9.jar",
                 "directDependencies": [
@@ -1466,6 +2900,21 @@
                 "sha256": "27f08f7586d5d87b9d5f1bb74371c8c283f4e76902b0370edd2e01fe5d9e3c66"
             },
             {
+                "coord": "com.typesafe.akka:akka-parsing_2.12:jar:sources:10.1.9",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.12/10.1.9/akka-parsing_2.12-10.1.9-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.12/10.1.9/akka-parsing_2.12-10.1.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.12/10.1.9/akka-parsing_2.12-10.1.9-sources.jar"
+                ],
+                "sha256": "1647b6c9115468b9bd9d2a33235a84e1721fdadd9ec89397f058f29087d93198"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-protobuf_2.12:2.5.23",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.12/2.5.23/akka-protobuf_2.12-2.5.23.jar",
                 "directDependencies": [
@@ -1479,6 +2928,21 @@
                     "https://repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.12/2.5.23/akka-protobuf_2.12-2.5.23.jar"
                 ],
                 "sha256": "e5096799da71c51a9c2164266e71ca32706cfcbf4c7c6a77abd6522b8e9cc70b"
+            },
+            {
+                "coord": "com.typesafe.akka:akka-protobuf_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.12/2.5.23/akka-protobuf_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.12/2.5.23/akka-protobuf_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.12/2.5.23/akka-protobuf_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "476d170f4a6e1900ada36c2f99f3b4252838f7dfd47443c70f5844d4b6bc1bd4"
             },
             {
                 "coord": "com.typesafe.akka:akka-slf4j_2.12:2.5.23",
@@ -1500,6 +2964,27 @@
                     "https://repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.12/2.5.23/akka-slf4j_2.12-2.5.23.jar"
                 ],
                 "sha256": "90606a5c3aa895c1103b6fcc176a80431d6348c3be82a08449089a15bad3f52a"
+            },
+            {
+                "coord": "com.typesafe.akka:akka-slf4j_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.12/2.5.23/akka-slf4j_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.12/2.5.23/akka-slf4j_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.12/2.5.23/akka-slf4j_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "093712633ec43ef3cd3f514335e8d6c2ce22407539cb97d60391373127fab959"
             },
             {
                 "coord": "com.typesafe.akka:akka-stream-testkit_2.12:2.5.23",
@@ -1528,6 +3013,32 @@
                 "sha256": "b84a46096a32875a58657eafd62fc4c8c3bd11a5bbdf6e49a7abc5cc493aa290"
             },
             {
+                "coord": "com.typesafe.akka:akka-stream-testkit_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream-testkit_2.12/2.5.23/akka-stream-testkit_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-stream_2.12:jar:sources:2.5.23",
+                    "com.typesafe.akka:akka-testkit_2.12:jar:sources:2.5.23",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.typesafe.akka:akka-stream_2.12:jar:sources:2.5.23",
+                    "com.typesafe.akka:akka-testkit_2.12:jar:sources:2.5.23",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-protobuf_2.12:jar:sources:2.5.23",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream-testkit_2.12/2.5.23/akka-stream-testkit_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream-testkit_2.12/2.5.23/akka-stream-testkit_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "fbd76acc5b834de7233139685c1b706372d43c689d3f37fb30187cd44bc61586"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-stream_2.12:2.5.23",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.23/akka-stream_2.12-2.5.23.jar",
                 "directDependencies": [
@@ -1554,6 +3065,32 @@
                 "sha256": "4dec37918a5971a214d3f489719f6987934f89e5231906e7b5e1ef50e3b97007"
             },
             {
+                "coord": "com.typesafe.akka:akka-stream_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.23/akka-stream_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-protobuf_2.12:jar:sources:2.5.23",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-protobuf_2.12:jar:sources:2.5.23",
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.23/akka-stream_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.23/akka-stream_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "fc6718ecf8792f8df7f0bb9eea719985710df89b8f2cfef345ef0e9fe2884900"
+            },
+            {
                 "coord": "com.typesafe.akka:akka-testkit_2.12:2.5.23",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.12/2.5.23/akka-testkit_2.12-2.5.23.jar",
                 "directDependencies": [
@@ -1571,6 +3108,25 @@
                     "https://repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.12/2.5.23/akka-testkit_2.12-2.5.23.jar"
                 ],
                 "sha256": "8b9f66d85639318438199a292ecb9cb7c8185ec5b9a66107a10f64301382fce5"
+            },
+            {
+                "coord": "com.typesafe.akka:akka-testkit_2.12:jar:sources:2.5.23",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.12/2.5.23/akka-testkit_2.12-2.5.23-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.typesafe.akka:akka-actor_2.12:jar:sources:2.5.23",
+                    "com.typesafe:config:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.12/2.5.23/akka-testkit_2.12-2.5.23-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.12/2.5.23/akka-testkit_2.12-2.5.23-sources.jar"
+                ],
+                "sha256": "636d01b0c0b474b1d9b9d246e97a82c790836e7449a8088d3576a4e6ed3394e5"
             },
             {
                 "coord": "com.typesafe.play:anorm-akka_2.12:2.5.3",
@@ -1596,6 +3152,29 @@
                 "sha256": "cd89fe5aa5bc20a64476082110cb3d4ea9ffb51001941e21982e580412c53abc"
             },
             {
+                "coord": "com.typesafe.play:anorm-akka_2.12:jar:sources:2.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/play/anorm-akka_2.12/2.5.3/anorm-akka_2.12-2.5.3-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.play:anorm_2.12:jar:sources:2.5.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.jsuereth:scala-arm_2.12:jar:sources:2.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe.play:anorm_2.12:jar:sources:2.5.3",
+                    "com.typesafe.play:anorm-tokenizer_2.12:jar:sources:2.5.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/play/anorm-akka_2.12/2.5.3/anorm-akka_2.12-2.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/play/anorm-akka_2.12/2.5.3/anorm-akka_2.12-2.5.3-sources.jar"
+                ],
+                "sha256": "1c000f57ce1bf6131288610818c56adf24fbe372fdf444c04b1e636d01e73b3e"
+            },
+            {
                 "coord": "com.typesafe.play:anorm-tokenizer_2.12:2.5.3",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/play/anorm-tokenizer_2.12/2.5.3/anorm-tokenizer_2.12-2.5.3.jar",
                 "directDependencies": [
@@ -1611,6 +3190,23 @@
                     "https://repo1.maven.org/maven2/com/typesafe/play/anorm-tokenizer_2.12/2.5.3/anorm-tokenizer_2.12-2.5.3.jar"
                 ],
                 "sha256": "74e556aa6fd60e887aeee2e52e017c6fe9a630cad43e0d0793689c2aaa70fb59"
+            },
+            {
+                "coord": "com.typesafe.play:anorm-tokenizer_2.12:jar:sources:2.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/play/anorm-tokenizer_2.12/2.5.3/anorm-tokenizer_2.12-2.5.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/play/anorm-tokenizer_2.12/2.5.3/anorm-tokenizer_2.12-2.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/play/anorm-tokenizer_2.12/2.5.3/anorm-tokenizer_2.12-2.5.3-sources.jar"
+                ],
+                "sha256": "6b502c17f3cc208b28772a42c7c16776cf97adbcca6a8d328b137bcc6e4e50fd"
             },
             {
                 "coord": "com.typesafe.play:anorm_2.12:2.5.3",
@@ -1639,6 +3235,32 @@
                 "sha256": "684f456d7c28590669ef012e49cfec032bbb8ebbf42e2c675112a6b748c51809"
             },
             {
+                "coord": "com.typesafe.play:anorm_2.12:jar:sources:2.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/play/anorm_2.12/2.5.3/anorm_2.12-2.5.3-sources.jar",
+                "directDependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "com.jsuereth:scala-arm_2.12:jar:sources:2.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe.play:anorm-tokenizer_2.12:jar:sources:2.5.3"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.jsuereth:scala-arm_2.12:jar:sources:2.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe.play:anorm-tokenizer_2.12:jar:sources:2.5.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/play/anorm_2.12/2.5.3/anorm_2.12-2.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/play/anorm_2.12/2.5.3/anorm_2.12-2.5.3-sources.jar"
+                ],
+                "sha256": "69622d61deff12562cb6a97ea8db57baf4d98a01a6c490d5fbab773fcd5e3e8b"
+            },
+            {
                 "coord": "com.typesafe.scala-logging:scala-logging_2.12:3.9.2",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.9.2/scala-logging_2.12-3.9.2.jar",
                 "directDependencies": [
@@ -1656,6 +3278,25 @@
                     "https://repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.9.2/scala-logging_2.12-3.9.2.jar"
                 ],
                 "sha256": "eb4e31b7785d305b5baf0abd23a64b160e11b8cbe2503a765aa4b01247127dad"
+            },
+            {
+                "coord": "com.typesafe.scala-logging:scala-logging_2.12:jar:sources:3.9.2",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.9.2/scala-logging_2.12-3.9.2-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.9.2/scala-logging_2.12-3.9.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.9.2/scala-logging_2.12-3.9.2-sources.jar"
+                ],
+                "sha256": "66684d657691bfee01f6a62ac6909a6366b074521645f0bbacb1221e916a8d5f"
             },
             {
                 "coord": "com.typesafe.slick:slick-hikaricp_2.12:3.3.0",
@@ -1680,6 +3321,28 @@
                 "sha256": "024547cefb74278fb00ee1681565222c06e835c2dc574d1497a020f8e1ba2a45"
             },
             {
+                "coord": "com.typesafe.slick:slick-hikaricp_2.12:jar:sources:3.3.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/slick/slick-hikaricp_2.12/3.3.0/slick-hikaricp_2.12-3.3.0-sources.jar",
+                "directDependencies": [
+                    "com.typesafe.slick:slick_2.12:jar:sources:3.3.0",
+                    "com.zaxxer:HikariCP:jar:sources:3.2.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.typesafe.slick:slick_2.12:jar:sources:3.3.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "com.zaxxer:HikariCP:jar:sources:3.2.0",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/slick/slick-hikaricp_2.12/3.3.0/slick-hikaricp_2.12-3.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/slick/slick-hikaricp_2.12/3.3.0/slick-hikaricp_2.12-3.3.0-sources.jar"
+                ],
+                "sha256": "6bf4883abeb5dfbd12ffc715dc5a3cf62191f2efa25fbed5712e51e196ca68ba"
+            },
+            {
                 "coord": "com.typesafe.slick:slick_2.12:3.3.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/slick/slick_2.12/3.3.0/slick_2.12-3.3.0.jar",
                 "directDependencies": [
@@ -1701,6 +3364,27 @@
                 "sha256": "5c4dee7032eb3d3a9ba0f5fbbeb71658f1b601404c9adc7abf98806f1d3786c5"
             },
             {
+                "coord": "com.typesafe.slick:slick_2.12:jar:sources:3.3.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/slick/slick_2.12/3.3.0/slick_2.12-3.3.0-sources.jar",
+                "directDependencies": [
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.typesafe:config:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/slick/slick_2.12/3.3.0/slick_2.12-3.3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/slick/slick_2.12/3.3.0/slick_2.12-3.3.0-sources.jar"
+                ],
+                "sha256": "635ce75720e6679672c66624c31bd32225709e275a81f1a541910978686f49af"
+            },
+            {
                 "coord": "com.typesafe:config:1.3.3",
                 "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3.jar",
                 "directDependencies": [],
@@ -1710,6 +3394,17 @@
                     "https://repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3.jar"
                 ],
                 "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621"
+            },
+            {
+                "coord": "com.typesafe:config:jar:sources:1.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3-sources.jar"
+                ],
+                "sha256": "fcd7c3070417c776b313cc559665c035d74e3a2b40a89bbb0e9bff6e567c9cc8"
             },
             {
                 "coord": "com.typesafe:ssl-config-core_2.12:0.3.7",
@@ -1731,6 +3426,25 @@
                 "sha256": "5e41dfedc96081c6cf6d14f83f0e83cbefed7f5a3c50ae0b4c98344cc91545ad"
             },
             {
+                "coord": "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                "file": "v1/https/repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.12/0.3.7/ssl-config-core_2.12-0.3.7-sources.jar",
+                "directDependencies": [
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.12/0.3.7/ssl-config-core_2.12-0.3.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.12/0.3.7/ssl-config-core_2.12-0.3.7-sources.jar"
+                ],
+                "sha256": "876aec553b4bd9575f51732074285705ec3bd2877b51379bf82e506e3e30bfc8"
+            },
+            {
                 "coord": "com.zaxxer:HikariCP:3.2.0",
                 "file": "v1/https/repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0.jar",
                 "directDependencies": [
@@ -1746,6 +3460,21 @@
                 "sha256": "b008de68bbd85811f4b6e8f0860d0966c6acb4f2e75fabd46ec2094569cbefeb"
             },
             {
+                "coord": "com.zaxxer:HikariCP:jar:sources:3.2.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0-sources.jar",
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0-sources.jar"
+                ],
+                "sha256": "a66fc818710bc62c3fe19accc933f234dcec7bb58ac7cb36518d46ff57a6c666"
+            },
+            {
                 "coord": "commons-codec:commons-codec:1.12",
                 "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar",
                 "directDependencies": [],
@@ -1755,6 +3484,17 @@
                     "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar"
                 ],
                 "sha256": "23df58fae9c83d1bcd277b99f9429e9d8c134f0600b73e2e86b2385ed793c81e"
+            },
+            {
+                "coord": "commons-codec:commons-codec:jar:sources:1.12",
+                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar"
+                ],
+                "sha256": "9938b259c2ec37cf0d25c4ea2b400b7b6636e6628189a6ef1852895dce7d2e2a"
             },
             {
                 "coord": "commons-collections:commons-collections:3.0",
@@ -1768,6 +3508,17 @@
                 "sha256": "505b94d86b214e7e6c1e75f04ff418a8264ea8454b55b8ced8c93c45884eb6a2"
             },
             {
+                "coord": "commons-collections:commons-collections:jar:sources:3.0",
+                "file": "v1/https/repo1.maven.org/maven2/commons-collections/commons-collections/3.0/commons-collections-3.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/commons-collections/commons-collections/3.0/commons-collections-3.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/commons-collections/commons-collections/3.0/commons-collections-3.0-sources.jar"
+                ],
+                "sha256": "4e15551f196a38ce167d8170c94f0abb2a514584ee7ac9b05151ed1600b98917"
+            },
+            {
                 "coord": "commons-io:commons-io:2.5",
                 "file": "v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar",
                 "directDependencies": [],
@@ -1777,6 +3528,17 @@
                     "https://repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"
                 ],
                 "sha256": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474"
+            },
+            {
+                "coord": "commons-io:commons-io:jar:sources:2.5",
+                "file": "v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar"
+                ],
+                "sha256": "3b69b518d9a844732e35509b79e499fca63a960ee4301b1c96dc32e87f3f60a1"
             },
             {
                 "coord": "commons-lang:commons-lang:2.6",
@@ -1790,6 +3552,17 @@
                 "sha256": "50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c"
             },
             {
+                "coord": "commons-lang:commons-lang:jar:sources:2.6",
+                "file": "v1/https/repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6-sources.jar"
+                ],
+                "sha256": "66c2760945cec226f26286ddf3f6ffe38544c4a69aade89700a9a689c9b92380"
+            },
+            {
                 "coord": "commons-logging:commons-logging:1.2",
                 "file": "v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
                 "directDependencies": [],
@@ -1799,6 +3572,17 @@
                     "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
                 ],
                 "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636"
+            },
+            {
+                "coord": "commons-logging:commons-logging:jar:sources:1.2",
+                "file": "v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar"
+                ],
+                "sha256": "44347acfe5860461728e9cb33251e97345be36f8a0dfd5c5130c172559455f41"
             },
             {
                 "coord": "io.circe:circe-core_2.12:0.10.0",
@@ -1822,6 +3606,29 @@
                     "https://repo1.maven.org/maven2/io/circe/circe-core_2.12/0.10.0/circe-core_2.12-0.10.0.jar"
                 ],
                 "sha256": "71d7866949089afbd925d14c1810182e9c43dd6d5031a8da067e4aa717cc9703"
+            },
+            {
+                "coord": "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-core_2.12/0.10.0/circe-core_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-core_2.12/0.10.0/circe-core_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-core_2.12/0.10.0/circe-core_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "3727da2f2aca9e4f574f75bd3667d89d34fb55f50b66eea09fa356b520858045"
             },
             {
                 "coord": "io.circe:circe-generic_2.12:0.10.0",
@@ -1850,6 +3657,32 @@
                 "sha256": "f3cea34efd423c092293d7eef76820c9445517b385430697befbc7ed2a714e9f"
             },
             {
+                "coord": "io.circe:circe-generic_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-generic_2.12/0.10.0/circe-generic_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-generic_2.12/0.10.0/circe-generic_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-generic_2.12/0.10.0/circe-generic_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "5311885edd82a38dd46ac5de46c88af121ab78c1a50a012bd8be14c838d5aa9b"
+            },
+            {
                 "coord": "io.circe:circe-jawn_2.12:0.10.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-jawn_2.12/0.10.0/circe-jawn_2.12-0.10.0.jar",
                 "directDependencies": [
@@ -1875,6 +3708,31 @@
                 "sha256": "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
             },
             {
+                "coord": "io.circe:circe-jawn_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-jawn_2.12/0.10.0/circe-jawn_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-jawn_2.12/0.10.0/circe-jawn_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-jawn_2.12/0.10.0/circe-jawn_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "dd626a8a597f82539e453a05c64faddce7431128e1227b3be9c034e45e197797"
+            },
+            {
                 "coord": "io.circe:circe-numbers_2.12:0.10.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.12/0.10.0/circe-numbers_2.12-0.10.0.jar",
                 "directDependencies": [
@@ -1888,6 +3746,21 @@
                     "https://repo1.maven.org/maven2/io/circe/circe-numbers_2.12/0.10.0/circe-numbers_2.12-0.10.0.jar"
                 ],
                 "sha256": "d7845d065c7320892f82bbc4d360e99de1f91892c32202115b09d96541fcb868"
+            },
+            {
+                "coord": "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.12/0.10.0/circe-numbers_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-numbers_2.12/0.10.0/circe-numbers_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-numbers_2.12/0.10.0/circe-numbers_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "10542f334c2c3350660983d2db01e1c91597a289eb91d4cc63863dbe7d60d59e"
             },
             {
                 "coord": "io.circe:circe-parser_2.12:0.10.0",
@@ -1916,6 +3789,32 @@
                 "sha256": "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
             },
             {
+                "coord": "io.circe:circe-parser_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-parser_2.12/0.10.0/circe-parser_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "io.circe:circe-jawn_2.12:jar:sources:0.10.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "io.circe:circe-jawn_2.12:jar:sources:0.10.0",
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-parser_2.12/0.10.0/circe-parser_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-parser_2.12/0.10.0/circe-parser_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "c8b642f70687dff6bedd6b0c596328f55e1c02212a0df9bb1b0b3dbd5883b045"
+            },
+            {
                 "coord": "io.circe:circe-yaml_2.12:0.10.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-yaml_2.12/0.10.0/circe-yaml_2.12-0.10.0.jar",
                 "directDependencies": [
@@ -1941,6 +3840,31 @@
                 "sha256": "72948d62ed794c3ea97cbf7411a4a0b4d85bc4114cc09e454cad49fe3b6277c0"
             },
             {
+                "coord": "io.circe:circe-yaml_2.12:jar:sources:0.10.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/circe/circe-yaml_2.12/0.10.0/circe-yaml_2.12-0.10.0-sources.jar",
+                "directDependencies": [
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.yaml:snakeyaml:jar:sources:1.24"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "io.circe:circe-core_2.12:jar:sources:0.10.0",
+                    "io.circe:circe-numbers_2.12:jar:sources:0.10.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.yaml:snakeyaml:jar:sources:1.24",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/circe/circe-yaml_2.12/0.10.0/circe-yaml_2.12-0.10.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/circe/circe-yaml_2.12/0.10.0/circe-yaml_2.12-0.10.0-sources.jar"
+                ],
+                "sha256": "2c5ca14d1ecd8c8f69b1d1d41c64abf30d6ad56d938a844c6fa4eb7b087c759b"
+            },
+            {
                 "coord": "io.dropwizard.metrics:metrics-core:4.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.0.0/metrics-core-4.0.0.jar",
                 "directDependencies": [
@@ -1954,6 +3878,21 @@
                     "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.0.0/metrics-core-4.0.0.jar"
                 ],
                 "sha256": "dc1019ece4b18cd9201ee7697eb4f557583c071378b2ac63347c4a7221c1820e"
+            },
+            {
+                "coord": "io.dropwizard.metrics:metrics-core:jar:sources:4.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.0.0/metrics-core-4.0.0-sources.jar",
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.0.0/metrics-core-4.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.0.0/metrics-core-4.0.0-sources.jar"
+                ],
+                "sha256": "d039d6d676a0533bc17e7eec878a6038a58e7de0849aeb55011be0f111d5fe22"
             },
             {
                 "coord": "io.dropwizard.metrics:metrics-jmx:4.0.0",
@@ -1971,6 +3910,23 @@
                     "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.0.0/metrics-jmx-4.0.0.jar"
                 ],
                 "sha256": "14ebc20796899a0fd28524fb5789d897bc569367449ad64a9685ce878056792c"
+            },
+            {
+                "coord": "io.dropwizard.metrics:metrics-jmx:jar:sources:4.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.0.0/metrics-jmx-4.0.0-sources.jar",
+                "directDependencies": [
+                    "io.dropwizard.metrics:metrics-core:jar:sources:4.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "io.dropwizard.metrics:metrics-core:jar:sources:4.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.0.0/metrics-jmx-4.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.0.0/metrics-jmx-4.0.0-sources.jar"
+                ],
+                "sha256": "605b881f7b989492a59e6f85dd0648e0f7ac26c9974c7a33d86ea6fbe72845ae"
             },
             {
                 "coord": "io.grpc:grpc-api:1.22.1",
@@ -1998,6 +3954,31 @@
                 "sha256": "0f3527c28ee5e2e1c48fa65a82dc8b5dab90c6de0174afd8c63c9a2af5f676a7"
             },
             {
+                "coord": "io.grpc:grpc-api:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-api/1.22.1/grpc-api-1.22.1-sources.jar",
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.22.1/grpc-api-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.22.1/grpc-api-1.22.1-sources.jar"
+                ],
+                "sha256": "50ddcb843713f0121aa57a88145bcdc4bcc17ed11fcd2b840fd86f48cd19850d"
+            },
+            {
                 "coord": "io.grpc:grpc-context:1.22.1",
                 "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.22.1/grpc-context-1.22.1.jar",
                 "directDependencies": [],
@@ -2007,6 +3988,17 @@
                     "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.22.1/grpc-context-1.22.1.jar"
                 ],
                 "sha256": "780a3937705b3c92e07292c97d065b2676fcbe031eae250f1622b026485f294e"
+            },
+            {
+                "coord": "io.grpc:grpc-context:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.22.1/grpc-context-1.22.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.22.1/grpc-context-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.22.1/grpc-context-1.22.1-sources.jar"
+                ],
+                "sha256": "8c3d881168efc1cec5063f3feb5e818a081d1d794d79b53a4f73cd08bf5622eb"
             },
             {
                 "coord": "io.grpc:grpc-core:1.22.1",
@@ -2039,6 +4031,38 @@
                     "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.22.1/grpc-core-1.22.1.jar"
                 ],
                 "sha256": "e1ace5cef0871fd5f768132c27b6594070dacaf95e124a973f446707b151040b"
+            },
+            {
+                "coord": "io.grpc:grpc-core:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.22.1/grpc-core-1.22.1-sources.jar",
+                "directDependencies": [
+                    "io.perfmark:perfmark-api:jar:sources:0.16.0",
+                    "com.google.android:annotations:jar:sources:4.1.1.4",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0",
+                    "io.opencensus:opencensus-contrib-grpc-metrics:jar:sources:0.21.0"
+                ],
+                "dependencies": [
+                    "io.perfmark:perfmark-api:jar:sources:0.16.0",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.android:annotations:jar:sources:4.1.1.4",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0",
+                    "io.opencensus:opencensus-contrib-grpc-metrics:jar:sources:0.21.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.22.1/grpc-core-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.22.1/grpc-core-1.22.1-sources.jar"
+                ],
+                "sha256": "22b1245067f1b7fa295905c8549ceac9c62ef63c72d70966be8587192dde5088"
             },
             {
                 "coord": "io.grpc:grpc-netty:1.22.1",
@@ -2081,6 +4105,46 @@
                 "sha256": "49dbec9689357fa632a6d8d30b344de266bd1caf3c458b05db04d1fd3932761b"
             },
             {
+                "coord": "io.grpc:grpc-netty:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty/1.22.1/grpc-netty-1.22.1-sources.jar",
+                "directDependencies": [
+                    "io.grpc:grpc-core:jar:sources:1.22.1",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.perfmark:perfmark-api:jar:sources:0.16.0",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.android:annotations:jar:sources:4.1.1.4",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.netty:netty-handler-proxy:jar:sources:4.1.37.Final",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.netty:netty-codec-socks:jar:sources:4.1.37.Final",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                    "io.opencensus:opencensus-contrib-grpc-metrics:jar:sources:0.21.0",
+                    "io.netty:netty-codec-http2:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.grpc:grpc-core:jar:sources:1.22.1",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.22.1/grpc-netty-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.22.1/grpc-netty-1.22.1-sources.jar"
+                ],
+                "sha256": "95e95bdd48587c2070275d73b34d66396bea583f694a2228baf592b14eb5eb91"
+            },
+            {
                 "coord": "io.grpc:grpc-protobuf-lite:1.22.1",
                 "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.22.1/grpc-protobuf-lite-1.22.1.jar",
                 "directDependencies": [
@@ -2105,6 +4169,32 @@
                     "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.22.1/grpc-protobuf-lite-1.22.1.jar"
                 ],
                 "sha256": "d9eb914b071aa41a02e1f2b9d8adee38e8674a924d3d85e0ff5200a49419f90e"
+            },
+            {
+                "coord": "io.grpc:grpc-protobuf-lite:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.22.1/grpc-protobuf-lite-1.22.1-sources.jar",
+                "directDependencies": [
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-api:jar:sources:1.22.1"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "exclusions": [
+                    "com.google.protobuf:protobuf-lite"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.22.1/grpc-protobuf-lite-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.22.1/grpc-protobuf-lite-1.22.1-sources.jar"
+                ],
+                "sha256": "3b9b2e9739c716bf642a325dbc8d7561bdfd156dd600f5da53b471ac87333c46"
             },
             {
                 "coord": "io.grpc:grpc-protobuf:1.22.1",
@@ -2134,6 +4224,35 @@
                     "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.22.1/grpc-protobuf-1.22.1.jar"
                 ],
                 "sha256": "de17e9d7ab5cce5b5444c7d8f641832e0e1445c76e9c6ad235af23741f3ab959"
+            },
+            {
+                "coord": "io.grpc:grpc-protobuf:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.22.1/grpc-protobuf-1.22.1-sources.jar",
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "com.google.api.grpc:proto-google-common-protos:jar:sources:1.12.0",
+                    "io.grpc:grpc-protobuf-lite:jar:sources:1.22.1"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.api.grpc:proto-google-common-protos:jar:sources:1.12.0",
+                    "io.grpc:grpc-protobuf-lite:jar:sources:1.22.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.22.1/grpc-protobuf-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.22.1/grpc-protobuf-1.22.1-sources.jar"
+                ],
+                "sha256": "e7bcbcf9f0a7df624de8d04af1b1bed5a4b843bdbc3dd8d7ac46d6fe5cdb7bc0"
             },
             {
                 "coord": "io.grpc:grpc-services:1.22.1",
@@ -2173,6 +4292,43 @@
                 "sha256": "08cef5e3e34ac5c1f8e403dc81f08771158c0df8dc3821f814914a60508c30ac"
             },
             {
+                "coord": "io.grpc:grpc-services:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-services/1.22.1/grpc-services-1.22.1-sources.jar",
+                "directDependencies": [
+                    "com.google.protobuf:protobuf-java-util:jar:sources:3.7.1",
+                    "io.grpc:grpc-core:jar:sources:1.22.1",
+                    "io.grpc:grpc-protobuf:jar:sources:1.22.1",
+                    "io.grpc:grpc-stub:jar:sources:1.22.1"
+                ],
+                "dependencies": [
+                    "io.grpc:grpc-stub:jar:sources:1.22.1",
+                    "io.perfmark:perfmark-api:jar:sources:0.16.0",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "com.google.android:annotations:jar:sources:4.1.1.4",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-protobuf:jar:sources:1.22.1",
+                    "com.google.protobuf:protobuf-java-util:jar:sources:3.7.1",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0",
+                    "io.opencensus:opencensus-contrib-grpc-metrics:jar:sources:0.21.0",
+                    "com.google.api.grpc:proto-google-common-protos:jar:sources:1.12.0",
+                    "io.grpc:grpc-protobuf-lite:jar:sources:1.22.1",
+                    "io.grpc:grpc-core:jar:sources:1.22.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.22.1/grpc-services-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.22.1/grpc-services-1.22.1-sources.jar"
+                ],
+                "sha256": "5577a29a7f2e557f05b53983a311c463ff7e26e81e0bbaf20141ec7ff4d4ebcb"
+            },
+            {
                 "coord": "io.grpc:grpc-stub:1.22.1",
                 "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-stub/1.22.1/grpc-stub-1.22.1.jar",
                 "directDependencies": [
@@ -2195,6 +4351,28 @@
                 "sha256": "4bb04a18ba89cd1b4079b2b248d8bd2a7ee392140e84f515e894bd5fa339cf69"
             },
             {
+                "coord": "io.grpc:grpc-stub:jar:sources:1.22.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/grpc/grpc-stub/1.22.1/grpc-stub-1.22.1-sources.jar",
+                "directDependencies": [
+                    "io.grpc:grpc-api:jar:sources:1.22.1"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "io.grpc:grpc-api:jar:sources:1.22.1",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "io.grpc:grpc-context:jar:sources:1.22.1",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.22.1/grpc-stub-1.22.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.22.1/grpc-stub-1.22.1-sources.jar"
+                ],
+                "sha256": "c73a03bb6afa240264130a71f333ea2746261fe3e2f027a576753d773728e2be"
+            },
+            {
                 "coord": "io.netty:netty-buffer:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.37.Final/netty-buffer-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2208,6 +4386,21 @@
                     "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.37.Final/netty-buffer-4.1.37.Final.jar"
                 ],
                 "sha256": "83805671c27e388976de74fe477a246bea5b8a71f228fcfefee32fc2593725cf"
+            },
+            {
+                "coord": "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.37.Final/netty-buffer-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.37.Final/netty-buffer-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.37.Final/netty-buffer-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "f1727d8991cb63e0bb61413873f4fd7dc04a65188eb6279a7136d185d2b584e7"
             },
             {
                 "coord": "io.netty:netty-codec-http2:4.1.37.Final",
@@ -2236,6 +4429,32 @@
                 "sha256": "42b42d0d08a3ab4e1bec058c1d4a442324cc105a40800798006ba67cd46b9c0f"
             },
             {
+                "coord": "io.netty:netty-codec-http2:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.37.Final/netty-codec-http2-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.37.Final/netty-codec-http2-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.37.Final/netty-codec-http2-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "1a87326d9462db317da994236b67442fe3f86ca5163e6e0235e65011ac132917"
+            },
+            {
                 "coord": "io.netty:netty-codec-http:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.37.Final/netty-codec-http-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2260,6 +4479,30 @@
                 "sha256": "334bf6b2929d1ea6b951a3ae44ffc6fcea5d7f7c5a1ff1dc023a7e57e4c8ad48"
             },
             {
+                "coord": "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.37.Final/netty-codec-http-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.37.Final/netty-codec-http-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.37.Final/netty-codec-http-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "e0719c3ba92b09a57f905c25543900ae400b726bcfe8f7c811ee0f9bfe15f298"
+            },
+            {
                 "coord": "io.netty:netty-codec-socks:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.37.Final/netty-codec-socks-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2282,6 +4525,28 @@
                 "sha256": "b2955422bb167caad2eb4008fcb49410928227f31f924a92f450eccb8b1e7fd5"
             },
             {
+                "coord": "io.netty:netty-codec-socks:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.37.Final/netty-codec-socks-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.37.Final/netty-codec-socks-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.37.Final/netty-codec-socks-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "5713a1625813b158a0966b3e86784e2d6a62ec89123d6dc9bc6c61167c0d8815"
+            },
+            {
                 "coord": "io.netty:netty-codec:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.37.Final/netty-codec-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2302,6 +4567,26 @@
                 "sha256": "7ed9b1a4dcd2abebd6fb80971a87262bb32799bf3a0cfe73287439e8be0bb456"
             },
             {
+                "coord": "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.37.Final/netty-codec-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.37.Final/netty-codec-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.37.Final/netty-codec-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "b8cdae8cd43d4b806571de57e4a22cb3444641333fc2d4788db5ebd24561aef6"
+            },
+            {
                 "coord": "io.netty:netty-common:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.37.Final/netty-common-4.1.37.Final.jar",
                 "directDependencies": [],
@@ -2311,6 +4596,17 @@
                     "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.37.Final/netty-common-4.1.37.Final.jar"
                 ],
                 "sha256": "4b1a4d670b5b8be99779588aa6677b9e78ffbd774fbb2a1311e0b3fa037773e6"
+            },
+            {
+                "coord": "io.netty:netty-common:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.37.Final/netty-common-4.1.37.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.37.Final/netty-common-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.37.Final/netty-common-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "8e9d5b5a953fbebbfc29e376af594acaefa814d8562cdca5a6d60a80ba3dafda"
             },
             {
                 "coord": "io.netty:netty-handler-proxy:4.1.37.Final",
@@ -2340,6 +4636,33 @@
                 "sha256": "30c206f82d5d9eca38aab94a99be909d2b9ca290dc5588a19b350d0983ce0350"
             },
             {
+                "coord": "io.netty:netty-handler-proxy:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.37.Final/netty-handler-proxy-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-codec-socks:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-codec-socks:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec-http:jar:sources:4.1.37.Final",
+                    "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.37.Final/netty-handler-proxy-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.37.Final/netty-handler-proxy-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "5c1833a20c30f59886e106955ce835338dded0689b54082460b136e64588dc1a"
+            },
+            {
                 "coord": "io.netty:netty-handler:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.37.Final/netty-handler-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2362,6 +4685,28 @@
                 "sha256": "0e51521918e84cfb11a381fec7b598649e6cd4669b2284e168c5155f247e3a4c"
             },
             {
+                "coord": "io.netty:netty-handler:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.37.Final/netty-handler-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-codec:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.37.Final/netty-handler-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.37.Final/netty-handler-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "2833b34f5c0c289ca448f3749ff26011e6cfcb7cd71666220e6d0d4fded1e8fc"
+            },
+            {
                 "coord": "io.netty:netty-resolver:4.1.37.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.37.Final/netty-resolver-4.1.37.Final.jar",
                 "directDependencies": [
@@ -2377,6 +4722,21 @@
                 "sha256": "ebaf963b7194f70039b11d74657d09161b0729e97ea4460bf1ba312c7d84ca7e"
             },
             {
+                "coord": "io.netty:netty-resolver:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.37.Final/netty-resolver-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.37.Final/netty-resolver-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.37.Final/netty-resolver-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "ea9b9eecad17dd00d0d8f337c261b59d37a534d65a8de1b069f296404584291a"
+            },
+            {
                 "coord": "io.netty:netty-tcnative-boringssl-static:2.0.25.Final",
                 "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.25.Final/netty-tcnative-boringssl-static-2.0.25.Final.jar",
                 "directDependencies": [],
@@ -2386,6 +4746,17 @@
                     "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.25.Final/netty-tcnative-boringssl-static-2.0.25.Final.jar"
                 ],
                 "sha256": "96d9c14ab4c47cbad7fec9bdb083917db971d3754d6c7fa89f958bc719e230ed"
+            },
+            {
+                "coord": "io.netty:netty-tcnative-boringssl-static:jar:sources:2.0.25.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.25.Final/netty-tcnative-boringssl-static-2.0.25.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.25.Final/netty-tcnative-boringssl-static-2.0.25.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.25.Final/netty-tcnative-boringssl-static-2.0.25.Final-sources.jar"
+                ],
+                "sha256": "dc44ab2ce5726ff14bedd4a12d16fd0eb1db45b04692d37af9ab0a3a3c295ce8"
             },
             {
                 "coord": "io.netty:netty-transport:4.1.37.Final",
@@ -2407,6 +4778,25 @@
                 "sha256": "962279abbdc58a261fbb39b55838225efb62771dc6ea938490567142135bd1fc"
             },
             {
+                "coord": "io.netty:netty-transport:jar:sources:4.1.37.Final",
+                "file": "v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.1.37.Final/netty-transport-4.1.37.Final-sources.jar",
+                "directDependencies": [
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "dependencies": [
+                    "io.netty:netty-common:jar:sources:4.1.37.Final",
+                    "io.netty:netty-buffer:jar:sources:4.1.37.Final",
+                    "io.netty:netty-resolver:jar:sources:4.1.37.Final"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.37.Final/netty-transport-4.1.37.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.37.Final/netty-transport-4.1.37.Final-sources.jar"
+                ],
+                "sha256": "8fdc79465ff2a8c944ececd14758ef76bafa9990d83d4182db3b6595963dd45b"
+            },
+            {
                 "coord": "io.opencensus:opencensus-api:0.21.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-api/0.21.0/opencensus-api-0.21.0.jar",
                 "directDependencies": [],
@@ -2421,6 +4811,22 @@
                     "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.21.0/opencensus-api-0.21.0.jar"
                 ],
                 "sha256": "8e2cb0f6391d8eb0a1bcd01e7748883f0033b1941754f4ed3f19d2c3e4276fc8"
+            },
+            {
+                "coord": "io.opencensus:opencensus-api:jar:sources:0.21.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-api/0.21.0/opencensus-api-0.21.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "com.google.code.findbugs:jsr305",
+                    "com.google.guava:guava",
+                    "io.grpc:grpc-context"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.21.0/opencensus-api-0.21.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.21.0/opencensus-api-0.21.0-sources.jar"
+                ],
+                "sha256": "a185e02627df9dd25ac982f8f1e81f6ac059550d82b0e8c149f9954bd750ad7f"
             },
             {
                 "coord": "io.opencensus:opencensus-contrib-grpc-metrics:0.21.0",
@@ -2443,6 +4849,26 @@
                 "sha256": "29fc79401082301542cab89d7054d2f0825f184492654c950020553ef4ff0ef8"
             },
             {
+                "coord": "io.opencensus:opencensus-contrib-grpc-metrics:jar:sources:0.21.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/opencensus/opencensus-contrib-grpc-metrics/0.21.0/opencensus-contrib-grpc-metrics-0.21.0-sources.jar",
+                "directDependencies": [
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0"
+                ],
+                "dependencies": [
+                    "io.opencensus:opencensus-api:jar:sources:0.21.0"
+                ],
+                "exclusions": [
+                    "com.google.code.findbugs:jsr305",
+                    "com.google.guava:guava",
+                    "io.grpc:grpc-context"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-grpc-metrics/0.21.0/opencensus-contrib-grpc-metrics-0.21.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-grpc-metrics/0.21.0/opencensus-contrib-grpc-metrics-0.21.0-sources.jar"
+                ],
+                "sha256": "6536dcddc505c73c53d8e031f12276dfd345b093a59c1943d050bf55dba4730f"
+            },
+            {
                 "coord": "io.perfmark:perfmark-api:0.16.0",
                 "file": "v1/https/repo1.maven.org/maven2/io/perfmark/perfmark-api/0.16.0/perfmark-api-0.16.0.jar",
                 "directDependencies": [
@@ -2460,6 +4886,23 @@
                 "sha256": "a93667875ea9d10315177768739a18d6c667df041c982d2841645ae8558d0af0"
             },
             {
+                "coord": "io.perfmark:perfmark-api:jar:sources:0.16.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/perfmark/perfmark-api/0.16.0/perfmark-api-0.16.0-sources.jar",
+                "directDependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.16.0/perfmark-api-0.16.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.16.0/perfmark-api-0.16.0-sources.jar"
+                ],
+                "sha256": "4838b2a8485b18cb9dc39432e52777530993887398744bdc7acc1ac0c4424c88"
+            },
+            {
                 "coord": "io.protostuff:protostuff-api:1.5.2",
                 "file": "v1/https/repo1.maven.org/maven2/io/protostuff/protostuff-api/1.5.2/protostuff-api-1.5.2.jar",
                 "directDependencies": [],
@@ -2469,6 +4912,17 @@
                     "https://repo1.maven.org/maven2/io/protostuff/protostuff-api/1.5.2/protostuff-api-1.5.2.jar"
                 ],
                 "sha256": "1f1cf8b3acb77c0342e3012bba2b7fdcb82852a8b37118fe105bd99121b45e0a"
+            },
+            {
+                "coord": "io.protostuff:protostuff-api:jar:sources:1.5.2",
+                "file": "v1/https/repo1.maven.org/maven2/io/protostuff/protostuff-api/1.5.2/protostuff-api-1.5.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/io/protostuff/protostuff-api/1.5.2/protostuff-api-1.5.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/protostuff/protostuff-api/1.5.2/protostuff-api-1.5.2-sources.jar"
+                ],
+                "sha256": "9c55cdffbe85291441965c0874c2cc6ba387afc33160f3e4abd535d1be17b2b2"
             },
             {
                 "coord": "io.protostuff:protostuff-core:1.5.2",
@@ -2486,6 +4940,21 @@
                 "sha256": "11c9f1b9f25ad9361b73e800f393ad3bf76eedfa66e866e9e7a7d6e8b016afc7"
             },
             {
+                "coord": "io.protostuff:protostuff-core:jar:sources:1.5.2",
+                "file": "v1/https/repo1.maven.org/maven2/io/protostuff/protostuff-core/1.5.2/protostuff-core-1.5.2-sources.jar",
+                "directDependencies": [
+                    "io.protostuff:protostuff-api:jar:sources:1.5.2"
+                ],
+                "dependencies": [
+                    "io.protostuff:protostuff-api:jar:sources:1.5.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/protostuff/protostuff-core/1.5.2/protostuff-core-1.5.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/protostuff/protostuff-core/1.5.2/protostuff-core-1.5.2-sources.jar"
+                ],
+                "sha256": "0dc32d420f3c21007accb4a19a040a306be58886606fdee341b672704a0f9192"
+            },
+            {
                 "coord": "io.reactivex.rxjava2:rxjava:2.2.1",
                 "file": "v1/https/repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1.jar",
                 "directDependencies": [
@@ -2501,6 +4970,21 @@
                 "sha256": "459a378ddd8dc93c851efa6a8553f6eb51623a2749c2ac1c3ee4222175f80dac"
             },
             {
+                "coord": "io.reactivex.rxjava2:rxjava:jar:sources:2.2.1",
+                "file": "v1/https/repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1-sources.jar",
+                "directDependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2"
+                ],
+                "dependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1-sources.jar"
+                ],
+                "sha256": "b51dec822a48b32742c73b38bb4c22ce25fc9ff52a507ae22c9a37837a477c81"
+            },
+            {
                 "coord": "io.spray:spray-json_2.12:1.3.3",
                 "file": "v1/https/repo1.maven.org/maven2/io/spray/spray-json_2.12/1.3.3/spray-json_2.12-1.3.3.jar",
                 "directDependencies": [
@@ -2514,6 +4998,21 @@
                     "https://repo1.maven.org/maven2/io/spray/spray-json_2.12/1.3.3/spray-json_2.12-1.3.3.jar"
                 ],
                 "sha256": "7e881bc7cabf18f3e1c54149af619c2e6a2e99206b5c0489ac8a75d4aa7868b9"
+            },
+            {
+                "coord": "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/io/spray/spray-json_2.12/1.3.3/spray-json_2.12-1.3.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/spray/spray-json_2.12/1.3.3/spray-json_2.12-1.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/spray/spray-json_2.12/1.3.3/spray-json_2.12-1.3.3-sources.jar"
+                ],
+                "sha256": "66d7eb38d4a12d7f74959f918eadc05020ed063f6e64f6fa1b684cc316f2853b"
             },
             {
                 "coord": "io.zipkin.brave:brave:4.6.0",
@@ -2533,6 +5032,23 @@
                 "sha256": "70d340f8bd294682adc8240cd41cd369a0b3f0037f3fb2f15bd9bd836a3402d9"
             },
             {
+                "coord": "io.zipkin.brave:brave:jar:sources:4.6.0",
+                "file": "v1/https/repo1.maven.org/maven2/io/zipkin/brave/brave/4.6.0/brave-4.6.0-sources.jar",
+                "directDependencies": [
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3",
+                    "io.zipkin.reporter:zipkin-reporter:jar:sources:1.0.4"
+                ],
+                "dependencies": [
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3",
+                    "io.zipkin.reporter:zipkin-reporter:jar:sources:1.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/zipkin/brave/brave/4.6.0/brave-4.6.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/zipkin/brave/brave/4.6.0/brave-4.6.0-sources.jar"
+                ],
+                "sha256": "a55ccb6f2c1d323c505f8256443882ac77cd266178068686ca754d789e0bb35a"
+            },
+            {
                 "coord": "io.zipkin.java:zipkin:1.31.3",
                 "file": "v1/https/repo1.maven.org/maven2/io/zipkin/java/zipkin/1.31.3/zipkin-1.31.3.jar",
                 "directDependencies": [],
@@ -2542,6 +5058,17 @@
                     "https://repo1.maven.org/maven2/io/zipkin/java/zipkin/1.31.3/zipkin-1.31.3.jar"
                 ],
                 "sha256": "e59babd8d2858a8b01172d65ddfdf74536e93808b45e19d11efbc6c624809562"
+            },
+            {
+                "coord": "io.zipkin.java:zipkin:jar:sources:1.31.3",
+                "file": "v1/https/repo1.maven.org/maven2/io/zipkin/java/zipkin/1.31.3/zipkin-1.31.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/io/zipkin/java/zipkin/1.31.3/zipkin-1.31.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/zipkin/java/zipkin/1.31.3/zipkin-1.31.3-sources.jar"
+                ],
+                "sha256": "99e17c4fabc486516553fbf6ff08b8823a14e335ede0b6ac4f9c99b9c98e4849"
             },
             {
                 "coord": "io.zipkin.reporter:zipkin-reporter:1.0.4",
@@ -2557,6 +5084,21 @@
                     "https://repo1.maven.org/maven2/io/zipkin/reporter/zipkin-reporter/1.0.4/zipkin-reporter-1.0.4.jar"
                 ],
                 "sha256": "ef36edaa89c573abc71fd2e7278ae3adb2eafca4f541a5ce5af1b25e0dae15f0"
+            },
+            {
+                "coord": "io.zipkin.reporter:zipkin-reporter:jar:sources:1.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/io/zipkin/reporter/zipkin-reporter/1.0.4/zipkin-reporter-1.0.4-sources.jar",
+                "directDependencies": [
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3"
+                ],
+                "dependencies": [
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/zipkin/reporter/zipkin-reporter/1.0.4/zipkin-reporter-1.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/zipkin/reporter/zipkin-reporter/1.0.4/zipkin-reporter-1.0.4-sources.jar"
+                ],
+                "sha256": "7b2dfc17c4787a955aaffeb23db8c20d111af4a26e690e7e064a8c4bc1fe4afc"
             },
             {
                 "coord": "io.zipkin.reporter:zipkin-sender-okhttp3:1.0.4",
@@ -2579,6 +5121,26 @@
                 "sha256": "02b560a786ff80457ce7336bc2662acf630add7079eef7e6469c44b49ab8106f"
             },
             {
+                "coord": "io.zipkin.reporter:zipkin-sender-okhttp3:jar:sources:1.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/io/zipkin/reporter/zipkin-sender-okhttp3/1.0.4/zipkin-sender-okhttp3-1.0.4-sources.jar",
+                "directDependencies": [
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3",
+                    "io.zipkin.reporter:zipkin-reporter:jar:sources:1.0.4"
+                ],
+                "dependencies": [
+                    "io.zipkin.java:zipkin:jar:sources:1.31.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "io.zipkin.reporter:zipkin-reporter:jar:sources:1.0.4",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/io/zipkin/reporter/zipkin-sender-okhttp3/1.0.4/zipkin-sender-okhttp3-1.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/io/zipkin/reporter/zipkin-sender-okhttp3/1.0.4/zipkin-sender-okhttp3-1.0.4-sources.jar"
+                ],
+                "sha256": "53ec8c5104893d06aac7e1687da3bf78c5bea2bb642bc2a61d234e266faccc92"
+            },
+            {
                 "coord": "javax.annotation:javax.annotation-api:1.2",
                 "file": "v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar",
                 "directDependencies": [],
@@ -2588,6 +5150,17 @@
                     "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar"
                 ],
                 "sha256": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04"
+            },
+            {
+                "coord": "javax.annotation:javax.annotation-api:jar:sources:1.2",
+                "file": "v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2-sources.jar"
+                ],
+                "sha256": "8bd08333ac2c195e224cc4063a72f4aab3c980cf5e9fb694130fad41689689d0"
             },
             {
                 "coord": "javax.servlet:javax.servlet-api:3.1.0",
@@ -2601,6 +5174,17 @@
                 "sha256": "af456b2dd41c4e82cf54f3e743bc678973d9fe35bd4d3071fa05c7e5333b8482"
             },
             {
+                "coord": "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                "file": "v1/https/repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0-sources.jar"
+                ],
+                "sha256": "5c6d640f01e8e7ffdba21b2b75c0f64f0c30fd1fc3372123750c034cb363012a"
+            },
+            {
                 "coord": "javax.ws.rs:javax.ws.rs-api:2.1",
                 "file": "v1/https/repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1.jar",
                 "directDependencies": [],
@@ -2610,6 +5194,17 @@
                     "https://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1.jar"
                 ],
                 "sha256": "1a4295889416c6972addcd425dfeeee6e6ede110e8b2dc8b49044e9b400ad5db"
+            },
+            {
+                "coord": "javax.ws.rs:javax.ws.rs-api:jar:sources:2.1",
+                "file": "v1/https/repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1-sources.jar"
+                ],
+                "sha256": "041411b622f9e28174d6eced5349427cd36e9b1978e94e1b722ac133ed53be04"
             },
             {
                 "coord": "jline:jline:2.14.4",
@@ -2623,6 +5218,17 @@
                 "sha256": "cb489eb7caf57811f01b7ac9d1fb8175ee1d2086627cc69f524e7d68f5f67982"
             },
             {
+                "coord": "jline:jline:jar:sources:2.14.4",
+                "file": "v1/https/repo1.maven.org/maven2/jline/jline/2.14.4/jline-2.14.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/jline/jline/2.14.4/jline-2.14.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/jline/jline/2.14.4/jline-2.14.4-sources.jar"
+                ],
+                "sha256": "521af91089abf9f6b154b42f32e99dca3d824fb8e22a844f78309f0fab5d1343"
+            },
+            {
                 "coord": "joda-time:joda-time:2.9.7",
                 "file": "v1/https/repo1.maven.org/maven2/joda-time/joda-time/2.9.7/joda-time-2.9.7.jar",
                 "directDependencies": [],
@@ -2632,6 +5238,17 @@
                     "https://repo1.maven.org/maven2/joda-time/joda-time/2.9.7/joda-time-2.9.7.jar"
                 ],
                 "sha256": "2bcac56802ec8d6f16941ef8a8d5fee4032902ba9937549be220f0a06eb9f503"
+            },
+            {
+                "coord": "joda-time:joda-time:jar:sources:2.9.7",
+                "file": "v1/https/repo1.maven.org/maven2/joda-time/joda-time/2.9.7/joda-time-2.9.7-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/joda-time/joda-time/2.9.7/joda-time-2.9.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/joda-time/joda-time/2.9.7/joda-time-2.9.7-sources.jar"
+                ],
+                "sha256": "71418dc22a61a104660f30557b5ddb706868d4e1818368fd2b898b48a31922a7"
             },
             {
                 "coord": "junit:junit-dep:4.10",
@@ -2649,6 +5266,21 @@
                 "sha256": "c1b81ad9bed9cec9da9df975ac1af252341313bd6af42a7442a1328e90a4d932"
             },
             {
+                "coord": "junit:junit-dep:jar:sources:4.10",
+                "file": "v1/https/repo1.maven.org/maven2/junit/junit-dep/4.10/junit-dep-4.10-sources.jar",
+                "directDependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "dependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/junit/junit-dep/4.10/junit-dep-4.10-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/junit/junit-dep/4.10/junit-dep-4.10-sources.jar"
+                ],
+                "sha256": "a68d6181b1072b184ea032f2e962990cd1005b5796b8fef719b71e7545586ecd"
+            },
+            {
                 "coord": "junit:junit:4.12",
                 "file": "v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
                 "directDependencies": [
@@ -2664,6 +5296,21 @@
                 "sha256": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a"
             },
             {
+                "coord": "junit:junit:jar:sources:4.12",
+                "file": "v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
+                "directDependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "dependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+                ],
+                "sha256": "9f43fea92033ad82bcad2ae44cec5c82abc9d6ee4b095cab921d11ead98bf2ff"
+            },
+            {
                 "coord": "log4j:log4j:1.2.17",
                 "file": "v1/https/repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar",
                 "directDependencies": [],
@@ -2673,6 +5320,17 @@
                     "https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar"
                 ],
                 "sha256": "1d31696445697720527091754369082a6651bd49781b6005deb94e56753406f9"
+            },
+            {
+                "coord": "log4j:log4j:jar:sources:1.2.17",
+                "file": "v1/https/repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar"
+                ],
+                "sha256": "4d9ba787af1692aa88417c2a47a37a98125d645b91ab556252dbee0f45225493"
             },
             {
                 "coord": "net.bytebuddy:byte-buddy-agent:1.9.7",
@@ -2686,6 +5344,17 @@
                 "sha256": "145ce0fab5390374e69b2b4070d65fedaa2b07c3cfad06b330bea1b6dcfa826f"
             },
             {
+                "coord": "net.bytebuddy:byte-buddy-agent:jar:sources:1.9.7",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7-sources.jar"
+                ],
+                "sha256": "f1ffcb60fb0cb3de2ab4ba36b3588f9c0f12b24e8eeb59f76c57664f42eaae80"
+            },
+            {
                 "coord": "net.bytebuddy:byte-buddy:1.9.7",
                 "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.7/byte-buddy-1.9.7.jar",
                 "directDependencies": [],
@@ -2695,6 +5364,17 @@
                     "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.7/byte-buddy-1.9.7.jar"
                 ],
                 "sha256": "69a9140c11de463789a1badfe6c3dcdc17608c4304cb443c5c3a179585b78b39"
+            },
+            {
+                "coord": "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.7/byte-buddy-1.9.7-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.7/byte-buddy-1.9.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.9.7/byte-buddy-1.9.7-sources.jar"
+                ],
+                "sha256": "cbeaa4d2f9836f456c7b77dd464b5accfcd35f70cea896086fbc0751cbe0f0e7"
             },
             {
                 "coord": "net.java.dev.jna:jna-platform:4.5.0",
@@ -2712,6 +5392,21 @@
                 "sha256": "68ee6431c6c07dda48deaa2627c56beeea0dec5927fe7848983e06f7a6a76a08"
             },
             {
+                "coord": "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                "file": "v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna-platform/4.5.0/jna-platform-4.5.0-sources.jar",
+                "directDependencies": [
+                    "net.java.dev.jna:jna:jar:sources:4.5.0"
+                ],
+                "dependencies": [
+                    "net.java.dev.jna:jna:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/4.5.0/jna-platform-4.5.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/4.5.0/jna-platform-4.5.0-sources.jar"
+                ],
+                "sha256": "c0d41cc08b93646f90495bf850105dc9af1116169868b93589366c689eb5ddee"
+            },
+            {
                 "coord": "net.java.dev.jna:jna:4.5.0",
                 "file": "v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.0/jna-4.5.0.jar",
                 "directDependencies": [],
@@ -2721,6 +5416,17 @@
                     "https://repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.0/jna-4.5.0.jar"
                 ],
                 "sha256": "617a8d75f66a57296255a13654a99f10f72f0964336e352211247ed046da3e94"
+            },
+            {
+                "coord": "net.java.dev.jna:jna:jar:sources:4.5.0",
+                "file": "v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.0/jna-4.5.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.0/jna-4.5.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/java/dev/jna/jna/4.5.0/jna-4.5.0-sources.jar"
+                ],
+                "sha256": "e4da62978d75a5f47641d6c3548a6859c193fad8c5d0bc95a5f049d8ec1a0f79"
             },
             {
                 "coord": "org.apache.commons:commons-compress:1.12",
@@ -2734,6 +5440,17 @@
                 "sha256": "2c1542faf343185b7cab9c3d55c8ae5471d6d095d3887a4adefdbdf2984dc0b6"
             },
             {
+                "coord": "org.apache.commons:commons-compress:jar:sources:1.12",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-compress/1.12/commons-compress-1.12-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.12/commons-compress-1.12-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.12/commons-compress-1.12-sources.jar"
+                ],
+                "sha256": "ae08ac41171c3805f5e8ff04c29a95163a1bf8fb25ccff49581f7af6c902606d"
+            },
+            {
                 "coord": "org.apache.commons:commons-exec:1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
                 "directDependencies": [],
@@ -2743,6 +5460,17 @@
                     "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar"
                 ],
                 "sha256": "cb49812dc1bfb0ea4f20f398bcae1a88c6406e213e67f7524fb10d4f8ad9347b"
+            },
+            {
+                "coord": "org.apache.commons:commons-exec:jar:sources:1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3-sources.jar"
+                ],
+                "sha256": "c121d8e70010092bafc56f358e7259ac484653db595aafea1e67a040f51aea66"
             },
             {
                 "coord": "org.apache.commons:commons-lang3:3.9",
@@ -2756,6 +5484,17 @@
                 "sha256": "de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230"
             },
             {
+                "coord": "org.apache.commons:commons-lang3:jar:sources:3.9",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar"
+                ],
+                "sha256": "d97341ce0a7554028db3403e407bb51f4d902bf3287f64f709d7a8156eaf1910"
+            },
+            {
                 "coord": "org.apache.commons:commons-math3:3.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2.jar",
                 "directDependencies": [],
@@ -2765,6 +5504,17 @@
                     "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2.jar"
                 ],
                 "sha256": "6268a9a0ea3e769fc493a21446664c0ef668e48c93d126791f6f3f757978fee2"
+            },
+            {
+                "coord": "org.apache.commons:commons-math3:jar:sources:3.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2-sources.jar"
+                ],
+                "sha256": "b62d60712ea06fb6259506269b3a0ed73a7da5ee11f891c0eb0399eb9bc71e3f"
             },
             {
                 "coord": "org.apache.commons:commons-text:1.4",
@@ -2780,6 +5530,21 @@
                     "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4.jar"
                 ],
                 "sha256": "d624e443240a5fccc93edbfe758df1b69c07d7eaab6fc5e8f98f77d86ced8259"
+            },
+            {
+                "coord": "org.apache.commons:commons-text:jar:sources:1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4-sources.jar",
+                "directDependencies": [
+                    "org.apache.commons:commons-lang3:jar:sources:3.9"
+                ],
+                "dependencies": [
+                    "org.apache.commons:commons-lang3:jar:sources:3.9"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4-sources.jar"
+                ],
+                "sha256": "00d006377bbe1667b8fdaa5bb3da35137c0d3bc28e7426276fcb1f5a50630eb2"
             },
             {
                 "coord": "org.apache.httpcomponents:httpclient:4.5.3",
@@ -2801,6 +5566,25 @@
                 "sha256": "db3d1b6c2d6a5e5ad47577ad61854e2f0e0936199b8e05eb541ed52349263135"
             },
             {
+                "coord": "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
+                ],
+                "dependencies": [
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "commons-logging:commons-logging:jar:sources:1.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar"
+                ],
+                "sha256": "6475ea5ce5bce787f88f449c4d29dc8cafbeba9f172683fcad15c2e4b5e2ed84"
+            },
+            {
                 "coord": "org.apache.httpcomponents:httpcore:4.4.6",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
                 "directDependencies": [],
@@ -2812,6 +5596,17 @@
                 "sha256": "d7f853dee87680b07293d30855b39b9eb56c1297bd16ff1cd6f19ddb8fa745fb"
             },
             {
+                "coord": "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6-sources.jar"
+                ],
+                "sha256": "292895822468716a4b8c65b07f9e45c8a9ff9946aa5407c883f5f455d09cdf9e"
+            },
+            {
                 "coord": "org.apache.logging.log4j:log4j-api:2.8.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1.jar",
                 "directDependencies": [],
@@ -2821,6 +5616,17 @@
                     "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1.jar"
                 ],
                 "sha256": "1205ab764b1326f7d96d99baa4a4e12614599bf3d735790947748ee116511fa2"
+            },
+            {
+                "coord": "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1-sources.jar"
+                ],
+                "sha256": "453201e25c223bacfc58e47262390fa2879dfe095c6d883dc913667917665ceb"
             },
             {
                 "coord": "org.apache.logging.log4j:log4j-core:2.8.1",
@@ -2836,6 +5642,21 @@
                     "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.8.1/log4j-core-2.8.1.jar"
                 ],
                 "sha256": "815a73e20e90a413662eefe8594414684df3d5723edcd76070e1a5aee864616e"
+            },
+            {
+                "coord": "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.8.1/log4j-core-2.8.1-sources.jar",
+                "directDependencies": [
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1"
+                ],
+                "dependencies": [
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.8.1/log4j-core-2.8.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.8.1/log4j-core-2.8.1-sources.jar"
+                ],
+                "sha256": "efb8bd06659beda231375b72fb38f44d884b7d086f34e050204ffc8efe0cf6c2"
             },
             {
                 "coord": "org.apache.logging.log4j:log4j-slf4j-impl:2.8.1",
@@ -2857,6 +5678,25 @@
                 "sha256": "43f325bb7b1592796554fa29448017941c94431c906fb0498c2f70e3d67bb3b6"
             },
             {
+                "coord": "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources:2.8.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.8.1/log4j-slf4j-impl-2.8.1-sources.jar",
+                "directDependencies": [
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.8.1/log4j-slf4j-impl-2.8.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.8.1/log4j-slf4j-impl-2.8.1-sources.jar"
+                ],
+                "sha256": "33b86ad14e4af9e74107cebd7e51ae5ff96a0ffe06b5c6fead6a84d3a903312a"
+            },
+            {
                 "coord": "org.apiguardian:apiguardian-api:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar",
                 "directDependencies": [],
@@ -2866,6 +5706,17 @@
                     "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar"
                 ],
                 "sha256": "1f58b77470d8d147a0538d515347dd322f49a83b9e884b8970051160464b65b3"
+            },
+            {
+                "coord": "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0-sources.jar"
+                ],
+                "sha256": "793b50c98fa62e6eec08cc8fa4364b95d4815c1b17ef17e5e9e59c457e54ce2e"
             },
             {
                 "coord": "org.awaitility:awaitility:3.1.6",
@@ -2887,6 +5738,25 @@
                 "sha256": "694e2e915312b6fe0123c3d532f6675eed3b6d60e4f2ab677d3688fde3defcfc"
             },
             {
+                "coord": "org.awaitility:awaitility:jar:sources:3.1.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/awaitility/awaitility/3.1.6/awaitility-3.1.6-sources.jar",
+                "directDependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.hamcrest:hamcrest-library:jar:sources:1.3",
+                    "org.objenesis:objenesis:jar:sources:2.6"
+                ],
+                "dependencies": [
+                    "org.objenesis:objenesis:jar:sources:2.6",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.hamcrest:hamcrest-library:jar:sources:1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/awaitility/awaitility/3.1.6/awaitility-3.1.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/awaitility/awaitility/3.1.6/awaitility-3.1.6-sources.jar"
+                ],
+                "sha256": "b27e80792fd074992a975c813a9d4d24bd9699741f4fe30c0cc7127fca3aa937"
+            },
+            {
                 "coord": "org.beanshell:bsh:2.0b4",
                 "file": "v1/https/repo1.maven.org/maven2/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar",
                 "directDependencies": [],
@@ -2896,6 +5766,12 @@
                     "https://repo1.maven.org/maven2/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar"
                 ],
                 "sha256": "91395c07885839a8c6986d5b7c577cd9bacf01bf129c89141f35e8ea858427b6"
+            },
+            {
+                "coord": "org.beanshell:bsh:jar:sources:2.0b4",
+                "file": null,
+                "directDependencies": [],
+                "dependencies": []
             },
             {
                 "coord": "org.checkerframework:checker-compat-qual:2.0.0",
@@ -2909,6 +5785,17 @@
                 "sha256": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b"
             },
             {
+                "coord": "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-sources.jar"
+                ],
+                "sha256": "8e287b29415fac2c0b9eb04f30224d9d2ad33c23b7a7ce8d23d1f197f0eb5074"
+            },
+            {
                 "coord": "org.checkerframework:checker:2.5.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4.jar",
                 "directDependencies": [],
@@ -2920,6 +5807,17 @@
                 "sha256": "2bff93185b4b70cde3f79370621700b3a102823ac9838e5eedf50df2b6124266"
             },
             {
+                "coord": "org.checkerframework:checker:jar:sources:2.5.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4-sources.jar"
+                ],
+                "sha256": "764f65795e857c36c381e07b76f2e19217a472cef4c352bd40a090ca94305326"
+            },
+            {
                 "coord": "org.codehaus.mojo:animal-sniffer-annotations:1.17",
                 "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
                 "directDependencies": [],
@@ -2929,6 +5827,17 @@
                     "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar"
                 ],
                 "sha256": "92654f493ecfec52082e76354f0ebf87648dc3d5cec2e3c3cdb947c016747a53"
+            },
+            {
+                "coord": "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                "file": "v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17-sources.jar"
+                ],
+                "sha256": "2571474a676f775a8cdd15fb9b1da20c4c121ed7f42a5d93fca0e7b6e2015b40"
             },
             {
                 "coord": "org.cvogt:scala-extensions_2.12:0.5.3",
@@ -2946,6 +5855,21 @@
                 "sha256": "8c5798066e8e04033fc0d84db924b4661d5e66a7d7dfc0cee8c90e6f90860bce"
             },
             {
+                "coord": "org.cvogt:scala-extensions_2.12:jar:sources:0.5.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/cvogt/scala-extensions_2.12/0.5.3/scala-extensions_2.12-0.5.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/cvogt/scala-extensions_2.12/0.5.3/scala-extensions_2.12-0.5.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/cvogt/scala-extensions_2.12/0.5.3/scala-extensions_2.12-0.5.3-sources.jar"
+                ],
+                "sha256": "21c3bd4c619d257aa283c338a231047cd65bfbe4c8a0922ee08fab8868706317"
+            },
+            {
                 "coord": "org.eclipse.jetty.websocket:websocket-api:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.8.v20171121/websocket-api-9.4.8.v20171121.jar",
                 "directDependencies": [],
@@ -2955,6 +5879,17 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.8.v20171121/websocket-api-9.4.8.v20171121.jar"
                 ],
                 "sha256": "196a626b68d7a75cd7067b49a6af22599425159354d11ec6fa4ddc80cb075bf3"
+            },
+            {
+                "coord": "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.8.v20171121/websocket-api-9.4.8.v20171121-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.8.v20171121/websocket-api-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.8.v20171121/websocket-api-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "d554e3da5c4eba923f0372388da132827da9c8f267414fac595de4ebc63f299f"
             },
             {
                 "coord": "org.eclipse.jetty.websocket:websocket-client:9.4.8.v20171121",
@@ -2982,6 +5917,31 @@
                 "sha256": "87c72fd4878d1beed377b9984748e6c6d8f8bdf5d611279dadfa85c6c7c0a1eb"
             },
             {
+                "coord": "org.eclipse.jetty.websocket:websocket-client:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.4.8.v20171121/websocket-client-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-client:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-client:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.4.8.v20171121/websocket-client-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.4.8.v20171121/websocket-client-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "88af1206c04f7dc5215b0205a37abf854a3e804cf28fa0092cdcc7af5244b8d4"
+            },
+            {
                 "coord": "org.eclipse.jetty.websocket:websocket-common:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.8.v20171121/websocket-common-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -2999,6 +5959,25 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.8.v20171121/websocket-common-9.4.8.v20171121.jar"
                 ],
                 "sha256": "5c56a6f6385172a284056af4906c00bd8edf472d5c9c87ac9b517aa781bfcbdb"
+            },
+            {
+                "coord": "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.8.v20171121/websocket-common-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.8.v20171121/websocket-common-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.8.v20171121/websocket-common-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "ee2ac1df0907cb18457320c480df1949f46bfd79f55c4d4a7388e4545c5fbb83"
             },
             {
                 "coord": "org.eclipse.jetty.websocket:websocket-server:9.4.8.v20171121",
@@ -3032,6 +6011,37 @@
                 "sha256": "8ae84e4d97e902fb4b6e9bd31f8b92db71188a4b1b7a6989b9bb81cc45ee8a6a"
             },
             {
+                "coord": "org.eclipse.jetty.websocket:websocket-server:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.4.8.v20171121/websocket-server-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty.websocket:websocket-client:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-servlet:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-client:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-common:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-client:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty.websocket:websocket-servlet:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.4.8.v20171121/websocket-server-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.4.8.v20171121/websocket-server-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "63edc290a072d887ff43e07cb3c19812c660b20b19bc72525c2a46a41550912b"
+            },
+            {
                 "coord": "org.eclipse.jetty.websocket:websocket-servlet:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.8.v20171121/websocket-servlet-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -3047,6 +6057,23 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.8.v20171121/websocket-servlet-9.4.8.v20171121.jar"
                 ],
                 "sha256": "4b0b71e3057bb46fe3271986ed189a0fc0dbbb8fe605de1a08b6b806ae9aac87"
+            },
+            {
+                "coord": "org.eclipse.jetty.websocket:websocket-servlet:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.8.v20171121/websocket-servlet-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty.websocket:websocket-api:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.8.v20171121/websocket-servlet-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.8.v20171121/websocket-servlet-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "b67bb8eeb69f8759458ebbb0ae79c307d4d9182237f2dafea6f2c59eba4493eb"
             },
             {
                 "coord": "org.eclipse.jetty:jetty-client:9.4.8.v20171121",
@@ -3067,6 +6094,24 @@
                 "sha256": "926cedd13ebf5b4e216c64a8fc5ff3d42cc81b721f2954639a2580f62f121093"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-client:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/9.4.8.v20171121/jetty-client-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/9.4.8.v20171121/jetty-client-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/9.4.8.v20171121/jetty-client-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "6a82e5b92559243f9bcf5519aceeb4668e6762d11f01bb8e31e00843fc7c5b7c"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-http:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.8.v20171121/jetty-http-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -3084,6 +6129,23 @@
                 "sha256": "bcb58b9e27a2b361db3003f4d0ab24e7494237247b17131cabb483f46a8c31f9"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.8.v20171121/jetty-http-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.8.v20171121/jetty-http-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.8.v20171121/jetty-http-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "123f6cd7fc2dbc1e34ad1cdde9bffd0dc19bc90b3d508ccd2301f67fb55f2356"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-io:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -3097,6 +6159,21 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121.jar"
                 ],
                 "sha256": "e06fb86653599b463e1516d2ac7682c9e4d9a4ad0e5f6bba6e13661c45d3c293"
+            },
+            {
+                "coord": "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.8.v20171121/jetty-io-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "df3d33834b3497cddf2945436a034ce0cab62ab270467d2a58df865d31eac2e9"
             },
             {
                 "coord": "org.eclipse.jetty:jetty-security:9.4.8.v20171121",
@@ -3116,6 +6193,25 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.8.v20171121/jetty-security-9.4.8.v20171121.jar"
                 ],
                 "sha256": "69963592170bcf14e2dda4370cd2de6c5d646adf89a9bd9d7ec88dc5fef310a9"
+            },
+            {
+                "coord": "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.8.v20171121/jetty-security-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.8.v20171121/jetty-security-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.8.v20171121/jetty-security-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "659164540a65c93e5aa94c125f263d95503be92803f3a30f28332cd6760e35e0"
             },
             {
                 "coord": "org.eclipse.jetty:jetty-server:9.4.8.v20171121",
@@ -3138,6 +6234,26 @@
                 "sha256": "686b6ffb11705a8afc0dcbc977a6dfca03d96b4720d5f643b6f4598b2dd975e2"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.8.v20171121/jetty-server-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.8.v20171121/jetty-server-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.8.v20171121/jetty-server-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "cb58ea2bb20e327303877175335386b5a7fab3a7a581872d55c255a9f04249bb"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-servlet:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.8.v20171121/jetty-servlet-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -3158,6 +6274,26 @@
                 "sha256": "e573169d2e8bdf319a773596b66636ff134d089f7d7484bcf42f9fd8080a839a"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.8.v20171121/jetty-servlet-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.8.v20171121/jetty-servlet-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.8.v20171121/jetty-servlet-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "1963d42aaa0ffdcbb0a936aa0001f97ca455f76efd6492bcc9079a2d5ad07ed2"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-util:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121.jar",
                 "directDependencies": [],
@@ -3167,6 +6303,17 @@
                     "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121.jar"
                 ],
                 "sha256": "06dd3d7238b341ada11a6aba94f5b1bcff5d8ce981c88d3de929563ca6fa934f"
+            },
+            {
+                "coord": "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.8.v20171121/jetty-util-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "34f2cb8c438a4137fa3a6675efe1a8a350e66a38c1c06e71f508d0004d0a2419"
             },
             {
                 "coord": "org.eclipse.jetty:jetty-webapp:9.4.8.v20171121",
@@ -3192,6 +6339,29 @@
                 "sha256": "35220283beb6a66774783e1fb1f061f795a7b3326278871b1755e390e120fc82"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-webapp:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/9.4.8.v20171121/jetty-webapp-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                    "javax.servlet:javax.servlet-api:jar:sources:3.1.0",
+                    "org.eclipse.jetty:jetty-io:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-server:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-servlet:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-http:jar:sources:9.4.8.v20171121",
+                    "org.eclipse.jetty:jetty-security:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/9.4.8.v20171121/jetty-webapp-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/9.4.8.v20171121/jetty-webapp-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "c81a6b3580e8913853b9d7b31e2d9d257bb972664c7c324b9abb0490c2e11b23"
+            },
+            {
                 "coord": "org.eclipse.jetty:jetty-xml:9.4.8.v20171121",
                 "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.8.v20171121/jetty-xml-9.4.8.v20171121.jar",
                 "directDependencies": [
@@ -3207,6 +6377,21 @@
                 "sha256": "b8cccf20d966604bc48fbb6009e74e788832a6ff1b352517c4cc9f0beff6b7cf"
             },
             {
+                "coord": "org.eclipse.jetty:jetty-xml:jar:sources:9.4.8.v20171121",
+                "file": "v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.8.v20171121/jetty-xml-9.4.8.v20171121-sources.jar",
+                "directDependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121"
+                ],
+                "dependencies": [
+                    "org.eclipse.jetty:jetty-util:jar:sources:9.4.8.v20171121"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.8.v20171121/jetty-xml-9.4.8.v20171121-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.8.v20171121/jetty-xml-9.4.8.v20171121-sources.jar"
+                ],
+                "sha256": "d5c170159010067f13053bf619a8f90ba18a6377020ea69f05bb521644ba817e"
+            },
+            {
                 "coord": "org.flywaydb:flyway-core:5.2.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/flywaydb/flyway-core/5.2.4/flyway-core-5.2.4.jar",
                 "directDependencies": [],
@@ -3218,6 +6403,17 @@
                 "sha256": "acfb5d8df20f85f11d215d625841fadc8b0b7fdb7729c3c5e5f4db4d5621a82e"
             },
             {
+                "coord": "org.flywaydb:flyway-core:jar:sources:5.2.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/flywaydb/flyway-core/5.2.4/flyway-core-5.2.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/5.2.4/flyway-core-5.2.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/5.2.4/flyway-core-5.2.4-sources.jar"
+                ],
+                "sha256": "38ce692e4d6e180a530182fa28edd57291c6bb0587c72765b2c39798daa5161c"
+            },
+            {
                 "coord": "org.freemarker:freemarker-gae:2.3.28",
                 "file": "v1/https/repo1.maven.org/maven2/org/freemarker/freemarker-gae/2.3.28/freemarker-gae-2.3.28.jar",
                 "directDependencies": [],
@@ -3227,6 +6423,17 @@
                     "https://repo1.maven.org/maven2/org/freemarker/freemarker-gae/2.3.28/freemarker-gae-2.3.28.jar"
                 ],
                 "sha256": "23dbccd3037b099ee103b24e1a3afaf4de2f6ed1392af829b214e8768f00c7af"
+            },
+            {
+                "coord": "org.freemarker:freemarker-gae:jar:sources:2.3.28",
+                "file": "v1/https/repo1.maven.org/maven2/org/freemarker/freemarker-gae/2.3.28/freemarker-gae-2.3.28-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/freemarker/freemarker-gae/2.3.28/freemarker-gae-2.3.28-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/freemarker/freemarker-gae/2.3.28/freemarker-gae-2.3.28-sources.jar"
+                ],
+                "sha256": "ef71f902b3b1505e40a83a4e1e08a13b21ecf2ee29693f5b5709591d5d6b9d83"
             },
             {
                 "coord": "org.gnieh:diffson-core_2.12:3.1.0",
@@ -3242,6 +6449,21 @@
                     "https://repo1.maven.org/maven2/org/gnieh/diffson-core_2.12/3.1.0/diffson-core_2.12-3.1.0.jar"
                 ],
                 "sha256": "a4bdcf37e1168de51ec624072fc6eb31dadc594f73069142013b2351bc15a77f"
+            },
+            {
+                "coord": "org.gnieh:diffson-core_2.12:jar:sources:3.1.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/gnieh/diffson-core_2.12/3.1.0/diffson-core_2.12-3.1.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/gnieh/diffson-core_2.12/3.1.0/diffson-core_2.12-3.1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/gnieh/diffson-core_2.12/3.1.0/diffson-core_2.12-3.1.0-sources.jar"
+                ],
+                "sha256": "ceff8bf97c870f7f35ae1ecfc32fecf821aa5f7c057e668f3965a51273261de7"
             },
             {
                 "coord": "org.gnieh:diffson-spray-json_2.12:3.1.0",
@@ -3263,6 +6485,25 @@
                 "sha256": "e29c52379a144b9652403eb7da3118b512dc17412ec175e6b64d58c961fc3ffc"
             },
             {
+                "coord": "org.gnieh:diffson-spray-json_2.12:jar:sources:3.1.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/gnieh/diffson-spray-json_2.12/3.1.0/diffson-spray-json_2.12-3.1.0-sources.jar",
+                "directDependencies": [
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.gnieh:diffson-core_2.12:jar:sources:3.1.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.gnieh:diffson-core_2.12:jar:sources:3.1.0",
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/gnieh/diffson-spray-json_2.12/3.1.0/diffson-spray-json_2.12-3.1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/gnieh/diffson-spray-json_2.12/3.1.0/diffson-spray-json_2.12-3.1.0-sources.jar"
+                ],
+                "sha256": "6c5c5cb80b84f93d526aa49c5ab5814d7236e58ef8cfcd3e06d3803c87234602"
+            },
+            {
                 "coord": "org.hamcrest:hamcrest-all:1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar",
                 "directDependencies": [],
@@ -3274,6 +6515,17 @@
                 "sha256": "4877670629ab96f34f5f90ab283125fcd9acb7e683e66319a68be6eb2cca60de"
             },
             {
+                "coord": "org.hamcrest:hamcrest-all:jar:sources:1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3-sources.jar"
+                ],
+                "sha256": "c53535c3d25b5bf0b00a324a5583c7dd2fed0fa6d1bbc622e2dec460c24faab3"
+            },
+            {
                 "coord": "org.hamcrest:hamcrest-core:1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
                 "directDependencies": [],
@@ -3283,6 +6535,17 @@
                     "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
                 ],
                 "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
+            },
+            {
+                "coord": "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+                ],
+                "sha256": "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df"
             },
             {
                 "coord": "org.hamcrest:hamcrest-library:1.3",
@@ -3300,6 +6563,21 @@
                 "sha256": "711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c"
             },
             {
+                "coord": "org.hamcrest:hamcrest-library:jar:sources:1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+                "directDependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "dependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar"
+                ],
+                "sha256": "1c0ff84455f539eb3c29a8c430de1f6f6f1ba4b9ab39ca19b195f33203cd539c"
+            },
+            {
                 "coord": "org.jboss.logging:jboss-logging:3.3.0.Final",
                 "file": "v1/https/repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar",
                 "directDependencies": [],
@@ -3311,6 +6589,17 @@
                 "sha256": "e0e0595e7f70c464609095aef9e47a8484e05f2f621c0aa5081c18e3db2d498c"
             },
             {
+                "coord": "org.jboss.logging:jboss-logging:jar:sources:3.3.0.Final",
+                "file": "v1/https/repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final-sources.jar"
+                ],
+                "sha256": "404bf96d25a54854d8c59331bc0650e06698c8747b1886738f036363b72be569"
+            },
+            {
                 "coord": "org.jetbrains:annotations:13.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
                 "directDependencies": [],
@@ -3320,6 +6609,17 @@
                     "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
                 ],
                 "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478"
+            },
+            {
+                "coord": "org.jetbrains:annotations:jar:sources:13.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
+                ],
+                "sha256": "42a5e144b8e81d50d6913d1007b695e62e614705268d8cf9f13dbdc478c2c68e"
             },
             {
                 "coord": "org.jline:jline-reader:3.7.1",
@@ -3337,6 +6637,21 @@
                 "sha256": "f3436bdf8365ff7203bd5badf3ab1ff844b6d0eada367f7ed7fe07bfbad9324b"
             },
             {
+                "coord": "org.jline:jline-reader:jar:sources:3.7.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/jline/jline-reader/3.7.1/jline-reader-3.7.1-sources.jar",
+                "directDependencies": [
+                    "org.jline:jline-terminal:jar:sources:3.7.1"
+                ],
+                "dependencies": [
+                    "org.jline:jline-terminal:jar:sources:3.7.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/jline/jline-reader/3.7.1/jline-reader-3.7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jline/jline-reader/3.7.1/jline-reader-3.7.1-sources.jar"
+                ],
+                "sha256": "34d58577ce7877487cd64bcfead0e850a6d4a978573639024c19f8f622593ac8"
+            },
+            {
                 "coord": "org.jline:jline-terminal:3.7.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.7.1/jline-terminal-3.7.1.jar",
                 "directDependencies": [],
@@ -3346,6 +6661,17 @@
                     "https://repo1.maven.org/maven2/org/jline/jline-terminal/3.7.1/jline-terminal-3.7.1.jar"
                 ],
                 "sha256": "4a656a6f409c53d3fab247aa7f33bb19f87c34a8648b0727fbcb446ef4ea3b6c"
+            },
+            {
+                "coord": "org.jline:jline-terminal:jar:sources:3.7.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.7.1/jline-terminal-3.7.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/jline/jline-terminal/3.7.1/jline-terminal-3.7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jline/jline-terminal/3.7.1/jline-terminal-3.7.1-sources.jar"
+                ],
+                "sha256": "7573c84d99993f0a72231a27ba84b32294fb680feafbcc2beafefc3a94a3ff0f"
             },
             {
                 "coord": "org.jline:jline:3.7.1",
@@ -3359,6 +6685,17 @@
                 "sha256": "1a386eef254e5d484a8ad8dd4479004b860701a38d127505f3b3121843edc8d0"
             },
             {
+                "coord": "org.jline:jline:jar:sources:3.7.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/jline/jline/3.7.1/jline-3.7.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/jline/jline/3.7.1/jline-3.7.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jline/jline/3.7.1/jline-3.7.1-sources.jar"
+                ],
+                "sha256": "6b0b70c0674d8d84de1bd02350f5b402b54685670b84425c9ec5b7ff00b1769e"
+            },
+            {
                 "coord": "org.joda:joda-convert:1.8.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/joda/joda-convert/1.8.1/joda-convert-1.8.1.jar",
                 "directDependencies": [],
@@ -3368,6 +6705,17 @@
                     "https://repo1.maven.org/maven2/org/joda/joda-convert/1.8.1/joda-convert-1.8.1.jar"
                 ],
                 "sha256": "96d8f5163fb77bc747b92dd2eefc6aa2cfbc9fccdfc392eba2190cb4709b4328"
+            },
+            {
+                "coord": "org.joda:joda-convert:jar:sources:1.8.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/joda/joda-convert/1.8.1/joda-convert-1.8.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/joda/joda-convert/1.8.1/joda-convert-1.8.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/joda/joda-convert/1.8.1/joda-convert-1.8.1-sources.jar"
+                ],
+                "sha256": "a4f140df48c0d25e22c80d958bae4a5e96ee5a9db58e12abf0dcbf0e248e2f86"
             },
             {
                 "coord": "org.jooq:jool:0.9.11",
@@ -3381,6 +6729,17 @@
                 "sha256": "510da4d8bd24bc09b71200ef3801f7af143eeaf7d48772254cec352585b97dd0"
             },
             {
+                "coord": "org.jooq:jool:jar:sources:0.9.11",
+                "file": "v1/https/repo1.maven.org/maven2/org/jooq/jool/0.9.11/jool-0.9.11-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/jooq/jool/0.9.11/jool-0.9.11-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/jooq/jool/0.9.11/jool-0.9.11-sources.jar"
+                ],
+                "sha256": "725ba786e32288f82dc8c9cb9922b82e84e733b2c29888b029c4237624f56b56"
+            },
+            {
                 "coord": "org.json:json:20090211",
                 "file": "v1/https/repo1.maven.org/maven2/org/json/json/20090211/json-20090211.jar",
                 "directDependencies": [],
@@ -3390,6 +6749,12 @@
                     "https://repo1.maven.org/maven2/org/json/json/20090211/json-20090211.jar"
                 ],
                 "sha256": "055be110a570f9cda3eba8d70a006ff46c77a048bc67868524879211c48b330a"
+            },
+            {
+                "coord": "org.json:json:jar:sources:20090211",
+                "file": null,
+                "directDependencies": [],
+                "dependencies": []
             },
             {
                 "coord": "org.junit.jupiter:junit-jupiter-api:5.0.0",
@@ -3409,6 +6774,25 @@
                     "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0.jar"
                 ],
                 "sha256": "559826fb47a05d541edd6a0034d2bbb9ad27078f49fb5fe76c0f07e23816b660"
+            },
+            {
+                "coord": "org.junit.jupiter:junit-jupiter-api:jar:sources:5.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0-sources.jar"
+                ],
+                "sha256": "124a0efee42f84bceb30f265272f60793d7838bd28c32f56d1756a9b052c6e07"
             },
             {
                 "coord": "org.junit.jupiter:junit-jupiter-engine:5.0.0",
@@ -3432,6 +6816,27 @@
                 "sha256": "906a6cc73dccf91beb328838092f6a1249a98731aa1958190b98b8b07ee50fe9"
             },
             {
+                "coord": "org.junit.jupiter:junit-jupiter-engine:jar:sources:5.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.0.0/junit-jupiter-engine-5.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.jupiter:junit-jupiter-api:jar:sources:5.0.0",
+                    "org.junit.platform:junit-platform-engine:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0",
+                    "org.junit.jupiter:junit-jupiter-api:jar:sources:5.0.0",
+                    "org.junit.platform:junit-platform-engine:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.0.0/junit-jupiter-engine-5.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.0.0/junit-jupiter-engine-5.0.0-sources.jar"
+                ],
+                "sha256": "7ae10d5b66a883ad15b8119a1edbac75e5693a1ec10d91c0af2c375aa3904e7e"
+            },
+            {
                 "coord": "org.junit.platform:junit-platform-commons:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0.jar",
                 "directDependencies": [
@@ -3445,6 +6850,21 @@
                     "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0.jar"
                 ],
                 "sha256": "ffa95e7d2180aa5c5f14df2e710cbb71bc479b47e3ac5a95be71e932e9d8bba7"
+            },
+            {
+                "coord": "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0-sources.jar"
+                ],
+                "sha256": "efadb2ccdf297aac87714cf5ba89cf43c4a0620699a226dffcb5f82937e92c42"
             },
             {
                 "coord": "org.junit.platform:junit-platform-engine:1.0.0",
@@ -3466,6 +6886,25 @@
                 "sha256": "36d6f7afe4ae00012c91efb3def6bd98347c900335ebffbdc1a90254bd812fa7"
             },
             {
+                "coord": "org.junit.platform:junit-platform-engine:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.0.0/junit-platform-engine-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.0.0/junit-platform-engine-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.0.0/junit-platform-engine-1.0.0-sources.jar"
+                ],
+                "sha256": "7dd3b5a84c0db4ed3c82846d1dd83a3d4df674e0cd3dc23b66c1270eac430a85"
+            },
+            {
                 "coord": "org.junit.platform:junit-platform-launcher:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0.jar",
                 "directDependencies": [
@@ -3483,6 +6922,25 @@
                     "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0.jar"
                 ],
                 "sha256": "6c660f6e41149921e6865d5a7715f08f414eb0a49c96874d3cc9c05ccfcbb0e3"
+            },
+            {
+                "coord": "org.junit.platform:junit-platform-launcher:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-engine:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-engine:jar:sources:1.0.0",
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0-sources.jar"
+                ],
+                "sha256": "c5c1f9dbadcfd91e8ba4ed8ab31fecf4e60b0e2bbaa22b59d4f8c48deeea76a4"
             },
             {
                 "coord": "org.junit.platform:junit-platform-runner:1.0.0",
@@ -3510,6 +6968,31 @@
                 "sha256": "6e1acc7c300452d05b9df3da529a5a885620c15258d4244d1027033e6d44aa38"
             },
             {
+                "coord": "org.junit.platform:junit-platform-runner:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.0.0/junit-platform-runner-1.0.0-sources.jar",
+                "directDependencies": [
+                    "junit:junit:jar:sources:4.12",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-launcher:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-suite-api:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.opentest4j:opentest4j:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-launcher:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-suite-api:jar:sources:1.0.0",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.junit.platform:junit-platform-engine:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "junit:junit:jar:sources:4.12",
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.0.0/junit-platform-runner-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.0.0/junit-platform-runner-1.0.0-sources.jar"
+                ],
+                "sha256": "420634db48f5962bb5b55e61419895ab038ae7df538a2c701cb0e2d059af4026"
+            },
+            {
                 "coord": "org.junit.platform:junit-platform-suite-api:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0.jar",
                 "directDependencies": [
@@ -3525,6 +7008,23 @@
                     "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0.jar"
                 ],
                 "sha256": "aac9a2bdf9b4a4b946fe32d87fdaa87a41638519f2e604237340452818148e45"
+            },
+            {
+                "coord": "org.junit.platform:junit-platform-suite-api:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0",
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.junit.platform:junit-platform-commons:jar:sources:1.0.0",
+                    "org.apiguardian:apiguardian-api:jar:sources:1.0.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0-sources.jar"
+                ],
+                "sha256": "d9359c6d987d2209f8dc5fb510d7a0e748d0ef80f34ab3a040c4d70324da31c7"
             },
             {
                 "coord": "org.mockito:mockito-core:2.25.0",
@@ -3546,6 +7046,25 @@
                 "sha256": "28028d70cc27d61442948fcb3d249d9df5b37c47aa0b82490a3d049094ff411f"
             },
             {
+                "coord": "org.mockito:mockito-core:jar:sources:2.25.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-core/2.25.0/mockito-core-2.25.0-sources.jar",
+                "directDependencies": [
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.9.7",
+                    "org.objenesis:objenesis:jar:sources:2.6"
+                ],
+                "dependencies": [
+                    "org.objenesis:objenesis:jar:sources:2.6",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.9.7",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-core/2.25.0/mockito-core-2.25.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-core/2.25.0/mockito-core-2.25.0-sources.jar"
+                ],
+                "sha256": "2230169d4ffad6f6c1b07bba0e81e30fa734941faf073e847839c695907645ff"
+            },
+            {
                 "coord": "org.mockito:mockito-inline:2.25.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-inline/2.25.0/mockito-inline-2.25.0.jar",
                 "directDependencies": [
@@ -3562,6 +7081,24 @@
                     "https://repo1.maven.org/maven2/org/mockito/mockito-inline/2.25.0/mockito-inline-2.25.0.jar"
                 ],
                 "sha256": "e620ad9caaaa36feeeb3ef7b5b5d6bf8d02529d3f8e028a21319a95135807bda"
+            },
+            {
+                "coord": "org.mockito:mockito-inline:jar:sources:2.25.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-inline/2.25.0/mockito-inline-2.25.0-sources.jar",
+                "directDependencies": [
+                    "org.mockito:mockito-core:jar:sources:2.25.0"
+                ],
+                "dependencies": [
+                    "org.objenesis:objenesis:jar:sources:2.6",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.9.7",
+                    "org.mockito:mockito-core:jar:sources:2.25.0",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-inline/2.25.0/mockito-inline-2.25.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-inline/2.25.0/mockito-inline-2.25.0-sources.jar"
+                ],
+                "sha256": "158dd666020ad14225945bd54af3afd3229fc64012e84aa534d1ac4740981253"
             },
             {
                 "coord": "org.mongodb.scala:mongo-scala-bson_2.12:2.2.0",
@@ -3583,6 +7120,27 @@
                     "https://repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-bson_2.12/2.2.0/mongo-scala-bson_2.12-2.2.0.jar"
                 ],
                 "sha256": "491b9e3e621f4b4a940812dafaedc701cac5d1c6a1ac0be65bb7fa86dae66165"
+            },
+            {
+                "coord": "org.mongodb.scala:mongo-scala-bson_2.12:jar:sources:2.2.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-bson_2.12/2.2.0/mongo-scala-bson_2.12-2.2.0-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                    "org.mongodb:mongodb-driver-core:jar:sources:3.6.4",
+                    "org.mongodb:bson:jar:sources:3.6.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-bson_2.12/2.2.0/mongo-scala-bson_2.12-2.2.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-bson_2.12/2.2.0/mongo-scala-bson_2.12-2.2.0-sources.jar"
+                ],
+                "sha256": "99e370ac050466234bc5aea6aba6c9078029575019dd9a62be9b6bb2d02a2fa5"
             },
             {
                 "coord": "org.mongodb.scala:mongo-scala-driver_2.12:2.2.0",
@@ -3608,6 +7166,29 @@
                 "sha256": "e88f19b48b192eba09f707ca103372ba9a9d5ece3a07b3faa1b9bfe71d30d632"
             },
             {
+                "coord": "org.mongodb.scala:mongo-scala-driver_2.12:jar:sources:2.2.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-driver_2.12/2.2.0/mongo-scala-driver_2.12-2.2.0-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                    "org.mongodb.scala:mongo-scala-bson_2.12:jar:sources:2.2.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                    "org.mongodb:mongodb-driver-core:jar:sources:3.6.4",
+                    "org.mongodb.scala:mongo-scala-bson_2.12:jar:sources:2.2.0",
+                    "org.mongodb:bson:jar:sources:3.6.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-driver_2.12/2.2.0/mongo-scala-driver_2.12-2.2.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/scala/mongo-scala-driver_2.12/2.2.0/mongo-scala-driver_2.12-2.2.0-sources.jar"
+                ],
+                "sha256": "6d3f72e30a1aafd03c58fcbd3729312e4a11357ac5907832492977fce0a0cbd7"
+            },
+            {
                 "coord": "org.mongodb:bson:3.6.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/mongodb/bson/3.6.4/bson-3.6.4.jar",
                 "directDependencies": [],
@@ -3617,6 +7198,17 @@
                     "https://repo1.maven.org/maven2/org/mongodb/bson/3.6.4/bson-3.6.4.jar"
                 ],
                 "sha256": "9fe73b83796294ffb05b886755bea22ae26a288c4ffb8a45155d67f37c8e561d"
+            },
+            {
+                "coord": "org.mongodb:bson:jar:sources:3.6.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/bson/3.6.4/bson-3.6.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/bson/3.6.4/bson-3.6.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/bson/3.6.4/bson-3.6.4-sources.jar"
+                ],
+                "sha256": "f4cef09af887cbd3167211922a89e837e6f768cdb675cc478d63eb3bb3027b55"
             },
             {
                 "coord": "org.mongodb:casbah-commons_2.12.0-RC1:3.1.1",
@@ -3640,6 +7232,29 @@
                     "https://repo1.maven.org/maven2/org/mongodb/casbah-commons_2.12.0-RC1/3.1.1/casbah-commons_2.12.0-RC1-3.1.1.jar"
                 ],
                 "sha256": "1e3a85887cb8af225843ace5fc8378202b2ae698434128586b116415ef0834b3"
+            },
+            {
+                "coord": "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-commons_2.12.0-RC1/3.1.1/casbah-commons_2.12.0-RC1-3.1.1-sources.jar",
+                "directDependencies": [
+                    "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                    "org.mongodb:mongo-java-driver:jar:sources:3.2.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.mongodb:mongo-java-driver:jar:sources:3.2.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/casbah-commons_2.12.0-RC1/3.1.1/casbah-commons_2.12.0-RC1-3.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/casbah-commons_2.12.0-RC1/3.1.1/casbah-commons_2.12.0-RC1-3.1.1-sources.jar"
+                ],
+                "sha256": "b1d7f4034171d464dcc5937343c49d49f31e190658aff59d01b71102ce23c6d6"
             },
             {
                 "coord": "org.mongodb:casbah-core_2.12.0-RC1:3.1.1",
@@ -3666,6 +7281,30 @@
                 "sha256": "6d33107431ca01105bbc92b8681a6dd2f2268b3f012a0ef14344b834c897e6d9"
             },
             {
+                "coord": "org.mongodb:casbah-core_2.12.0-RC1:jar:sources:3.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-core_2.12.0-RC1/3.1.1/casbah-core_2.12.0-RC1-3.1.1-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.mongodb:casbah-query_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.mongodb:casbah-query_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.mongodb:mongo-java-driver:jar:sources:3.2.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/casbah-core_2.12.0-RC1/3.1.1/casbah-core_2.12.0-RC1-3.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/casbah-core_2.12.0-RC1/3.1.1/casbah-core_2.12.0-RC1-3.1.1-sources.jar"
+                ],
+                "sha256": "4e1251be43bce7e48d2768ef3ba7824ea0de0885e589f56498eebd0602827737"
+            },
+            {
                 "coord": "org.mongodb:casbah-gridfs_2.12.0-RC1:3.1.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-gridfs_2.12.0-RC1/3.1.1/casbah-gridfs_2.12.0-RC1-3.1.1.jar",
                 "directDependencies": [
@@ -3690,6 +7329,30 @@
                 "sha256": "2faf13091bd0c012acc7df945fb493ae0c1bb3572e2c39641f8e1a08bcfbc166"
             },
             {
+                "coord": "org.mongodb:casbah-gridfs_2.12.0-RC1:jar:sources:3.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-gridfs_2.12.0-RC1/3.1.1/casbah-gridfs_2.12.0-RC1-3.1.1-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:casbah-core_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.mongodb:casbah-query_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.mongodb:mongo-java-driver:jar:sources:3.2.2",
+                    "org.mongodb:casbah-core_2.12.0-RC1:jar:sources:3.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/casbah-gridfs_2.12.0-RC1/3.1.1/casbah-gridfs_2.12.0-RC1-3.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/casbah-gridfs_2.12.0-RC1/3.1.1/casbah-gridfs_2.12.0-RC1-3.1.1-sources.jar"
+                ],
+                "sha256": "a5bbdd1e2261fc2f04e4265c4bb126fcbfb5f215c081c60ba033ec1b7c701010"
+            },
+            {
                 "coord": "org.mongodb:casbah-query_2.12.0-RC1:3.1.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-query_2.12.0-RC1/3.1.1/casbah-query_2.12.0-RC1-3.1.1.jar",
                 "directDependencies": [
@@ -3712,6 +7375,28 @@
                 "sha256": "730fee0c4eec3ef0ba594a2874feea2eb93376ea2c06c68f7a9ea168a5f6bfe1"
             },
             {
+                "coord": "org.mongodb:casbah-query_2.12.0-RC1:jar:sources:3.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/casbah-query_2.12.0-RC1/3.1.1/casbah-query_2.12.0-RC1-3.1.1-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "joda-time:joda-time:jar:sources:2.9.7",
+                    "com.github.nscala-time:nscala-time_2.12.0-RC1:jar:sources:2.14.0",
+                    "org.joda:joda-convert:jar:sources:1.8.1",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.mongodb:casbah-commons_2.12.0-RC1:jar:sources:3.1.1",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.mongodb:mongo-java-driver:jar:sources:3.2.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/casbah-query_2.12.0-RC1/3.1.1/casbah-query_2.12.0-RC1-3.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/casbah-query_2.12.0-RC1/3.1.1/casbah-query_2.12.0-RC1-3.1.1-sources.jar"
+                ],
+                "sha256": "41a2f47e81c2f167c60c4b8bbd83dced8532b915794db27ebe6b9f681eac0aa6"
+            },
+            {
                 "coord": "org.mongodb:mongo-java-driver:3.2.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.2.2/mongo-java-driver-3.2.2.jar",
                 "directDependencies": [],
@@ -3721,6 +7406,17 @@
                     "https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.2.2/mongo-java-driver-3.2.2.jar"
                 ],
                 "sha256": "2d2890279767a61f2cb1a0b17a3581b437bc3762df900a0f9dc1122e9292b387"
+            },
+            {
+                "coord": "org.mongodb:mongo-java-driver:jar:sources:3.2.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.2.2/mongo-java-driver-3.2.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.2.2/mongo-java-driver-3.2.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.2.2/mongo-java-driver-3.2.2-sources.jar"
+                ],
+                "sha256": "4d5561e29ff12869597cc6dffa967fce65780cdd9c8e7fdd66b29ebab6ac9551"
             },
             {
                 "coord": "org.mongodb:mongodb-driver-async:3.6.4",
@@ -3740,6 +7436,23 @@
                 "sha256": "a7a3dea47fbf3b9760c189ba3750574e712060f5bfa4ea3de7ae7ef359170e7b"
             },
             {
+                "coord": "org.mongodb:mongodb-driver-async:jar:sources:3.6.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/mongodb-driver-async/3.6.4/mongodb-driver-async-3.6.4-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:bson:jar:sources:3.6.4",
+                    "org.mongodb:mongodb-driver-core:jar:sources:3.6.4"
+                ],
+                "dependencies": [
+                    "org.mongodb:mongodb-driver-core:jar:sources:3.6.4",
+                    "org.mongodb:bson:jar:sources:3.6.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-async/3.6.4/mongodb-driver-async-3.6.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-async/3.6.4/mongodb-driver-async-3.6.4-sources.jar"
+                ],
+                "sha256": "7775b42b05dbcabf9ad932931da6ceb682cbf2a01aa02ca4efe54fc414ae2697"
+            },
+            {
                 "coord": "org.mongodb:mongodb-driver-core:3.6.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/3.6.4/mongodb-driver-core-3.6.4.jar",
                 "directDependencies": [
@@ -3755,6 +7468,21 @@
                 "sha256": "90dd4c85a5501fb82ab44a180a432bcd92d41c48ef718280eb642c1f5a51293b"
             },
             {
+                "coord": "org.mongodb:mongodb-driver-core:jar:sources:3.6.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/3.6.4/mongodb-driver-core-3.6.4-sources.jar",
+                "directDependencies": [
+                    "org.mongodb:bson:jar:sources:3.6.4"
+                ],
+                "dependencies": [
+                    "org.mongodb:bson:jar:sources:3.6.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/3.6.4/mongodb-driver-core-3.6.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/3.6.4/mongodb-driver-core-3.6.4-sources.jar"
+                ],
+                "sha256": "eb52b25a2ead9e009fd308ac6c64a28d5320903f1959c93d882791782b6e75c0"
+            },
+            {
                 "coord": "org.objenesis:objenesis:2.6",
                 "file": "v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6.jar",
                 "directDependencies": [],
@@ -3766,6 +7494,17 @@
                 "sha256": "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d"
             },
             {
+                "coord": "org.objenesis:objenesis:jar:sources:2.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar"
+                ],
+                "sha256": "52d9f4dba531677fc074eff00ea07f22a1d42e5a97cc9e8571c4cd3d459b6be0"
+            },
+            {
                 "coord": "org.opentest4j:opentest4j:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0.jar",
                 "directDependencies": [],
@@ -3775,6 +7514,17 @@
                     "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0.jar"
                 ],
                 "sha256": "6a05b14e8764a1fa51551ccef29e7271681d65fa907a8136136b94de92a0b862"
+            },
+            {
+                "coord": "org.opentest4j:opentest4j:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0-sources.jar"
+                ],
+                "sha256": "68e5bbe7dbe3b8cfe2b98976a3271830a366ac5c5f5a450ed301c6b4f08bb822"
             },
             {
                 "coord": "org.ow2.asm:asm-analysis:5.0.3",
@@ -3793,6 +7543,22 @@
                 "sha256": "e8fa2a63462c96557dcd36c25525e1264b77366ff851cf0b94eb7592b290849d"
             },
             {
+                "coord": "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3-sources.jar",
+                "directDependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3"
+                ],
+                "dependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3-sources.jar"
+                ],
+                "sha256": "1e9ee309d909b3dbf33291fcfd36c76adba4ed1215b8156c3ac61a774cc86bf1"
+            },
+            {
                 "coord": "org.ow2.asm:asm-commons:5.0.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.3/asm-commons-5.0.3.jar",
                 "directDependencies": [
@@ -3809,6 +7575,22 @@
                 "sha256": "18c1e092230233c9d29e46f21943d769bdb48130cc279e4b0e663f423948c2da"
             },
             {
+                "coord": "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.3/asm-commons-5.0.3-sources.jar",
+                "directDependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3"
+                ],
+                "dependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.3/asm-commons-5.0.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.3/asm-commons-5.0.3-sources.jar"
+                ],
+                "sha256": "1e9ee309d909b3dbf33291fcfd36c76adba4ed1215b8156c3ac61a774cc86bf1"
+            },
+            {
                 "coord": "org.ow2.asm:asm-tree:5.0.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3.jar",
                 "directDependencies": [
@@ -3822,6 +7604,21 @@
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3.jar"
                 ],
                 "sha256": "347a7a9400f9964e87c91d3980e48eebdc8d024bc3b36f7f22189c662853a51c"
+            },
+            {
+                "coord": "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3-sources.jar",
+                "directDependencies": [
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "dependencies": [
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3-sources.jar"
+                ],
+                "sha256": "1e9ee309d909b3dbf33291fcfd36c76adba4ed1215b8156c3ac61a774cc86bf1"
             },
             {
                 "coord": "org.ow2.asm:asm-util:5.0.3",
@@ -3840,6 +7637,22 @@
                 "sha256": "2768edbfa2681b5077f08151de586a6d66b916703cda3ab297e58b41ae8f2362"
             },
             {
+                "coord": "org.ow2.asm:asm-util:jar:sources:5.0.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-util/5.0.3/asm-util-5.0.3-sources.jar",
+                "directDependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3"
+                ],
+                "dependencies": [
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/ow2/asm/asm-util/5.0.3/asm-util-5.0.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/ow2/asm/asm-util/5.0.3/asm-util-5.0.3-sources.jar"
+                ],
+                "sha256": "1e9ee309d909b3dbf33291fcfd36c76adba4ed1215b8156c3ac61a774cc86bf1"
+            },
+            {
                 "coord": "org.ow2.asm:asm:5.0.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar",
                 "directDependencies": [],
@@ -3849,6 +7662,17 @@
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar"
                 ],
                 "sha256": "896618ed8ae62702521a78bc7be42b7c491a08e6920a15f89a3ecdec31e9a220"
+            },
+            {
+                "coord": "org.ow2.asm:asm:jar:sources:5.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4-sources.jar"
+                ],
+                "sha256": "7ba89bc14669d86c1c0dc6abaeb74a87715089f3b904cc2016969e8737d70707"
             },
             {
                 "coord": "org.parboiled:parboiled_2.12:2.1.4",
@@ -3869,6 +7693,24 @@
                 "sha256": "557836e4250a968be75d780c8392eeed2b164ea90dbe858530473aa14ee6d010"
             },
             {
+                "coord": "org.parboiled:parboiled_2.12:jar:sources:2.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/parboiled/parboiled_2.12/2.1.4/parboiled_2.12-2.1.4-sources.jar",
+                "directDependencies": [
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/parboiled/parboiled_2.12/2.1.4/parboiled_2.12-2.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/parboiled/parboiled_2.12/2.1.4/parboiled_2.12-2.1.4-sources.jar"
+                ],
+                "sha256": "dd1450c6bcd6b41cde8a4dbba802dfe27082a5dd17444b7425a48f228b5c38fa"
+            },
+            {
                 "coord": "org.pcollections:pcollections:2.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3.jar",
                 "directDependencies": [],
@@ -3880,6 +7722,17 @@
                 "sha256": "f94a44a953006ea13f0ea989881ae17fa1c0378ed855d3ba9fef44b71f71a8d1"
             },
             {
+                "coord": "org.pcollections:pcollections:jar:sources:2.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3-sources.jar"
+                ],
+                "sha256": "326b66bf9a18727c59fdd77306cd2f22dfcf678049998b4f823dd29c632ccc0a"
+            },
+            {
                 "coord": "org.postgresql:postgresql:42.2.6",
                 "file": "v1/https/repo1.maven.org/maven2/org/postgresql/postgresql/42.2.6/postgresql-42.2.6.jar",
                 "directDependencies": [],
@@ -3889,6 +7742,17 @@
                     "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.6/postgresql-42.2.6.jar"
                 ],
                 "sha256": "07daadb33e87638703bf41f3307fc0dbdb386e54af5d5d6481511a36f50ca004"
+            },
+            {
+                "coord": "org.postgresql:postgresql:jar:sources:42.2.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/postgresql/postgresql/42.2.6/postgresql-42.2.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.6/postgresql-42.2.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.6/postgresql-42.2.6-sources.jar"
+                ],
+                "sha256": "0d7f02c19f88d42045111ea8352428b1074723f1f756e72989850351bdfeabea"
             },
             {
                 "coord": "org.reactivestreams:reactive-streams-examples:1.0.2",
@@ -3904,6 +7768,21 @@
                     "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2.jar"
                 ],
                 "sha256": "b0285302f2b372f6423977a21344549b2aa0e4c8c053f66c9bdc478d632779b3"
+            },
+            {
+                "coord": "org.reactivestreams:reactive-streams-examples:jar:sources:1.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2-sources.jar",
+                "directDependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2"
+                ],
+                "dependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2-sources.jar"
+                ],
+                "sha256": "33b5499acdd9be206d6657c18026a02a77c3150967d8ef04e396ee9132c0764a"
             },
             {
                 "coord": "org.reactivestreams:reactive-streams-tck:1.0.2",
@@ -3930,6 +7809,30 @@
                 "sha256": "67fa341c934ad75587f2274af1f4d156935ec7da44784d12d6f7cb6155aa338e"
             },
             {
+                "coord": "org.reactivestreams:reactive-streams-tck:jar:sources:1.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-tck/1.0.2/reactive-streams-tck-1.0.2-sources.jar",
+                "directDependencies": [
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.reactivestreams:reactive-streams-examples:jar:sources:1.0.2",
+                    "org.testng:testng:jar:sources:5.14.10"
+                ],
+                "dependencies": [
+                    "com.beust:jcommander:jar:sources:1.12",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.beanshell:bsh:jar:sources:2.0b4",
+                    "org.reactivestreams:reactive-streams-examples:jar:sources:1.0.2",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.testng:testng:jar:sources:5.14.10",
+                    "org.yaml:snakeyaml:jar:sources:1.24",
+                    "junit:junit:jar:sources:4.12"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams-tck/1.0.2/reactive-streams-tck-1.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams-tck/1.0.2/reactive-streams-tck-1.0.2-sources.jar"
+                ],
+                "sha256": "091743da053ddffbf632a77e9e583441b8ef8c0e4814ceedb7e6b35d6bc181a5"
+            },
+            {
                 "coord": "org.reactivestreams:reactive-streams:1.0.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar",
                 "directDependencies": [],
@@ -3939,6 +7842,17 @@
                     "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar"
                 ],
                 "sha256": "cc09ab0b140e0d0496c2165d4b32ce24f4d6446c0a26c5dc77b06bdf99ee8fae"
+            },
+            {
+                "coord": "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2-sources.jar"
+                ],
+                "sha256": "963a6480f46a64013d0f144ba41c6c6e63c4d34b655761717a436492886f3667"
             },
             {
                 "coord": "org.rnorth.duct-tape:duct-tape:1.0.6",
@@ -3954,6 +7868,21 @@
                     "https://repo1.maven.org/maven2/org/rnorth/duct-tape/duct-tape/1.0.6/duct-tape-1.0.6.jar"
                 ],
                 "sha256": "c6a1b28e0a477f1454771534980908d19dbcf35fddc71c31afb3f83044a36473"
+            },
+            {
+                "coord": "org.rnorth.duct-tape:duct-tape:jar:sources:1.0.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/rnorth/duct-tape/duct-tape/1.0.6/duct-tape-1.0.6-sources.jar",
+                "directDependencies": [
+                    "org.jetbrains:annotations:jar:sources:13.0"
+                ],
+                "dependencies": [
+                    "org.jetbrains:annotations:jar:sources:13.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/rnorth/duct-tape/duct-tape/1.0.6/duct-tape-1.0.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/rnorth/duct-tape/duct-tape/1.0.6/duct-tape-1.0.6-sources.jar"
+                ],
+                "sha256": "567227df0cd6c6a20be925d3e496441be6a29419a6749b817f5f12457d91ea53"
             },
             {
                 "coord": "org.rnorth.visible-assertions:visible-assertions:2.0.0",
@@ -3981,6 +7910,30 @@
                 "sha256": "caaade9f72a95d60c008d87d8766ae4539bc0a51b7ab2d6975e910fb2350a6b8"
             },
             {
+                "coord": "org.rnorth.visible-assertions:visible-assertions:jar:sources:2.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/rnorth/visible-assertions/visible-assertions/2.0.0/visible-assertions-2.0.0-sources.jar",
+                "directDependencies": [
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/rnorth/visible-assertions/visible-assertions/2.0.0/visible-assertions-2.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/rnorth/visible-assertions/visible-assertions/2.0.0/visible-assertions-2.0.0-sources.jar"
+                ],
+                "sha256": "6bdf0f5e8dd78710bea71344b813f5568f27e792dc80b59583897597b2990fd5"
+            },
+            {
                 "coord": "org.rnorth:tcp-unix-socket-proxy:1.0.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/rnorth/tcp-unix-socket-proxy/1.0.1/tcp-unix-socket-proxy-1.0.1.jar",
                 "directDependencies": [
@@ -4002,6 +7955,27 @@
                 "sha256": "c0197fa8b3b6cd3c6a2123a66578ac7f905b406bd969569cc047832036bbd0d9"
             },
             {
+                "coord": "org.rnorth:tcp-unix-socket-proxy:jar:sources:1.0.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/rnorth/tcp-unix-socket-proxy/1.0.1/tcp-unix-socket-proxy-1.0.1-sources.jar",
+                "directDependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "log4j:log4j:jar:sources:1.2.17"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/rnorth/tcp-unix-socket-proxy/1.0.1/tcp-unix-socket-proxy-1.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/rnorth/tcp-unix-socket-proxy/1.0.1/tcp-unix-socket-proxy-1.0.1-sources.jar"
+                ],
+                "sha256": "217f093b19e7dce5372c6dd62c8b15a382394b88fb4f6cc4e30a00e9b51671a7"
+            },
+            {
                 "coord": "org.sangria-graphql:macro-visit_2.12:0.1.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.12/0.1.1/macro-visit_2.12-0.1.1.jar",
                 "directDependencies": [
@@ -4019,6 +7993,23 @@
                 "sha256": "c3410fdbd0c420488f49121ea3c7757890dd98eec0c826ca1ac6946e2c263fd1"
             },
             {
+                "coord": "org.sangria-graphql:macro-visit_2.12:jar:sources:0.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.12/0.1.1/macro-visit_2.12-0.1.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.12/0.1.1/macro-visit_2.12-0.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.12/0.1.1/macro-visit_2.12-0.1.1-sources.jar"
+                ],
+                "sha256": "76c0e62f6ecc8117d7408bfa78ab9dddeac7d903735d2acc413dd7ba2fe7509c"
+            },
+            {
                 "coord": "org.sangria-graphql:sangria-marshalling-api_2.12:1.0.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.12/1.0.3/sangria-marshalling-api_2.12-1.0.3.jar",
                 "directDependencies": [
@@ -4032,6 +8023,21 @@
                     "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.12/1.0.3/sangria-marshalling-api_2.12-1.0.3.jar"
                 ],
                 "sha256": "31c665e7d653e600fc5bafabd4cfcc87278717dc55620dc71198ece99c18ca97"
+            },
+            {
+                "coord": "org.sangria-graphql:sangria-marshalling-api_2.12:jar:sources:1.0.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.12/1.0.3/sangria-marshalling-api_2.12-1.0.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.12/1.0.3/sangria-marshalling-api_2.12-1.0.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.12/1.0.3/sangria-marshalling-api_2.12-1.0.3-sources.jar"
+                ],
+                "sha256": "b0926ba3d86257ccf8ba49a79a157d25f5ead18d90a55e716fe79891a2e7a9d5"
             },
             {
                 "coord": "org.sangria-graphql:sangria-spray-json_2.12:1.0.1",
@@ -4053,6 +8059,25 @@
                 "sha256": "e5a4621f7648f73b41fb9b72547f1f7bdbc517ecd4e0b52119a9178eaee8814b"
             },
             {
+                "coord": "org.sangria-graphql:sangria-spray-json_2.12:jar:sources:1.0.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-spray-json_2.12/1.0.1/sangria-spray-json_2.12-1.0.1-sources.jar",
+                "directDependencies": [
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3",
+                    "org.sangria-graphql:sangria-marshalling-api_2.12:jar:sources:1.0.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.sangria-graphql:sangria-marshalling-api_2.12:jar:sources:1.0.3",
+                    "io.spray:spray-json_2.12:jar:sources:1.3.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-spray-json_2.12/1.0.1/sangria-spray-json_2.12-1.0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-spray-json_2.12/1.0.1/sangria-spray-json_2.12-1.0.1-sources.jar"
+                ],
+                "sha256": "f56a19398fb90892c23f2cc6c03dfc1c43b34a9211d184653ebcd9e870848e8f"
+            },
+            {
                 "coord": "org.sangria-graphql:sangria-streaming-api_2.12:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.12/1.0.0/sangria-streaming-api_2.12-1.0.0.jar",
                 "directDependencies": [
@@ -4066,6 +8091,21 @@
                     "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.12/1.0.0/sangria-streaming-api_2.12-1.0.0.jar"
                 ],
                 "sha256": "700b9b59861d57152ab42442d8c212ce8898a0b5a2c579e1c221762b8f418f51"
+            },
+            {
+                "coord": "org.sangria-graphql:sangria-streaming-api_2.12:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.12/1.0.0/sangria-streaming-api_2.12-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.12/1.0.0/sangria-streaming-api_2.12-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.12/1.0.0/sangria-streaming-api_2.12-1.0.0-sources.jar"
+                ],
+                "sha256": "9d07923cc5b93c0cb0c878704f6faa31c010fb84843d456db78c76110fb35722"
             },
             {
                 "coord": "org.sangria-graphql:sangria_2.12:1.4.2",
@@ -4095,6 +8135,33 @@
                 "sha256": "3fe3af011272c4cc3931523329249e6d7cd0da9ce69690501df3b6ef7fc1e31f"
             },
             {
+                "coord": "org.sangria-graphql:sangria_2.12:jar:sources:1.4.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria_2.12/1.4.2/sangria_2.12-1.4.2-sources.jar",
+                "directDependencies": [
+                    "org.sangria-graphql:sangria-marshalling-api_2.12:jar:sources:1.0.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.parboiled:parboiled_2.12:jar:sources:2.1.4",
+                    "org.sangria-graphql:macro-visit_2.12:jar:sources:0.1.1",
+                    "org.sangria-graphql:sangria-streaming-api_2.12:jar:sources:1.0.0"
+                ],
+                "dependencies": [
+                    "org.sangria-graphql:sangria-marshalling-api_2.12:jar:sources:1.0.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.parboiled:parboiled_2.12:jar:sources:2.1.4",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "org.sangria-graphql:macro-visit_2.12:jar:sources:0.1.1",
+                    "org.sangria-graphql:sangria-streaming-api_2.12:jar:sources:1.0.0",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/sangria-graphql/sangria_2.12/1.4.2/sangria_2.12-1.4.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/sangria-graphql/sangria_2.12/1.4.2/sangria_2.12-1.4.2-sources.jar"
+                ],
+                "sha256": "e47bff99b1fe6aad9c3dbc672301aae39fa8b35cb69639d57b96c18c76a72064"
+            },
+            {
                 "coord": "org.scala-lang.modules:scala-java8-compat_2.12:0.9.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0.jar",
                 "directDependencies": [
@@ -4108,6 +8175,21 @@
                     "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0.jar"
                 ],
                 "sha256": "1875d3cf1399bb2d3675e5852cd18f282f069e7c38e35b2fff553eefd6428bd8"
+            },
+            {
+                "coord": "org.scala-lang.modules:scala-java8-compat_2.12:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0-sources.jar"
+                ],
+                "sha256": "1383c220b0c25125841d7afcd9f0c580d5fa6ef8872d07477123a8e232d86b14"
             },
             {
                 "coord": "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4",
@@ -4125,6 +8207,21 @@
                 "sha256": "282c78d064d3e8f09b3663190d9494b85e0bb7d96b0da05994fe994384d96111"
             },
             {
+                "coord": "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+                ],
+                "sha256": "cb4ba7b7e598530faec863e5069864a28268ee4c636b0c46443884dcc4e07ac6"
+            },
+            {
                 "coord": "org.scala-lang.modules:scala-xml_2.12:1.0.6",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar",
                 "directDependencies": [
@@ -4138,6 +8235,21 @@
                     "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar"
                 ],
                 "sha256": "7cc3b6ceb56e879cb977e8e043f4bfe2e062f78795efd7efa09f85003cb3230a"
+            },
+            {
+                "coord": "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6-sources.jar"
+                ],
+                "sha256": "a7e8aac79394df396afda98b35537791809d815ce15ab2224f7d31e50c753922"
             },
             {
                 "coord": "org.scala-lang:scala-compiler:2.12.7",
@@ -4159,6 +8271,25 @@
                 "sha256": "6e80ef4493127214d31631287a6789170bf6c9a771d6094acd8dc785e8970270"
             },
             {
+                "coord": "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.7/scala-compiler-2.12.7-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.7/scala-compiler-2.12.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.7/scala-compiler-2.12.7-sources.jar"
+                ],
+                "sha256": "676f9865eee108b703d812a21ba0bd9530e166157d431171cdc1964d359d514f"
+            },
+            {
                 "coord": "org.scala-lang:scala-library:2.12.8",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8.jar",
                 "directDependencies": [],
@@ -4168,6 +8299,17 @@
                     "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8.jar"
                 ],
                 "sha256": "321fb55685635c931eba4bc0d7668349da3f2c09aee2de93a70566066ff25c28"
+            },
+            {
+                "coord": "org.scala-lang:scala-library:jar:sources:2.12.8",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8-sources.jar"
+                ],
+                "sha256": "11482bcb49b2e47baee89c3b1ae10c6a40b89e2fbb0da2a423e062f444e13492"
             },
             {
                 "coord": "org.scala-lang:scala-reflect:2.12.7",
@@ -4183,6 +8325,21 @@
                     "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.7/scala-reflect-2.12.7.jar"
                 ],
                 "sha256": "7427d7ee5771e8c36c1db5a09368fa3078f6eceb77d7c797a322a088c5dddb76"
+            },
+            {
+                "coord": "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.7/scala-reflect-2.12.7-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.7/scala-reflect-2.12.7-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.7/scala-reflect-2.12.7-sources.jar"
+                ],
+                "sha256": "2b84d948a67fa7f5c4c6cca9c4aefb83bc3bed76db69989d1e2d0977532942c2"
             },
             {
                 "coord": "org.scala-sbt.ipcsocket:ipcsocket:1.0.0",
@@ -4202,6 +8359,23 @@
                 "sha256": "f9a142c9f58f42eef49bfbe6b8f5b7bc4520e438d914505aa39a5b911ccee5ec"
             },
             {
+                "coord": "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.0.0/ipcsocket-1.0.0-sources.jar",
+                "directDependencies": [
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "dependencies": [
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.0.0/ipcsocket-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.0.0/ipcsocket-1.0.0-sources.jar"
+                ],
+                "sha256": "38a837c0cab9ebba5087499219fabfd765ce60ecb3beb1320be9dce9a01b11be"
+            },
+            {
                 "coord": "org.scala-sbt.ivy:ivy:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310.jar",
                 "directDependencies": [],
@@ -4211,6 +8385,17 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310.jar"
                 ],
                 "sha256": "6d4457a2024be52c4be16e23c52dbfe0a2511926e89927c27f7ca9f0e2afd715"
+            },
+            {
+                "coord": "org.scala-sbt.ivy:ivy:jar:sources:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310-sources.jar"
+                ],
+                "sha256": "c91deaf638f4dcb7bc5ae0228b38cbfc39a7adf00bdce677b1f9723053bd1dd1"
             },
             {
                 "coord": "org.scala-sbt:actions_2.12:1.1.4",
@@ -4303,6 +8488,96 @@
                 "sha256": "dbaf81b2fd9bb8fb83ebec421d518996a2f33ee7dc8e1d65adb4637546a18700"
             },
             {
+                "coord": "org.scala-sbt:actions_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.1.4/actions_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:testing_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:testing_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "org.scala-sbt:zinc_2.12:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.1.4/actions_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.1.4/actions_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "764c2aa913a39439b2c11c11d9ce5f0cb931fde69059804a1052c887a00497ed"
+            },
+            {
                 "coord": "org.scala-sbt:collections_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.1.4/collections_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -4323,6 +8598,28 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.1.4/collections_2.12-1.1.4.jar"
                 ],
                 "sha256": "0ab9808d81d7963ca73f9b1b9cd1826c7cbb4da8bf324d8b3de4429adad835b6"
+            },
+            {
+                "coord": "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.1.4/collections_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.1.4/collections_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.1.4/collections_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "9f5b7193432a5f10a7780a8695237f1a103b9e91efd1f8be27c5775939d6beb6"
             },
             {
                 "coord": "org.scala-sbt:command_2.12:1.1.4",
@@ -4392,6 +8689,73 @@
                 "sha256": "cec2e48dd409121e6eb7b303e1e80eb800b7553456ff73c0372368bc761ca3bc"
             },
             {
+                "coord": "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.1.4/command_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:template-resolver:jar:sources:0.1",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-sbt:template-resolver:jar:sources:0.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.1.4/command_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.1.4/command_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "b39c7947716dbc19c199f4ef5ccffb9a93c35804502ead98b70015bb51bbaacb"
+            },
+            {
                 "coord": "org.scala-sbt:compiler-interface:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.1.5/compiler-interface-1.1.5.jar",
                 "directDependencies": [
@@ -4405,6 +8769,21 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.1.5/compiler-interface-1.1.5.jar"
                 ],
                 "sha256": "e3ee5eca6cf7d5340fa8d95cf890b2cb4391e1fc3344bfada72191da05c19643"
+            },
+            {
+                "coord": "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.1.5/compiler-interface-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.1.5/compiler-interface-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.1.5/compiler-interface-1.1.5-sources.jar"
+                ],
+                "sha256": "9fe103830a26e876f3eb0e85d1b91876af7881a0b958e87e78a48d1de1eb67bd"
             },
             {
                 "coord": "org.scala-sbt:completion_2.12:1.1.4",
@@ -4438,6 +8817,37 @@
                 "sha256": "9815d36de51171a64bb12eb2778a6be0f1c8fcb504348461a38f77e20b84b7a8"
             },
             {
+                "coord": "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.1.4/completion_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "jline:jline:jar:sources:2.14.4",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.1.4/completion_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.1.4/completion_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "4710178e82e9267717e739d0b22bf4d1ecbd476f57e232b15984149fce11eb6b"
+            },
+            {
                 "coord": "org.scala-sbt:core-macros_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.1.4/core-macros_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -4464,6 +8874,32 @@
                 "sha256": "73a910bce72d77c164cd75a2c93fb7056db367f9a5186fa2b12d71c82673817a"
             },
             {
+                "coord": "org.scala-sbt:core-macros_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.1.4/core-macros_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.1.4/core-macros_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.1.4/core-macros_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "c9ea9123f499f9b8e21b16cc9b4287a9d193a44904f1b16a74aa4497865f1efc"
+            },
+            {
                 "coord": "org.scala-sbt:io_2.12:1.1.6",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.1.6/io_2.12-1.1.6.jar",
                 "directDependencies": [
@@ -4485,6 +8921,27 @@
                 "sha256": "c59f2f91ffdd3e4a3add9d8cc2d0e172160e638e6b20e1c3ef42b302f06916a1"
             },
             {
+                "coord": "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.1.6/io_2.12-1.1.6-sources.jar",
+                "directDependencies": [
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.1.6/io_2.12-1.1.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.1.6/io_2.12-1.1.6-sources.jar"
+                ],
+                "sha256": "d65b6f66808ad01b6b5f9d03b7f097be54ec7ee06acdbb9d8fe5837791e84ef6"
+            },
+            {
                 "coord": "org.scala-sbt:launcher-interface:1.0.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.0.4/launcher-interface-1.0.4.jar",
                 "directDependencies": [],
@@ -4494,6 +8951,17 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.0.4/launcher-interface-1.0.4.jar"
                 ],
                 "sha256": "8aa936aec79ebdbc6c8d4982a7aa7478a753abcbcb9ace31f8f6c69d30c4bb08"
+            },
+            {
+                "coord": "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.0.4/launcher-interface-1.0.4-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.0.4/launcher-interface-1.0.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.0.4/launcher-interface-1.0.4-sources.jar"
+                ],
+                "sha256": "b372eeaf38fcd8df19e9c4ab982332395cb6f8989e06604d8560ffa6525826c1"
             },
             {
                 "coord": "org.scala-sbt:librarymanagement-core_2.12:1.1.4",
@@ -4555,6 +9023,65 @@
                 "sha256": "6e00c7670de3403eb0c5382d67e123ddbaf8fd1619a340ef97f6fd702ad32cb6"
             },
             {
+                "coord": "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.1.4/librarymanagement-core_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.1.4/librarymanagement-core_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.1.4/librarymanagement-core_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "a7250bc2d145cf143499d8ec9e4e1eb5b17570e08d88a80d88ac6b1dc6473fab"
+            },
+            {
                 "coord": "org.scala-sbt:librarymanagement-ivy_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.1.4/librarymanagement-ivy_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -4607,6 +9134,58 @@
                 "sha256": "1fdf9d664360e80a65f7571f9a8ef0ea475fb63f4e420b94c4f8e3048e3775cb"
             },
             {
+                "coord": "org.scala-sbt:librarymanagement-ivy_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.1.4/librarymanagement-ivy_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt.ivy:ivy:jar:sources:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt.ivy:ivy:jar:sources:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.1.4/librarymanagement-ivy_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.1.4/librarymanagement-ivy_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "d7df013608179940cff8c9623d79a8d08474053740978ebe0d1d8b9cdba591d7"
+            },
+            {
                 "coord": "org.scala-sbt:logic_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.1.4/logic_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -4629,6 +9208,30 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.1.4/logic_2.12-1.1.4.jar"
                 ],
                 "sha256": "9e766be5a535aac6c6f02f1b82696a8597b6cc6663e931482a2d1270f5c62585"
+            },
+            {
+                "coord": "org.scala-sbt:logic_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.1.4/logic_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.1.4/logic_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.1.4/logic_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "e32a055a26fbc4992a5a72a64ae5489de8262689712c59cdf748ff55f3e1342a"
             },
             {
                 "coord": "org.scala-sbt:main-settings_2.12:1.1.4",
@@ -4701,6 +9304,78 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.1.4/main-settings_2.12-1.1.4.jar"
                 ],
                 "sha256": "4137bef94af4db78a7e084d3cf592fb6690852de8016b0f120a9c10175568e7d"
+            },
+            {
+                "coord": "org.scala-sbt:main-settings_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.1.4/main-settings_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:core-macros_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-sbt:template-resolver:jar:sources:0.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:core-macros_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.1.4/main-settings_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.1.4/main-settings_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "c423f3e0748a7476d664d7b0e75311ac2be6bc15c087507676f8481dbe383282"
             },
             {
                 "coord": "org.scala-sbt:main_2.12:1.1.4",
@@ -4810,6 +9485,113 @@
                 "sha256": "6c386802366e79933bfe90dd88934df7b289e416851f15315253e78b99ddc358"
             },
             {
+                "coord": "org.scala-sbt:main_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.1.4/main_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                    "com.github.cb372:scalacache-caffeine_2.12:jar:sources:0.20.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-sbt:main-settings_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:logic_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-ivy_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-compile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:actions_2.12:jar:sources:1.1.4"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:testing_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-sbt:template-resolver:jar:sources:0.1",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.github.cb372:scalacache-caffeine_2.12:jar:sources:0.20.0",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-sbt:main-settings_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:logic_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-ivy_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                    "com.github.cb372:scalacache-core_2.12:jar:sources:0.20.0",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "org.scala-sbt:zinc_2.12:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "org.scala-sbt:zinc-compile_2.12:jar:sources:1.1.5",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:core-macros_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-sbt.ivy:ivy:jar:sources:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:actions_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.1.4/main_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.1.4/main_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "db61b23f3d19fdce32c142728f5e8811ce70b9e3c5ebe01bce0f1ade25b5f721"
+            },
+            {
                 "coord": "org.scala-sbt:protocol_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.1.4/protocol_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -4844,6 +9626,42 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.1.4/protocol_2.12-1.1.4.jar"
                 ],
                 "sha256": "d179be958398a660b98d7024cea1ea7dde1244cc6cbbe387902a56279850769a"
+            },
+            {
+                "coord": "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.1.4/protocol_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "jline:jline:jar:sources:2.14.4",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.1.4/protocol_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.1.4/protocol_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "3953366f0949b7ccdc1c704c399ab8da30badce65cb0321a1a35346ae028b9e3"
             },
             {
                 "coord": "org.scala-sbt:run_2.12:1.1.4",
@@ -4887,6 +9705,47 @@
                 "sha256": "42b483e902fe8c25a71b03db2705080db3be09ff7453d1b22cb09bf88975aa84"
             },
             {
+                "coord": "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.1.4/run_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.1.4/run_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.1.4/run_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "deeb178e75133e93dfd8d2450542fa83f269c7fd1482b302ac02afd3cbd17dc0"
+            },
+            {
                 "coord": "org.scala-sbt:sbinary_2.12:0.4.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4.jar",
                 "directDependencies": [
@@ -4902,6 +9761,23 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4.jar"
                 ],
                 "sha256": "24a7a488a6992b6ab4d8e78b170f5fbc02ef13eadada88851fd41cb2ccfa802a"
+            },
+            {
+                "coord": "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4-sources.jar"
+                ],
+                "sha256": "1bace3a75fa2d5d73c0ea7d3be8107eec76fddeedba301af91fc6c99c6a774c9"
             },
             {
                 "coord": "org.scala-sbt:sbt:1.1.4",
@@ -4995,6 +9871,97 @@
                 "sha256": "792959de62b4f9d86ce4510d21cebc9bb92bcc05915c3f6d8e5c707928c8dbaf"
             },
             {
+                "coord": "org.scala-sbt:sbt:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.1.4/sbt-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:main_2.12:jar:sources:1.1.4"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:testing_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:command_2.12:jar:sources:1.1.4",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-sbt:template-resolver:jar:sources:0.1",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:run_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.github.cb372:scalacache-caffeine_2.12:jar:sources:0.20.0",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-sbt:main-settings_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:protocol_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:logic_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.github.ben-manes.caffeine:caffeine:jar:sources:2.6.2",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.scala-sbt:completion_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:librarymanagement-ivy_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt.ipcsocket:ipcsocket:jar:sources:1.0.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                    "com.github.cb372:scalacache-core_2.12:jar:sources:0.20.0",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "org.scala-sbt:zinc_2.12:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "org.scala-sbt:zinc-compile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:main_2.12:jar:sources:1.1.4",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:core-macros_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-sbt.ivy:ivy:jar:sources:2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:actions_2.12:jar:sources:1.1.4",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/sbt/1.1.4/sbt-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/sbt/1.1.4/sbt-1.1.4-sources.jar"
+                ],
+                "sha256": "3df45e9aa3003b6d9b16de01f088191d989dd4574b1cd674476feaaf89091641"
+            },
+            {
                 "coord": "org.scala-sbt:task-system_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.1.4/task-system_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -5036,6 +10003,47 @@
                 "sha256": "a5c66383dbe10919e881c29b78df7d26cfc1b82d4761b3b71fc2fe624339735d"
             },
             {
+                "coord": "org.scala-sbt:task-system_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.1.4/task-system_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "jline:jline:jar:sources:2.14.4",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.1.4/task-system_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.1.4/task-system_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "9e6079674360f679e62259aa8fa4cb7a77f2c138cd29ddcff278ba6bb5d84f7a"
+            },
+            {
                 "coord": "org.scala-sbt:tasks_2.12:1.1.4",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.1.4/tasks_2.12-1.1.4.jar",
                 "directDependencies": [
@@ -5060,6 +10068,30 @@
                 "sha256": "872ae0e2761d47ebc6e804cb528469933fdb9f688d87e11f669fc5736d15e537"
             },
             {
+                "coord": "org.scala-sbt:tasks_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.1.4/tasks_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:collections_2.12:jar:sources:1.1.4",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.1.4/tasks_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.1.4/tasks_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "fd6aa889098db351a3d954b817e0d5b959f5cc801524025097e2b562fdbf41e1"
+            },
+            {
                 "coord": "org.scala-sbt:template-resolver:0.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1.jar",
                 "directDependencies": [],
@@ -5069,6 +10101,17 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1.jar"
                 ],
                 "sha256": "0bb8d56b20e6aef40d3d69c1b1a82a607ffec32e74ff35cb8d92c46388487c56"
+            },
+            {
+                "coord": "org.scala-sbt:template-resolver:jar:sources:0.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar"
+                ],
+                "sha256": "6ef0aacb207aa1187cb02d4f666ccedb7ebac591d0482675235969b75cf1392d"
             },
             {
                 "coord": "org.scala-sbt:test-agent:1.1.4",
@@ -5086,6 +10129,21 @@
                 "sha256": "483a4ca0c3bb2e12c94931e429bd6d17eab7d658abd1f86a9e0f1fba9404aa3f"
             },
             {
+                "coord": "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.1.4/test-agent-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:test-interface:jar:sources:1.0"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:test-interface:jar:sources:1.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/test-agent/1.1.4/test-agent-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/test-agent/1.1.4/test-agent-1.1.4-sources.jar"
+                ],
+                "sha256": "55125ccc52cdd133cc78b82078df09c57b81d980645194b1f05481b27b6bb269"
+            },
+            {
                 "coord": "org.scala-sbt:test-interface:1.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar",
                 "directDependencies": [],
@@ -5095,6 +10153,17 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
                 ],
                 "sha256": "15f70b38bb95f3002fec9aea54030f19bb4ecfbad64c67424b5e5fea09cd749e"
+            },
+            {
+                "coord": "org.scala-sbt:test-interface:jar:sources:1.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+                ],
+                "sha256": "c314491c9df4f0bd9dd125ef1d51228d70bd466ee57848df1cd1b96aea18a5ad"
             },
             {
                 "coord": "org.scala-sbt:testing_2.12:1.1.4",
@@ -5142,6 +10211,51 @@
                 "sha256": "54975ec056c158e4efdfda17be5c300181ea1c6a60b872682e5fc1df0f3a7971"
             },
             {
+                "coord": "org.scala-sbt:testing_2.12:jar:sources:1.1.4",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.1.4/testing_2.12-1.1.4-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt:test-agent:jar:sources:1.1.4",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.1.4/testing_2.12-1.1.4-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.1.4/testing_2.12-1.1.4-sources.jar"
+                ],
+                "sha256": "8986494b5c0fb1f8fc0c6d78a8104cfea5fb53ad40985443ddb9737271649f08"
+            },
+            {
                 "coord": "org.scala-sbt:util-cache_2.12:1.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.1.3/util-cache_2.12-1.1.3.jar",
                 "directDependencies": [
@@ -5171,6 +10285,35 @@
                 "sha256": "3f69c0056db6a2bedd6b48fb5b5c69fa8260826bb2ec1fb0ffd4dfd7c2c7c66f"
             },
             {
+                "coord": "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.1.3/util-cache_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.1.3/util-cache_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.1.3/util-cache_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "8c9e9cfaa958e01bc6c4db5eb174003cd0983bcf7a6825fe2d47d4845d7b1995"
+            },
+            {
                 "coord": "org.scala-sbt:util-control_2.12:1.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.1.3/util-control_2.12-1.1.3.jar",
                 "directDependencies": [
@@ -5186,6 +10329,21 @@
                 "sha256": "7a291f8a3080d7843620b087ab5c797c0ee5f43460a1e4f3ce4422afb73ae799"
             },
             {
+                "coord": "org.scala-sbt:util-control_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.1.3/util-control_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.1.3/util-control_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.1.3/util-control_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "988b1faeaa4fcb1d3ac3c7e8647b67f9325828021246b516a0eec3d3d9abcd53"
+            },
+            {
                 "coord": "org.scala-sbt:util-interface:1.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.1.3/util-interface-1.1.3.jar",
                 "directDependencies": [],
@@ -5195,6 +10353,17 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.1.3/util-interface-1.1.3.jar"
                 ],
                 "sha256": "c671b55697207eb7ac680fea390c249f383fdf2e445b3e98f8cae4f6bc324860"
+            },
+            {
+                "coord": "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.1.3/util-interface-1.1.3-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.1.3/util-interface-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.1.3/util-interface-1.1.3-sources.jar"
+                ],
+                "sha256": "2e194c784c8c9dd3d34603a4378bfa7193708c1decba0ddb9aafe5b1ceccb6ab"
             },
             {
                 "coord": "org.scala-sbt:util-logging_2.12:1.1.3",
@@ -5230,6 +10399,39 @@
                 "sha256": "14ec8942b844658a7da7e04f60555751661ab1273f8b31b57cfd86b473be2653"
             },
             {
+                "coord": "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.1.3/util-logging_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "jline:jline:jar:sources:2.14.4",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "jline:jline:jar:sources:2.14.4",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.1.3/util-logging_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.1.3/util-logging_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "d0315dec95a9da6a2faefaf785f3d53953cda084e1e4b8e6bdc030c7d3f9917d"
+            },
+            {
                 "coord": "org.scala-sbt:util-position_2.12:1.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.1.3/util-position_2.12-1.1.3.jar",
                 "directDependencies": [
@@ -5245,6 +10447,21 @@
                 "sha256": "20fd912315e925f7f122aced8ae9aca3f099ae1ce6f1b00a201e1fcff1cdd360"
             },
             {
+                "coord": "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.1.3/util-position_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.1.3/util-position_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.1.3/util-position_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "7b0a5c848212de1ccda400d242074666423ddb47534af8100c0d4b474b6cf6be"
+            },
+            {
                 "coord": "org.scala-sbt:util-relation_2.12:1.1.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.1.3/util-relation_2.12-1.1.3.jar",
                 "directDependencies": [
@@ -5258,6 +10475,21 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.1.3/util-relation_2.12-1.1.3.jar"
                 ],
                 "sha256": "dff98263c5fd5fc374ac241221cb83619a6bcce328c060482589d810617c2287"
+            },
+            {
+                "coord": "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.1.3/util-relation_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.1.3/util-relation_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.1.3/util-relation_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "8a14088c870199b828ec3e87da6d9cbe39b0b766ce51c9cbf6ba294fe9fed3c0"
             },
             {
                 "coord": "org.scala-sbt:util-tracking_2.12:1.1.3",
@@ -5286,6 +10518,34 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.1.3/util-tracking_2.12-1.1.3.jar"
                 ],
                 "sha256": "17c1f8cd839f9232acf8c18d8ee03c7a27bd66d255f8ef5e9de72917e1f2ef39"
+            },
+            {
+                "coord": "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.1.3/util-tracking_2.12-1.1.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.1.3/util-tracking_2.12-1.1.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.1.3/util-tracking_2.12-1.1.3-sources.jar"
+                ],
+                "sha256": "37f7db9ada6dc7ecdf22b6f0e2275f63321231bba1df918ca4a3e4b3914a38ac"
             },
             {
                 "coord": "org.scala-sbt:zinc-apiinfo_2.12:1.1.5",
@@ -5322,6 +10582,40 @@
                 "sha256": "eeecbbe7a930c456b0df8a6f6f8cc7e0a9651ee29dae3285e44f9ecfceb2237f"
             },
             {
+                "coord": "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.1.5/zinc-apiinfo_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.1.5/zinc-apiinfo_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.1.5/zinc-apiinfo_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "60b60681191abe00b5d05c05f3bcdfbe996568d9d07f987e957393ac9ff32fa3"
+            },
+            {
                 "coord": "org.scala-sbt:zinc-classfile_2.12:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.1.5/zinc-classfile_2.12-1.1.5.jar",
                 "directDependencies": [
@@ -5356,6 +10650,40 @@
                 "sha256": "23e0a2497465dfba428409c0e61635ef6c35c13876606036dd6beedf4dbac5c7"
             },
             {
+                "coord": "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.1.5/zinc-classfile_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.1.5/zinc-classfile_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.1.5/zinc-classfile_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "adc8935f070e44ba20ba07f4035f1a995e38e5c32455e2e4c9bf50ccf6af7608"
+            },
+            {
                 "coord": "org.scala-sbt:zinc-classpath_2.12:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.1.5/zinc-classpath_2.12-1.1.5.jar",
                 "directDependencies": [
@@ -5383,6 +10711,35 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.1.5/zinc-classpath_2.12-1.1.5.jar"
                 ],
                 "sha256": "e596521e95fcdbeb2563d6ff984295e9ec05039b1da6acda55efbb4914dea078"
+            },
+            {
+                "coord": "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.1.5/zinc-classpath_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.1.5/zinc-classpath_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.1.5/zinc-classpath_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "1f9a563d477bc35981f00620ef1783e95ad062ac9d3308f5c6f81bfe3574761c"
             },
             {
                 "coord": "org.scala-sbt:zinc-compile-core_2.12:1.1.5",
@@ -5433,6 +10790,54 @@
                 "sha256": "d8b9f9bf70b34cf3da0276211a6555ce836bd5e68084875184101943e4a41acc"
             },
             {
+                "coord": "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.1.5/zinc-compile-core_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.1.5/zinc-compile-core_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.1.5/zinc-compile-core_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "d2511f0d623cc6b64caaf9413427e6121cf94d90cc0fc83954915f9358506153"
+            },
+            {
                 "coord": "org.scala-sbt:zinc-compile_2.12:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.1.5/zinc-compile_2.12-1.1.5.jar",
                 "directDependencies": [
@@ -5478,6 +10883,51 @@
                 "sha256": "aebd2e2fcca003af758aae1a3a5ae0973562115f6dcf1957602bc22d55730706"
             },
             {
+                "coord": "org.scala-sbt:zinc-compile_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.1.5/zinc-compile_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-tracking_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.1.5/zinc-compile_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.1.5/zinc-compile_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "f458e6a40723a9d31184f3936bf83f28e1d616d61e96217fcabe1119021483bf"
+            },
+            {
                 "coord": "org.scala-sbt:zinc-core_2.12:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.1.5/zinc-core_2.12-1.1.5.jar",
                 "directDependencies": [
@@ -5520,6 +10970,50 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.1.5/zinc-core_2.12-1.1.5.jar"
                 ],
                 "sha256": "b87d51c92fbe38010bb1948bbc9b75fc04a1e57d6405230ea4ae945e5ca4d537"
+            },
+            {
+                "coord": "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.1.5/zinc-core_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.1.5/zinc-core_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.1.5/zinc-core_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "b03729232ca540df7769524238dec06b4e32d13dfa5e1216abcc7d25e02eeb74"
             },
             {
                 "coord": "org.scala-sbt:zinc-ivy-integration_2.12:1.1.5",
@@ -5578,6 +11072,62 @@
                 "sha256": "3f690ba039680c5577cd3af45e1c0fd75d598329763d7d772267fbfc53b2f3b7"
             },
             {
+                "coord": "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-ivy-integration_2.12/1.1.5/zinc-ivy-integration_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-ivy-integration_2.12/1.1.5/zinc-ivy-integration_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-ivy-integration_2.12/1.1.5/zinc-ivy-integration_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "a6deaa10a148d216440b5739e0d3186342d33ff4f8c1592d3dddff00b4c26335"
+            },
+            {
                 "coord": "org.scala-sbt:zinc-persist_2.12:1.1.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.1.5/zinc-persist_2.12-1.1.5.jar",
                 "directDependencies": [
@@ -5624,6 +11174,54 @@
                     "https://repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.1.5/zinc-persist_2.12-1.1.5.jar"
                 ],
                 "sha256": "c1e76a3278db183ab106798fdcdb88eb5fd9a35bdc37aa8721ccc9e46cba7be4"
+            },
+            {
+                "coord": "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.1.5/zinc-persist_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.1.5/zinc-persist_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.1.5/zinc-persist_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "16cf5ec29654802a90a1e58bc19b99819a9f2250b67b8630e69651cf097db223"
             },
             {
                 "coord": "org.scala-sbt:zinc_2.12:1.1.5",
@@ -5695,6 +11293,75 @@
                 "sha256": "6295057ab9ef618412f2b5a9839e08f9e844c83e581e291b7aefe78cf202d5c0"
             },
             {
+                "coord": "org.scala-sbt:zinc_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.1.5/zinc_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5"
+                ],
+                "dependencies": [
+                    "org.scala-sbt:util-interface:jar:sources:1.1.3",
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scala-sbt:util-position_2.12:jar:sources:1.1.3",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scala-sbt:zinc-core_2.12:jar:sources:1.1.5",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "com.swoval:apple-file-events:jar:sources:1.3.0",
+                    "org.scala-sbt:util-logging_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:launcher-interface:jar:sources:1.0.4",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.eed3si9n:gigahorse-okhttp_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:util-relation_2.12:jar:sources:1.1.3",
+                    "org.reactivestreams:reactive-streams:jar:sources:1.0.2",
+                    "org.scala-lang.modules:scala-parser-combinators_2.12:jar:sources:1.0.4",
+                    "com.typesafe:config:jar:sources:1.3.3",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.logging.log4j:log4j-core:jar:sources:2.8.1",
+                    "com.eed3si9n:shaded-scalajson_2.12:jar:sources:1.0.0-M4",
+                    "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "org.scala-sbt:sbinary_2.12:jar:sources:0.4.4",
+                    "org.scala-sbt:librarymanagement-core_2.12:jar:sources:1.1.4",
+                    "com.jcraft:jsch:jar:sources:0.1.54",
+                    "org.apache.logging.log4j:log4j-api:jar:sources:2.8.1",
+                    "org.scala-sbt:io_2.12:jar:sources:1.1.6",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "com.eed3si9n:sjson-new-scalajson_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:compiler-interface:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-persist_2.12:jar:sources:1.1.5",
+                    "com.squareup.okhttp3:okhttp-urlconnection:jar:sources:3.7.0",
+                    "jline:jline:jar:sources:2.14.4",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "com.eed3si9n:gigahorse-core_2.12:jar:sources:0.3.0",
+                    "org.scala-sbt:zinc-classpath_2.12:jar:sources:1.1.5",
+                    "net.java.dev.jna:jna:jar:sources:4.5.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.typesafe:ssl-config-core_2.12:jar:sources:0.3.7",
+                    "com.lmax:disruptor:jar:sources:3.3.6",
+                    "com.eed3si9n:sjson-new-core_2.12:jar:sources:0.8.2",
+                    "com.eed3si9n:sjson-new-murmurhash_2.12:jar:sources:0.8.2",
+                    "org.scala-sbt:zinc-apiinfo_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-cache_2.12:jar:sources:1.1.3",
+                    "org.scala-sbt:zinc-compile-core_2.12:jar:sources:1.1.5",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "net.java.dev.jna:jna-platform:jar:sources:4.5.0",
+                    "org.scala-sbt:zinc-ivy-integration_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:zinc-classfile_2.12:jar:sources:1.1.5",
+                    "org.scala-sbt:util-control_2.12:jar:sources:1.1.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.1.5/zinc_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.1.5/zinc_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "f69cf4b63250920948b95efeea9e53b89efa9f5be941586d64d21ec38e9a684d"
+            },
+            {
                 "coord": "org.scala-tools.testing:test-interface:0.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scala-tools/testing/test-interface/0.5/test-interface-0.5.jar",
                 "directDependencies": [],
@@ -5704,6 +11371,12 @@
                     "https://repo1.maven.org/maven2/org/scala-tools/testing/test-interface/0.5/test-interface-0.5.jar"
                 ],
                 "sha256": "0caa2cd67ca6b5a1df925a5acac99c48342967543df1a6861d1202476596a812"
+            },
+            {
+                "coord": "org.scala-tools.testing:test-interface:jar:sources:0.5",
+                "file": null,
+                "directDependencies": [],
+                "dependencies": []
             },
             {
                 "coord": "org.scalacheck:scalacheck_2.12:1.14.0",
@@ -5723,6 +11396,23 @@
                 "sha256": "1e6f5b292bb74b03be74195047816632b7d95e40e7f9c13d5d2c53bafeece62e"
             },
             {
+                "coord": "org.scalacheck:scalacheck_2.12:jar:sources:1.14.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalacheck/scalacheck_2.12/1.14.0/scalacheck_2.12-1.14.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:test-interface:jar:sources:1.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-sbt:test-interface:jar:sources:1.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalacheck/scalacheck_2.12/1.14.0/scalacheck_2.12-1.14.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalacheck/scalacheck_2.12/1.14.0/scalacheck_2.12-1.14.0-sources.jar"
+                ],
+                "sha256": "6d51786f6ed8241bc02ea90bdd769ef16f2cc034624e06877de1d4a735efcb7f"
+            },
+            {
                 "coord": "org.scalactic:scalactic_2.12:3.0.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.5/scalactic_2.12-3.0.5.jar",
                 "directDependencies": [
@@ -5740,6 +11430,23 @@
                 "sha256": "57e25b4fd969b1758fe042595112c874dfea99dca5cc48eebe07ac38772a0c41"
             },
             {
+                "coord": "org.scalactic:scalactic_2.12:jar:sources:3.0.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.5/scalactic_2.12-3.0.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.5/scalactic_2.12-3.0.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.5/scalactic_2.12-3.0.5-sources.jar"
+                ],
+                "sha256": "0455eaecaa2b8ce0be537120c2ccd407c4606cbe53e63cb6a7fc8b31b5b65461"
+            },
+            {
                 "coord": "org.scalameta:common_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/common_2.12/1.8.0/common_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -5755,6 +11462,23 @@
                     "https://repo1.maven.org/maven2/org/scalameta/common_2.12/1.8.0/common_2.12-1.8.0.jar"
                 ],
                 "sha256": "4d9d8425ef1432a1fe17c343e6e32a88f657201ae7461c3aab61a9d24d171af0"
+            },
+            {
+                "coord": "org.scalameta:common_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/common_2.12/1.8.0/common_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/common_2.12/1.8.0/common_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/common_2.12/1.8.0/common_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "a9d52a2cdab685d21deb22a4eb61fcf9c9d7c87299a62892a7137eb011fb4116"
             },
             {
                 "coord": "org.scalameta:contrib_2.12:1.8.0",
@@ -5791,6 +11515,40 @@
                 "sha256": "577fc8a43e0dea992939ea21ef48704893f9a526a88788f049dc4ecea714ffd9"
             },
             {
+                "coord": "org.scalameta:contrib_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/contrib_2.12/1.8.0/contrib_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:scalameta_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inline_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:quasiquotes_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:scalameta_2.12:jar:sources:1.8.0",
+                    "org.scalameta:semantic_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0",
+                    "org.scalameta:transversers_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/contrib_2.12/1.8.0/contrib_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/contrib_2.12/1.8.0/contrib_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "391873384222d5234da6d6be2d044fe4532c28cf2ef2e00185e6e226cda51a2d"
+            },
+            {
                 "coord": "org.scalameta:dialects_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/dialects_2.12/1.8.0/dialects_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -5807,6 +11565,24 @@
                     "https://repo1.maven.org/maven2/org/scalameta/dialects_2.12/1.8.0/dialects_2.12-1.8.0.jar"
                 ],
                 "sha256": "fbf109b6894ace59db70484feb8c4d9836742d2919e4dd604b8cdc676531932b"
+            },
+            {
+                "coord": "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/dialects_2.12/1.8.0/dialects_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/dialects_2.12/1.8.0/dialects_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/dialects_2.12/1.8.0/dialects_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "8af330c54038c6c5f74cb5bd0a7cd252f51d8fb01576a0da05984efc5683be97"
             },
             {
                 "coord": "org.scalameta:inline_2.12:1.8.0",
@@ -5829,6 +11605,26 @@
                 "sha256": "8a663252ccc3390ea4d2d7542c6fd27f8f10ed7162316bc9b0a45bfc726bc073"
             },
             {
+                "coord": "org.scalameta:inline_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/inline_2.12/1.8.0/inline_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/inline_2.12/1.8.0/inline_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/inline_2.12/1.8.0/inline_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "c022c68f419ab4e0683b91c232ad63b936df179b9bb04b70e6d9e2d4cc447010"
+            },
+            {
                 "coord": "org.scalameta:inputs_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/inputs_2.12/1.8.0/inputs_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -5849,6 +11645,26 @@
                 "sha256": "c20fce78674f13252ec77bd1904780e6e9c8246f535e62d4f378d961960b31c9"
             },
             {
+                "coord": "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/inputs_2.12/1.8.0/inputs_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/inputs_2.12/1.8.0/inputs_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/inputs_2.12/1.8.0/inputs_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "b173778fb74441db081f72951dad7960969c92568c77e6049caa29fb80891f0b"
+            },
+            {
                 "coord": "org.scalameta:io_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/io_2.12/1.8.0/io_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -5865,6 +11681,24 @@
                     "https://repo1.maven.org/maven2/org/scalameta/io_2.12/1.8.0/io_2.12-1.8.0.jar"
                 ],
                 "sha256": "c12c503c9525fd1d7e7d2cb245e2548ef60e39ee8d43cddd77905bd3508d6cb8"
+            },
+            {
+                "coord": "org.scalameta:io_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/io_2.12/1.8.0/io_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/io_2.12/1.8.0/io_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/io_2.12/1.8.0/io_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "f063f01e7ef0c9847684abf38377bb068333180d61465987ea9461620768edae"
             },
             {
                 "coord": "org.scalameta:paradise_2.12.6:3.0.0-M11",
@@ -5884,6 +11718,25 @@
                     "https://repo1.maven.org/maven2/org/scalameta/paradise_2.12.6/3.0.0-M11/paradise_2.12.6-3.0.0-M11.jar"
                 ],
                 "sha256": "0b3be39054d5324bd535b4d8eebb3a0e51f53f891b655243ec5dea27204253a2"
+            },
+            {
+                "coord": "org.scalameta:paradise_2.12.6:jar:sources:3.0.0-M11",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/paradise_2.12.6/3.0.0-M11/paradise_2.12.6-3.0.0-M11-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/paradise_2.12.6/3.0.0-M11/paradise_2.12.6-3.0.0-M11-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/paradise_2.12.6/3.0.0-M11/paradise_2.12.6-3.0.0-M11-sources.jar"
+                ],
+                "sha256": "86cacee644e24b7838efd7bc73f71c31a99aa70a74a4adaa3416e8fc7cb669c5"
             },
             {
                 "coord": "org.scalameta:parsers_2.12:1.8.0",
@@ -5916,6 +11769,36 @@
                 "sha256": "deca0f7866ca34d29f2a04ac8718532e75d3aff73c87903a2a1dfced7da7569d"
             },
             {
+                "coord": "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/parsers_2.12/1.8.0/parsers_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/parsers_2.12/1.8.0/parsers_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/parsers_2.12/1.8.0/parsers_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "d2c7d5caf41877079cada0b36a0ee7a415a1c7648b0b6ecb43742e1fda5f5ff0"
+            },
+            {
                 "coord": "org.scalameta:quasiquotes_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/quasiquotes_2.12/1.8.0/quasiquotes_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -5944,6 +11827,36 @@
                     "https://repo1.maven.org/maven2/org/scalameta/quasiquotes_2.12/1.8.0/quasiquotes_2.12-1.8.0.jar"
                 ],
                 "sha256": "968808a44e2765e93943c298b90f3e71bd2fcb228510ee89a373eae1da26f3d7"
+            },
+            {
+                "coord": "org.scalameta:quasiquotes_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/quasiquotes_2.12/1.8.0/quasiquotes_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/quasiquotes_2.12/1.8.0/quasiquotes_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/quasiquotes_2.12/1.8.0/quasiquotes_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "e2d63c4a4e8579564b8f0e8010963cb22a0ad081239a54ea53f26cd0190e0964"
             },
             {
                 "coord": "org.scalameta:scalameta_2.12:1.8.0",
@@ -5989,6 +11902,49 @@
                 "sha256": "8bed0f568e4efa58598f226556997041960edd78374e7f159c06a3e8042c6344"
             },
             {
+                "coord": "org.scalameta:scalameta_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/scalameta_2.12/1.8.0/scalameta_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inline_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:quasiquotes_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:semantic_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0",
+                    "org.scalameta:transversers_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inline_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:quasiquotes_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:semantic_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0",
+                    "org.scalameta:transversers_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/scalameta_2.12/1.8.0/scalameta_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/scalameta_2.12/1.8.0/scalameta_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "ac6a2d17621e6e88794cd9c0ee4a6a7db202328ec82c2a41282cb232d942b75a"
+            },
+            {
                 "coord": "org.scalameta:semantic_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/semantic_2.12/1.8.0/semantic_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -6021,6 +11977,38 @@
                 "sha256": "1df7b38adb01f86d78019471b154b73bc1da8c98c4fca709b9fcb522f7f4cbbd"
             },
             {
+                "coord": "org.scalameta:semantic_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/semantic_2.12/1.8.0/semantic_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "com.google.protobuf:protobuf-java:jar:sources:3.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:parsers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.lenses:lenses_2.12:jar:sources:0.4.10",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.trueaccord.scalapb:scalapb-runtime_2.12:jar:sources:0.6.0-pre2",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/semantic_2.12/1.8.0/semantic_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/semantic_2.12/1.8.0/semantic_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "3a19cadf91f735236b7e2a5a15efea07d8b7042914354f6ed84c1569fd2bd3dc"
+            },
+            {
                 "coord": "org.scalameta:tokenizers_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/tokenizers_2.12/1.8.0/tokenizers_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -6048,6 +12036,33 @@
                 "sha256": "059d69c02f301fe98661c8e15297bb9217113c8c2ac4986f0d27eca20e59e8d4"
             },
             {
+                "coord": "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/tokenizers_2.12/1.8.0/tokenizers_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/tokenizers_2.12/1.8.0/tokenizers_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/tokenizers_2.12/1.8.0/tokenizers_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "00573f2e0d53f020eec1cda9e34477e9960b51bdd7a91d0ac0b17ccc632a5dc8"
+            },
+            {
                 "coord": "org.scalameta:tokens_2.12:1.8.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalameta/tokens_2.12/1.8.0/tokens_2.12-1.8.0.jar",
                 "directDependencies": [
@@ -6069,6 +12084,29 @@
                     "https://repo1.maven.org/maven2/org/scalameta/tokens_2.12/1.8.0/tokens_2.12-1.8.0.jar"
                 ],
                 "sha256": "78cc3d2cafe9307ea491b9d6ddc499d7ebc56416c64bc0b068a86cc21bca21f4"
+            },
+            {
+                "coord": "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/tokens_2.12/1.8.0/tokens_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/tokens_2.12/1.8.0/tokens_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/tokens_2.12/1.8.0/tokens_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "4ea53e68c5e78a9c051c7959346359aebfecafae771149a0e22784aa54c1daca"
             },
             {
                 "coord": "org.scalameta:transversers_2.12:1.8.0",
@@ -6095,6 +12133,32 @@
                     "https://repo1.maven.org/maven2/org/scalameta/transversers_2.12/1.8.0/transversers_2.12-1.8.0.jar"
                 ],
                 "sha256": "f9819930d6e632c7f08e2257292ffd5c26d3f5df041a61fbaaa9d105a08ffdd1"
+            },
+            {
+                "coord": "org.scalameta:transversers_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/transversers_2.12/1.8.0/transversers_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/transversers_2.12/1.8.0/transversers_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/transversers_2.12/1.8.0/transversers_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "bb8aa63d8fac37d0c7977dcda10bc1e2de42c276c1473efef8c8aeddcddce834"
             },
             {
                 "coord": "org.scalameta:trees_2.12:1.8.0",
@@ -6125,6 +12189,34 @@
                 "sha256": "017bf3779dc0510a243f0436ab446d8e7142145fb59bce6c6b855bb1a8659c7a"
             },
             {
+                "coord": "org.scalameta:trees_2.12:jar:sources:1.8.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalameta/trees_2.12/1.8.0/trees_2.12-1.8.0-sources.jar",
+                "directDependencies": [
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0"
+                ],
+                "dependencies": [
+                    "com.lihaoyi:fastparse_2.12:jar:sources:2.1.3",
+                    "org.scalameta:common_2.12:jar:sources:1.8.0",
+                    "org.scalameta:tokens_2.12:jar:sources:1.8.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalameta:tokenizers_2.12:jar:sources:1.8.0",
+                    "org.scalameta:dialects_2.12:jar:sources:1.8.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.scalameta:inputs_2.12:jar:sources:1.8.0",
+                    "org.scalameta:io_2.12:jar:sources:1.8.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalameta/trees_2.12/1.8.0/trees_2.12-1.8.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalameta/trees_2.12/1.8.0/trees_2.12-1.8.0-sources.jar"
+                ],
+                "sha256": "86fe063cc1e7b6fe2796c8798953a172b4b6066303756e5f88e5eba871b2d964"
+            },
+            {
                 "coord": "org.scalatest:scalatest_2.12:3.0.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.5/scalatest_2.12-3.0.5.jar",
                 "directDependencies": [
@@ -6146,6 +12238,27 @@
                 "sha256": "b416b5bcef6720da469a8d8a5726e457fc2d1cd5d316e1bc283aa75a2ae005e5"
             },
             {
+                "coord": "org.scalatest:scalatest_2.12:jar:sources:3.0.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.5/scalatest_2.12-3.0.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scalactic:scalactic_2.12:jar:sources:3.0.5"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalactic:scalactic_2.12:jar:sources:3.0.5",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.5/scalatest_2.12-3.0.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.5/scalatest_2.12-3.0.5-sources.jar"
+                ],
+                "sha256": "22081ee83810098adc9af4d84d05dd5891d7c0e15f9095bcdaf4ac7a228b92df"
+            },
+            {
                 "coord": "org.scalaz:scalaz-concurrent_2.12:7.2.24",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.12/7.2.24/scalaz-concurrent_2.12-7.2.24.jar",
                 "directDependencies": [
@@ -6165,6 +12278,25 @@
                 "sha256": "9f186bff32951f5dd4d4c8fa8252dfac5ee234234d748dd67e9a51762738a4a5"
             },
             {
+                "coord": "org.scalaz:scalaz-concurrent_2.12:jar:sources:7.2.24",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.12/7.2.24/scalaz-concurrent_2.12-7.2.24-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.12/7.2.24/scalaz-concurrent_2.12-7.2.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.12/7.2.24/scalaz-concurrent_2.12-7.2.24-sources.jar"
+                ],
+                "sha256": "a2e318bbe924cc5c1eca3f6540192733237fc2c478946055925baf652349f176"
+            },
+            {
                 "coord": "org.scalaz:scalaz-core_2.12:7.2.24",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-core_2.12/7.2.24/scalaz-core_2.12-7.2.24.jar",
                 "directDependencies": [
@@ -6178,6 +12310,21 @@
                     "https://repo1.maven.org/maven2/org/scalaz/scalaz-core_2.12/7.2.24/scalaz-core_2.12-7.2.24.jar"
                 ],
                 "sha256": "947694deedc07fa0287eaa0f83721dcdc4bc5b96a0177bd6743cea250173dbd8"
+            },
+            {
+                "coord": "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-core_2.12/7.2.24/scalaz-core_2.12-7.2.24-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalaz/scalaz-core_2.12/7.2.24/scalaz-core_2.12-7.2.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalaz/scalaz-core_2.12/7.2.24/scalaz-core_2.12-7.2.24-sources.jar"
+                ],
+                "sha256": "af1c3e386bcdcaf752de866e7ed3da5cd8d9d1ebb6a4751a5db84c8d5de695e1"
             },
             {
                 "coord": "org.scalaz:scalaz-effect_2.12:7.2.24",
@@ -6197,6 +12344,23 @@
                 "sha256": "4aeaaaa2985878923bf26f27607a573ce9eeeec9ecc518c8f58feb51588a0503"
             },
             {
+                "coord": "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-effect_2.12/7.2.24/scalaz-effect_2.12-7.2.24-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalaz/scalaz-effect_2.12/7.2.24/scalaz-effect_2.12-7.2.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalaz/scalaz-effect_2.12/7.2.24/scalaz-effect_2.12-7.2.24-sources.jar"
+                ],
+                "sha256": "87ba69ec3f185289965846b9f0268f7b4a4f550cb6458a92a1e6785d332309c9"
+            },
+            {
                 "coord": "org.scalaz:scalaz-iteratee_2.12:7.2.24",
                 "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.12/7.2.24/scalaz-iteratee_2.12-7.2.24.jar",
                 "directDependencies": [
@@ -6214,6 +12378,25 @@
                     "https://repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.12/7.2.24/scalaz-iteratee_2.12-7.2.24.jar"
                 ],
                 "sha256": "e6f23b401488b8d188d8cad6aecefce92272872b2a89b5a04f7c12ce8add43cb"
+            },
+            {
+                "coord": "org.scalaz:scalaz-iteratee_2.12:jar:sources:7.2.24",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.12/7.2.24/scalaz-iteratee_2.12-7.2.24-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.12/7.2.24/scalaz-iteratee_2.12-7.2.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.12/7.2.24/scalaz-iteratee_2.12-7.2.24-sources.jar"
+                ],
+                "sha256": "abe49bbb93fc11b9671793ab9d0bd579d4135aec1a137093236040bee4f8b669"
             },
             {
                 "coord": "org.scalaz:scalaz-scalacheck-binding_2.12:7.2.24-scalacheck-1.14",
@@ -6241,6 +12424,31 @@
                 "sha256": "b034b77fa438cf8eba2fa62f5fcf2cd4779b84ce3fe54e487402eeffe4998190"
             },
             {
+                "coord": "org.scalaz:scalaz-scalacheck-binding_2.12:jar:sources:7.2.24-scalacheck-1.14",
+                "file": "v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-scalacheck-binding_2.12/7.2.24-scalacheck-1.14/scalaz-scalacheck-binding_2.12-7.2.24-scalacheck-1.14-sources.jar",
+                "directDependencies": [
+                    "org.scalacheck:scalacheck_2.12:jar:sources:1.14.0",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-iteratee_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-concurrent_2.12:jar:sources:7.2.24"
+                ],
+                "dependencies": [
+                    "org.scalacheck:scalacheck_2.12:jar:sources:1.14.0",
+                    "org.scalaz:scalaz-core_2.12:jar:sources:7.2.24",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scalaz:scalaz-iteratee_2.12:jar:sources:7.2.24",
+                    "org.scala-sbt:test-interface:jar:sources:1.0",
+                    "org.scalaz:scalaz-concurrent_2.12:jar:sources:7.2.24",
+                    "org.scalaz:scalaz-effect_2.12:jar:sources:7.2.24"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scalaz/scalaz-scalacheck-binding_2.12/7.2.24-scalacheck-1.14/scalaz-scalacheck-binding_2.12-7.2.24-scalacheck-1.14-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scalaz/scalaz-scalacheck-binding_2.12/7.2.24-scalacheck-1.14/scalaz-scalacheck-binding_2.12-7.2.24-scalacheck-1.14-sources.jar"
+                ],
+                "sha256": "81e8072d075ff35d3ffca73e0131871393819f281ca7901edeb4181f57061acb"
+            },
+            {
                 "coord": "org.scijava:native-lib-loader:2.0.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/scijava/native-lib-loader/2.0.2/native-lib-loader-2.0.2.jar",
                 "directDependencies": [],
@@ -6250,6 +12458,17 @@
                     "https://repo1.maven.org/maven2/org/scijava/native-lib-loader/2.0.2/native-lib-loader-2.0.2.jar"
                 ],
                 "sha256": "e567c71e9f3ff53f78bd58fd6ba6d471ce31e1263f5e87d1e1fcc5d3eda1e248"
+            },
+            {
+                "coord": "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/scijava/native-lib-loader/2.0.2/native-lib-loader-2.0.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/scijava/native-lib-loader/2.0.2/native-lib-loader-2.0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scijava/native-lib-loader/2.0.2/native-lib-loader-2.0.2-sources.jar"
+                ],
+                "sha256": "7edb0a26ed4b2c1393b38d5336eeabfc18d87f46bd7ce1a1ed49d68c337d723d"
             },
             {
                 "coord": "org.scodec:scodec-bits_2.12:1.1.5",
@@ -6267,6 +12486,21 @@
                 "sha256": "dc943c1dfc4e9365d89f9cd6f40b8af036ea4ea9cefa2ba18cd3b89435356c46"
             },
             {
+                "coord": "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/scodec/scodec-bits_2.12/1.1.5/scodec-bits_2.12-1.1.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/scodec/scodec-bits_2.12/1.1.5/scodec-bits_2.12-1.1.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/scodec/scodec-bits_2.12/1.1.5/scodec-bits_2.12-1.1.5-sources.jar"
+                ],
+                "sha256": "2d9cdb222dd0616b0f61ef4f196a2510b096f4bb8ff135fec36903778dc4cece"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-api:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.12.0/selenium-api-3.12.0.jar",
                 "directDependencies": [],
@@ -6276,6 +12510,17 @@
                     "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.12.0/selenium-api-3.12.0.jar"
                 ],
                 "sha256": "acf13c48e2c9409ac5bd5b9ec7cf9a06a77e9d06d78307d3af1fe28079965f9a"
+            },
+            {
+                "coord": "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.12.0/selenium-api-3.12.0-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.12.0/selenium-api-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.12.0/selenium-api-3.12.0-sources.jar"
+                ],
+                "sha256": "93bdfbbe1f059b93caaab182e784ac707ef7192b95bea943d30c499f9b2dec1b"
             },
             {
                 "coord": "org.seleniumhq.selenium:selenium-chrome-driver:3.12.0",
@@ -6320,6 +12565,48 @@
                 "sha256": "e94ab7d85ee2523673aae75fe1dd4e2f9a6509e666ea6edf7fb9ebea8abd732d"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-chrome-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "7e61fb4c0b251abbd21e4aee4f7bf1db2d8b273ccd6dbbcd30b614df14a10bf0"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-edge-driver:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0.jar",
                 "directDependencies": [
@@ -6360,6 +12647,48 @@
                     "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0.jar"
                 ],
                 "sha256": "e36328729d7f5e557f4a9bfaec7b41b42fcca49db7a18411b9392d644e22230b"
+            },
+            {
+                "coord": "org.seleniumhq.selenium:selenium-edge-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "adfc72646af39c1cc3506dae64e170c8fb44bdfb770dccb7502512188b0b4957"
             },
             {
                 "coord": "org.seleniumhq.selenium:selenium-firefox-driver:3.12.0",
@@ -6404,6 +12733,48 @@
                 "sha256": "315e37cb48ce437d26db085426d2b1c8aa8a2cf3a4cd6b889f2587964649d63f"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "d2354bd60ca2e48dcec0f6ae94b7b8f07e96fd49fb837f08cd685c41d85acd88"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-ie-driver:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0.jar",
                 "directDependencies": [
@@ -6444,6 +12815,48 @@
                     "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0.jar"
                 ],
                 "sha256": "bb482e711422d5b0b72cdf6976cd0cd54f0a80d3e58abe6589861a9095b9e97c"
+            },
+            {
+                "coord": "org.seleniumhq.selenium:selenium-ie-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "b5fb7b5bfdec5d780b9aba348ff13a6e4c4137e780574cab08932a414c76a43c"
             },
             {
                 "coord": "org.seleniumhq.selenium:selenium-java:3.12.0",
@@ -6502,6 +12915,62 @@
                 "sha256": "68444954199e78a5b73db6957d88dd3e5358cd2b6be36d00947d2445943e020b"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-java:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.seleniumhq.selenium:selenium-ie-driver:jar:sources:3.12.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.seleniumhq.selenium:selenium-support:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-edge-driver:jar:sources:3.12.0",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-chrome-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.seleniumhq.selenium:selenium-ie-driver:jar:sources:3.12.0",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.seleniumhq.selenium:selenium-support:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-edge-driver:jar:sources:3.12.0",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-chrome-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar"
+                ],
+                "sha256": "8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-opera-driver:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0.jar",
                 "directDependencies": [
@@ -6544,6 +13013,48 @@
                 "sha256": "e359edf68e09e833d5c7b49e7f445eb19c94cbbf57acf57999d0495b067c0da2"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "78d7d3ed5757db57c90a3c9b68db2f461e3bb6533a1c7b8b91d8c2de909f171b"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0.jar",
                 "directDependencies": [
@@ -6582,6 +13093,46 @@
                     "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0.jar"
                 ],
                 "sha256": "f7135cd31b38738064b0154ef3863476754dc808a4d9e3d1a8f0ec4a04f427e6"
+            },
+            {
+                "coord": "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "04c90099b7c76d2356363bd851c033f37f434f0fa39b3da52b02e430187ac0b8"
             },
             {
                 "coord": "org.seleniumhq.selenium:selenium-safari-driver:3.12.0",
@@ -6626,6 +13177,48 @@
                 "sha256": "926a67e39613aa7b2940aeb201b4f09516c1df62686a59edb29747e59c52350b"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar"
+                ],
+                "sha256": "ceb7f9a9a8769646573f5d01263ab46d900cd7d205788b1b2a4ef37bb7aab37a"
+            },
+            {
                 "coord": "org.seleniumhq.selenium:selenium-support:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0.jar",
                 "directDependencies": [
@@ -6668,6 +13261,48 @@
                 "sha256": "b3c230f5c805fcace7800aad55756f5757d081f2172c8cd438f8516303d29972"
             },
             {
+                "coord": "org.seleniumhq.selenium:selenium-support:jar:sources:3.12.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0-sources.jar",
+                "directDependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                ],
+                "dependencies": [
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "com.squareup.okio:okio:jar:sources:1.13.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "org.apache.commons:commons-exec:jar:sources:1.3",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.google.code.gson:gson:jar:sources:2.8.2",
+                    "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0-sources.jar"
+                ],
+                "sha256": "984882712d2e031d9866b83c0cedf81c53db8570fece53c5d42d0e7c3a56873a"
+            },
+            {
                 "coord": "org.skyscreamer:jsonassert:1.1.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/skyscreamer/jsonassert/1.1.1/jsonassert-1.1.1.jar",
                 "directDependencies": [
@@ -6685,6 +13320,23 @@
                 "sha256": "e17dfdb37e4c2f1d768bb18654bbcce26294b802b3a4af74949500cf401a8da3"
             },
             {
+                "coord": "org.skyscreamer:jsonassert:jar:sources:1.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/skyscreamer/jsonassert/1.1.1/jsonassert-1.1.1-sources.jar",
+                "directDependencies": [
+                    "commons-collections:commons-collections:jar:sources:3.0",
+                    "org.json:json:jar:sources:20090211"
+                ],
+                "dependencies": [
+                    "commons-collections:commons-collections:jar:sources:3.0",
+                    "org.json:json:jar:sources:20090211"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/skyscreamer/jsonassert/1.1.1/jsonassert-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/skyscreamer/jsonassert/1.1.1/jsonassert-1.1.1-sources.jar"
+                ],
+                "sha256": "40d6822052258d6e32ee796c6d36cdb05efdfcb4b3a8650880d99372d6e60a3f"
+            },
+            {
                 "coord": "org.slf4j:jcl-over-slf4j:1.7.21",
                 "file": "v1/https/repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar",
                 "directDependencies": [
@@ -6700,6 +13352,21 @@
                 "sha256": "686b9dab357b7b665b969bbbf3dcdc67edd88ee9500699e893b5e70927be5e3f"
             },
             {
+                "coord": "org.slf4j:jcl-over-slf4j:jar:sources:1.7.21",
+                "file": "v1/https/repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21-sources.jar",
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21-sources.jar"
+                ],
+                "sha256": "5f9edefe7db1dfd99eb341f253b721e515f82dd3b528aa48630fccd6bb39e3a6"
+            },
+            {
                 "coord": "org.slf4j:slf4j-api:1.7.26",
                 "file": "v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26.jar",
                 "directDependencies": [],
@@ -6709,6 +13376,17 @@
                     "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26.jar"
                 ],
                 "sha256": "6d9e5b86cfd1dd44c676899285b5bb4fa0d371cf583e8164f9c8a0366553242b"
+            },
+            {
+                "coord": "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                "file": "v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26-sources.jar"
+                ],
+                "sha256": "9e25ad98a324e6685752fd01fbbd0588ceec5df564e53c49486946a2d19dc482"
             },
             {
                 "coord": "org.slf4j:slf4j-ext:1.7.25",
@@ -6726,6 +13404,21 @@
                 "sha256": "9df4ea4d390eb559f153716fa77658c26540f4f83635973b8c0e0da70d6fa944"
             },
             {
+                "coord": "org.slf4j:slf4j-ext:jar:sources:1.7.25",
+                "file": "v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-ext/1.7.25/slf4j-ext-1.7.25-sources.jar",
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-ext/1.7.25/slf4j-ext-1.7.25-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/slf4j/slf4j-ext/1.7.25/slf4j-ext-1.7.25-sources.jar"
+                ],
+                "sha256": "784e1fe8ad73ccb3a2df7eb76c4f55704f91986aeda394c0b9a77d3fe5e17ae6"
+            },
+            {
                 "coord": "org.slf4j:slf4j-simple:1.7.26",
                 "file": "v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26.jar",
                 "directDependencies": [
@@ -6741,6 +13434,21 @@
                 "sha256": "4b8ed75e2273850bf4eeb411ae5de5e0c0a44da59a96ca68d284749a6a373678"
             },
             {
+                "coord": "org.slf4j:slf4j-simple:jar:sources:1.7.26",
+                "file": "v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26-sources.jar",
+                "directDependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26-sources.jar"
+                ],
+                "sha256": "342b07260d82e5e79e0338daf15cb960b515c6831025d9b5303ca04f0e5a47f5"
+            },
+            {
                 "coord": "org.spire-math:jawn-parser_2.12:0.13.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/spire-math/jawn-parser_2.12/0.13.0/jawn-parser_2.12-0.13.0.jar",
                 "directDependencies": [
@@ -6754,6 +13462,21 @@
                     "https://repo1.maven.org/maven2/org/spire-math/jawn-parser_2.12/0.13.0/jawn-parser_2.12-0.13.0.jar"
                 ],
                 "sha256": "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
+            },
+            {
+                "coord": "org.spire-math:jawn-parser_2.12:jar:sources:0.13.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/spire-math/jawn-parser_2.12/0.13.0/jawn-parser_2.12-0.13.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/spire-math/jawn-parser_2.12/0.13.0/jawn-parser_2.12-0.13.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/spire-math/jawn-parser_2.12/0.13.0/jawn-parser_2.12-0.13.0-sources.jar"
+                ],
+                "sha256": "5581edbcc17bf64ec3c503e2b4859d14d24563904fb379adb1cbf3e8f6d154da"
             },
             {
                 "coord": "org.spire-math:kind-projector_2.12:0.9.3",
@@ -6773,6 +13496,25 @@
                     "https://repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3.jar"
                 ],
                 "sha256": "e36078e83a85c9ab908ebdf5882ae8b124db860c66ab98e873189249f575c929"
+            },
+            {
+                "coord": "org.spire-math:kind-projector_2.12:jar:sources:0.9.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3-sources.jar"
+                ],
+                "sha256": "0fdd6c57a4f235531ddad4b298c37820a6ffe4b7416d60fd173d71f82ba02149"
             },
             {
                 "coord": "org.testcontainers:jdbc:1.4.2",
@@ -6819,6 +13561,49 @@
                 "sha256": "b142a866c2be3df014d17c6a3abde0484e936713b814978cfef3ad66abc642e3"
             },
             {
+                "coord": "org.testcontainers:jdbc:jar:sources:1.4.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/jdbc/1.4.2/jdbc-1.4.2-sources.jar",
+                "directDependencies": [
+                    "org.testcontainers:testcontainers:jar:sources:1.4.2"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "org.slf4j:slf4j-ext:jar:sources:1.7.25",
+                    "org.jetbrains:annotations:jar:sources:13.0",
+                    "org.apache.commons:commons-compress:jar:sources:1.12",
+                    "org.slf4j:jcl-over-slf4j:jar:sources:1.7.21",
+                    "commons-lang:commons-lang:jar:sources:2.6",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.rnorth:tcp-unix-socket-proxy:jar:sources:1.0.1",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.rnorth.duct-tape:duct-tape:jar:sources:1.0.6",
+                    "org.zeroturnaround:zt-exec:jar:sources:1.8",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.rnorth.visible-assertions:visible-assertions:jar:sources:2.0.0",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "log4j:log4j:jar:sources:1.2.17",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "junit:junit:jar:sources:4.12",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3",
+                    "org.testcontainers:testcontainers:jar:sources:1.4.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/testcontainers/jdbc/1.4.2/jdbc-1.4.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/testcontainers/jdbc/1.4.2/jdbc-1.4.2-sources.jar"
+                ],
+                "sha256": "3fa531d0e040b33c2b8a2e4089f87bc9dccb2cffe56a12f7878b8f5483ee607d"
+            },
+            {
                 "coord": "org.testcontainers:postgresql:1.4.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/postgresql/1.4.2/postgresql-1.4.2.jar",
                 "directDependencies": [
@@ -6862,6 +13647,50 @@
                     "https://repo1.maven.org/maven2/org/testcontainers/postgresql/1.4.2/postgresql-1.4.2.jar"
                 ],
                 "sha256": "e76f488b23b07d4f30dc40c22bf242c9e6e8d4183a59e5edb44ec02901b9cc8e"
+            },
+            {
+                "coord": "org.testcontainers:postgresql:jar:sources:1.4.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/postgresql/1.4.2/postgresql-1.4.2-sources.jar",
+                "directDependencies": [
+                    "org.testcontainers:jdbc:jar:sources:1.4.2"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "org.slf4j:slf4j-ext:jar:sources:1.7.25",
+                    "org.jetbrains:annotations:jar:sources:13.0",
+                    "org.apache.commons:commons-compress:jar:sources:1.12",
+                    "org.slf4j:jcl-over-slf4j:jar:sources:1.7.21",
+                    "commons-lang:commons-lang:jar:sources:2.6",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.rnorth:tcp-unix-socket-proxy:jar:sources:1.0.1",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.rnorth.duct-tape:duct-tape:jar:sources:1.0.6",
+                    "org.zeroturnaround:zt-exec:jar:sources:1.8",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.rnorth.visible-assertions:visible-assertions:jar:sources:2.0.0",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "org.testcontainers:jdbc:jar:sources:1.4.2",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "log4j:log4j:jar:sources:1.2.17",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "junit:junit:jar:sources:4.12",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3",
+                    "org.testcontainers:testcontainers:jar:sources:1.4.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/testcontainers/postgresql/1.4.2/postgresql-1.4.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/testcontainers/postgresql/1.4.2/postgresql-1.4.2-sources.jar"
+                ],
+                "sha256": "c6f4858a536ec49400b7d75bfa53d565d3e015b6bd4c440b647c225206614439"
             },
             {
                 "coord": "org.testcontainers:testcontainers:1.4.2",
@@ -6934,6 +13763,74 @@
                 "sha256": "48c86e311681bac27bf7ea049ce7dbc63887ce9857625d29eb4288e94b071fe6"
             },
             {
+                "coord": "org.testcontainers:testcontainers:jar:sources:1.4.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/testcontainers/1.4.2/testcontainers-1.4.2-sources.jar",
+                "directDependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "org.slf4j:slf4j-ext:jar:sources:1.7.25",
+                    "org.jetbrains:annotations:jar:sources:13.0",
+                    "org.apache.commons:commons-compress:jar:sources:1.12",
+                    "org.slf4j:jcl-over-slf4j:jar:sources:1.7.21",
+                    "commons-lang:commons-lang:jar:sources:2.6",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.rnorth:tcp-unix-socket-proxy:jar:sources:1.0.1",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.rnorth.duct-tape:duct-tape:jar:sources:1.0.6",
+                    "org.zeroturnaround:zt-exec:jar:sources:1.8",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.rnorth.visible-assertions:visible-assertions:jar:sources:2.0.0",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "junit:junit:jar:sources:4.12",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "dependencies": [
+                    "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
+                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "org.slf4j:slf4j-ext:jar:sources:1.7.25",
+                    "org.jetbrains:annotations:jar:sources:13.0",
+                    "org.apache.commons:commons-compress:jar:sources:1.12",
+                    "org.slf4j:jcl-over-slf4j:jar:sources:1.7.21",
+                    "commons-lang:commons-lang:jar:sources:2.6",
+                    "com.github.jnr:jffi:jar:sources:1.2.15",
+                    "com.github.jnr:jnr-constants:jar:sources:0.9.8",
+                    "com.kohlschutter.junixsocket:junixsocket-common:jar:sources:2.0.4",
+                    "org.ow2.asm:asm-commons:jar:sources:5.0.3",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.rnorth:tcp-unix-socket-proxy:jar:sources:1.0.1",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "com.github.jnr:jnr-posix:jar:sources:3.0.41",
+                    "com.kohlschutter.junixsocket:junixsocket-native-common:jar:sources:2.0.4",
+                    "org.rnorth.duct-tape:duct-tape:jar:sources:1.0.6",
+                    "org.zeroturnaround:zt-exec:jar:sources:1.8",
+                    "org.ow2.asm:asm-tree:jar:sources:5.0.3",
+                    "org.rnorth.visible-assertions:visible-assertions:jar:sources:2.0.0",
+                    "org.ow2.asm:asm:jar:sources:5.0.4",
+                    "org.scijava:native-lib-loader:jar:sources:2.0.2",
+                    "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "log4j:log4j:jar:sources:1.2.17",
+                    "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
+                    "junit:junit:jar:sources:4.12",
+                    "org.ow2.asm:asm-util:jar:sources:5.0.3"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.4.2/testcontainers-1.4.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.4.2/testcontainers-1.4.2-sources.jar"
+                ],
+                "sha256": "0a243d19a57f0a72c03850db6cc3b4a3952c20f846d3566e80d676517dfd85fb"
+            },
+            {
                 "coord": "org.testng:testng:5.14.10",
                 "file": "v1/https/repo1.maven.org/maven2/org/testng/testng/5.14.10/testng-5.14.10.jar",
                 "directDependencies": [
@@ -6954,6 +13851,28 @@
                     "https://repo1.maven.org/maven2/org/testng/testng/5.14.10/testng-5.14.10.jar"
                 ],
                 "sha256": "9739c41611e4dcf4a4b7fa8ff76842a7216d831caffeb3085abf3198840d432c"
+            },
+            {
+                "coord": "org.testng:testng:jar:sources:5.14.10",
+                "file": "v1/https/repo1.maven.org/maven2/org/testng/testng/5.14.10/testng-5.14.10-sources.jar",
+                "directDependencies": [
+                    "com.beust:jcommander:jar:sources:1.12",
+                    "junit:junit:jar:sources:4.12",
+                    "org.beanshell:bsh:jar:sources:2.0b4",
+                    "org.yaml:snakeyaml:jar:sources:1.24"
+                ],
+                "dependencies": [
+                    "com.beust:jcommander:jar:sources:1.12",
+                    "org.beanshell:bsh:jar:sources:2.0b4",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.yaml:snakeyaml:jar:sources:1.24",
+                    "junit:junit:jar:sources:4.12"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/testng/testng/5.14.10/testng-5.14.10-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/testng/testng/5.14.10/testng-5.14.10-sources.jar"
+                ],
+                "sha256": "8607eb8955fdafeb59c1daced1c7219bed6523506b4b77688f0306b6bb701429"
             },
             {
                 "coord": "org.tpolecat:doobie-core_2.12:0.6.0",
@@ -6988,6 +13907,38 @@
                 "sha256": "b51d54aaf41be41d713b081b9754168c59c80483e6b30d7a107dafb0dbdcd302"
             },
             {
+                "coord": "org.tpolecat:doobie-core_2.12:jar:sources:0.6.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-core_2.12/0.6.0/doobie-core_2.12-0.6.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.tpolecat:doobie-free_2.12:jar:sources:0.6.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.typelevel:cats-free_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.tpolecat:doobie-free_2.12:jar:sources:0.6.0",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/tpolecat/doobie-core_2.12/0.6.0/doobie-core_2.12-0.6.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/tpolecat/doobie-core_2.12/0.6.0/doobie-core_2.12-0.6.0-sources.jar"
+                ],
+                "sha256": "c644140c1a60ae05703f214670a8822653fff19d4e5dc9be1329fa7982183ab1"
+            },
+            {
                 "coord": "org.tpolecat:doobie-free_2.12:0.6.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-free_2.12/0.6.0/doobie-free_2.12-0.6.0.jar",
                 "directDependencies": [
@@ -7013,6 +13964,33 @@
                     "https://repo1.maven.org/maven2/org/tpolecat/doobie-free_2.12/0.6.0/doobie-free_2.12-0.6.0.jar"
                 ],
                 "sha256": "2c3af03d1ff4596e400d88c6f5f65aea4a6f39acab3fe60e9f07112bbcfdeb4b"
+            },
+            {
+                "coord": "org.tpolecat:doobie-free_2.12:jar:sources:0.6.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-free_2.12/0.6.0/doobie-free_2.12-0.6.0-sources.jar",
+                "directDependencies": [
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-free_2.12:jar:sources:1.4.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-free_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/tpolecat/doobie-free_2.12/0.6.0/doobie-free_2.12-0.6.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/tpolecat/doobie-free_2.12/0.6.0/doobie-free_2.12-0.6.0-sources.jar"
+                ],
+                "sha256": "0b856fcfc5df82f06b7051088cc0aceb30e3149bf4a8483af1530c1766287d66"
             },
             {
                 "coord": "org.tpolecat:doobie-postgres_2.12:0.6.0",
@@ -7049,6 +14027,40 @@
                 "sha256": "24d882b9d30fe1bd07c70b870e26ff4c1bd077634eb44672ab5212c3f123b904"
             },
             {
+                "coord": "org.tpolecat:doobie-postgres_2.12:jar:sources:0.6.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-postgres_2.12/0.6.0/doobie-postgres_2.12-0.6.0-sources.jar",
+                "directDependencies": [
+                    "co.fs2:fs2-io_2.12:jar:sources:1.0.0",
+                    "org.postgresql:postgresql:jar:sources:42.2.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.tpolecat:doobie-core_2.12:jar:sources:0.6.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scodec:scodec-bits_2.12:jar:sources:1.1.5",
+                    "org.tpolecat:doobie-core_2.12:jar:sources:0.6.0",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "co.fs2:fs2-io_2.12:jar:sources:1.0.0",
+                    "com.chuusai:shapeless_2.12:jar:sources:2.3.2",
+                    "co.fs2:fs2-core_2.12:jar:sources:1.0.0",
+                    "org.postgresql:postgresql:jar:sources:42.2.6",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "com.lihaoyi:sourcecode_2.12:jar:sources:0.1.7",
+                    "org.typelevel:cats-free_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.tpolecat:doobie-free_2.12:jar:sources:0.6.0",
+                    "org.typelevel:macro-compat_2.12:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/tpolecat/doobie-postgres_2.12/0.6.0/doobie-postgres_2.12-0.6.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/tpolecat/doobie-postgres_2.12/0.6.0/doobie-postgres_2.12-0.6.0-sources.jar"
+                ],
+                "sha256": "90582e3442a460a6708114132e2794d096d2aa72c4d79898a1a5579438ce6684"
+            },
+            {
                 "coord": "org.typelevel:cats-core_2.12:1.4.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.12/1.4.0/cats-core_2.12-1.4.0.jar",
                 "directDependencies": [
@@ -7071,6 +14083,28 @@
                 "sha256": "ab9eeca930b3e51bd063d45c1ec51097a41dd6f61d155d880f5f14be0ab14f35"
             },
             {
+                "coord": "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.12/1.4.0/cats-core_2.12-1.4.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/cats-core_2.12/1.4.0/cats-core_2.12-1.4.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/cats-core_2.12/1.4.0/cats-core_2.12-1.4.0-sources.jar"
+                ],
+                "sha256": "a83c31f10ac2d85a3d80f1dc1b406b6a2f1c659c959f19256344620a773aac84"
+            },
+            {
                 "coord": "org.typelevel:cats-effect_2.12:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-effect_2.12/1.0.0/cats-effect_2.12-1.0.0.jar",
                 "directDependencies": [
@@ -7090,6 +14124,27 @@
                     "https://repo1.maven.org/maven2/org/typelevel/cats-effect_2.12/1.0.0/cats-effect_2.12-1.0.0.jar"
                 ],
                 "sha256": "b4c58e58da2ac4a38ed1596d62d15ee4db75fdf6089e581157fb069ea76cf925"
+            },
+            {
+                "coord": "org.typelevel:cats-effect_2.12:jar:sources:1.0.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-effect_2.12/1.0.0/cats-effect_2.12-1.0.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/cats-effect_2.12/1.0.0/cats-effect_2.12-1.0.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/cats-effect_2.12/1.0.0/cats-effect_2.12-1.0.0-sources.jar"
+                ],
+                "sha256": "4db834829c553372b13bea7d12340f17dd9770557db2a3f9987e266653e37e2e"
             },
             {
                 "coord": "org.typelevel:cats-free_2.12:1.4.0",
@@ -7115,6 +14170,29 @@
                 "sha256": "3a2a42a9537348aeaeb9d988d894f8b21e47f6387b30dc2e935c7a96dd39d5c0"
             },
             {
+                "coord": "org.typelevel:cats-free_2.12:jar:sources:1.4.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-free_2.12/1.4.0/cats-free_2.12-1.4.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                    "org.typelevel:cats-core_2.12:jar:sources:1.4.0"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/cats-free_2.12/1.4.0/cats-free_2.12-1.4.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/cats-free_2.12/1.4.0/cats-free_2.12-1.4.0-sources.jar"
+                ],
+                "sha256": "893dc3b03760429c436db9204d0de86b5d4d08dee9eacaac9a91d7023c677dee"
+            },
+            {
                 "coord": "org.typelevel:cats-kernel_2.12:1.4.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.12/1.4.0/cats-kernel_2.12-1.4.0.jar",
                 "directDependencies": [
@@ -7128,6 +14206,21 @@
                     "https://repo1.maven.org/maven2/org/typelevel/cats-kernel_2.12/1.4.0/cats-kernel_2.12-1.4.0.jar"
                 ],
                 "sha256": "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
+            },
+            {
+                "coord": "org.typelevel:cats-kernel_2.12:jar:sources:1.4.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.12/1.4.0/cats-kernel_2.12-1.4.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/cats-kernel_2.12/1.4.0/cats-kernel_2.12-1.4.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/cats-kernel_2.12/1.4.0/cats-kernel_2.12-1.4.0-sources.jar"
+                ],
+                "sha256": "7761b528f8fb430e4371de2343b024fb8a0ad0037408e040d88a97004c59d727"
             },
             {
                 "coord": "org.typelevel:cats-macros_2.12:1.4.0",
@@ -7148,6 +14241,24 @@
                 "sha256": "28d318d6265ed08f15f61af407a22bacbe6f5e139075cc06df21e6d48a7a7eb2"
             },
             {
+                "coord": "org.typelevel:cats-macros_2.12:jar:sources:1.4.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/cats-macros_2.12/1.4.0/cats-macros_2.12-1.4.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/cats-macros_2.12/1.4.0/cats-macros_2.12-1.4.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/cats-macros_2.12/1.4.0/cats-macros_2.12-1.4.0-sources.jar"
+                ],
+                "sha256": "1000c1f9f43c95b1bcdd245330c407a5666243680295f248e2b0461daef01840"
+            },
+            {
                 "coord": "org.typelevel:machinist_2.12:0.6.5",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/machinist_2.12/0.6.5/machinist_2.12-0.6.5.jar",
                 "directDependencies": [
@@ -7165,6 +14276,23 @@
                 "sha256": "9b449314637d967b8acf1bcb744b605e118fe6ac6c7d08e8db68b7f39267d8e5"
             },
             {
+                "coord": "org.typelevel:machinist_2.12:jar:sources:0.6.5",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/machinist_2.12/0.6.5/machinist_2.12-0.6.5-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/machinist_2.12/0.6.5/machinist_2.12-0.6.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/machinist_2.12/0.6.5/machinist_2.12-0.6.5-sources.jar"
+                ],
+                "sha256": "a7439aa63f3c25bd108464e575653307e8688c3dfb868f4303e56a810eb5ea37"
+            },
+            {
                 "coord": "org.typelevel:macro-compat_2.12:1.1.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar",
                 "directDependencies": [
@@ -7180,6 +14308,21 @@
                 "sha256": "8b1514ec99ac9c7eded284367b6c9f8f17a097198a44e6f24488706d66bbd2b8"
             },
             {
+                "coord": "org.typelevel:macro-compat_2.12:jar:sources:1.1.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+                ],
+                "sha256": "c748cbcda2e8828dd25e788617a4c559abf92960ef0f92f9f5d3ea67774c34c8"
+            },
+            {
                 "coord": "org.typelevel:paiges-core_2.12:0.2.1",
                 "file": "v1/https/repo1.maven.org/maven2/org/typelevel/paiges-core_2.12/0.2.1/paiges-core_2.12-0.2.1.jar",
                 "directDependencies": [
@@ -7193,6 +14336,21 @@
                     "https://repo1.maven.org/maven2/org/typelevel/paiges-core_2.12/0.2.1/paiges-core_2.12-0.2.1.jar"
                 ],
                 "sha256": "70d38aacec6ecdcedf2a438ba0e3e3636d4aa1bac2dca75596ed9ed908e02de7"
+            },
+            {
+                "coord": "org.typelevel:paiges-core_2.12:jar:sources:0.2.1",
+                "file": "v1/https/repo1.maven.org/maven2/org/typelevel/paiges-core_2.12/0.2.1/paiges-core_2.12-0.2.1-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/typelevel/paiges-core_2.12/0.2.1/paiges-core_2.12-0.2.1-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/typelevel/paiges-core_2.12/0.2.1/paiges-core_2.12-0.2.1-sources.jar"
+                ],
+                "sha256": "487a19150b88d400e2306bfd2a9a7662fa7ed610561f7529ea2a822ce605b04a"
             },
             {
                 "coord": "org.wartremover:wartremover_2.12:2.2.0",
@@ -7214,6 +14372,25 @@
                 "sha256": "f8ea0aebf0d8d81e657294492f5d13c0b15c7251274d3ca1985a05f1e97cb2d8"
             },
             {
+                "coord": "org.wartremover:wartremover_2.12:jar:sources:2.2.0",
+                "file": "v1/https/repo1.maven.org/maven2/org/wartremover/wartremover_2.12/2.2.0/wartremover_2.12-2.2.0-sources.jar",
+                "directDependencies": [
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8"
+                ],
+                "dependencies": [
+                    "org.scala-lang.modules:scala-xml_2.12:jar:sources:1.0.6",
+                    "org.scala-lang:scala-library:jar:sources:2.12.8",
+                    "org.scala-lang:scala-compiler:jar:sources:2.12.7",
+                    "org.scala-lang:scala-reflect:jar:sources:2.12.7"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/wartremover/wartremover_2.12/2.2.0/wartremover_2.12-2.2.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/wartremover/wartremover_2.12/2.2.0/wartremover_2.12-2.2.0-sources.jar"
+                ],
+                "sha256": "e15236770b2409de1fac08767b99fa2e7f33b6e71a9824d52dba5cbf19053e7e"
+            },
+            {
                 "coord": "org.xerial:sqlite-jdbc:3.25.2",
                 "file": "v1/https/repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2.jar",
                 "directDependencies": [],
@@ -7225,6 +14402,17 @@
                 "sha256": "a45da61abed61568a533fdece125093180828edeb0d4b6f6d572e0cf457465f6"
             },
             {
+                "coord": "org.xerial:sqlite-jdbc:jar:sources:3.25.2",
+                "file": "v1/https/repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2-sources.jar"
+                ],
+                "sha256": "58073a1103ffa769b2511c60f88c647a922ab0f6ab621625f9ade223064f89e3"
+            },
+            {
                 "coord": "org.yaml:snakeyaml:1.24",
                 "file": "v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.jar",
                 "directDependencies": [],
@@ -7234,6 +14422,17 @@
                     "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.jar"
                 ],
                 "sha256": "d3f7f09989d5b0ce5c4791818ef937ee7663f1e359c2ef2d312f938aad0763da"
+            },
+            {
+                "coord": "org.yaml:snakeyaml:jar:sources:1.24",
+                "file": "v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "url": "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24-sources.jar"
+                ],
+                "sha256": "2ca4a62e017fb92f4ddd57692a71dfe2be23a2482bf0bd8b6821a08506fe04fe"
             },
             {
                 "coord": "org.zeroturnaround:zt-exec:1.8",
@@ -7253,6 +14452,23 @@
                 "sha256": "376b8123d65882f73ce5c6f2f3aa93492ceea3d4c74c26f02749fdef72a85ed4"
             },
             {
+                "coord": "org.zeroturnaround:zt-exec:jar:sources:1.8",
+                "file": "v1/https/repo1.maven.org/maven2/org/zeroturnaround/zt-exec/1.8/zt-exec-1.8-sources.jar",
+                "directDependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "dependencies": [
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "org.slf4j:slf4j-api:jar:sources:1.7.26"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/zeroturnaround/zt-exec/1.8/zt-exec-1.8-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/zeroturnaround/zt-exec/1.8/zt-exec-1.8-sources.jar"
+                ],
+                "sha256": "3e6927a301583f97ed55e983404ffa1daaccb77d8df94d4dbfd7ea4a317c35e2"
+            },
+            {
                 "coord": "uk.co.datumedge:hamcrest-json:0.2",
                 "file": "v1/https/repo1.maven.org/maven2/uk/co/datumedge/hamcrest-json/0.2/hamcrest-json-0.2.jar",
                 "directDependencies": [
@@ -7270,9 +14486,28 @@
                     "https://repo1.maven.org/maven2/uk/co/datumedge/hamcrest-json/0.2/hamcrest-json-0.2.jar"
                 ],
                 "sha256": "7415b8969eba90fe5ae710cf43dd871392c3512c821f1cda4d46ae6a22a33f65"
+            },
+            {
+                "coord": "uk.co.datumedge:hamcrest-json:jar:sources:0.2",
+                "file": "v1/https/repo1.maven.org/maven2/uk/co/datumedge/hamcrest-json/0.2/hamcrest-json-0.2-sources.jar",
+                "directDependencies": [
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.skyscreamer:jsonassert:jar:sources:1.1.1"
+                ],
+                "dependencies": [
+                    "commons-collections:commons-collections:jar:sources:3.0",
+                    "org.json:json:jar:sources:20090211",
+                    "org.hamcrest:hamcrest-core:jar:sources:1.3",
+                    "org.skyscreamer:jsonassert:jar:sources:1.1.1"
+                ],
+                "url": "https://repo1.maven.org/maven2/uk/co/datumedge/hamcrest-json/0.2/hamcrest-json-0.2-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/uk/co/datumedge/hamcrest-json/0.2/hamcrest-json-0.2-sources.jar"
+                ],
+                "sha256": "eaaf63283c929066efe8b90715f8268c55e551f9c539b130977dbc3374662148"
             }
         ],
         "version": "0.1.0",
-        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -487526900
+        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -573544503
     }
 }


### PR DESCRIPTION
- Set `fetch_source = True` in `maven_install`
- Run `bazel run @unpinned_maven//:pin`

`maven_install` will fetch srcjars and store them next to the regular jars. Each package's `JavaInfo` will have the `source_jar` field set. 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
