### PR TITLE
Add dedupCreate/dedupExercise helpers to the DAML trigger API

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -207,26 +207,8 @@ created using ``exerciseCmd`` and ``createCmd``.
 
 Finally, we also need to create copies that do not already exists. We
 want to avoid creating copies for which there is already a command in
-flight. To find these, we first need a helper function that given a
-``Command`` returns ``Some copy`` if the ``Command`` corresponds to
-the creation of ``copy`` or ``None`` otherwise. For that, we pattern
-match on the ``Command`` and if it was a ``CreateCommand``, we call
-the ``fromAnyTemplate`` function which will return ``Some tpl`` if the
-template is of the given type (``Copy`` in this example) and ``None``
-otherwise.
-
-.. literalinclude:: ./template-root/src/CopyTrigger.daml
-   :language: daml
-   :start-after: -- TO_CREATE_COPY_BEGIN
-   :end-before: -- TO_CREATE_COPY_END
-
-Equipped with ``toCreateCopy``, we can define the set of
-``pendingCopies`` by filtering the commands in flight and the set of
-``eventualCopies``, i.e., either pending copies or copies that already
-exist.  The copies that we need to create are then the set of
-``neeedCopies`` that are not already in ``pendingCopies``. Similar to
-archiving, we use ``emitCommands`` to actually create them, this time
-with ``createCmd`` instead of ``exerciseCmd``.
+flight. The DAML Trigger API provides a ``dedupCreate`` helper for this
+which only sends the commands if it is not already in flight.
 
 .. literalinclude:: ./template-root/src/CopyTrigger.daml
    :language: daml

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -6,8 +6,6 @@ module CopyTrigger where
 
 import DA.List
 import DA.Next.Map (Map)
-import qualified DA.Next.Map as Map
-import DA.Optional
 
 import Daml.Trigger
 
@@ -97,16 +95,8 @@ copyRule party acs commandsInFlight () = do
 -- ARCHIVE_COMMAND_END
 
 -- CREATE_COPIES_BEGIN
-  let pendingCopies = concatMap (mapOptional toCreateCopy . snd) $ Map.toList commandsInFlight
-  let eventualCopies = pendingCopies <> map snd copiesToKeep
   let neededCopies = [Copy m o | (_, m) <- ownedOriginals, o <- subscribingParties]
-  let createCopies = filter (\c -> c `notElem` eventualCopies) neededCopies
-  forA createCopies $ \copy -> emitCommands [createCmd copy]
+  let createCopies = filter (\c -> c `notElem` map snd copiesToKeep) neededCopies
+  mapA dedupCreate createCopies
 -- CREATE_COPIES_END
   pure ()
-
--- TO_CREATE_COPY_BEGIN
-toCreateCopy : Command -> Optional Copy
-toCreateCopy (CreateCommand tpl) = fromAnyTemplate tpl
-toCreateCopy (ExerciseCommand _ _) = None
--- TO_CREATE_COPY_END

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -17,12 +17,15 @@ module Daml.Trigger
  , fromAnyContractId
  , exerciseCmd
  , createCmd
+ , dedupExercise
+ , dedupCreate
  , Message(..)
  , Completion(..)
  , Transaction(..)
  , CompletionStatus(..)
  ) where
 
+import DA.Action
 import DA.Action.State
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
@@ -73,6 +76,38 @@ emitCommands cmds = do
   TriggerA $ modify $ \s -> s { emittedCommands = commands :: s.emittedCommands, nextCommandId = s.nextCommandId + 1 }
   pure id
 
+-- | Create the template if it’s not already in the list of commands
+-- in flight (it will still be created if it is in the ACS).
+--
+-- Note that this will send the create as a single-command transaction.
+-- If you need to send multiple commands in one transaction, use
+-- `emitCommands` with `createCmd` and handle filtering yourself.
+dedupCreate : (Eq t, Template t) => t -> TriggerA ()
+dedupCreate t = do
+  aState <- TriggerA get
+  -- This is a very naive approach that is linear in the number of commands in flight.
+  -- We probably want to change this to express the commands in flight as some kind of
+  -- map to make these lookups cheaper.
+  let cmds = concat $ map snd (Map.toList aState.commandsInFlight) <> map commands aState.emittedCommands
+  unless (any ((Some t ==) . fromCreate) cmds) $
+    void $ emitCommands [createCmd t]
+
+-- | Exercise the choice on the given contract if it is not already
+-- in flight.
+--
+-- Note that this will send the exercise as a single-command transaction.
+-- If you need to send multiple commands in one transaction, use
+-- `emitCommands` with `exerciseCmd` and handle filtering yourself.
+dedupExercise : (Eq c, Choice t c r) => AbsoluteContractId t -> c -> TriggerA ()
+dedupExercise cid c = do
+  aState <- TriggerA get
+  -- This is a very naive approach that is linear in the number of commands in flight.
+  -- We probably want to change this to express the commands in flight as some kind of
+  -- map to make these lookups cheaper.
+  let cmds = concat $ map snd (Map.toList aState.commandsInFlight) <> map commands aState.emittedCommands
+  unless (any ((Some (cid, c) ==) . fromExercise) cmds) $
+    void $ emitCommands [exerciseCmd cid c]
+
 -- | Transform the high-level trigger type into the one from `Daml.Trigger.LowLevel`.
 runTrigger : Trigger s -> LowLevel.Trigger (TriggerState s)
 runTrigger userTrigger = LowLevel.Trigger
@@ -107,12 +142,6 @@ runTrigger userTrigger = LowLevel.Trigger
                 Some commandId -> Map.delete commandId state.commandsInFlight
               state' = state { acs, userState, commandsInFlight }
           in runRule userTrigger.rule state'
-
-numCreates : Commands -> Int
-numCreates (Commands _ cmds) = length $ filter (\x -> case x of CreateCommand {} -> True; _ -> False) cmds
-
-numExercises : Commands -> Int
-numExercises (Commands _ cmds) = length $ filter (\x -> case x of ExerciseCommand {} -> True; _ -> False) cmds
 
 -- Internal API
 

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -24,8 +24,10 @@ module Daml.Trigger.LowLevel
   , Commands(..)
   , TemplateId(..)
   , Command(..)
-  , exerciseCmd
   , createCmd
+  , exerciseCmd
+  , fromCreate
+  , fromExercise
   ) where
 
 import DA.Next.Map (MapKey(..))
@@ -163,6 +165,18 @@ createCmd templateArg =
 exerciseCmd : forall t c r. Choice t c r => AbsoluteContractId t -> c -> Command
 exerciseCmd contractId choiceArg =
   ExerciseCommand (toAnyContractId contractId) (toAnyChoice @t choiceArg)
+
+-- | Check if the command corresponds to a create command
+-- for the given template.
+fromCreate : Template t => Command -> Optional t
+fromCreate (CreateCommand t) = fromAnyTemplate t
+fromCreate _ = None
+
+-- | Check if the command corresponds to an exercise command
+-- for the given template.
+fromExercise : forall t c r. Choice t c r => Command -> Optional (AbsoluteContractId t, c)
+fromExercise (ExerciseCommand cid c) = (,) <$> fromAnyContractId cid <*> fromAnyChoice @t c
+fromExercise _ = None
 
 -- | A set of commands that are submitted as a single transaction.
 data Commands = Commands

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -10,3 +10,5 @@ HEAD — ongoing
 --------------
 
 - [DAML Compiler] Reduce the memory footprint of the IDE and the command line tools (ca. 18% in our experiments).
+- [DAML Triggers] Add ``dedupCreate`` and ``dedupExercise`` helpers that will only send
+  commands if they are not already in flight.


### PR DESCRIPTION
Given how common this is, it seems worthwile to add helpers for this.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
