### PR TITLE
docs cron: fix content-type header

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -201,7 +201,7 @@ tell_hubspot latest = do
     let summary = "Release notes for version " <> name latest <> "."
     token <- Env.getEnv "HUBSPOT_TOKEN"
     submit_blog <- http_post ("https://api.hubapi.com/content/api/v2/blog-posts?hapikey=" <> token)
-                             [("Content-Type", "application.json")]
+                             [("Content-Type", "application/json")]
                              $ JSON.encode $ SubmitBlog { body = LBS.toString desc,
                                                           date,
                                                           summary,
@@ -210,7 +210,7 @@ tell_hubspot latest = do
       Nothing -> Exit.die $ "No blog id from HubSpot: \n" <> LBS.toString submit_blog
       Just BlogId { blog_id } -> do
           _ <- http_post ("https://api.hubapi.com/content/api/v2/blog-posts/" <> show blog_id <> "/publish-action?hapikey=" <> token)
-                         [("Content-Type", "application.json")]
+                         [("Content-Type", "application/json")]
                          (JSON.encode $ JSON.object [("action", "schedule-publish")])
           return ()
 


### PR DESCRIPTION
Reviewing this script in the context of the failed 0.13.32 HubSpot announce, I noticed I had a typo in the Content-Type MIME identifier. I can't be sure this is the only issue, but it definitely is a blocking one as HubSpot is pretty picky about that header.
