### PR TITLE
pin Terraform to 0.11

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -243,7 +243,9 @@ in rec {
     gsutil = gcloud;
     # used to set up the webide CI pipeline in azure-cron.yml
     docker-credential-gcr = pkgs.docker-credential-gcr;
-    terraform = pkgs.terraform.withPlugins (p: with p; [
+    # Note: we need to pin Terraform to 0.11 until nixpkgs includes a version
+    # of the secret provider that is compatiblz with Terraform 0.12 (1.1.0+)
+    terraform = pkgs.terraform_0_11.withPlugins (p: with p; [
       google
       google-beta
       random


### PR DESCRIPTION
The latest nixpkgs upgrade has gotten us Terraform 0.12, which is a major, breaking version upgrade. In particular, besides syntactic changes in Terraform configuration, 0.12 is not compatible with the [secrets provider](https://github.com/tweag/terraform-provider-secret) plugin we use. (This does mean nixpkgs itself is currently "broken" in that way.)

That plugin _does_ have a version compatible with Terraform 0.12, but for some reason that has not been included in any nixpkgs release yet. As a stop-gap, to get things working right now, I suggest we pin Terraform to a working version.