### PR TITLE
--test_env is a build option as well

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,7 +49,7 @@ build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build --distinct_host_configuration=false
 
 # Propagate locales and the java home to the test environment.
-test --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE --test_env=JAVA_HOME
+build --test_env=LANG=en_US.utf8 --test_env=LOCALE_ARCHIVE --test_env=JAVA_HOME
 
 # Disable c-ares support in grpc. We don't need a faster DNS library
 # since we're only connecting to localhost.


### PR DESCRIPTION
The `.bazelrc` file specified `--test_env` as a `test` option only. However, this is a `build` option as well. Only specifying it for `test` caused Bazel to unnecessarily redo the analysis phase:

```
INFO: Build option --test_env has changed, discarding analysis cache.
```

The effect can be observed by repeatedly running `bazel build` and `bazel test` on a test target.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
