### PR TITLE
Navigator properly sets the max incoming message size again.

### DIFF
--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,6 +9,7 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
+- [Navigator] Fixed regression in Navigator to properly respect the CLI option ``--ledger-api-inbound-message-size-max`` again. See `issue #3301 <https://github.com/digital-asset/daml/issues/3301>`__.
 - [DAML Compiler] Reduce the memory footprint of the IDE and the command line tools (ca. 18% in our experiments).
 - [DAML Triggers] Add ``dedupCreate`` and ``dedupExercise`` helpers that will only send
   commands if they are not already in flight.


### PR DESCRIPTION
The symptom for receiving messages larger than the configured maxInboundMessageSize is a
gRPC error like:

Oct 31, 2019 1:52:37 PM io.grpc.internal.AbstractClientStream$TransportState inboundDataReceived
INFO: Received data on closed stream

Fixes #3301.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
