### PR TITLE
Extractor stores exercise events in single table data format.

### DIFF
--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -115,6 +115,7 @@ daml_compile(
 
 testDependencies = [
     ":extractor",
+    "//bazel_tools/runfiles:scala_runfiles",
     "//daml-lf/data-scalacheck",
     "//daml-lf/transaction-scalacheck",
     "//ledger/sandbox:sandbox",
@@ -175,6 +176,5 @@ da_scala_test_suite(
     resources = glob(["src/test/resources/**/*"]),
     deps = [
         ":extractor-scala-tests-lib",
-        "//bazel_tools/runfiles:scala_runfiles",
     ] + testDependencies,
 )

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/SingleTableDataFormat.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/SingleTableDataFormat.scala
@@ -49,10 +49,19 @@ class SingleTableDataFormat extends DataFormat[SingleTableState.type] {
       transaction: TransactionTree,
       event: ExercisedEvent
   ): Writer.RefreshPackages \/ ConnectionIO[Unit] = {
-    val query =
-      setContractArchived(event.contractId, transaction.transactionId, event.eventId)
+    val update =
+      if (event.consuming)
+        setContractArchived(event.contractId, transaction.transactionId, event.eventId).update.run.void
+      else
+        connection.pure(())
 
-    query.update.run.void.right
+    val insert =
+      insertExercise(
+        event,
+        transaction.transactionId,
+        transaction.rootEventIds.contains(event.eventId)).update.run.void
+
+    (update *> insert).right
   }
 
   def handleCreatedEvent(

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -41,7 +41,7 @@ trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
     ),
   )
 
-  protected def outputFormat: String
+  protected def outputFormat: String = "single-table"
 
   protected def configureExtractor(ec: ExtractorConfig): ExtractorConfig = ec
 

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -41,13 +41,15 @@ trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
     ),
   )
 
+  protected def outputFormat: String
+
   protected def configureExtractor(ec: ExtractorConfig): ExtractorConfig = ec
 
   protected def target: PostgreSQLTarget = PostgreSQLTarget(
     connectUrl = postgresFixture.jdbcUrl,
     user = "test",
     password = "",
-    outputFormat = "combined",
+    outputFormat = outputFormat,
     schemaPerPackage = false,
     mergeIdentical = false,
     stripPrefix = None

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionMultiTableSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionMultiTableSpec.scala
@@ -3,24 +3,24 @@
 
 package com.digitalasset.extractor
 
-import com.digitalasset.daml.bazeltools.BazelRunfiles._
-import com.digitalasset.extractor.services.{CustomMatchers, ExtractorFixtureAroundAll}
-import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
-import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
-
 import java.io.File
 import java.sql.Timestamp
 import java.time.Instant
 
 import cats.implicits._
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.extractor.services.{CustomMatchers, ExtractorFixtureAroundAll}
+import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import io.circe.syntax._
+import doobie.implicits._
 
 import org.scalatest._
 
 import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class TransactionSpec
+class TransactionMultiTableSpec
     extends FlatSpec
     with Suite
     with PostgresAroundAll
@@ -34,6 +34,8 @@ class TransactionSpec
   override protected def darFile = new File(rlocation("extractor/TransactionExample.dar"))
 
   override def scenario: Option[String] = Some("TransactionExample:example")
+
+  override protected def outputFormat: String = "multi-table"
 
   "Transactions" should "be extracted" in {
     getTransactions should have length 2
@@ -73,34 +75,35 @@ class TransactionSpec
     getExercises should have length 1
   }
 
-  "Contracts" should "be extracted" in {
-    getContracts should have length 2
-  }
-
   "All the data" should "represent what went down in the scenario" in {
     // `transaction1` created `contract1`, then
     // `transaction2` created `exercise`, which archived `contract1` and resulted `contract2`
 
     val List(transaction1, transaction2) = getTransactions.sortBy(_.seq)
     val List(exercise) = getExercises
-    val List(contract1, contract2) = getContracts
+    val List((archived_by_event_id1, transaction_id1, archived_by_transaction_id1)) =
+      getResultList[(Option[String], String, Option[String])](
+        sql"SELECT _archived_by_event_id, _transaction_id, _archived_by_transaction_id FROM template.transactionexample_rightofuseoffer")
+    val List((event_id2, archived_by_event_id2, transaction_id2, archived_by_transaction_id2)) =
+      getResultList[(String, Option[String], String, Option[String])](
+        sql"SELECT _event_id, _archived_by_event_id, _transaction_id, _archived_by_transaction_id FROM template.transactionexample_rightofuseagreement")
 
     // `transaction1` created `contract1`, then
-    contract1.transaction_id shouldEqual transaction1.transaction_id
+    transaction_id1 shouldEqual transaction1.transaction_id
 
     // `transaction2` created `exercise`
     exercise.transaction_id shouldEqual transaction2.transaction_id
 
     // `exercised` archived `contract1`
-    contract1.archived_by_transaction_id shouldEqual Some(transaction2.transaction_id)
-    contract1.archived_by_event_id shouldEqual Some(exercise.event_id)
+    archived_by_transaction_id1 shouldEqual Some(transaction2.transaction_id)
+    archived_by_event_id1 shouldEqual Some(exercise.event_id)
 
     // ... while it resulted in `contract2`
-    exercise.child_event_ids shouldEqual List(contract2.event_id).asJson
-    contract2.transaction_id shouldEqual transaction2.transaction_id
+    exercise.child_event_ids shouldEqual List(event_id2).asJson
+    transaction_id2 shouldEqual transaction2.transaction_id
     // which is not archived
-    contract2.archived_by_transaction_id shouldEqual None
-    contract2.archived_by_event_id shouldEqual None
+    archived_by_transaction_id2 shouldEqual None
+    archived_by_event_id2 shouldEqual None
   }
 
 }

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
@@ -33,8 +33,6 @@ abstract class TransactionSingleTableSpec
 
   override def scenario: Option[String] = Some("TransactionExample:example")
 
-  override protected def outputFormat: String = "single-table"
-
   "Transactions" should "be extracted" in {
     getTransactions should have length 2
   }

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor
+
+import java.io.File
+import java.sql.Timestamp
+import java.time.Instant
+
+import cats.implicits._
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.extractor.services.{CustomMatchers, ExtractorFixtureAroundAll}
+import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
+import io.circe.syntax._
+import org.scalatest._
+
+import scala.concurrent.duration._
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+abstract class TransactionSingleTableSpec
+    extends FlatSpec
+    with Suite
+    with PostgresAroundAll
+    with SuiteResourceManagementAroundAll
+    with ExtractorFixtureAroundAll
+    with Inside
+    with Inspectors
+    with Matchers
+    with CustomMatchers {
+
+  override protected def darFile = new File(rlocation("extractor/TransactionExample.dar"))
+
+  override def scenario: Option[String] = Some("TransactionExample:example")
+
+  override protected def outputFormat: String = "single-table"
+
+  "Transactions" should "be extracted" in {
+    getTransactions should have length 2
+  }
+
+  it should "be valid transactions" in {
+    forAll(getTransactions) { transaction =>
+      inside(transaction) {
+        case TransactionResult(
+            transaction_id,
+            seq,
+            workflow_id,
+            effective_at,
+            extracted_at,
+            ledger_offset
+            ) =>
+          transaction_id should not be empty
+          seq should be >= 1
+          workflow_id should not be empty
+          effective_at should be(new Timestamp(0L))
+          extracted_at should beWithin(30.seconds)(Timestamp.from(Instant.now()))
+          ledger_offset should not be empty
+      }
+    }
+  }
+
+  it should "be transactions with different ids" in {
+    val transactions = getTransactions
+
+    transactions.map(_.transaction_id).toSet should have size 2
+    transactions.map(_.workflow_id).toSet should have size 2
+    transactions.map(_.seq).toSet should have size 2
+    transactions.map(_.ledger_offset).toSet should have size 2
+  }
+
+  "Exercises" should "be extracted" in {
+    getExercises should have length 1
+  }
+
+  "Contracts" should "be extracted" in {
+    getContracts should have length 2
+  }
+
+  "All the data" should "represent what went down in the scenario" in {
+    // `transaction1` created `contract1`, then
+    // `transaction2` created `exercise`, which archived `contract1` and resulted `contract2`
+
+    val List(transaction1, transaction2) = getTransactions.sortBy(_.seq)
+    val List(exercise) = getExercises
+    val List(contract1, contract2) = getContracts
+
+    // `transaction1` created `contract1`, then
+    contract1.transaction_id shouldEqual transaction1.transaction_id
+
+    // `transaction2` created `exercise`
+    exercise.transaction_id shouldEqual transaction2.transaction_id
+
+    // `exercised` archived `contract1`
+    contract1.archived_by_transaction_id shouldEqual Some(transaction2.transaction_id)
+    contract1.archived_by_event_id shouldEqual Some(exercise.event_id)
+
+    // ... while it resulted in `contract2`
+    exercise.child_event_ids shouldEqual List(contract2.event_id).asJson
+    contract2.transaction_id shouldEqual transaction2.transaction_id
+    // which is not archived
+    contract2.archived_by_transaction_id shouldEqual None
+    contract2.archived_by_event_id shouldEqual None
+  }
+
+}

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -17,3 +17,4 @@ HEAD — ongoing
 - [DAML Integration Kit] Re-add :doc:`integration kit documentation </daml-integration-kit/index>` that got accidentally deleted.
 - [Ledger API] Disallow empty commands. See `issue #592 <https://github.com/digital-asset/daml/issues/592>`__.
 - [DAML Stdlib] Add `DA.TextMap.filter` and `DA.Next.Map.filter`.
+- [Extractor - Experimental] Extractor now stores exercise events in the single table data format. See `issue #3274 <https://github.com/digital-asset/daml/issues/3274>`__.


### PR DESCRIPTION
This also fixes a bug where extractor would set archived_by_transaction_id even
if the exercise event was non-consuming.

Fixes #3274.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
