### PR TITLE
Correctly handle package dependencies in Result#needPackage

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -102,11 +102,13 @@ object Result {
     compiledPackages.getPackage(packageId) match {
       case Some(pkg) => resume(pkg)
       case None =>
-        ResultNeedPackage(packageId, {
-          case None => ResultError(Error(s"Couldn't find package $packageId"))
-          case Some(pkg) =>
-            compiledPackages.addPackage(packageId, pkg).flatMap(_ => resume(pkg))
-        })
+        ResultNeedPackage(
+          packageId, {
+            case None => ResultError(Error(s"Couldn't find package $packageId"))
+            case Some(pkg) =>
+              compiledPackages.addPackage(packageId, pkg).flatMap(_ => resume(pkg))
+          }
+        )
     }
 
   def needDefinition[A](

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -105,8 +105,7 @@ object Result {
         ResultNeedPackage(packageId, {
           case None => ResultError(Error(s"Couldn't find package $packageId"))
           case Some(pkg) =>
-            compiledPackages.addPackage(packageId, pkg)
-            resume(pkg)
+            compiledPackages.addPackage(packageId, pkg).flatMap(_ => resume(pkg))
         })
     }
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1089,6 +1089,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "be retained when reinterpreting single fetch nodes" in {
+      val engine = Engine()
+
       val Right(tx) = runExample(fetcher1StrCid, clara)
       val fetchNodes =
         tx.fold(GenTx.TopDown, Seq[(NodeId, GenNode.WithTxValue[NodeId, ContractId])]()) {


### PR DESCRIPTION
When a package has dependencies, `ConcurrentCompiledPackages#addPackage` returns
a `ResultNeedPackage` on the dependency.

This return value was ignored in `Result#needPackage`. As a consequence,
the package would never be added to the map of compiled packages in
this way.

This is problematic for the reinterpretation of `Fetch` nodes, when
performed on an `Engine` with a clean cache. The package would never get
loaded, but the interpretation would commence and then blow up. See
the modified test in `EngineTest.scala`.

The problem would not appear for other types of nodes, because the other
`CommandPreprocessor#preprocess*` functions (e.g., preprocessCreate)
also invoke `translateValue`, which correctly chains the result of `addPackage`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
