### PR TITLE
Expose DB wait/exec times over JMX as well as logs

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -109,7 +109,8 @@ class JdbcIndexerFactory[Status <: InitStatus] private (loggerFactory: NamedLogg
         jdbcUrl,
         if (dbType.supportsParallelWrites) defaultNumberOfShortLivedConnections else 1,
         defaultNumberOfStreamingConnections,
-        loggerFactory)
+        loggerFactory,
+        mm)
     val ledgerDao = LedgerDao.metered(
       JdbcLedgerDao(
         dbDispatcher,
@@ -118,7 +119,8 @@ class JdbcIndexerFactory[Status <: InitStatus] private (loggerFactory: NamedLogg
         ValueSerializer,
         KeyHasher,
         dbType,
-        loggerFactory))(mm)
+        loggerFactory),
+      mm)
     ledgerDao
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -133,7 +133,7 @@ class StandaloneIndexServer(
   private def buildAndStartApiServer(infra: Infrastructure)(
       implicit ec: ExecutionContext): Future[ApiServerState] = {
     implicit val mat = infra.materializer
-    implicit val mm: MetricsManager = infra.metricsManager
+    val mm: MetricsManager = infra.metricsManager
 
     val packageStore = loadDamlPackages()
     preloadPackages(packageStore)
@@ -147,7 +147,8 @@ class StandaloneIndexServer(
         domain.LedgerId(cond.ledgerId),
         participantId,
         config.jdbcUrl,
-        loggerFactory)
+        loggerFactory,
+        mm)
       apiServer <- LedgerApiServer.create(
         (am: ActorMaterializer, esf: ExecutionSequencerFactory) =>
           ApiServices

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -176,7 +176,8 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
       startMode: SqlStartMode = SqlStartMode.ContinueIfExists): ApiServerState = {
     implicit val mat = infra.materializer
     implicit val ec: ExecutionContext = infra.executionContext
-    implicit val mm: MetricsManager = infra.metricsManager
+
+    val mm: MetricsManager = infra.metricsManager
 
     val ledgerId = config.ledgerIdMode match {
       case LedgerIdMode.Static(id) => id
@@ -210,7 +211,8 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
           startMode,
           config.commandConfig.maxCommandsInFlight * 2, // we can get commands directly as well on the submission service
           packageStore,
-          loggerFactory
+          loggerFactory,
+          mm
         )
 
       case None =>
@@ -222,7 +224,8 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
             timeProvider,
             acs,
             ledgerEntries,
-            packageStore
+            packageStore,
+            mm
           ))
     }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
@@ -35,6 +35,8 @@ final class MetricsManager(enableJmxReporter: Boolean) extends AutoCloseable {
 
   if (enableJmxReporter) jmxReporter.start()
 
+  def unmanagedTimer(name: String) = metrics.timer(name)
+
   def timedFuture[T](timerName: String, f: => Future[T]) = {
     val timer = metrics.timer(timerName)
     val ctx = timer.time()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
   * users so they can be safely enabled all the time. */
 final class MetricsManager(enableJmxReporter: Boolean) extends AutoCloseable {
 
-  private val metrics = new MetricRegistry()
+  val metrics = new MetricRegistry()
 
   private lazy val jmxReporter = JmxReporter
     .forRegistry(metrics)
@@ -34,8 +34,6 @@ final class MetricsManager(enableJmxReporter: Boolean) extends AutoCloseable {
     .build()
 
   if (enableJmxReporter) jmxReporter.start()
-
-  def unmanagedTimer(name: String) = metrics.timer(name)
 
   def timedFuture[T](timerName: String, f: => Future[T]) = {
     val timer = metrics.timer(timerName)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -72,9 +72,8 @@ object SandboxIndexAndWriteService {
       startMode: SqlStartMode,
       queueDepth: Int,
       templateStore: InMemoryPackageStore,
-      loggerFactory: NamedLoggerFactory)(
-      implicit mat: Materializer,
-      mm: MetricsManager): Future[IndexAndWriteService] =
+      loggerFactory: NamedLoggerFactory,
+      mm: MetricsManager)(implicit mat: Materializer): Future[IndexAndWriteService] =
     Ledger
       .jdbcBacked(
         jdbcUrl,
@@ -85,10 +84,11 @@ object SandboxIndexAndWriteService {
         ledgerEntries,
         queueDepth,
         startMode,
-        loggerFactory
+        loggerFactory,
+        mm
       )
       .map(ledger =>
-        createInstance(Ledger.metered(ledger), participantId, timeModel, timeProvider))(DEC)
+        createInstance(Ledger.metered(ledger, mm), participantId, timeModel, timeProvider))(DEC)
 
   def inMemory(
       ledgerId: LedgerId,
@@ -97,11 +97,10 @@ object SandboxIndexAndWriteService {
       timeProvider: TimeProvider,
       acs: InMemoryActiveLedgerState,
       ledgerEntries: ImmArray[LedgerEntryOrBump],
-      templateStore: InMemoryPackageStore)(
-      implicit mat: Materializer,
-      mm: MetricsManager): IndexAndWriteService = {
+      templateStore: InMemoryPackageStore,
+      mm: MetricsManager)(implicit mat: Materializer): IndexAndWriteService = {
     val ledger =
-      Ledger.metered(Ledger.inMemory(ledgerId, timeProvider, acs, templateStore, ledgerEntries))
+      Ledger.metered(Ledger.inMemory(ledgerId, timeProvider, acs, templateStore, ledgerEntries), mm)
     createInstance(ledger, participantId, timeModel, timeProvider)
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -154,9 +154,10 @@ object Ledger {
   def jdbcBackedReadOnly(
       jdbcUrl: String,
       ledgerId: LedgerId,
-      loggerFactory: NamedLoggerFactory
-  )(implicit mat: Materializer, mm: MetricsManager): Future[ReadOnlyLedger] =
-    ReadOnlySqlLedger(jdbcUrl, Some(ledgerId), loggerFactory)
+      loggerFactory: NamedLoggerFactory,
+      mm: MetricsManager
+  )(implicit mat: Materializer): Future[ReadOnlyLedger] =
+    ReadOnlySqlLedger(jdbcUrl, Some(ledgerId), loggerFactory, mm)
 
   /** Wraps the given Ledger adding metrics around important calls */
   def metered(ledger: Ledger, mm: MetricsManager): Ledger = MeteredLedger(ledger, mm)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -129,8 +129,9 @@ object Ledger {
       ledgerEntries: ImmArray[LedgerEntryOrBump],
       queueDepth: Int,
       startMode: SqlStartMode,
-      loggerFactory: NamedLoggerFactory
-  )(implicit mat: Materializer, mm: MetricsManager): Future[Ledger] =
+      loggerFactory: NamedLoggerFactory,
+      mm: MetricsManager
+  )(implicit mat: Materializer): Future[Ledger] =
     SqlLedger(
       jdbcUrl,
       Some(ledgerId),
@@ -140,7 +141,8 @@ object Ledger {
       ledgerEntries,
       queueDepth,
       startMode,
-      loggerFactory)
+      loggerFactory,
+      mm)
 
   /**
     * Creates a JDBC backed read only ledger
@@ -157,10 +159,10 @@ object Ledger {
     ReadOnlySqlLedger(jdbcUrl, Some(ledgerId), loggerFactory)
 
   /** Wraps the given Ledger adding metrics around important calls */
-  def metered(ledger: Ledger)(implicit mm: MetricsManager): Ledger = MeteredLedger(ledger)
+  def metered(ledger: Ledger, mm: MetricsManager): Ledger = MeteredLedger(ledger, mm)
 
   /** Wraps the given Ledger adding metrics around important calls */
-  def meteredReadOnly(ledger: ReadOnlyLedger)(implicit mm: MetricsManager): ReadOnlyLedger =
-    MeteredReadOnlyLedger(ledger)
+  def meteredReadOnly(ledger: ReadOnlyLedger, mm: MetricsManager): ReadOnlyLedger =
+    MeteredReadOnlyLedger(ledger, mm)
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -64,7 +64,7 @@ private class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, mm: MetricsManager)
 }
 
 object MeteredReadOnlyLedger {
-  def apply(ledger: ReadOnlyLedger)(implicit mm: MetricsManager): ReadOnlyLedger =
+  def apply(ledger: ReadOnlyLedger, mm: MetricsManager): ReadOnlyLedger =
     new MeteredReadOnlyLedger(ledger, mm)
 }
 
@@ -102,5 +102,5 @@ private class MeteredLedger(ledger: Ledger, mm: MetricsManager)
 }
 
 object MeteredLedger {
-  def apply(ledger: Ledger)(implicit mm: MetricsManager): Ledger = new MeteredLedger(ledger, mm)
+  def apply(ledger: Ledger, mm: MetricsManager): Ledger = new MeteredLedger(ledger, mm)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -74,9 +74,8 @@ object SqlLedger {
       initialLedgerEntries: ImmArray[LedgerEntryOrBump],
       queueDepth: Int,
       startMode: SqlStartMode = SqlStartMode.ContinueIfExists,
-      loggerFactory: NamedLoggerFactory)(
-      implicit mat: Materializer,
-      mm: MetricsManager): Future[Ledger] = {
+      loggerFactory: NamedLoggerFactory,
+      mm: MetricsManager)(implicit mat: Materializer): Future[Ledger] = {
     implicit val ec: ExecutionContext = DEC
 
     new FlywayMigrations(jdbcUrl, loggerFactory).migrate()
@@ -99,7 +98,8 @@ object SqlLedger {
         ValueSerializer,
         KeyHasher,
         dbType,
-        loggerFactory))
+        loggerFactory),
+      mm)
 
     val sqlLedgerFactory = SqlLedgerFactory(ledgerDao, loggerFactory)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -88,7 +88,8 @@ object SqlLedger {
         jdbcUrl,
         noOfShortLivedConnections,
         defaultNumberOfStreamingConnections,
-        loggerFactory)
+        loggerFactory,
+        mm)
 
     val ledgerDao = LedgerDao.metered(
       JdbcLedgerDao(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
@@ -227,7 +227,7 @@ trait LedgerDao extends LedgerReadDao with LedgerWriteDao {
 object LedgerDao {
 
   /** Wraps the given LedgerDao adding metrics around important calls */
-  def metered(dao: LedgerDao)(implicit mm: MetricsManager): LedgerDao = MeteredLedgerDao(dao)
-  def meteredRead(dao: LedgerReadDao)(implicit mm: MetricsManager): LedgerReadDao =
+  def metered(dao: LedgerDao, mm: MetricsManager): LedgerDao = MeteredLedgerDao(dao, mm)
+  def meteredRead(dao: LedgerReadDao, mm: MetricsManager): LedgerReadDao =
     new MeteredLedgerReadDao(dao, mm)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
@@ -125,9 +125,9 @@ private class MeteredLedgerDao(ledgerDao: LedgerDao, mm: MetricsManager)
 }
 
 object MeteredLedgerDao {
-  def apply(ledgerDao: LedgerDao)(implicit mm: MetricsManager): LedgerDao =
+  def apply(ledgerDao: LedgerDao, mm: MetricsManager): LedgerDao =
     new MeteredLedgerDao(ledgerDao, mm)
 
-  def apply(ledgerDao: LedgerReadDao)(implicit mm: MetricsManager): LedgerReadDao =
+  def apply(ledgerDao: LedgerReadDao, mm: MetricsManager): LedgerReadDao =
     new MeteredLedgerReadDao(ledgerDao, mm)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.common.util.DirectExecutionContext
+import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
@@ -44,7 +45,8 @@ private class DbDispatcherImpl(
     jdbcUrl: String,
     val noOfShortLivedConnections: Int,
     noOfStreamingConnections: Int,
-    loggerFactory: NamedLoggerFactory)
+    loggerFactory: NamedLoggerFactory,
+    mm: MetricsManager)
     extends DbDispatcher {
 
   private val logger = loggerFactory.getLogger(getClass)
@@ -54,7 +56,7 @@ private class DbDispatcherImpl(
       noOfShortLivedConnections,
       noOfStreamingConnections,
       loggerFactory)
-  private val sqlExecutor = SqlExecutor(noOfShortLivedConnections, loggerFactory)
+  private val sqlExecutor = SqlExecutor(noOfShortLivedConnections, loggerFactory, mm)
 
   private val connectionGettingThreadPool = ExecutionContext.fromExecutorService(
     Executors.newSingleThreadExecutor(
@@ -103,10 +105,13 @@ object DbDispatcher {
       jdbcUrl: String,
       noOfShortLivedConnections: Int,
       noOfStreamingConnections: Int,
-      loggerFactory: NamedLoggerFactory): DbDispatcher =
+      loggerFactory: NamedLoggerFactory,
+      mm: MetricsManager): DbDispatcher =
     new DbDispatcherImpl(
       jdbcUrl,
       noOfShortLivedConnections,
       noOfStreamingConnections,
-      loggerFactory)
+      loggerFactory,
+      mm
+    )
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -70,7 +70,7 @@ private class DbDispatcherImpl(
 
   override def executeSql[T](description: String, extraLog: Option[String] = None)(
       sql: Connection => T): Future[T] =
-    sqlExecutor.runQuery(description)(connectionProvider.runSQL(conn => sql(conn)))
+    sqlExecutor.runQuery(description, extraLog)(connectionProvider.runSQL(conn => sql(conn)))
 
   override def runStreamingSql[T](
       sql: Connection => Source[T, Future[Done]]): Source[T, NotUsed] = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/SqlExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/SqlExecutor.scala
@@ -33,7 +33,7 @@ final class SqlExecutor(noOfThread: Int, loggerFactory: NamedLoggerFactory, mm: 
         .build()
     )
 
-  def runQuery[A](description: String, extraLog: Option[String] = None)(block: => A): Future[A] = {
+  def runQuery[A](description: String, extraLog: Option[String])(block: => A): Future[A] = {
     val promise = Promise[A]
     val waitTimer = mm.metrics.timer(s"sql_${description}_wait")
     val execTimer = mm.metrics.timer(s"sql_${description}_exec")

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -48,9 +48,8 @@ object LedgerResource {
   def postgres(
       ledgerId: LedgerId,
       timeProvider: TimeProvider,
-      packages: InMemoryPackageStore = InMemoryPackageStore.empty)(
-      implicit mat: Materializer,
-      mm: MetricsManager) = {
+      mm: MetricsManager,
+      packages: InMemoryPackageStore = InMemoryPackageStore.empty)(implicit mat: Materializer) = {
     new Resource[Ledger] {
       @volatile
       private var postgres: Resource[PostgresFixture] = null
@@ -75,7 +74,8 @@ object LedgerResource {
               ImmArray.empty,
               128,
               SqlStartMode.AlwaysReset,
-              NamedLoggerFactory(Tag.unwrap(ledgerId))
+              NamedLoggerFactory(Tag.unwrap(ledgerId)),
+              mm
           ))
         ledger.setup()
       }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
@@ -9,7 +9,7 @@ import org.scalatest.BeforeAndAfterAll
 trait MetricsAround extends BeforeAndAfterAll {
   self: org.scalatest.Suite =>
 
-  @volatile implicit var metricsManager: MetricsManager = _
+  @volatile protected var metricsManager: MetricsManager = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -65,7 +65,8 @@ trait TestHelpers {
         TimeProvider.Constant(Instant.EPOCH),
         InMemoryActiveLedgerState.empty,
         ImmArray.empty,
-        packageStore
+        packageStore,
+        mm
       )
 
     ApiSubmissionService.create(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -81,7 +81,7 @@ class ImplicitPartyAdditionIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
-        LedgerResource.postgres(ledgerId, timeProvider)
+        LedgerResource.postgres(ledgerId, timeProvider, metricsManager)
     }
 
   private def publishSingleNodeTx(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -9,8 +9,8 @@ import akka.stream.scaladsl.Sink
 import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
+import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Transaction.{NodeId, TContractId, Value}
-import com.digitalasset.daml.lf.transaction.{BlindingInfo, GenTransaction}
 import com.digitalasset.ledger.api.domain.{LedgerId, RejectionReason}
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
@@ -61,7 +61,7 @@ class TransactionMRTComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
-        LedgerResource.postgres(ledgerId, timeProvider)
+        LedgerResource.postgres(ledgerId, timeProvider, metricsManager)
     }
 
   val LET = Instant.EPOCH.plusSeconds(2)
@@ -69,7 +69,6 @@ class TransactionMRTComplianceIT
 
   "A Ledger" should {
     "reject transactions with a record time after the MRT" in allFixtures { ledger =>
-      val emptyBlinding = BlindingInfo(Map.empty, Map.empty, Map.empty)
       val dummyTransaction =
         GenTransaction[NodeId, TContractId, Value[TContractId]](
           Map.empty,
@@ -97,7 +96,7 @@ class TransactionMRTComplianceIT
         .map {
           _ should matchPattern {
             case LedgerEntry.Rejection(
-                recordTime,
+                _,
                 "cmdId",
                 "appId",
                 "submitter",

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -41,6 +41,7 @@ import com.digitalasset.ledger.api.domain.{
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.participant.util.EventFilter
+import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.ActiveContract
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
@@ -83,7 +84,7 @@ class JdbcLedgerDaoSpec
     super.beforeAll()
     val loggerFactory = NamedLoggerFactory(JdbcLedgerDaoSpec.getClass)
     FlywayMigrations(postgresFixture.jdbcUrl, loggerFactory).migrate()
-    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4, loggerFactory)
+    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4, loggerFactory, MetricsManager())
     ledgerDao = JdbcLedgerDao(
       dbDispatcher,
       ContractSerializer,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -4,18 +4,18 @@
 package com.digitalasset.platform.sandbox.stores.ledger.sql
 
 import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
+import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.sandbox.MetricsAround
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundEach
-import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.platform.sandbox.stores.{InMemoryActiveLedgerState, InMemoryPackageStore}
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
 import scala.concurrent.duration._
-import com.digitalasset.ledger.api.domain.LedgerId
-import com.digitalasset.platform.common.logging.NamedLoggerFactory
 
 class SqlLedgerSpec
     extends AsyncWordSpec
@@ -45,7 +45,8 @@ class SqlLedgerSpec
         initialLedgerEntries = ImmArray.empty,
         queueDepth,
         startMode = SqlStartMode.ContinueIfExists,
-        loggerFactory
+        loggerFactory,
+        metricsManager
       )
 
       ledgerF.map { ledger =>
@@ -63,7 +64,8 @@ class SqlLedgerSpec
         initialLedgerEntries = ImmArray.empty,
         queueDepth,
         startMode = SqlStartMode.ContinueIfExists,
-        loggerFactory
+        loggerFactory,
+        metricsManager
       )
 
       ledgerF.map { ledger =>
@@ -83,7 +85,8 @@ class SqlLedgerSpec
           initialLedgerEntries = ImmArray.empty,
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          loggerFactory
+          loggerFactory,
+          metricsManager
         )
 
         ledger2 <- SqlLedger(
@@ -95,7 +98,8 @@ class SqlLedgerSpec
           initialLedgerEntries = ImmArray.empty,
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          loggerFactory
+          loggerFactory,
+          metricsManager
         )
 
         ledger3 <- SqlLedger(
@@ -107,7 +111,8 @@ class SqlLedgerSpec
           initialLedgerEntries = ImmArray.empty,
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          loggerFactory
+          loggerFactory,
+          metricsManager
         )
 
       } yield {
@@ -129,7 +134,8 @@ class SqlLedgerSpec
           initialLedgerEntries = ImmArray.empty,
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          loggerFactory
+          loggerFactory,
+          metricsManager
         )
         _ <- SqlLedger(
           jdbcUrl = postgresFixture.jdbcUrl,
@@ -140,7 +146,8 @@ class SqlLedgerSpec
           initialLedgerEntries = ImmArray.empty,
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          loggerFactory
+          loggerFactory,
+          metricsManager
         )
       } yield (())
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -20,3 +20,4 @@ HEAD — ongoing
 - [Extractor - Experimental] Extractor now stores exercise events in the single table data format. See `issue #3274 <https://github.com/digital-asset/daml/issues/3274>`__.
 - [DAML Compiler] Fix compile error caused by instantiating generic
   templates at ``Numeric n``.
+- [Sandbox] Timing about database operations are now exposed over JMX as well as via the logs.


### PR DESCRIPTION
Replaces bespoke log prints with metric collection through the `MetricsManager`, which has both a JMX and an SLF4J sink. Times are now captured on a query-by-query _and_ overall basis.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
