### PR TITLE
Fix superclass detection for Numeric

### DIFF
--- a/compiler/damlc/tests/daml-test-files/NumericInstance.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericInstance.daml
@@ -1,0 +1,15 @@
+-- @SINCE-LF 1.7
+daml 1.2
+module NumericInstance where
+
+template Ord a => FooG a
+  with
+    sig : Party
+    a   : a
+   where
+    signatory sig
+
+-- The Ord constraint on FooG will result in a superclass constraint of the form `dict @10`
+-- so this test checks that we properly handle superclass dicts that are not simple variables.
+
+template instance Test = FooG (Numeric 10)

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -18,3 +18,5 @@ HEAD — ongoing
 - [Ledger API] Disallow empty commands. See `issue #592 <https://github.com/digital-asset/daml/issues/592>`__.
 - [DAML Stdlib] Add `DA.TextMap.filter` and `DA.Next.Map.filter`.
 - [Extractor - Experimental] Extractor now stores exercise events in the single table data format. See `issue #3274 <https://github.com/digital-asset/daml/issues/3274>`__.
+- [DAML Compiler] Fix compile error caused by instantiating generic
+  templates at ``Numeric n``.


### PR DESCRIPTION
For numeric, the superclass dicts can be of the for `dict @10` so only
handling variables doesn’t work. Now we walk down applications and
check the name on the left.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
