### PR TITLE
pin hoogle version to avoid surprises

### DIFF
--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -74,6 +74,7 @@ curl -sSL https://get.haskellstack.org/ | sh
 runuser -u hoogle bash <<HOOGLE_SETUP
 git clone https://github.com/ndmitchell/hoogle.git
 cd hoogle
+git checkout 73fa6b5c156e0015e135a564e2821719611abe03
 stack init --resolver=lts-14.7
 stack build
 stack install


### PR DESCRIPTION
A month ago https://hoogle.daml.com broke because the stack resolver moved from under us. The suggestion [from the Hoogle maintainer](https://github.com/ndmitchell/hoogle/issues/321#issuecomment-536166997) was to pin the Stack resolver to the by-then latest known-working version, which we did. Today, https://hoogle.daml.com broken because hoogle has changed its dependencies and no longer match that Stack snapshot. In the interest of stability, I am now pinning both the hoogle and the Stack snapshot versions.

If hoogle does have major new features we really want, we can always update to a known good combination at that point.

Note: given that service is interrupted at the moment, I have already gone ahead and applied those changes. The new configuration is deployed but hoogle machines take about an hour to boot up as they compile from source.