### PR TITLE
ledger/ledger-api-test-tool: Implement diff correctly for sequences.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -12,8 +12,8 @@ import com.digitalasset.ledger.test_stable.Test.AgreementFactory
 import com.digitalasset.ledger.test_stable.Test.AgreementFactory._
 import io.grpc.{Status, StatusException, StatusRuntimeException}
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
 private[testtool] object LedgerTestSuite {
@@ -126,4 +126,41 @@ private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
     }
   }
 
+  implicit def diffShowSeq[T](implicit diffShowT: DiffShow[T]): DiffShow[Seq[T]] =
+    new DiffShow[Seq[T]] {
+      override def show(t: Seq[T]): String = t.toString
+
+      override def diff(left: Seq[T], right: Seq[T]): Comparison = {
+        val leftList = left.toList
+        val rightList = right.toList
+        val changed = leftList
+          .zip(rightList)
+          .zipWithIndex
+          .map { case ((l, r), index) => index -> diffShowT.diff(l, r) }
+          .filter { case (_, diff) => !diff.isIdentical }
+          .map { case (index, diff) => index.toString -> diff.string }
+        val removed = leftList.zipWithIndex.drop(rightList.length).map {
+          case (value, index) => index.toString -> red(diffShowT.show(value))
+        }
+        val added = rightList.zipWithIndex.drop(leftList.length).map {
+          case (value, index) => index.toString -> green(diffShowT.show(value))
+        }
+
+        assert(
+          removed.isEmpty || added.isEmpty,
+          "Diff[Seq[_]] thinks that both sequences are longer than each other.")
+
+        if (changed.isEmpty && removed.isEmpty && added.isEmpty) {
+          Identical(left)
+        } else {
+          val changedOption =
+            if (changed.isEmpty)
+              List(None)
+            else
+              changed.map(Some(_))
+          val differences = changedOption ++ removed.map(Some(_)) ++ added.map(Some(_))
+          Different(DiffShow.constructorOption("Seq", differences))
+        }
+      }
+    }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import ai.x.diff.conversions._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTest, LedgerTestSuite}
 import com.digitalasset.ledger.api.v1.value.{Record, RecordField, Value}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import ai.x.diff.conversions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTest, LedgerTestSuite}
 import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.ledger.api.v1.value.{RecordField, Value}


### PR DESCRIPTION
Previously, we were using `x.ai.diff.conversions._`, which converts them
into sets. This is obviously not helpful when comparing, for example,
`Seq(7, 8, 9) and `Seq(7, 7, 8, 9)`, as the assertion will pass.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
