### PR TITLE
DAML-LF add Type Representation value

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -155,6 +155,7 @@ data BuiltinType
   | BTMap
   | BTArrow
   | BTAny
+  | BTTypeRep
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Type as used in typed binders.
@@ -448,7 +449,7 @@ data Expr
     { fromAnyType :: !Type
     , fromAnyBody :: !Expr
     }
-  | EToTextTypeConName !(Qualified TypeConName)
+  | ETypeRep !Type
   -- | Update expression.
   | EUpdate !Update
   -- | Scenario expression.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -135,6 +135,7 @@ instance Pretty BuiltinType where
     BTMap -> "Map"
     BTArrow -> "(->)"
     BTAny -> "Any"
+    BTTypeRep -> "TypeRep"
 
 prettyRecord :: (Pretty a) =>
   PrettyLevel -> Doc ann -> [(FieldName, a)] -> Doc ann
@@ -449,7 +450,7 @@ instance Pretty Expr where
     ENone typ -> prettyAppKeyword lvl prec "none" [TyArg typ]
     EToAny ty body -> prettyAppKeyword lvl prec "to_any" [TyArg ty, TmArg body]
     EFromAny ty body -> prettyAppKeyword lvl prec "from_any" [TyArg ty, TmArg body]
-    EToTextTypeConName tycon -> prettyAppKeyword lvl prec "to_text_type_con_name" [tplArg tycon]
+    ETypeRep ty -> prettyAppKeyword lvl prec "type_rep" [TyArg ty]
 
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -45,7 +45,7 @@ data ExprF expr
   | ESomeF       !Type !expr
   | EToAnyF !Type !expr
   | EFromAnyF !Type !expr
-  | EToTextTypeConNameF !(Qualified TypeConName)
+  | ETypeRepF !Type
   deriving (Foldable, Functor, Traversable)
 
 data BindingF expr = BindingF !(ExprVarName, Type) !expr
@@ -177,7 +177,7 @@ instance Recursive Expr where
     ESome       a b   -> ESomeF         a b
     EToAny a b  -> EToAnyF a b
     EFromAny a b -> EFromAnyF a b
-    EToTextTypeConName a -> EToTextTypeConNameF a
+    ETypeRep a -> ETypeRepF a
 
 instance Corecursive Expr where
   embed = \case
@@ -207,4 +207,4 @@ instance Corecursive Expr where
     ESomeF       a b   -> ESome a b
     EToAnyF a b  -> EToAny a b
     EFromAnyF a b -> EFromAny a b
-    EToTextTypeConNameF a -> EToTextTypeConName a
+    ETypeRepF a -> ETypeRep a

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -154,7 +154,7 @@ infixr 1 :->
 pattern (:->) :: Type -> Type -> Type
 pattern a :-> b = TArrow `TApp` a `TApp` b
 
-pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow, TNumeric10, TAny, TNat10 :: Type
+pattern TUnit, TBool, TInt64, TDecimal, TText, TTimestamp, TParty, TDate, TArrow, TNumeric10, TAny, TNat10, TTypeRep :: Type
 pattern TUnit       = TBuiltin BTUnit
 pattern TBool       = TBuiltin BTBool
 pattern TInt64      = TBuiltin BTInt64
@@ -167,6 +167,7 @@ pattern TParty      = TBuiltin BTParty
 pattern TDate       = TBuiltin BTDate
 pattern TArrow      = TBuiltin BTArrow
 pattern TAny        = TBuiltin BTAny
+pattern TTypeRep    = TBuiltin BTTypeRep
 
 pattern TList, TOptional, TMap, TUpdate, TScenario, TContractId, TNumeric :: Type -> Type
 pattern TList typ = TApp (TBuiltin BTList) typ

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -67,11 +67,11 @@ featureAnyType = Feature
    , featureCppFlag = "DAML_ANY_TYPE"
    }
 
-featureTemplateTypeRep :: Feature
-featureTemplateTypeRep = Feature
-    { featureName = "templateTypeRep builtin"
+featureTypeRep :: Feature
+featureTypeRep = Feature
+    { featureName = "TypeRep type"
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_TEMPLATE_TYPE_REP"
+    , featureCppFlag = "DAML_TYPE_REP"
     }
 
 featureStringInterning :: Feature

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -85,6 +85,7 @@ allFeatures :: [Feature]
 allFeatures =
     [ featureNumeric
     , featureAnyType
+    , featureTypeRep
     , featureStringInterning
     ]
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -298,6 +298,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_DATE -> BEEqual BTDate
   LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
   LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
+  LF1.BuiltinFunctionEQUAL_TYPE_REP -> BEEqual BTTypeRep
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -506,9 +506,8 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     type' <- mayDecode "expr_FromAnyType" mbType decodeType
     expr <- mayDecode "expr_FromAnyExpr" mbExpr decodeExpr
     return (EFromAny type' expr)
-  LF1.ExprSumToTextTypeConName tycon -> do
-    con <- decodeTypeConName tycon
-    return (EToTextTypeConName con)
+  LF1.ExprSumTypeRep typ ->
+    ETypeRep <$> decodeType typ
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case
@@ -678,6 +677,7 @@ decodePrim = pure . \case
   LF1.PrimTypeMAP -> BTMap
   LF1.PrimTypeARROW -> BTArrow
   LF1.PrimTypeANY -> BTAny
+  LF1.PrimTypeTYPE_REP -> BTTypeRep
 
 decodeTypeLevelNat :: Integer -> Decode TypeLevelNat
 decodeTypeLevelNat m =

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -276,6 +276,7 @@ encodeBuiltinType = P.Enumerated . Right . \case
     BTArrow -> P.PrimTypeARROW
     BTNumeric -> P.PrimTypeNUMERIC
     BTAny -> P.PrimTypeANY
+    BTTypeRep -> P.PrimTypeTYPE_REP
 
 encodeType' :: Type -> Encode P.Type
 encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
@@ -579,8 +580,8 @@ encodeExpr' = \case
         expr_FromAnyType <- encodeType ty
         expr_FromAnyExpr <- encodeExpr body
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
-    EToTextTypeConName tycon -> do
-        expr . P.ExprSumToTextTypeConName <$> encodeQualTypeConName' tycon
+    ETypeRep ty -> do
+        expr . P.ExprSumTypeRep <$> encodeType' ty
   where
     expr = P.Expr Nothing . Just
     pureExpr = pure . expr

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -355,6 +355,7 @@ encodeBuiltinExpr = \case
       BTDate -> builtin P.BuiltinFunctionEQUAL_DATE
       BTParty -> builtin P.BuiltinFunctionEQUAL_PARTY
       BTBool -> builtin P.BuiltinFunctionEQUAL_BOOL
+      BTTypeRep -> builtin P.BuiltinFunctionEQUAL_TYPE_REP
       other -> error $ "BEEqual unexpected type " <> show other
 
     BELessEq typ -> case typ of

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -59,7 +59,7 @@ freeVarsStep = \case
   ESomeF _ s -> s
   EToAnyF _ s -> s
   EFromAnyF _ s -> s
-  EToTextTypeConNameF _ -> mempty
+  ETypeRepF _ -> mempty
   EUpdateF u ->
     case u of
       UPureF _ s -> s
@@ -217,7 +217,7 @@ safetyStep = \case
   EFromAnyF _ s
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
-  EToTextTypeConNameF _ -> Safe 0
+  ETypeRepF _ -> Safe 0
 
 
 infoStep :: ExprF Info -> Info

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -121,6 +121,7 @@ kindOfBuiltin = \case
   BTMap -> KStar `KArrow` KStar
   BTArrow -> KStar `KArrow` KStar `KArrow` KStar
   BTAny -> KStar
+  BTTypeRep -> KStar
 
 kindOf :: MonadGamma m => Type -> m Kind
 kindOf = \case
@@ -502,24 +503,23 @@ typeOf = \case
   ESome bodyType bodyExpr -> checkSome bodyType bodyExpr $> TOptional bodyType
   ENone bodyType -> checkType bodyType KStar $> TOptional bodyType
   EToAny ty bodyExpr -> do
-    checkAnyType ty
+    checkSimpleType ty
     checkExpr bodyExpr ty
     pure $ TBuiltin BTAny
   EFromAny ty bodyExpr -> do
-    checkAnyType ty
+    checkSimpleType ty
     checkExpr bodyExpr (TBuiltin BTAny)
     pure $ TOptional ty
-  EToTextTypeConName tycon -> do
-    -- Ensure that the type is known.
-    _ <- inWorld (lookupDataType tycon)
-    pure $ TBuiltin BTText
+  ETypeRep ty -> do
+    checkSimpleType ty
+    pure $ TBuiltin BTTypeRep
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf expr
 
 -- Check that the type contains no type variables or quantifiers
-checkAnyType :: MonadGamma m => Type -> m ()
-checkAnyType ty =
+checkSimpleType :: MonadGamma m => Type -> m ()
+checkSimpleType ty =
     when (para (\t children -> or (isForbidden t : children)) ty) $ throwWithContext $ EExpectedAnyType ty
   where isForbidden (TVar _) = True
         isForbidden (TForall _ _) = True

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -511,19 +511,24 @@ typeOf = \case
     checkExpr bodyExpr (TBuiltin BTAny)
     pure $ TOptional ty
   ETypeRep ty -> do
-    checkSimpleType ty
+    checkGroundType ty
     pure $ TBuiltin BTTypeRep
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf expr
 
 -- Check that the type contains no type variables or quantifiers
-checkGroundType :: MonadGamma m => Type -> m ()
-checkGroundType ty =
+checkGroundType' :: MonadGamma m => Type -> m ()
+checkGroundType' ty =
     when (para (\t children -> or (isForbidden t : children)) ty) $ throwWithContext $ EExpectedAnyType ty
   where isForbidden (TVar _) = True
         isForbidden (TForall _ _) = True
         isForbidden _ = False
+
+checkGroundType :: MonadGamma m => Type -> m ()
+checkGroundType ty = do
+    _ <- checkType ty KStar
+    checkGroundType' ty
 
 checkExpr' :: MonadGamma m => Expr -> Type -> m Type
 checkExpr' expr typ = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -503,11 +503,11 @@ typeOf = \case
   ESome bodyType bodyExpr -> checkSome bodyType bodyExpr $> TOptional bodyType
   ENone bodyType -> checkType bodyType KStar $> TOptional bodyType
   EToAny ty bodyExpr -> do
-    checkSimpleType ty
+    checkGroundType ty
     checkExpr bodyExpr ty
     pure $ TBuiltin BTAny
   EFromAny ty bodyExpr -> do
-    checkSimpleType ty
+    checkGroundType ty
     checkExpr bodyExpr (TBuiltin BTAny)
     pure $ TOptional ty
   ETypeRep ty -> do
@@ -518,8 +518,8 @@ typeOf = \case
   ELocation _ expr -> typeOf expr
 
 -- Check that the type contains no type variables or quantifiers
-checkSimpleType :: MonadGamma m => Type -> m ()
-checkSimpleType ty =
+checkGroundType :: MonadGamma m => Type -> m ()
+checkGroundType ty =
     when (para (\t children -> or (isForbidden t : children)) ty) $ throwWithContext $ EExpectedAnyType ty
   where isForbidden (TVar _) = True
         isForbidden (TForall _ _) = True

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -62,6 +62,7 @@ data UnserializabilityReason
   | URNumericOutOfRange !Natural
   | URTypeLevelNat
   | URAny -- ^ It contains a value of type Any.
+  | URTypeRep -- ^ It contains a value of type TypeRep.
 
 data Error
   = EUnknownTypeVar        !TypeVarName
@@ -168,6 +169,7 @@ instance Pretty UnserializabilityReason where
     URNumericOutOfRange n -> "Numeric scale " <> integer (fromIntegral n) <> " is out of range (needs to be between 0 and 38)"
     URTypeLevelNat -> "type-level nat"
     URAny -> "Any"
+    URTypeRep -> "TypeRep"
 
 instance Pretty Error where
   pPrint = \case

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -98,6 +98,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTArrow -> Left URFunction
         BTNumeric -> Left URNumeric -- 'Numeric' is used as a higher-kinded type constructor.
         BTAny -> Left URAny
+        BTTypeRep -> Left URTypeRep
       TForall{} -> Left URForall
       TTuple{} -> Left URTuple
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -538,6 +538,8 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
             LF.BTNumeric -> mkGhcType "Numeric"
             -- TODO see https://github.com/digital-asset/daml/issues/2876
             LF.BTAny -> error "Any type not yet supported in upgrades"
+            LF.BTTypeRep -> error "TypeRep type not yet supported in upgrades"
+
     mkGhcType =
         HsTyVar noExt NotPromoted .
         noLoc . mkOrig gHC_TYPES . mkOccName varName
@@ -646,6 +648,7 @@ generateSrcFromLf (Qualify qualify) thisPkgId pkgMap m = noLoc mod
             LF.BTNumeric -> (primUnitId, LF.ModuleName ["GHC", "Types"])
             -- TODO: see https://github.com/digital-asset/daml/issues/2876
             LF.BTAny -> error "Any type not yet supported in upgrades"
+            LF.BTTypeRep -> error "TypeRep type not yet supported in upgrades"
 
     translateModName ::
            forall a. NamedThing a

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -461,7 +461,7 @@ convertGenericTemplate env x
                 in
                 ETyLam (proxyName, KStar `KArrow` KStar) $!
                     if envLfVersion env `supports` featureTemplateTypeRep
-                        then ETmLam (arg, argType) $ ERecCon resType [(resField, EToTextTypeConName monoTyCon)]
+                        then ETmLam (arg, argType) $ ERecCon resType [(resField, ETypeRep (TCon monoTyCon))]
                         else EBuiltin BEError `ETyApp` (argType :-> typeConAppToType resType) `ETmApp` EBuiltin (BEText "templateTypeRep is not supported in this DAML-LF version")
         tyArgs <- mapM (convertType env) tyArgs
         -- NOTE(MH): The additional lambda is DICTIONARY SANITIZATION step (3).

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -41,8 +41,6 @@ module DA.Internal.LF
   , AnyChoice
 
   , TemplateTypeRep
-  , templateTypeRepToText
-  , templateTypeRepFromText
   ) where
 
 import GHC.Types (Opaque, Symbol)
@@ -221,12 +219,13 @@ newtype AnyTemplate = AnyTemplate { getAnyTemplate : Any }
 -- | Existential choice type that can wrap an arbitrary chice.
 newtype AnyChoice = AnyChoice { getAnyChoice : Any }
 
+-- | Value-level representation of a type.
+-- We do not expose this directly and instead only expose TemplateTypeRep.
+data TypeRep = TypeRep Opaque
+
 -- | Unique textual representation of a template Id.
-newtype TemplateTypeRep = TemplateTypeRep { getTemplateTypeRep : Text }
-  deriving (Eq, Ord, Show)
+newtype TemplateTypeRep = TemplateTypeRep { getTemplateTypeRep : TypeRep }
+  deriving Eq
 
-templateTypeRepToText : TemplateTypeRep -> Text
-templateTypeRepToText = getTemplateTypeRep
-
-templateTypeRepFromText : Text -> Optional TemplateTypeRep
-templateTypeRepFromText = Some . TemplateTypeRep
+instance Eq TypeRep where
+  (==) = error "unimplemented"

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS -Wno-unused-binds #-} -- the opaque constructors are not exported
 
@@ -228,4 +229,8 @@ newtype TemplateTypeRep = TemplateTypeRep { getTemplateTypeRep : TypeRep }
   deriving Eq
 
 instance Eq TypeRep where
-  (==) = error "unimplemented"
+#ifdef DAML_TYPE_REP
+  (==) = primitive @"BEEqual"
+#else
+  (==) = error "TYPE_REP not supported in this version of DAML-LF"
+#endif

--- a/compiler/damlc/daml-stdlib-src/DA/Next/Map.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Next/Map.daml
@@ -60,10 +60,6 @@ instance MapKey Party where
   keyToText = partyToText
   keyFromText = fromSome . partyFromText
 
-instance MapKey TemplateTypeRep where
-  keyToText = templateTypeRepToText
-  keyFromText = fromSome . templateTypeRepFromText
-
 instance MapKey Int where
   keyToText = show
   keyFromText = fromSome . parseInt

--- a/compiler/damlc/tests/daml-test-files/TemplateTypeRep.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateTypeRep.daml
@@ -4,7 +4,7 @@
 -- @SINCE-LF 1.dev
 daml 1.2 module TemplateTypeRep where
 
-import DA.Assert
+import DA.Action
 import qualified TemplateTypeRep2
 
 template T1
@@ -31,12 +31,21 @@ template Template t => GenericT t
 template instance GT1 = GenericT T1
 template instance GT2 = GenericT T2
 
-main = scenario do
-  templateTypeRep @T1 === templateTypeRep @T1
-  templateTypeRep @T2 === templateTypeRep @T2
-  templateTypeRep @GT1 === templateTypeRep @GT1
-  templateTypeRep @GT2 === templateTypeRep @GT2
+assertTypeRepEq : CanAbort m => TemplateTypeRep -> TemplateTypeRep -> m ()
+assertTypeRepEq a b =
+  unless (a == b) $ abort "TypeReps are not equal"
 
-  templateTypeRep @T1 =/= templateTypeRep @T2
-  templateTypeRep @GT1 =/= templateTypeRep @GT2
-  templateTypeRep @T1 =/= templateTypeRep @TemplateTypeRep2.T1
+assertTypeRepNeq : CanAbort m => TemplateTypeRep -> TemplateTypeRep -> m ()
+assertTypeRepNeq a b =
+  unless (a /= b) $ abort "TypeReps are equal"
+
+
+main = scenario do
+  assertTypeRepEq (templateTypeRep @T1) (templateTypeRep @T1)
+  assertTypeRepEq (templateTypeRep @T2) (templateTypeRep @T2)
+  assertTypeRepEq (templateTypeRep @GT1) (templateTypeRep @GT1)
+  assertTypeRepEq (templateTypeRep @GT2) (templateTypeRep @GT2)
+
+  assertTypeRepNeq (templateTypeRep @T1) (templateTypeRep @T2)
+  assertTypeRepNeq (templateTypeRep @GT1) (templateTypeRep @GT2)
+  assertTypeRepNeq (templateTypeRep @T1) (templateTypeRep @TemplateTypeRep2.T1)

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -487,6 +487,8 @@ enum BuiltinFunction {
   EQUAL_BOOL = 85;
   EQUAL_CONTRACT_ID = 86;
   EQUAL_LIST = 87;
+  EQUAL_TYPE_REP = 123;
+
 
   TRACE = 88;
 
@@ -494,7 +496,7 @@ enum BuiltinFunction {
 
   TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
-  // Next id is 123. 122 is SHIFT_NUMERIC.
+  // Next id is 124. 123 is EQUAL_TYPE_REP.
 }
 
 // Builtin literals

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -274,6 +274,10 @@ enum PrimType {
   // Builtin type 'Any'
   // *Available in versions >= 1.dev*
   ANY = 18;
+
+  // Builtin type 'TypeRep'
+  // *Available in versions >= 1.dev*
+  TYPE_REP = 19;
 }
 
 // Types
@@ -878,9 +882,9 @@ message Expr {
     // *Available in versions >= 1.dev*
     FromAny from_any = 31;
 
-    // Obtain a unique textual representation of a type constructor
+    // A type representation
     // *Available in versions >= 1.dev*
-    TypeConName to_text_type_con_name = 32;
+    Type type_rep = 32;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1405,6 +1405,7 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(EQUAL_BOOL, BEqualBool),
       BuiltinFunctionInfo(EQUAL_LIST, BEqualList),
       BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId),
+      BuiltinFunctionInfo(EQUAL_TYPE_REP, BEqualTypeRep),
       BuiltinFunctionInfo(TRACE, BTrace),
       BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId, minVersion = coerceContractId)
     )

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -842,9 +842,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             decodeType(lfExpr.getFromAny.getType),
             decodeExpr(lfExpr.getFromAny.getExpr, definition))
 
-        case PLF.Expr.SumCase.TO_TEXT_TYPE_CON_NAME =>
-          assertSince(LV.Features.toTextTypeConName, "Expr.ToTextTypeConName")
-          EToTextTypeConName(decodeTypeConName(lfExpr.getToTextTypeConName))
+        case PLF.Expr.SumCase.TYPE_REP =>
+          assertSince(LV.Features.typeRep, "Expr.type_rep")
+          ETypeRep(decodeType(lfExpr.getTypeRep))
 
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
@@ -1223,7 +1223,8 @@ private[lf] object DecodeV1 {
       BuiltinTypeInfo(MAP, BTMap, minVersion = optional),
       BuiltinTypeInfo(ARROW, BTArrow, minVersion = arrowType),
       BuiltinTypeInfo(NUMERIC, BTNumeric, minVersion = numeric),
-      BuiltinTypeInfo(ANY, BTAny, minVersion = anyType)
+      BuiltinTypeInfo(ANY, BTAny, minVersion = anyType),
+      BuiltinTypeInfo(TYPE_REP, BTTypeRep, minVersion = typeRep)
     )
   }
 

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -141,23 +141,7 @@ object Ref {
 
   /* A fully-qualified identifier pointing to a definition in the
    * specified package. */
-  case class Identifier(packageId: PackageId, qualifiedName: QualifiedName) {
-    override def toString: String = packageId.toString + ":" + qualifiedName.toString
-  }
-  object Identifier {
-    type T = Identifier
-
-    def fromString(s: String): Either[String, Identifier] = {
-      val segments = split(s, ':')
-      if (segments.length != 3)
-        Left(s"Expecting three segments in $s, but got ${segments.length}")
-      else
-        for {
-          packageId <- PackageId.fromString(segments(0))
-          qualifiedName <- QualifiedName.fromString(segments(1) + ":" + segments(2))
-        } yield Identifier(packageId, qualifiedName)
-    }
-  }
+  case class Identifier(packageId: PackageId, qualifiedName: QualifiedName)
 
   /* Choice name in a template. */
   val ChoiceName: Name.type = Name

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -240,7 +240,7 @@ object InterfaceReader {
           unserializableDataType(
             ctx,
             s"Unserializable primitive type: $a must be applied to one and only one TNat")
-        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow | Ast.BTAny =>
+        case Ast.BTUpdate | Ast.BTScenario | Ast.BTArrow | Ast.BTAny | Ast.BTTypeRep =>
           unserializableDataType(ctx, s"Unserializable primitive type: $a")
       }
       (arity, primType) = ab

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -71,6 +71,7 @@ class TypeSpec extends WordSpec with Matchers {
           case Pkg.BTOptional => TypePrim(PrimTypeOptional, ImmArraySeq(assertOneArg(args)))
           case Pkg.BTArrow => sys.error("cannot use arrow in interface type")
           case Pkg.BTAny => sys.error("cannot use any in interface type")
+          case Pkg.BTTypeRep => sys.error("cannot use type representation in interface type")
         }
       case Pkg.TTyCon(tycon) => TypeCon(TypeConName(tycon), args.toImmArray.toSeq)
       case Pkg.TNat(_) => sys.error("cannot use nat type in interface type")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -296,6 +296,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
               case BEqualParty => SBEqual
               case BEqualBool => SBEqual
               case BEqualContractId => SBEqual
+              case BEqualTypeRep => SBEqual
 
               // Map
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -598,8 +598,8 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
       case EFromAny(ty, e) =>
         SEApp(SEBuiltin(SBFromAny(ty)), Array(translate(e)))
 
-      case EToTextTypeConName(tyCon) =>
-        SEValue(SText(tyCon.toString))
+      case ETypeRep(typ) =>
+        SEValue(STypeRep(typ))
     }
 
   @tailrec
@@ -1038,7 +1038,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
 
     def goV(v: SValue): Unit = {
       v match {
-        case _: SPrimLit | STNat(_) =>
+        case _: SPrimLit | STNat(_) | STypeRep(_) =>
         case SList(a) => a.iterator.foreach(goV)
         case SOptional(x) => x.foreach(goV)
         case SMap(map) => map.values.foreach(goV)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -295,7 +295,7 @@ object SBuiltin {
         case SParty(p) => p
         case SUnit => s"<unit>"
         case SDate(date) => date.toString
-        case SContractId(_) | SNumeric(_) => crash("litToText: literal not supported")
+        case SContractId(_) | SNumeric(_) | STypeRep(_) => crash("litToText: literal not supported")
       })
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -177,8 +177,6 @@ object SValue {
 
   final case class SAny(ty: Type, value: SValue) extends SValue
 
-  final case class STypeRep(ty: Type) extends SValue
-
   // Corresponds to a DAML-LF Nat type reified as a Speedy value.
   // It is currently used to track at runtime the scale of the
   // Numeric builtin's arguments/output. Should never be translated
@@ -197,6 +195,7 @@ object SValue {
   final case object SUnit extends SPrimLit
   final case class SDate(value: Time.Date) extends SPrimLit
   final case class SContractId(value: V.ContractId) extends SPrimLit
+  final case class STypeRep(ty: Type) extends SPrimLit
   // The "effect" token for update or scenario builtin functions.
   final case object SToken extends SValue
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -508,8 +508,8 @@ object Speedy {
             }
           }
         case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | SAny(_, _) | STypeRep(_) | STNat(_) |
-            _: SPAP | SToken =>
+            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | SAny(_, _) | STypeRep(_) |
+            STNat(_) | _: SPAP | SToken =>
           crash("Match on non-matchable value")
       }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -508,7 +508,7 @@ object Speedy {
             }
           }
         case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | SAny(_, _) | STNat(_) |
+            STimestamp(_) | STuple(_, _) | SMap(_) | SRecord(_, _, _) | SAny(_, _) | STypeRep(_) | STNat(_) |
             _: SPAP | SToken =>
           crash("Match on non-matchable value")
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1133,16 +1133,15 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     )
 
     "is reflexive" in {
-      forEvery(values)( v => {
+      forEvery(values)(v => {
         val e = e"EQUAL_TYPE_REP $v $v"
         eval(e) shouldBe Right(SBool(true))
       })
     }
 
     "works as expected" in {
-      forEvery(values)(v1 => forEvery(values)(v2 =>
-        eval(e"EQUAL_TYPE_REP $v1 $v2") shouldBe Right(SBool(v1 == v2))
-      ))
+      forEvery(values)(v1 =>
+        forEvery(values)(v2 => eval(e"EQUAL_TYPE_REP $v1 $v2") shouldBe Right(SBool(v1 == v2))))
     }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1121,6 +1121,31 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
   }
 
+  "EQUAL_CONTRACT_ID" - {
+
+    val values = Table(
+      "values",
+      "(type_rep @Mod:T)",
+      "(type_rep @Mod:R)",
+      "(type_rep @Int64)",
+      "(type_rep @(Mod:Tree (List Text)))",
+      "(type_rep @((ContractId Mod:T) -> Mod:Color))",
+    )
+
+    "is reflexive" in {
+      forEvery(values)( v => {
+        val e = e"EQUAL_TYPE_REP $v $v"
+        eval(e) shouldBe Right(SBool(true))
+      })
+    }
+
+    "works as expected" in {
+      forEvery(values)(v1 => forEvery(values)(v2 =>
+        eval(e"EQUAL_TYPE_REP $v1 $v2") shouldBe Right(SBool(v1 == v2))
+      ))
+    }
+  }
+
   "Debugging builtins" - {
 
     "TRACE" - {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -207,8 +207,10 @@ class SpeedyTest extends WordSpec with Matchers {
     "produces expected output" in {
       eval(e"""type_rep @Test:T1""", anyPkgs) shouldBe Right(STypeRep(t"Test:T1"))
       eval(e"""type_rep @Test2:T2""", anyPkgs) shouldBe Right(STypeRep(t"Test2:T2"))
-      eval(e"""type_rep @(Mod:Tree (List Text))""", anyPkgs) shouldBe Right(STypeRep(t"Mod:Tree (List Text)"))
-      eval(e"""type_rep @((ContractId Mod:T) -> Mod:Color)""", anyPkgs) shouldBe Right(STypeRep(t"(ContractId Mod:T) -> Mod:Color"))
+      eval(e"""type_rep @(Mod:Tree (List Text))""", anyPkgs) shouldBe Right(
+        STypeRep(t"Mod:Tree (List Text)"))
+      eval(e"""type_rep @((ContractId Mod:T) -> Mod:Color)""", anyPkgs) shouldBe Right(
+        STypeRep(t"(ContractId Mod:T) -> Mod:Color"))
     }
 
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -202,11 +202,13 @@ class SpeedyTest extends WordSpec with Matchers {
     }
   }
 
-  "to_text_type_con_name" should {
+  "type_rep" should {
 
     "produces expected output" in {
-      eval(e"""to_text_type_con_name @Test:T1""", anyPkgs) shouldBe Right(SText("-pkgId-:Test:T1"))
-      eval(e"""to_text_type_con_name @Test:T2""", anyPkgs) shouldBe Right(SText("-pkgId-:Test:T2"))
+      eval(e"""type_rep @Test:T1""", anyPkgs) shouldBe Right(STypeRep(t"Test:T1"))
+      eval(e"""type_rep @Test2:T2""", anyPkgs) shouldBe Right(STypeRep(t"Test2:T2"))
+      eval(e"""type_rep @(Mod:Tree (List Text))""", anyPkgs) shouldBe Right(STypeRep(t"Mod:Tree (List Text)"))
+      eval(e"""type_rep @((ContractId Mod:T) -> Mod:Color)""", anyPkgs) shouldBe Right(STypeRep(t"(ContractId Mod:T) -> Mod:Color"))
     }
 
   }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -423,6 +423,7 @@ object Ast {
   final case object BEqualBool extends BuiltinFunction(2) // : Bool -> Bool -> Bool
   final case object BEqualList extends BuiltinFunction(3) // : ∀a. (a -> a -> Bool) -> List a -> List a -> Bool
   final case object BEqualContractId extends BuiltinFunction(2) // : ∀a. ContractId a -> ContractId a -> Bool
+  final case object BEqualTypeRep extends BuiltinFunction(2) // : TypeRep -> TypeRep -> Bool
   final case object BCoerceContractId extends BuiltinFunction(1) // : ∀a b. ContractId a -> ContractId b
 
   //

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -152,7 +152,7 @@ object Ast {
   final case class EFromAny(ty: Type, body: Expr) extends Expr
 
   /** Unique textual representation of template Id **/
-  final case class EToTextTypeConName(tyCon: TypeConName) extends Expr
+  final case class ETypeRep(typ: Type) extends Expr
 
   //
   // Kinds
@@ -289,6 +289,7 @@ object Ast {
   case object BTContractId extends BuiltinType
   case object BTArrow extends BuiltinType
   case object BTAny extends BuiltinType
+  case object BTTypeRep extends BuiltinType
 
   //
   // Primitive literals

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -59,7 +59,7 @@ object LanguageVersion {
     val internedDottedNames = v1_dev
     val numeric = v1_dev
     val anyType = v1_dev
-    val toTextTypeConName = v1_dev
+    val typeRep = v1_dev
 
     /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
       * compatibility, we introduce a new DAML-LF version where this restriction is in

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -49,6 +49,7 @@ object Util {
   val TDate = TBuiltin(BTDate)
   val TParty = TBuiltin(BTParty)
   val TAny = TBuiltin(BTAny)
+  val TTypeRep = TBuiltin(BTTypeRep)
 
   val TNumeric = new ParametricType1(BTNumeric)
   val TList = new ParametricType1(BTList)

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -71,8 +71,7 @@ private[digitalasset] class AstRewriter(
       exprRule(x)
     else
       x match {
-        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
-             ETypeRep(_) =>
+        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) | ETypeRep(_) =>
           x
         case EVal(ref) =>
           EVal(apply(ref))

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -72,7 +72,7 @@ private[digitalasset] class AstRewriter(
     else
       x match {
         case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
-            EToTextTypeConName(_) =>
+             ETypeRep(_) =>
           x
         case EVal(ref) =>
           EVal(apply(ref))

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -188,7 +188,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     }
 
   private lazy val eToTextTypeConName: Parser[Expr] =
-    `to_text_type_con_name` ~! `@` ~> fullIdentifier ^^ EToTextTypeConName
+    `type_rep` ~>! argTyp ^^ ETypeRep
 
   private lazy val pattern: Parser[CasePat] =
     primCon ^^ CPPrimCon |

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -289,6 +289,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "EQUAL_BOOL" -> BEqualBool,
     "EQUAL_LIST" -> BEqualList,
     "EQUAL_CONTRACT_ID" -> BEqualContractId,
+    "EQUAL_TYPE_REP" -> BEqualTypeRep,
     "COERCE_CONTRACT_ID" -> BCoerceContractId,
   )
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -42,7 +42,7 @@ private[parser] object Lexer extends RegexParsers {
     "to" -> `to`,
     "to_any" -> `to_any`,
     "from_any" -> `from_any`,
-    "to_text_type_con_name" -> `to_text_type_con_name`
+    "type_rep" -> `type_rep`
   )
 
   val token: Parser[Token] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -53,7 +53,7 @@ private[parser] object Token {
   case object `to` extends Token
   case object `to_any` extends Token
   case object `from_any` extends Token
-  case object `to_text_type_con_name` extends Token
+  case object `type_rep` extends Token
 
   final case class Id(s: String) extends Token
   final case class ContractId(s: String) extends Token

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -29,6 +29,7 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
     "Arrow" -> BTArrow,
     "Map" -> BTMap,
     "Any" -> BTAny,
+    "TypeRep" -> BTTypeRep,
   )
 
   private[parser] def fullIdentifier: Parser[Ref.Identifier] =

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -233,6 +233,7 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "EQUAL_BOOL" -> BEqualBool,
         "EQUAL_LIST" -> BEqualList,
         "EQUAL_CONTRACT_ID" -> BEqualContractId,
+        "EQUAL_TYPE_REP" -> BEqualTypeRep,
         "COERCE_CONTRACT_ID" -> BCoerceContractId,
       )
 

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -245,8 +245,7 @@ Version: 1.dev
     ``from_any`` and ``to_any`` functions to convert from/to
     an arbitrary ground type (i.e. a type with no free type variables) to ``Any``.
 
-  * **Add** ``to_text_type_con_name`` to generate a unique textual representation
-    of a type constructor.
+  * **Add** ``type_rep``, a value presenting a type.
 
 Abstract syntax
 ^^^^^^^^^^^^^^^
@@ -544,6 +543,7 @@ Then we can define our kinds, types, and expressions::
        |  'Update'                                  -- BTyUpdate
        |  'ContractId'                              -- BTyContractId
        |  'Any'                                     -- BTyAny
+       |  'TypeRep'                                 -- BTTypeRep
 
   Types (mnemonic: tau for type)
     τ, σ
@@ -590,7 +590,7 @@ Then we can define our kinds, types, and expressions::
        |  u                                         -- ExpUpdate: Update expression
        | 'to_any' @τ t                              -- ExpToAny: Wrap a value of the given type in Any
        | 'from_any' @τ t                            -- ExpToAny: Extract a value of the given from Any or return None
-       | 'to_text_type_con_name' @Mod:T             -- ExpToTextTypeConName: Generate a unique textual representation of the given TypeConName
+       | 'type_rep' @τ                              -- ExpToTypeRep: A type representation
 
   Patterns
     p
@@ -807,6 +807,9 @@ First, we formally defined *well-formed types*. ::
     ————————————————————————————————————————————— TyAny
       Γ  ⊢  'Any' : ⋆
 
+    ————————————————————————————————————————————— TyTypeRep
+      Γ  ⊢  'TypeRep' : ⋆
+
       'record' T (α₁:k₁) … (αₙ:kₙ) ↦ … ∈ 〚Ξ〛Mod
     ————————————————————————————————————————————— TyRecordCon
       Γ  ⊢  Mod:T : k₁ → … → kₙ  → ⋆
@@ -893,17 +896,9 @@ Then we define *well-formed expressions*. ::
     ——————————————————————————————————————————————————————————————— ExpFromAny
       Γ  ⊢  'from_any' @τ e  :  'Optional' τ
 
-      'record' (x : T) ↦ …  ∈  〚Ξ〛Mod
-    ——————————————————————————————————————————————————————————————— ExpToTextTypeConNameRecord
-      Γ  ⊢  'to_text_type_con_name' @Mod:T  :  'Text'
-
-      'variant' (x : T) ↦ …  ∈  〚Ξ〛Mod
-    ——————————————————————————————————————————————————————————————— ExpToTextTypeConNameVariant
-      Γ  ⊢  'to_text_type_con_name' @Mod:T  :  'Text'
-
-      'enum' (x : T) ↦ …  ∈  〚Ξ〛Mod
-    ——————————————————————————————————————————————————————————————— ExpToTextTypeConNameEnum
-      Γ  ⊢  'to_text_type_con_name' @Mod:T  :  'Text'
+      ε  ⊢  τ : *     τ contains no quantifiers
+    ——————————————————————————————————————————————————————————————— ExpTypeRep
+      Γ  ⊢  'type_rep' @τ  :  'TypeRep'
 
     ——————————————————————————————————————————————————————————————— ExpBuiltin
       Γ  ⊢  F : 𝕋(F)
@@ -1508,10 +1503,12 @@ need to be evaluated further. ::
    ——————————————————————————————————————————————————— ValExpTupleCon
      ⊢ᵥ  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩
 
-
      ⊢ᵥ  e
    ——————————————————————————————————————————————————— ValExpToAny
      ⊢ᵥ  'to_any' @τ e
+
+   ——————————————————————————————————————————————————— ValExpTypeRep
+     ⊢ᵥ  'type_rep' @τ
 
      ⊢ᵥ  e
    ——————————————————————————————————————————————————— ValExpUpdPure
@@ -1682,10 +1679,6 @@ exact output.
       e ‖ E₀  ⇓  Ok ('to_any' @τ₁ v) ‖ E₁     τ₁ ≠ τ₂
     —————————————————————————————————————————————————————————————————————— EvExpFromAnyFail
       'from_any' @τ₂ e ‖ E₀  ⇓  'None' ‖ E₁
-
-
-    —————————————————————————————————————————————————————————————————————— EvExpToTextTypeConName
-      'to_text_type_con_name' @Mod:T ‖ E₀  ⇓  "Mod:T" ‖ E₀
 
       e₁ ‖ E₀  ⇓  Ok v₁ ‖ E₁
       v 'matches' p₁  ⇝  Succ (x₁ ↦ v₁ · … · xₘ ↦ vₘ · ε)
@@ -2569,6 +2562,16 @@ Map functions
   Return the number of elements in the map.
 
   [*Available in versions >= 1.3*]
+
+Type Representation function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``EQUAL_TYPE_REP`` : 'TypeRep' → 'TypeRep' → 'Bool'``
+
+  Returns ``'True'`` if the first type representation is syntactically equal to
+  the second one, ``'False'`` otherwise.
+
+  [*Available in versions >= 1.dev*]
 
 Conversions functions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -97,6 +97,8 @@ private[validation] object Serializability {
             unserializable(URFunction)
           case BTAny =>
             unserializable(URAny)
+          case BTTypeRep =>
+            unserializable(URTypeRep)
         }
       case TForall(_, _) =>
         unserializable(URForall)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -112,10 +112,10 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
   }
 
   def apply(expr0: Expr): Expr = expr0 match {
-    case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _)
-         | EEnumCon(_, _)
-          // Type checking ensures there is no type variables in the arg of  ETypeRep
-         | ETypeRep(_) =>
+    case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
+        EEnumCon(_, _)
+        // Type checking ensures there is no type variables in the arg of  ETypeRep
+        | ETypeRep(_) =>
       expr0
     case ERecCon(tycon, fields) =>
       ERecCon(apply(tycon), fields.transform { (_, x) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -112,8 +112,10 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
   }
 
   def apply(expr0: Expr): Expr = expr0 match {
-    case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) |
-        EEnumCon(_, _) | EToTextTypeConName(_) =>
+    case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _)
+         | EEnumCon(_, _)
+          // Type checking ensures there is no type variables in the arg of  ETypeRep
+         | ETypeRep(_) =>
       expr0
     case ERecCon(tycon, fields) =>
       ERecCon(apply(tycon), fields.transform { (_, x) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -181,6 +181,7 @@ private[validation] object Typing {
           (alpha ->: alpha ->: TBool) ->: TList(alpha) ->: TList(alpha) ->: TBool),
       BEqualContractId ->
         TForall(alpha.name -> KStar, TContractId(alpha) ->: TContractId(alpha) ->: TBool),
+      BEqualTypeRep -> (TTypeRep ->: TTypeRep ->: TBool),
       BCoerceContractId ->
         TForall(
           alpha.name -> KStar,
@@ -728,17 +729,17 @@ private[validation] object Typing {
     }
 
     // we check that typ contains neither variables nor quantifiers
-    private def checkSimpleType_(typ: Type): Unit = {
+    private def checkGroundType_(typ: Type): Unit = {
       typ match {
         case TVar(_) | TForall(_, _) =>
           throw EExpectedAnyType(ctx, typ)
         case _ =>
-          TypeTraversable(typ).foreach(checkSimpleType_)
+          TypeTraversable(typ).foreach(checkGroundType_)
       }
     }
 
-    private def checkSimpleType(typ:Type): Unit  = {
-      checkSimpleType_(typ)
+    private def checkGroundType(typ:Type): Unit  = {
+      checkGroundType_(typ)
       checkType(typ, KStar)
     }
 
@@ -807,15 +808,15 @@ private[validation] object Typing {
         val _ = checkExpr(body, typ)
         TOptional(typ)
       case EToAny(typ, body) =>
-        checkSimpleType(typ)
+        checkGroundType(typ)
         checkExpr(body, typ)
         TAny
       case EFromAny(typ, body) =>
-        checkSimpleType(typ)
+        checkGroundType(typ)
         checkExpr(body, TAny)
         TOptional(typ)
       case ETypeRep(typ) =>
-        checkSimpleType(typ)
+        checkGroundType(typ)
         TTypeRep
     }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -738,11 +738,10 @@ private[validation] object Typing {
       }
     }
 
-    private def checkGroundType(typ:Type): Unit  = {
+    private def checkGroundType(typ: Type): Unit = {
       checkGroundType_(typ)
       checkType(typ, KStar)
     }
-
 
     def typeOf(expr0: Expr): Type = expr0 match {
       case EVar(name) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -141,6 +141,9 @@ case object URUninhabitatedType extends UnserializabilityReason {
 case object URAny extends UnserializabilityReason {
   def pretty: String = "Any"
 }
+case object URTypeRep extends UnserializabilityReason {
+  def pretty: String = "TypeRep"
+}
 
 abstract class ValidationError extends java.lang.RuntimeException with Product with Serializable {
   def context: Context

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -13,7 +13,7 @@ private[validation] object ExprTraversable {
   private[traversable] def foreach[U](x: Expr, f: Expr => U): Unit = {
     x match {
       case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EContractId(_, _) |
-          EEnumCon(_, _) | EToTextTypeConName(_) =>
+           EEnumCon(_, _) | ETypeRep(_) =>
       case ELocation(_, expr) =>
         f(expr)
       case ERecCon(tycon @ _, fields) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -13,7 +13,7 @@ private[validation] object ExprTraversable {
   private[traversable] def foreach[U](x: Expr, f: Expr => U): Unit = {
     x match {
       case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EContractId(_, _) |
-           EEnumCon(_, _) | ETypeRep(_) =>
+          EEnumCon(_, _) | ETypeRep(_) =>
       case ELocation(_, expr) =>
         f(expr)
       case ERecCon(tycon @ _, fields) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -61,8 +61,8 @@ private[validation] object TypeTraversable {
       case EFromAny(typ, expr) =>
         f(typ)
         foreach(expr, f)
-      case EToTextTypeConName(tyCon) =>
-        f(TTyCon(tyCon))
+      case ETypeRep(tyCon) =>
+        f(tyCon)
       case ENil(typ) =>
         f(typ)
       case ECons(typ, front, tail) =>

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -183,7 +183,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           T"Any → Option Text",
         E"""λ (t: Any) → (( from_any @Int64 t ))""" ->
           T"Any → Option Int64",
-        // ExpToTextTypeConName
+        // ExpTypeRep
         E"""(( type_rep @Mod:T ))""" ->
           T"TypeRep",
         E"""(( type_rep @Int64 ))""" ->
@@ -377,7 +377,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"λ (t: Mod:T) → (( from_any @Mod:T t ))",
         E"Λ (τ : *). λ (t: Any) → (( to_any @(∀ (α : ⋆). Int64) t ))",
         E"Λ (τ : *). λ (t: Any) → (( to_any @(List (Optional (∀ (α : ⋆). Int64))) t ))",
-        // ExpToTextTypeConName
+        // ExpTypeRep
         E"(( type_rep @Mod:NoSuchType ))",
         E"Λ (τ : *). (( type_rep @τ ))",
         E"(( type_rep @(∀(τ : *) . Int64) ))",

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -378,9 +378,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"Λ (τ : *). λ (t: Any) → (( to_any @(∀ (α : ⋆). Int64) t ))",
         E"Λ (τ : *). λ (t: Any) → (( to_any @(List (Optional (∀ (α : ⋆). Int64))) t ))",
         // ExpToTextTypeConName
-//        E"(( type_rep @Mod:NoSuchType ))",
-//        E"Λ (τ : *). (( type_rep @τ ))",
-//        E"(( type_rep @(Λ (τ : *). Int64) ))",
+        E"(( type_rep @Mod:NoSuchType ))",
+        E"Λ (τ : *). (( type_rep @τ ))",
+        E"(( type_rep @(∀(τ : *) . Int64) ))",
         // ScnPure
         E"Λ (τ : ⋆ → ⋆). λ (e: τ) → (( spure @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e: τ) → (( spure @σ e ))",

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -166,32 +166,32 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"Λ (τ : ⋆) (σ : ⋆). λ (e₁ : τ) (e₂: σ) → (( case e₁ of _ → e₂ ))" ->
           T"∀ (τ : ⋆) (σ : ⋆). τ → σ → (( σ ))",
         // ExpToAny
-        E"""λ (t : Mod:T) -> (( to_any @Mod:T t ))""" ->
-          T"Mod:T -> Any",
-        E"""λ (t : Mod:R Text) -> (( to_any @(Mod:R Text) t ))""" ->
-          T"Mod:R Text -> Any",
-        E"""λ (t : Text) -> (( to_any @Text t ))""" ->
-          T"Text -> Any",
-        E"""λ (t : Int64) -> (( to_any @Int64 t ))""" ->
+        E"""λ (t : Mod:T) → (( to_any @Mod:T t ))""" ->
+          T"Mod:T → Any",
+        E"""λ (t : Mod:R Text) → (( to_any @(Mod:R Text) t ))""" ->
+          T"Mod:R Text → Any",
+        E"""λ (t : Text) → (( to_any @Text t ))""" ->
+          T"Text → Any",
+        E"""λ (t : Int64) → (( to_any @Int64 t ))""" ->
           T"Int64 -> Any",
         // ExpFromAny
-        E"""λ (t: Any) -> (( from_any @Mod:T t ))""" ->
+        E"""λ (t: Any) → (( from_any @Mod:T t ))""" ->
           T"Any → Option Mod:T",
-        E"""λ (t: Any) -> (( from_any @(Mod:R Text) t ))""" ->
+        E"""λ (t: Any) → (( from_any @(Mod:R Text) t ))""" ->
           T"Any → Option (Mod:R Text)",
-        E"""λ (t: Any) -> (( from_any @Text t ))""" ->
+        E"""λ (t: Any) → (( from_any @Text t ))""" ->
           T"Any → Option Text",
-        E"""λ (t: Any) -> (( from_any @Int64 t ))""" ->
+        E"""λ (t: Any) → (( from_any @Int64 t ))""" ->
           T"Any → Option Int64",
         // ExpToTextTypeConName
-        E"""(( to_text_type_con_name @Mod:T ))""" ->
-          T"Text",
-        E"""(( to_text_type_con_name @Mod:R ))""" ->
-          T"Text",
-        E"""(( to_text_type_con_name @Mod:Tree ))""" ->
-          T"Text",
-        E"""(( to_text_type_con_name @Mod:Color ))""" ->
-          T"Text",
+        E"""(( type_rep @Mod:T ))""" ->
+          T"TypeRep",
+        E"""(( type_rep @Int64 ))""" ->
+          T"TypeRep",
+        E"""(( type_rep @(Mod:Tree (List Text)) ))""" ->
+          T"TypeRep",
+        E"""(( type_rep @((ContractId Mod:T) → Mod:Color) ))""" ->
+          T"TypeRep",
       )
 
       forEvery(testCases) { (exp: Expr, expectedType: Type) =>
@@ -378,7 +378,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         E"Λ (τ : *). λ (t: Any) → (( to_any @(∀ (α : ⋆). Int64) t ))",
         E"Λ (τ : *). λ (t: Any) → (( to_any @(List (Optional (∀ (α : ⋆). Int64))) t ))",
         // ExpToTextTypeConName
-        E"to_text_type_con_name @Mod:NoSuchType",
+//        E"(( type_rep @Mod:NoSuchType ))",
+//        E"Λ (τ : *). (( type_rep @τ ))",
+//        E"(( type_rep @(Λ (τ : *). Int64) ))",
         // ScnPure
         E"Λ (τ : ⋆ → ⋆). λ (e: τ) → (( spure @τ e ))",
         E"Λ (τ : ⋆) (σ : ⋆). λ (e: τ) → (( spure @σ e ))",

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -38,13 +38,15 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 
 -- | Active contract set, you can use `getTemplates` to access the templates of
 -- a given type.
-newtype ACS = ACS (Map TemplateTypeRep [(AnyContractId, AnyTemplate)])
+
+-- This will change to a Map once we have proper maps in DAML-LF
+newtype ACS = ACS [(AnyContractId, AnyTemplate)]
 
 -- | Extract the templates of a given type from the ACS.
 getTemplates : forall a. Template a => ACS -> [(AbsoluteContractId a, a)]
-getTemplates (ACS tpls) = map fromAny $ fromOptional [] $ Map.lookup (templateTypeRep @a) tpls
+getTemplates (ACS tpls) = mapOptional fromAny tpls
   where
-    fromAny (cid, tpl) = (fromSome (fromAnyContractId cid), fromSome (fromAnyTemplate tpl))
+    fromAny (cid, tpl) = (,) <$> fromAnyContractId cid <*> fromAnyTemplate tpl
 
 -- | This is the type of your trigger. `s` is the user-defined state type which
 -- you can often leave at `()`.
@@ -116,7 +118,7 @@ runTrigger userTrigger = LowLevel.Trigger
   }
   where
     initialState party (ActiveContracts createdEvents) =
-      let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS Map.empty) createdEvents
+      let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS []) createdEvents
           userState = userTrigger.initialize acs
           state = TriggerState acs party userState Map.empty 0
       in runRule userTrigger.rule state
@@ -149,21 +151,14 @@ addCommands : Map CommandId [Command] -> Commands -> Map CommandId [Command]
 addCommands m (Commands cid cmds) = Map.insert cid cmds m
 
 insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
-insertTpl cid tpl (ACS acs) =
-  case Map.lookup cid.templateId acs of
-    None -> ACS (Map.insert cid.templateId [(cid, tpl)] acs)
-    Some items -> ACS (Map.insert cid.templateId ((cid, tpl) :: items) acs)
+insertTpl cid tpl (ACS acs) = ACS ((cid, tpl) :: acs)
 
 deleteTpl : AnyContractId -> ACS -> ACS
-deleteTpl cid (ACS acs) =
-  case Map.lookup cid.templateId acs of
-    None -> ACS acs
-    Some items -> ACS (Map.insert cid.templateId (filter (\(cid', _) -> cid /= cid') items) acs)
+deleteTpl cid (ACS acs) = ACS (filter (\(cid', _) -> cid /= cid') acs)
 
 lookupTpl : Template a => AnyContractId -> ACS -> Optional a
 lookupTpl cid (ACS acs) = do
-  items <- Map.lookup cid.templateId acs
-  (_, tpl) <- find ((cid ==) . fst) items
+  (_, tpl) <- find ((cid ==) . fst) acs
   fromAnyTemplate tpl
 
 applyEvent : Event -> ACS -> ACS

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -37,7 +37,15 @@ import DA.Next.Map (MapKey(..))
 data AnyContractId = AnyContractId
   { templateId : TemplateTypeRep
   , contractId : Text
-  } deriving (Show, Eq, Ord)
+  } deriving Eq
+
+-- We can’t derive the Show instance since TemplateTypeRep does not have a Show instance
+-- but it is useful for debugging so we add one that omits the type.
+instance Show AnyContractId where
+  showsPrec d (AnyContractId _ cid) = showParen (d > app_prec) $
+    showString "AnyContractId " . showsPrec (app_prec +1) cid
+    where app_prec = 10
+
 
 -- | An absolute contract id on the ledger.
 -- Contrary to the `ContractId` type which is used

--- a/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/daml/trigger/Converter.scala
@@ -110,12 +110,13 @@ object Converter {
   }
 
   private def fromIdentifier(id: value.Identifier): SValue = {
-    SText(
-      Identifier(
-        PackageId.assertFromString(id.packageId),
-        QualifiedName(
-          DottedName.assertFromString(id.moduleName),
-          DottedName.assertFromString(id.entityName))).toString())
+    STypeRep(
+      TTyCon(
+        TypeConName(
+          PackageId.assertFromString(id.packageId),
+          QualifiedName(
+            DottedName.assertFromString(id.moduleName),
+            DottedName.assertFromString(id.entityName)))))
   }
 
   private def fromTransactionId(triggerIds: TriggerIds, transactionId: String): SValue = {
@@ -283,8 +284,8 @@ object Converter {
 
   private def toIdentifier(v: SValue): Either[String, Identifier] = {
     v match {
-      case SText(s) => Identifier.fromString(s)
-      case _ => Left(s"Expected Identifier but got $v")
+      case STypeRep(TTyCon(id)) => Right(id)
+      case _ => Left(s"Expected STypeRep but got $v")
     }
   }
 


### PR DESCRIPTION
We add Type representation value to daml-lf.

This is used by the triggers instead the `to_text_type_con` primitive.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
