### PR TITLE
Use regular ContractIds in DAML triggers

### DIFF
--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -4,7 +4,7 @@
 daml 1.2
 module CopyTrigger where
 
-import DA.List
+import DA.List hiding (dedup)
 import DA.Next.Map (Map)
 
 import Daml.Trigger
@@ -62,9 +62,9 @@ copyRule : Party -> ACS -> Map CommandId [Command] -> () -> TriggerA ()
 copyRule party acs commandsInFlight () = do
 -- RULE_SIGNATURE_END
 -- ACS_QUERY_BEGIN
-  let subscribers : [(AbsoluteContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
-  let originals : [(AbsoluteContractId Original, Original)] = getTemplates @Original acs
-  let copies : [(AbsoluteContractId Copy, Copy)] = getTemplates @Copy acs
+  let subscribers : [(ContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
+  let originals : [(ContractId Original, Original)] = getTemplates @Original acs
+  let copies : [(ContractId Copy, Copy)] = getTemplates @Copy acs
 -- ACS_QUERY_END
 
 -- ACS_FILTER_BEGIN
@@ -78,7 +78,7 @@ copyRule party acs commandsInFlight () = do
 -- SUBSCRIBING_PARTIES_END
 
 -- GROUP_COPIES_BEGIN
-  let groupedCopies : [[(AbsoluteContractId Copy, Copy)]]
+  let groupedCopies : [[(ContractId Copy, Copy)]]
       groupedCopies = groupOn snd $ sortOn snd $ ownedCopies
   let copiesToKeep = map head groupedCopies
   let archiveDuplicateCopies = concatMap tail groupedCopies
@@ -100,3 +100,9 @@ copyRule party acs commandsInFlight () = do
   mapA dedupCreate createCopies
 -- CREATE_COPIES_END
   pure ()
+
+-- | The dedup function from DA.List requires an Ord constraint which we do not have for `ContractId k`. Therefore,
+-- we resort to the n^2 version for now. Once we have Maps we can use those to implement a more efficient dedup.
+dedup : Eq k => [k] -> [k]
+dedup [] = []
+dedup (x :: xs) = x :: dedup (filter (/= x) xs)

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -11,8 +11,7 @@ module Daml.Trigger
  , runTrigger
  , CommandId
  , Command(..)
- , AnyContractId(..)
- , AbsoluteContractId(..)
+ , AnyContractId
  , toAnyContractId
  , fromAnyContractId
  , exerciseCmd
@@ -43,7 +42,7 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 newtype ACS = ACS [(AnyContractId, AnyTemplate)]
 
 -- | Extract the templates of a given type from the ACS.
-getTemplates : forall a. Template a => ACS -> [(AbsoluteContractId a, a)]
+getTemplates : forall a. Template a => ACS -> [(ContractId a, a)]
 getTemplates (ACS tpls) = mapOptional fromAny tpls
   where
     fromAny (cid, tpl) = (,) <$> fromAnyContractId cid <*> fromAnyTemplate tpl
@@ -100,7 +99,7 @@ dedupCreate t = do
 -- Note that this will send the exercise as a single-command transaction.
 -- If you need to send multiple commands in one transaction, use
 -- `emitCommands` with `exerciseCmd` and handle filtering yourself.
-dedupExercise : (Eq c, Choice t c r) => AbsoluteContractId t -> c -> TriggerA ()
+dedupExercise : (Eq c, Choice t c r) => ContractId t -> c -> TriggerA ()
 dedupExercise cid c = do
   aState <- TriggerA get
   -- This is a very naive approach that is linear in the number of commands in flight.

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -7,8 +7,7 @@ module Daml.Trigger.LowLevel
   , Completion(..)
   , CompletionStatus(..)
   , Transaction(..)
-  , AnyContractId(..)
-  , AbsoluteContractId(..)
+  , AnyContractId
   , toAnyContractId
   , fromAnyContractId
   , TransactionId(..)
@@ -36,7 +35,7 @@ import DA.Next.Map (MapKey(..))
 -- You can use `fromAnyContractId` to check which template it corresponds to.
 data AnyContractId = AnyContractId
   { templateId : TemplateTypeRep
-  , contractId : Text
+  , contractId : ContractId ()
   } deriving Eq
 
 -- We can’t derive the Show instance since TemplateTypeRep does not have a Show instance
@@ -47,26 +46,18 @@ instance Show AnyContractId where
     where app_prec = 10
 
 
--- | An absolute contract id on the ledger.
--- Contrary to the `ContractId` type which is used
--- while building up a transaction in DAML, `AbsoluteContractId`
--- represents the id of a contract that has been committed to the ledger.
--- This allows us to get more instances, in particular `MapKey`.
-newtype AbsoluteContractId t = AbsoluteContractId { contractId : Text }
-  deriving (Show, Eq, Ord)
-
--- | Wrap an `AbsoluteContractId t` in `AnyContractId`.
-toAnyContractId : forall t. Template t => AbsoluteContractId t -> AnyContractId
-toAnyContractId (AbsoluteContractId contractId) = AnyContractId
+-- | Wrap a `ContractId t` in `AnyContractId`.
+toAnyContractId : forall t. Template t => ContractId t -> AnyContractId
+toAnyContractId cid = AnyContractId
   { templateId = templateTypeRep @t
-  , contractId = contractId
+  , contractId = coerceContractId cid
   }
 
 -- | Check if a `AnyContractId` corresponds to the given template or return
 -- `None` otherwise.
-fromAnyContractId : forall t. Template t => AnyContractId -> Optional (AbsoluteContractId t)
+fromAnyContractId : forall t. Template t => AnyContractId -> Optional (ContractId t)
 fromAnyContractId cid
-  | cid.templateId == templateTypeRep @t = Some (AbsoluteContractId cid.contractId)
+  | cid.templateId == templateTypeRep @t = Some (coerceContractId cid.contractId)
   | otherwise = None
 
 newtype TransactionId = TransactionId Text
@@ -97,7 +88,7 @@ data Created = Created
   }
 
 -- | Check if a `Created` event corresponds to the given template.
-fromCreated : Template t => Created -> Optional (EventId, AbsoluteContractId t, t)
+fromCreated : Template t => Created -> Optional (EventId, ContractId t, t)
 fromCreated Created {eventId, contractId, argument}
   | Some contractId' <- fromAnyContractId contractId
   , Some argument' <- fromAnyTemplate argument
@@ -112,7 +103,7 @@ data Archived = Archived
   } deriving (Show, Eq)
 
 -- | Check if an `Archived` event corresponds to the given template.
-fromArchived : Template t => Archived -> Optional (EventId, AbsoluteContractId t)
+fromArchived : Template t => Archived -> Optional (EventId, ContractId t)
 fromArchived Archived {eventId, contractId}
   | Some contractId' <- fromAnyContractId contractId
   = Some (eventId, contractId')
@@ -170,7 +161,7 @@ createCmd templateArg =
   CreateCommand (toAnyTemplate templateArg)
 
 -- | Exercise the given choice.
-exerciseCmd : forall t c r. Choice t c r => AbsoluteContractId t -> c -> Command
+exerciseCmd : forall t c r. Choice t c r => ContractId t -> c -> Command
 exerciseCmd contractId choiceArg =
   ExerciseCommand (toAnyContractId contractId) (toAnyChoice @t choiceArg)
 
@@ -182,7 +173,7 @@ fromCreate _ = None
 
 -- | Check if the command corresponds to an exercise command
 -- for the given template.
-fromExercise : forall t c r. Choice t c r => Command -> Optional (AbsoluteContractId t, c)
+fromExercise : forall t c r. Choice t c r => Command -> Optional (ContractId t, c)
 fromExercise (ExerciseCommand cid c) = (,) <$> fromAnyContractId cid <*> fromAnyChoice @t c
 fromExercise _ = None
 

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -4,13 +4,10 @@
 daml 1.2
 module ACS where
 
-import DA.TextMap (TextMap)
-import qualified DA.TextMap as TM
-
 import Daml.Trigger.LowLevel
 
 data TriggerState = TriggerState
-  { activeAssets : TextMap TemplateTypeRep
+  { activeAssets : [ContractId (Asset ())]
   , successfulCompletions : Int
   , failedCompletions : Int
   , nextCommandId : Int
@@ -19,20 +16,20 @@ data TriggerState = TriggerState
 
 initState : Party -> ActiveContracts -> TriggerState
 initState party (ActiveContracts events) = TriggerState
-  { activeAssets = (foldl updateAcs TM.empty events)
+  { activeAssets = (foldl updateAcs [] events)
   , nextCommandId = 0
   , party = party
   , successfulCompletions = 0
   , failedCompletions = 0
   }
   where
-    updateAcs : TextMap TemplateTypeRep -> Created -> TextMap TemplateTypeRep
-    updateAcs acs (Created _ cId argument)
-      | Some Asset{} <- fromAnyTemplate @(Asset ()) argument = TM.insert cId.contractId cId.templateId acs
+    updateAcs : [ContractId (Asset ())] -> Created -> [ContractId (Asset ())]
+    updateAcs acs created
+      | Some (_, cid, _) <- fromCreated @(Asset ()) created = cid :: acs
       | otherwise = acs
 
 -- | This is a very silly trigger for testing purposes:
--- We track the active Asset contracts (we make no attempts to distinguish different things called Asset)
+-- We track the active Asset contracts
 -- and we create a new AssetMirror contract whenever an Asset contract is created (but we do not archive them).
 test : Trigger TriggerState
 test = Trigger
@@ -53,16 +50,16 @@ test = Trigger
         , [Commands (CommandId $ "command_" <> show state.nextCommandId) cmds]
         )
       where
-        updateEvent : ([Command], TextMap TemplateTypeRep) -> Event -> ([Command], TextMap TemplateTypeRep)
+        updateEvent : ([Command], [ContractId (Asset ())]) -> Event -> ([Command], [ContractId (Asset ())])
         updateEvent (cmds, acs) ev = case ev of
-          CreatedEvent (fromCreated -> Some (_, assetId, Asset {issuer} : Asset ())) ->
-            let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer })
-            in (proposeMirror :: cmds, TM.insert assetId.contractId (templateTypeRep @(Asset ())) acs)
+          CreatedEvent (fromCreated @(Asset ()) -> Some (_, assetId, asset)) ->
+            let proposeMirror : Command = createCmd (AssetMirrorProposal { issuer = asset.issuer })
+            in (proposeMirror :: cmds, assetId :: acs)
           CreatedEvent (fromCreated -> Some (_, proposalId, AssetMirrorProposal {})) ->
             let accept : Command = exerciseCmd proposalId Accept
             in (accept :: cmds, acs)
           ArchivedEvent (fromArchived @(Asset ()) -> Some (_, assetId)) ->
-            (cmds, TM.delete assetId.contractId acs)
+            (cmds, filter (/= assetId) acs)
           _ -> (cmds, acs)
 
 -- This is only a generic template to test that we do the conversion properly.

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -45,7 +45,7 @@ toCreate : Template t => Command -> Optional t
 toCreate (CreateCommand t) = fromAnyTemplate t
 toCreate ExerciseCommand {} = None
 
-toExercise : Command -> Optional (AbsoluteContractId T, C)
+toExercise : Command -> Optional (ContractId T, C)
 toExercise CreateCommand {} = None
 toExercise (ExerciseCommand cid choice) =
   liftA2 (,) (fromAnyContractId cid) (fromAnyChoice @T choice)

--- a/triggers/tests/src/test/scala/com/daml/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/daml/trigger/test/TestMain.scala
@@ -223,7 +223,11 @@ case class AcsTests(dar: Dar[(PackageId, Package)], runner: TestRunner) {
           for {
             _ <- TestRunner.assertEqual(vals.size, 5, "number of record fields")
             activeAssets <- vals.get(0) match {
-              case SMap(v) => Right(v.keySet)
+              case SList(v) =>
+                Right(
+                  v.map(x =>
+                      x.asInstanceOf[SContractId].value.asInstanceOf[Lf.AbsoluteContractId].coid)
+                    .toSet)
               case _ => Left(s"Expected a map but got ${vals.get(0)}")
             }
             successfulCompletions <- vals.get(1) match {

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -22,3 +22,4 @@ HEAD — ongoing
 - [DAML Compiler] Fix compile error caused by instantiating generic
   templates at ``Numeric n``.
 - [Sandbox] Timing about database operations are now exposed over JMX as well as via the logs.
+- [DAML Triggers] Remove the custom ``AbsoluteContractId`` type in favor of the regular ``ContractId`` type used in DAML templates.


### PR DESCRIPTION
The only reason for having AbsoluteContractId was that we could get
some more instances in particular `Ord` and `MapKey` but given that
`ContractId` will be a valid key type for the new DAML-LF maps, we can
just use slower implementations for now and switch to Map-based
implementations once that has landed.

fixes #3336

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
