### PR TITLE
changes to allow daml-assistant/integration-tests to be added into to…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -227,10 +227,12 @@ buildifier(
 # Default target for da-ghci, da-ghcid.
 da_haskell_repl(
     name = "repl",
+    testonly = True,
     visibility = ["//visibility:public"],
     deps = [
         ":damlc",
         "//daml-assistant:daml",
         "//daml-assistant/daml-helper",
+        "//daml-assistant/integration-tests",
     ],
 )

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -65,7 +65,7 @@ genrule(
 da_haskell_test(
     name = "integration-tests",
     timeout = "long",
-    srcs = ["src/Main.hs"],
+    srcs = glob(["src/**/*.hs"]),
     data = [
         ":integration-tests-mvn",
         "//release:sdk-release-tarball",
@@ -98,6 +98,8 @@ da_haskell_test(
         "text",
         "zip-archive",
     ],
+    main_function = "DA.Daml.Assistant.IntegrationTests.main",
+    visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
         "//compiler/damlc/daml-opts:daml-opts-types",

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -1,8 +1,8 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-module Main (main) where
+module DA.Daml.Assistant.IntegrationTests (main) where
 
-import qualified Codec.Archive.Zip as Zip
+import qualified "zip-archive" Codec.Archive.Zip as Zip
 import Conduit hiding (connect)
 import qualified Data.Conduit.Zlib as Zlib
 import Data.Conduit.Tar.Extra (dropDirectory1)


### PR DESCRIPTION
Changes to allow daml-assistant/integration-tests to be added into top-level repl.
- rename file to avoid duplicate `Main.hs`
- fix import of `Zip` to avoid ambiguity (as is done already in Damlc.hs)

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
