### PR TITLE
sandbox: specify dar to load as option

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -34,6 +34,13 @@ object Cli {
   private val cmdArgParser = new scopt.OptionParser[SandboxConfig]("sandbox") {
     head(s"Sandbox version ${BuildInfo.Version}")
 
+    arg[File]("<archive>...")
+      .optional()
+      .unbounded()
+      .validate(f => Either.cond(checkIfZip(f), (), s"Invalid dar file: ${f.getName}"))
+      .action((f, c) => c.copy(damlPackages = f :: c.damlPackages))
+      .text("DAML archives to load in .dar format. Only DAML-LF v1 Archives are currently supported. Can be mixed in with optional arguments.")
+
     opt[Int]('p', "port")
       .action((x, c) => c.copy(port = x))
       .text(s"Sandbox service port. Defaults to ${SandboxConfig.DefaultPort}.")
@@ -81,13 +88,6 @@ object Cli {
           "Note that when using --postgres-backend the scenario will be ran only if starting from a fresh database, _not_ when resuming from an existing one. " +
           "Two identifier formats are supported: Module.Name:Entity.Name (preferred) and Module.Name.Entity.Name (deprecated, will print a warning when used)." +
           "Also note that instructing the sandbox to load a scenario will have the side effect of loading _all_ the .dar files provided eagerly (see --eager-package-loading).")
-
-    arg[File]("<archive>...")
-      .optional()
-      .unbounded()
-      .validate(f => Either.cond(checkIfZip(f), (), s"Invalid dar file: ${f.getName}"))
-      .action((f, c) => c.copy(damlPackages = f :: c.damlPackages))
-      .text("DAML archives to load in .dar format. Only DAML-LF v1 Archives are currently supported.")
 
     opt[String]("pem")
       .optional()


### PR DESCRIPTION
This PR does two things.

Firstly, it changes the order of options such that the description for what has to be the final segment of the CLI invocation, the list of archives to load at startup, appears first, rather than in the middle of the description, when running `daml sandbox --help`. Compare how easy it is to find help about the positional argument in:
```
$ daml-head sandbox --help
Sandbox version 100.13.32
Usage: sandbox [options] [<archive>...]

  <archive>...             DAML archives to load in .dar format. Only DAML-LF v
1 Archives are currently supported.
  -d, --archive <value>    Loads the specified DAR archive in the same way as i
f specified after the options.
  -p, --port <value>       Sandbox service port. Defaults to 6865.
  --port-file <value>      File to write the allocated port number to. Used to 
inform clients in CI about the allocated port.
  -a, --address <value>    Sandbox service host. Defaults to binding on all add
resses.
  --dalf                   This argument is present for backwards compatibility
. DALF and DAR archives are now identified by their extensions.
  -s, --static-time        Use static time, configured with TimeService through
 gRPC.
  -w, --wall-clock-time    Use wall clock time (UTC). When not provided, static
 time is used.
  --no-parity              Legacy flag with no effect.
  --scenario <value>       If set, the sandbox will execute the given scenario 
on startup and store all the contracts created by it. Note that when using --po
stgres-backend the scenario will be ran only if starting from a fresh database,
 _not_ when resuming from an existing one. Two identifier formats are supported
: Module.Name:Entity.Name (preferred) and Module.Name.Entity.Name (deprecated, 
will print a warning when used).Also note that instructing the sandbox to load 
a scenario will have the side effect of loading _all_ the .dar files provided e
agerly (see --eager-package-loading).
  --pem <value>            TLS: The pem file to be used as the private key.
  --crt <value>            TLS: The crt file to be used as the cert chain. Requ
ired if any other TLS parameters are set.
  --cacrt <value>          TLS: The crt file to be used as the the trusted root
 CA.
  --maxInboundMessageSize <value>
                           Max inbound message size in bytes. Defaults to 41943
04.
  --jdbcurl <value>        This flag is deprecated -- please use --sql-backend-
jdbcurl.
  --sql-backend-jdbcurl <value>
                           The JDBC connection URL to a Postgres database conta
ining the username and password as well. If present, the Sandbox will use the d
atabase to persist its data.
  --ledgerid <value>       Sandbox ledger ID. If missing, a random unique ledge
r ID will be used. Only useful with persistent stores.
  --log-level <value>      Default logging level to use. Available values are I
NFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO.
  --eager-package-loading  Whether to load all the packages in the .dar files p
rovided eagerly, rather than when needed as the commands come.
  --max-ttl-seconds <value>
                           The maximum TTL allowed for commands in seconds
  --help                   Print the usage text
$
```
vs the current release:
```
$ daml sandbox --help
Sandbox version 100.13.32
Usage: sandbox [options] [<archive>...]

  -p, --port <value>       Sandbox service port. Defaults to 6865.
  --port-file <value>      File to write the allocated port number to. Used to
inform clients in CI about the allocated port.
  -a, --address <value>    Sandbox service host. Defaults to binding on all add
resses.
  --dalf                   This argument is present for backwards compatibility
. DALF and DAR archives are now identified by their extensions.
  -s, --static-time        Use static time, configured with TimeService through
 gRPC.
  -w, --wall-clock-time    Use wall clock time (UTC). When not provided, static
 time is used.
  --no-parity              Legacy flag with no effect.
  --scenario <value>       If set, the sandbox will execute the given scenario 
on startup and store all the contracts created by it. Note that when using --po
stgres-backend the scenario will be ran only if starting from a fresh database,
 _not_ when resuming from an existing one. Two identifier formats are supported
: Module.Name:Entity.Name (preferred) and Module.Name.Entity.Name (deprecated, 
will print a warning when used).Also note that instructing the sandbox to load 
a scenario will have the side effect of loading _all_ the .dar files provided e
agerly (see --eager-package-loading).
  <archive>...             DAML archives to load in .dar format. Only DAML-LF v
1 Archives are currently supported.
  --pem <value>            TLS: The pem file to be used as the private key.
  --crt <value>            TLS: The crt file to be used as the cert chain. Requ
ired if any other TLS parameters are set.
  --cacrt <value>          TLS: The crt file to be used as the the trusted root
 CA.
  --maxInboundMessageSize <value>
                           Max inbound message size in bytes. Defaults to 41943
04.
  --jdbcurl <value>        This flag is deprecated -- please use --sql-backend-
jdbcurl.
  --sql-backend-jdbcurl <value>
                           The JDBC connection URL to a Postgres database conta
ining the username and password as well. If present, the Sandbox will use the d
atabase to persist its data.
  --ledgerid <value>       Sandbox ledger ID. If missing, a random unique ledge
r ID will be used. Only useful with persistent stores.
  --log-level <value>      Default logging level to use. Available values are I
NFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO.
  --eager-package-loading  Whether to load all the packages in the .dar files p
rovided eagerly, rather than when needed as the commands come.
  --max-ttl-seconds <value>
                           The maximum TTL allowed for commands in seconds
  --help                   Print the usage text
$
```

~Secondly, it adds a way to specify archives within the options, rather than after them, as either `-d` (for DAR) or `--archive` (to keep consistent with the current naming of `<archive>`). This is useful in scripting scenarios where the CLI invocation is built up programmatically and it may not always be convenient to put the archive files last. The motivational use-case was building a Docker container that will always want to load the same DAR file (as it is contained within the Docker container itself) but will need to receive the `sql-backend-jdbcurl` option dynamically.~

Secondly, it adds a sentence to the output of `--help` to notify users that DAR archives can be passed it at any point, and do not have to be all at the end.