### PR TITLE
use explicit imports when importing external code

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -41,7 +41,7 @@ import qualified Network.HTTP.Types as HTTP.Types
 import qualified Network.URI as URI
 
 import Development.IDE.Import.DependencyInformation
-import Development.IDE.Core.Rules hiding (mainRule)
+import Development.IDE.Core.Rules (useE,usesE,useNoFileE,priorityGenerateCore,generateCore,toIdeResult,defineNoFile,priorityFilesOfInterest,fileFromParsedModule,getAtPoint,getDefinition,getDependencies)
 import qualified Development.IDE.Core.Rules as IDE
 import Development.IDE.Core.Service.Daml
 import Development.IDE.Core.Shake

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -70,11 +70,11 @@ import "ghc-lib-parser" DynFlags
 import GHC.Conc
 import "ghc-lib-parser" Module
 import qualified Network.Socket as NS
-import Options.Applicative.Extended
+import Options.Applicative.Extended (Mod,CommandFields,Parser,ParserInfo,command,info,helper,progDesc,fullDesc,optional,long,strOption,metavar,flag',help,many,switch,option,auto,subparser,internal,headerDoc,(<|>),handleParseResult)
 import qualified Proto3.Suite as PS
 import qualified Proto3.Suite.JSONPB as Proto.JSONPB
 import System.Directory.Extra
-import System.Environment
+import System.Environment (getArgs,withProgName)
 import System.Exit
 import System.FilePath
 import System.IO.Extra


### PR DESCRIPTION
Be explicit when importing from external code.
- I would prefer to be explicit *always*, so every module is self contained.
- But not everyone agrees!
- However, for imports to external code, the case for being explicit is the strongest.
- These changes are to places which actually caused difficultly for me when reading the code. And once I had gone to the effort of discovering where this stuff comes from, it seems a shame to throw this information away.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
