### PR TITLE
Document how to override the SDK version without modifying daml.yaml

### DIFF
--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -110,6 +110,8 @@ Here is what each field means:
 - ``sdk-version``: the SDK version that this project uses.
 
    The assistant automatically downloads and installs this version if needed (see the ``auto-install`` setting in the global config). We recommend keeping this up to date with the latest stable release of the SDK.
+   It is possible to override the version without modifying the ``daml.yaml`` file by setting the ``DAML_SDK_VERSION`` environment variable. This is mainly useful when you are working with an
+   external project that you want to build with a specific version.
 
    The assistant will warn you when it is time to update this setting (see the ``update-check`` setting in the global config  to control how often it checks, or to disable this check entirely).
 - ``name``: the name of the project. This determines the filename of the ``.dar`` file compiled by ``daml build``.


### PR DESCRIPTION
This has come up in some discussions around packaging where people
want to clone a repo and build it with the same SDK version that is
used in their own project so they can depend on it. While it’s
possible to `sed` the `daml.yaml`, setting the env var seems like a
nicer solution.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
