### PR TITLE
language: dont hide modules without aliases

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -63,7 +63,7 @@ toCompileOpts options@Options{..} reportProgress =
       , optDefer = Ghcide.IdeDefer False
       }
   where
-    toRenaming aliases = ModRenaming False [(GHC.mkModuleName mod, GHC.mkModuleName alias) | (mod, alias) <- aliases]
+    toRenaming aliases = ModRenaming True [(GHC.mkModuleName mod, GHC.mkModuleName alias) | (mod, alias) <- aliases]
     locateInPkgDb :: String -> PackageConfig -> GHC.Module -> IO (Maybe FilePath)
     locateInPkgDb ext pkgConfig mod
       | (importDir : _) <- importDirs pkgConfig = do

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -177,7 +177,7 @@ packagingTests = testGroup "packaging"
         writeFileUTF8 (projectB </> "daml" </> "B.daml") $ unlines
             [ "daml 1.2"
             , "module B where"
-            , "import A"
+            , "import C"
             , "import Foo.Bar.Baz"
             , "b : ()"
             , "b = a"
@@ -194,7 +194,11 @@ packagingTests = testGroup "packaging"
             , "  - daml-prim"
             , "  - daml-stdlib"
             , "  - " <> aDar
+            , "build-options:"
+            , "- '--package=(\"a-1.0\", [(\"A\", \"C\")])'"
             ]
+            -- the last option checks that module aliases work and modules imported without aliases
+            -- are still exposed.
         withCurrentDirectory projectB $ callCommandQuiet "daml build"
         assertBool "b.dar was not created." =<< doesFileExist bDar
     , testCaseSteps "Dependency on a package with source: A.daml" $ \step -> withTempDir $ \tmpDir -> do


### PR DESCRIPTION
Currently we hide modules, for which we don't define an alias, when we
specify one alias for a module. With this change, all modules without
aliases are still exposed.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
