### PR TITLE
Limit Bazel build parallelism on Windows to physical cores

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -82,6 +82,11 @@ build:windows --noremote_accept_cached
 # problem on CI if all builds share a similar directory structure.
 build:windows-ci --remote_accept_cached=true
 
+# The Windows CI machines have 4 physical and 8 logical cores. By default Bazel
+# will parallelize up to the number of logical cores. This can cause flakyness
+# in timing sensitive tests.
+build:windows-ci --jobs=4
+
 # Instruct bazel to globally use this flag for compiling protobuf files.
 # We need the source info for generating proto docs. By default proto_library strips
 # source information and doesn't provide an option to turn this flag on.


### PR DESCRIPTION
A few timing sensitive test-cases have been flaky on Windows. Experiments on [this PR](https://github.com/digital-asset/daml/pull/3249) indicate that it may be related to too many tasks running in parallel. This limits the build/test parallelism to the number of physical cores on Windows CI machines. The default is to use all logical cores.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
