### PR TITLE
language: cross sdk dalf/dar imports

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -231,6 +231,7 @@ da_haskell_repl(
     visibility = ["//visibility:public"],
     deps = [
         ":damlc",
+        "//compiler/damlc/tests:generate-simple-dalf",
         "//daml-assistant:daml",
         "//daml-assistant/daml-helper",
         "//daml-assistant/integration-tests",

--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -8,6 +8,7 @@ da_haskell_library(
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
         "base",
+        "bytestring",
         "containers",
         "deepseq",
         "Decimal",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -5,6 +5,7 @@
 
 module DA.Daml.LF.Ast.World(
     World,
+    DalfPackage(..),
     getWorldSelf,
     initWorld,
     initWorldSelf,
@@ -23,6 +24,7 @@ import DA.Pretty
 
 import Control.DeepSeq
 import Control.Lens
+import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HMS
 import Data.List
 import qualified Data.NameMap as NM
@@ -52,6 +54,14 @@ data ExternalPackage = ExternalPackage PackageId Package
     deriving (Show, Eq, Generic)
 
 instance NFData ExternalPackage
+
+data DalfPackage = DalfPackage
+    { dalfPackageId :: PackageId
+    , dalfPackagePkg :: ExternalPackage
+    , dalfPackageBytes :: BS.ByteString
+    } deriving (Show, Eq, Generic)
+
+instance NFData DalfPackage
 
 -- | Rewrite all `PRSelf` references to `PRImport` references.
 rewriteSelfReferences :: PackageId -> Package -> ExternalPackage

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -125,7 +125,7 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                  -- get all dalf dependencies.
                  dalfDependencies0 <- getDalfDependencies files
                  let dalfDependencies =
-                         [ (T.pack $ unitIdString unitId, dalfPackageBytes pkg)
+                         [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0
                          ]
                  let dataFiles = [mkConfFile pkgConf pkgModuleNames (T.unpack pkgId)]

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -108,6 +108,7 @@ generateTemplateInstancesPkgFromLf getUnitId pkgId pkg =
         ]
 
 -- | Generate a module containing template/generic instances for all the contained templates.
+-- Return Nothing if there are no instances, so no unnecessary modules are created.
 generateTemplateInstanceModule ::
        Env -> LF.PackageId -> Maybe (NormalizedFilePath, String)
 generateTemplateInstanceModule env externPkgId

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -141,8 +141,9 @@ generateTemplateInstanceModule env externPkgId
 templateInstances :: Env -> LF.PackageId -> [HsDecl GhcPs]
 templateInstances env externPkgId =
     [ generateTemplateInstance env dataTypeCon dataParams externPkgId
-    | LF.DefDataType {..} <- NM.toList $ LF.moduleDataTypes mod
-    , dataTypeCon `elem` (NM.names $ LF.moduleTemplates mod)
+    | dataTypeCon <- NM.names $ LF.moduleTemplates mod
+    , Just (LF.DefDataType {..}) <-
+          [NM.lookup dataTypeCon (LF.moduleDataTypes mod)]
     ]
   where
     mod = envMod env

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -7,7 +7,7 @@ module DA.Daml.Compiler.Upgrade
     , generateTemplateInstance
     , generateSrcFromLf
     , generateSrcPkgFromLf
-    , generateInstancesPkgFromLf
+    , generateTemplateInstancesPkgFromLf
     , generateGenInstancesPkgFromLf
     , Env(..)
     , DiffSdkVers(..)
@@ -90,14 +90,14 @@ upgradeTemplates n =
 -- package. It _only_ contains the instance stubs. The correct implementation happens in the
 -- conversion to daml-lf, where `extenal` calls are inlined to daml-lf contained in the dalf of the
 -- external package.
-generateInstancesPkgFromLf ::
+generateTemplateInstancesPkgFromLf ::
        (LF.PackageRef -> UnitId)
     -> LF.PackageId
     -> LF.Package
     -> [(NormalizedFilePath, String)]
-generateInstancesPkgFromLf getUnitId pkgId pkg =
+generateTemplateInstancesPkgFromLf getUnitId pkgId pkg =
     catMaybes
-        [ generateInstanceModule
+        [ generateTemplateInstanceModule
             Env
                 { envGetUnitId = getUnitId
                 , envQualify = False
@@ -108,9 +108,9 @@ generateInstancesPkgFromLf getUnitId pkgId pkg =
         ]
 
 -- | Generate a module containing template/generic instances for all the contained templates.
-generateInstanceModule ::
+generateTemplateInstanceModule ::
        Env -> LF.PackageId -> Maybe (NormalizedFilePath, String)
-generateInstanceModule env externPkgId
+generateTemplateInstanceModule env externPkgId
     | not $ null instances =
         Just
             ( toNormalizedFilePath modFilePath

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -142,7 +142,7 @@ templateInstances :: Env -> LF.PackageId -> [HsDecl GhcPs]
 templateInstances env externPkgId =
     [ generateTemplateInstance env dataTypeCon dataParams externPkgId
     | dataTypeCon <- NM.names $ LF.moduleTemplates mod
-    , Just (LF.DefDataType {..}) <-
+    , Just LF.DefDataType {..} <-
           [NM.lookup dataTypeCon (LF.moduleDataTypes mod)]
     ]
   where

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -87,7 +87,9 @@ upgradeTemplates n =
     ]
 
 -- | Generate the source for a package containing template instances for all templates defined in a
--- package.
+-- package. It _only_ contains the instance stubs. The correct implementation happens in the
+-- conversion to daml-lf, where `extenal` calls are inlined to daml-lf contained in the dalf of the
+-- external package.
 generateInstancesPkgFromLf ::
        (LF.PackageRef -> UnitId)
     -> LF.PackageId

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -53,15 +53,8 @@ type instance RuleResult GeneratePackage = WhnfPackage
 type instance RuleResult GenerateRawPackage = WhnfPackage
 type instance RuleResult GeneratePackageDeps = WhnfPackage
 
-data DalfPackage = DalfPackage
-    { dalfPackageId :: LF.PackageId
-    , dalfPackagePkg :: LF.ExternalPackage
-    , dalfPackageBytes :: BS.ByteString
-    } deriving (Show, Eq, Generic)
 
-instance NFData DalfPackage
-
-type instance RuleResult GeneratePackageMap = Map UnitId DalfPackage
+type instance RuleResult GeneratePackageMap = Map UnitId LF.DalfPackage
 
 -- | Runs all scenarios in the given file (but not scenarios in imports).
 type instance RuleResult RunScenarios = [(VirtualResource, Either SS.Error SS.ScenarioResult)]

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/Visualize.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/Visualize.hs
@@ -39,7 +39,7 @@ onCommand ide execParsms = case execParsms of
                     WhnfPackage package <- runAction ide (use_ GeneratePackage mod)
                     pkgMap <- runAction ide (useNoFile_ GeneratePackageMap)
                     let modules = NM.toList $ LF.packageModules package
-                    let extpkgs = map dalfPackagePkg $ Map.elems pkgMap
+                    let extpkgs = map LF.dalfPackagePkg $ Map.elems pkgMap
                     let wrld = LF.initWorldSelf extpkgs package
                     let dots = T.pack $ Visual.dotFileGen modules wrld
                     return $ Aeson.String dots

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1586,7 +1586,10 @@ convertExternal env stdlibRef primId lfType
                 "archive" ->
                     let archiveChoice = ChoiceName "Archive"
                      in case NM.lookup archiveChoice tplChoices of
-                            Nothing -> errorExpr "archive"
+                            Nothing ->
+                              EBuiltin BEError `ETyApp` lfType `ETmApp`
+                              EBuiltin
+                                  (BEText $ "convertExternal: archive is not implemented in external package")
                             Just TemplateChoice {..} ->
                                 case chcArgBinder of
                                     (_, LF.TCon tcon) ->
@@ -1673,10 +1676,6 @@ convertExternal env stdlibRef primId lfType
                 other -> error "convertExternal: Unknown external method"
     | otherwise = error $ "convertExternal: Unable to inline call to external method: " <> primId
   where
-    errorExpr s =
-        EBuiltin BEError `ETyApp` lfType `ETmApp`
-        EBuiltin
-            (BEText $ "convertExternal: method " <> s <> " not implemented")
     lookup pId modName temName = do
         mods <- MS.lookup pId pkgIdToModules
         mod <- NM.lookup (LF.ModuleName $ map T.pack $ splitOn "." modName) mods

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -221,8 +221,6 @@ convertPrim _ "BEToTextNumeric" (TNumeric n :-> TText) =
     ETyApp (EBuiltin BEToTextNumeric) n
 convertPrim _ "BENumericFromText" (TText :-> TOptional (TNumeric n)) =
     ETyApp (EBuiltin BENumericFromText) n
-
-
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty
 
 -- | Some builtins are only supported in specific versions of DAML-LF.

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -22,7 +22,7 @@ module GHC.Types (
         Text, Decimal,
         Opaque,
         ifThenElse,
-        primitive, magic,
+        primitive, magic, external
         DamlEnum,
 
 #ifdef DAML_NUMERIC
@@ -136,6 +136,10 @@ data TyCon = TyCon Word# Word#           -- Fingerprint
                    Int#                  -- How many kind variables do we accept?
                    KindRep               -- A representation of the type's kind
 
+
+-- | HIDE A DAML-LF call to an external package
+external : forall (f : Symbol) b. b
+external = external --deleted by the compiler
 
 -- | HIDE A DAML-LF primitive
 primitive : forall (f : Symbol) b. b

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -22,7 +22,7 @@ module GHC.Types (
         Text, Decimal,
         Opaque,
         ifThenElse,
-        primitive, magic, external
+        primitive, magic, external,
         DamlEnum,
 
 #ifdef DAML_NUMERIC

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -564,7 +564,7 @@ createProjectPackageDb opts fps = do
                           let getUid = getUnitId unitId pkgMap
                           let src = generateSrcPkgFromLf getUid pkgId dalf
                           let templInstSrc =
-                                  generateInstancesPkgFromLf
+                                  generateTemplateInstancesPkgFromLf
                                       getUid
                                       pkgId
                                       dalf


### PR DESCRIPTION
The final piece for cross sdk imports. With this PR we can import the
data types of packages and dalfs that were created with different sdks.

This is done by generating interface files from dalfs and an 'instances'
package that contains the template instance definitions of template data
types. The instances itself are defined via the `external` keyword,
which is inlined to proper daml-lf instance definitions given in the
respective dalf package.

We test that cross sdk imports work by importing the `simple-dalf` in
the daml-assistant integation tests and running a scenario.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
