### PR TITLE
Remove git-revision from dependency graph

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,12 +61,6 @@ build --action_env=GIT_SSL_CAINFO
 build:linux --action_env=LOCALE_ARCHIVE
 build:windows --action_env=JAVA_HOME
 
-
-# Pass workspace status for stamped actions
-build:linux --workspace_status_command=bazel_tools/workspace_status.sh
-build:darwin --workspace_status_command=bazel_tools/workspace_status.sh
-build:windows --workspace_status_command=bazel_tools/workspace_status.cmd
-
 # Tell bazel to use the nixpkgs Haskell toolchain on Linux and Darwin
 build:linux --host_platform=@rules_haskell//haskell/platforms:linux_x86_64_nixpkgs
 build:darwin --host_platform=@rules_haskell//haskell/platforms:darwin_x86_64_nixpkgs

--- a/BUILD
+++ b/BUILD
@@ -156,15 +156,6 @@ da_haskell_library(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "git-revision",
-    outs = [".git-revision"],
-    cmd = """
-        grep '^STABLE_GIT_REVISION ' bazel-out/stable-status.txt | cut -d ' ' -f 2 > $@
-    """,
-    stamp = True,
-)
-
 #
 # Common aliases
 #

--- a/bazel_tools/workspace_status.cmd
+++ b/bazel_tools/workspace_status.cmd
@@ -1,7 +1,0 @@
-:: Copyright (c) 2019 The DAML Authors. All rights reserved.
-:: SPDX-License-Identifier: Apache-2.0
-
-@echo off
-
-for /f %%i in ('git rev-parse HEAD') do set RESULT=%%i
-echo STABLE_GIT_REVISION %RESULT%

--- a/bazel_tools/workspace_status.sh
+++ b/bazel_tools/workspace_status.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Copyright (c) 2019 The DAML Authors. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-
-echo "STABLE_GIT_REVISION $(git rev-parse HEAD)"

--- a/navigator/README.md
+++ b/navigator/README.md
@@ -58,10 +58,10 @@ Note: Browsers are instructed never to cache `index.html`, and indefinitely cach
 Scala binary, compiled as a fat JAR.
 Code from `backend/src/**/*.scala`, bundled frontend code is copied to `backend/src/main/resources/frontend`.
 
-### backend commit and version
+### backend version
 
-The commit and version are included as resource files in the Navigator fat jar.
-This is to reduce rebuild times when the git commit changes.
+The version is included as resource files in the Navigator fat jar.
+This is to reduce rebuild times when the version changes.
 
 ### frontend development build
 
@@ -72,3 +72,6 @@ For developing frontend code, `webpack-dev-server` is used. This serves the curr
 - Forward network requests to a different port, where a Navigator backend is expected to run.
 
 This is orders of magnitude faster than what the current Bazel build offers, so it is desirable to keep the `webpack-dev-server` setup working. 
+
+Note, the browser is instructed to cache assets based on the SDK version.
+During development this is too aggressive and you will need to manually refresh to see updates to the front-end.

--- a/navigator/backend/BUILD.bazel
+++ b/navigator/backend/BUILD.bazel
@@ -37,33 +37,6 @@ java_library(
     ],
 )
 
-# Revision file, as a top level resources.
-java_library(
-    name = "revision-resource",
-    resources = [
-        "//:git-revision",
-    ],
-)
-
-# Fake git revision, using SHA-1 of the empty string
-# Used in tests, to make sure we don't rerun tests on every commit.
-genrule(
-    name = "test-revision",
-    srcs = [],
-    outs = [".git-revision"],
-    cmd = "echo \"da39a3ee5e6b4b0d3255bfef95601890afd80709\" > \"$@\"",
-)
-
-# Fake git revision file, as a top level resource.
-# Used in tests, to make sure we don't rerun tests on every commit.
-java_library(
-    name = "test-revision-resource",
-    resource_strip_prefix = "navigator/backend",
-    resources = [
-        ":test-revision",
-    ],
-)
-
 # Static backend resources.
 java_library(
     name = "backend-resources",
@@ -167,7 +140,6 @@ da_scala_binary(
         ":backend-resources",
         ":frontend-resources",
         ":navigator-library",
-        ":revision-resource",
         ":version-resource",
     ],
 )
@@ -190,6 +162,5 @@ da_scala_test_suite(
         ":navigator-tests-library",
         ":test-resources",
         ":version-resource",
-        ":test-revision-resource",
     ] + testDependencies,
 )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/ApplicationInfo.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/ApplicationInfo.scala
@@ -9,10 +9,9 @@ import spray.json.DefaultJsonProtocol
 case class ApplicationInfo(
     id: String,
     name: String,
-    version: String,
-    revision: String
+    version: String
 )
 
 trait ApplicationInfoJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  implicit val applicationInfoFormat = jsonFormat4(ApplicationInfo)
+  implicit val applicationInfoFormat = jsonFormat3(ApplicationInfo)
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/NavigatorBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/NavigatorBackend.scala
@@ -21,7 +21,6 @@ object NavigatorBackend extends UIBackend {
     id = s"Navigator-${UUID.randomUUID().toString}",
     name = "Navigator",
     version = Source.fromResource("COMPONENT-VERSION").mkString("").trim(),
-    revision = Source.fromResource(".git-revision").mkString("").trim()
   )
   override def banner: Option[String] =
     Some(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -108,9 +108,9 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
     // Users can quickly switch between Navigator versions, so we don't want to cache this resource for any amount of time.
     // Note: The server still uses E-Tags, so repeated fetches will complete with a "304: Not Modified".
     def mutableResource = respondWithHeader(`Cache-Control`(`no-cache`))
-    // Add an ETag with value equal to the revision used to build the application.
+    // Add an ETag with value equal to the version used to build the application.
     // Use as a cheap ETag for resources that may change between builds.
-    def revisionETag = conditional(EntityTag(applicationInfo.revision))
+    def versionETag = conditional(EntityTag(applicationInfo.version))
     // A resource that is never going to change. Its path must use some kind of content hash.
     // Such a resource may be cached indefinitely.
     def immutableResource =
@@ -181,7 +181,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
               } ~
               path("graphql") {
                 get {
-                  revisionETag { mutableResource { getFromResource("graphiql.html") } }
+                  versionETag { mutableResource { getFromResource("graphiql.html") } }
                 } ~
                   post {
                     authorize(session.isDefined) {
@@ -208,7 +208,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
               } ~
                 // Serve index on root and anything else to allow History API to behave
                 // as expected on reloading.
-                revisionETag {
+                versionETag {
                   mutableResource { withoutFileETag { getFromResource("frontend/index.html") } }
                 }
             case Some(folder) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Info.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Info.scala
@@ -133,6 +133,6 @@ case object Info extends SimpleCommand {
       .fromResource("banner.txt")
       .getLines
       .toList
-    banner.mkString("\n") + s"\nVersion ${state.applicationInfo.version} commit ${state.applicationInfo.revision}"
+    banner.mkString("\n") + s"\nVersion ${state.applicationInfo.version}"
   }
 }

--- a/navigator/frontend/src/applets/about/index.tsx
+++ b/navigator/frontend/src/applets/about/index.tsx
@@ -25,7 +25,6 @@ export interface BackendVersionInfo {
   id: string;
   name: string;
   version: string;
-  revision: string;
 }
 
 export type BackendVersionInfoResult
@@ -134,7 +133,6 @@ const BackendInfo: React.StatelessComponent<{info: BackendVersionInfoResult}>
     case 'loaded': return (
       <p>
         Version: {info.info.version} <br/>
-        Revision: {info.info.revision} <br/>
         Application ID: {info.info.id}
       </p>
     );


### PR DESCRIPTION
The navigator binary depended on the current git-revision. The issue is
that any target/test depending on the git-revision will have to be
rebuilt/rerun on every commit.

The navigator package itself was careful to avoid unnecessary
rebuilds/reruns. However, the SDK release tarball depends on the
navigator binary and thereby on the git-revision. The daml-assistant
integration tests, which depend on the SDK release tarball, therefore
had to be rerun on every commit.

This change removes the git-revision from the navigator alltogether. For
issue reporting the SDK version is still available.

Previously the revision was used as an ETag to control browser caching, this is now changed to use the SDK version. For development that is too coarse and manual reload will be required during development, the navigator README has been updated to mention this.

The git-revision target and workspace status scripts are no longer used anywhere and have been removed.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
