### PR TITLE
Add support for on-disk incremental builds in damlc build

### DIFF
--- a/3rdparty/haskell/BUILD.ghcide
+++ b/3rdparty/haskell/BUILD.ghcide
@@ -42,11 +42,8 @@ depends = [
 ] + ([] if is_windows else [hazel_library("unix")])
 
 hidden = [
-    "Development.IDE.Core.Compile",
     "Development.IDE.GHC.CPP",
-    "Development.IDE.GHC.Error",
     "Development.IDE.GHC.Orphans",
-    "Development.IDE.GHC.Warnings",
     "Development.IDE.Import.FindImports",
     "Development.IDE.LSP.CodeAction",
     "Development.IDE.LSP.Definition",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -685,7 +685,7 @@ hazel_custom_package_github(
     strip_prefix = "wai-app-static",
 )
 
-GHCIDE_REV = "0f25910d097c58c97033366b003561683d818a5e"
+GHCIDE_REV = "9fc894592db875dac3804e44c8f7c0ef74d45021"
 
 # We need a custom build file to depend on ghc-lib and ghc-lib-parser
 hazel_custom_package_github(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -685,7 +685,7 @@ hazel_custom_package_github(
     strip_prefix = "wai-app-static",
 )
 
-GHCIDE_REV = "9fc894592db875dac3804e44c8f7c0ef74d45021"
+GHCIDE_REV = "7a215d22ef22c447a050fbcc63900e9b5405e901"
 
 # We need a custom build file to depend on ghc-lib and ghc-lib-parser
 hazel_custom_package_github(

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -7,6 +7,7 @@
 
 module DA.Daml.LF.Proto3.DecodeV1
     ( decodePackage
+    , decodeScenarioModule
     , Error(..)
     ) where
 
@@ -170,6 +171,11 @@ decodePackage minorText (LF1.Package mods internedStringsV internedDottedNamesV)
   let env = DecodeEnv{..}
   runDecode env $ do
     Package version <$> decodeNM DuplicateModule decodeModule mods
+
+decodeScenarioModule :: TL.Text -> LF1.Package -> Either Error Module
+decodeScenarioModule minorText protoPkg = do
+    Package _ modules <- decodePackage minorText protoPkg
+    pure $ head $ NM.toList modules
 
 decodeModule :: LF1.Module -> Decode Module
 decodeModule (LF1.Module name flags dataTypes values templates) =

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -43,6 +43,7 @@ da_haskell_library(
         "transformers",
         "utf8-string",
         "vector",
+        "proto3-suite",
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -34,7 +34,10 @@ import qualified DA.Daml.LF.ScenarioServiceClient as SS
 
 import Language.Haskell.HLint4
 
+import HscTypes (ModIface, ModSummary)
+
 type instance RuleResult GenerateDalf = LF.Module
+type instance RuleResult GenerateSerializedDalf = ()
 type instance RuleResult GenerateRawDalf = LF.Module
 
 -- | A newtype wrapper for LF.Package that does not force the modules
@@ -82,11 +85,43 @@ type instance RuleResult GetScenarioRoot = NormalizedFilePath
 -- envOfInterestVar and envOpenVirtualResources.
 type instance RuleResult GetOpenVirtualResources = Set VirtualResource
 
+-- | This is used for on-disk incremental builds
+type instance RuleResult ReadSerializedDalf = LF.Module
+-- | Read the interface and the summary. This rule has a cutoff on the ABI hash of the interface.
+-- It is important to get the modsummary from this rule rather than depending on the parsed module.
+-- Otherwise you will always recompile module B if B depends on A and A changed even if A’s ABI stayed
+-- the same
+type instance RuleResult ReadInterface = (ModSummary, ModIface)
+
+instance Show ModIface where
+    show _ = "<ModIface>"
+
+instance NFData ModIface where
+    rnf = rwhnf
+
 data GenerateDalf = GenerateDalf
     deriving (Eq, Show, Typeable, Generic)
 instance Binary   GenerateDalf
 instance Hashable GenerateDalf
 instance NFData   GenerateDalf
+
+data GenerateSerializedDalf = GenerateSerializedDalf
+    deriving (Eq, Show, Typeable, Generic)
+instance Binary GenerateSerializedDalf
+instance Hashable GenerateSerializedDalf
+instance NFData GenerateSerializedDalf
+
+data ReadSerializedDalf = ReadSerializedDalf
+    deriving (Eq, Show, Typeable, Generic)
+instance Binary   ReadSerializedDalf
+instance Hashable ReadSerializedDalf
+instance NFData   ReadSerializedDalf
+
+data ReadInterface = ReadInterface
+    deriving (Eq, Show, Typeable, Generic)
+instance Binary   ReadInterface
+instance Hashable ReadInterface
+instance NFData   ReadInterface
 
 data GenerateRawDalf = GenerateRawDalf
     deriving (Eq, Show, Typeable, Generic)
@@ -140,16 +175,19 @@ data GetScenarioRoots = GetScenarioRoots
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetScenarioRoots
 instance NFData   GetScenarioRoots
+instance Binary   GetScenarioRoots
 
 data GetScenarioRoot = GetScenarioRoot
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetScenarioRoot
 instance NFData   GetScenarioRoot
+instance Binary   GetScenarioRoot
 
 data GetOpenVirtualResources = GetOpenVirtualResources
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetOpenVirtualResources
 instance NFData   GetOpenVirtualResources
+instance Binary   GetOpenVirtualResources
 
 data GetDlintSettings = GetDlintSettings
     deriving (Eq, Show, Typeable, Generic)
@@ -158,6 +196,7 @@ instance NFData   GetDlintSettings
 instance NFData Hint where rnf = rwhnf
 instance NFData Classify where rnf = rwhnf
 instance Show Hint where show = const "<hint>"
+instance Binary GetDlintSettings
 
 type instance RuleResult GetDlintSettings = ([Classify], Hint)
 
@@ -165,6 +204,7 @@ data GetDlintDiagnostics = GetDlintDiagnostics
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetDlintDiagnostics
 instance NFData   GetDlintDiagnostics
+instance Binary   GetDlintDiagnostics
 
 type instance RuleResult GetDlintDiagnostics = ()
 
@@ -172,6 +212,7 @@ data GenerateDocTestModule = GenerateDocTestModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GenerateDocTestModule
 instance NFData   GenerateDocTestModule
+instance Binary   GenerateDocTestModule
 
 -- | File path of the generated module
 type instance RuleResult GenerateDocTestModule = GeneratedModule
@@ -183,3 +224,4 @@ data OfInterest = OfInterest
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable OfInterest
 instance NFData   OfInterest
+instance Binary   OfInterest

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -876,7 +876,7 @@ discardInternalModules files =
     pure $ filter (\f -> not $ any (\internalMod -> internalMod `isSuffixOf` fromNormalizedFilePath f) internalModules) files
 
 internalModules :: [FilePath]
-internalModules = map normalise $
+internalModules = map normalise
   [ "Data/String.daml"
   , "GHC/CString.daml"
   , "GHC/Integer/Type.daml"

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -876,7 +876,7 @@ discardInternalModules files =
     pure $ filter (\f -> not $ any (\internalMod -> internalMod `isSuffixOf` fromNormalizedFilePath f) internalModules) files
 
 internalModules :: [FilePath]
-internalModules =
+internalModules = map normalise $
   [ "Data/String.daml"
   , "GHC/CString.daml"
   , "GHC/Integer/Type.daml"

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -33,7 +33,7 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
           logInfo (ideLogger ide) $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)
-          mbModMapping <- runAction ide (useWithStale GenerateDalf filePath)
+          mbModMapping <- runAction ide (useWithStale GenerateRawDalf filePath)
           case mbModMapping of
               Nothing -> pure []
               Just (mod, mapping) ->

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -7,6 +7,7 @@ module DA.Daml.Options.Types
     , SkipScenarioValidation(..)
     , DlintUsage(..)
     , Haddock(..)
+    , IncrementalBuild(..)
     , defaultOptionsIO
     , defaultOptions
     , mkOptions
@@ -76,7 +77,12 @@ data Options = Options
   , optGhcVersionFile :: Maybe FilePath
     -- ^ Path to "ghcversion.h". Needed for running CPP. We ship this
     -- as part of our runfiles. This is set by 'mkOptions'.
+  , optIncrementalBuild :: IncrementalBuild
+  -- ^ Whether to do an incremental on-disk build as opposed to keeping everything in memory.
   } deriving Show
+
+newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
+  deriving Show
 
 newtype Haddock = Haddock Bool
   deriving Show
@@ -169,6 +175,7 @@ defaultOptions mbVersion =
         , optHaddock = Haddock False
         , optCppPath = Nothing
         , optGhcVersionFile = Nothing
+        , optIncrementalBuild = IncrementalBuild False
         }
 
 getBaseDir :: IO FilePath

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -56,6 +56,7 @@ toCompileOpts options@Options{..} reportProgress =
           }
       , optExtensions = ["daml"]
       , optThreads = optThreads
+      , optShakeFiles = if getIncrementalBuild optIncrementalBuild then Just ".daml/build/shake" else Nothing
       , optShakeProfiling = optShakeProfiling
       , optReportProgress = reportProgress
       , optLanguageSyntax = "daml"

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -417,6 +417,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure (Haddock False)
     <*> optCppPath
     <*> pure Nothing
+    <*> pure (IncrementalBuild False)
   where
     optImportPath :: Parser [FilePath]
     optImportPath =
@@ -516,3 +517,6 @@ shakeProfilingOpt = optional $ strOption $
        metavar "PROFILING-REPORT"
     <> help "Directory for Shake profiling reports"
     <> long "shake-profiling"
+
+incrementalBuildOpt :: Parser IncrementalBuild
+incrementalBuildOpt = IncrementalBuild <$> flagYesNoAuto "incremental" False "Enable incremental builds" idm

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -195,6 +195,30 @@ da_haskell_test(
     visibility = ["//visibility:public"],
 )
 
+# Tests for incremental builds
+da_haskell_test(
+    name = "incremental",
+    srcs = ["src/DA/Test/IncrementalBuilds.hs"],
+    data = [
+        "//compiler/damlc",
+        "//daml-lf/repl",
+    ],
+    hackage_deps = [
+        "base",
+        "containers",
+        "directory",
+        "extra",
+        "filepath",
+        "process",
+        "tasty",
+        "tasty-hunit",
+    ],
+    main_function = "DA.Test.IncrementalBuilds.main",
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = ["//libs-haskell/bazel-runfiles"],
+)
+
 # Memory tests
 
 da_haskell_binary(

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -1,0 +1,159 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Test.IncrementalBuilds (main) where
+
+import Control.Monad.Extra
+import DA.Bazel.Runfiles
+import Data.Foldable
+import qualified Data.Set as Set
+import Data.Traversable
+import System.Directory.Extra
+import System.Exit
+import System.FilePath
+import System.IO.Extra
+import System.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = do
+    damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
+    repl <- locateRunfiles (mainWorkspace </> "daml-lf" </> "repl" </> "repl")
+    defaultMain $ tests damlc repl
+
+tests :: FilePath -> FilePath -> TestTree
+tests damlc repl = testGroup "Incremental builds"
+    [ test "No changes"
+        [ ("daml/A.daml", unlines
+           [ "daml 1.2"
+           , "module A where"
+           ]
+          )
+        ]
+        []
+        []
+        (ShouldSucceed True)
+    , test "Modify single file"
+        [ ("daml/A.daml", unlines
+           [ "daml 1.2"
+           , "module A where"
+           , "test = scenario $ assert True"
+           ]
+          )
+        ]
+        [ ("daml/A.daml", unlines
+           [ "daml 1.2"
+           , "module A where"
+           , "test = scenario $ assert False"
+           ]
+          )
+        ]
+        ["daml/A.daml"]
+        (ShouldSucceed False)
+    , test "Modify dependency without ABI change"
+        [ ("daml/A.daml", unlines
+           [ "daml 1.2"
+           , "module A where"
+           , "import B"
+           , "test = scenario $ b"
+           ]
+          )
+        , ("daml/B.daml", unlines
+           [ "daml 1.2"
+           , "module B where"
+           , "b = scenario $ assert True"
+           ]
+          )
+        ]
+        [ ("daml/B.daml", unlines
+           [ "daml 1.2"
+           , "module B where"
+           , "b = scenario $ assert False"
+           ]
+          )
+        ]
+        ["daml/B.daml"]
+        (ShouldSucceed False)
+    , test "Modify dependency with ABI change"
+        [ ("daml/A.daml", unlines
+           [ "daml 1.2"
+           , "module A where"
+           , "import B"
+           , "test = scenario $ do _ <- b; pure ()"
+           ]
+          )
+        , ("daml/B.daml", unlines
+           [ "daml 1.2"
+           , "module B where"
+           , "b : Scenario Bool"
+           , "b = pure True"
+           ]
+          )
+        ]
+        [ ("daml/B.daml", unlines
+           [ "daml 1.2"
+           , "module B where"
+           , "b : Scenario ()"
+           , "b = assert False"
+           ]
+          )
+        ]
+        ["daml/A.daml", "daml/B.daml"]
+        (ShouldSucceed False)
+    ]
+  where
+      -- ShouldSucceed indicates if scenarios should still succeed after modifications.
+      -- This is useful to make sure that modifications have propagated correctly into the DAR.
+      test :: String -> [(FilePath, String)] -> [(FilePath, String)] -> [FilePath] -> ShouldSucceed -> TestTree
+      test name initial modification expectedRebuilds shouldSucceed = testCase name $ withTempDir $ \dir -> do
+          writeFileUTF8 (dir </> "daml.yaml") $ unlines
+            [ "sdk-version: 0.0.0"
+            , "name: test-project"
+            , "source: daml"
+            , "version: 0.0.1"
+            , "dependencies: [daml-prim, daml-stdlib]"
+            ]
+          for_ initial $ \(file, content) -> do
+              createDirectoryIfMissing True (takeDirectory $ dir </> file)
+              writeFileUTF8 (dir </> file) content
+          let dar = dir </> "out.dar"
+          callProcessSilent (ShouldSucceed True) damlc ["build", "--project-root", dir, "-o", dar, "--incremental=yes"]
+          callProcessSilent (ShouldSucceed True) repl ["testAll", dar]
+          dalfFiles <- getDalfFiles $ dir </> ".daml/build"
+          dalfModTimes <- for dalfFiles $ \f -> do
+              modTime <- getModificationTime f
+              pure (f, modTime)
+          for_ modification $ \(file, content) -> do
+              createDirectoryIfMissing True (takeDirectory $ dir </> file)
+              writeFileUTF8 (dir </> file) content
+          callProcessSilent (ShouldSucceed True) damlc ["build", "--project-root", dir, "-o", dar, "--incremental=yes"]
+          rebuilds <- forMaybeM dalfModTimes $ \(f, oldModTime) -> do
+              newModTime <- getModificationTime f
+              pure $ if newModTime == oldModTime
+                  then Nothing
+                  else Just (makeRelative (dir </> ".daml/build") f -<.> ".daml")
+          assertEqual "Expected rebuilds" (Set.fromList $ map normalise expectedRebuilds) (Set.fromList $ map normalise rebuilds)
+          callProcessSilent (ShouldSucceed True) repl ["validate", dar]
+          callProcessSilent shouldSucceed repl ["testAll", dar]
+          pure ()
+
+getDalfFiles :: FilePath -> IO [FilePath]
+getDalfFiles dir = do
+    files <- listFilesRecursive dir
+    pure $ filter (\f -> takeExtension f == ".dalf") files
+
+newtype ShouldSucceed = ShouldSucceed Bool
+
+-- | Only displays stdout and stderr on errors
+callProcessSilent :: ShouldSucceed -> FilePath -> [String] -> IO ()
+callProcessSilent (ShouldSucceed shouldSucceed) cmd args = do
+    (exitCode, out, err) <- readProcessWithExitCode cmd args ""
+    unless (shouldSucceed == (exitCode == ExitSuccess)) $ do
+      hPutStrLn stderr $ "Failure: Command \"" <> cmd <> " " <> unwords args <> "\" exited with " <> show exitCode
+      hPutStrLn stderr $ unlines ["stdout:", out]
+      hPutStrLn stderr $ unlines ["stderr: ", err]
+      exitFailure
+
+forMaybeM :: Monad m => [a] -> (a -> m (Maybe b)) -> m [b]
+forMaybeM = flip mapMaybeM

--- a/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
+++ b/compiler/damlc/tests/src/DA/Test/IncrementalBuilds.hs
@@ -19,7 +19,7 @@ import Test.Tasty.HUnit
 main :: IO ()
 main = do
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
-    repl <- locateRunfiles (mainWorkspace </> "daml-lf" </> "repl" </> "repl")
+    repl <- locateRunfiles (mainWorkspace </> "daml-lf" </> "repl" </> exe "repl")
     defaultMain $ tests damlc repl
 
 tests :: FilePath -> FilePath -> TestTree

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -15,3 +15,6 @@ HEAD — ongoing
    * Allow a ledger api server to share the DAML engine with the DAML-on-X participant node for performance. See `issue #2975 <https://github.com/digital-asset/daml/issues/2975>`__.
    * Allow non-alphanumeric characters in ledger api server participant ids (space, colon, hash, slash, dot).
    * Include SQL statement type in ledger api server logging of SQL errors.
+- [DAML Compiler] Support for incremental builds in ``daml build`` using the ``--incremental=yes`` flag.
+  This is still experimental and disabled by default but will become enabled by default in the future.
+  On large codebases, this can significantly improve compile times and reduce memory usage.


### PR DESCRIPTION
This is a first version of incremental builds in DAML. On a large codebase I’m able to gain more than a 2x improvement and a reduction in memory usage on incremental builds measured for the whole runtime of `daml build`. Just measuring compilation leads to significantly larger speedups suggesting that we can probably improve this even further by speeding up the DAR creation.

This depends on https://github.com/digital-asset/ghcide/pull/189

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
