### PR TITLE
Reduce useless dependency on GenerateDalf

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -132,9 +132,6 @@ getRawDalf absFile = fmap getWhnfPackage <$> use GenerateRawPackage absFile
 getDalf :: NormalizedFilePath -> Action (Maybe LF.Package)
 getDalf file = fmap getWhnfPackage <$> use GeneratePackage file
 
-getDalfModule :: NormalizedFilePath -> Action (Maybe LF.Module)
-getDalfModule file = use GenerateDalf file
-
 -- | A dependency on a compiled library.
 data DalfDependency = DalfDependency
   { ddName         :: !T.Text

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -33,7 +33,7 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath -> filePath) -> do
           logInfo (ideLogger ide) $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)
-          mbModMapping <- runAction ide (useWithStale GenerateDalf filePath)
+          mbModMapping <- runAction ide (useWithStale GenerateRawDalf filePath)
           case mbModMapping of
               Nothing -> pure []
               Just (mod, mapping) ->


### PR DESCRIPTION
We don’t gain anything by making codelenses depend on GenerateDalf and
getDalfModule is simply unused.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
