### PR TITLE
Fix to support Archive choice with proper choice record ID lookup

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -100,8 +100,10 @@ object HttpService extends StrictLogging {
 
       commandService = new CommandService(
         packageService.resolveTemplateId,
+        packageService.resolveChoiceRecordId,
         LedgerClientJwt.submitAndWaitForTransaction(clientConfig, clientChannel),
-        TimeProvider.UTC)
+        TimeProvider.UTC
+      )
 
       contractsService = new ContractsService(
         packageService.resolveTemplateIds,
@@ -172,6 +174,7 @@ object HttpService extends StrictLogging {
     val encoder = new DomainJsonEncoder(apiRecordToJsObject, apiValueToJsValue)
     val decoder = new DomainJsonDecoder(
       packageService.resolveTemplateId,
+      packageService.resolveChoiceRecordId,
       jsObjectToApiRecord,
       jsValueToApiValue)
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
@@ -8,45 +8,36 @@ import java.time.Instant
 import com.digitalasset.api.util.TimestampConversion.fromInstant
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => lav1}
+import com.typesafe.scalalogging.StrictLogging
 
-object Commands {
+object Commands extends StrictLogging {
   def create(
       templateId: lar.TemplateId,
-      arguments: lav1.value.Record): lav1.commands.Command.Command.Create =
+      arguments: lav1.value.Record): lav1.commands.Command.Command.Create = {
+
     lav1.commands.Command.Command.Create(
       lav1.commands.CreateCommand(
         templateId = Some(lar.TemplateId.unwrap(templateId)),
         createArguments = Some(arguments)))
+  }
 
   def exercise(
       templateId: lar.TemplateId,
       contractId: lar.ContractId,
       choice: lar.Choice,
+      choiceRecordId: lav1.value.Identifier,
       arguments: lav1.value.Record): lav1.commands.Command.Command.Exercise = {
-
-    val choiceStr: String = lar.Choice.unwrap(choice)
-    val id: lav1.value.Identifier = lar.TemplateId.unwrap(templateId)
 
     lav1.commands.Command.Command.Exercise(
       lav1.commands.ExerciseCommand(
-        templateId = Some(id),
+        templateId = Some(lar.TemplateId.unwrap(templateId)),
         contractId = lar.ContractId.unwrap(contractId),
-        choice = choiceStr,
-        choiceArgument = Some(lav1.value.Value(
-          lav1.value.Value.Sum.Record(recordWithRecordId(arguments, id, choiceStr))))
+        choice = lar.Choice.unwrap(choice),
+        choiceArgument = Some(
+          lav1.value.Value(
+            lav1.value.Value.Sum.Record(arguments.copy(recordId = Some(choiceRecordId)))
+          ))
       ))
-  }
-
-  private def recordWithRecordId(
-      record: lav1.value.Record,
-      templateId: lav1.value.Identifier,
-      choice: String): lav1.value.Record = {
-
-    val recordId = lav1.value.Identifier(
-      packageId = templateId.packageId,
-      moduleName = templateId.moduleName,
-      entityName = choice)
-    record.copy(recordId = Some(recordId))
   }
 
   def submitAndWaitRequest(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/IdentifierConverters.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/IdentifierConverters.scala
@@ -33,18 +33,6 @@ object IdentifierConverters {
     )
   }
 
-  def lfIdentifier(
-      id: http.domain.TemplateId.RequiredPkg,
-      choice: lar.Choice): lf.data.Ref.Identifier = {
-    import lf.data.Ref
-    Ref.Identifier(
-      Ref.PackageId.assertFromString(id.packageId),
-      Ref.QualifiedName(
-        Ref.ModuleName.assertFromString(id.moduleName),
-        Ref.DottedName.assertFromString(lar.Choice.unwrap(choice)))
-    )
-  }
-
   def apiIdentifier(a: lf.data.Ref.Identifier): lav1.value.Identifier =
     lav1.value.Identifier(
       packageId = a.packageId,

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
@@ -123,7 +123,8 @@ class PackageServiceTest
             val templateIdStr: String = templateId.packageId.fold(
               domain.TemplateId((), templateId.moduleName, templateId.entityName).toString)(p =>
               domain.TemplateId(p, templateId.moduleName, templateId.entityName).toString)
-            e shouldBe PackageService.InputError(s"Cannot resolve $templateIdStr")
+            e shouldBe PackageService.InputError(
+              s"Cannot resolve template ID, given: $templateIdStr")
         }
     }
   }

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -18,3 +18,4 @@ HEAD — ongoing
 - [DAML Compiler] Support for incremental builds in ``daml build`` using the ``--incremental=yes`` flag.
   This is still experimental and disabled by default but will become enabled by default in the future.
   On large codebases, this can significantly improve compile times and reduce memory usage.
+- [JSON API - Experimental] Fix to support Archive choice. See issue #3219


### PR DESCRIPTION
Fixes: #3219

> ... Note that on the LF level we also don’t require the choice argument to have a record type.

The above has NOT been addressed, we are still assuming that choice arguments specified as a record. See: #3390.

Wider refactoring is required to support any LF type (`com.digitalasset.daml.lf.iface.Type`) for the choice argument.
```
final case class TemplateChoice[+Ty](param: Ty, consuming: Boolean, returnType: Ty)
```
where `Ty` is `com.digitalasset.daml.lf.iface.Type`

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
