### PR TITLE
Fix Navigator crashing on ledgers with no packages

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -52,12 +52,10 @@ case class PackageRegistry(
       }
 
     val newTemplates = newPackages
-      .map(_._2.templates)
-      .reduce(_ ++ _)
+      .flatMap(_._2.templates)
 
     val newTypeDefs = newPackages
-      .map(_._2.typeDefs)
-      .reduce(_ ++ _)
+      .flatMap(_._2.typeDefs)
 
     copy(
       packages = packages ++ newPackages,

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -15,3 +15,4 @@ HEAD — ongoing
   that allows you to mark contracts as pending. Those contracts will
   be automatically filtered from the result of ``getContracts`` until
   we receive the corresponding completion/transaction.
+- [Navigator] Fixed a bug where Navigator becomes unresponsive if the ledger does not contain any DAML packages.


### PR DESCRIPTION
This fixes a `java.lang.UnsupportedOperationException: empty.reduceLeft` exception when the packages service returns an empty list, which manifests as an unresponsive Navigator.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
