### PR TITLE
ledger-api-test-tool: Allocate participants and parties declaratively.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Allocation.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Allocation.scala
@@ -7,10 +7,10 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestCo
 import com.digitalasset.ledger.client.binding.Primitive.Party
 
 private[testtool] object Allocation {
-  def allocate(partyCounts: PartyCount*): ParticipantAllocation =
-    ParticipantAllocation(partyCounts)
+  def allocate(firstPartyCount: PartyCount, partyCounts: PartyCount*): ParticipantAllocation =
+    ParticipantAllocation(firstPartyCount +: partyCounts)
 
-  final case class ParticipantAllocation(partyCounts: Seq[PartyCount])
+  final case class ParticipantAllocation private (partyCounts: Seq[PartyCount])
 
   sealed trait PartyCount {
     val count: Int
@@ -30,7 +30,9 @@ private[testtool] object Allocation {
 
   final case class Parties(override val count: Int) extends PartyCount
 
-  final case class Participants(participants: Participant*)
+  final case class Participants private[infrastructure] (participants: Participant*)
 
-  final case class Participant(ledger: ParticipantTestContext, parties: Party*)
+  final case class Participant private[infrastructure] (
+      ledger: ParticipantTestContext,
+      parties: Party*)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Allocation.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Allocation.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.infrastructure
+
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
+import com.digitalasset.ledger.client.binding.Primitive.Party
+
+private[testtool] object Allocation {
+  def allocate(partyCounts: PartyCount*): ParticipantAllocation =
+    ParticipantAllocation(partyCounts)
+
+  final case class ParticipantAllocation(partyCounts: Seq[PartyCount])
+
+  sealed trait PartyCount {
+    val count: Int
+  }
+
+  case object NoParties extends PartyCount {
+    override val count = 0
+  }
+
+  case object SingleParty extends PartyCount {
+    override val count = 1
+  }
+
+  case object TwoParties extends PartyCount {
+    override val count = 2
+  }
+
+  final case class Parties(override val count: Int) extends PartyCount
+
+  final case class Participants(participants: Participant*)
+
+  final case class Participant(ledger: ParticipantTestContext, parties: Party*)
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
@@ -3,15 +3,18 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{ParticipantAllocation, Participants}
 import com.digitalasset.daml.lf.data.Ref
 
-import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
 
 final class LedgerTestCase(
     val shortIdentifier: Ref.LedgerString,
     val description: String,
     val timeout: Duration,
-    runTestCase: LedgerTestContext => Future[Unit]) {
-  def apply(context: LedgerTestContext): Future[Unit] = runTestCase(context)
+    participants: ParticipantAllocation,
+    runTestCase: Participants => Future[Unit]) {
+  def apply(context: LedgerTestContext)(implicit ec: ExecutionContext): Future[Unit] =
+    context.provision(participants).flatMap(runTestCase)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
@@ -16,5 +16,5 @@ final class LedgerTestCase(
     participants: ParticipantAllocation,
     runTestCase: Participants => Future[Unit]) {
   def apply(context: LedgerTestContext)(implicit ec: ExecutionContext): Future[Unit] =
-    context.provision(participants).flatMap(runTestCase)
+    context.allocate(participants).flatMap(runTestCase)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -3,6 +3,11 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{
+  Participant,
+  ParticipantAllocation,
+  Participants
+}
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -11,13 +16,19 @@ private[testtool] final class LedgerTestContext private[infrastructure] (
     participants: Vector[ParticipantTestContext])(implicit ec: ExecutionContext) {
 
   private[this] val participantsRing = Iterator.continually(participants).flatten
+
+  def provision(allocation: ParticipantAllocation): Future[Participants] =
+    Future
+      .sequence(allocation.partyCounts.map(partyCount => {
+        val participant = nextParticipant()
+        participant
+          .allocateParties(partyCount.count)
+          .map(parties => Participant(participant, parties: _*))
+      }))
+      .map(Participants(_: _*))
+
   private[this] def nextParticipant(): ParticipantTestContext =
-    participantsRing.synchronized { participantsRing.next() }
-
-  def participant(): Future[ParticipantTestContext] =
-    Future.successful(nextParticipant())
-
-  def participants(n: Int): Future[Vector[ParticipantTestContext]] =
-    Future.sequence(Vector.fill(n)(participant()))
-
+    participantsRing.synchronized {
+      participantsRing.next()
+    }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -20,7 +20,8 @@ private[testtool] final class LedgerTestContext private[infrastructure] (
   /**
     * This allocates participants and a specified number of parties for each participant.
     *
-    * e.g. `allocate(SingleParty, Parties(3), NoParties, TwoParties)` will eventually return:
+    * e.g. `allocate(ParticipantAllocation(SingleParty, Parties(3), NoParties, TwoParties))`
+    * will eventually return:
     *
     * {{{
     * Participants(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -17,7 +17,24 @@ private[testtool] final class LedgerTestContext private[infrastructure] (
 
   private[this] val participantsRing = Iterator.continually(participants).flatten
 
-  def provision(allocation: ParticipantAllocation): Future[Participants] =
+  /**
+    * This allocates participants and a specified number of parties for each participant.
+    *
+    * e.g. `allocate(SingleParty, Parties(3), NoParties, TwoParties)` will eventually return:
+    *
+    * {{{
+    * Participants(
+    *   Participant(alpha: ParticipantTestContext, alice: Party),
+    *   Participant(beta: ParticipantTestContext, bob: Party, barbara: Party, bernard: Party),
+    *   Participant(gamma: ParticipantTestContext),
+    *   Participant(delta: ParticipantTestContext, doreen: Party, dan: Party),
+    * )
+    * }}}
+    *
+    * Each test allocates participants, then deconstructs the result and uses the various ledgers
+    * and parties throughout the test.
+    */
+  def allocate(allocation: ParticipantAllocation): Future[Participants] =
     Future
       .sequence(allocation.partyCounts.map(partyCount => {
         val participant = nextParticipant()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{ParticipantAllocation, Participants}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite._
 import com.digitalasset.daml.lf.data.Ref
 
@@ -22,9 +23,11 @@ private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
   protected final def test(
       shortIdentifier: String,
       description: String,
-      timeout: Duration = 30.seconds)(testCase: LedgerTestContext => Future[Unit]): Unit = {
+      participants: ParticipantAllocation,
+      timeout: Duration = 30.seconds)(testCase: Participants => Future[Unit]): Unit = {
     val shortIdentifierRef = Ref.LedgerString.assertFromString(shortIdentifier)
-    testCaseBuffer.append(new LedgerTestCase(shortIdentifierRef, description, timeout, testCase))
+    testCaseBuffer.append(
+      new LedgerTestCase(shortIdentifierRef, description, timeout, participants, testCase))
   }
 
   protected final def skip(reason: String): Future[Unit] = Future.failed(SkipTestException(reason))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.api.testtool.tests
 
 import java.util.UUID
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
@@ -23,71 +24,74 @@ import scalaz.syntax.tag._
 import scala.concurrent.duration.DurationInt
 
 final class CommandService(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("CSsubmitAndWait", "SubmitAndWait creates a contract of the expected template") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      _ <- ledger.submitAndWait(request)
-      active <- ledger.activeContracts(alice)
-    } yield {
-      assert(active.size == 1)
-      val dummyTemplateId = active.flatMap(_.templateId.toList).head
-      assert(dummyTemplateId == Dummy.id.unwrap)
-    }
+  test(
+    "CSsubmitAndWait",
+    "SubmitAndWait creates a contract of the expected template",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submitAndWait(request)
+        active <- ledger.activeContracts(party)
+      } yield {
+        assert(active.size == 1)
+        val dummyTemplateId = active.flatMap(_.templateId.toList).head
+        assert(dummyTemplateId == Dummy.id.unwrap)
+      }
   }
 
   test(
     "CSsubmitAndWaitForTransactionId",
-    "SubmitAndWaitForTransactionId returns a valid transaction identifier") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      transactionId <- ledger.submitAndWaitForTransactionId(request)
-      retrievedTransaction <- ledger.transactionTreeById(transactionId, alice)
-      transactions <- ledger.flatTransactions(alice)
-    } yield {
+    "SubmitAndWaitForTransactionId returns a valid transaction identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        transactionId <- ledger.submitAndWaitForTransactionId(request)
+        retrievedTransaction <- ledger.transactionTreeById(transactionId, party)
+        transactions <- ledger.flatTransactions(party)
+      } yield {
 
-      assert(transactionId.nonEmpty, "The transaction identifier was empty but shouldn't.")
-      assert(
-        transactions.size == 1,
-        s"$alice should see only one transaction but sees ${transactions.size}")
-      val events = transactions.head.events
+        assert(transactionId.nonEmpty, "The transaction identifier was empty but shouldn't.")
+        assert(
+          transactions.size == 1,
+          s"$party should see only one transaction but sees ${transactions.size}")
+        val events = transactions.head.events
 
-      assert(events.size == 1, s"$alice should see only one event but sees ${events.size}")
-      assert(
-        events.head.event.isCreated,
-        s"$alice should see only one create but sees ${events.head.event}")
-      val created = transactions.head.events.head.getCreated
+        assert(events.size == 1, s"$party should see only one event but sees ${events.size}")
+        assert(
+          events.head.event.isCreated,
+          s"$party should see only one create but sees ${events.head.event}")
+        val created = transactions.head.events.head.getCreated
 
-      assert(
-        retrievedTransaction.transactionId == transactionId,
-        s"$alice should see the transaction for the created contract $transactionId but sees ${retrievedTransaction.transactionId}"
-      )
-      assert(
-        retrievedTransaction.rootEventIds.size == 1,
-        s"The retrieved transaction should contain a single event but contains ${retrievedTransaction.rootEventIds.size}"
-      )
-      val retrievedEvent = retrievedTransaction.eventsById(retrievedTransaction.rootEventIds.head)
+        assert(
+          retrievedTransaction.transactionId == transactionId,
+          s"$party should see the transaction for the created contract $transactionId but sees ${retrievedTransaction.transactionId}"
+        )
+        assert(
+          retrievedTransaction.rootEventIds.size == 1,
+          s"The retrieved transaction should contain a single event but contains ${retrievedTransaction.rootEventIds.size}"
+        )
+        val retrievedEvent = retrievedTransaction.eventsById(retrievedTransaction.rootEventIds.head)
 
-      assert(
-        retrievedEvent.kind.isCreated,
-        s"The only event seen should be a created but instead it's $retrievedEvent")
-      assert(
-        retrievedEvent.getCreated == created,
-        s"The retrieved created event does not match the one in the flat transactions: event=$created retrieved=$retrievedEvent"
-      )
+        assert(
+          retrievedEvent.kind.isCreated,
+          s"The only event seen should be a created but instead it's $retrievedEvent")
+        assert(
+          retrievedEvent.getCreated == created,
+          s"The retrieved created event does not match the one in the flat transactions: event=$created retrieved=$retrievedEvent"
+        )
 
-    }
+      }
   }
 
-  test("CSsubmitAndWaitForTransaction", "SubmitAndWaitForTransaction returns a transaction") {
-    context =>
+  test(
+    "CSsubmitAndWaitForTransaction",
+    "SubmitAndWaitForTransaction returns a transaction",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
         transaction <- ledger.submitAndWaitForTransaction(request)
       } yield {
         assert(
@@ -110,56 +114,56 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSsubmitAndWaitForTransactionTree",
-    "SubmitAndWaitForTransactionTree returns a transaction tree") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      transactionTree <- ledger.submitAndWaitForTransactionTree(request)
-    } yield {
-      assert(
-        transactionTree.transactionId.nonEmpty,
-        "The transaction identifier was empty but shouldn't.")
-      assert(
-        transactionTree.eventsById.size == 1,
-        s"The returned transaction tree should contain 1 event, but contained ${transactionTree.eventsById.size}")
-      val event = transactionTree.eventsById.head._2
-      assert(
-        event.kind.isCreated,
-        s"The returned transaction tree should contain a created-event, but was ${event.kind}")
-      assert(
-        event.getCreated.getTemplateId == Dummy.id.unwrap,
-        s"The template ID of the created-event should by ${Dummy.id.unwrap}, but was ${event.getCreated.getTemplateId}"
-      )
-    }
+    "SubmitAndWaitForTransactionTree returns a transaction tree",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        transactionTree <- ledger.submitAndWaitForTransactionTree(request)
+      } yield {
+        assert(
+          transactionTree.transactionId.nonEmpty,
+          "The transaction identifier was empty but shouldn't.")
+        assert(
+          transactionTree.eventsById.size == 1,
+          s"The returned transaction tree should contain 1 event, but contained ${transactionTree.eventsById.size}")
+        val event = transactionTree.eventsById.head._2
+        assert(
+          event.kind.isCreated,
+          s"The returned transaction tree should contain a created-event, but was ${event.kind}")
+        assert(
+          event.getCreated.getTemplateId == Dummy.id.unwrap,
+          s"The template ID of the created-event should by ${Dummy.id.unwrap}, but was ${event.getCreated.getTemplateId}"
+        )
+      }
   }
 
   test(
     "CSduplicateSubmitAndWait",
-    "SubmitAndWait should be idempotent when reusing the same command identifier") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      _ <- ledger.submitAndWait(request)
-      _ <- ledger.submitAndWait(request)
-      transactions <- ledger.flatTransactions(alice)
-    } yield {
-      assert(
-        transactions.size == 1,
-        s"Expected only 1 transaction, but received ${transactions.size}")
+    "SubmitAndWait should be idempotent when reusing the same command identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submitAndWait(request)
+        _ <- ledger.submitAndWait(request)
+        transactions <- ledger.flatTransactions(party)
+      } yield {
+        assert(
+          transactions.size == 1,
+          s"Expected only 1 transaction, but received ${transactions.size}")
 
-    }
+      }
   }
 
   test(
     "CSduplicateSubmitAndWaitForTransactionId",
-    "SubmitAndWaitForTransactionId should be idempotent when reusing the same command identifier") {
-    context =>
+    "SubmitAndWaitForTransactionId should be idempotent when reusing the same command identifier",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
         transactionId1 <- ledger.submitAndWaitForTransactionId(request)
         transactionId2 <- ledger.submitAndWaitForTransactionId(request)
       } yield {
@@ -171,12 +175,12 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSduplicateSubmitAndWaitForTransaction",
-    "SubmitAndWaitForTransaction should be idempotent when reusing the same command identifier") {
-    context =>
+    "SubmitAndWaitForTransaction should be idempotent when reusing the same command identifier",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
         transaction1 <- ledger.submitAndWaitForTransaction(request)
         transaction2 <- ledger.submitAndWaitForTransaction(request)
       } yield {
@@ -188,12 +192,12 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSduplicateSubmitAndWaitForTransactionTree",
-    "SubmitAndWaitForTransactionTree should be idempotent when reusing the same command identifier") {
-    context =>
+    "SubmitAndWaitForTransactionTree should be idempotent when reusing the same command identifier",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
         transactionTree1 <- ledger.submitAndWaitForTransactionTree(request)
         transactionTree2 <- ledger.submitAndWaitForTransactionTree(request)
       } yield {
@@ -203,13 +207,14 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       }
   }
 
-  test("CSsubmitAndWaitInvalidLedgerId", "SubmitAndWait should fail for invalid ledger ids") {
-    context =>
+  test(
+    "CSsubmitAndWaitInvalidLedgerId",
+    "SubmitAndWait should fail for invalid ledger ids",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "CSsubmitAndWaitInvalidLedgerId"
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
         badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
         failure <- ledger.submit(badLedgerId).failed
       } yield
@@ -218,245 +223,244 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSsubmitAndWaitForTransactionIdInvalidLedgerId",
-    "SubmitAndWaitForTransactionId should fail for invalid ledger ids") { context =>
-    val invalidLedgerId = "CSsubmitAndWaitForTransactionIdInvalidLedgerId"
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
-      failure <- ledger.submitAndWaitForTransactionId(badLedgerId).failed
-    } yield
-      assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
+    "SubmitAndWaitForTransactionId should fail for invalid ledger ids",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val invalidLedgerId = "CSsubmitAndWaitForTransactionIdInvalidLedgerId"
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
+        failure <- ledger.submitAndWaitForTransactionId(badLedgerId).failed
+      } yield
+        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
   }
 
   test(
     "CSsubmitAndWaitForTransactionInvalidLedgerId",
-    "SubmitAndWaitForTransaction should fail for invalid ledger ids") { context =>
-    val invalidLedgerId = "CSsubmitAndWaitForTransactionInvalidLedgerId"
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
-      failure <- ledger.submitAndWaitForTransaction(badLedgerId).failed
-    } yield
-      assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
+    "SubmitAndWaitForTransaction should fail for invalid ledger ids",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val invalidLedgerId = "CSsubmitAndWaitForTransactionInvalidLedgerId"
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
+        failure <- ledger.submitAndWaitForTransaction(badLedgerId).failed
+      } yield
+        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
   }
 
   test(
     "CSsubmitAndWaitForTransactionTreeInvalidLedgerId",
-    "SubmitAndWaitForTransactionTree should fail for invalid ledger ids") { context =>
-    val invalidLedgerId = "CSsubmitAndWaitForTransactionTreeInvalidLedgerId"
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-      badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
-      failure <- ledger.submitAndWaitForTransactionTree(badLedgerId).failed
-    } yield
-      assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
+    "SubmitAndWaitForTransactionTree should fail for invalid ledger ids",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val invalidLedgerId = "CSsubmitAndWaitForTransactionTreeInvalidLedgerId"
+      for {
+        request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
+        badLedgerId = request.update(_.commands.ledgerId := invalidLedgerId)
+        failure <- ledger.submitAndWaitForTransactionTree(badLedgerId).failed
+      } yield
+        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
   }
 
   test(
     "CSDisallowEmptyTransactionsSubmission",
-    "The submission of an empty command should be rejected with INVALID_ARGUMENT"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      emptyRequest <- ledger.submitRequest(party)
-      failure <- ledger.submit(emptyRequest).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: commands")
-    }
+    "The submission of an empty command should be rejected with INVALID_ARGUMENT",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        emptyRequest <- ledger.submitRequest(party)
+        failure <- ledger.submit(emptyRequest).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: commands")
+      }
   }
 
   test(
     "CSRefuseBadChoice",
-    "The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT"
-  ) { context =>
-    val badChoice = "THIS_IS_NOT_A_VALID_CHOICE"
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      exercise = dummy.exerciseDummyChoice1(party).command
-      wrongExercise = exercise.update(_.exercise.choice := badChoice)
-      wrongRequest <- ledger.submitRequest(party, wrongExercise)
-      failure <- ledger.submit(wrongRequest).failed
-    } yield {
-      assertGrpcError(
-        failure,
-        Status.Code.INVALID_ARGUMENT,
-        s"Couldn't find requested choice $badChoice")
-    }
+    "The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val badChoice = "THIS_IS_NOT_A_VALID_CHOICE"
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        exercise = dummy.exerciseDummyChoice1(party).command
+        wrongExercise = exercise.update(_.exercise.choice := badChoice)
+        wrongRequest <- ledger.submitRequest(party, wrongExercise)
+        failure <- ledger.submit(wrongRequest).failed
+      } yield {
+        assertGrpcError(
+          failure,
+          Status.Code.INVALID_ARGUMENT,
+          s"Couldn't find requested choice $badChoice")
+      }
   }
 
   test(
     "CSReturnStackTrace",
-    "A submission resulting in an interpretation error should return the stack trace"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      failure <- ledger.exercise(party, dummy.exerciseFailingClone).failed
-    } yield {
-      assertGrpcError(
-        failure,
-        Status.Code.INVALID_ARGUMENT,
-        "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:20], partial transaction: root node"
-      )
-    }
+    "A submission resulting in an interpretation error should return the stack trace",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        failure <- ledger.exercise(party, dummy.exerciseFailingClone).failed
+      } yield {
+        assertGrpcError(
+          failure,
+          Status.Code.INVALID_ARGUMENT,
+          "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:20], partial transaction: root node"
+        )
+      }
   }
 
   test(
     "CSExerciseByKey",
-    "Exercising by key should be possible only when the corresponding contract is available"
-  ) { context =>
-    val keyString = UUID.randomUUID.toString
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      expectedKey = Value(
+    "Exercising by key should be possible only when the corresponding contract is available",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val keyString = UUID.randomUUID.toString
+      val expectedKey = Value(
         Value.Sum.Record(
           Record(
             fields = Seq(
               RecordField("_1", Some(Value(Value.Sum.Party(party.unwrap)))),
               RecordField("_2", Some(Value(Value.Sum.Text(keyString))))
             ))))
-      failureBeforeCreation <- ledger
-        .exerciseByKey(
+      for {
+        failureBeforeCreation <- ledger
+          .exerciseByKey(
+            party,
+            TextKey.id,
+            expectedKey,
+            "TextKeyChoice",
+            Value(Value.Sum.Record(Record())))
+          .failed
+        _ <- ledger.create(party, TextKey(party, keyString, Primitive.List.empty))
+        _ <- ledger.exerciseByKey(
           party,
           TextKey.id,
           expectedKey,
           "TextKeyChoice",
           Value(Value.Sum.Record(Record())))
-        .failed
-      _ <- ledger.create(party, TextKey(party, keyString, Primitive.List.empty))
-      _ <- ledger.exerciseByKey(
-        party,
-        TextKey.id,
-        expectedKey,
-        "TextKeyChoice",
-        Value(Value.Sum.Record(Record())))
-      failureAfterConsuming <- ledger
-        .exerciseByKey(
-          party,
-          TextKey.id,
-          expectedKey,
-          "TextKeyChoice",
-          Value(Value.Sum.Record(Record())))
-        .failed
-    } yield {
-      assertGrpcError(
-        failureBeforeCreation,
-        Status.Code.INVALID_ARGUMENT,
-        "dependency error: couldn't find key"
-      )
-      assertGrpcError(
-        failureAfterConsuming,
-        Status.Code.INVALID_ARGUMENT,
-        "dependency error: couldn't find key"
-      )
-    }
-  }
-
-  test("CSDiscloseCreateToObservers", "Disclose create to observers") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(giver, observer1) <- alpha.allocateParties(2)
-      observer2 <- beta.allocateParty()
-      template = WithObservers(giver, Primitive.List(observer1, observer2))
-      _ <- alpha.create(giver, template)
-      observer1View <- alpha.transactionTrees(observer1)
-      observer2View <- beta.transactionTrees(observer2)
-    } yield {
-      val observer1Created = assertSingleton(
-        "The first observer should see exactly one creation",
-        observer1View.flatMap(createdEvents))
-      val observer2Created = assertSingleton(
-        "The second observer should see exactly one creation",
-        observer2View.flatMap(createdEvents))
-      assertEquals(
-        "The two observers should see the same creation",
-        observer1Created.getCreateArguments.fields,
-        observer2Created.getCreateArguments.fields)
-      assertEquals(
-        "The observers shouls see the created contract",
-        observer1Created.getCreateArguments.fields,
-        encode(template).getRecord.fields
-      )
-    }
-  }
-
-  test("CSDiscloseExerciseToObservers", "Diclose exercise to observers") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(giver, observer1) <- alpha.allocateParties(2)
-      observer2 <- beta.allocateParty()
-      template = WithObservers(giver, Primitive.List(observer1, observer2))
-      withObservers <- alpha.create(giver, template)
-      _ <- alpha.exercise(giver, withObservers.exercisePing)
-      observer1View <- alpha.transactionTrees(observer1)
-      observer2View <- beta.transactionTrees(observer2)
-    } yield {
-      val observer1Exercise = assertSingleton(
-        "The first observer should see exactly one exercise",
-        observer1View.flatMap(exercisedEvents))
-      val observer2Exercise = assertSingleton(
-        "The second observer should see exactly one exercise",
-        observer2View.flatMap(exercisedEvents))
-      assert(
-        observer1Exercise.contractId == observer2Exercise.contractId,
-        "The two observers should see the same exercise")
-      assert(
-        observer1Exercise.contractId == withObservers.unwrap,
-        "The observers shouls see the exercised contract")
-    }
-  }
-
-  test("CSHugeCommandSubmittion", "The server should accept a submission with 15 commands") {
-    context =>
-      {
-        val target = 15
-        for {
-          ledger <- context.participant()
-          party <- ledger.allocateParty()
-          commands = Vector.fill(target)(Dummy(party).create.command)
-          request <- ledger.submitAndWaitRequest(party, commands: _*)
-          _ <- ledger.submitAndWait(request)
-          acs <- ledger.activeContracts(party)
-        } yield {
-          assert(
-            acs.size == target,
-            s"Expected $target contracts to be created, got ${acs.size} instead")
-        }
+        failureAfterConsuming <- ledger
+          .exerciseByKey(
+            party,
+            TextKey.id,
+            expectedKey,
+            "TextKeyChoice",
+            Value(Value.Sum.Record(Record())))
+          .failed
+      } yield {
+        assertGrpcError(
+          failureBeforeCreation,
+          Status.Code.INVALID_ARGUMENT,
+          "dependency error: couldn't find key"
+        )
+        assertGrpcError(
+          failureAfterConsuming,
+          Status.Code.INVALID_ARGUMENT,
+          "dependency error: couldn't find key"
+        )
       }
   }
 
-  test("CSCallablePayout", "Run CallablePayout and return the right events") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(giver, newReceiver) <- alpha.allocateParties(2)
-      receiver <- beta.allocateParty()
-      callablePayout <- alpha.create(giver, CallablePayout(giver, receiver))
-      tree <- beta.exercise(receiver, callablePayout.exerciseTransfer(_, newReceiver))
-    } yield {
-      val created = assertSingleton("There should only be one creation", createdEvents(tree))
-      assertEquals(
-        "The created event should be the expected one",
-        created.getCreateArguments.fields,
-        encode(CallablePayout(giver, newReceiver)).getRecord.fields)
-    }
+  test(
+    "CSDiscloseCreateToObservers",
+    "Disclose create to observers",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, giver, observer1), Participant(beta, observer2)) =>
+      val template = WithObservers(giver, Primitive.List(observer1, observer2))
+      for {
+        _ <- alpha.create(giver, template)
+        observer1View <- alpha.transactionTrees(observer1)
+        observer2View <- beta.transactionTrees(observer2)
+      } yield {
+        val observer1Created = assertSingleton(
+          "The first observer should see exactly one creation",
+          observer1View.flatMap(createdEvents))
+        val observer2Created = assertSingleton(
+          "The second observer should see exactly one creation",
+          observer2View.flatMap(createdEvents))
+        assertEquals(
+          "The two observers should see the same creation",
+          observer1Created.getCreateArguments.fields,
+          observer2Created.getCreateArguments.fields)
+        assertEquals(
+          "The observers shouls see the created contract",
+          observer1Created.getCreateArguments.fields,
+          encode(template).getRecord.fields
+        )
+      }
   }
 
-  test("CSReadyForExercise", "It should be possible to exercise a choice on a created contract") {
-    context =>
+  test(
+    "CSDiscloseExerciseToObservers",
+    "Diclose exercise to observers",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, giver, observer1), Participant(beta, observer2)) =>
+      val template = WithObservers(giver, Primitive.List(observer1, observer2))
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
+        withObservers <- alpha.create(giver, template)
+        _ <- alpha.exercise(giver, withObservers.exercisePing)
+        observer1View <- alpha.transactionTrees(observer1)
+        observer2View <- beta.transactionTrees(observer2)
+      } yield {
+        val observer1Exercise = assertSingleton(
+          "The first observer should see exactly one exercise",
+          observer1View.flatMap(exercisedEvents))
+        val observer2Exercise = assertSingleton(
+          "The second observer should see exactly one exercise",
+          observer2View.flatMap(exercisedEvents))
+        assert(
+          observer1Exercise.contractId == observer2Exercise.contractId,
+          "The two observers should see the same exercise")
+        assert(
+          observer1Exercise.contractId == withObservers.unwrap,
+          "The observers shouls see the exercised contract")
+      }
+  }
+
+  test(
+    "CSHugeCommandSubmittion",
+    "The server should accept a submission with 15 commands",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val target = 15
+      val commands = Vector.fill(target)(Dummy(party).create.command)
+      for {
+        request <- ledger.submitAndWaitRequest(party, commands: _*)
+        _ <- ledger.submitAndWait(request)
+        acs <- ledger.activeContracts(party)
+      } yield {
+        assert(
+          acs.size == target,
+          s"Expected $target contracts to be created, got ${acs.size} instead")
+      }
+  }
+
+  test(
+    "CSCallablePayout",
+    "Run CallablePayout and return the right events",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, giver, newReceiver), Participant(beta, receiver)) =>
+      for {
+        callablePayout <- alpha.create(giver, CallablePayout(giver, receiver))
+        tree <- beta.exercise(receiver, callablePayout.exerciseTransfer(_, newReceiver))
+      } yield {
+        val created = assertSingleton("There should only be one creation", createdEvents(tree))
+        assertEquals(
+          "The created event should be the expected one",
+          created.getCreateArguments.fields,
+          encode(CallablePayout(giver, newReceiver)).getRecord.fields)
+      }
+  }
+
+  test(
+    "CSReadyForExercise",
+    "It should be possible to exercise a choice on a created contract",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
         factory <- ledger.create(party, DummyFactory(party))
         tree <- ledger.exercise(party, factory.exerciseDummyFactoryCall)
       } yield {
@@ -469,32 +473,28 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSCompletions",
-    "Read completions correctly with a correct application identifier and reading party") {
-    context =>
-      {
-        for {
-          ledger <- context.participant()
-          party <- ledger.allocateParty()
-          request <- ledger.submitRequest(party, Dummy(party).create.command)
-          _ <- ledger.submit(request)
-          completions <- ledger.firstCompletions(party)
-        } yield {
-          val commandId =
-            assertSingleton("Expected only one completion", completions.map(_.commandId))
-          assert(
-            commandId == request.commands.get.commandId,
-            "Wrong command identifier on completion")
-        }
+    "Read completions correctly with a correct application identifier and reading party",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submit(request)
+        completions <- ledger.firstCompletions(party)
+      } yield {
+        val commandId =
+          assertSingleton("Expected only one completion", completions.map(_.commandId))
+        assert(
+          commandId == request.commands.get.commandId,
+          "Wrong command identifier on completion")
       }
   }
 
   test(
     "CSNoCompletionsWithoutRightAppId",
-    "Read no completions without the correct application identifier") { context =>
-    {
+    "Read no completions without the correct application identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         request <- ledger.submitRequest(party, Dummy(party).create.command)
         _ <- ledger.submit(request)
         invalidRequest = ledger
@@ -504,21 +504,19 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assert(failed == TimeoutException, "Timeout expected")
       }
-    }
   }
 
-  test("CSNoCompletionsWithoutRightParty", "Read no completions without the correct party") {
-    context =>
-      {
-        for {
-          ledger <- context.participant()
-          Vector(party, notTheSubmittingParty) <- ledger.allocateParties(2)
-          request <- ledger.submitRequest(party, Dummy(party).create.command)
-          _ <- ledger.submit(request)
-          failed <- WithTimeout(5.seconds)(ledger.firstCompletions(notTheSubmittingParty)).failed
-        } yield {
-          assert(failed == TimeoutException, "Timeout expected")
-        }
+  test(
+    "CSNoCompletionsWithoutRightParty",
+    "Read no completions without the correct party",
+    allocate(TwoParties)) {
+    case Participants(Participant(ledger, party, notTheSubmittingParty)) =>
+      for {
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submit(request)
+        failed <- WithTimeout(5.seconds)(ledger.firstCompletions(notTheSubmittingParty)).failed
+      } yield {
+        assert(failed == TimeoutException, "Timeout expected")
       }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeys.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeys.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.api.testtool.tests
 
 import java.util.UUID
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
@@ -20,49 +21,48 @@ import io.grpc.Status
 import scalaz.Tag
 
 final class ContractKeys(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("CKFetchOrLookup", "Divulged contracts can be fetched or looked up by key") { context =>
-    val key = s"${UUID.randomUUID.toString}-key"
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      owner <- alpha.allocateParty()
-      delegate <- beta.allocateParty()
-
-      // create contracts to work with
-      delegated <- alpha.create(owner, Delegated(owner, key))
-      delegation <- alpha.create(owner, Delegation(owner, delegate))
-      showDelegated <- alpha.create(owner, ShowDelegated(owner, delegate))
-
-      // divulge the contract
-      _ <- alpha.exercise(owner, showDelegated.exerciseShowIt(_, delegated))
-
-      // fetch delegated
-      _ <- eventually {
-        beta.exercise(delegate, delegation.exerciseFetchDelegated(_, delegated))
-      }
-
-      // fetch by key delegation is allowed
-      _ <- beta.exercise(
-        delegate,
-        delegation.exerciseFetchByKeyDelegated(_, owner, key, Some(delegated)))
-
-      // lookup by key delegation is allowed
-      _ <- beta.exercise(
-        delegate,
-        delegation.exerciseLookupByKeyDelegated(_, owner, key, Some(delegated)))
-    } yield {
-      // No assertions to make, since all exercises went through as expected
-      ()
-    }
-  }
-
-  test("CKNoFetchUndisclosed", "Contract Keys should reject fetching an undisclosed contract") {
-    context =>
+  test(
+    "CKFetchOrLookup",
+    "Divulged contracts can be fetched or looked up by key",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
       val key = s"${UUID.randomUUID.toString}-key"
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        owner <- alpha.allocateParty()
-        delegate <- beta.allocateParty()
+        // create contracts to work with
+        delegated <- alpha.create(owner, Delegated(owner, key))
+        delegation <- alpha.create(owner, Delegation(owner, delegate))
+        showDelegated <- alpha.create(owner, ShowDelegated(owner, delegate))
 
+        // divulge the contract
+        _ <- alpha.exercise(owner, showDelegated.exerciseShowIt(_, delegated))
+
+        // fetch delegated
+        _ <- eventually {
+          beta.exercise(delegate, delegation.exerciseFetchDelegated(_, delegated))
+        }
+
+        // fetch by key delegation is allowed
+        _ <- beta.exercise(
+          delegate,
+          delegation.exerciseFetchByKeyDelegated(_, owner, key, Some(delegated)))
+
+        // lookup by key delegation is allowed
+        _ <- beta.exercise(
+          delegate,
+          delegation.exerciseLookupByKeyDelegated(_, owner, key, Some(delegated)))
+      } yield {
+        // No assertions to make, since all exercises went through as expected
+        ()
+      }
+  }
+
+  test(
+    "CKNoFetchUndisclosed",
+    "Contract Keys should reject fetching an undisclosed contract",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
+      val key = s"${UUID.randomUUID.toString}-key"
+      for {
         // create contracts to work with
         delegated <- alpha.create(owner, Delegated(owner, key))
         delegation <- alpha.create(owner, Delegation(owner, delegate))
@@ -92,116 +92,117 @@ final class ContractKeys(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("CKMaintainerScoped", "Contract keys should be scoped by maintainer") { context =>
-    val keyPrefix = UUID.randomUUID.toString
-    val key1 = s"$keyPrefix-some-key"
-    val key2 = s"$keyPrefix-some-other-key"
-    val unknownKey = s"$keyPrefix-unknown-key"
+  test(
+    "CKMaintainerScoped",
+    "Contract keys should be scoped by maintainer",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+      val keyPrefix = UUID.randomUUID.toString
+      val key1 = s"$keyPrefix-some-key"
+      val key2 = s"$keyPrefix-some-other-key"
+      val unknownKey = s"$keyPrefix-unknown-key"
 
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      alice <- alpha.allocateParty()
-      bob <- beta.allocateParty()
+      for {
+        // create contracts to work with
+        tk1 <- alpha.create(alice, TextKey(alice, key1, List(bob)))
+        tk2 <- alpha.create(alice, TextKey(alice, key2, List(bob)))
+        aliceTKO <- alpha.create(alice, TextKeyOperations(alice))
+        bobTKO <- beta.create(bob, TextKeyOperations(bob))
 
-      // create contracts to work with
-      tk1 <- alpha.create(alice, TextKey(alice, key1, List(bob)))
-      tk2 <- alpha.create(alice, TextKey(alice, key2, List(bob)))
-      aliceTKO <- alpha.create(alice, TextKeyOperations(alice))
-      bobTKO <- beta.create(bob, TextKeyOperations(bob))
+        _ <- synchronize(alpha, beta)
 
-      _ <- synchronize(alpha, beta)
+        // creating a contract with a duplicate key should fail
+        duplicateKeyFailure <- alpha.create(alice, TextKey(alice, key1, List(bob))).failed
 
-      // creating a contract with a duplicate key should fail
-      duplicateKeyFailure <- alpha.create(alice, TextKey(alice, key1, List(bob))).failed
+        // trying to lookup an unauthorized key should fail
+        bobLooksUpTextKeyFailure <- beta
+          .exercise(bob, bobTKO.exerciseTKOLookup(_, Tuple2(alice, key1), Some(tk1)))
+          .failed
 
-      // trying to lookup an unauthorized key should fail
-      bobLooksUpTextKeyFailure <- beta
-        .exercise(bob, bobTKO.exerciseTKOLookup(_, Tuple2(alice, key1), Some(tk1)))
-        .failed
+        // trying to lookup an unauthorized non-existing key should fail
+        bobLooksUpBogusTextKeyFailure <- beta
+          .exercise(bob, bobTKO.exerciseTKOLookup(_, Tuple2(alice, unknownKey), None))
+          .failed
 
-      // trying to lookup an unauthorized non-existing key should fail
-      bobLooksUpBogusTextKeyFailure <- beta
-        .exercise(bob, bobTKO.exerciseTKOLookup(_, Tuple2(alice, unknownKey), None))
-        .failed
+        // successful, authorized lookup
+        _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, key1), Some(tk1)))
 
-      // successful, authorized lookup
-      _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, key1), Some(tk1)))
+        // successful fetch
+        _ <- alpha.exercise(alice, aliceTKO.exerciseTKOFetch(_, Tuple2(alice, key1), tk1))
 
-      // successful fetch
-      _ <- alpha.exercise(alice, aliceTKO.exerciseTKOFetch(_, Tuple2(alice, key1), tk1))
+        // successful, authorized lookup of non-existing key
+        _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, unknownKey), None))
 
-      // successful, authorized lookup of non-existing key
-      _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, unknownKey), None))
+        // failing fetch
+        aliceFailedFetch <- alpha
+          .exercise(alice, aliceTKO.exerciseTKOFetch(_, Tuple2(alice, unknownKey), tk1))
+          .failed
 
-      // failing fetch
-      aliceFailedFetch <- alpha
-        .exercise(alice, aliceTKO.exerciseTKOFetch(_, Tuple2(alice, unknownKey), tk1))
-        .failed
+        // now we exercise the contract, thus archiving it, and then verify
+        // that we cannot look it up anymore
+        _ <- alpha.exercise(alice, tk1.exerciseTextKeyChoice)
+        _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, key1), None))
 
-      // now we exercise the contract, thus archiving it, and then verify
-      // that we cannot look it up anymore
-      _ <- alpha.exercise(alice, tk1.exerciseTextKeyChoice)
-      _ <- alpha.exercise(alice, aliceTKO.exerciseTKOLookup(_, Tuple2(alice, key1), None))
+        // lookup the key, consume it, then verify we cannot look it up anymore
+        _ <- alpha.exercise(
+          alice,
+          aliceTKO.exerciseTKOConsumeAndLookup(_, tk2, Tuple2(alice, key2)))
 
-      // lookup the key, consume it, then verify we cannot look it up anymore
-      _ <- alpha.exercise(alice, aliceTKO.exerciseTKOConsumeAndLookup(_, tk2, Tuple2(alice, key2)))
-
-      // failing create when a maintainer is not a signatory
-      maintainerNotSignatoryFailed <- alpha
-        .create(alice, MaintainerNotSignatory(alice, bob))
-        .failed
-    } yield {
-      assertGrpcError(duplicateKeyFailure, Status.Code.INVALID_ARGUMENT, "DuplicateKey")
-      assertGrpcError(
-        bobLooksUpTextKeyFailure,
-        Status.Code.INVALID_ARGUMENT,
-        "requires authorizers")
-      assertGrpcError(
-        bobLooksUpBogusTextKeyFailure,
-        Status.Code.INVALID_ARGUMENT,
-        "requires authorizers")
-      assertGrpcError(aliceFailedFetch, Status.Code.INVALID_ARGUMENT, "couldn't find key")
-      assertGrpcError(
-        maintainerNotSignatoryFailed,
-        Status.Code.INVALID_ARGUMENT,
-        "are not a subset of the signatories")
-    }
+        // failing create when a maintainer is not a signatory
+        maintainerNotSignatoryFailed <- alpha
+          .create(alice, MaintainerNotSignatory(alice, bob))
+          .failed
+      } yield {
+        assertGrpcError(duplicateKeyFailure, Status.Code.INVALID_ARGUMENT, "DuplicateKey")
+        assertGrpcError(
+          bobLooksUpTextKeyFailure,
+          Status.Code.INVALID_ARGUMENT,
+          "requires authorizers")
+        assertGrpcError(
+          bobLooksUpBogusTextKeyFailure,
+          Status.Code.INVALID_ARGUMENT,
+          "requires authorizers")
+        assertGrpcError(aliceFailedFetch, Status.Code.INVALID_ARGUMENT, "couldn't find key")
+        assertGrpcError(
+          maintainerNotSignatoryFailed,
+          Status.Code.INVALID_ARGUMENT,
+          "are not a subset of the signatories")
+      }
   }
 
-  test("CKRecreate", "Contract keys can be recreated in single transaction") { context =>
-    val key = s"${UUID.randomUUID.toString}-key"
-    for {
-      ledger <- context.participant()
-      owner <- ledger.allocateParty()
+  test("CKRecreate", "Contract keys can be recreated in single transaction", allocate(SingleParty)) {
+    case Participants(Participant(ledger, owner)) =>
+      val key = s"${UUID.randomUUID.toString}-key"
+      for {
+        delegated1TxTree <- ledger
+          .submitAndWaitRequest(owner, Delegated(owner, key).create.command)
+          .flatMap(ledger.submitAndWaitForTransactionTree)
+        delegated1Id = com.digitalasset.ledger.client.binding.Primitive
+          .ContractId[Delegated](delegated1TxTree.eventsById.head._2.getCreated.contractId)
 
-      delegated1TxTree <- ledger
-        .submitAndWaitRequest(owner, Delegated(owner, key).create.command)
-        .flatMap(ledger.submitAndWaitForTransactionTree)
-      delegated1Id = com.digitalasset.ledger.client.binding.Primitive
-        .ContractId[Delegated](delegated1TxTree.eventsById.head._2.getCreated.contractId)
+        delegated2TxTree <- ledger.exercise(owner, delegated1Id.exerciseRecreate)
+      } yield {
+        assert(delegated2TxTree.eventsById.size == 2)
+        val event = delegated2TxTree.eventsById.filter(_._2.kind.isCreated).head._2
+        assert(
+          Tag.unwrap(delegated1Id) != event.getCreated.contractId,
+          "New contract was not created")
+        assert(
+          event.getCreated.contractKey == delegated1TxTree.eventsById.head._2.getCreated.contractKey,
+          "Contract keys did not match")
 
-      delegated2TxTree <- ledger.exercise(owner, delegated1Id.exerciseRecreate)
-    } yield {
-      assert(delegated2TxTree.eventsById.size == 2)
-      val event = delegated2TxTree.eventsById.filter(_._2.kind.isCreated).head._2
-      assert(
-        Tag.unwrap(delegated1Id) != event.getCreated.contractId,
-        "New contract was not created")
-      assert(
-        event.getCreated.contractKey == delegated1TxTree.eventsById.head._2.getCreated.contractKey,
-        "Contract keys did not match")
-
-    }
+      }
   }
 
-  test("CKTransients", "Contract keys created by transient contracts are properly archived") {
-    context =>
+  test(
+    "CKTransients",
+    "Contract keys created by transient contracts are properly archived",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, owner)) =>
       val key = s"${UUID.randomUUID.toString}-key"
       val key2 = s"${UUID.randomUUID.toString}-key"
 
       for {
-        ledger <- context.participant()
-        owner <- ledger.allocateParty()
         delegation <- ledger.create(owner, Delegation(owner, owner))
         delegated <- ledger.create(owner, Delegated(owner, key))
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
@@ -3,17 +3,19 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.digitalasset.ledger.test_stable.Test.Divulgence2._
 import com.digitalasset.ledger.test_stable.Test.{Divulgence1, Divulgence2}
 import scalaz.Tag
 
 final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("DivulgenceTx", "Divulged contracts should not be exposed by the transaction service") {
-    context =>
+  test(
+    "DivulgenceTx",
+    "Divulged contracts should not be exposed by the transaction service",
+    allocate(TwoParties)) {
+    case Participants(Participant(ledger, alice, bob)) =>
       for {
-        ledger <- context.participant()
-        Vector(alice, bob) <- ledger.allocateParties(2)
         divulgence1 <- ledger.create(alice, Divulgence1(alice))
         divulgence2 <- ledger.create(bob, Divulgence2(bob, alice))
         _ <- ledger.exercise(alice, divulgence2.exerciseDivulgence2Archive(_, divulgence1))
@@ -141,11 +143,12 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
       }
   }
 
-  test("DivulgenceAcs", "Divulged contracts should not be exposed by the active contract service") {
-    context =>
+  test(
+    "DivulgenceAcs",
+    "Divulged contracts should not be exposed by the active contract service",
+    allocate(TwoParties)) {
+    case Participants(Participant(ledger, alice, bob)) =>
       for {
-        ledger <- context.participant()
-        Vector(alice, bob) <- ledger.allocateParties(2)
         divulgence1 <- ledger.create(alice, Divulgence1(alice))
         divulgence2 <- ledger.create(bob, Divulgence2(bob, alice))
         _ <- ledger.exercise(alice, divulgence2.exerciseDivulgence2Fetch(_, divulgence1))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Identity.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Identity.scala
@@ -3,14 +3,19 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 
+import scala.concurrent.Future
+
 final class Identity(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("IdNotEmpty", "A ledger should return a non-empty string as its identity") { context =>
-    for {
-      ledger <- context.participant()
-    } yield {
-      assert(ledger.ledgerId.nonEmpty, "The returned ledger identifier was empty")
-    }
+  test(
+    "IdNotEmpty",
+    "A ledger should return a non-empty string as its identity",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      Future {
+        assert(ledger.ledgerId.nonEmpty, "The returned ledger identifier was empty")
+      }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.ProtobufConverters._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
@@ -13,24 +14,24 @@ import com.google.protobuf
 import io.grpc.{Status, StatusException, StatusRuntimeException}
 
 class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("ConfigSucceeds", "Return a valid configuration for a valid request") { context =>
-    for {
-      ledger <- context.participant()
-      config <- ledger.configuration()
-    } yield {
-      assert(config.minTtl.isDefined, "The minTTL field of the configuration is empty")
-      assert(config.maxTtl.isDefined, "The maxTTL field of the configuration is empty")
-    }
+  test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        config <- ledger.configuration()
+      } yield {
+        assert(config.minTtl.isDefined, "The minTTL field of the configuration is empty")
+        assert(config.maxTtl.isDefined, "The maxTTL field of the configuration is empty")
+      }
   }
 
-  test("ConfigLedgerId", "Return NOT_FOUND to invalid ledger identifier") { context =>
-    val invalidLedgerId = "THIS_IS_AN_INVALID_LEDGER_ID"
-    for {
-      ledger <- context.participant()
-      failure <- ledger.configuration(overrideLedgerId = Some(invalidLedgerId)).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
-    }
+  test("ConfigLedgerId", "Return NOT_FOUND to invalid ledger identifier", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      val invalidLedgerId = "THIS_IS_AN_INVALID_LEDGER_ID"
+      for {
+        failure <- ledger.configuration(overrideLedgerId = Some(invalidLedgerId)).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
+      }
   }
 
   private def setTtl(request: SubmitRequest, ttl: java.time.Duration): SubmitRequest =
@@ -39,104 +40,104 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
         commands.copy(
           maximumRecordTime = commands.ledgerEffectiveTime.map(_.asJava.plus(ttl).asProtobuf))))
 
-  test("ConfigJustMinTtl", "LET+minTTL should be an acceptable MRT") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      LedgerConfiguration(Some(minTtl), _) <- ledger.configuration()
-      request <- ledger.submitRequest(party, Dummy(party).create.command)
-      _ <- ledger.submit(setTtl(request, minTtl.asJava))
-    } yield {
-      // Nothing to do, success is enough
-    }
+  test("ConfigJustMinTtl", "LET+minTTL should be an acceptable MRT", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(Some(minTtl), _) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submit(setTtl(request, minTtl.asJava))
+      } yield {
+        // Nothing to do, success is enough
+      }
   }
 
-  test("ConfigUnderflowMinTtl", "LET+minTTL-1 should NOT be an acceptable MRT") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      LedgerConfiguration(Some(minTtl), _) <- ledger.configuration()
-      request <- ledger.submitRequest(party, Dummy(party).create.command)
-      failure <- ledger.submit(setTtl(request, minTtl.asJava.minusSeconds(1))).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "out of bounds")
-    }
+  test(
+    "ConfigUnderflowMinTtl",
+    "LET+minTTL-1 should NOT be an acceptable MRT",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(Some(minTtl), _) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        failure <- ledger.submit(setTtl(request, minTtl.asJava.minusSeconds(1))).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "out of bounds")
+      }
   }
 
-  test("ConfigJustMaxTtl", "LET+maxTTL should be an acceptable MRT") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
-      request <- ledger.submitRequest(party, Dummy(party).create.command)
-      _ <- ledger.submit(setTtl(request, maxTtl.asJava.minusSeconds(1)))
-    } yield {
-      // Nothing to do, success is enough
-    }
+  test("ConfigJustMaxTtl", "LET+maxTTL should be an acceptable MRT", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        _ <- ledger.submit(setTtl(request, maxTtl.asJava.minusSeconds(1)))
+      } yield {
+        // Nothing to do, success is enough
+      }
   }
 
-  test("ConfigOverflowMaxTtl", "LET+maxTTL+1 should NOT be an acceptable MRT") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
-      request <- ledger.submitRequest(party, Dummy(party).create.command)
-      failure <- ledger.submit(setTtl(request, maxTtl.asJava.plusSeconds(1))).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "out of bounds")
-    }
+  test(
+    "ConfigOverflowMaxTtl",
+    "LET+maxTTL+1 should NOT be an acceptable MRT",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        failure <- ledger.submit(setTtl(request, maxTtl.asJava.plusSeconds(1))).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "out of bounds")
+      }
   }
 
-  test("CSLSuccessIfLetRight", "Submission returns OK if LET is within the accepted interval") {
-    context =>
+  test(
+    "CSLSuccessIfLetRight",
+    "Submission returns OK if LET is within the accepted interval",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       // The maximum accepted clock skew depends on the ledger and is not exposed through the LedgerConfigurationService,
       // and there might be an actual clock skew between the devices running the test and the ledger.
       // This test therefore does not attempt to simulate any clock skew
       // but simply checks whether basic command submission with an unmodified LET works.
-
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        request <- ledger.submitRequest(alice, Dummy(alice).create.command)
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
         _ <- ledger.submit(request)
       } yield {
         // No assertions to make, since the command went through as expected
       }
   }
 
-  test("CSLAbortIfLetHigh", "Submission returns ABORTED if LET is too high") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
-      request <- ledger.submitRequest(alice, Dummy(alice).create.command)
-      invalidRequest = request
-        .update(_.commands.ledgerEffectiveTime.modify(overflow(maxTtl)))
-        .update(_.commands.maximumRecordTime.modify(overflow(maxTtl)))
-      failure <- ledger.submit(invalidRequest).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.ABORTED, "TRANSACTION_OUT_OF_TIME_WINDOW: ")
-    }
+  test("CSLAbortIfLetHigh", "Submission returns ABORTED if LET is too high", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        invalidRequest = request
+          .update(_.commands.ledgerEffectiveTime.modify(overflow(maxTtl)))
+          .update(_.commands.maximumRecordTime.modify(overflow(maxTtl)))
+        failure <- ledger.submit(invalidRequest).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.ABORTED, "TRANSACTION_OUT_OF_TIME_WINDOW: ")
+      }
   }
 
-  test("CSLAbortIfLetLow", "Submission returns ABORTED if LET is too low") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
-      request <- ledger.submitRequest(alice, Dummy(alice).create.command)
-      invalidRequest = request
-        .update(_.commands.ledgerEffectiveTime.modify(underflow(maxTtl)))
-        .update(_.commands.maximumRecordTime.modify(underflow(maxTtl)))
-      failure <- ledger.submit(invalidRequest).failed
-    } yield {
-      // In this case, the ledger's response races with the client's timeout detection.
-      // So we can't be sure what the error message will be.
-      failure match {
-        case _: StatusRuntimeException | _: StatusException => ()
-        case _ => fail("Submission should have failed with gRPC exception")
+  test("CSLAbortIfLetLow", "Submission returns ABORTED if LET is too low", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        LedgerConfiguration(_, Some(maxTtl)) <- ledger.configuration()
+        request <- ledger.submitRequest(party, Dummy(party).create.command)
+        invalidRequest = request
+          .update(_.commands.ledgerEffectiveTime.modify(underflow(maxTtl)))
+          .update(_.commands.maximumRecordTime.modify(underflow(maxTtl)))
+        failure <- ledger.submit(invalidRequest).failed
+      } yield {
+        // In this case, the ledger's response races with the client's timeout detection.
+        // So we can't be sure what the error message will be.
+        failure match {
+          case _: StatusRuntimeException | _: StatusException => ()
+          case _ => fail("Submission should have failed with gRPC exception")
+        }
       }
-    }
   }
 
   private def overflow(ttl: protobuf.duration.Duration)(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Packages.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Packages.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import io.grpc.Status
@@ -12,54 +13,58 @@ final class Packages(session: LedgerSession) extends LedgerTestSuite(session) {
   /** A package ID that is guaranteed to not be uploaded */
   private[this] val unknownPackageId = " "
 
-  test("PackagesList", "Listing packages should return a result") { context =>
-    for {
-      ledger <- context.participant()
-      knownPackages <- ledger.listPackages()
-    } yield
-      assert(
-        knownPackages.size >= 3,
-        s"List of packages was expected to contain at least 3 packages, got ${knownPackages.size} instead.")
-  }
-
-  test("PackagesGet", "Getting package content should return a valid result") { context =>
-    for {
-      ledger <- context.participant()
-      somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
-      somePackage <- ledger.getPackage(somePackageId)
-    } yield {
-      assert(somePackage.hash.length > 0, s"Package $somePackageId has an empty hash.")
-      assert(
-        somePackage.hash == somePackageId,
-        s"Package $somePackageId has hash ${somePackage.hash}, expected hash to be equal to the package ID.")
-      assert(somePackage.archivePayload.size() >= 0, s"Package $somePackageId has zero size.")
-    }
-  }
-
-  test("PackagesGetUnknown", "Getting package content for an unknown package should fail") {
-    context =>
+  test("PackagesList", "Listing packages should return a result", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
       for {
-        ledger <- context.participant()
+        knownPackages <- ledger.listPackages()
+      } yield
+        assert(
+          knownPackages.size >= 3,
+          s"List of packages was expected to contain at least 3 packages, got ${knownPackages.size} instead.")
+  }
+
+  test("PackagesGet", "Getting package content should return a valid result", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
+        somePackage <- ledger.getPackage(somePackageId)
+      } yield {
+        assert(somePackage.hash.length > 0, s"Package $somePackageId has an empty hash.")
+        assert(
+          somePackage.hash == somePackageId,
+          s"Package $somePackageId has hash ${somePackage.hash}, expected hash to be equal to the package ID.")
+        assert(somePackage.archivePayload.size() >= 0, s"Package $somePackageId has zero size.")
+      }
+  }
+
+  test(
+    "PackagesGetUnknown",
+    "Getting package content for an unknown package should fail",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
         failure <- ledger.getPackage(unknownPackageId).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, "")
       }
   }
 
-  test("PackagesStatus", "Getting package status should return a valid result") { context =>
-    for {
-      ledger <- context.participant()
-      somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
-      status <- ledger.getPackageStatus(somePackageId)
-    } yield {
-      assert(status.isRegistered, s"Package $somePackageId is not registered.")
-    }
+  test("PackagesStatus", "Getting package status should return a valid result", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
+        status <- ledger.getPackageStatus(somePackageId)
+      } yield {
+        assert(status.isRegistered, s"Package $somePackageId is not registered.")
+      }
   }
 
-  test("PackagesStatusUnknown", "Getting package status for an unknown package should fail") {
-    context =>
+  test(
+    "PackagesStatusUnknown",
+    "Getting package status for an unknown package should fail",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
       for {
-        ledger <- context.participant()
         status <- ledger.getPackageStatus(unknownPackageId)
       } yield {
         assert(status.isUnknown, s"Package $unknownPackageId is not unknown.")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import scalaz.Tag
 
@@ -11,78 +12,82 @@ import scala.util.Random
 final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "PMNonEmptyParticipantID",
-    "Asking for the participant identifier should return a non-empty string") { context =>
-    for {
-      ledger <- context.participant()
-      participantId <- ledger.participantId()
-    } yield {
-      assert(participantId.nonEmpty, "The ledger returned an empty participant identifier")
-    }
+    "Asking for the participant identifier should return a non-empty string",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        participantId <- ledger.participantId()
+      } yield {
+        assert(participantId.nonEmpty, "The ledger returned an empty participant identifier")
+      }
   }
 
   private val pMAllocateWithHint = "PMAllocateWithHint"
   test(
     pMAllocateWithHint,
-    "It should be possible to provide a hint when allocating a party"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty(
-        partyHintId = Some(pMAllocateWithHint + "_" + Random.alphanumeric.take(10).mkString),
-        displayName = Some("Bob Ross"))
-    } yield assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
+    "It should be possible to provide a hint when allocating a party",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        party <- ledger.allocateParty(
+          partyHintId = Some(pMAllocateWithHint + "_" + Random.alphanumeric.take(10).mkString),
+          displayName = Some("Bob Ross"))
+      } yield
+        assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
   }
 
   test(
     "PMAllocateWithoutHint",
-    "It should be possible to not provide a hint when allocating a party"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty(partyHintId = None, displayName = Some("Jebediah Kerman"))
-    } yield assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
+    "It should be possible to not provide a hint when allocating a party",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        party <- ledger.allocateParty(partyHintId = None, displayName = Some("Jebediah Kerman"))
+      } yield
+        assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
   }
 
   private val pMAllocateWithoutDisplayName = "PMAllocateWithoutDisplayName"
   test(
     pMAllocateWithoutDisplayName,
-    "It should be possible to not provide a display name when allocating a party"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty(
-        partyHintId =
-          Some(pMAllocateWithoutDisplayName + "_" + Random.alphanumeric.take(10).mkString),
-        displayName = None)
-    } yield assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
+    "It should be possible to not provide a display name when allocating a party",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        party <- ledger.allocateParty(
+          partyHintId =
+            Some(pMAllocateWithoutDisplayName + "_" + Random.alphanumeric.take(10).mkString),
+          displayName = None)
+      } yield
+        assert(Tag.unwrap(party).nonEmpty, "The allocated party identifier is an empty string")
   }
 
   test(
     "PMAllocateDuplicateDisplayName",
-    "It should be possible to allocate parties with the same display names"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      p1 <- ledger.allocateParty(partyHintId = None, displayName = Some("Ononym McOmonymface"))
-      p2 <- ledger.allocateParty(partyHintId = None, displayName = Some("Ononym McOmonymface"))
-    } yield {
-      assert(Tag.unwrap(p1).nonEmpty, "The first allocated party identifier is an empty string")
-      assert(Tag.unwrap(p2).nonEmpty, "The second allocated party identifier is an empty string")
-      assert(p1 != p2, "The two parties have the same party identifier")
-    }
+    "It should be possible to allocate parties with the same display names",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        p1 <- ledger.allocateParty(partyHintId = None, displayName = Some("Ononym McOmonymface"))
+        p2 <- ledger.allocateParty(partyHintId = None, displayName = Some("Ononym McOmonymface"))
+      } yield {
+        assert(Tag.unwrap(p1).nonEmpty, "The first allocated party identifier is an empty string")
+        assert(Tag.unwrap(p2).nonEmpty, "The second allocated party identifier is an empty string")
+        assert(p1 != p2, "The two parties have the same party identifier")
+      }
   }
 
   test(
     "PMAllocateOneHundred",
-    "It should create unique party names when allocating many parties"
-  ) { context =>
-    for {
-      ledger <- context.participant()
-      parties <- ledger.allocateParties(100)
-    } yield {
-      val nonUniqueNames = parties.groupBy(Tag.unwrap).mapValues(_.size).filter(_._2 > 1)
-      assert(nonUniqueNames.isEmpty, s"There are non-unique party names: ${nonUniqueNames
-        .map { case (name, count) => s"$name ($count)" } mkString (", ")}")
-    }
+    "It should create unique party names when allocating many parties",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        parties <- ledger.allocateParties(100)
+      } yield {
+        val nonUniqueNames = parties.groupBy(Tag.unwrap).mapValues(_.size).filter(_._2 > 1)
+        assert(nonUniqueNames.isEmpty, s"There are non-unique party names: ${nonUniqueNames
+          .map { case (name, count) => s"$name ($count)" } mkString (", ")}")
+      }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
@@ -40,50 +41,55 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
    * 2. `act` does not happen after the contract has been consumend (i.e. no double spending)
    */
 
-  test("SemanticDoubleSpend", "Cannot double spend across transactions") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(payer, owner) <- alpha.allocateParties(2)
-      Vector(newOwner, leftWithNothing) <- beta.allocateParties(2)
-      iou <- alpha.create(payer, Iou(payer, owner, onePound))
-      _ <- alpha.exercise(owner, iou.exerciseTransfer(_, newOwner))
-      failure <- alpha.exercise(owner, iou.exerciseTransfer(_, leftWithNothing)).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
-    }
+  test(
+    "SemanticDoubleSpend",
+    "Cannot double spend across transactions",
+    allocate(TwoParties, TwoParties)) {
+    case Participants(
+        Participant(alpha, payer, owner),
+        Participant(_, newOwner, leftWithNothing)) =>
+      for {
+        iou <- alpha.create(payer, Iou(payer, owner, onePound))
+        _ <- alpha.exercise(owner, iou.exerciseTransfer(_, newOwner))
+        failure <- alpha.exercise(owner, iou.exerciseTransfer(_, leftWithNothing)).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
+      }
   }
 
-  test("SemanticDoubleSpendSameTx", "Cannot double spend within a transaction") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(payer, owner) <- alpha.allocateParties(2)
-      Vector(newOwner1, newOwner2) <- beta.allocateParties(2)
-      iou <- alpha.create(payer, Iou(payer, owner, onePound))
-      doubleSpend <- alpha.submitAndWaitRequest(
-        owner,
-        iou.exerciseTransfer(owner, newOwner1).command,
-        iou.exerciseTransfer(owner, newOwner2).command)
-      failure <- alpha.submitAndWait(doubleSpend).failed
-    } yield {
-      assertGrpcError(
-        failure,
-        Status.Code.INVALID_ARGUMENT,
-        "Update failed due to fetch of an inactive contract")
-    }
+  test(
+    "SemanticDoubleSpendSameTx",
+    "Cannot double spend within a transaction",
+    allocate(TwoParties, TwoParties)) {
+    case Participants(Participant(alpha, payer, owner), Participant(_, newOwner1, newOwner2)) =>
+      for {
+        iou <- alpha.create(payer, Iou(payer, owner, onePound))
+        doubleSpend <- alpha.submitAndWaitRequest(
+          owner,
+          iou.exerciseTransfer(owner, newOwner1).command,
+          iou.exerciseTransfer(owner, newOwner2).command)
+        failure <- alpha.submitAndWait(doubleSpend).failed
+      } yield {
+        assertGrpcError(
+          failure,
+          Status.Code.INVALID_ARGUMENT,
+          "Update failed due to fetch of an inactive contract")
+      }
   }
 
-  test("SemanticDoubleSpendShared", "Different parties cannot spend the same contract") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(payer, owner1) <- alpha.allocateParties(2)
-      owner2 <- beta.allocateParty()
-      shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
-      _ <- alpha.exercise(owner1, shared.exerciseSharedContract_Consume1)
-      _ <- synchronize(alpha, beta)
-      failure <- beta.exercise(owner2, shared.exerciseSharedContract_Consume2).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
-    }
+  test(
+    "SemanticDoubleSpendShared",
+    "Different parties cannot spend the same contract",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, payer, owner1), Participant(beta, owner2)) =>
+      for {
+        shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
+        _ <- alpha.exercise(owner1, shared.exerciseSharedContract_Consume1)
+        _ <- synchronize(alpha, beta)
+        failure <- beta.exercise(owner2, shared.exerciseSharedContract_Consume2).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
+      }
   }
 
   /*
@@ -96,38 +102,39 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
    * 2. the required authorizers of an Exercise or a Fetch action are its actors
    */
 
-  test("SemanticPaintOffer", "Conduct the paint offer workflow successfully") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(bank, houseOwner) <- alpha.allocateParties(2)
-      painter <- beta.allocateParty()
-      iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
-      offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
-      tree <- eventually { alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou)) }
-    } yield {
-      val agreement = assertSingleton(
-        "SemanticPaintOffer",
-        createdEvents(tree).filter(_.getTemplateId == Tag.unwrap(PaintAgree.id)))
-      assertEquals(
-        "Paint agreement parameters",
-        agreement.getCreateArguments,
-        Record(
-          recordId = Some(Tag.unwrap(PaintAgree.id)),
-          fields = Seq(
-            RecordField("painter", Some(Value(Value.Sum.Party(Tag.unwrap(painter))))),
-            RecordField("houseOwner", Some(Value(Value.Sum.Party(Tag.unwrap(houseOwner)))))
+  test(
+    "SemanticPaintOffer",
+    "Conduct the paint offer workflow successfully",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
+      for {
+        iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
+        offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
+        tree <- eventually { alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou)) }
+      } yield {
+        val agreement = assertSingleton(
+          "SemanticPaintOffer",
+          createdEvents(tree).filter(_.getTemplateId == Tag.unwrap(PaintAgree.id)))
+        assertEquals(
+          "Paint agreement parameters",
+          agreement.getCreateArguments,
+          Record(
+            recordId = Some(Tag.unwrap(PaintAgree.id)),
+            fields = Seq(
+              RecordField("painter", Some(Value(Value.Sum.Party(Tag.unwrap(painter))))),
+              RecordField("houseOwner", Some(Value(Value.Sum.Party(Tag.unwrap(houseOwner)))))
+            )
           )
         )
-      )
-    }
+      }
   }
 
-  test("SemanticPaintCounterOffer", "Conduct the paint counter-offer worflow successfully") {
-    context =>
+  test(
+    "SemanticPaintCounterOffer",
+    "Conduct the paint counter-offer worflow successfully",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        Vector(bank, houseOwner) <- alpha.allocateParties(2)
-        painter <- beta.allocateParty()
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
         offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, twoPounds))
         counter <- eventually {
@@ -156,25 +163,22 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
 
   test(
     "SemanticPartialSignatories",
-    "A signatory should not be able to create a contract on behalf of two parties") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      houseOwner <- alpha.allocateParty()
-      painter <- beta.allocateParty()
-      failure <- alpha.create(houseOwner, PaintAgree(painter, houseOwner)).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
-    }
+    "A signatory should not be able to create a contract on behalf of two parties",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, houseOwner), Participant(_, painter)) =>
+      for {
+        failure <- alpha.create(houseOwner, PaintAgree(painter, houseOwner)).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
+      }
   }
 
   test(
     "SemanticAcceptOnBehalf",
-    "It should not be possible to exercise a choice without the consent of the controller") {
-    context =>
+    "It should not be possible to exercise a choice without the consent of the controller",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        Vector(bank, houseOwner) <- alpha.allocateParties(2)
-        painter <- beta.allocateParty()
         iou <- beta.create(painter, Iou(painter, houseOwner, onePound))
         offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
         failure <- beta.exercise(painter, offer.exercisePaintOffer_Accept(_, iou)).failed
@@ -193,61 +197,60 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
 
   test(
     "SemanticPrivacyProjections",
-    "Test visibility via contract fetches for the paint-offer flow") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(bank, houseOwner) <- alpha.allocateParties(2)
-      painter <- beta.allocateParty()
-      iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
-      _ <- synchronize(alpha, beta)
+    "Test visibility via contract fetches for the paint-offer flow",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
+      for {
+        iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
+        _ <- synchronize(alpha, beta)
 
-      // The IOU should be visible only to the payer and the owner
-      _ <- fetchIou(alpha, bank, iou)
-      _ <- fetchIou(alpha, houseOwner, iou)
-      iouFetchFailure <- fetchIou(beta, painter, iou).failed
+        // The IOU should be visible only to the payer and the owner
+        _ <- fetchIou(alpha, bank, iou)
+        _ <- fetchIou(alpha, houseOwner, iou)
+        iouFetchFailure <- fetchIou(beta, painter, iou).failed
 
-      offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
-      _ <- synchronize(alpha, beta)
+        offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
+        _ <- synchronize(alpha, beta)
 
-      // The house owner and the painter can see the offer but the bank can't
-      _ <- fetchPaintOffer(alpha, houseOwner, offer)
-      _ <- fetchPaintOffer(beta, painter, offer)
-      paintOfferFetchFailure <- fetchPaintOffer(alpha, bank, offer).failed
+        // The house owner and the painter can see the offer but the bank can't
+        _ <- fetchPaintOffer(alpha, houseOwner, offer)
+        _ <- fetchPaintOffer(beta, painter, offer)
+        paintOfferFetchFailure <- fetchPaintOffer(alpha, bank, offer).failed
 
-      tree <- alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou))
-      (newIouEvent +: _, agreementEvent +: _) = createdEvents(tree).partition(
-        _.getTemplateId == Tag.unwrap(Iou.id))
-      newIou = Primitive.ContractId[Iou](newIouEvent.contractId)
-      agreement = Primitive.ContractId[PaintAgree](agreementEvent.contractId)
-      _ <- synchronize(alpha, beta)
+        tree <- alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou))
+        (newIouEvent +: _, agreementEvent +: _) = createdEvents(tree).partition(
+          _.getTemplateId == Tag.unwrap(Iou.id))
+        newIou = Primitive.ContractId[Iou](newIouEvent.contractId)
+        agreement = Primitive.ContractId[PaintAgree](agreementEvent.contractId)
+        _ <- synchronize(alpha, beta)
 
-      // The Bank can see the new IOU, but it cannot see the PaintAgree contract
-      _ <- fetchIou(alpha, bank, newIou)
-      paintAgreeFetchFailure <- fetchPaintAgree(alpha, bank, agreement).failed
+        // The Bank can see the new IOU, but it cannot see the PaintAgree contract
+        _ <- fetchIou(alpha, bank, newIou)
+        paintAgreeFetchFailure <- fetchPaintAgree(alpha, bank, agreement).failed
 
-      // The house owner and the painter can see the contract
-      _ <- fetchPaintAgree(beta, painter, agreement)
-      _ <- fetchPaintAgree(alpha, houseOwner, agreement)
+        // The house owner and the painter can see the contract
+        _ <- fetchPaintAgree(beta, painter, agreement)
+        _ <- fetchPaintAgree(alpha, houseOwner, agreement)
 
-      // The painter sees its new IOU but the house owner cannot see it
-      _ <- fetchIou(beta, painter, newIou)
-      secondIouFetchFailure <- fetchIou(alpha, houseOwner, newIou).failed
+        // The painter sees its new IOU but the house owner cannot see it
+        _ <- fetchIou(beta, painter, newIou)
+        secondIouFetchFailure <- fetchIou(alpha, houseOwner, newIou).failed
 
-    } yield {
-      assertGrpcError(iouFetchFailure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
-      assertGrpcError(
-        paintOfferFetchFailure,
-        Status.Code.INVALID_ARGUMENT,
-        "couldn't find contract")
-      assertGrpcError(
-        paintAgreeFetchFailure,
-        Status.Code.INVALID_ARGUMENT,
-        "couldn't find contract")
-      assertGrpcError(
-        secondIouFetchFailure,
-        Status.Code.INVALID_ARGUMENT,
-        "requires one of the stakeholders")
-    }
+      } yield {
+        assertGrpcError(iouFetchFailure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
+        assertGrpcError(
+          paintOfferFetchFailure,
+          Status.Code.INVALID_ARGUMENT,
+          "couldn't find contract")
+        assertGrpcError(
+          paintAgreeFetchFailure,
+          Status.Code.INVALID_ARGUMENT,
+          "couldn't find contract")
+        assertGrpcError(
+          secondIouFetchFailure,
+          Status.Code.INVALID_ARGUMENT,
+          "requires one of the stakeholders")
+      }
   }
 
   private def fetchIou(
@@ -283,30 +286,28 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
    * Divulgence
    */
 
-  test("SemanticDivulgence", "Respect divulgence rules") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(issuer, owner) <- alpha.allocateParties(2)
-      delegate <- beta.allocateParty()
-      token <- alpha.create(issuer, Token(issuer, owner, 1))
-      delegation <- alpha.create(owner, Delegation(owner, delegate))
+  test("SemanticDivulgence", "Respect divulgence rules", allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, issuer, owner), Participant(beta, delegate)) =>
+      for {
+        token <- alpha.create(issuer, Token(issuer, owner, 1))
+        delegation <- alpha.create(owner, Delegation(owner, delegate))
 
-      // The owner tries to divulge with a non-consuming choice, which actually doesn't work
-      noDivulgeToken <- alpha.create(owner, Delegation(owner, delegate))
-      _ <- alpha.exercise(owner, noDivulgeToken.exerciseDelegation_Wrong_Divulge_Token(_, token))
-      _ <- synchronize(alpha, beta)
-      failure <- beta
-        .exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
-        .failed
+        // The owner tries to divulge with a non-consuming choice, which actually doesn't work
+        noDivulgeToken <- alpha.create(owner, Delegation(owner, delegate))
+        _ <- alpha.exercise(owner, noDivulgeToken.exerciseDelegation_Wrong_Divulge_Token(_, token))
+        _ <- synchronize(alpha, beta)
+        failure <- beta
+          .exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+          .failed
 
-      // Successful divulgence and delegation
-      divulgeToken <- alpha.create(owner, Delegation(owner, delegate))
-      _ <- alpha.exercise(owner, divulgeToken.exerciseDelegation_Divulge_Token(_, token))
-      _ <- eventually {
-        beta.exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+        // Successful divulgence and delegation
+        divulgeToken <- alpha.create(owner, Delegation(owner, delegate))
+        _ <- alpha.exercise(owner, divulgeToken.exerciseDelegation_Divulge_Token(_, token))
+        _ <- eventually {
+          beta.exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+        }
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
       }
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
-    }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Time.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Time.scala
@@ -5,19 +5,20 @@ package com.daml.ledger.api.testtool.tests
 
 import java.time.Duration
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 
 final class Time(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("PassTime", "Advancing time should return the new time") { context =>
-    for {
-      ledger <- context.participant()
-      t1 <- ledger.time()
-      _ <- ledger.passTime(Duration.ofSeconds(1))
-      t2 <- ledger.time()
-      travel = Duration.between(t1, t2)
-    } yield
-      assert(
-        travel == Duration.ofSeconds(1),
-        s"Time travel was expected to be 1 second but was instead $travel")
+  test("PassTime", "Advancing time should return the new time", allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      for {
+        t1 <- ledger.time()
+        _ <- ledger.passTime(Duration.ofSeconds(1))
+        t2 <- ledger.time()
+        travel = Duration.between(t1, t2)
+      } yield
+        assert(
+          travel == Duration.ofSeconds(1),
+          s"Time travel was expected to be 1 second but was instead $travel")
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
@@ -30,13 +31,12 @@ import scala.concurrent.Future
 class TransactionService(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "TXBeginToBegin",
-    "An empty stream should be served when getting transactions from and to the beginning of the ledger") {
-    context =>
+    "An empty stream should be served when getting transactions from and to the beginning of the ledger",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val request = ledger.getTransactionsRequest(Seq(party))
+      val fromAndToBegin = request.update(_.begin := ledger.begin, _.end := ledger.begin)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        request = ledger.getTransactionsRequest(Seq(party))
-        fromAndToBegin = request.update(_.begin := ledger.begin, _.end := ledger.begin)
         transactions <- ledger.flatTransactions(fromAndToBegin)
       } yield {
         assert(
@@ -47,13 +47,13 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTreesBeginToBegin",
-    "An empty stream of trees should be served when getting transactions from and to the beginning of the ledger") {
-    context =>
+    "An empty stream of trees should be served when getting transactions from and to the beginning of the ledger",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
+      val request = ledger.getTransactionsRequest(Seq(party))
+      val fromAndToBegin = request.update(_.begin := ledger.begin, _.end := ledger.begin)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        request = ledger.getTransactionsRequest(Seq(party))
-        fromAndToBegin = request.update(_.begin := ledger.begin, _.end := ledger.begin)
         transactions <- ledger.transactionTrees(fromAndToBegin)
       } yield {
         assert(
@@ -64,11 +64,10 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXEndToEnd",
-    "An empty stream should be served when getting transactions from and to the end of the ledger") {
-    context =>
+    "An empty stream should be served when getting transactions from and to the end of the ledger",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- ledger.create(party, Dummy(party))
         request = ledger.getTransactionsRequest(Seq(party))
         endToEnd = request.update(_.begin := ledger.end, _.end := ledger.end)
@@ -80,32 +79,35 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXServeUntilCancellation", "Items should be served until the client cancels") { context =>
-    val transactionsToSubmit = 14
-    val transactionsToRead = 10
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummies <- Future.sequence(
-        Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
-      transactions <- ledger.flatTransactions(transactionsToRead, party)
-    } yield {
-      assert(
-        dummies.size == transactionsToSubmit,
-        s"$transactionsToSubmit should have been submitted but ${dummies.size} were instead")
-      assert(
-        transactions.size == transactionsToRead,
-        s"$transactionsToRead should have been received but ${transactions.size} were instead")
-    }
+  test(
+    "TXServeUntilCancellation",
+    "Items should be served until the client cancels",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val transactionsToSubmit = 14
+      val transactionsToRead = 10
+      for {
+        dummies <- Future.sequence(
+          Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
+        transactions <- ledger.flatTransactions(transactionsToRead, party)
+      } yield {
+        assert(
+          dummies.size == transactionsToSubmit,
+          s"$transactionsToSubmit should have been submitted but ${dummies.size} were instead")
+        assert(
+          transactions.size == transactionsToRead,
+          s"$transactionsToRead should have been received but ${transactions.size} were instead")
+      }
   }
 
-  test("TXServeTreesUntilCancellation", "Trees should be served until the client cancels") {
-    context =>
+  test(
+    "TXServeTreesUntilCancellation",
+    "Trees should be served until the client cancels",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val transactionsToSubmit = 14
       val treesToRead = 10
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         dummies <- Future.sequence(
           Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
         trees <- ledger.transactionTrees(treesToRead, party)
@@ -121,12 +123,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXDeduplicateCommands",
-    "Commands with identical submitter, command identifier, and application identifier should be accepted and deduplicated") {
-    context =>
+    "Commands with identical submitter, command identifier, and application identifier should be accepted and deduplicated",
+    allocate(TwoParties)
+  ) {
+    case Participants(Participant(ledger, alice, bob)) =>
       for {
-        ledger <- context.participant()
-        alice <- ledger.allocateParty()
-        bob <- ledger.allocateParty()
         aliceRequest <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
         _ <- ledger.submitAndWait(aliceRequest)
         _ <- ledger.submitAndWait(aliceRequest)
@@ -152,26 +153,26 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXRejectEmptyFilter",
-    "A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status") {
-    context =>
+    "A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val request = ledger.getTransactionsRequest(Seq(party))
+      val requestWithEmptyFilter = request.update(_.filter.filtersByParty := Map.empty)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        request = ledger.getTransactionsRequest(Seq(party))
-        requestWithEmptyFilter = request.update(_.filter.filtersByParty := Map.empty)
         failure <- ledger.flatTransactions(requestWithEmptyFilter).failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "filtersByParty cannot be empty")
       }
   }
 
-  test("TXCompleteOnLedgerEnd", "A stream should complete as soon as the ledger end is hit") {
-    context =>
+  test(
+    "TXCompleteOnLedgerEnd",
+    "A stream should complete as soon as the ledger end is hit",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val transactionsToSubmit = 14
+      val transactionsFuture = ledger.flatTransactions(party)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        transactionsFuture = ledger.flatTransactions(party)
         _ <- Future.sequence(Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
         _ <- transactionsFuture
       } yield {
@@ -181,27 +182,26 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXCompleteTreesOnLedgerEnd",
-    "A stream of trees should complete as soon as the ledger end is hit") { context =>
-    val transactionsToSubmit = 14
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      transactionsFuture = ledger.transactionTrees(party)
-      _ <- Future.sequence(Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
-      _ <- transactionsFuture
-    } yield {
-      // doing nothing: we are just checking that `transactionsFuture` completes successfully
-    }
+    "A stream of trees should complete as soon as the ledger end is hit",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val transactionsToSubmit = 14
+      val transactionsFuture = ledger.transactionTrees(party)
+      for {
+        _ <- Future.sequence(Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
+        _ <- transactionsFuture
+      } yield {
+        // doing nothing: we are just checking that `transactionsFuture` completes successfully
+      }
   }
 
   test(
     "TXProcessInTwoChunks",
-    "Serve the complete sequence of transactions even if processing is stopped and resumed") {
-    context =>
+    "Serve the complete sequence of transactions even if processing is stopped and resumed",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val transactionsToSubmit = 5
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- Future.sequence(Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
         endAfterFirstSection <- ledger.currentEnd()
         firstSectionRequest = ledger
@@ -227,13 +227,14 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXParallel", "The same data should be served for more than 1 identical, parallel requests") {
-    context =>
+  test(
+    "TXParallel",
+    "The same data should be served for more than 1 identical, parallel requests",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val transactionsToSubmit = 5
       val parallelRequests = 10
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- Future.sequence(Vector.fill(transactionsToSubmit)(ledger.create(party, Dummy(party))))
         results <- Future.sequence(Vector.fill(parallelRequests)(ledger.flatTransactions(party)))
       } yield {
@@ -245,12 +246,12 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXNotDivulge", "Data should not be exposed to parties unrelated to a transaction") {
-    context =>
+  test(
+    "TXNotDivulge",
+    "Data should not be exposed to parties unrelated to a transaction",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(_, bob)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
         _ <- alpha.create(alice, Dummy(alice))
         bobsView <- alpha.flatTransactions(bob)
       } yield {
@@ -263,84 +264,83 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXRejectBeginAfterEnd",
-    "A request with the end before the begin should be rejected with INVALID_ARGUMENT") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      earlier <- ledger.currentEnd()
-      _ <- ledger.create(party, Dummy(party))
-      later <- ledger.currentEnd()
-      request = ledger.getTransactionsRequest(Seq(party))
-      invalidRequest = request.update(_.begin := later, _.end := earlier)
-      failure <- ledger.flatTransactions(invalidRequest).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "is before Begin offset")
-    }
+    "A request with the end before the begin should be rejected with INVALID_ARGUMENT",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        earlier <- ledger.currentEnd()
+        _ <- ledger.create(party, Dummy(party))
+        later <- ledger.currentEnd()
+        request = ledger.getTransactionsRequest(Seq(party))
+        invalidRequest = request.update(_.begin := later, _.end := earlier)
+        failure <- ledger.flatTransactions(invalidRequest).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "is before Begin offset")
+      }
   }
 
   test(
     "TXHideCommandIdToNonSubmittingStakeholders",
-    "A transaction should be visible to a non-submitting stakeholder but its command identifier should be empty"
-  ) { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      submitter <- alpha.allocateParty()
-      listener <- beta.allocateParty()
-      (id, _) <- alpha.createAndGetTransactionId(submitter, AgreementFactory(listener, submitter))
-      tree <- eventually { beta.transactionTreeById(id, listener) }
-    } yield {
-      assert(
-        tree.commandId.isEmpty,
-        s"The command identifier was supposed to be empty but it's `${tree.commandId}` instead.")
-    }
+    "A transaction should be visible to a non-submitting stakeholder but its command identifier should be empty",
+    allocate(SingleParty, SingleParty)
+  ) {
+    case Participants(Participant(alpha, submitter), Participant(beta, listener)) =>
+      for {
+        (id, _) <- alpha.createAndGetTransactionId(submitter, AgreementFactory(listener, submitter))
+        tree <- eventually { beta.transactionTreeById(id, listener) }
+      } yield {
+        assert(
+          tree.commandId.isEmpty,
+          s"The command identifier was supposed to be empty but it's `${tree.commandId}` instead.")
+      }
   }
 
   test(
     "TXFilterByTemplate",
-    "The transaction service should correctly filter by template identifier") { context =>
-    val filterBy = Dummy.id
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      create <- ledger.submitAndWaitRequest(
-        party,
-        Dummy(party).create.command,
-        DummyFactory(party).create.command)
-      _ <- ledger.submitAndWait(create)
-      transactions <- ledger.flatTransactionsByTemplateId(filterBy, party)
-    } yield {
-      val contract = assertSingleton("FilterByTemplate", transactions.flatMap(createdEvents))
-      assertEquals("FilterByTemplate", contract.getTemplateId, Tag.unwrap(filterBy))
-    }
+    "The transaction service should correctly filter by template identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val filterBy = Dummy.id
+      for {
+        create <- ledger.submitAndWaitRequest(
+          party,
+          Dummy(party).create.command,
+          DummyFactory(party).create.command)
+        _ <- ledger.submitAndWait(create)
+        transactions <- ledger.flatTransactionsByTemplateId(filterBy, party)
+      } yield {
+        val contract = assertSingleton("FilterByTemplate", transactions.flatMap(createdEvents))
+        assertEquals("FilterByTemplate", contract.getTemplateId, Tag.unwrap(filterBy))
+      }
   }
 
   test(
     "TXUseCreateToExercise",
-    "Should be able to directly use a contract identifier to exercise a choice") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummyFactory <- ledger.create(party, DummyFactory(party))
-      transactions <- ledger.exercise(party, dummyFactory.exerciseDummyFactoryCall)
-    } yield {
-      val events = transactions.rootEventIds.collect(transactions.eventsById)
-      val exercised = events.filter(_.kind.isExercised)
-      assert(exercised.size == 1, s"Only one exercise expected, got ${exercised.size}")
-      assert(
-        exercised.head.getExercised.contractId == Tag.unwrap(dummyFactory),
-        s"The identifier of the exercised contract should have been ${Tag
-          .unwrap(dummyFactory)} but instead it was ${exercised.head.getExercised.contractId}"
-      )
-    }
+    "Should be able to directly use a contract identifier to exercise a choice",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummyFactory <- ledger.create(party, DummyFactory(party))
+        transactions <- ledger.exercise(party, dummyFactory.exerciseDummyFactoryCall)
+      } yield {
+        val events = transactions.rootEventIds.collect(transactions.eventsById)
+        val exercised = events.filter(_.kind.isExercised)
+        assert(exercised.size == 1, s"Only one exercise expected, got ${exercised.size}")
+        assert(
+          exercised.head.getExercised.contractId == Tag.unwrap(dummyFactory),
+          s"The identifier of the exercised contract should have been ${Tag
+            .unwrap(dummyFactory)} but instead it was ${exercised.head.getExercised.contractId}"
+        )
+      }
   }
 
   test(
     "TXContractIdFromExerciseWhenFilter",
-    "Expose contract identifiers that are results of exercising choices when filtering by template") {
-    context =>
+    "Expose contract identifiers that are results of exercising choices when filtering by template",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         factory <- ledger.create(party, DummyFactory(party))
         _ <- ledger.exercise(party, factory.exerciseDummyFactoryCall)
         dummyWithParam <- ledger.flatTransactionsByTemplateId(DummyWithParam.id, party)
@@ -363,37 +363,41 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXRejectOnFailingAssertion", "Reject a transaction on a failing assertion") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      failure <- ledger
-        .exercise(
-          party,
-          dummy.exerciseConsumeIfTimeIsBetween(_, Primitive.Timestamp.MAX, Primitive.Timestamp.MAX))
-        .failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Assertion failed")
-    }
+  test(
+    "TXRejectOnFailingAssertion",
+    "Reject a transaction on a failing assertion",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        failure <- ledger
+          .exercise(
+            party,
+            dummy
+              .exerciseConsumeIfTimeIsBetween(_, Primitive.Timestamp.MAX, Primitive.Timestamp.MAX))
+          .failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Assertion failed")
+      }
   }
 
-  test("TXCreateWithAnyType", "Creates should not have issues dealing with any type of argument") {
-    context =>
+  test(
+    "TXCreateWithAnyType",
+    "Creates should not have issues dealing with any type of argument",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val template = ParameterShowcase(
+        party,
+        42L,
+        BigDecimal("47.0000000000"),
+        "some text",
+        true,
+        Primitive.Timestamp.MIN,
+        NestedOptionalInteger(OptionalInteger.SomeInteger(-1L)),
+        Primitive.List(0L, 1L, 2L, 3L),
+        Primitive.Optional("some optional text")
+      )
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        template = ParameterShowcase(
-          party,
-          42L,
-          BigDecimal("47.0000000000"),
-          "some text",
-          true,
-          Primitive.Timestamp.MIN,
-          NestedOptionalInteger(OptionalInteger.SomeInteger(-1L)),
-          Primitive.List(0L, 1L, 2L, 3L),
-          Primitive.Optional("some optional text")
-        )
         create <- ledger.submitAndWaitRequest(party, template.create.command)
         transaction <- ledger.submitAndWaitForTransaction(create)
       } yield {
@@ -402,32 +406,33 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXExerciseWithAnyType", "Exercise should not have issues dealing with any type of argument") {
-    context =>
+  test(
+    "TXExerciseWithAnyType",
+    "Exercise should not have issues dealing with any type of argument",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val template = ParameterShowcase(
+        party,
+        42L,
+        BigDecimal("47.0000000000"),
+        "some text",
+        true,
+        Primitive.Timestamp.MIN,
+        NestedOptionalInteger(OptionalInteger.SomeInteger(-1L)),
+        Primitive.List(0L, 1L, 2L, 3L),
+        Primitive.Optional("some optional text")
+      )
+      val choice1 = Choice1(
+        template.integer,
+        BigDecimal("37.0000000000"),
+        template.text,
+        template.bool,
+        template.time,
+        template.nestedOptionalInteger,
+        template.integerList,
+        template.optionalText
+      )
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        template = ParameterShowcase(
-          party,
-          42L,
-          BigDecimal("47.0000000000"),
-          "some text",
-          true,
-          Primitive.Timestamp.MIN,
-          NestedOptionalInteger(OptionalInteger.SomeInteger(-1L)),
-          Primitive.List(0L, 1L, 2L, 3L),
-          Primitive.Optional("some optional text")
-        )
-        choice1 = Choice1(
-          template.integer,
-          BigDecimal("37.0000000000"),
-          template.text,
-          template.bool,
-          template.time,
-          template.nestedOptionalInteger,
-          template.integerList,
-          template.optionalText
-        )
         parameterShowcase <- ledger.create(
           party,
           template
@@ -439,13 +444,14 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXVeryLongList", "Accept a submission with a very long list (10,000 items)") { context =>
-    val n = 10000
-    val veryLongList = Primitive.List(List.iterate(0L, n)(_ + 1): _*)
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      template = ParameterShowcase(
+  test(
+    "TXVeryLongList",
+    "Accept a submission with a very long list (10,000 items)",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val n = 10000
+      val veryLongList = Primitive.List(List.iterate(0L, n)(_ + 1): _*)
+      val template = ParameterShowcase(
         party,
         42L,
         BigDecimal("47.0000000000"),
@@ -456,22 +462,21 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
         veryLongList,
         Primitive.Optional("some optional text")
       )
-      create <- ledger.submitAndWaitRequest(party, template.create.command)
-      transaction <- ledger.submitAndWaitForTransaction(create)
-    } yield {
-      val contract = assertSingleton("VeryLongList", createdEvents(transaction))
-      assertEquals("VeryLongList", contract.getCreateArguments, template.arguments)
-    }
+      for {
+        create <- ledger.submitAndWaitRequest(party, template.create.command)
+        transaction <- ledger.submitAndWaitForTransaction(create)
+      } yield {
+        val contract = assertSingleton("VeryLongList", createdEvents(transaction))
+        assertEquals("VeryLongList", contract.getCreateArguments, template.arguments)
+      }
   }
 
   test(
     "TXNotArchiveNonConsuming",
-    "Expressing a non-consuming choice on a contract should not result in its archival") {
-    context =>
+    "Expressing a non-consuming choice on a contract should not result in its archival",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, receiver), Participant(beta, giver)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        receiver <- alpha.allocateParty()
-        giver <- beta.allocateParty()
         agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
         _ <- alpha.exercise(receiver, agreementFactory.exerciseCreateAgreement)
         _ <- synchronize(alpha, beta)
@@ -484,13 +489,13 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXRequireAuthorization", "Require only authorization of chosen branching signatory") {
-    context =>
+  test(
+    "TXRequireAuthorization",
+    "Require only authorization of chosen branching signatory",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(_, bob)) =>
+      val template = BranchingSignatories(true, alice, bob)
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
-        template = BranchingSignatories(true, alice, bob)
         _ <- alpha.create(alice, template)
         transactions <- alpha.flatTransactions(alice)
       } yield {
@@ -498,13 +503,13 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXNotDiscloseCreateToNonSignatory", "Not disclose create to non-chosen branching signatory") {
-    context =>
+  test(
+    "TXNotDiscloseCreateToNonSignatory",
+    "Not disclose create to non-chosen branching signatory",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+      val template = BranchingSignatories(false, alice, bob)
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
-        template = BranchingSignatories(false, alice, bob)
         create <- beta.submitAndWaitRequest(bob, template.create.command)
         transaction <- beta.submitAndWaitForTransaction(create)
         _ <- synchronize(alpha, beta)
@@ -516,13 +521,13 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXDiscloseCreateToSignatory", "Disclose create to the chosen branching controller") {
-    context =>
+  test(
+    "TXDiscloseCreateToSignatory",
+    "Disclose create to the chosen branching controller",
+    allocate(SingleParty, TwoParties)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob, eve)) =>
+      val template = BranchingControllers(alice, true, bob, eve)
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        Vector(bob, eve) <- beta.allocateParties(2)
-        template = BranchingControllers(alice, true, bob, eve)
         _ <- alpha.create(alice, template)
         _ <- eventually {
           for {
@@ -552,61 +557,64 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXNotDiscloseCreateToNonChosenBranchingController",
-    "Not disclose create to non-chosen branching controller") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      alice <- alpha.allocateParty()
-      Vector(bob, eve) <- beta.allocateParties(2)
-      template = BranchingControllers(alice, false, bob, eve)
-      create <- alpha.submitAndWaitRequest(alice, template.create.command)
-      transaction <- alpha.submitAndWaitForTransaction(create)
-      _ <- synchronize(alpha, beta)
-      transactions <- beta.flatTransactions(bob)
-    } yield {
-      assert(
-        !transactions.exists(_.transactionId != transaction.transactionId),
-        s"The transaction ${transaction.transactionId} should not have been disclosed.")
-    }
-  }
-
-  test("TXDiscloseCreateToObservers", "Disclose create to observers") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      alice <- alpha.allocateParty()
-      observers <- beta.allocateParties(2)
-      template = WithObservers(alice, Primitive.List(observers: _*))
-      create <- alpha.submitAndWaitRequest(alice, template.create.command)
-      transactionId <- alpha.submitAndWaitForTransactionId(create)
-      _ <- eventually {
-        for {
-          transactions <- beta.flatTransactions(observers: _*)
-        } yield {
-          assert(transactions.exists(_.transactionId == transactionId))
-        }
-      }
-    } yield {
-      // Checks performed in the `eventually` block
-    }
-  }
-
-  test("TXUnitAsArgumentToNothing", "DAML engine returns Unit as argument to Nothing") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      template = NothingArgument(party, Primitive.Optional.empty)
-      create <- ledger.submitAndWaitRequest(party, template.create.command)
-      transaction <- ledger.submitAndWaitForTransaction(create)
-    } yield {
-      val contract = assertSingleton("UnitAsArgumentToNothing", createdEvents(transaction))
-      assertEquals("UnitAsArgumentToNothing", contract.getCreateArguments, template.arguments)
-    }
-  }
-
-  test("TXAgreementText", "Expose the agreement text for templates with an explicit agreement text") {
-    context =>
+    "Not disclose create to non-chosen branching controller",
+    allocate(SingleParty, TwoParties)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob, eve)) =>
+      val template = BranchingControllers(alice, false, bob, eve)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
+        create <- alpha.submitAndWaitRequest(alice, template.create.command)
+        transaction <- alpha.submitAndWaitForTransaction(create)
+        _ <- synchronize(alpha, beta)
+        transactions <- beta.flatTransactions(bob)
+      } yield {
+        assert(
+          !transactions.exists(_.transactionId != transaction.transactionId),
+          s"The transaction ${transaction.transactionId} should not have been disclosed.")
+      }
+  }
+
+  test(
+    "TXDiscloseCreateToObservers",
+    "Disclose create to observers",
+    allocate(SingleParty, TwoParties)) {
+    case Participants(Participant(alpha, alice), Participant(beta, observers @ _*)) =>
+      val template = WithObservers(alice, Primitive.List(observers: _*))
+      for {
+        create <- alpha.submitAndWaitRequest(alice, template.create.command)
+        transactionId <- alpha.submitAndWaitForTransactionId(create)
+        _ <- eventually {
+          for {
+            transactions <- beta.flatTransactions(observers: _*)
+          } yield {
+            assert(transactions.exists(_.transactionId == transactionId))
+          }
+        }
+      } yield {
+        // Checks performed in the `eventually` block
+      }
+  }
+
+  test(
+    "TXUnitAsArgumentToNothing",
+    "DAML engine returns Unit as argument to Nothing",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val template = NothingArgument(party, Primitive.Optional.empty)
+      for {
+        create <- ledger.submitAndWaitRequest(party, template.create.command)
+        transaction <- ledger.submitAndWaitForTransaction(create)
+      } yield {
+        val contract = assertSingleton("UnitAsArgumentToNothing", createdEvents(transaction))
+        assertEquals("UnitAsArgumentToNothing", contract.getCreateArguments, template.arguments)
+      }
+  }
+
+  test(
+    "TXAgreementText",
+    "Expose the agreement text for templates with an explicit agreement text",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
         _ <- ledger.create(party, Dummy(party))
         transactions <- ledger.flatTransactionsByTemplateId(Dummy.id, party)
       } yield {
@@ -615,11 +623,12 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXAgreementTextDefault", "Expose the default text for templates without an agreement text") {
-    context =>
+  test(
+    "TXAgreementTextDefault",
+    "Expose the default text for templates without an agreement text",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- ledger.create(party, DummyWithParam(party))
         transactions <- ledger.flatTransactions(party)
       } yield {
@@ -628,26 +637,24 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXStakeholders", "Expose the correct stakeholders") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      receiver <- alpha.allocateParty()
-      giver <- beta.allocateParty()
-      _ <- beta.create(giver, CallablePayout(giver, receiver))
-      transactions <- beta.flatTransactions(giver, receiver)
-    } yield {
-      val contract = assertSingleton("Stakeholders", transactions.flatMap(createdEvents))
-      assertEquals("Signatories", contract.signatories, Seq(Tag.unwrap(giver)))
-      assertEquals("Observers", contract.observers, Seq(Tag.unwrap(receiver)))
-    }
+  test("TXStakeholders", "Expose the correct stakeholders", allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, receiver), Participant(beta, giver)) =>
+      for {
+        _ <- beta.create(giver, CallablePayout(giver, receiver))
+        transactions <- beta.flatTransactions(giver, receiver)
+      } yield {
+        val contract = assertSingleton("Stakeholders", transactions.flatMap(createdEvents))
+        assertEquals("Signatories", contract.signatories, Seq(Tag.unwrap(giver)))
+        assertEquals("Observers", contract.observers, Seq(Tag.unwrap(receiver)))
+      }
   }
 
-  test("TXNoContractKey", "There should be no contract key if the template does not specify one") {
-    context =>
+  test(
+    "TXNoContractKey",
+    "There should be no contract key if the template does not specify one",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, receiver), Participant(beta, giver)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        receiver <- alpha.allocateParty()
-        giver <- beta.allocateParty()
         _ <- beta.create(giver, CallablePayout(giver, receiver))
         transactions <- beta.flatTransactions(giver, receiver)
       } yield {
@@ -658,33 +665,34 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
       }
   }
 
-  test("TXContractKey", "The contract key should be exposed if the template specifies one") {
-    context =>
+  test(
+    "TXContractKey",
+    "The contract key should be exposed if the template specifies one",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val expectedKey = "some-fancy-key"
       for {
-        ledger <- context.participant()
-        tkParty <- ledger.allocateParty()
-        _ <- ledger.create(tkParty, TextKey(tkParty, expectedKey, Primitive.List.empty))
-        transactions <- ledger.flatTransactions(tkParty)
+        _ <- ledger.create(party, TextKey(party, expectedKey, Primitive.List.empty))
+        transactions <- ledger.flatTransactions(party)
       } yield {
         val contract = assertSingleton(s"ContractKey", transactions.flatMap(createdEvents))
         assertEquals(
           "ContractKey",
           contract.getContractKey.getRecord.fields,
           Seq(
-            RecordField("_1", Some(Value(Value.Sum.Party(Tag.unwrap(tkParty))))),
+            RecordField("_1", Some(Value(Value.Sum.Party(Tag.unwrap(party))))),
             RecordField("_2", Some(Value(Value.Sum.Text(expectedKey))))
           )
         )
       }
   }
 
-  test("TXMultiActorChoiceOk", "Accept exercising a well-authorized multi-actor choice") {
-    context =>
+  test(
+    "TXMultiActorChoiceOk",
+    "Accept exercising a well-authorized multi-actor choice",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        Vector(operator, receiver) <- alpha.allocateParties(2)
-        giver <- beta.allocateParty()
         agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
         agreement <- alpha.exerciseAndGetContract[Agreement](
           receiver,
@@ -705,12 +713,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXMultiActorChoiceOkCoincidingControllers",
-    "Accept exercising a well-authorized multi-actor choice with coinciding controllers") {
-    context =>
+    "Accept exercising a well-authorized multi-actor choice with coinciding controllers",
+    allocate(SingleParty, SingleParty)
+  ) {
+    case Participants(Participant(alpha, operator), Participant(beta, giver)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        operator <- alpha.allocateParty()
-        giver <- beta.allocateParty()
         agreementFactory <- beta.create(giver, AgreementFactory(giver, giver))
         agreement <- beta
           .exerciseAndGetContract[Agreement](giver, agreementFactory.exerciseAgreementFactoryAccept)
@@ -730,22 +737,21 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXRejectMultiActorMissingAuth",
-    "Reject exercising a multi-actor choice with missing authorizers") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(operator, receiver) <- alpha.allocateParties(2)
-      giver <- beta.allocateParty()
-      triProposal <- alpha.create(operator, TriProposal(operator, receiver, giver))
-      _ <- eventually {
-        for {
-          failure <- beta.exercise(giver, triProposal.exerciseTriProposalAccept).failed
-        } yield {
-          assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
+    "Reject exercising a multi-actor choice with missing authorizers",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
+      for {
+        triProposal <- alpha.create(operator, TriProposal(operator, receiver, giver))
+        _ <- eventually {
+          for {
+            failure <- beta.exercise(giver, triProposal.exerciseTriProposalAccept).failed
+          } yield {
+            assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
+          }
         }
+      } yield {
+        // Check performed in the `eventually` block
       }
-    } yield {
-      // Check performed in the `eventually` block
-    }
   }
 
   // This is the current, most conservative semantics of multi-actor choice authorization.
@@ -753,85 +759,82 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
   // also remove the 'UnrestrictedAcceptTriProposal' choice from the 'Agreement' template.
   test(
     "TXRejectMultiActorExcessiveAuth",
-    "Reject exercising a multi-actor choice with too many authorizers") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      Vector(operator, receiver) <- alpha.allocateParties(2)
-      giver <- beta.allocateParty()
-      agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
-      agreement <- alpha
-        .exerciseAndGetContract[Agreement](
-          receiver,
-          agreementFactory.exerciseAgreementFactoryAccept)
-      triProposalTemplate = TriProposal(operator, giver, giver)
-      triProposal <- alpha.create(operator, triProposalTemplate)
-      _ <- eventually {
-        for {
-          failure <- beta
-            .exercise(giver, agreement.exerciseAcceptTriProposal(_, triProposal))
-            .failed
-        } yield {
-          assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Assertion failed")
+    "Reject exercising a multi-actor choice with too many authorizers",
+    allocate(TwoParties, SingleParty)) {
+    case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
+      for {
+        agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
+        agreement <- alpha
+          .exerciseAndGetContract[Agreement](
+            receiver,
+            agreementFactory.exerciseAgreementFactoryAccept)
+        triProposalTemplate = TriProposal(operator, giver, giver)
+        triProposal <- alpha.create(operator, triProposalTemplate)
+        _ <- eventually {
+          for {
+            failure <- beta
+              .exercise(giver, agreement.exerciseAcceptTriProposal(_, triProposal))
+              .failed
+          } yield {
+            assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Assertion failed")
+          }
         }
+      } yield {
+        // Check performed in the `eventually` block
       }
-    } yield {
-      // Check performed in the `eventually` block
-    }
   }
 
-  test("TXNoReorder", "Don't reorder fields in data structures of choices") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      tree <- ledger.exercise(
-        party,
-        dummy.exerciseWrapWithAddress(_, Address("street", "city", "state", "zip")))
-    } yield {
-      val contract = assertSingleton("Contract in transaction", createdEvents(tree))
-      val fields = assertLength("Fields in contract", 2, contract.getCreateArguments.fields)
-      assertEquals(
-        "NoReorder",
-        fields.flatMap(_.getValue.getRecord.fields).map(_.getValue.getText).zipWithIndex,
-        Seq("street" -> 0, "city" -> 1, "state" -> 2, "zip" -> 3))
-    }
+  test("TXNoReorder", "Don't reorder fields in data structures of choices", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        tree <- ledger.exercise(
+          party,
+          dummy.exerciseWrapWithAddress(_, Address("street", "city", "state", "zip")))
+      } yield {
+        val contract = assertSingleton("Contract in transaction", createdEvents(tree))
+        val fields = assertLength("Fields in contract", 2, contract.getCreateArguments.fields)
+        assertEquals(
+          "NoReorder",
+          fields.flatMap(_.getValue.getRecord.fields).map(_.getValue.getText).zipWithIndex,
+          Seq("street" -> 0, "city" -> 1, "state" -> 2, "zip" -> 3))
+      }
   }
 
-  test("TXLargeCommand", "Accept huge submissions with a large number of commands") { context =>
-    val targetNumberOfSubCommands = 1500
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      request <- ledger.submitAndWaitRequest(
-        party,
-        List.fill(targetNumberOfSubCommands)(Dummy(party).create.command): _*)
-      result <- ledger.submitAndWaitForTransaction(request)
-    } yield {
-      val _ = assertLength("LargeCommand", targetNumberOfSubCommands, result.events)
-    }
+  test(
+    "TXLargeCommand",
+    "Accept huge submissions with a large number of commands",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val targetNumberOfSubCommands = 1500
+      for {
+        request <- ledger.submitAndWaitRequest(
+          party,
+          List.fill(targetNumberOfSubCommands)(Dummy(party).create.command): _*)
+        result <- ledger.submitAndWaitForTransaction(request)
+      } yield {
+        val _ = assertLength("LargeCommand", targetNumberOfSubCommands, result.events)
+      }
   }
 
-  test("TXManyCommands", "Accept many, large commands at once") { context =>
-    val targetNumberOfCommands = 500
-    val oneKbOfText = new String(Array.fill(512 /* two bytes each */ )('a'))
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      contractIds <- Future.sequence((1 to targetNumberOfCommands).map(_ =>
-        ledger.create(party, TextContainer(party, oneKbOfText))))
-    } yield {
-      val _ = assertLength("ManyCommands", targetNumberOfCommands, contractIds)
-    }
+  test("TXManyCommands", "Accept many, large commands at once", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val targetNumberOfCommands = 500
+      val oneKbOfText = new String(Array.fill(512 /* two bytes each */ )('a'))
+      for {
+        contractIds <- Future.sequence((1 to targetNumberOfCommands).map(_ =>
+          ledger.create(party, TextContainer(party, oneKbOfText))))
+      } yield {
+        val _ = assertLength("ManyCommands", targetNumberOfCommands, contractIds)
+      }
   }
 
   test(
     "TXSingleMultiSame",
-    "The same transaction should be served regardless of subscribing as one or multiple parties") {
-    context =>
+    "The same transaction should be served regardless of subscribing as one or multiple parties",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
         _ <- alpha.create(alice, Dummy(alice))
         _ <- beta.create(bob, Dummy(bob))
         aliceView <- alpha.flatTransactions(alice)
@@ -854,12 +857,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXSingleMultiSameTrees",
-    "The same transaction trees should be served regardless of subscribing as one or multiple parties") {
-    context =>
+    "The same transaction trees should be served regardless of subscribing as one or multiple parties",
+    allocate(SingleParty, SingleParty)
+  ) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
         _ <- alpha.create(alice, Dummy(alice))
         _ <- beta.create(bob, Dummy(bob))
         aliceView <- alpha.transactionTrees(alice)
@@ -882,36 +884,35 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFetchContractCreatedInTransaction",
-    "It should be possible to fetch a contract created within a transaction") { context =>
-    for {
-      ledger <- context.participant()
-      alice <- ledger.allocateParty()
-      createAndFetch <- ledger.create(alice, CreateAndFetch(alice))
-      transaction <- ledger.exerciseForFlatTransaction(
-        alice,
-        createAndFetch.exerciseCreateAndFetch_Run)
-    } yield {
-      val _ = assertSingleton("There should be only one create", createdEvents(transaction))
-      val exercise =
-        assertSingleton("There should be only one archive", archivedEvents(transaction))
-      assertEquals(
-        "The contract identifier of the exercise does not match",
-        Tag.unwrap(createAndFetch),
-        exercise.contractId)
-    }
+    "It should be possible to fetch a contract created within a transaction",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        createAndFetch <- ledger.create(party, CreateAndFetch(party))
+        transaction <- ledger.exerciseForFlatTransaction(
+          party,
+          createAndFetch.exerciseCreateAndFetch_Run)
+      } yield {
+        val _ = assertSingleton("There should be only one create", createdEvents(transaction))
+        val exercise =
+          assertSingleton("There should be only one archive", archivedEvents(transaction))
+        assertEquals(
+          "The contract identifier of the exercise does not match",
+          Tag.unwrap(createAndFetch),
+          exercise.contractId)
+      }
   }
 
   test(
     "TXFlatTransactionsWrongLedgerId",
-    "The getTransactions endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getTransactions endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionsRequest(Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionsRequest(Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.flatTransactions(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -920,15 +921,14 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreesWrongLedgerId",
-    "The getTransactionTrees endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getTransactionTrees endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionsRequest(Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionsRequest(Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.transactionTrees(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -937,15 +937,14 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreeByIdWrongLedgerId",
-    "The getTransactionTreeById endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getTransactionTreeById endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionByIdRequest("not-relevant", Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionByIdRequest("not-relevant", Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.transactionTreeById(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -954,15 +953,14 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatTransactionByIdWrongLedgerId",
-    "The getFlatTransactionById endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getFlatTransactionById endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionByIdRequest("not-relevant", Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionByIdRequest("not-relevant", Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.flatTransactionById(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -971,15 +969,15 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreeByEventIdWrongLedgerId",
-    "The getTransactionTreeByEventId endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getTransactionTreeByEventId endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionByEventIdRequest("not-relevant", Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionByEventIdRequest("not-relevant", Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.transactionTreeByEventId(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -988,15 +986,15 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatTransactionByEventIdWrongLedgerId",
-    "The getFlatTransactionByEventId endpoint should reject calls with the wrong ledger identifier") {
-    context =>
+    "The getFlatTransactionByEventId endpoint should reject calls with the wrong ledger identifier",
+    allocate(SingleParty)
+  ) {
+    case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      val invalidRequest = ledger
+        .getTransactionByEventIdRequest("not-relevant", Seq(party))
+        .update(_.ledgerId := invalidLedgerId)
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
-        invalidRequest = ledger
-          .getTransactionByEventIdRequest("not-relevant", Seq(party))
-          .update(_.ledgerId := invalidLedgerId)
         failure <- ledger.flatTransactionByEventId(invalidRequest).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
@@ -1005,62 +1003,65 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreeByIdWrongLedgerId",
-    "The ledgerEnd endpoint should reject calls with the wrong ledger identifier") { context =>
-    val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
-    for {
-      ledger <- context.participant()
-      failure <- ledger.currentEnd(invalidLedgerId).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
-    }
+    "The ledgerEnd endpoint should reject calls with the wrong ledger identifier",
+    allocate(NoParties)) {
+    case Participants(Participant(ledger)) =>
+      val invalidLedgerId = "DEFINITELY_NOT_A_VALID_LEDGER_IDENTIFIER"
+      for {
+        failure <- ledger.currentEnd(invalidLedgerId).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
+      }
   }
 
-  test("TXTransactionTreeById", "Expose a visible transaction tree by identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      tree <- ledger.exercise(party, dummy.exerciseDummyChoice1)
-      byId <- ledger.transactionTreeById(tree.transactionId, party)
-    } yield {
-      assertEquals("The transaction fetched by identifier does not match", tree, byId)
-    }
+  test(
+    "TXTransactionTreeById",
+    "Expose a visible transaction tree by identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        tree <- ledger.exercise(party, dummy.exerciseDummyChoice1)
+        byId <- ledger.transactionTreeById(tree.transactionId, party)
+      } yield {
+        assertEquals("The transaction fetched by identifier does not match", tree, byId)
+      }
   }
 
   test(
     "TXInvisibleTransactionTreeById",
-    "Do not expose an invisible transaction tree by identifier") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      party <- alpha.allocateParty()
-      intruder <- beta.allocateParty()
-      dummy <- alpha.create(party, Dummy(party))
-      tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
-      _ <- synchronize(alpha, beta)
-      failure <- beta.transactionTreeById(tree.transactionId, intruder).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
-  }
-
-  test(
-    "TXTransactionTreeByIdNotFound",
-    "Return NOT_FOUND when looking up an inexistent transaction tree by identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      failure <- ledger.transactionTreeById("a" * 60, party).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
-  }
-
-  test(
-    "TXTransactionTreeByIdNotFound",
-    "Return INVALID_ARGUMENT when looking up a transaction tree by identifier without specifying a party") {
-    context =>
+    "Do not expose an invisible transaction tree by identifier",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, party), Participant(beta, intruder)) =>
       for {
-        ledger <- context.participant()
+        dummy <- alpha.create(party, Dummy(party))
+        tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
+        _ <- synchronize(alpha, beta)
+        failure <- beta.transactionTreeById(tree.transactionId, intruder).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
+  }
+
+  test(
+    "TXTransactionTreeByIdNotFound",
+    "Return NOT_FOUND when looking up an inexistent transaction tree by identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        failure <- ledger.transactionTreeById("a" * 60, party).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
+  }
+
+  test(
+    "TXTransactionTreeByIdNotFound",
+    "Return INVALID_ARGUMENT when looking up a transaction tree by identifier without specifying a party",
+    allocate(NoParties)
+  ) {
+    case Participants(Participant(ledger)) =>
+      for {
         failure <- ledger.transactionTreeById("not-relevant").failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: requesting_parties")
@@ -1069,70 +1070,69 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreeByIdSameAsTransactionStream",
-    "Expose the same events for each transaction as the output of getTransactionTrees") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      submitter <- alpha.allocateParty()
-      listener <- beta.allocateParty()
-      _ <- alpha.create(submitter, AgreementFactory(listener, submitter))
-      _ <- synchronize(alpha, beta)
-      trees <- alpha.transactionTrees(listener, submitter)
-      byId <- Future.sequence(
-        trees.map(t => beta.transactionTreeById(t.transactionId, listener, submitter)))
-    } yield {
-      assertEquals(
-        "The events fetched by identifier did not match with the ones on the transaction stream",
-        trees,
-        byId)
-    }
+    "Expose the same events for each transaction as the output of getTransactionTrees",
+    allocate(SingleParty, SingleParty)
+  ) {
+    case Participants(Participant(alpha, submitter), Participant(beta, listener)) =>
+      for {
+        _ <- alpha.create(submitter, AgreementFactory(listener, submitter))
+        _ <- synchronize(alpha, beta)
+        trees <- alpha.transactionTrees(listener, submitter)
+        byId <- Future.sequence(
+          trees.map(t => beta.transactionTreeById(t.transactionId, listener, submitter)))
+      } yield {
+        assertEquals(
+          "The events fetched by identifier did not match with the ones on the transaction stream",
+          trees,
+          byId)
+      }
   }
 
-  test("TXFlatTransactionById", "Expose a visible transaction by identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      dummy <- ledger.create(party, Dummy(party))
-      transaction <- ledger.exerciseForFlatTransaction(party, dummy.exerciseDummyChoice1)
-      byId <- ledger.flatTransactionById(transaction.transactionId, party)
-    } yield {
-      assertEquals("The transaction fetched by identifier does not match", transaction, byId)
-    }
+  test("TXFlatTransactionById", "Expose a visible transaction by identifier", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        transaction <- ledger.exerciseForFlatTransaction(party, dummy.exerciseDummyChoice1)
+        byId <- ledger.flatTransactionById(transaction.transactionId, party)
+      } yield {
+        assertEquals("The transaction fetched by identifier does not match", transaction, byId)
+      }
   }
 
   test(
     "TXInvisibleFlatTransactionById",
-    "Do not expose an invisible flat transaction by identifier") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      party <- alpha.allocateParty()
-      intruder <- beta.allocateParty()
-      dummy <- alpha.create(party, Dummy(party))
-      tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
-      _ <- synchronize(alpha, beta)
-      failure <- beta.flatTransactionById(tree.transactionId, intruder).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
-  }
-
-  test(
-    "TXFlatTransactionByIdNotFound",
-    "Return NOT_FOUND when looking up an inexistent flat transaction by identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      failure <- ledger.flatTransactionById("a" * 60, party).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
-  }
-
-  test(
-    "TXFlatTransactionByIdNotFound",
-    "Return INVALID_ARGUMENT when looking up a flat transaction by identifier without specifying a party") {
-    context =>
+    "Do not expose an invisible flat transaction by identifier",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, party), Participant(beta, intruder)) =>
       for {
-        ledger <- context.participant()
+        dummy <- alpha.create(party, Dummy(party))
+        tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
+        _ <- synchronize(alpha, beta)
+        failure <- beta.flatTransactionById(tree.transactionId, intruder).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
+  }
+
+  test(
+    "TXFlatTransactionByIdNotFound",
+    "Return NOT_FOUND when looking up an inexistent flat transaction by identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        failure <- ledger.flatTransactionById("a" * 60, party).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
+  }
+
+  test(
+    "TXFlatTransactionByIdNotFound",
+    "Return INVALID_ARGUMENT when looking up a flat transaction by identifier without specifying a party",
+    allocate(NoParties)
+  ) {
+    case Participants(Participant(ledger)) =>
+      for {
         failure <- ledger.flatTransactionById("not-relevant").failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: requesting_parties")
@@ -1141,29 +1141,30 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatTransactionByIdSameAsTransactionStream",
-    "Expose the same events for each transaction as the output of getTransactions") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      submitter <- alpha.allocateParty()
-      listener <- beta.allocateParty()
-      _ <- alpha.create(submitter, AgreementFactory(listener, submitter))
-      _ <- synchronize(alpha, beta)
-      transactions <- alpha.flatTransactions(listener, submitter)
-      byId <- Future.sequence(
-        transactions.map(t => beta.flatTransactionById(t.transactionId, listener, submitter)))
-    } yield {
-      assertEquals(
-        "The events fetched by identifier did not match with the ones on the transaction stream",
-        transactions,
-        byId)
-    }
+    "Expose the same events for each transaction as the output of getTransactions",
+    allocate(SingleParty, SingleParty)
+  ) {
+    case Participants(Participant(alpha, submitter), Participant(beta, listener)) =>
+      for {
+        _ <- alpha.create(submitter, AgreementFactory(listener, submitter))
+        _ <- synchronize(alpha, beta)
+        transactions <- alpha.flatTransactions(listener, submitter)
+        byId <- Future.sequence(
+          transactions.map(t => beta.flatTransactionById(t.transactionId, listener, submitter)))
+      } yield {
+        assertEquals(
+          "The events fetched by identifier did not match with the ones on the transaction stream",
+          transactions,
+          byId)
+      }
   }
 
-  test("TXTransactionTreeByEventId", "Expose a visible transaction tree by event identifier") {
-    context =>
+  test(
+    "TXTransactionTreeByEventId",
+    "Expose a visible transaction tree by event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         dummy <- ledger.create(party, Dummy(party))
         tree <- ledger.exercise(party, dummy.exerciseDummyChoice1)
         byId <- ledger.transactionTreeByEventId(tree.rootEventIds.head, party)
@@ -1174,39 +1175,37 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXInvisibleTransactionTreeByEventId",
-    "Do not expose an invisible transaction tree by event identifier") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      party <- alpha.allocateParty()
-      intruder <- beta.allocateParty()
-      dummy <- alpha.create(party, Dummy(party))
-      tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
-      _ <- synchronize(alpha, beta)
-      failure <- beta.transactionTreeByEventId(tree.rootEventIds.head, intruder).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
+    "Do not expose an invisible transaction tree by event identifier",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, party), Participant(beta, intruder)) =>
+      for {
+        dummy <- alpha.create(party, Dummy(party))
+        tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
+        _ <- synchronize(alpha, beta)
+        failure <- beta.transactionTreeByEventId(tree.rootEventIds.head, intruder).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
   }
 
   test(
     "TXTransactionTreeByEventIdInvalid",
-    "Return INVALID when looking up an invalid transaction tree by event identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      failure <- ledger.transactionTreeByEventId("dont' worry, be happy", party).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Invalid field event_id")
-    }
+    "Return INVALID when looking up an invalid transaction tree by event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        failure <- ledger.transactionTreeByEventId("dont' worry, be happy", party).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Invalid field event_id")
+      }
   }
 
   test(
     "TXTransactionTreeByEventIdNotFound",
-    "Return NOT_FOUND when looking up an inexistent transaction tree by event identifier") {
-    context =>
+    "Return NOT_FOUND when looking up an inexistent transaction tree by event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         failure <- ledger.transactionTreeByEventId(s"#${"a" * 60}:000", party).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
@@ -1215,21 +1214,23 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXTransactionTreeByEventIdNotFound",
-    "Return INVALID_ARGUMENT when looking up a transaction tree by event identifier without specifying a party") {
-    context =>
+    "Return INVALID_ARGUMENT when looking up a transaction tree by event identifier without specifying a party",
+    allocate(NoParties)
+  ) {
+    case Participants(Participant(ledger)) =>
       for {
-        ledger <- context.participant()
         failure <- ledger.transactionTreeByEventId("not-relevant").failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: requesting_parties")
       }
   }
 
-  test("TXFlatTransactionByEventId", "Expose a visible flat transaction by event identifier") {
-    context =>
+  test(
+    "TXFlatTransactionByEventId",
+    "Expose a visible flat transaction by event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         dummy <- ledger.create(party, Dummy(party))
         transaction <- ledger.exerciseForFlatTransaction(party, dummy.exerciseDummyChoice1)
         event = transaction.events.head.event
@@ -1242,39 +1243,37 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXInvisibleFlatTransactionByEventId",
-    "Do not expose an invisible flat transaction by event identifier") { context =>
-    for {
-      Vector(alpha, beta) <- context.participants(2)
-      party <- alpha.allocateParty()
-      intruder <- beta.allocateParty()
-      dummy <- alpha.create(party, Dummy(party))
-      tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
-      _ <- synchronize(alpha, beta)
-      failure <- beta.flatTransactionByEventId(tree.rootEventIds.head, intruder).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
-    }
+    "Do not expose an invisible flat transaction by event identifier",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, party), Participant(beta, intruder)) =>
+      for {
+        dummy <- alpha.create(party, Dummy(party))
+        tree <- alpha.exercise(party, dummy.exerciseDummyChoice1)
+        _ <- synchronize(alpha, beta)
+        failure <- beta.flatTransactionByEventId(tree.rootEventIds.head, intruder).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
+      }
   }
 
   test(
     "TXFlatTransactionByEventIdInvalid",
-    "Return INVALID when looking up a flat transaction by an invalid event identifier") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-      failure <- ledger.flatTransactionByEventId("dont' worry, be happy", party).failed
-    } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Invalid field event_id")
-    }
+    "Return INVALID when looking up a flat transaction by an invalid event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        failure <- ledger.flatTransactionByEventId("dont' worry, be happy", party).failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Invalid field event_id")
+      }
   }
 
   test(
     "TXFlatTransactionByEventIdNotFound",
-    "Return NOT_FOUND when looking up an inexistent flat transaction by event identifier") {
-    context =>
+    "Return NOT_FOUND when looking up an inexistent flat transaction by event identifier",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         failure <- ledger.flatTransactionByEventId(s"#${"a" * 60}:000", party).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, "Transaction not found, or not visible.")
@@ -1283,10 +1282,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatTransactionByEventIdNotFound",
-    "Return INVALID_ARGUMENT when looking up a flat transaction by event identifier without specifying a party") {
-    context =>
+    "Return INVALID_ARGUMENT when looking up a flat transaction by event identifier without specifying a party",
+    allocate(NoParties)
+  ) {
+    case Participants(Participant(ledger)) =>
       for {
-        ledger <- context.participant()
         failure <- ledger.flatTransactionByEventId("not-relevant").failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: requesting_parties")
@@ -1338,12 +1338,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXSingleSubscriptionInOrder",
-    "Archives should always come after creations when subscribing as a single party") {
-    val contracts = 50
-    context =>
+    "Archives should always come after creations when subscribing as a single party",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val contracts = 50
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- Future.sequence(
           Vector.fill(contracts)(
             ledger
@@ -1357,13 +1356,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXMultiSubscriptionInOrder",
-    "Archives should always come after creations when subscribing as more than on party") {
-    val contracts = 50
-    context =>
+    "Archives should always come after creations when subscribing as more than on party",
+    allocate(SingleParty, SingleParty)) {
+    case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+      val contracts = 50
       for {
-        Vector(alpha, beta) <- context.participants(2)
-        alice <- alpha.allocateParty()
-        bob <- beta.allocateParty()
         _ <- Future.sequence(
           Vector.tabulate(contracts)(
             n =>
@@ -1387,12 +1384,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatSubsetOfTrees",
-    "The event identifiers in the flat stream should be a subset of those in the trees stream") {
-    val contracts = 50
-    context =>
+    "The event identifiers in the flat stream should be a subset of those in the trees stream",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val contracts = 50
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- Future.sequence(
           Vector.fill(contracts)(
             ledger
@@ -1412,12 +1408,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
 
   test(
     "TXFlatWitnessesSubsetOfTrees",
-    "The witnesses in the flat stream should be a subset of those in the trees stream") {
-    val contracts = 50
-    context =>
+    "The witnesses in the flat stream should be a subset of those in the trees stream",
+    allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      val contracts = 50
       for {
-        ledger <- context.participant()
-        party <- ledger.allocateParty()
         _ <- Future.sequence(
           Vector.fill(contracts)(
             ledger

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.digitalasset.ledger.test_stable.Test.DivulgeWitnesses._
 import com.digitalasset.ledger.test_stable.Test.Witnesses._
@@ -9,90 +10,88 @@ import com.digitalasset.ledger.test_stable.Test.{DivulgeWitnesses, Witnesses => 
 import scalaz.Tag
 
 final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("RespectDisclosureRules", "The ledger should respect disclosure rules") { context =>
-    for {
-      ledger <- context.participant()
-      Vector(alice, bob, charlie) <- ledger.allocateParties(3)
+  test("RespectDisclosureRules", "The ledger should respect disclosure rules", allocate(Parties(3))) {
+    case Participants(Participant(ledger, alice, bob, charlie)) =>
+      for {
+        // Create the Witnesses contract as Alice and get the resulting transaction as seen by all parties
+        (witnessesTransactionId, witnesses) <- ledger.createAndGetTransactionId(
+          alice,
+          WitnessesTemplate(alice, bob, charlie))
+        witnessesTransaction <- ledger.transactionTreeById(
+          witnessesTransactionId,
+          alice,
+          bob,
+          charlie)
 
-      // Create the Witnesses contract as Alice and get the resulting transaction as seen by all parties
-      (witnessesTransactionId, witnesses) <- ledger.createAndGetTransactionId(
-        alice,
-        WitnessesTemplate(alice, bob, charlie))
-      witnessesTransaction <- ledger.transactionTreeById(
-        witnessesTransactionId,
-        alice,
-        bob,
-        charlie)
+        // Charlie is not a stakeholder of Witnesses and thus cannot see any such contract unless divulged.
+        // Such contract is divulged by creating a DivulgeWitness with Charlie as a signatory and exercising
+        // a choice as Alice that causes divulgence (in this case, the Witnesses instance previously
+        // created is fetched as part of the transaction).
+        divulgeWitness <- ledger.create(charlie, DivulgeWitnesses(alice, charlie))
+        _ <- ledger.exercise(alice, divulgeWitness.exerciseDivulge(_, witnesses))
 
-      // Charlie is not a stakeholder of Witnesses and thus cannot see any such contract unless divulged.
-      // Such contract is divulged by creating a DivulgeWitness with Charlie as a signatory and exercising
-      // a choice as Alice that causes divulgence (in this case, the Witnesses instance previously
-      // created is fetched as part of the transaction).
-      divulgeWitness <- ledger.create(charlie, DivulgeWitnesses(alice, charlie))
-      _ <- ledger.exercise(alice, divulgeWitness.exerciseDivulge(_, witnesses))
+        // A non-consuming choice is exercised with the expectation
+        // that Charlie is now able to exercise a choice on the divulged contract
+        // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
+        nonConsuming <- ledger.exercise(charlie, witnesses.exerciseWitnessesNonConsumingChoice)
+        nonConsumingTree <- ledger.transactionTreeById(
+          nonConsuming.transactionId,
+          alice,
+          bob,
+          charlie)
 
-      // A non-consuming choice is exercised with the expectation
-      // that Charlie is now able to exercise a choice on the divulged contract
-      // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
-      nonConsuming <- ledger.exercise(charlie, witnesses.exerciseWitnessesNonConsumingChoice)
-      nonConsumingTree <- ledger.transactionTreeById(
-        nonConsuming.transactionId,
-        alice,
-        bob,
-        charlie)
+        // A consuming choice is exercised with the expectation
+        // that Charlie is now able to exercise a choice on the divulged contract
+        // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
+        consuming <- ledger.exercise(charlie, witnesses.exerciseWitnessesChoice)
+        consumingTree <- ledger.transactionTreeById(consuming.transactionId, alice, bob, charlie)
+      } yield {
 
-      // A consuming choice is exercised with the expectation
-      // that Charlie is now able to exercise a choice on the divulged contract
-      // The tree is fetched from the identifier to ensure we get the witnesses as seen by all parties
-      consuming <- ledger.exercise(charlie, witnesses.exerciseWitnessesChoice)
-      consumingTree <- ledger.transactionTreeById(consuming.transactionId, alice, bob, charlie)
-    } yield {
+        assert(
+          witnessesTransaction.eventsById.size == 1,
+          s"The transaction for creating the Witness contract should only contain a single event, but has ${witnessesTransaction.eventsById.size}"
+        )
+        val (_, creationEvent) = witnessesTransaction.eventsById.head
+        assert(
+          creationEvent.kind.isCreated,
+          s"The event in the transaction for creating the Witness should be a CreatedEvent, but was ${creationEvent.kind}")
 
-      assert(
-        witnessesTransaction.eventsById.size == 1,
-        s"The transaction for creating the Witness contract should only contain a single event, but has ${witnessesTransaction.eventsById.size}"
-      )
-      val (_, creationEvent) = witnessesTransaction.eventsById.head
-      assert(
-        creationEvent.kind.isCreated,
-        s"The event in the transaction for creating the Witness should be a CreatedEvent, but was ${creationEvent.kind}")
+        val expectedWitnessesOfCreation = Tag.unsubst(Seq(alice, bob)).sorted
+        assert(
+          creationEvent.getCreated.witnessParties.sorted == expectedWitnessesOfCreation,
+          s"The parties for witnessing the CreatedEvent should be ${expectedWitnessesOfCreation}, but were ${creationEvent.getCreated.witnessParties}"
+        )
+        assert(
+          nonConsumingTree.eventsById.size == 1,
+          s"The transaction for exercising the non-consuming choice should only contain a single event, but has ${nonConsumingTree.eventsById.size}"
+        )
+        val (_, nonConsumingEvent) = nonConsumingTree.eventsById.head
+        assert(
+          nonConsumingEvent.kind.isExercised,
+          s"The event in the transaction for exercising the non-consuming choice should be an ExercisedEvent, but was ${nonConsumingEvent.kind}"
+        )
 
-      val expectedWitnessesOfCreation = Tag.unsubst(Seq(alice, bob)).sorted
-      assert(
-        creationEvent.getCreated.witnessParties.sorted == expectedWitnessesOfCreation,
-        s"The parties for witnessing the CreatedEvent should be ${expectedWitnessesOfCreation}, but were ${creationEvent.getCreated.witnessParties}"
-      )
-      assert(
-        nonConsumingTree.eventsById.size == 1,
-        s"The transaction for exercising the non-consuming choice should only contain a single event, but has ${nonConsumingTree.eventsById.size}"
-      )
-      val (_, nonConsumingEvent) = nonConsumingTree.eventsById.head
-      assert(
-        nonConsumingEvent.kind.isExercised,
-        s"The event in the transaction for exercising the non-consuming choice should be an ExercisedEvent, but was ${nonConsumingEvent.kind}"
-      )
+        val expectedWitnessesOfNonConsumingChoice = Tag.unsubst(Seq(alice, charlie)).sorted
+        assert(
+          nonConsumingEvent.getExercised.witnessParties.sorted == expectedWitnessesOfNonConsumingChoice,
+          s"The parties for witnessing the non-consuming ExercisedEvent should be ${expectedWitnessesOfNonConsumingChoice}, but were ${nonConsumingEvent.getCreated.witnessParties}"
+        )
+        assert(
+          consumingTree.eventsById.size == 1,
+          s"The transaction for exercising the consuming choice should only contain a single event, but has ${consumingTree.eventsById.size}"
+        )
 
-      val expectedWitnessesOfNonConsumingChoice = Tag.unsubst(Seq(alice, charlie)).sorted
-      assert(
-        nonConsumingEvent.getExercised.witnessParties.sorted == expectedWitnessesOfNonConsumingChoice,
-        s"The parties for witnessing the non-consuming ExercisedEvent should be ${expectedWitnessesOfNonConsumingChoice}, but were ${nonConsumingEvent.getCreated.witnessParties}"
-      )
-      assert(
-        consumingTree.eventsById.size == 1,
-        s"The transaction for exercising the consuming choice should only contain a single event, but has ${consumingTree.eventsById.size}"
-      )
+        val (_, consumingEvent) = consumingTree.eventsById.head
+        assert(
+          consumingEvent.kind.isExercised,
+          s"The event in the transaction for exercising the consuming choice should be an ExercisedEvent, but was ${consumingEvent.kind}"
+        )
+        val expectedWitnessesOfConsumingChoice = Tag.unsubst(Seq(alice, bob, charlie)).sorted
+        assert(
+          consumingEvent.getExercised.witnessParties.sorted == expectedWitnessesOfConsumingChoice,
+          s"The parties for witnessing the consuming ExercisedEvent should be ${expectedWitnessesOfConsumingChoice}, but were ${consumingEvent.getCreated.witnessParties}"
+        )
 
-      val (_, consumingEvent) = consumingTree.eventsById.head
-      assert(
-        consumingEvent.kind.isExercised,
-        s"The event in the transaction for exercising the consuming choice should be an ExercisedEvent, but was ${consumingEvent.kind}"
-      )
-      val expectedWitnessesOfConsumingChoice = Tag.unsubst(Seq(alice, bob, charlie)).sorted
-      assert(
-        consumingEvent.getExercised.witnessParties.sorted == expectedWitnessesOfConsumingChoice,
-        s"The parties for witnessing the consuming ExercisedEvent should be ${expectedWitnessesOfConsumingChoice}, but were ${consumingEvent.getCreated.witnessParties}"
-      )
-
-    }
+      }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractId.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractId.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.digitalasset.ledger.client.binding.Primitive
@@ -12,35 +13,31 @@ import com.digitalasset.ledger.test_stable.Test.{Delegated, Delegation, Dummy, D
 import io.grpc.Status.Code
 
 final class WronglyTypedContractId(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("WTExerciseFails", "Exercising on a wrong type fails") { context =>
-    for {
-      ledger <- context.participant()
-      party <- ledger.allocateParty()
-
-      dummy <- ledger.create(party, Dummy(party))
-      fakeDummyWithParam = dummy.asInstanceOf[Primitive.ContractId[DummyWithParam]]
-      exerciseFailure <- ledger
-        .exercise(party, fakeDummyWithParam.exerciseDummyChoice2(_, "txt"))
-        .failed
-    } yield {
-      assertGrpcError(exerciseFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
-    }
+  test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty)) {
+    case Participants(Participant(ledger, party)) =>
+      for {
+        dummy <- ledger.create(party, Dummy(party))
+        fakeDummyWithParam = dummy.asInstanceOf[Primitive.ContractId[DummyWithParam]]
+        exerciseFailure <- ledger
+          .exercise(party, fakeDummyWithParam.exerciseDummyChoice2(_, "txt"))
+          .failed
+      } yield {
+        assertGrpcError(exerciseFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
+      }
   }
 
-  test("WTFetchFails", "Fetching of the wrong type fails") { context =>
-    for {
-      ledger <- context.participant()
-      Vector(owner, delegate) <- ledger.allocateParties(2)
+  test("WTFetchFails", "Fetching of the wrong type fails", allocate(TwoParties)) {
+    case Participants(Participant(ledger, owner, delegate)) =>
+      for {
+        dummy <- ledger.create(owner, Dummy(owner))
+        fakeDelegated = dummy.asInstanceOf[Primitive.ContractId[Delegated]]
+        delegation <- ledger.create(owner, Delegation(owner, delegate))
 
-      dummy <- ledger.create(owner, Dummy(owner))
-      fakeDelegated = dummy.asInstanceOf[Primitive.ContractId[Delegated]]
-      delegation <- ledger.create(owner, Delegation(owner, delegate))
-
-      fetchFailure <- ledger
-        .exercise(owner, delegation.exerciseFetchDelegated(_, fakeDelegated))
-        .failed
-    } yield {
-      assertGrpcError(fetchFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
-    }
+        fetchFailure <- ledger
+          .exercise(owner, delegation.exerciseFetchDelegated(_, fakeDelegated))
+          .failed
+      } yield {
+        assertGrpcError(fetchFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
+      }
   }
 }


### PR DESCRIPTION
I highly recommend ignoring whitespace when reviewing.

Part of a solution to #3380.

Rather than allocating participants and parties line by line, instruct
the test to construct a number up-front.

This will make it easier to serve multi-participant ledgers, as we can
make sure we wait for all parties to be available on all participants
before starting the test. Once we can do that, tests will hopefully be
much less flaky on ledgers other than the Sandbox.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
