### PR TITLE
Mark dev_env_tool as local

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -794,13 +794,25 @@ dev_env_tool(
         "share",
     ],
     nix_label = "@node_nix",
-    nix_paths = [],
+    nix_paths = [
+        "bin/node",
+        "bin/npm",
+        "bin/npx",
+    ],
     prefix = "nodejs_dev_env",
-    tools = [],
+    tools = [
+        "node",
+        "npm",
+        "npx",
+    ],
     win_include = [
         ".",
     ],
-    win_paths = [],
+    win_paths = [
+        "node.exe",
+        "npm.cmd",
+        "npx.cmd",
+    ],
     win_tool = "nodejs-10.12.0",
 )
 

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -76,6 +76,11 @@ def _dev_env_tool_impl(ctx):
         dadew = _dadew_where(ctx, ps)
         find = _dadew_tool_home(dadew, "msys2") + "\\usr\\bin\\find.exe"
         tool_home = _dadew_tool_home(dadew, ctx.attr.win_tool)
+
+        # Copy the manifest to ensure that updates are noticed.
+        ctx.template("bazel-support\\manifest.json", "%s\\manifest.json" % tool_home, executable = False)
+
+        # Link the requested files.
         for i in ctx.attr.win_include:
             src = "%s\%s" % (tool_home, i)
             dst = ctx.attr.win_include_as.get(i, i)

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -137,4 +137,5 @@ dev_env_tool = repository_rule(
         ),
         "prefix": attr.string(),
     },
+    local = True,
 )

--- a/build.ps1
+++ b/build.ps1
@@ -30,6 +30,10 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+# Manually fetch a Windows dev-env tool to avoid the following error:
+#   ERROR loading ~/.scoop: The process cannot access the file 'C:\Users\VssAdministrator\.scoop' because it is being used by another process.
+bazel fetch @makensis_dev_env//...
+
 bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log //...
 
 bazel shutdown


### PR DESCRIPTION
To avoid errors of the following form on Windows:

```
ERROR: D:/a/1/s/release/windows-installer/BUILD.bazel:20:1: no such package '@makensis_dev_env//': BUILD file not found in directory '' of external repository @makensis_dev_env and referenced by '//release/windows-installer:windows-installer'
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
