### PR TITLE
RxJava Bindings: Allow bot to run on a scheduler

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/components/Bot.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/components/Bot.java
@@ -13,6 +13,7 @@ import com.daml.ledger.rxjava.components.helpers.Pair;
 import com.daml.ledger.rxjava.util.FlowableLogger;
 import com.google.rpc.Code;
 import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.ReplaySubject;
 import io.reactivex.subjects.Subject;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -55,11 +56,36 @@ public class Bot {
      *                  and save space.
      * @param <R> The type of the result of transform.
      */
+
     public static <R> void wire(String applicationId,
                                 LedgerClient ledgerClient,
                                 TransactionFilter transactionFilter,
                                 Function<LedgerViewFlowable.LedgerView<R>, Flowable<CommandsAndPendingSet>> bot,
                                 Function<CreatedContract, R> transform) {
+        wire(applicationId, ledgerClient, transactionFilter, bot, transform, Schedulers.io());
+    }
+
+    /**
+     * Wires the Bot logic to an existing {@link LedgerClient} instance.
+     *
+     * @param applicationId The application identifier that will be sent to the Ledger
+     * @param ledgerClient The {@link LedgerClient} instance which will be wired to the
+     *                     bot.
+     * @param transactionFilter A server-side filter of incoming transactions
+     * @param bot The business logic of the bot.
+     * @param transform A function from the arguments of a Contract on the Ledger to
+     *                  a more refined type R. This can be used by the developer to, for
+     *                  instance, discard the fields of a Contract that are not needed
+     *                  and save space.
+     * @param scheduler The scheduler used to run the flows
+     * @param <R> The type of the result of transform.
+     */
+    public static <R> void wire(String applicationId,
+                                LedgerClient ledgerClient,
+                                TransactionFilter transactionFilter,
+                                Function<LedgerViewFlowable.LedgerView<R>, Flowable<CommandsAndPendingSet>> bot,
+                                Function<CreatedContract, R> transform,
+                                Scheduler scheduler) {
 
         logger.info("Bot wiring started for parties {}", transactionFilter.getParties());
 
@@ -67,7 +93,7 @@ public class Bot {
         // ACS is disabled until the Ledger supports verbose = true for it
 //        Flowable<GetActiveContractsResponse> acs = FlowableLogger.log(ledgerClient.getActiveContractSetClient().getActiveContracts(transactionFilter, true), "acs");
         Flowable<GetActiveContractsResponse> acs = Flowable.empty();
-        Single<Pair<LedgerViewFlowable.LedgerView<R>, LedgerOffset>> acsLedgerViewSingle = LedgerViewFlowable.ledgerViewAndOffsetFromACS(acs, transform);
+        Single<Pair<LedgerViewFlowable.LedgerView<R>, LedgerOffset>> acsLedgerViewSingle = LedgerViewFlowable.ledgerViewAndOffsetFromACS(acs, transform).observeOn(scheduler);
 
         Single<Pair<LedgerViewFlowable.LedgerView<R>, LedgerOffset>> ledgerViewAndOffsetSingle = acsLedgerViewSingle.flatMap(
                 acsLedgerViewAndOffset -> {
@@ -89,14 +115,17 @@ public class Bot {
             LedgerViewFlowable.@NonNull LedgerView<R> initialLedgerView = ledgerViewAndOffset.getFirst();
             @NonNull LedgerOffset ledgerOffset = ledgerViewAndOffset.getSecond();
             logger.debug("LedgerView accumulated from acs and transactions completed. Offset: {} LedgerView: {}", ledgerOffset, initialLedgerView);
-            Flowable<Transaction> transactions = FlowableLogger.log(transactionsClient.getTransactions(ledgerOffset, transactionFilter, true), "transactions");
-            Flowable<LedgerViewFlowable.CompletionFailure> completionFailures = FlowableLogger.log(failuresCommandIds(transactionFilter.getParties(), ledgerClient.getCommandCompletionClient().completionStream(applicationId, LedgerOffset.LedgerEnd.getInstance(), transactionFilter.getParties())), "completionFailures");
+            Flowable<Transaction> transactions = FlowableLogger.log(transactionsClient.getTransactions(ledgerOffset, transactionFilter, true), "transactions").observeOn(scheduler);
+            Flowable<LedgerViewFlowable.CompletionFailure> completionFailures = FlowableLogger.log(failuresCommandIds(transactionFilter.getParties(), ledgerClient.getCommandCompletionClient().completionStream(applicationId, LedgerOffset.LedgerEnd.getInstance(), transactionFilter.getParties())), "completionFailures")
+                    .observeOn(scheduler);
 
             Subject<LedgerViewFlowable.SubmissionFailure> submissionFailuresSubject = ReplaySubject.create();
             Subject<CommandsAndPendingSet> commandsAndPendingSetSubject = ReplaySubject.create();
 
-            Flowable<LedgerViewFlowable.SubmissionFailure> submissionFailures = FlowableLogger.log(submissionFailuresSubject.toFlowable(BackpressureStrategy.BUFFER), "submissionsFailures");
-            Flowable<CommandsAndPendingSet> commandsAndPendingsSet = FlowableLogger.log(commandsAndPendingSetSubject.toFlowable(BackpressureStrategy.BUFFER), "commandsAndPendingSet");
+            Flowable<LedgerViewFlowable.SubmissionFailure> submissionFailures = FlowableLogger.log(submissionFailuresSubject.toFlowable(BackpressureStrategy.BUFFER), "submissionsFailures")
+                    .observeOn(scheduler);
+            Flowable<CommandsAndPendingSet> commandsAndPendingsSet = FlowableLogger.log(commandsAndPendingSetSubject.toFlowable(BackpressureStrategy.BUFFER), "commandsAndPendingSet")
+                    .observeOn(scheduler);
 
             Flowable<LedgerViewFlowable.LedgerView<R>> ledgerViews = LedgerViewFlowable.<R>of(
                     initialLedgerView,
@@ -130,7 +159,7 @@ public class Bot {
             logger.info("Bot wiring complete for parties {}", transactionFilter.getParties());
         });
         // Since we have removed the blockingGet call, we now need to make sure that the flow is actually triggered
-        mainFlow.toFlowable().publish().connect();
+        mainFlow.toFlowable().observeOn(scheduler).publish().connect();
     }
 
     /**

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -295,20 +295,20 @@ final class BotTest extends FlatSpec with Matchers {
     Bot.wireSimple(appId, ledgerClient, transactionFilter, bot)
 
     // when the bot is wired-up, no command should have been submitted to the server
-    Thread.sleep(1l)
+    Thread.sleep(100l)
     ledgerClient.submitted.size shouldBe 0
 
     // when the bot receives a transaction, a command should be submitted to the server
     val createdEvent1 = create(party, templateId)
     transactions.emit(transactionArray(createdEvent1))
-    Thread.sleep(1l)
+    Thread.sleep(100l)
     ledgerClient.submitted.size shouldBe 1
 
     val archivedEvent1 = archive(createdEvent1)
     val createEvent2 = create(party, templateId)
     val createEvent3 = create(party, templateId)
     transactions.emit(transactionArray(archivedEvent1, createEvent2, createEvent3))
-    Thread.sleep(1l)
+    Thread.sleep(100l)
     ledgerClient.submitted.size shouldBe 3
 
     // we complete the first command with success and then check that the client hasn't submitted a new command
@@ -322,7 +322,7 @@ final class BotTest extends FlatSpec with Matchers {
             .setStatus(Status.newBuilder().setCode(OK.value).build())
             .build()).asJava
       ))
-    Thread.sleep(1l)
+    Thread.sleep(100l)
     ledgerClient.submitted.size shouldBe 3
 
     // WARNING: THE FOLLOWING TEST IS NOT PASSING YET


### PR DESCRIPTION
It seems that having many bots results in a some sort of deadlock
or blocking of data flow within the flowable network.

Adding some async boundaries to allow for concurrent processing
seems to help.

Fixes #2356

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
