### PR TITLE
Rewrite PRSelf when loading a dependency package

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -11,7 +11,6 @@ module DA.Daml.LF.Ast.World(
     initWorldSelf,
     extendWorldSelf,
     ExternalPackage(..),
-    rewriteSelfReferences,
     LookupError,
     lookupTemplate,
     lookupDataType,
@@ -31,7 +30,6 @@ import qualified Data.NameMap as NM
 import GHC.Generics
 
 import DA.Daml.LF.Ast.Base
-import DA.Daml.LF.Ast.Optics (moduleModuleRef)
 import DA.Daml.LF.Ast.Pretty ()
 import DA.Daml.LF.Ast.Version
 
@@ -62,14 +60,6 @@ data DalfPackage = DalfPackage
     } deriving (Show, Eq, Generic)
 
 instance NFData DalfPackage
-
--- | Rewrite all `PRSelf` references to `PRImport` references.
-rewriteSelfReferences :: PackageId -> Package -> ExternalPackage
-rewriteSelfReferences pkgId = ExternalPackage pkgId . rewrite
-    where
-        rewrite = over (_packageModules . NM.traverse . moduleModuleRef . _1) $ \case
-            PRSelf -> PRImport pkgId
-            ref@PRImport{} -> ref
 
 -- | Construct the 'World' from only the imported packages.
 initWorld :: [ExternalPackage] -> Version -> World

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Decode.hs
@@ -7,14 +7,14 @@ module DA.Daml.LF.Proto3.Decode
   ) where
 
 import Com.Digitalasset.DamlLfDev.DamlLf (ArchivePayload(..), ArchivePayloadSum(..))
-import DA.Daml.LF.Ast (Package)
+import DA.Daml.LF.Ast (Package, PackageRef)
 import DA.Daml.LF.Proto3.Error
 import qualified DA.Daml.LF.Proto3.DecodeV1 as DecodeV1
 
-decodePayload :: ArchivePayload -> Either Error Package
-decodePayload payload = case archivePayloadSum payload of
+decodePayload :: PackageRef -> ArchivePayload -> Either Error Package
+decodePayload selfPackageRef payload = case archivePayloadSum payload of
     Just ArchivePayloadSumDamlLf0{} -> Left $ ParseError "Payload is DamlLf0"
-    Just (ArchivePayloadSumDamlLf1 package) -> DecodeV1.decodePackage minor package
+    Just (ArchivePayloadSumDamlLf1 package) -> DecodeV1.decodePackage minor selfPackageRef package
     Nothing -> Left $ ParseError "Empty payload"
     where
         minor = archivePayloadMinor payload

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -409,9 +409,9 @@ generatePackageMap fps = do
         return $ do
           (pkgId, package) <-
             mapLeft (ideErrorPretty $ toNormalizedFilePath dalf) $
-            Archive.decodeArchive dalfBS
+            Archive.decodeArchive Archive.DecodeAsDependency dalfBS
           let unitId = stringToUnitId $ dropExtension $ takeFileName dalf
-          Right (unitId, LF.DalfPackage pkgId (LF.rewriteSelfReferences pkgId package) dalfBS)
+          Right (unitId, LF.DalfPackage pkgId (LF.ExternalPackage pkgId package) dalfBS)
   return (diags, Map.fromList pkgs)
 
 generatePackageMapRule :: Options -> Rules ()

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -189,12 +189,12 @@ moduleAndTemplates :: LF.World -> LF.Module -> [TemplateChoices]
 moduleAndTemplates world mod = map (\t -> TemplateChoices t (LF.moduleName mod) (templatePossibleUpdates world t)) $ NM.toList $ LF.moduleTemplates mod
 
 dalfBytesToPakage :: BSL.ByteString -> ExternalPackage
-dalfBytesToPakage bytes = case Archive.decodeArchive $ BSL.toStrict bytes of
-    Right (pkgId, pkg) -> rewriteSelfReferences pkgId pkg
+dalfBytesToPakage bytes = case Archive.decodeArchive Archive.DecodeAsDependency $ BSL.toStrict bytes of
+    Right (pkgId, pkg) -> ExternalPackage pkgId pkg
     Left err -> error (show err)
 
 darToWorld :: Dalfs -> LF.World
-darToWorld Dalfs{..} = case Archive.decodeArchive $ BSL.toStrict mainDalf of
+darToWorld Dalfs{..} = case Archive.decodeArchive Archive.DecodeAsMain $ BSL.toStrict mainDalf of
     Right (_, mainPkg) -> AST.initWorldSelf pkgs mainPkg
     Left err -> error (show err)
     where

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -10,7 +10,7 @@ import Control.Concurrent
 import Control.Monad
 import Control.Monad.IO.Class(liftIO)
 import DA.Bazel.Runfiles
-import DA.Daml.LF.Proto3.Archive (decodeArchive)
+import DA.Daml.LF.Proto3.Archive (DecodingMode(DecodeAsMain), decodeArchive)
 import DA.Daml.LF.Reader(Dalfs(..),readDalfs)
 import DA.Ledger.Sandbox (Sandbox,SandboxSpec(..),startSandbox,shutdownSandbox,withSandbox)
 import Data.List (elem,isPrefixOf,isInfixOf,(\\))
@@ -693,7 +693,7 @@ mainPackageId :: SandboxSpec -> IO PackageId
 mainPackageId (SandboxSpec dar) = do
     archive <- Zip.toArchive <$> BSL.readFile dar
     Dalfs { mainDalf } <- either fail pure $ readDalfs archive
-    case decodeArchive (BSL.toStrict mainDalf) of
+    case decodeArchive DecodeAsMain (BSL.toStrict mainDalf) of
         Left err -> fail $ show err
         Right (LF.PackageId pId, _) -> pure (PackageId $ Text.fromStrict pId)
 


### PR DESCRIPTION
Currently, we first load the package as is and rewrite the `PRSelf`
references in a second step. This PR moves the rewriting directly
in the loading step.

When buidling simple project that has our favourite large project as a
dependency, this decreased
- total allocations from 63GB to 57GB
- run time from 34.0s to 31.5s

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3406)
<!-- Reviewable:end -->
