### PR TITLE
Ledger api test tool wrap two remote exercises with "eventually"

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -478,7 +478,7 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
     case Participants(Participant(alpha, receiver), Participant(beta, giver)) =>
       for {
         agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
-        _ <- alpha.exercise(receiver, agreementFactory.exerciseCreateAgreement)
+        _ <- eventually { alpha.exercise(receiver, agreementFactory.exerciseCreateAgreement) }
         _ <- synchronize(alpha, beta)
         transactions <- alpha.flatTransactions(receiver, giver)
       } yield {
@@ -694,9 +694,11 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
     case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
       for {
         agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
-        agreement <- alpha.exerciseAndGetContract[Agreement](
-          receiver,
-          agreementFactory.exerciseAgreementFactoryAccept)
+        agreement <- eventually {
+          alpha.exerciseAndGetContract[Agreement](
+            receiver,
+            agreementFactory.exerciseAgreementFactoryAccept)
+        }
         triProposalTemplate = TriProposal(operator, receiver, giver)
         triProposal <- alpha.create(operator, triProposalTemplate)
         tree <- eventually {


### PR DESCRIPTION
Two tests issued a create and exercise on different participants without
allowing for a delay publishing the contract. Added two missing eventually
statements to two TransactionService tests.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description
