### PR TITLE
Remove an inaccurate FIXME

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -554,7 +554,6 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
         forM allDalfs $ \(name, dalf) -> do
             (pkgId, package) <-
                 either (fail . DA.Pretty.renderPretty) pure $
-                -- FIXME(MH): This keeps the old behaviour but seems wrong to me.
                 Archive.decodeArchive Archive.DecodeAsMain dalf
             pure (pkgId, package, dalf, stringToUnitId name)
     -- mapping from package id's to unit id's. if the same package is imported with


### PR DESCRIPTION
I didn't really read the code around the FIXME. After spending a few moments
on it, I'm now convinces the current behaviour is the right behaviour. I
can't think of a short way to explain it in a comment without inflicting my
my previous confusion on others. Thus, I just remove the FIXME.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3412)
<!-- Reviewable:end -->
