### PR TITLE
Fix Bazel warnings

### DIFF
--- a/compiler/damlc/jar/BUILD.bazel
+++ b/compiler/damlc/jar/BUILD.bazel
@@ -36,12 +36,9 @@ genrule(
     TMP_DIR=damlc-jar-tmp
     rm -rf "$$TMP_DIR"
     mkdir "$$TMP_DIR"
-    $(location @tar_dev_env//:tar) xzf $< -C "$$TMP_DIR"
-    $(location @bazel_tools//tools/jdk:jar) c0Mf $@ -C "$$TMP_DIR" .
+    $(execpath @tar_dev_env//:tar) xzf $< -C "$$TMP_DIR"
+    $(JAVABASE)/bin/jar c0Mf $@ -C "$$TMP_DIR" .
   """,
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
-    tools = [
-        "@bazel_tools//tools/jdk:jar",
-        "@tar_dev_env//:tar",
-    ],
+    tools = ["@tar_dev_env//:tar"],
 )

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -314,7 +314,7 @@ sh_test(
 # Generate a simple DALF for plain DALF import testing
 
 genrule(
-    name = "simple-dalf.dalf",
+    name = "simple-dalf",
     outs = ["simple-dalf.dalf"],
     cmd = "$(location :generate-simple-dalf) $@",
     tools = [":generate-simple-dalf"],

--- a/language-support/java/codegen/codegen.bzl
+++ b/language-support/java/codegen/codegen.bzl
@@ -24,15 +24,13 @@ def dar_to_java(**kwargs):
         outs = [mangle(src_jar)],
         cmd = """
             $(execpath //language-support/java/codegen:codegen) -o {gen_out} -d com.daml.ledger.javaapi.TestDecoder {gen_in}
-            $(execpath @bazel_tools//tools/jdk:jar) -cf $@ -C {gen_out} .
+            $(JAVABASE)/bin/jar -cf $@ -C {gen_out} .
         """.format(
             gen_in = "$(location %s)=%s" % (dar, package_prefix),
             gen_out = src_out,
         ),
-        tools = [
-            "//language-support/java/codegen:codegen",
-            "@bazel_tools//tools/jdk:jar",
-        ],
+        toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+        tools = ["//language-support/java/codegen:codegen"],
     )
 
     native.java_library(

--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -106,17 +106,14 @@ genrule(
 
     # Package result (.JAR)
     echo "Packaging result from $$OUT to $(@D)/frontend.jar"
-    $(location @bazel_tools//tools/jdk:jar) c0Mf "$(@D)/frontend.jar" -C $$OUT .
+    $(JAVABASE)/bin/jar c0Mf "$(@D)/frontend.jar" -C $$OUT .
     """.format(
         PATHS_CASE_CHECK = "false" if is_windows else "true",
         WP_IN = "$$(cygpath -w $$IN)" if is_windows else "$$IN",
         WP_OUT = "$$(cygpath -w $$OUT)" if is_windows else "$$OUT",
     ),
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
-    tools = [
-        ":webpack",
-        "@bazel_tools//tools/jdk:jar",
-    ],
+    tools = [":webpack"],
     visibility = [
         "//navigator:__subpackages__",
     ],


### PR DESCRIPTION
- No longer depend on "@bazel_tools//tools/jdk:jar"
    To avoid the following warnings
    ```
    WARNING: /home/aj/.cache/bazel/_bazel_aj/c1e06e2358666d118d0ae50e2d32c25d/external/bazel_tools/tools/jdk/BUILD:124:1: in alias rule @bazel_tools//tools/jdk:jar: target '@bazel_tools//tools/jdk:jar' depends on deprecated target '@local_jdk//:jar': Don't depend on targets in the JDK workspace; use @bazel_tools//tools/jdk:current_java_runtime instead (see bazelbuild/bazel#5594)
    ```
- Targets and files should not share names
    To avoid the warning
    ```
    WARNING: /home/aj/tweag.io/da/da-master/compiler/damlc/tests/BUILD.bazel:316:1: target 'simple-dalf.dalf' is both a rule and a file; please choose another name for the rule
    ```
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
