### PR TITLE
Fix potential race in Dispatcher

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ApiTimeService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/testing/ApiTimeService.scala
@@ -55,7 +55,7 @@ class ApiTimeService private (
       Source.failed, { ledgerId =>
         logger.trace("Request for time with ledger ID {}", ledgerId)
         dispatcher
-          .subscribe(None)
+          .subscribe()
           .map(_ => backend.getCurrentTime)
           .scan[Option[Instant]](Some(backend.getCurrentTime)) {
             case (Some(previousTime), currentTime) if previousTime == currentTime => None
@@ -106,7 +106,7 @@ class ApiTimeService private (
       //_ <- updateTime(expectedTime, requestedTime)
     } yield {
       updateTime(expectedTime, requestedTime).map { _ =>
-        dispatcher.signal(requestedTime)
+        dispatcher.signal()
         Empty()
       }
     }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
@@ -26,33 +26,33 @@ class SignalDispatcherTest
   "SignalDispatcher" should {
 
     "send a signal on subscription if requested" in { sut =>
-      sut.subscribe(Some(())).runWith(Sink.head).map(_ => succeed)
+      sut.subscribe(true).runWith(Sink.head).map(_ => succeed)
     }
 
     "not send a signal on subscription if not requested" in { sut =>
-      val s = sut.subscribe(None).runWith(TestSink.probe[Unit])
+      val s = sut.subscribe(false).runWith(TestSink.probe[SignalDispatcher.Signal])
       s.request(1L)
       s.expectNoMessage(1.second)
       succeed
     }
 
     "output a signal when it arrives" in { sut =>
-      val result = sut.subscribe(None).runWith(Sink.head).map(_ => succeed)
-      sut.signal(())
+      val result = sut.subscribe(false).runWith(Sink.head).map(_ => succeed)
+      sut.signal()
       result
     }
 
     "output multiple signals when they arrive" in { sut =>
       val count = 10
-      val result = sut.subscribe(None).take(count.toLong).runWith(Sink.seq).map(_ => succeed)
-      1.to(count).foreach(_ => sut.signal(()))
+      val result = sut.subscribe(false).take(count.toLong).runWith(Sink.seq).map(_ => succeed)
+      1.to(count).foreach(_ => sut.signal)
       result
     }
 
     "remove queues from its state when the stream terminates behind them" in { sut =>
-      val s = sut.subscribe(Some(())).runWith(TestSink.probe[Unit])
+      val s = sut.subscribe(true).runWith(TestSink.probe[SignalDispatcher.Signal])
       s.request(1L)
-      s.expectNext(())
+      s.expectNext(SignalDispatcher.Signal)
       sut.getRunningState should have size 1L
       s.cancel()
       await("Cancellation handling")
@@ -62,19 +62,19 @@ class SignalDispatcherTest
     }
 
     "remove queues from its state when closed" in { sut =>
-      val s = sut.subscribe(Some(())).runWith(TestSink.probe[Unit])
+      val s = sut.subscribe(true).runWith(TestSink.probe[SignalDispatcher.Signal])
       s.request(1L)
-      s.expectNext(())
+      s.expectNext(SignalDispatcher.Signal)
       sut.getRunningState should have size 1L
       sut.close()
       assertThrows[IllegalStateException](sut.getRunningState)
-      assertThrows[IllegalStateException](sut.signal(()))
+      assertThrows[IllegalStateException](sut.signal())
       s.expectComplete()
       succeed
     }
   }
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    test.apply(SignalDispatcher[Unit]())
-  override type FixtureParam = SignalDispatcher[Unit]
+    test.apply(SignalDispatcher())
+  override type FixtureParam = SignalDispatcher
   override def timeLimit: Span = scaled(10.seconds)
 }

--- a/ledger/ledger-api-integration-tests/src/test/resources/logback-test.xml
+++ b/ledger/ledger-api-integration-tests/src/test/resources/logback-test.xml
@@ -64,7 +64,7 @@
     <logger name="io.grpc.netty" level="warn"/>
     <logger name="io.netty" level="warn"/>
 
-    <root level="INFO">
+    <root level="TRACE">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Instead of using the value of the state at the time of subscription,
we need to call getHead explicitly.
Otherwise it could happen that the state gets updated between reading it
and completing the subscription, which means the stream would miss an update
of head.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
