### PR TITLE
cleanup equality for SValues

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -16,10 +16,11 @@ import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.{GenTransaction => GenTx, Transaction => Tx}
 import com.digitalasset.daml.lf.value.Value
 import Value._
-import com.digitalasset.daml.lf.speedy.SValue
+import com.digitalasset.daml.lf.speedy.{SValue, svalue}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.command._
 import com.digitalasset.daml.lf.value.ValueVersions.assertAsVersionedValue
+import org.scalactic.Equality
 import org.scalatest.{EitherValues, Matchers, WordSpec}
 import scalaz.std.either._
 import scalaz.syntax.apply._
@@ -401,12 +402,12 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
       translator
         .translateValue(typ, someValue)
-        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldBe
+        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldEqual
         Right(SRecord(id, Name.Array("recField"), ArrayList(SOptional(Some(SText("foo"))))))
 
       translator
         .translateValue(typ, noneValue)
-        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldBe
+        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldEqual
         Right(SRecord(id, Name.Array("recField"), ArrayList(SOptional(None))))
 
     }
@@ -1174,6 +1175,13 @@ object EngineTest {
     val a = new util.ArrayList[X](as.length)
     as.foreach(a.add)
     a
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private implicit def resultEq: Equality[Either[Error, SValue]] = {
+    case (Right(v1: SValue), Right(v2: SValue)) => svalue.Equality.areEqual(v1, v2)
+    case (Left(e1), Left(e2)) => e1 == e2
+    case _ => false
   }
 
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -286,7 +286,7 @@ object SBuiltin {
         case SParty(p) => p
         case SUnit => s"<unit>"
         case SDate(date) => date.toString
-        case SContractId(_) | SNumeric(_) | STypeRep(_) => crash("litToText: literal not supported")
+        case SContractId(_) | SNumeric(_) => crash("litToText: literal not supported")
       })
     }
   }
@@ -566,8 +566,7 @@ object SBuiltin {
   //
   final case object SBEqual extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue.bool(
-        args.get(0).asInstanceOf[SPrimLit].equalTo(args.get(1).asInstanceOf[SPrimLit]))
+      machine.ctrl = CtrlValue.bool(svalue.Equality.areEqual(args.get(0), args.get(1)))
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.speedy.svalue
+
+import com.digitalasset.daml.lf.data.FrontStack
+import com.digitalasset.daml.lf.speedy.SValue
+import com.digitalasset.daml.lf.speedy.SValue._
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+// FIXME https://github.com/digital-asset/daml/issues/2256
+// add extensive tests
+object Equality {
+
+  // Equality between two SValues of same type.
+  def areEqual(x: SValue, y: SValue): Boolean = equality(FrontStack((x, y)))
+
+  private[this] def zipAndPush[X, Y](
+      h1: Iterator[X],
+      h2: Iterator[Y],
+      stack: FrontStack[(X, Y)]): FrontStack[(X, Y)] =
+    (stack /: (h1 zip h2))(_.+:(_))
+
+  @tailrec
+  private[this] def equality(stack0: FrontStack[(SValue, SValue)]): Boolean = {
+    stack0.pop match {
+      case Some((tuple, stack)) =>
+        tuple match {
+          case (x: SPrimLit, y: SPrimLit) =>
+            x == y && equality(stack)
+          case (SEnum(tyCon1, con1), SEnum(tyCon2, con2)) =>
+            tyCon1 == tyCon2 && con1 == con2 && equality(stack)
+          case (SRecord(tyCon1, fields1, args1), SRecord(tyCon2, fields2, args2)) =>
+            tyCon1 == tyCon2 && (fields1 sameElements fields2) &&
+              equality(zipAndPush(args1.iterator().asScala, args2.iterator().asScala, stack))
+          case (SVariant(tyCon1, con1, arg1), SVariant(tyCon2, con2, arg2)) =>
+            tyCon1 == tyCon2 && con1 == con2 && equality((arg1, arg2) +: stack)
+          case (SList(lst1), SList(lst2)) =>
+            lst1.length == lst1.length &&
+              equality(zipAndPush(lst1.iterator, lst2.iterator, stack))
+          case (SOptional(opt1), SOptional(opt2)) =>
+            (opt1, opt2) match {
+              case (None, None) => equality(stack)
+              case (Some(v1), Some(v2)) => equality((v1, v2) +: stack)
+              case _ => false
+            }
+          case (SMap(map1), SMap(map2)) =>
+            map1.keySet == map2.keySet && {
+              val keys = map1.keys
+              equality(zipAndPush(keys.iterator.map(map1), keys.iterator.map(map2), stack))
+            }
+          case (STuple(fields1, args1), STuple(fields2, args2)) =>
+            val map1 = (fields1.iterator zip args1.iterator().asScala).toMap
+            val map2 = (fields2.iterator zip args2.iterator().asScala).toMap
+            val keys = map1.keys
+            fields1.length == map1.size && map1.size == map2.size && map2.size == fields2.length &&
+            equality(zipAndPush(keys.iterator.map(map1), keys.iterator.map(map2), stack))
+          case (SAny(t1, v1), SAny(t2, v2)) =>
+            t1 == t2 && equality((v1, v2) +: stack)
+          case (STypeRep(t1), STypeRep(t2)) =>
+            t1 == t2 && equality(stack)
+          case _ =>
+            false
+        }
+      case _ =>
+        true
+    }
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -38,7 +38,7 @@ object Equality {
           case (SVariant(tyCon1, con1, arg1), SVariant(tyCon2, con2, arg2)) =>
             tyCon1 == tyCon2 && con1 == con2 && equality((arg1, arg2) +: stack)
           case (SList(lst1), SList(lst2)) =>
-            lst1.length == lst1.length &&
+            lst1.length == lst2.length &&
               equality(zipAndPush(lst1.iterator, lst2.iterator, stack))
           case (SOptional(opt1), SOptional(opt2)) =>
             (opt1, opt2) match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -13,6 +13,7 @@ import com.digitalasset.daml.lf.speedy.SError.{DamlEArithmeticError, SError}
 import com.digitalasset.daml.lf.speedy.SResult.{SResultContinue, SResultError}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
+import org.scalactic.Equality
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -48,9 +49,9 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "ADD_INT64" - {
       "throws an exception if it overflows" in {
-        eval(e"ADD_INT64 $MaxInt64 -1") shouldBe Right(SInt64(MaxInt64 - 1))
+        eval(e"ADD_INT64 $MaxInt64 -1") shouldEqual Right(SInt64(MaxInt64 - 1))
         eval(e"ADD_INT64 $MaxInt64 1") shouldBe 'left
-        eval(e"ADD_INT64 $MinInt64 1") shouldBe Right(SInt64(MinInt64 + 1))
+        eval(e"ADD_INT64 $MinInt64 1") shouldEqual Right(SInt64(MinInt64 + 1))
         eval(e"ADD_INT64 $MinInt64 -1") shouldBe 'left
         eval(e"ADD_INT64 $aBigOddInt64 $aBigOddInt64") shouldBe
           Left(DamlEArithmeticError(s"Int64 overflow when adding $aBigOddInt64 to $aBigOddInt64."))
@@ -59,11 +60,11 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "SUB_INT64" - {
       "throws an exception if it overflows" in {
-        eval(e"SUB_INT64 $MaxInt64 1") shouldBe Right(SInt64(MaxInt64 - 1))
+        eval(e"SUB_INT64 $MaxInt64 1") shouldEqual Right(SInt64(MaxInt64 - 1))
         eval(e"SUB_INT64 $MaxInt64 -1") shouldBe 'left
-        eval(e"SUB_INT64 $MinInt64 -1") shouldBe Right(SInt64(MinInt64 + 1))
+        eval(e"SUB_INT64 $MinInt64 -1") shouldEqual Right(SInt64(MinInt64 + 1))
         eval(e"SUB_INT64 $MinInt64 1") shouldBe 'left
-        eval(e"SUB_INT64 -$aBigOddInt64 $aBigOddInt64") shouldBe Left(
+        eval(e"SUB_INT64 -$aBigOddInt64 $aBigOddInt64") shouldEqual Left(
           DamlEArithmeticError(
             s"Int64 overflow when subtracting $aBigOddInt64 from -$aBigOddInt64."))
       }
@@ -71,27 +72,27 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "MUL_INT64" - {
       "throws an exception if it overflows" in {
-        eval(e"MUL_INT64 ${1L << 31} ${1L << 31}") shouldBe Right(SInt64(1L << 62))
+        eval(e"MUL_INT64 ${1L << 31} ${1L << 31}") shouldEqual Right(SInt64(1L << 62))
         eval(e"MUL_INT64 ${1L << 32} ${1L << 31}") shouldBe 'left
-        eval(e"MUL_INT64 ${1L << 32} -${1L << 31}") shouldBe Right(SInt64(1L << 63))
+        eval(e"MUL_INT64 ${1L << 32} -${1L << 31}") shouldEqual Right(SInt64(1L << 63))
         eval(e"MUL_INT64 ${1L << 32} -${1L << 32}") shouldBe 'left
         eval(e"MUL_INT64 ${1L << 32} -${1L << 32}") shouldBe 'left
-        eval(e"MUL_INT64 $aBigOddInt64 42") shouldBe
+        eval(e"MUL_INT64 $aBigOddInt64 42") shouldEqual
           Left(DamlEArithmeticError(s"Int64 overflow when multiplying $aBigOddInt64 by 42."))
       }
     }
 
     "DIV_INT64" - {
       "throws an exception if it overflows" in {
-        eval(e"DIV_INT64 $MaxInt64 -1") shouldBe Right(SInt64(-MaxInt64))
-        eval(e"DIV_INT64 $MinInt64 -1") shouldBe
+        eval(e"DIV_INT64 $MaxInt64 -1") shouldEqual Right(SInt64(-MaxInt64))
+        eval(e"DIV_INT64 $MinInt64 -1") shouldEqual
           Left(DamlEArithmeticError(s"Int64 overflow when dividing $MinInt64 by -1."))
       }
 
       "throws an exception when dividing by 0" in {
-        eval(e"DIV_INT64 1 $MaxInt64") shouldBe Right(SInt64(0))
+        eval(e"DIV_INT64 1 $MaxInt64") shouldEqual Right(SInt64(0))
         eval(e"DIV_INT64 1 0") shouldBe 'left
-        eval(e"DIV_INT64 $aBigOddInt64 0") shouldBe
+        eval(e"DIV_INT64 $aBigOddInt64 0") shouldEqual
           Left(DamlEArithmeticError(s"Attempt to divide $aBigOddInt64 by 0."))
       }
     }
@@ -99,30 +100,30 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "EXP_INT64" - {
 
       "throws an exception if the exponent is negative" in {
-        eval(e"EXP_INT64 1 0") shouldBe Right(SInt64(1))
+        eval(e"EXP_INT64 1 0") shouldEqual Right(SInt64(1))
         eval(e"EXP_INT64 1 -1") shouldBe 'left
         eval(e"EXP_INT64 0 -1") shouldBe 'left
         eval(e"EXP_INT64 10 -1") shouldBe 'left
         eval(e"EXP_INT64 10 -20") shouldBe 'left
-        eval(e"EXP_INT64 $aBigOddInt64 -42") shouldBe Left(
+        eval(e"EXP_INT64 $aBigOddInt64 -42") shouldEqual Left(
           DamlEArithmeticError(s"Attempt to raise $aBigOddInt64 to the negative exponent -42."))
       }
 
       "throws an exception if it overflows" in {
-        eval(e"EXP_INT64 ${1L << 6} 9") shouldBe Right(SInt64(1L << 54))
+        eval(e"EXP_INT64 ${1L << 6} 9") shouldEqual Right(SInt64(1L << 54))
         eval(e"EXP_INT64 ${1L << 7} 9") shouldBe 'left
-        eval(e"EXP_INT64 ${-(1L << 7)} 9") shouldBe Right(SInt64(1L << 63))
+        eval(e"EXP_INT64 ${-(1L << 7)} 9") shouldEqual Right(SInt64(1L << 63))
         eval(e"EXP_INT64 ${-(1L << 7)} 10") shouldBe 'left
-        eval(e"EXP_INT64 3 $aBigOddInt64") shouldBe Left(
+        eval(e"EXP_INT64 3 $aBigOddInt64") shouldEqual Left(
           DamlEArithmeticError(s"Int64 overflow when raising 3 to the exponent $aBigOddInt64.")
         )
       }
 
       "accepts huge exponents for bases -1, 0 and, 1" in {
         eval(e"EXP_INT64 2 $aBigOddInt64") shouldBe 'left
-        eval(e"EXP_INT64 -1 $aBigOddInt64") shouldBe Right(SInt64(-1))
-        eval(e"EXP_INT64 0 $aBigOddInt64") shouldBe Right(SInt64(0))
-        eval(e"EXP_INT64 1 $aBigOddInt64") shouldBe Right(SInt64(1))
+        eval(e"EXP_INT64 -1 $aBigOddInt64") shouldEqual Right(SInt64(-1))
+        eval(e"EXP_INT64 0 $aBigOddInt64") shouldEqual Right(SInt64(0))
+        eval(e"EXP_INT64 1 $aBigOddInt64") shouldEqual Right(SInt64(1))
       }
 
       "returns the proper result" in {
@@ -159,7 +160,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         forEvery(testCases) { (base: Long, exponent: Int) =>
           val result = BigInt(base).pow(exponent)
           assert(result == result.longValue())
-          eval(e"EXP_INT64 $base $exponent") shouldBe Right(SInt64(result.longValue()))
+          eval(e"EXP_INT64 $base $exponent") shouldEqual Right(SInt64(result.longValue()))
         }
       }
     }
@@ -167,24 +168,24 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "Integer binary operations computes proper results" in {
       // EXP_INT64 is tested independently
 
-      val testCases = Table[String, (Long, Long) => Either[Any, SValue]](
+      val testCases = Table[String, (Long, Long) => Option[SValue]](
         ("builtin", "reference"),
-        ("ADD_INT64", (a, b) => Right(SInt64(a + b))),
-        ("SUB_INT64", (a, b) => Right(SInt64(a - b))),
-        ("MUL_INT64", (a, b) => Right(SInt64(a * b))),
-        ("DIV_INT64", (a, b) => if (b == 0) Left(()) else Right(SInt64(a / b))),
-        ("MOD_INT64", (a, b) => if (b == 0) Left(()) else Right(SInt64(a % b))),
-        ("LESS_EQ_INT64", (a, b) => Right(SBool(a <= b))),
-        ("GREATER_EQ_INT64", (a, b) => Right(SBool(a >= b))),
-        ("LESS_INT64", (a, b) => Right(SBool(a < b))),
-        ("GREATER_INT64", (a, b) => Right(SBool(a > b))),
-        ("EQUAL_INT64", (a, b) => Right(SBool(a == b))),
+        ("ADD_INT64", (a, b) => Some(SInt64(a + b))),
+        ("SUB_INT64", (a, b) => Some(SInt64(a - b))),
+        ("MUL_INT64", (a, b) => Some(SInt64(a * b))),
+        ("DIV_INT64", (a, b) => if (b == 0) None else Some(SInt64(a / b))),
+        ("MOD_INT64", (a, b) => if (b == 0) None else Some(SInt64(a % b))),
+        ("LESS_EQ_INT64", (a, b) => Some(SBool(a <= b))),
+        ("GREATER_EQ_INT64", (a, b) => Some(SBool(a >= b))),
+        ("LESS_INT64", (a, b) => Some(SBool(a < b))),
+        ("GREATER_INT64", (a, b) => Some(SBool(a > b))),
+        ("EQUAL_INT64", (a, b) => Some(SBool(a == b))),
       )
 
       forEvery(testCases) { (builtin, ref) =>
         forEvery(smallInt64s) { a =>
           forEvery(smallInt64s) { b =>
-            eval(e"$builtin $a $b").left.map(_ => ()) shouldBe ref(a, b)
+            eval(e"$builtin $a $b").right.toOption shouldEqual ref(a, b)
           }
         }
       }
@@ -193,7 +194,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "TO_TEXT_INT64" - {
       "return proper results" in {
         forEvery(smallInt64s) { a =>
-          eval(e"TO_TEXT_INT64 $a") shouldBe Right(SText(a.toString))
+          eval(e"TO_TEXT_INT64 $a") shouldEqual Right(SText(a.toString))
         }
       }
     }
@@ -232,11 +233,11 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"$builtin @0 ${"9" * 38}. 1.") shouldBe 'left
         eval(e"$builtin @37 9.${"9" * 37} -0.${"0" * 36}1") shouldBe 'right
         eval(e"$builtin @37 9.${"9" * 37} 0.${"0" * 36}1") shouldBe 'left
-        eval(e"$builtin @10 ${s(10, bigBigDecimal)} ${s(10, two)}") shouldBe Right(
+        eval(e"$builtin @10 ${s(10, bigBigDecimal)} ${s(10, two)}") shouldEqual Right(
           SNumeric(n(10, bigBigDecimal + 2)))
         eval(e"$builtin @10 ${s(10, maxDecimal)} ${s(10, minPosDecimal)}") shouldBe 'left
         eval(e"$builtin @10 ${s(10, maxDecimal.negate)} ${s(10, -minPosDecimal)}") shouldBe 'left
-        eval(e"$builtin @10 ${s(10, bigBigDecimal)} ${s(10, bigBigDecimal - 1)}") shouldBe
+        eval(e"$builtin @10 ${s(10, bigBigDecimal)} ${s(10, bigBigDecimal - 1)}") shouldEqual
           Left(DamlEArithmeticError(
             s"(Numeric 10) overflow when adding ${s(10, bigBigDecimal - 1)} to ${s(10, bigBigDecimal)}."))
       }
@@ -250,7 +251,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"$builtin @0 -${"9" * 38}. 1.") shouldBe 'left
         eval(e"$builtin @37 -9.${"9" * 37} -0.${"0" * 36}1") shouldBe 'right
         eval(e"$builtin @37 -9.${"9" * 37} 0.${"0" * 36}1") shouldBe 'left
-        eval(e"$builtin @10 $bigBigDecimal ${s(10, two)}") shouldBe Right(
+        eval(e"$builtin @10 $bigBigDecimal ${s(10, two)}") shouldEqual Right(
           SNumeric(n(10, bigBigDecimal - 2)))
         eval(e"$builtin @10 ${s(10, maxDecimal)} -$minPosDecimal") shouldBe 'left
         eval(e"$builtin @10 ${maxDecimal.negate} ${s(10, minPosDecimal)}") shouldBe 'left
@@ -270,12 +271,12 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"$builtin @0 @0 @0 1${"0" * 19}.  1${"0" * 19}.") shouldBe 'left
         eval(e"$builtin @37 @37 @37 $underSqrtOfTen $underSqrtOfTen") shouldBe 'right
         eval(e"$builtin @37 @37 @37 $overSqrtOfTen $underSqrtOfTen") shouldBe 'left
-        eval(e"$builtin @10 @10 @10 1.1000000000 2.2000000000") shouldBe Right(
+        eval(e"$builtin @10 @10 @10 1.1000000000 2.2000000000") shouldEqual Right(
           SNumeric(n(10, 2.42)))
-        eval(e"$builtin @10 @10 @10 ${tenPowerOf(13)} ${tenPowerOf(14)}") shouldBe Right(
+        eval(e"$builtin @10 @10 @10 ${tenPowerOf(13)} ${tenPowerOf(14)}") shouldEqual Right(
           SNumeric(n(10, "1E27")))
         eval(e"$builtin @10 @10 @10 ${tenPowerOf(14)} ${tenPowerOf(14)}") shouldBe 'left
-        eval(e"$builtin @10 @10 @10 ${s(10, bigBigDecimal)} ${bigBigDecimal - 1}") shouldBe Left(
+        eval(e"$builtin @10 @10 @10 ${s(10, bigBigDecimal)} ${bigBigDecimal - 1}") shouldEqual Left(
           DamlEArithmeticError(
             s"(Numeric 10) overflow when multiplying ${s(10, bigBigDecimal)} by ${s(10, bigBigDecimal - 1)}.")
         )
@@ -290,21 +291,22 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         eval(e"$builtin @37 @37 @37 ${s(37, "1E-18")} ${s(37, "-1E-19")}") shouldBe 'left
         eval(e"$builtin @1 @1 @1 ${s(1, "1E36")} 0.2") shouldBe 'right
         eval(e"$builtin @1 @1 @1 ${s(1, "1E36")} 0.1") shouldBe 'left
-        eval(e"$builtin @10 @10 @10 1.1000000000 2.2000000000") shouldBe Right(SNumeric(n(10, 0.5)))
+        eval(e"$builtin @10 @10 @10 1.1000000000 2.2000000000") shouldEqual Right(
+          SNumeric(n(10, 0.5)))
         eval(e"$builtin @10 @10 @10 ${s(10, bigBigDecimal)} ${tenPowerOf(-10)}") shouldBe 'left
-        eval(e"$builtin @10 @10 @10 ${tenPowerOf(17)} ${tenPowerOf(-10)}") shouldBe Right(
+        eval(e"$builtin @10 @10 @10 ${tenPowerOf(17)} ${tenPowerOf(-10)}") shouldEqual Right(
           SNumeric(n(10, "1E27")))
-        eval(e"$builtin @10 @10 @10 ${tenPowerOf(18)} ${tenPowerOf(-10)}") shouldBe Left(
+        eval(e"$builtin @10 @10 @10 ${tenPowerOf(18)} ${tenPowerOf(-10)}") shouldEqual Left(
           DamlEArithmeticError(
             s"(Numeric 10) overflow when dividing ${tenPowerOf(18)} by ${tenPowerOf(-10)}.")
         )
       }
 
       "throws an exception when divided by 0" in {
-        eval(e"$builtin @10 @10 @10 ${s(10, one)} ${tenPowerOf(-10)}") shouldBe Right(
+        eval(e"$builtin @10 @10 @10 ${s(10, one)} ${tenPowerOf(-10)}") shouldEqual Right(
           SNumeric(n(10, tenPowerOf(10))))
         eval(e"$builtin @10 @10 @10 ${s(10, one)} ${s(10, zero)}") shouldBe 'left
-        eval(e"$builtin @10 @10 @10 ${s(10, bigBigDecimal)} ${s(10, zero)}") shouldBe Left(
+        eval(e"$builtin @10 @10 @10 ${s(10, bigBigDecimal)} ${s(10, zero)}") shouldEqual Left(
           DamlEArithmeticError(s"Attempt to divide ${s(10, bigBigDecimal)} by 0.0000000000.")
         )
 
@@ -333,7 +335,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases) { (rounding, input, result) =>
-          eval(e"ROUND_NUMERIC @10 $rounding ${n(10, input)}") shouldBe Right(
+          eval(e"ROUND_NUMERIC @10 $rounding ${n(10, input)}") shouldEqual Right(
             SNumeric(n(10, result)))
         }
       }
@@ -343,26 +345,27 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
       def round(x: BigDecimal) = n(10, x.setScale(10, BigDecimal.RoundingMode.HALF_EVEN))
 
-      val testCases = Table[String, (Numeric, Numeric) => Either[Any, SValue]](
+      val testCases = Table[String, (Numeric, Numeric) => Option[SValue]](
         ("builtin", "reference"),
-        ("ADD_NUMERIC @10", (a, b) => Right(SNumeric(n(10, a add b)))),
-        ("SUB_NUMERIC @10", (a, b) => Right(SNumeric(n(10, a subtract b)))),
-        ("MUL_NUMERIC @10 @10 @10 ", (a, b) => Right(SNumeric(round(a multiply b)))),
+        ("ADD_NUMERIC @10", (a, b) => Some(SNumeric(n(10, a add b)))),
+        ("SUB_NUMERIC @10", (a, b) => Some(SNumeric(n(10, a subtract b)))),
+        ("MUL_NUMERIC @10 @10 @10 ", (a, b) => Some(SNumeric(round(a multiply b)))),
         (
           "DIV_NUMERIC @10 @10 @10",
-          (a, b) => Either.cond(b.signum != 0, SNumeric(round(BigDecimal(a) / BigDecimal(b))), ())),
-        ("LESS_EQ_NUMERIC @10", (a, b) => Right(SBool(BigDecimal(a) <= BigDecimal(b)))),
-        ("GREATER_EQ_NUMERIC @10", (a, b) => Right(SBool(BigDecimal(a) >= BigDecimal(b)))),
-        ("LESS_NUMERIC @10", (a, b) => Right(SBool(BigDecimal(a) < BigDecimal(b)))),
-        ("GREATER_NUMERIC @10", (a, b) => Right(SBool(BigDecimal(a) > BigDecimal(b)))),
-        ("EQUAL_NUMERIC @10", (a, b) => Right(SBool(BigDecimal(a) == BigDecimal(b)))),
+          (a, b) =>
+            if (b.signum != 0) Some(SNumeric(round(BigDecimal(a) / BigDecimal(b)))) else None),
+        ("LESS_EQ_NUMERIC @10", (a, b) => Some(SBool(BigDecimal(a) <= BigDecimal(b)))),
+        ("GREATER_EQ_NUMERIC @10", (a, b) => Some(SBool(BigDecimal(a) >= BigDecimal(b)))),
+        ("LESS_NUMERIC @10", (a, b) => Some(SBool(BigDecimal(a) < BigDecimal(b)))),
+        ("GREATER_NUMERIC @10", (a, b) => Some(SBool(BigDecimal(a) > BigDecimal(b)))),
+        ("EQUAL_NUMERIC @10", (a, b) => Some(SBool(BigDecimal(a) == BigDecimal(b)))),
       )
 
       forEvery(testCases) { (builtin, ref) =>
         forEvery(decimals) { a =>
           forEvery(decimals) { b =>
-            eval(e"$builtin ${s(10, a)} ${s(10, b)}").left
-              .map(_ => ()) shouldBe ref(n(10, a), n(10, b))
+            eval(e"$builtin ${s(10, a)} ${s(10, b)}").right.toOption shouldEqual
+              ref(n(10, a), n(10, b))
           }
         }
       }
@@ -371,7 +374,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "TO_TEXT_NUMERIC" - {
       "returns proper results" in {
         forEvery(decimals) { a =>
-          eval(e"TO_TEXT_NUMERIC @10 ${s(10, a)}") shouldBe Right(SText(a))
+          eval(e"TO_TEXT_NUMERIC @10 ${s(10, a)}") shouldEqual Right(SText(a))
         }
       }
     }
@@ -416,7 +419,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           (20, 10, tenPowerOf(10, 20)),
         )
         forEvery(testCases) { (inputScale, outputScale, x) =>
-          eval(e"CAST_NUMERIC @$inputScale @$outputScale $x") shouldBe Right(
+          eval(e"CAST_NUMERIC @$inputScale @$outputScale $x") shouldEqual Right(
             SNumeric(n(outputScale, x)))
         }
       }
@@ -437,7 +440,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           (20, 10, tenPowerOf(10, 20), tenPowerOf(20, 10)),
         )
         forEvery(testCases) { (inputScale, outputScale, input, output) =>
-          eval(e"SHIFT_NUMERIC @$inputScale @$outputScale $input") shouldBe Right(
+          eval(e"SHIFT_NUMERIC @$inputScale @$outputScale $input") shouldEqual Right(
             SNumeric(n(outputScale, output)))
         }
       }
@@ -452,7 +455,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "EXPLODE_TEXT" - {
       "works on full unicode" in {
-        eval(e"""EXPLODE_TEXT "a¶‱😂"""") shouldBe Right(
+        eval(e"""EXPLODE_TEXT "a¶‱😂"""") shouldEqual Right(
           SList(
             FrontStack(
               SText("a"),
@@ -465,7 +468,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "IMPLODE_TEXT" - {
       "works properly" in {
-        eval(e"""IMPLODE_TEXT (Cons @TEXT ["", "", ""] (Nil @TEXT)) """) shouldBe Right(SText(""))
+        eval(e"""IMPLODE_TEXT (Cons @TEXT ["", "", ""] (Nil @TEXT)) """) shouldEqual Right(
+          SText(""))
         eval(e"""IMPLODE_TEXT (Cons @TEXT ["a", "¶", "‱", "😂"] (Nil @TEXT)) """) shouldBe
           Right(SText("a¶‱😂"))
         eval(
@@ -496,7 +500,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
             "8f1cc14a85321115abcd2854e34f9ca004f4f199d367c3c9a84a355f287cec2e"
         )
         forEvery(testCases) { (input, output) =>
-          eval(e"""SHA256_TEXT "$input"""") shouldBe Right(SText(output))
+          eval(e"""SHA256_TEXT "$input"""") shouldEqual Right(SText(output))
         }
 
       }
@@ -505,7 +509,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "TEXT_TO_TEXT" - {
       "is idempotent" in {
         forEvery(strings) { s =>
-          eval(e""" TO_TEXT_TEXT "$s" """) shouldBe Right(SText(s))
+          eval(e""" TO_TEXT_TEXT "$s" """) shouldEqual Right(SText(s))
         }
       }
     }
@@ -519,7 +523,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       assert(Ordering.String.gt("｡", "😂"))
       assert(unicodeOrdering.lt("｡", "😂"))
 
-      val testCases = Table[String, (String, String) => Either[Any, SValue]](
+      val testCases = Table[String, (String, String) => Either[SError, SValue]](
         ("builtin", "reference"),
         ("APPEND_TEXT", (a, b) => Right(SText(a + b))),
         ("LESS_EQ_TEXT", (a, b) => Right(SBool(unicodeOrdering.lteq(a, b)))),
@@ -532,7 +536,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       forEvery(testCases) { (builtin, ref) =>
         forEvery(strings) { a =>
           forEvery(strings) { b =>
-            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldBe ref(a, b)
+            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldEqual ref(a, b)
           }
         }
       }
@@ -574,7 +578,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases)(cp =>
-          eval(e"""TEXT_FROM_CODE_POINTS ${intList('\''.toLong, cp.toLong, '\''.toLong)}""") shouldBe Right(
+          eval(e"""TEXT_FROM_CODE_POINTS ${intList('\''.toLong, cp.toLong, '\''.toLong)}""") shouldEqual Right(
             SText("'" + new String(Character.toChars(cp)) + "'")))
       }
 
@@ -627,7 +631,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         "1970-01-01T00:00:00.000000Z",
         "2000-12-31T23:00:00.000000Z")
 
-      val testCases = Table[String, (String, String) => Either[Any, SValue]](
+      val testCases = Table[String, (String, String) => Either[SError, SValue]](
         ("builtin", "reference"),
         ("LESS_EQ_TIMESTAMP", (a, b) => Right(SBool(a <= b))),
         ("GREATER_EQ_TIMESTAMP", (a, b) => Right(SBool(a >= b))),
@@ -639,7 +643,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       forEvery(testCases) { (builtin, ref) =>
         forEvery(timeStamp) { a =>
           forEvery(timeStamp) { b =>
-            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldBe ref(a, b)
+            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldEqual ref(a, b)
           }
         }
       }
@@ -660,7 +664,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           )
 
         forEvery(testCases) { s =>
-          eval(e"TO_TEXT_TEXT $s") shouldBe Right(SText(s))
+          eval(e"TO_TEXT_TEXT $s") shouldEqual Right(SText(s))
         }
       }
     }
@@ -675,7 +679,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
       val timeStamp = Table[String]("timestamp", "1969-07-21", "1970-01-01", "2001-01-01")
 
-      val testCases = Table[String, (String, String) => Either[Any, SValue]](
+      val testCases = Table[String, (String, String) => Either[SError, SValue]](
         ("builtin", "reference"),
         ("LESS_EQ_DATE", (a, b) => Right(SBool(a <= b))),
         ("GREATER_EQ_DATE", (a, b) => Right(SBool(a >= b))),
@@ -687,7 +691,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       forEvery(testCases) { (builtin, ref) =>
         forEvery(timeStamp) { a =>
           forEvery(timeStamp) { b =>
-            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldBe ref(a, b)
+            eval(e""" $builtin "$a" "$b" """).left.map(_ => ()) shouldEqual ref(a, b)
           }
         }
       }
@@ -695,7 +699,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "TEXT_TO_DATE" - {
       "works as expected" in {
-        eval(e"TO_TEXT_TEXT  1879-03-14").left.map(_ => ()) shouldBe Right(SText("1879-03-14"))
+        eval(e"TO_TEXT_TEXT  1879-03-14").left.map(_ => ()) shouldEqual Right(SText("1879-03-14"))
       }
     }
   }
@@ -704,8 +708,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "EQUAL_CONTRACT_ID" - {
       "works as expected" in {
-        eval(e"EQUAL_CONTRACT_ID @Mod:T 'contract1' 'contract1'") shouldBe Right(SBool(true))
-        eval(e"EQUAL_CONTRACT_ID @Mod:T 'contract1' 'contract2'") shouldBe Right(SBool(false))
+        eval(e"EQUAL_CONTRACT_ID @Mod:T 'contract1' 'contract1'") shouldEqual Right(SBool(true))
+        eval(e"EQUAL_CONTRACT_ID @Mod:T 'contract1' 'contract2'") shouldEqual Right(SBool(false))
       }
     }
 
@@ -717,15 +721,15 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "FOLDL" - {
       "works as expected" in {
-        eval(e"FOLDL @Int64 @Int64 $f 5 ${intList()}") shouldBe Right(SInt64(5))
-        eval(e"FOLDL @Int64 @Int64 $f 5 ${intList(7, 11, 13)}") shouldBe Right(SInt64(5476))
+        eval(e"FOLDL @Int64 @Int64 $f 5 ${intList()}") shouldEqual Right(SInt64(5))
+        eval(e"FOLDL @Int64 @Int64 $f 5 ${intList(7, 11, 13)}") shouldEqual Right(SInt64(5476))
       }
     }
 
     "FOLDR" - {
       "works as expected" in {
-        eval(e"FOLDR @Int64 @Int64 $f 5 ${intList()}") shouldBe Right(SInt64(5))
-        eval(e"FOLDR @Int64 @Int64 $f 5 ${intList(7, 11, 13)}") shouldBe Right(SInt64(5260))
+        eval(e"FOLDR @Int64 @Int64 $f 5 ${intList()}") shouldEqual Right(SInt64(5))
+        eval(e"FOLDR @Int64 @Int64 $f 5 ${intList(7, 11, 13)}") shouldEqual Right(SInt64(5260))
       }
     }
 
@@ -734,14 +738,15 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         val sameParity =
           """(\ (x:Int64) (y:Int64) -> EQUAL_INT64 (MOD_INT64 x 2) (MOD_INT64 y 2))"""
 
-        eval(e"EQUAL_LIST @Int64 $sameParity ${intList()} ${intList()}") shouldBe Right(SBool(true))
-        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1, 2, 3)} ${intList(5, 6, 7)}") shouldBe Right(
+        eval(e"EQUAL_LIST @Int64 $sameParity ${intList()} ${intList()}") shouldEqual Right(
           SBool(true))
-        eval(e"EQUAL_LIST @Int64 $sameParity ${intList()} ${intList(1)}") shouldBe Right(
+        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1, 2, 3)} ${intList(5, 6, 7)}") shouldEqual Right(
+          SBool(true))
+        eval(e"EQUAL_LIST @Int64 $sameParity ${intList()} ${intList(1)}") shouldEqual Right(
           SBool(false))
-        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1)} ${intList(1, 2)}") shouldBe Right(
+        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1)} ${intList(1, 2)}") shouldEqual Right(
           SBool(false))
-        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1, 2, 3)} ${intList(5, 6, 4)}") shouldBe Right(
+        eval(e"EQUAL_LIST @Int64 $sameParity ${intList(1, 2, 3)} ${intList(5, 6, 4)}") shouldEqual Right(
           SBool(false))
       }
     }
@@ -754,7 +759,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "MAP_EMPTY" - {
       "produces a map" in {
-        eval(e"MAP_EMPTY @Int64") shouldBe Right(SMap(HashMap.empty))
+        eval(e"MAP_EMPTY @Int64") shouldEqual Right(SMap(HashMap.empty))
       }
     }
 
@@ -770,7 +775,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
         eval(e"$map") shouldBe
           Right(SMap(HashMap("a" -> SInt64(1), "b" -> SInt64(2), "c" -> SInt64(3))))
-        eval(e"""MAP_INSERT @Int64 "b" 4 $map""") shouldBe Right(
+        eval(e"""MAP_INSERT @Int64 "b" 4 $map""") shouldEqual Right(
           SMap(HashMap("a" -> SInt64(1), "b" -> SInt64(4), "c" -> SInt64(3))))
       }
     }
@@ -782,10 +787,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         for {
           x <- List("a" -> 1L, "b" -> 2L, "c" -> 3L)
           (k, v) = x
-        } eval(e"""MAP_LOOKUP @Int64 "$k" $map""") shouldBe Right(SOptional(Some(SInt64(v))))
+        } eval(e"""MAP_LOOKUP @Int64 "$k" $map""") shouldEqual Right(SOptional(Some(SInt64(v))))
       }
       "not finds non-existing key" in {
-        eval(e"""MAP_LOOKUP @Int64 "d" $map""") shouldBe Right(SOptional(None))
+        eval(e"""MAP_LOOKUP @Int64 "d" $map""") shouldEqual Right(SOptional(None))
       }
     }
 
@@ -793,13 +798,13 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       val map = buildMap("Int64", "a" -> 1, "b" -> 2, "c" -> 3)
 
       "deletes existing key" in {
-        eval(e"""MAP_DELETE @Int64 "a" $map""") shouldBe Right(
+        eval(e"""MAP_DELETE @Int64 "a" $map""") shouldEqual Right(
           SMap(HashMap("b" -> SInt64(2), "c" -> SInt64(3))))
-        eval(e"""MAP_DELETE @Int64 "b" $map""") shouldBe Right(
+        eval(e"""MAP_DELETE @Int64 "b" $map""") shouldEqual Right(
           SMap(HashMap("a" -> SInt64(1), "c" -> SInt64(3))))
       }
       "does nothing with non-existing key" in {
-        eval(e"""MAP_DELETE @Int64 "d" $map""") shouldBe Right(
+        eval(e"""MAP_DELETE @Int64 "d" $map""") shouldEqual Right(
           SMap(HashMap("a" -> SInt64(1), "b" -> SInt64(2), "c" -> SInt64(3))))
       }
     }
@@ -820,7 +825,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           "favor" -> 9,
         )
 
-        eval(e"MAP_TO_LIST @Int64 ${buildMap("Int64", words: _*)}") shouldBe
+        eval(e"MAP_TO_LIST @Int64 ${buildMap("Int64", words: _*)}") shouldEqual
           Right(
             SList(FrontStack(
               mapEntry("cover", SInt64(8)),
@@ -839,12 +844,12 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
     "MAP_SIZE" - {
       "returns 0 for empty Map" in {
-        eval(e"MAP_SIZE @Int64 (MAP_EMPTY @Int64)") shouldBe Right(SInt64(0))
+        eval(e"MAP_SIZE @Int64 (MAP_EMPTY @Int64)") shouldEqual Right(SInt64(0))
       }
 
       "returns the expected size for non-empty Map" in {
         val map = buildMap("Int64", "a" -> 1, "b" -> 2, "c" -> 3)
-        eval(e"MAP_SIZE @Int64 $map") shouldBe Right(SInt64(3))
+        eval(e"MAP_SIZE @Int64 $map") shouldEqual Right(SInt64(3))
       }
     }
 
@@ -857,13 +862,13 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "NUMERIC_TO_INT64" - {
       "throws exception in case of overflow" in {
         eval(e"NUMERIC_TO_INT64 @0 ${s(0, -BigDecimal(2).pow(63) - 1)}") shouldBe 'left
-        eval(e"NUMERIC_TO_INT64 @3 ${s(3, -BigDecimal(2).pow(63) - 1 + almostZero(3))}") shouldBe Right(
+        eval(e"NUMERIC_TO_INT64 @3 ${s(3, -BigDecimal(2).pow(63) - 1 + almostZero(3))}") shouldEqual Right(
           SInt64(Long.MinValue))
-        eval(e"NUMERIC_TO_INT64 @7 ${s(7, -BigDecimal(2).pow(63))}") shouldBe Right(
+        eval(e"NUMERIC_TO_INT64 @7 ${s(7, -BigDecimal(2).pow(63))}") shouldEqual Right(
           SInt64(Long.MinValue))
-        eval(e"NUMERIC_TO_INT64 @11 ${s(11, BigDecimal(2).pow(63) - 1)}") shouldBe Right(
+        eval(e"NUMERIC_TO_INT64 @11 ${s(11, BigDecimal(2).pow(63) - 1)}") shouldEqual Right(
           SInt64(Long.MaxValue))
-        eval(e"NUMERIC_TO_INT64 @13 ${s(13, BigDecimal(2).pow(63) - almostZero(13))}") shouldBe Right(
+        eval(e"NUMERIC_TO_INT64 @13 ${s(13, BigDecimal(2).pow(63) - almostZero(13))}") shouldEqual Right(
           SInt64(Long.MaxValue))
         eval(e"NUMERIC_TO_INT64 @17 ${s(17, BigDecimal(2).pow(63))}") shouldBe 'left
         eval(e"NUMERIC_TO_INT64 @13 ${s(13, "1E22")}") shouldBe 'left
@@ -881,8 +886,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases) { (scale, decimal, int64) =>
-          eval(e"NUMERIC_TO_INT64 @$scale $decimal") shouldBe Right(SInt64(int64))
-          eval(e"NUMERIC_TO_INT64 @$scale -$decimal") shouldBe Right(SInt64(-int64))
+          eval(e"NUMERIC_TO_INT64 @$scale $decimal") shouldEqual Right(SInt64(int64))
+          eval(e"NUMERIC_TO_INT64 @$scale -$decimal") shouldEqual Right(SInt64(-int64))
         }
       }
     }
@@ -892,7 +897,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         val testCases = Table[Long]("Int64", 167, 11, 2, 1, 0, -1, -2, -13, -113)
 
         forEvery(testCases) { int64 =>
-          eval(e"INT64_TO_NUMERIC @10 $int64") shouldBe Right(SNumeric(n(10, int64)))
+          eval(e"INT64_TO_NUMERIC @10 $int64") shouldEqual Right(SNumeric(n(10, int64)))
         }
       }
     }
@@ -929,10 +934,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases) { (timestamp, int64) =>
-          eval(e"TIMESTAMP_TO_UNIX_MICROSECONDS $timestamp") shouldBe Right(SInt64(int64))
-          eval(e"UNIX_MICROSECONDS_TO_TIMESTAMP $int64") shouldBe Right(
+          eval(e"TIMESTAMP_TO_UNIX_MICROSECONDS $timestamp") shouldEqual Right(SInt64(int64))
+          eval(e"UNIX_MICROSECONDS_TO_TIMESTAMP $int64") shouldEqual Right(
             STimestamp(Time.Timestamp.assertFromLong(int64)))
-          eval(e"EQUAL_TIMESTAMP (UNIX_MICROSECONDS_TO_TIMESTAMP $int64) $timestamp") shouldBe Right(
+          eval(e"EQUAL_TIMESTAMP (UNIX_MICROSECONDS_TO_TIMESTAMP $int64) $timestamp") shouldEqual Right(
             SBool(true))
         }
       }
@@ -970,28 +975,28 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases) { (date, int) =>
-          eval(e"DATE_TO_UNIX_DAYS $date") shouldBe Right(SInt64(int))
-          eval(e"UNIX_DAYS_TO_DATE $int") shouldBe Time.Date
+          eval(e"DATE_TO_UNIX_DAYS $date") shouldEqual Right(SInt64(int))
+          eval(e"UNIX_DAYS_TO_DATE $int") shouldEqual Time.Date
             .asInt(int)
             .map(i => SDate(Time.Date.assertFromDaysSinceEpoch(i)))
-          eval(e"EQUAL_DATE (UNIX_DAYS_TO_DATE $int) $date") shouldBe Right(SBool(true))
+          eval(e"EQUAL_DATE (UNIX_DAYS_TO_DATE $int) $date") shouldEqual Right(SBool(true))
         }
       }
     }
 
     "Text Operations" - {
       "TO_QUOTED_TEXT_PARTY single quotes" in {
-        eval(e"TO_QUOTED_TEXT_PARTY 'alice'") shouldBe Right(SText("'alice'"))
+        eval(e"TO_QUOTED_TEXT_PARTY 'alice'") shouldEqual Right(SText("'alice'"))
       }
 
       "TO_TEXT_PARTY does not single quote" in {
-        eval(e"TO_TEXT_PARTY 'alice'") shouldBe Right(SText("alice"))
+        eval(e"TO_TEXT_PARTY 'alice'") shouldEqual Right(SText("alice"))
       }
 
       "FROM_TEXT_PARTY" in {
-        eval(e"""FROM_TEXT_PARTY "alice" """) shouldBe Right(
+        eval(e"""FROM_TEXT_PARTY "alice" """) shouldEqual Right(
           SOptional(Some(SParty(Ref.Party.assertFromString("alice")))))
-        eval(e"""FROM_TEXT_PARTY "bad%char" """) shouldBe Right(SOptional(None))
+        eval(e"""FROM_TEXT_PARTY "bad%char" """) shouldEqual Right(SOptional(None))
       }
 
       "FROM_TEXT_INT64" in {
@@ -1027,10 +1032,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           )
 
         forEvery(positiveTestCases) { s =>
-          eval(e"""FROM_TEXT_INT64 "$s"""") shouldBe Right(SOptional(Some(SInt64(s.toLong))))
+          eval(e"""FROM_TEXT_INT64 "$s"""") shouldEqual Right(SOptional(Some(SInt64(s.toLong))))
         }
         forEvery(negativeTestCases) { s =>
-          eval(e"""FROM_TEXT_INT64 "$s"""") shouldBe Right(SOptional(None))
+          eval(e"""FROM_TEXT_INT64 "$s"""") shouldEqual Right(SOptional(None))
         }
       }
 
@@ -1044,7 +1049,8 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         val builtin = e"""FROM_TEXT_INT64"""
 
         forEvery(testCases) { (input, output) =>
-          eval(Ast.EApp(builtin, Ast.EPrimLit(PLText(input())))) shouldBe Right(SOptional(output))
+          eval(Ast.EApp(builtin, Ast.EPrimLit(PLText(input())))) shouldEqual Right(
+            SOptional(output))
         }
 
       }
@@ -1094,10 +1100,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
       forEvery(positiveTestCases) { (input, expected) =>
         val e = e"""FROM_TEXT_NUMERIC @10 "$input""""
-        eval(e) shouldBe Right(SOptional(Some(SNumeric(n(10, expected)))))
+        eval(e) shouldEqual Right(SOptional(Some(SNumeric(n(10, expected)))))
       }
       forEvery(negativeTestCases) { input =>
-        eval(e"""FROM_TEXT_NUMERIC @10 "$input"""") shouldBe Right(SOptional(None))
+        eval(e"""FROM_TEXT_NUMERIC @10 "$input"""") shouldEqual Right(SOptional(None))
       }
     }
 
@@ -1114,7 +1120,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       val builtin = e"""FROM_TEXT_NUMERIC @10"""
 
       forEvery(testCases) { (input, output) =>
-        eval(Ast.EApp(builtin, Ast.EPrimLit(PLText(input())))) shouldBe Right(SOptional(output))
+        eval(Ast.EApp(builtin, Ast.EPrimLit(PLText(input())))) shouldEqual Right(SOptional(output))
       }
 
     }
@@ -1135,13 +1141,13 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
     "is reflexive" in {
       forEvery(values)(v => {
         val e = e"EQUAL_TYPE_REP $v $v"
-        eval(e) shouldBe Right(SBool(true))
+        eval(e) shouldEqual Right(SBool(true))
       })
     }
 
     "works as expected" in {
       forEvery(values)(v1 =>
-        forEvery(values)(v2 => eval(e"EQUAL_TYPE_REP $v1 $v2") shouldBe Right(SBool(v1 == v2))))
+        forEvery(values)(v2 => eval(e"EQUAL_TYPE_REP $v1 $v2") shouldEqual Right(SBool(v1 == v2))))
     }
   }
 
@@ -1163,12 +1169,12 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         )
 
         forEvery(testCases) { (exp, result) =>
-          eval(e"""TRACE "message" ($exp)""") shouldBe Right(result)
+          eval(e"""TRACE "message" ($exp)""") shouldEqual Right(result)
         }
       }
 
       "throws an expression if its argument throws one" in {
-        eval(e"""TRACE "message" 1""") shouldBe Right(SInt64(1))
+        eval(e"""TRACE "message" 1""") shouldEqual Right(SInt64(1))
         eval(e"""TRACE "message" (ERROR "error")""") shouldBe 'left
         eval(e"""TRACE "message" (DIV_INT64 1 0)""") shouldBe 'left
       }
@@ -1219,6 +1225,20 @@ object SBuiltinTest {
     args.add(SText(k))
     args.add(v)
     STuple(entryFields, args)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private implicit def resultEq: Equality[Either[SError, SValue]] = {
+    case (Right(v1: SValue), Right(v2: SValue)) => svalue.Equality.areEqual(v1, v2)
+    case (Left(e1), Left(e2)) => e1 == e2
+    case _ => false
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private implicit def optionEq: Equality[Option[SValue]] = {
+    case (Some(v1: SValue), Some(v2: SValue)) => svalue.Equality.areEqual(v1, v2)
+    case (None, None) => true
+    case _ => false
   }
 
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -15,6 +15,7 @@ import com.digitalasset.daml.lf.speedy.SResult.{SResultContinue, SResultError}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import com.digitalasset.daml.lf.validation.Validation
+import org.scalactic.Equality
 import org.scalatest.{Matchers, WordSpec}
 
 class SpeedyTest extends WordSpec with Matchers {
@@ -58,15 +59,15 @@ class SpeedyTest extends WordSpec with Matchers {
 
     "works as expected on primitive constructors" in {
 
-      eval(e"Matcher:unit ()", pkgs) shouldBe Right(SInt64(2))
-      eval(e"Matcher:bool True", pkgs) shouldBe Right(SInt64(3))
-      eval(e"Matcher:bool False", pkgs) shouldBe Right(SInt64(5))
+      eval(e"Matcher:unit ()", pkgs) shouldEqual Right(SInt64(2))
+      eval(e"Matcher:bool True", pkgs) shouldEqual Right(SInt64(3))
+      eval(e"Matcher:bool False", pkgs) shouldEqual Right(SInt64(5))
 
     }
 
     "works as expected on lists" in {
-      eval(e"Matcher:list @Int64 ${intList()}", pkgs) shouldBe Right(SOptional(None))
-      eval(e"Matcher:list @Int64 ${intList(7, 11, 13)}", pkgs) shouldBe Right(
+      eval(e"Matcher:list @Int64 ${intList()}", pkgs) shouldEqual Right(SOptional(None))
+      eval(e"Matcher:list @Int64 ${intList(7, 11, 13)}", pkgs) shouldEqual Right(
         SOptional(
           Some(STuple(
             Ref.Name.Array(n"x1", n"x2"),
@@ -74,21 +75,22 @@ class SpeedyTest extends WordSpec with Matchers {
     }
 
     "works as expected on Optionals" in {
-      eval(e"Matcher:option @Int64 17 (None @Int64)", pkgs) shouldBe Right(SInt64(17))
-      eval(e"Matcher:option @Int64 17 (Some @Int64 19)", pkgs) shouldBe Right(SInt64(19))
+      eval(e"Matcher:option @Int64 17 (None @Int64)", pkgs) shouldEqual Right(SInt64(17))
+      eval(e"Matcher:option @Int64 17 (Some @Int64 19)", pkgs) shouldEqual Right(SInt64(19))
     }
 
     "works as expected on Variants" in {
-      eval(e"""Matcher:variant @Int64 (Mod:Tree:Leaf @Int64 23)""", pkgs) shouldBe Right(SInt64(23))
+      eval(e"""Matcher:variant @Int64 (Mod:Tree:Leaf @Int64 23)""", pkgs) shouldEqual Right(
+        SInt64(23))
       eval(
         e"""Matcher:variant @Int64 (Mod:Tree:Node @Int64 (Mod:Tree.Node @Int64 {left = Mod:Tree:Leaf @Int64 27, right = Mod:Tree:Leaf @Int64 29 }))""",
-        pkgs) shouldBe Right(SInt64(27))
+        pkgs) shouldEqual Right(SInt64(27))
     }
 
     "works as expected on Enums" in {
-      eval(e"""Matcher:enum Mod:Color:Red""", pkgs) shouldBe Right(SInt64(37))
-      eval(e"""Matcher:enum Mod:Color:Green""", pkgs) shouldBe Right(SInt64(41))
-      eval(e"""Matcher:enum Mod:Color:Blue""", pkgs) shouldBe Right(SInt64(43))
+      eval(e"""Matcher:enum Mod:Color:Red""", pkgs) shouldEqual Right(SInt64(37))
+      eval(e"""Matcher:enum Mod:Color:Green""", pkgs) shouldEqual Right(SInt64(41))
+      eval(e"""Matcher:enum Mod:Color:Blue""", pkgs) shouldEqual Right(SInt64(43))
     }
 
   }
@@ -123,10 +125,10 @@ class SpeedyTest extends WordSpec with Matchers {
   "to_any" should {
 
     "succeed on Int64" in {
-      eval(e"""to_any @Int64 1""", anyPkgs) shouldBe Right(SAny(TBuiltin(BTInt64), SInt64(1)))
+      eval(e"""to_any @Int64 1""", anyPkgs) shouldEqual Right(SAny(TBuiltin(BTInt64), SInt64(1)))
     }
     "succeed on record type without parameters" in {
-      eval(e"""to_any @Test:T1 (Test:T1 {party = 'Alice'})""", anyPkgs) shouldBe
+      eval(e"""to_any @Test:T1 (Test:T1 {party = 'Alice'})""", anyPkgs) shouldEqual
         Right(
           SAny(
             Ast.TTyCon(Identifier(pkgId, QualifiedName.assertFromString("Test:T1"))),
@@ -138,7 +140,7 @@ class SpeedyTest extends WordSpec with Matchers {
           ))
     }
     "succeed on record type with parameters" in {
-      eval(e"""to_any @(Test:T3 Int64) (Test:T3 @Int64 {party = 'Alice'})""", anyPkgs) shouldBe
+      eval(e"""to_any @(Test:T3 Int64) (Test:T3 @Int64 {party = 'Alice'})""", anyPkgs) shouldEqual
         Right(
           SAny(
             TApp(
@@ -150,7 +152,7 @@ class SpeedyTest extends WordSpec with Matchers {
               ArrayList(SParty(Party.assertFromString("Alice")))
             )
           ))
-      eval(e"""to_any @(Test:T3 Text) (Test:T3 @Text {party = 'Alice'})""", anyPkgs) shouldBe
+      eval(e"""to_any @(Test:T3 Text) (Test:T3 @Text {party = 'Alice'})""", anyPkgs) shouldEqual
         Right(
           SAny(
             TApp(
@@ -172,7 +174,7 @@ class SpeedyTest extends WordSpec with Matchers {
     }
 
     "return Some(tpl) if template type matches" in {
-      eval(e"""from_any @Test:T1 (to_any @Test:T1 (Test:T1 {party = 'Alice'}))""", anyPkgs) shouldBe
+      eval(e"""from_any @Test:T1 (to_any @Test:T1 (Test:T1 {party = 'Alice'}))""", anyPkgs) shouldEqual
         Right(
           SOptional(Some(SRecord(
             Identifier(pkgId, QualifiedName.assertFromString("Test:T1")),
@@ -182,13 +184,13 @@ class SpeedyTest extends WordSpec with Matchers {
     }
 
     "return None if template type does not match" in {
-      eval(e"""from_any @Test:T2 (to_any @Test:T1 (Test:T1 {party = 'Alice'}))""", anyPkgs) shouldBe Right(
+      eval(e"""from_any @Test:T2 (to_any @Test:T1 (Test:T1 {party = 'Alice'}))""", anyPkgs) shouldEqual Right(
         SOptional(None))
     }
     "return Some(v) if type parameter is the same" in {
       eval(
         e"""from_any @(Test:T3 Int64) (to_any @(Test:T3 Int64) (Test:T3 @Int64 {party = 'Alice'}))""",
-        anyPkgs) shouldBe Right(
+        anyPkgs) shouldEqual Right(
         SOptional(Some(SRecord(
           Identifier(pkgId, QualifiedName.assertFromString("Test:T3")),
           Name.Array(Name.assertFromString("party")),
@@ -198,18 +200,18 @@ class SpeedyTest extends WordSpec with Matchers {
     "return None if type parameter is different" in {
       eval(
         e"""from_any @(Test:T3 Int64) (to_any @(Test:T3 Text) (Test:T3 @Int64 {party = 'Alice'}))""",
-        anyPkgs) shouldBe Right(SOptional(None))
+        anyPkgs) shouldEqual Right(SOptional(None))
     }
   }
 
   "type_rep" should {
 
     "produces expected output" in {
-      eval(e"""type_rep @Test:T1""", anyPkgs) shouldBe Right(STypeRep(t"Test:T1"))
-      eval(e"""type_rep @Test2:T2""", anyPkgs) shouldBe Right(STypeRep(t"Test2:T2"))
-      eval(e"""type_rep @(Mod:Tree (List Text))""", anyPkgs) shouldBe Right(
+      eval(e"""type_rep @Test:T1""", anyPkgs) shouldEqual Right(STypeRep(t"Test:T1"))
+      eval(e"""type_rep @Test2:T2""", anyPkgs) shouldEqual Right(STypeRep(t"Test2:T2"))
+      eval(e"""type_rep @(Mod:Tree (List Text))""", anyPkgs) shouldEqual Right(
         STypeRep(t"Mod:Tree (List Text)"))
-      eval(e"""type_rep @((ContractId Mod:T) -> Mod:Color)""", anyPkgs) shouldBe Right(
+      eval(e"""type_rep @((ContractId Mod:T) -> Mod:Color)""", anyPkgs) shouldEqual Right(
         STypeRep(t"(ContractId Mod:T) -> Mod:Color"))
     }
 
@@ -238,6 +240,13 @@ object SpeedyTest {
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private implicit def resultEq: Equality[Either[SError, SValue]] = {
+    case (Right(v1: SValue), Right(v2: SValue)) => svalue.Equality.areEqual(v1, v2)
+    case (Left(e1), Left(e2)) => e1 == e2
+    case _ => false
+  }
+
   private def typeAndCompile(pkg: Ast.Package): PureCompiledPackages = {
     val rawPkgs = Map(defaultParserParameters.defaultPackageId -> pkg)
     Validation.checkPackage(rawPkgs, defaultParserParameters.defaultPackageId)
@@ -253,4 +262,5 @@ object SpeedyTest {
     as.foreach(a.add)
     a
   }
+
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -262,5 +262,4 @@ object SpeedyTest {
     as.foreach(a.add)
     a
   }
-
 }


### PR DESCRIPTION
This PR advances the state of #2256. 

Concretely,  it redefines properly SValue equality following the change describe in #3260.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
