### PR TITLE
Use TreeMap for storing transaction nodes

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -109,7 +109,7 @@ object Blinding {
     * transaction has Nid references that are not present in its nodes. Use `isWellFormed`
     * if you are getting the transaction from a third party.
     */
-  def divulgedTransaction[Nid, Cid, Val](
+  def divulgedTransaction[Nid: Ordering, Cid, Val](
       divulgences: Relation[Nid, Party],
       party: Party,
       tx: GenTransaction[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] = {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.{EitherValues, Matchers, WordSpec}
 import scalaz.std.either._
 import scalaz.syntax.apply._
 
+import scala.collection.immutable.TreeMap
 import scala.language.implicitConversions
 
 @SuppressWarnings(
@@ -1097,7 +1098,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         }
       fetchNodes.foreach {
         case (nid, n) =>
-          val fetchTx = GenTx(Map(nid -> n), ImmArray(nid), Set(basicTestsPkgId))
+          val fetchTx = GenTx(TreeMap(nid -> n), ImmArray(nid), Set(basicTestsPkgId))
           val Right(reinterpreted) = engine
             .reinterpret(n.requiredAuthorizers, Seq(n), let)
             .consume(lookupContract, lookupPackage, lookupKey)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -16,7 +16,6 @@ import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.collection.breakOut
 import scala.collection.immutable
-import scala.collection.immutable.{SortedMap, TreeMap}
 
 /** An in-memory representation of a ledger for scenarios */
 object Ledger {
@@ -124,7 +123,7 @@ object Ledger {
       committer: Party,
       effectiveAt: Time.Timestamp,
       roots: ImmArray[ScenarioNodeId],
-      nodes: SortedMap[ScenarioNodeId, Node],
+      nodes: immutable.SortedMap[ScenarioNodeId, Node],
       explicitDisclosure: Relation[ScenarioNodeId, Party],
       localImplicitDisclosure: Relation[ScenarioNodeId, Party],
       globalImplicitDisclosure: Relation[AbsoluteContractId, Party],
@@ -137,7 +136,7 @@ object Ledger {
       // The transaction root nodes.
       roots: ImmArray[Transaction.NodeId],
       // All nodes of this transaction.
-      nodes: SortedMap[Transaction.NodeId, Transaction.Node],
+      nodes: immutable.SortedMap[Transaction.NodeId, Transaction.Node],
       // A relation between a node id and the parties to which this node gets explicitly disclosed.
       explicitDisclosure: Relation[Transaction.NodeId, Party],
       // A relation between a node id and the parties to which this node get implictly disclosed

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -14,6 +14,7 @@ import com.digitalasset.daml.lf.data.Relation.Relation
 
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
+import scala.collection.breakOut
 import scala.collection.immutable
 import scala.collection.immutable.{SortedMap, TreeMap}
 
@@ -164,10 +165,10 @@ object Ledger {
     committer = committer,
     effectiveAt = effectiveAt,
     roots = enrichedTx.roots.map(ScenarioNodeId(commitPrefix, _)),
-    nodes = TreeMap.empty[ScenarioNodeId, Node] ++ enrichedTx.nodes.map {
+    nodes = enrichedTx.nodes.map {
       case (nodeId, node) =>
         (ScenarioNodeId(commitPrefix, nodeId), translateNode(commitPrefix, node))
-    },
+    }(breakOut),
     explicitDisclosure = enrichedTx.explicitDisclosure.map {
       case (nodeId, ps) =>
         (ScenarioNodeId(commitPrefix, nodeId), ps)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.lf.types
 
 import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.{ImmArray, Time}
 import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.Transaction
@@ -14,6 +15,7 @@ import com.digitalasset.daml.lf.data.Relation.Relation
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.collection.immutable
+import scala.collection.immutable.{SortedMap, TreeMap}
 
 /** An in-memory representation of a ledger for scenarios */
 object Ledger {
@@ -121,7 +123,7 @@ object Ledger {
       committer: Party,
       effectiveAt: Time.Timestamp,
       roots: ImmArray[ScenarioNodeId],
-      nodes: Map[ScenarioNodeId, Node],
+      nodes: SortedMap[ScenarioNodeId, Node],
       explicitDisclosure: Relation[ScenarioNodeId, Party],
       localImplicitDisclosure: Relation[ScenarioNodeId, Party],
       globalImplicitDisclosure: Relation[AbsoluteContractId, Party],
@@ -134,7 +136,7 @@ object Ledger {
       // The transaction root nodes.
       roots: ImmArray[Transaction.NodeId],
       // All nodes of this transaction.
-      nodes: Map[Transaction.NodeId, Transaction.Node],
+      nodes: SortedMap[Transaction.NodeId, Transaction.Node],
       // A relation between a node id and the parties to which this node gets explicitly disclosed.
       explicitDisclosure: Relation[Transaction.NodeId, Party],
       // A relation between a node id and the parties to which this node get implictly disclosed
@@ -162,7 +164,7 @@ object Ledger {
     committer = committer,
     effectiveAt = effectiveAt,
     roots = enrichedTx.roots.map(ScenarioNodeId(commitPrefix, _)),
-    nodes = enrichedTx.nodes.map {
+    nodes = TreeMap.empty[ScenarioNodeId, Node] ++ enrichedTx.nodes.map {
       case (nodeId, node) =>
         (ScenarioNodeId(commitPrefix, nodeId), translateNode(commitPrefix, node))
     },

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -17,6 +17,7 @@ import com.digitalasset.daml.lf.transaction._
 import com.digitalasset.daml.lf.value.Value._
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
+import scala.collection.immutable.TreeMap
 import scalaz.syntax.apply._
 import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz.std.string.parseInt
@@ -382,7 +383,7 @@ object ValueGenerators {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(NodeId.unsafeFromIndex))
-    } yield GenTransaction(nodes.toMap, ImmArray(roots), Set.empty)
+    } yield GenTransaction(TreeMap(nodes: _*), ImmArray(roots), Set.empty)
   }
 
   @deprecated("use malformedGenTransaction instead", since = "100.11.17")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -19,6 +19,8 @@ import scalaz.syntax.traverse.ToTraverseOps
 import scalaz.std.either.eitherMonad
 import scalaz.std.option._
 
+import scala.collection.immutable.TreeMap
+
 object TransactionCoder {
 
   import ValueCoder.{DecodeCid, EncodeCid, codecContractId}
@@ -382,7 +384,7 @@ object TransactionCoder {
     * @tparam Cid contract id type
     * @return protobuf encoded transaction
     */
-  private[transaction] def encodeTransaction[Nid, Cid](
+  private[transaction] def encodeTransaction[Nid: Ordering, Cid](
       encodeNid: EncodeNid[Nid],
       encodeCid: EncodeCid[Cid],
       tx: GenTransaction[Nid, Cid, VersionedValue[Cid]])
@@ -402,7 +404,7 @@ object TransactionCoder {
     * @tparam Cid contract id type
     * @return protobuf encoded transaction
     */
-  def encodeTransactionWithCustomVersion[Nid, Cid](
+  def encodeTransactionWithCustomVersion[Nid: Ordering, Cid](
       encodeNid: EncodeNid[Nid],
       encodeCid: EncodeCid[Cid],
       transaction: VersionedTransaction[Nid, Cid])
@@ -452,7 +454,7 @@ object TransactionCoder {
     * @tparam Cid contract id type
     * @return  decoded transaction
     */
-  def decodeVersionedTransaction[Nid, Cid, Val](
+  def decodeVersionedTransaction[Nid: Ordering, Cid, Val](
       decodeNid: String => Either[DecodeError, Nid],
       decodeCid: DecodeCid[Cid],
       protoTx: TransactionOuterClass.Transaction)
@@ -481,7 +483,7 @@ object TransactionCoder {
     * @tparam Val value type
     * @return  decoded transaction
     */
-  private def decodeTransaction[Nid, Cid, Val](
+  private def decodeTransaction[Nid: Ordering, Cid, Val](
       decodeNid: String => Either[DecodeError, Nid],
       decodeCid: DecodeCid[Cid],
       decodeVal: ValueOuterClass.VersionedValue => Either[DecodeError, Val],
@@ -496,7 +498,7 @@ object TransactionCoder {
       .map(_.toImmArray)
 
     val nodes = protoTx.getNodesList.asScala
-      .foldLeft[Either[DecodeError, Map[Nid, GenNode[Nid, Cid, Val]]]](Right(Map.empty)) {
+      .foldLeft[Either[DecodeError, TreeMap[Nid, GenNode[Nid, Cid, Val]]]](Right(TreeMap.empty)) {
         case (Left(e), _) => Left(e)
         case (Right(acc), s) =>
           decodeNode(decodeNid, decodeCid, decodeVal, txVersion, s).map(acc + _)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -307,12 +307,18 @@ object Value {
     override def toString = "NodeId(" + index.toString + ")"
 
     val name: LedgerString = LedgerString.assertFromString(index.toString)
+
   }
 
   object NodeId {
     val first = new NodeId(0)
 
     def unsafeFromIndex(i: Int) = new NodeId(i)
+  }
+
+  implicit object NodeIdOrdering extends Ordering[NodeId] {
+    override def compare(x: NodeId, y: NodeId): Int =
+      x.index.compare(y.index)
   }
 
   /*** Keys cannot contain contract ids */

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -16,6 +16,8 @@ import com.digitalasset.daml.lf.transaction.VersionTimeline.Implicits._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Inside, Matchers, WordSpec}
 
+import scala.collection.immutable.TreeMap
+
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class TransactionCoderSpec
     extends WordSpec
@@ -251,7 +253,7 @@ class TransactionCoderSpec
         (nid.toString, node)
       })
       val tx = GenTransaction(
-        nodes = Map(nodes.toSeq: _*),
+        nodes = TreeMap(nodes.toSeq: _*),
         roots = nodes.map(_._1),
         usedPackages = Set.empty
       )
@@ -298,12 +300,12 @@ class TransactionCoderSpec
       case _ => gn
     }
 
-  def transactionWithout[Nid, Cid, Val](
+  def transactionWithout[Nid: Ordering, Cid, Val](
       t: GenTransaction[Nid, Cid, Val],
       f: GenNode[Nid, Cid, Val] => GenNode[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] =
-    t copy (nodes = t.nodes transform ((_, gn) => f(gn)))
+    t copy (nodes = TreeMap.empty ++ (t.nodes transform ((_, gn) => f(gn))))
 
-  def minimalistTx[Nid, Cid, Val](
+  def minimalistTx[Nid: Ordering, Cid, Val](
       txvMin: TransactionVersion,
       tx: GenTransaction[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] =
     if (txvMin precedes minExerciseResult)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -16,6 +16,7 @@ import com.digitalasset.daml.lf.transaction.VersionTimeline.Implicits._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Inside, Matchers, WordSpec}
 
+import scala.collection.breakOut
 import scala.collection.immutable.TreeMap
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -303,7 +304,7 @@ class TransactionCoderSpec
   def transactionWithout[Nid: Ordering, Cid, Val](
       t: GenTransaction[Nid, Cid, Val],
       f: GenNode[Nid, Cid, Val] => GenNode[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] =
-    t copy (nodes = TreeMap.empty ++ (t.nodes transform ((_, gn) => f(gn))))
+    t copy (nodes = t.nodes.transform((_, gn) => f(gn))(breakOut))
 
   def minimalistTx[Nid: Ordering, Cid, Val](
       txvMin: TransactionVersion,

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -20,6 +20,7 @@ import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
 
+import scala.collection.immutable.TreeMap
 import scala.language.implicitConversions
 
 class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropertyChecks {
@@ -27,23 +28,23 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
   "isWellFormed" - {
     "detects dangling references in roots" in {
-      val tx = StringTransaction(Map.empty, ImmArray("1"))
+      val tx = StringTransaction(TreeMap.empty, ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", DanglingNodeId))
     }
 
     "detects dangling references in children" in {
-      val tx = StringTransaction(Map("1" -> dummyExerciseNode(ImmArray("2"))), ImmArray("1"))
+      val tx = StringTransaction(TreeMap("1" -> dummyExerciseNode(ImmArray("2"))), ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("2", DanglingNodeId))
     }
 
     "detects cycles" in {
-      val tx = StringTransaction(Map("1" -> dummyExerciseNode(ImmArray("1"))), ImmArray("1"))
+      val tx = StringTransaction(TreeMap("1" -> dummyExerciseNode(ImmArray("1"))), ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", AliasedNode))
     }
 
     "detects aliasing from roots and exercise" in {
       val tx = StringTransaction(
-        Map(
+        TreeMap(
           "0" -> dummyExerciseNode(ImmArray("1")),
           "1" -> dummyExerciseNode(ImmArray("2")),
           "2" -> dummyCreateNode),
@@ -52,7 +53,7 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
     }
 
     "detects orphans" in {
-      val tx = StringTransaction(Map("1" -> dummyCreateNode), ImmArray.empty)
+      val tx = StringTransaction(TreeMap("1" -> dummyCreateNode), ImmArray.empty)
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", OrphanedNode))
     }
   }
@@ -114,7 +115,7 @@ object TransactionSpec {
   private[this] type Value[+Cid] = V[Cid]
   type StringTransaction = GenTransaction[String, String, Value[String]]
   def StringTransaction(
-      nodes: Map[String, GenNode[String, String, Value[String]]],
+      nodes: TreeMap[String, GenNode[String, String, Value[String]]],
       roots: ImmArray[String]): StringTransaction = GenTransaction(nodes, roots, Set.empty)
 
   def dummyExerciseNode(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -9,8 +9,9 @@ import value.Value
 import Value.{ValueOptional, VersionedValue}
 import value.ValueVersions.asVersionedValue
 import TransactionVersions.assignVersion
-
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.immutable.TreeMap
 
 class TransactionVersionSpec extends WordSpec with Matchers {
   import TransactionVersionSpec._
@@ -51,10 +52,12 @@ object TransactionVersionSpec {
   import TransactionSpec.{dummyCreateNode, dummyExerciseNode, StringTransaction}
   private[this] val singleId = "a"
   private val dummyCreateTransaction =
-    StringTransaction(Map((singleId, dummyCreateNode)), ImmArray(singleId))
+    StringTransaction(TreeMap((singleId, dummyCreateNode)), ImmArray(singleId))
   private val dummyExerciseWithResultTransaction =
-    StringTransaction(Map((singleId, dummyExerciseNode(ImmArray.empty))), ImmArray(singleId))
+    StringTransaction(TreeMap((singleId, dummyExerciseNode(ImmArray.empty))), ImmArray(singleId))
   private val dummyExerciseTransaction =
-    StringTransaction(Map((singleId, dummyExerciseNode(ImmArray.empty, false))), ImmArray(singleId))
+    StringTransaction(
+      TreeMap((singleId, dummyExerciseNode(ImmArray.empty, false))),
+      ImmArray(singleId))
 
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -8,8 +8,10 @@ import java.time.Instant
 import brave.propagation.TraceContext
 
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import scalaz.{@@, Tag}
+import scalaz.syntax.tag._
 import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.daml.lf.command.{Commands => LfCommands}
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ValueRecord}
@@ -253,6 +255,7 @@ object domain {
 
   type EventId = Ref.LedgerString @@ EventIdTag
   val EventId: Tag.TagOf[EventIdTag] = Tag.of[EventIdTag]
+  implicit val eventIdOrdering = scala.math.Ordering.by[EventId, Ref.LedgerString](_.unwrap)
 
   sealed trait LedgerIdTag
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -19,6 +19,8 @@ import com.digitalasset.daml.lf.value.Value.{
 import com.digitalasset.daml.lf.value.ValueVersions
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.collection.immutable.TreeMap
+
 class ProjectionsSpec extends WordSpec with Matchers {
 
   def makeCreateNode(cid: ContractId, signatories: Set[Party], stakeholders: Set[Party]) =
@@ -68,7 +70,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
   "computePerPartyProjectionRoots" should {
 
     "yield no roots with empty transaction" in {
-      val emptyTransaction: Transaction = GenTransaction(Map.empty, ImmArray.empty, Set.empty)
+      val emptyTransaction: Transaction = GenTransaction(TreeMap.empty, ImmArray.empty, Set.empty)
       project(emptyTransaction) shouldBe List.empty
     }
 
@@ -79,7 +81,10 @@ class ProjectionsSpec extends WordSpec with Matchers {
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice"), Party.assertFromString("Bob")))
       val tx =
-        GenTransaction(nodes = Map(nid -> root), roots = ImmArray(nid), usedPackages = Set.empty)
+        GenTransaction(
+          nodes = TreeMap(nid -> root),
+          roots = ImmArray(nid),
+          usedPackages = Set.empty)
 
       project(tx) shouldBe List(
         ProjectionRoots(Party.assertFromString("Alice"), BackStack(nid)),
@@ -119,7 +124,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
 
       val tx =
         GenTransaction(
-          nodes = Map(nid1 -> exe, nid2 -> create, nid3 -> bobCreate, nid4 -> charlieCreate),
+          nodes = TreeMap(nid1 -> exe, nid2 -> create, nid3 -> bobCreate, nid4 -> charlieCreate),
           roots = ImmArray(nid1, nid3, nid4),
           usedPackages = Set.empty)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.Update._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.Ref.LedgerString
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId}
 import com.digitalasset.daml_lf_dev.DamlLf

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxEventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/transaction/SandboxEventIdFormatter.scala
@@ -4,9 +4,9 @@
 package com.digitalasset.platform.sandbox.services.transaction
 
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, TransactionIdString}
-import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.types.Ledger
+import com.digitalasset.daml.lf.value.{Value => Lf}
 
 import scala.util.{Failure, Success, Try}
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -19,6 +19,7 @@ import com.digitalasset.daml.lf.types.Ledger.ScenarioTransactionId
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry.Transaction
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.transaction.VersionTimeline
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 
 import scala.collection.breakOut
 import scala.collection.mutable.ArrayBuffer

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionConversion.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionConversion.scala
@@ -7,6 +7,7 @@ import com.digitalasset.daml.lf.engine
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
 import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.api.domain.eventIdOrdering
 import com.digitalasset.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import com.digitalasset.platform.api.v1.event.EventOps.getEventIndex
 import com.digitalasset.platform.common.{PlatformTypes => P}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -20,6 +20,7 @@ import com.daml.ledger.participant.state.v1.{
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{PackageId, Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref.Party
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/TransactionSerializer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/TransactionSerializer.scala
@@ -4,6 +4,7 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation
 
 import com.digitalasset.daml.lf.archive.{Decode, Reader}
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.transaction._
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
 import com.digitalasset.daml.lf.value.ValueCoder.{DecodeError, EncodeError}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -31,6 +31,7 @@ import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 import com.digitalasset.ledger.api.domain.LedgerId
 
+import scala.collection.immutable.TreeMap
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.implicitConversions
@@ -92,7 +93,7 @@ class ImplicitPartyAdditionIT
     val event1: NodeId = NodeId.unsafeFromIndex(0)
 
     val transaction = GenTransaction[NodeId, TContractId, Value[TContractId]](
-      Map(event1 -> node),
+      TreeMap(event1 -> node),
       ImmArray(event1),
       Set.empty
     )

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -23,6 +23,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
+import scala.collection.immutable.TreeMap
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
@@ -71,7 +72,7 @@ class TransactionMRTComplianceIT
     "reject transactions with a record time after the MRT" in allFixtures { ledger =>
       val dummyTransaction =
         GenTransaction[NodeId, TContractId, Value[TContractId]](
-          Map.empty,
+          TreeMap.empty,
           ImmArray.empty,
           Set.empty)
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.v1.Offset
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
+import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Node.{
@@ -56,6 +57,7 @@ import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher
 import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}
 
+import scala.collection.immutable.TreeMap
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.language.implicitConversions
@@ -158,7 +160,7 @@ class JdbcLedgerDaoSpec
         let,
         let,
         GenTransaction(
-          Map(
+          TreeMap(
             event1 -> NodeCreate(
               absCid,
               contractInstance,
@@ -349,7 +351,7 @@ class JdbcLedgerDaoSpec
         let,
         let,
         GenTransaction(
-          Map(
+          TreeMap(
             event1 -> NodeCreate(
               absCid,
               contractInstance,
@@ -405,7 +407,7 @@ class JdbcLedgerDaoSpec
         // normally the record time is some time after the ledger effective time
         let.plusMillis(42),
         GenTransaction(
-          Map(
+          TreeMap(
             event1 -> NodeCreate(
               absCid,
               contractInstance,
@@ -470,7 +472,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            Map(
+            TreeMap(
               (s"event$id": EventId) -> NodeCreate(
                 absCid,
                 contractInstance,
@@ -498,7 +500,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            Map(
+            TreeMap(
               (s"event$id": EventId) -> NodeExercises(
                 targetCid,
                 templateId,


### PR DESCRIPTION
Going forward we require deterministic serialization for transaction nodes.
This PR switches the `Transaction.nodes` to use a TreeMap instead of HashMap,
which gives us deterministic serialization order for the transaction nodes.

An alternative would be to sort the transaction nodes when serializing, but
I feel avoiding HashMap altogether is the safer option as this may bite us
elsewhere as well (e.g. tests, new serialization code, etc.).

I had a discussion with @meiersi-da on whether we'd prefer pre-order (e.g. implementable with InsertOrdMap) or in-order here. I agree with him that in-order makes more sense as the ordering is simply the lexiographical sorting of the node identifiers.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
