### PR TITLE
Improve LedgerClient

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
@@ -5,9 +5,6 @@ package com.digitalasset.http
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
-import com.digitalasset.http.Statement.discard
-import com.digitalasset.http.util.FutureUtil.toFuture
 import com.digitalasset.jwt.domain.Jwt
 import com.digitalasset.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.digitalasset.ledger.api.v1.command_service.{
@@ -18,13 +15,8 @@ import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.ledger.api.v1.transaction_filter.TransactionFilter
 import com.digitalasset.ledger.client.LedgerClient
-import com.digitalasset.ledger.client.configuration.LedgerClientConfiguration
-import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
-import io.grpc.stub.MetadataUtils
-import io.grpc.{Channel, ClientInterceptors, Metadata}
-import scalaz.\/
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 object LedgerClientJwt {
 
@@ -37,87 +29,23 @@ object LedgerClientJwt {
   type GetCreatesAndArchivesSince =
     (Jwt, TransactionFilter, LedgerOffset) => Source[Transaction, NotUsed]
 
-  def singleHostChannel(
-      hostIp: String,
-      port: Int,
-      configuration: LedgerClientConfiguration,
-      maxInboundMessageSize: Int)(
-      implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory): Throwable \/ Channel = \/.fromTryCatchNonFatal {
+  private def bearer(jwt: Jwt): Some[String] = Some(s"Bearer ${jwt.value: String}")
 
-    val builder: NettyChannelBuilder = NettyChannelBuilder
-      .forAddress(hostIp, port)
-      .maxInboundMessageSize(maxInboundMessageSize)
-
-    discard {
-      configuration.sslContext
-        .fold {
-          builder.usePlaintext()
-        } { sslContext =>
-          builder.sslContext(sslContext).negotiationType(NegotiationType.TLS)
-        }
-    }
-
-    val channel = builder.build()
-
-    val _ = sys.addShutdownHook { val _ = channel.shutdownNow() }
-
-    channel
-  }
-
-  def forChannel(jwt: Jwt, configuration: LedgerClientConfiguration, channel: Channel)(
-      implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory
-  ): Future[LedgerClient] =
-    for {
-      channelWithJwt <- toFuture(decorateChannel(channel, jwt))
-      clientWithJwt <- LedgerClient.forChannel(configuration, channelWithJwt)
-    } yield clientWithJwt
-
-  // TODO(Leo): all examples show it as `authorization` but not `Authorization`, why???
-  private val authorizationKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
-
-  private def decorateChannel(channel: Channel, jwt: Jwt): Throwable \/ Channel =
-    \/.fromTryCatchNonFatal {
-      val extraHeaders = new Metadata()
-      //  `Authorization: Bearer json-web-token`.
-      extraHeaders.put(authorizationKey, s"Bearer ${jwt.value: String}")
-      val interceptor = MetadataUtils.newAttachHeadersInterceptor(extraHeaders)
-      ClientInterceptors.intercept(channel, interceptor)
-    }
-
-  def submitAndWaitForTransaction(config: LedgerClientConfiguration, channel: io.grpc.Channel)(
-      implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory): SubmitAndWaitForTransaction =
-    (jwt, req) =>
-      forChannel(jwt, config, channel)
-        .flatMap(_.commandServiceClient.submitAndWaitForTransaction(req))
+  def submitAndWaitForTransaction(client: LedgerClient): SubmitAndWaitForTransaction =
+    (jwt, req) => client.commandServiceClient.submitAndWaitForTransaction(req, bearer(jwt))
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def getActiveContracts(config: LedgerClientConfiguration, channel: io.grpc.Channel)(
-      implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory): GetActiveContracts =
+  def getActiveContracts(client: LedgerClient): GetActiveContracts =
     (jwt, filter, flag) =>
-      Source
-        .fromFuture(forChannel(jwt, config, channel))
-        .flatMapConcat(client => client.activeContractSetClient.getActiveContracts(filter, flag))
+      client.activeContractSetClient
+        .getActiveContracts(filter, flag, bearer(jwt))
+        .mapMaterializedValue(_ => NotUsed)
 
-  def getCreatesAndArchivesSince(config: LedgerClientConfiguration, channel: io.grpc.Channel)(
-      implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory): GetCreatesAndArchivesSince =
+  def getCreatesAndArchivesSince(client: LedgerClient): GetCreatesAndArchivesSince =
     (jwt, filter, offset) =>
       Source
-        .fromFuture(for {
-          client <- forChannel(jwt, config, channel)
-          es <- client.transactionClient.getLedgerEnd()
-        } yield (client, es.offset getOrElse sys.error("bad response from getLedgerEnd")))
-        .flatMapConcat {
-          case (client, end) =>
-            client.transactionClient.getTransactions(
-              start = offset,
-              end = Some(end),
-              filter,
-              verbose = true)
-      }
+        .fromFuture(client.transactionClient.getLedgerEnd(bearer(jwt)))
+        .flatMapConcat(end =>
+          client.transactionClient.getTransactions(offset, end.offset, filter, true, bearer(jwt)))
 
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
@@ -6,22 +6,17 @@ package com.digitalasset.ledger.client
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc
-import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsServiceStub
+import com.digitalasset.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc
 import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc
-import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionServiceStub
 import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc
-import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandServiceStub
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
-import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionServiceStub
 import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc
-import com.digitalasset.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityServiceStub
 import com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc
-import com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc.PackageServiceStub
 import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc
-import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc.TransactionServiceStub
 import com.digitalasset.ledger.client.auth.LedgerClientCallCredentials.authenticatingStub
 import com.digitalasset.ledger.client.configuration.LedgerClientConfiguration
 import com.digitalasset.ledger.client.services.acs.ActiveContractSetClient
+import com.digitalasset.ledger.client.services.admin.PartyManagementClient
 import com.digitalasset.ledger.client.services.commands.{CommandClient, SynchronousCommandClient}
 import com.digitalasset.ledger.client.services.identity.LedgerIdentityClient
 import com.digitalasset.ledger.client.services.pkg.PackageClient
@@ -32,66 +27,54 @@ import io.grpc.stub.AbstractStub
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class LedgerClient(
-    transactionService: TransactionServiceStub,
-    activeContractsService: ActiveContractsServiceStub,
-    commandSubmissionService: CommandSubmissionServiceStub,
-    commandCompletionService: CommandCompletionServiceStub,
-    commandService: CommandServiceStub,
-    packageService: PackageServiceStub,
-    ledgerClientConfiguration: LedgerClientConfiguration,
+final class LedgerClient private (
+    val channel: Channel,
+    config: LedgerClientConfiguration,
     val ledgerId: LedgerId
-)(implicit esf: ExecutionSequencerFactory) {
+)(implicit ec: ExecutionContext, esf: ExecutionSequencerFactory) {
 
   val activeContractSetClient =
-    new ActiveContractSetClient(ledgerId, activeContractsService)
+    new ActiveContractSetClient(
+      ledgerId,
+      LedgerClient.stub(ActiveContractsServiceGrpc.stub(channel), config.token))
 
   val commandClient: CommandClient =
     new CommandClient(
-      commandSubmissionService,
-      commandCompletionService,
+      LedgerClient.stub(CommandSubmissionServiceGrpc.stub(channel), config.token),
+      LedgerClient.stub(CommandCompletionServiceGrpc.stub(channel), config.token),
       ledgerId,
-      ledgerClientConfiguration.applicationId,
-      ledgerClientConfiguration.commandClient
+      config.applicationId,
+      config.commandClient
     )
 
   val commandServiceClient: SynchronousCommandClient =
-    new SynchronousCommandClient(commandService)
+    new SynchronousCommandClient(LedgerClient.stub(CommandServiceGrpc.stub(channel), config.token))
 
   val packageClient: PackageClient =
-    new PackageClient(ledgerId, packageService)
+    new PackageClient(ledgerId, LedgerClient.stub(PackageServiceGrpc.stub(channel), config.token))
+
+  val partyManagementClient: PartyManagementClient =
+    new PartyManagementClient(
+      LedgerClient.stub(PartyManagementServiceGrpc.stub(channel), config.token))
 
   val transactionClient: TransactionClient =
-    new TransactionClient(ledgerId, transactionService)
+    new TransactionClient(
+      ledgerId,
+      LedgerClient.stub(TransactionServiceGrpc.stub(channel), config.token))
 
 }
 
 object LedgerClient {
 
   def apply(
-      ledgerIdentityService: LedgerIdentityServiceStub,
-      transactionService: TransactionServiceStub,
-      activeContractsService: ActiveContractsServiceStub,
-      commandSubmissionService: CommandSubmissionServiceStub,
-      commandCompletionService: CommandCompletionServiceStub,
-      commandService: CommandServiceStub,
-      packageService: PackageServiceStub,
-      ledgerClientConfiguration: LedgerClientConfiguration
+      channel: Channel,
+      config: LedgerClientConfiguration
   )(implicit ec: ExecutionContext, esf: ExecutionSequencerFactory): Future[LedgerClient] = {
     for {
-      ledgerId <- new LedgerIdentityClient(ledgerIdentityService)
-        .satisfies(ledgerClientConfiguration.ledgerIdRequirement)
+      ledgerId <- new LedgerIdentityClient(LedgerIdentityServiceGrpc.stub(channel))
+        .satisfies(config.ledgerIdRequirement)
     } yield {
-      new LedgerClient(
-        transactionService,
-        activeContractsService,
-        commandSubmissionService,
-        commandCompletionService,
-        commandService,
-        packageService,
-        ledgerClientConfiguration,
-        ledgerId
-      )
+      new LedgerClient(channel, config, ledgerId)
     }
   }
 
@@ -99,44 +82,38 @@ object LedgerClient {
     token.fold(stub)(authenticatingStub(stub))
 
   /**
-    * Constructs a [[Channel]], ensuring that the [[LedgerClientConfiguration]] is picked up and valid
-    *
-    * You'll generally want to use [[singleHost]], use this only if you need a higher level of control
-    * over your [[Channel]].
-    */
-  def constructChannel(
-      hostIp: String,
-      port: Int,
-      configuration: LedgerClientConfiguration): NettyChannelBuilder = {
-    val builder: NettyChannelBuilder = NettyChannelBuilder.forAddress(hostIp, port)
-    configuration.sslContext.fold(builder.usePlaintext())(
-      builder.sslContext(_).negotiationType(NegotiationType.TLS))
-    builder
-  }
-
-  /**
-    * A convenient shortcut to build a [[LedgerClient]]
+    * A convenient shortcut to build a [[LedgerClient]], use [[fromBuilder]] for a more
+    * flexible alternative.
     */
   def singleHost(hostIp: String, port: Int, configuration: LedgerClientConfiguration)(
       implicit ec: ExecutionContext,
-      esf: ExecutionSequencerFactory): Future[LedgerClient] = {
-    val channel = constructChannel(hostIp, port, configuration).build
-    val _ = sys.addShutdownHook { val _ = channel.shutdownNow() }
-    forChannel(configuration, channel)
-  }
+      esf: ExecutionSequencerFactory): Future[LedgerClient] =
+    fromBuilder(NettyChannelBuilder.forAddress(hostIp, port), configuration)
 
+  @deprecated("Use the safer and more flexible `fromBuilder` method", "0.13.35")
   def forChannel(configuration: LedgerClientConfiguration, channel: Channel)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory): Future[LedgerClient] =
-    apply(
-      LedgerIdentityServiceGrpc.stub(channel),
-      TransactionServiceGrpc.stub(channel),
-      ActiveContractsServiceGrpc.stub(channel),
-      CommandSubmissionServiceGrpc.stub(channel),
-      CommandCompletionServiceGrpc.stub(channel),
-      CommandServiceGrpc.stub(channel),
-      PackageServiceGrpc.stub(channel),
-      configuration
-    )
+    apply(channel, configuration)
+
+  /**
+    * Takes a [[NettyChannelBuilder]], possibly set up with some relevant extra options
+    * that cannot be specified though the [[LedgerClientConfiguration]] (e.g. a set of
+    * default [[io.grpc.CallCredentials]] to be used with all calls unless explicitly
+    * set on a per-call basis), sets the relevant options specified by the configuration
+    * (possibly overriding the existing builder settings), and returns a [[LedgerClient]].
+    *
+    * A shutdown hook is also added to close the channel when the JVM stops.
+    *
+    */
+  def fromBuilder(builder: NettyChannelBuilder, configuration: LedgerClientConfiguration)(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory): Future[LedgerClient] = {
+    configuration.sslContext.fold(builder.usePlaintext())(
+      builder.sslContext(_).negotiationType(NegotiationType.TLS))
+    val channel = builder.build()
+    val _ = sys.addShutdownHook { val _ = channel.shutdownNow() }
+    apply(channel, configuration)
+  }
 
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -10,9 +10,11 @@ import io.netty.handler.ssl.SslContext
   * @param ledgerIdRequirement A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
   * @param commandClient The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
   * @param sslContext If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
+  * @param token If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
   */
 final case class LedgerClientConfiguration(
     applicationId: String,
     ledgerIdRequirement: LedgerIdRequirement,
     commandClient: CommandClientConfiguration,
-    sslContext: Option[SslContext])
+    sslContext: Option[SslContext],
+    token: Option[String] = None)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/SynchronousCommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/SynchronousCommandClient.scala
@@ -3,30 +3,33 @@
 
 package com.digitalasset.ledger.client.services.commands
 
-import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
+import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc.CommandServiceStub
 import com.digitalasset.ledger.api.v1.command_service._
+import com.digitalasset.ledger.client.LedgerClient
 import com.google.protobuf.empty.Empty
 
 import scala.concurrent.Future
 
-class SynchronousCommandClient(commandService: CommandService) {
+class SynchronousCommandClient(service: CommandServiceStub) {
 
-  def submitAndWait(submitAndWaitRequest: SubmitAndWaitRequest): Future[Empty] = {
-    commandService.submitAndWait(submitAndWaitRequest)
-  }
+  def submitAndWait(
+      submitAndWaitRequest: SubmitAndWaitRequest,
+      token: Option[String] = None): Future[Empty] =
+    LedgerClient.stub(service, token).submitAndWait(submitAndWaitRequest)
 
   def submitAndWaitForTransactionId(
-      submitAndWaitRequest: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionIdResponse] = {
-    commandService.submitAndWaitForTransactionId(submitAndWaitRequest)
-  }
+      submitAndWaitRequest: SubmitAndWaitRequest,
+      token: Option[String] = None): Future[SubmitAndWaitForTransactionIdResponse] =
+    LedgerClient.stub(service, token).submitAndWaitForTransactionId(submitAndWaitRequest)
 
   def submitAndWaitForTransaction(
-      submitAndWaitRequest: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] = {
-    commandService.submitAndWaitForTransaction(submitAndWaitRequest)
-  }
+      submitAndWaitRequest: SubmitAndWaitRequest,
+      token: Option[String] = None): Future[SubmitAndWaitForTransactionResponse] =
+    LedgerClient.stub(service, token).submitAndWaitForTransaction(submitAndWaitRequest)
 
-  def submitAndWaitForTransactionTree(submitAndWaitRequest: SubmitAndWaitRequest)
-    : Future[SubmitAndWaitForTransactionTreeResponse] = {
-    commandService.submitAndWaitForTransactionTree(submitAndWaitRequest)
-  }
+  def submitAndWaitForTransactionTree(
+      submitAndWaitRequest: SubmitAndWaitRequest,
+      token: Option[String] = None): Future[SubmitAndWaitForTransactionTreeResponse] =
+    LedgerClient.stub(service, token).submitAndWaitForTransactionTree(submitAndWaitRequest)
+
 }


### PR DESCRIPTION
- Adds a `fromBuilder` method to get a builder instead of a channel to allow for a more fine-grained control over the communication channel from the caller while still allowing to manage the shutdown hook and consumption of `LedgerClientConfiguration` on the caller's behalf.
- Makes `forChannel` deprecated (you can still use the `apply` method, if you really want to risk shooting yourself in the foot :slightly_smiling_face: ).
- Makes the HTTP/JSON API use the newly introduced authorization token parameter on the `LedgerClient` instead of custom code
- Makes use of the newly introduced constructor in Navigator, Extractor and the HTTP/JSON API
- Reintroduces the possibility of specifying a default token on construction

@gerolf-da: on the last point, I thought of adding back the `Option[() => Try[String]]` but since `LedgerClient` should not handle error cases, I'm not sure of the significance of pushing the token acquisition onto the library. Since the optional token in this case is there to act as a shortcut for short-lived applications, I think a simple `Option[String]` makes more sense, since this already leaves the caller in control of how to read the token.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
