### PR TITLE
Relax restrictions on contract ids

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -132,11 +132,8 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
             Numeric.fromBigDecimal(s, d).fold(fail, d => ResultDone(SNumeric(d)))
           case (TParty, ValueParty(p)) =>
             ResultDone(SParty(p))
-          case (TContractId(typ), ValueContractId(c)) =>
-            typ match {
-              case TTyCon(_) => ResultDone(SContractId(c))
-              case _ => fail(s"Expected a type constructor but found $typ.")
-            }
+          case (TContractId(_), ValueContractId(c)) =>
+            ResultDone(SContractId(c))
 
           // optional
           case (TOptional(elemType), ValueOptional(mb)) =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -6,7 +6,7 @@ package lf
 package engine
 
 import com.digitalasset.daml.lf.data._
-import com.digitalasset.daml.lf.language.Ast.{TNat, TTyCon}
+import com.digitalasset.daml.lf.language.Ast.{TApp, TNat, TTyCon}
 import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import com.digitalasset.daml.lf.value.Value._
@@ -23,6 +23,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
   private implicit def toName(s: String): Ref.Name = Ref.Name.assertFromString(s)
 
   val recordCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Record"))
+  val polyRecordCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:PolyRecord"))
   val variantCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Variant"))
   val enumCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Enum"))
 
@@ -31,6 +32,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
         module Module {
 
           record Record = { field : Int64 };
+          record PolyRecord a = { fieldA : a };
           variant Variant = variant1 : Text | variant2 : Int64 ;
           enum Enum = value1 | value2;
 
@@ -61,6 +63,8 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
       TParty ->
         ValueParty(Ref.Party.assertFromString("Alice")),
       TContractId(TTyCon(recordCon)) ->
+        ValueContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString("contractId"))),
+      TContractId(TApp(TTyCon(polyRecordCon), TUnit)) ->
         ValueContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString("contractId"))),
       TList(TText) ->
         ValueList(FrontStack(ValueText("a"), ValueText("b"))),


### PR DESCRIPTION
Consider the following DAML code

```
template FooG a
  with
    p : Party
    a : a
  where
    signatory p

template instance Foo = FooG Decimal

template Boo
  with
    p : Party
  where
    signatory p

    controller p can
      nonconsuming ArchiveFoo: ()
        with
          fooCid : ContractId Foo
        do
          archive fooCid
```

This will generate an ArchiveFoo record with a field of type
`ContractId (FooG Decimal)` so no monomorphization takes place. This
is valid and is not rejected by the LF typechecker. However, currently
the validation logic here will reject this making it impossible to
call this choice.

This PR relaxes this restriction so that it is possible to call this choice.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
