### PR TITLE
[daml-triggers] Rename getTemplates to getContracts

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -153,8 +153,8 @@ rather than something required for them to function correctly.
 
 First, we get all ``Subscriber``, ``Original`` and ``Copy`` contracts
 from the ACS. For that, the DAML trigger API provides a
-``getTemplates`` function that given the ACS will return a list of all
-contracts of a given type.
+``getContracts`` function that given the ACS will return a list of all
+contracts of a given template.
 
 .. literalinclude:: ./template-root/src/CopyTrigger.daml
    :language: daml

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -62,9 +62,9 @@ copyRule : Party -> ACS -> Map CommandId [Command] -> () -> TriggerA ()
 copyRule party acs commandsInFlight () = do
 -- RULE_SIGNATURE_END
 -- ACS_QUERY_BEGIN
-  let subscribers : [(ContractId Subscriber, Subscriber)] = getTemplates @Subscriber acs
-  let originals : [(ContractId Original, Original)] = getTemplates @Original acs
-  let copies : [(ContractId Copy, Copy)] = getTemplates @Copy acs
+  let subscribers : [(ContractId Subscriber, Subscriber)] = getContracts @Subscriber acs
+  let originals : [(ContractId Original, Original)] = getContracts @Original acs
+  let copies : [(ContractId Copy, Copy)] = getContracts @Copy acs
 -- ACS_QUERY_END
 
 -- ACS_FILTER_BEGIN

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -4,6 +4,7 @@
 daml 1.2
 module Daml.Trigger
  ( ACS
+ , getContracts
  , getTemplates
  , Trigger(..)
  , TriggerA
@@ -37,15 +38,19 @@ import qualified Daml.Trigger.LowLevel as LowLevel
 
 -- public API
 
--- | Active contract set, you can use `getTemplates` to access the templates of
+-- | Active contract set, you can use `getContracts` to access the templates of
 -- a given type.
 
 -- This will change to a Map once we have proper maps in DAML-LF
 newtype ACS = ACS [(AnyContractId, AnyTemplate)]
 
--- | Extract the templates of a given type from the ACS.
+{-# DEPRECATED getTemplates "getTemplates is deprecated in favor of getContracts" #-}
 getTemplates : forall a. Template a => ACS -> [(ContractId a, a)]
-getTemplates (ACS tpls) = mapOptional fromAny tpls
+getTemplates = getContracts
+
+-- | Extract the contracts of a given template from the ACS.
+getContracts : forall a. Template a => ACS -> [(ContractId a, a)]
+getContracts (ACS tpls) = mapOptional fromAny tpls
   where
     fromAny (cid, tpl) = (,) <$> fromAnyContractId cid <*> fromAnyTemplate tpl
 

--- a/triggers/tests/daml/ExerciseByKey.daml
+++ b/triggers/tests/daml/ExerciseByKey.daml
@@ -21,9 +21,9 @@ exerciseByKeyTrigger = Trigger
 -- Create one T template and then call a choice by key to create T_.
 retryRule : Party -> ACS -> Map CommandId [Command] -> Int -> TriggerA ()
 retryRule party acs commandsInFlight allowedRetries
-  | [] <- getTemplates @T acs = do
+  | [] <- getContracts @T acs = do
     dedupCreate T { p = party }
-  | ((_, T { p = party' } ) :: _) <- getTemplates @T acs
+  | ((_, T { p = party' } ) :: _) <- getContracts @T acs
   , party == party' =
     dedupExerciseByKey @T party C
   | otherwise = pure ()

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -22,13 +22,13 @@ retryTrigger = Trigger
 -- finally we create Done
 retryRule : Party -> ACS -> Map CommandId [Command] -> Int -> TriggerA ()
 retryRule party acs commandsInFlight allowedRetries
-  | [] <- getTemplates @T acs = do
+  | [] <- getContracts @T acs = do
     dedupCreate T { p = party }
-  | ((cid, _) :: _) <- getTemplates @T acs
+  | ((cid, _) :: _) <- getContracts @T acs
   , allowedRetries > 0 = do
     dedupExercise cid C
   | allowedRetries == 0
-  , [] <- getTemplates @Done acs = do
+  , [] <- getContracts @Done acs = do
     dedupCreate Done { p = party }
   | otherwise = pure ()
 

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -29,3 +29,5 @@ HEAD — ongoing
 - [DAML Triggers] Added ``exerciseByKeyCmd`` and
   ``dedupExerciseByKey`` to exercise a choice given the contract key
   instead of the contract id.
+- [DAML Triggers] ``getTemplates`` has been renamed to ``getContracts`` to describe its behavior more accurately.
+  ``getTemplates`` still exists as a compatiblity helper but it is deprecated and will be removed in a future SDK release.


### PR DESCRIPTION
Given that this returns the contracts of a given template rather than
returning templates, this name makes a lot more sense.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
