### PR TITLE
Clean up IT Logback config, reduce noise in CI logs

### DIFF
--- a/ledger/ledger-api-integration-tests/src/test/resources/logback-test.xml
+++ b/ledger/ledger-api-integration-tests/src/test/resources/logback-test.xml
@@ -1,53 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="true">
-    <!--<appender name="file-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
-        <!--<filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
-            <!--<level>debug</level>-->
-        <!--</filter>-->
-        <!--<file>${logFileLocation}/${logFileName}</file>-->
-        <!--<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
-            <!--<fileNamePattern>logs/viper-test_%d{yyyy-MM-dd}.log</fileNamePattern>-->
-            <!--<maxHistory>30</maxHistory>-->
-        <!--</rollingPolicy>-->
-        <!--<encoder class="net.logstash.logback.encoder.LogstashEncoder">-->
-            <!--<timeZone>UTC</timeZone>-->
-            <!--<provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />-->
-            <!--<shortenedLoggerNameLength>36</shortenedLoggerNameLength>-->
-            <!--<throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">-->
-                <!--<rootCauseFirst>true</rootCauseFirst>-->
-            <!--</throwableConverter>-->
-            <!--<fieldNames>-->
-                <!--<timestamp>timestamp</timestamp>-->
-                <!--<level>level</level>-->
-                <!--<levelValue>[ignore]</levelValue>-->
-                <!--<logger>logger</logger>-->
-                <!--<thread>thread</thread>-->
-                <!--<version>[ignore]</version>-->
-            <!--</fieldNames>-->
-            <!--<includeContext>false</includeContext>-->
-        <!--</encoder>-->
-    <!--</appender>-->
-
-    <!--Added because values passed in through markers do not get logged to standard console logger-->
-    <!--<appender name="JSON-STDOUT" class="ch.qos.logback.core.ConsoleAppender">-->
-        <!--<encoder class="net.logstash.logback.encoder.LogstashEncoder">-->
-            <!--<timeZone>UTC</timeZone>-->
-            <!--<provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />-->
-            <!--<shortenedLoggerNameLength>36</shortenedLoggerNameLength>-->
-            <!--<throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">-->
-                <!--<rootCauseFirst>true</rootCauseFirst>-->
-            <!--</throwableConverter>-->
-            <!--<fieldNames>-->
-                <!--<timestamp>timestamp</timestamp>-->
-                <!--<level>level</level>-->
-                <!--<levelValue>[ignore]</levelValue>-->
-                <!--<logger>logger</logger>-->
-                <!--<thread>thread</thread>-->
-                <!--<version>[ignore]</version>-->
-            <!--</fieldNames>-->
-            <!--<includeContext>false</includeContext>-->
-        <!--</encoder>-->
-    <!--</appender>-->
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -55,16 +7,16 @@
         </encoder>
     </appender>
 
-    <logger name="com.digitalasset.platform.api.rest" level="warn" />
-    <logger name="org.flywaydb" level="warn"/>
-    <logger name="org.hibernate" level="warn"/>
-    <logger name="org.springframework" level="warn"/>
-    <logger name="org.apache.cassandra" level="warn"/>
+    <logger name="com.codahale.metrics.jmx" level="warn"/>
     <logger name="com.digitalasset.grpc" level="warn"/>
+    <logger name="com.digitalasset.platform.api.rest" level="warn" />
+    <logger name="com.zaxxer.hikari" level="warn"/>
     <logger name="io.grpc.netty" level="warn"/>
     <logger name="io.netty" level="warn"/>
+    <logger name="org.flywaydb" level="warn"/>
 
     <root level="TRACE">
         <appender-ref ref="STDOUT" />
     </root>
+
 </configuration>


### PR DESCRIPTION
Removes libraries that we didn't use anymore from the integration tests `logback-test.xml` file, removes commented lines (that will always be available thanks to the power of `git`), adds a couple of lines for those who now produce a lot of unnecessary noise (especially now that we enabled `TRACE` logging) and sort them alphabetically (exclusively for my own delight).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
