### PR TITLE
ledger-api-test-tool: Run tests on Canton, and fix a few issues.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,26 @@ nixpkgs_package(
     repositories = dev_env_nix_repos,
 )
 
+# netcat dependency
+nixpkgs_package(
+    name = "netcat_nix",
+    attribute_path = "netcat-gnu",
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+dev_env_tool(
+    name = "netcat_dev_env",
+    nix_include = ["bin/nc"],
+    nix_label = "@netcat_nix",
+    nix_paths = ["bin/nc"],
+    tools = ["nc"],
+    win_include = ["usr/bin/nc.exe"],
+    win_paths = ["usr/bin/nc.exe"],
+    win_tool = "msys2",
+)
+
 # Tar & gzip dependency
 nixpkgs_package(
     name = "tar_nix",
@@ -176,6 +196,22 @@ dev_env_tool(
 nixpkgs_package(
     name = "awk_nix",
     attribute_path = "gawk",
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+nixpkgs_package(
+    name = "coreutils_nix",
+    attribute_path = "coreutils",
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+nixpkgs_package(
+    name = "grpcurl_nix",
+    attribute_path = "grpcurl",
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -947,3 +947,14 @@ dev_env_tool(
     ],
     win_tool = "msys2",
 )
+
+http_archive(
+    name = "canton",
+    build_file_content = '''
+package(default_visibility = ["//visibility:public"])
+filegroup(name="jars", srcs=glob(["lib/**"]))
+''',
+    sha256 = "b67215655bdcfaf0f4b271ebd3f9ce8f887c3c81a53351f47165a9bf5b93e435",
+    strip_prefix = "canton-0.3.0",
+    urls = ["https://github.com/digital-asset/canton/releases/download/v0.3.0/canton-0.3.0.tar.gz"],
+)

--- a/bazel_tools/client_server/client_server_test.bzl
+++ b/bazel_tools/client_server/client_server_test.bzl
@@ -42,15 +42,21 @@ $runner "$client" "$client_args" "$server" "$server_args"
         is_executable = True,
     )
 
-    runfiles = ctx.runfiles(files = [wrapper], collect_data = True)
-    runfiles = runfiles.merge(ctx.attr._runner[DefaultInfo].default_runfiles)
-    runfiles = runfiles.merge(ctx.attr.client[DefaultInfo].default_runfiles)
-    runfiles = runfiles.merge(ctx.attr.server[DefaultInfo].default_runfiles)
+    wrapper_runfiles = ctx.runfiles(files = [wrapper], collect_data = True)
+    default_runfiles = wrapper_runfiles \
+        .merge(ctx.attr._runner[DefaultInfo].default_runfiles) \
+        .merge(ctx.attr.client[DefaultInfo].default_runfiles) \
+        .merge(ctx.attr.server[DefaultInfo].default_runfiles)
+    data_runfiles = wrapper_runfiles \
+        .merge(ctx.attr._runner[DefaultInfo].data_runfiles) \
+        .merge(ctx.attr.client[DefaultInfo].data_runfiles) \
+        .merge(ctx.attr.server[DefaultInfo].data_runfiles)
 
     return DefaultInfo(
         executable = wrapper,
         files = depset([wrapper]),
-        runfiles = runfiles,
+        default_runfiles = default_runfiles,
+        data_runfiles = data_runfiles,
     )
 
 client_server_test = rule(

--- a/bazel_tools/client_server/client_server_test.bzl
+++ b/bazel_tools/client_server/client_server_test.bzl
@@ -42,21 +42,15 @@ $runner "$client" "$client_args" "$server" "$server_args"
         is_executable = True,
     )
 
-    wrapper_runfiles = ctx.runfiles(files = [wrapper], collect_data = True)
-    default_runfiles = wrapper_runfiles \
-        .merge(ctx.attr._runner[DefaultInfo].default_runfiles) \
-        .merge(ctx.attr.client[DefaultInfo].default_runfiles) \
-        .merge(ctx.attr.server[DefaultInfo].default_runfiles)
-    data_runfiles = wrapper_runfiles \
-        .merge(ctx.attr._runner[DefaultInfo].data_runfiles) \
-        .merge(ctx.attr.client[DefaultInfo].data_runfiles) \
-        .merge(ctx.attr.server[DefaultInfo].data_runfiles)
+    runfiles = ctx.runfiles(files = [wrapper], collect_data = True)
+    runfiles = runfiles.merge(ctx.attr._runner[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.client[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.server[DefaultInfo].default_runfiles)
 
     return DefaultInfo(
         executable = wrapper,
         files = depset([wrapper]),
-        default_runfiles = default_runfiles,
-        data_runfiles = data_runfiles,
+        runfiles = runfiles,
     )
 
 client_server_test = rule(

--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -4,6 +4,7 @@
     "url": [
         "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-jq-1.6-2-any.pkg.tar.xz#/jq.msys2",
+        "http://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz",
         "http://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-openssl-1.1.1.c-1-any.pkg.tar.xz#/openssl.msys2",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-postgresql-11.3-1-any.pkg.tar.xz#/pgsql.msys2"
@@ -11,6 +12,7 @@
     "hash": [
         "4e799b5c3efcf9efcb84923656b7bcff16f75a666911abd6620ea8e5e1e9870c",
         "da8a3b88d6ad1f5d28bc190405de9ca0f802ebcae19080a5b5b2b30a7614272b",
+        "32fa739d26fd49a3f8c22717ae338472d71d4798844cbc0db5e7780131fe69aa",
         "5c18ce8979e9019d24abd2aee7ddcdf8824e31c4c7e162a204d4dc39b3b73776",
         "28c8f3acbfa3b5435cd3759cd3f051e7cdeb0c6bb5cfccb7bacb70c8b91f66db",
         "df53271e77f85f9f2b5fc959da1976af8482cc9ae24229ac8ffd6103f6428123"
@@ -26,6 +28,7 @@
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -S --noconfirm unzip zip mingw-w64-x86_64-gcc'\"",
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -S --noconfirm tar diffutils'\"",
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -U --noconfirm /jq.msys2'\"",
+            "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -U --noconfirm /netcat.msys2'\"",
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -U --noconfirm /patch.msys2'\"",
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -U --noconfirm /openssl.msys2'\"",
             "iex \"$dir\\usr\\bin\\bash.exe -lc 'pacman -U --noconfirm /pgsql.msys2'\"",
@@ -51,6 +54,7 @@
         "usr\\bin\\expr.exe",
         "usr\\bin\\ln.exe",
         "usr\\bin\\ls.exe",
+        "usr\\bin\\nc.exe",
         "usr\\bin\\rm.exe",
         "usr\\bin\\sed.exe",
         "usr\\bin\\sh.exe",

--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -4,7 +4,7 @@
     "url": [
         "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-jq-1.6-2-any.pkg.tar.xz#/jq.msys2",
-        "http://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz",
+        "http://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
         "http://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-openssl-1.1.1.c-1-any.pkg.tar.xz#/openssl.msys2",
         "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-postgresql-11.3-1-any.pkg.tar.xz#/pgsql.msys2"

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -1,0 +1,16 @@
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(":template.bzl", "template")
+load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
+
+java_import(
+    name = "canton-lib",
+    jars = ["@canton//:jars"],
+)
+
+java_binary(
+    name = "canton",
+    main_class = "com.digitalasset.canton.CantonApp",
+    runtime_deps = [":canton-lib"],
+)

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -1,8 +1,8 @@
 # Copyright (c) 2019 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load(":template.bzl", "template")
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
+load("@os_info//:os_info.bzl", "is_windows")
 
 java_import(
     name = "canton-lib",
@@ -14,3 +14,59 @@ java_binary(
     main_class = "com.digitalasset.canton.CantonApp",
     runtime_deps = [":canton-lib"],
 )
+
+# Disabled on Windows because `coreutils` and `grpcurl` aren't easily available.
+genrule(
+    name = "canton-test-runner-with-dependencies-script",
+    srcs = [
+        ":canton-test-runner.sh",
+    ],
+    outs = ["canton-test-runner-with-dependencies.sh"],
+    cmd = """
+cat > $@ <<EOF
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "\$${RUNFILES_DIR:-/dev/null}/\$$f" 2>/dev/null || \
+  source "\$$(grep -sm1 "^\$$f " "\$${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "\$$0.runfiles/\$$f" 2>/dev/null || \
+  source "\$$(grep -sm1 "^\$$f " "\$$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "\$$(grep -sm1 "^\$$f " "\$$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find \$$f"; exit 1; }; f=; set -e
+
+PATH="\$$(rlocation coreutils_nix/bin):\$$(rlocation jq_nix/bin):\$$(rlocation grpcurl_nix/bin):\$$(rlocation jq_dev_env/bin):\$$(rlocation netcat_dev_env/bin):\$$PATH"
+export PATH
+
+EOF
+cat $< >> $@
+""",
+) if not is_windows else None
+
+# Required because running `canton-test-runner-with-dependencies-script` directly fails.
+sh_binary(
+    name = "canton-test-runner-with-dependencies",
+    srcs = [":canton-test-runner-with-dependencies-script"],
+    # Ideally these would be part of the script definition above, but that doesn't seem to work.
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+) if not is_windows else None
+
+conformance_test(
+    name = "conformance-test",
+    # Ideally these would be part of the script definition above, but that doesn't seem to work.
+    extra_data = [
+        ":bootstrap.canton",
+        ":canton",
+        ":canton.conf",
+        "@coreutils_nix//:bin/base64",
+        "@grpcurl_nix//:bin/grpcurl",
+        "@jq_dev_env//:jq",
+        "@netcat_dev_env//:nc",
+    ],
+    ports = [
+        5011,
+        5021,
+    ],
+    server = ":canton-test-runner-with-dependencies",
+) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/bootstrap.canton
+++ b/ledger/ledger-api-test-tool-on-canton/bootstrap.canton
@@ -1,0 +1,7 @@
+all start
+
+all_participants foreach (connect(_, test_domain))
+
+retryUntilTrue() {
+  all_participants forall (participant_is_active(_, test_domain.name))
+}

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -u
+set -o pipefail
+
+CANTON_COMMAND=(
+  "$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/canton)"
+  daemon
+  "--config=$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/canton.conf)"
+  "--bootstrap=$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/bootstrap.canton)"
+)
+
+PARTICIPANT_1_LEDGER_API_HOST=localhost
+PARTICIPANT_1_LEDGER_API_PORT=5011
+PARTICIPANT_2_LEDGER_API_HOST=localhost
+PARTICIPANT_2_LEDGER_API_PORT=5021
+PARTICIPANTS=(
+  "${PARTICIPANT_1_LEDGER_API_HOST}:${PARTICIPANT_1_LEDGER_API_PORT}"
+  "${PARTICIPANT_2_LEDGER_API_HOST}:${PARTICIPANT_2_LEDGER_API_PORT}"
+)
+
+TIMEOUT=30
+
+function wait_for_ports {
+  local start success host port
+
+  start="$(date +%s)"
+  while true; do
+    if [[ "$(( "$(date +%s)" - start ))" -gt "$TIMEOUT" ]]; then
+      echo >&2 "Timed out after ${TIMEOUT} seconds."
+      return 1
+    fi
+
+    success=true
+    for (( i=1; i < $#; i++ )); do
+      host="${!i}"
+      i=$(( i + 1 ))
+      port="${!i}"
+      if ! nc -w 1 -z "$host" "$port"; then
+        success=false
+        break
+      fi
+    done
+
+    if "$success"; then
+      return 0
+    fi
+
+    sleep 1
+  done
+}
+
+command=("${CANTON_COMMAND[@]}")
+dars=()
+port_file=''
+while (( $# )); do
+  # extract the port file
+  if [[ "$1" == '--port-file' ]]; then
+    port_file="$2"
+    shift
+    shift
+  # upload DARs with the DAML assistant
+  elif [[ "$1" =~ \.dar$ ]]; then
+    dars+=("$1")
+    shift
+  else
+    command+=("$1")
+    shift
+  fi
+done
+
+if [[ -z "$port_file" ]]; then
+  # shellcheck disable=SC2016
+  echo >&2 'You must specify a port file with the `--port-file` switch.'
+  exit 2
+fi
+
+# Redirect the Canton logs to a file for now, because they're really, really noisy.
+log_file="$(mktemp -t 'canton.XXXXX.log')"
+echo >&2 'Starting Canton...'
+echo >&2 "(Logs will be written to \"${log_file}\".)"
+"${command[@]}" >& "$log_file" &
+pid="$!"
+
+sleep 1
+if ! kill -0 "$pid" 2> /dev/null; then
+  echo >&2 'Failed to start Canton.'
+  exit 1
+fi
+
+function stop {
+  local status
+  status=$?
+  kill "$pid" || :
+  rm -f "$port_file" || :
+  exit "$status"
+}
+
+trap stop EXIT INT TERM
+
+wait_for_ports \
+  "$PARTICIPANT_1_LEDGER_API_HOST" "$PARTICIPANT_1_LEDGER_API_PORT" \
+  "$PARTICIPANT_2_LEDGER_API_HOST" "$PARTICIPANT_2_LEDGER_API_PORT"
+
+for participant in "${PARTICIPANTS[@]}"; do
+  for dar in "${dars[@]}"; do
+    base64 "$dar" \
+      | jq -R --slurp '{"darFile": .}' \
+      | grpcurl \
+        -plaintext \
+        -d @ \
+        "$participant" \
+        com.digitalasset.ledger.api.v1.admin.PackageManagementService.UploadDarFile \
+      > /dev/null
+  done
+done
+
+# This should write two ports, but the runner doesn't support that.
+echo "$PARTICIPANT_1_LEDGER_API_PORT" > "$port_file"
+
+echo >&2 'Canton is up and running.'
+
+wait "$pid"

--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -1,0 +1,47 @@
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+canton {
+  domains {
+    test_domain {
+      storage {
+        type = memory
+      }
+
+      server {
+        public.port = 4011
+        admin.port = 4012
+      }
+    }
+  }
+
+  participants {
+    participant_1 {
+      storage {
+        type = memory
+      }
+
+      ledger-api {
+        port = 5011
+      }
+
+      admin-api {
+        port = 5012
+      }
+    }
+
+    participant_2 {
+      storage {
+        type = memory
+      }
+
+      ledger-api {
+        port = 5021
+      }
+
+      admin-api {
+        port = 5022
+      }
+    }
+  }
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -73,6 +73,15 @@ object LedgerApiTestTool {
       sys.exit(0)
     }
 
+    val missingTests = (config.included ++ config.excluded).filterNot(tests.all.contains)
+    if (missingTests.nonEmpty) {
+      println("The following tests could not be found:")
+      missingTests.foreach { testName =>
+        println(s"  - $testName")
+      }
+      sys.exit(2)
+    }
+
     val included =
       if (config.allTests) tests.all.keySet
       else if (config.included.isEmpty) tests.default.keySet

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Eventually.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Eventually.scala
@@ -3,14 +3,15 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 
 object Eventually {
-  private val withRetryStrategy = RetryStrategy.exponentialBackoff(10, 10.millis)
-
-  def eventually[A](runAssertion: => Future[A])(implicit ec: ExecutionContext): Future[A] =
-    withRetryStrategy { _ =>
+  def eventually[A](
+      runAssertion: => Future[A],
+      attempts: Int = 10,
+      firstWaitTime: Duration = 10.millis)(implicit ec: ExecutionContext): Future[A] =
+    RetryStrategy.exponentialBackoff(attempts, firstWaitTime) { _ =>
       runAssertion
     }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -19,7 +19,8 @@ import com.digitalasset.ledger.api.v1.admin.package_management_service.{
 }
 import com.digitalasset.ledger.api.v1.admin.party_management_service.{
   AllocatePartyRequest,
-  GetParticipantIdRequest
+  GetParticipantIdRequest,
+  ListKnownPartiesRequest
 }
 import com.digitalasset.ledger.api.v1.command_completion_service.{
   CompletionStreamRequest,
@@ -187,6 +188,11 @@ private[testtool] final class ParticipantTestContext private[participant] (
 
   def allocateParties(n: Int): Future[Vector[Party]] =
     Future.sequence(Vector.fill(n)(allocateParty()))
+
+  def listParties(): Future[Set[Party]] =
+    services.partyManagement
+      .listKnownParties(new ListKnownPartiesRequest())
+      .map(_.partyDetails.map(partyDetails => Party(partyDetails.party)).toSet)
 
   def activeContracts(
       request: GetActiveContractsRequest): Future[(Option[LedgerOffset], Vector[CreatedEvent])] =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.digitalasset.ledger.api.v1.transaction.Transaction
-import com.digitalasset.ledger.api.v1.value.{RecordField, Value}
 import com.digitalasset.ledger.client.binding.Primitive
 import com.digitalasset.ledger.client.binding.Value.encode
 import com.digitalasset.ledger.test_dev.Test.TextContainer
@@ -662,28 +661,6 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
         assert(
           contract.getContractKey.sum.isEmpty,
           s"The key is not empty: ${contract.getContractKey}")
-      }
-  }
-
-  test(
-    "TXContractKey",
-    "The contract key should be exposed if the template specifies one",
-    allocate(SingleParty)) {
-    case Participants(Participant(ledger, party)) =>
-      val expectedKey = "some-fancy-key"
-      for {
-        _ <- ledger.create(party, TextKey(party, expectedKey, Primitive.List.empty))
-        transactions <- ledger.flatTransactions(party)
-      } yield {
-        val contract = assertSingleton(s"ContractKey", transactions.flatMap(createdEvents))
-        assertEquals(
-          "ContractKey",
-          contract.getContractKey.getRecord.fields,
-          Seq(
-            RecordField("_1", Some(Value(Value.Sum.Party(Tag.unwrap(party))))),
-            RecordField("_2", Some(Value(Value.Sum.Text(expectedKey))))
-          )
-        )
       }
   }
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/PostgresAround.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/PostgresAround.scala
@@ -110,7 +110,7 @@ trait PostgresAround {
       } catch {
         case NonFatal(e) =>
           throw new IllegalStateException(
-            s"Cannot start Postgres fixture. Failed command: ${command.toString}",
+            s"Cannot start Postgres fixture. Failed command: ${command.mkString(" ")}",
             e)
       }
     }

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -6,15 +6,18 @@
 }:
 let shared = rec {
   inherit (pkgs)
+    coreutils
     curl
     docker
     gawk
     gnutar
+    grpcurl
     gzip
     hlint
     imagemagick
     jdk8
     jq
+    netcat-gnu
     nodejs
     patchelf
     postgresql_9_6


### PR DESCRIPTION
Run the ledger-api-test-tool against [Canton][], a distributed ledger built by Digital Asset that supports DAML.

This adds Canton v0.3.0 to our external dependencies. We will endeavor to track the released version of Canton.

Right now we only run the SemanticTests, as a few of the other tests fail.

There are two main changes to the test suite:

- We now wait for all parties to propagate to all participants. Previously we didn't bother, as most ledgers are not truly distributed and centralize party creation. This closes #3380.
- All tests referencing contract keys have been moved into the "ContractKeys" test file, as Canton does not yet support contract keys and it's useful to be able to exclude those tests.

I've also made a change to the test runner to fail fast if a test name specified in an `--include` or `--exclude` switch is misspelled.

In other news, I hate Bazel. (About as much as all the other build tools.)

[Canton]: https://www.canton.io/

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
