### PR TITLE
Remove logging output coloring

### DIFF
--- a/extractor/src/main/resources/logback.xml
+++ b/extractor/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
             <level>trace</level>
         </filter>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{5}@[%-4.30thread]) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/language-support/java/codegen/src/main/resources/logback.xml
+++ b/language-support/java/codegen/src/main/resources/logback.xml
@@ -1,16 +1,14 @@
 <configuration>
 
     <appender name="STDOUT-SIMPLE" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <encoder>
-            <pattern>[%highlight(%-5level)] %msg%n</pattern>
+            <pattern>[%-5level] %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT-BACKEND" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <encoder>
-            <pattern>[%highlight(%-5level)] %msg \(%X{entityType} %X{moduleName}:%X{entityName}, package %X{packageIdShort}\)%n</pattern>
+            <pattern>[%-5level] %msg \(%X{entityType} %X{moduleName}:%X{entityName}, package %X{packageIdShort}\)%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/api-server-damlonx/reference-v2/src/main/resources/logback.xml
+++ b/ledger/api-server-damlonx/reference-v2/src/main/resources/logback.xml
@@ -2,14 +2,14 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{5}) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>
-          <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{5}) - %msg%n</pattern>
+          <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-api-test-tool/src/main/resources/logback.xml
+++ b/ledger/ledger-api-test-tool/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
             <level>trace</level>
         </filter>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{5}@[%-4.30thread]) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
It looks cool but the places in which it's used should either direct logging to a file (no coloring there) or give us feedback on CI (no coloring there). Plus, it requires extra steps to work on Windows, otherwise noisy stack traces pop up, hiding true failures.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
