### PR TITLE
language: fix for tuple types in source generation

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -686,25 +686,25 @@ convType env =
             HsTyVar noExt NotPromoted $ mkRdrName $ LF.unTypeVarName tyVarName
         LF.TCon LF.Qualified {..} ->
             case LF.unTypeConName qualObject of
-                ["Tuple2"] -> mkTuple 2
-                ["Tuple3"] -> mkTuple 3
-                ["Tuple4"] -> mkTuple 4
-                ["Tuple5"] -> mkTuple 5
-                ["Tuple6"] -> mkTuple 6
-                ["Tuple7"] -> mkTuple 7
-                ["Tuple8"] -> mkTuple 8
-                ["Tuple9"] -> mkTuple 9
-                ["Tuple10"] -> mkTuple 10
-                ["Tuple11"] -> mkTuple 11
-                ["Tuple12"] -> mkTuple 12
-                ["Tuple13"] -> mkTuple 13
-                ["Tuple14"] -> mkTuple 14
-                ["Tuple15"] -> mkTuple 15
-                ["Tuple16"] -> mkTuple 16
-                ["Tuple17"] -> mkTuple 17
-                ["Tuple18"] -> mkTuple 18
-                ["Tuple19"] -> mkTuple 19
-                ["Tuple20"] -> mkTuple 20
+                ["Tuple2"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 2
+                ["Tuple3"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 3
+                ["Tuple4"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 4
+                ["Tuple5"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 5
+                ["Tuple6"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 6
+                ["Tuple7"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 7
+                ["Tuple8"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 8
+                ["Tuple9"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 9
+                ["Tuple10"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 10
+                ["Tuple11"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 11
+                ["Tuple12"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 12
+                ["Tuple13"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 13
+                ["Tuple14"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 14
+                ["Tuple15"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 15
+                ["Tuple16"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 16
+                ["Tuple17"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 17
+                ["Tuple18"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 18
+                ["Tuple19"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 19
+                ["Tuple20"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 20
                 [name] ->
                     HsTyVar noExt NotPromoted $
                     noLoc $

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -685,7 +685,8 @@ convType env =
           | qualModule == LF.ModuleName ["DA", "Types"]
           , [name] <- LF.unTypeConName qualObject
           , Just n <- stripPrefix "Tuple" $ T.unpack name
-          , Just i <- readMay n -> mkTuple i
+          , Just i <- readMay n
+          , 2 <= i && i <= 20 -> mkTuple i
         LF.TCon LF.Qualified {..} ->
           case LF.unTypeConName qualObject of
                 [name] ->

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -31,13 +31,10 @@ import "ghc-lib-parser" FastString
 import "ghc-lib" GHC
 import "ghc-lib-parser" Module
 import "ghc-lib-parser" Name
-import "ghc-lib-parser" Outputable
-    ( alwaysQualify
-    , ppr
-    , showSDocForUser
-    )
+import "ghc-lib-parser" Outputable (alwaysQualify, ppr, showSDocForUser)
 import "ghc-lib-parser" PrelNames
 import "ghc-lib-parser" RdrName
+import Safe
 import SdkVersion
 import System.FilePath.Posix
 import "ghc-lib-parser" TcEvidence (HsWrapper(..))
@@ -684,27 +681,13 @@ convType env =
     \case
         LF.TVar tyVarName ->
             HsTyVar noExt NotPromoted $ mkRdrName $ LF.unTypeVarName tyVarName
+        LF.TCon LF.Qualified {..}
+          | qualModule == LF.ModuleName ["DA", "Types"]
+          , [name] <- LF.unTypeConName qualObject
+          , Just n <- stripPrefix "Tuple" $ T.unpack name
+          , Just i <- readMay n -> mkTuple i
         LF.TCon LF.Qualified {..} ->
-            case LF.unTypeConName qualObject of
-                ["Tuple2"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 2
-                ["Tuple3"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 3
-                ["Tuple4"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 4
-                ["Tuple5"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 5
-                ["Tuple6"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 6
-                ["Tuple7"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 7
-                ["Tuple8"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 8
-                ["Tuple9"]  | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 9
-                ["Tuple10"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 10
-                ["Tuple11"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 11
-                ["Tuple12"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 12
-                ["Tuple13"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 13
-                ["Tuple14"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 14
-                ["Tuple15"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 15
-                ["Tuple16"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 16
-                ["Tuple17"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 17
-                ["Tuple18"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 18
-                ["Tuple19"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 19
-                ["Tuple20"] | qualModule == LF.ModuleName ["DA", "Types"] -> mkTuple 20
+          case LF.unTypeConName qualObject of
                 [name] ->
                     HsTyVar noExt NotPromoted $
                     noLoc $

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -381,10 +381,11 @@ generateSrcPkgFromLf getUnitId thisPkgId pkg = do
     modName = LF.unModuleName . LF.moduleName
     header m = header0 ++ header1 m
     header0 =
-        ["{-# LANGUAGE NoDamlSyntax #-}", "{-# LANGUAGE NoImplicitPrelude #-}"]
+        ["{-# LANGUAGE NoDamlSyntax #-}"
+        , "{-# LANGUAGE NoImplicitPrelude #-}"
+        , "{-# LANGUAGE TypeOperators #-}"
+        ]
     header1 m
-        | modName m == ["DA", "Generics"] =
-            ["", "{-# LANGUAGE TypeOperators #-}"]
         | modName m == ["GHC", "Types"] = ["", "{-# LANGUAGE MagicHash #-}"]
         | otherwise = []
     --
@@ -515,8 +516,7 @@ generateSrcFromLf env thisPkgId = noLoc mod
             pure [dataDecl]
 
     convDataCons :: T.Text -> LF.DataCons -> [LConDecl GhcPs]
-    convDataCons dataTypeCon0 =
-        \case
+    convDataCons dataTypeCon0 = \case
             LF.DataRecord fields ->
                 [ noLoc $
                   ConDeclH98
@@ -686,6 +686,25 @@ convType env =
             HsTyVar noExt NotPromoted $ mkRdrName $ LF.unTypeVarName tyVarName
         LF.TCon LF.Qualified {..} ->
             case LF.unTypeConName qualObject of
+                ["Tuple2"] -> mkTuple 2
+                ["Tuple3"] -> mkTuple 3
+                ["Tuple4"] -> mkTuple 4
+                ["Tuple5"] -> mkTuple 5
+                ["Tuple6"] -> mkTuple 6
+                ["Tuple7"] -> mkTuple 7
+                ["Tuple8"] -> mkTuple 8
+                ["Tuple9"] -> mkTuple 9
+                ["Tuple10"] -> mkTuple 10
+                ["Tuple11"] -> mkTuple 11
+                ["Tuple12"] -> mkTuple 12
+                ["Tuple13"] -> mkTuple 13
+                ["Tuple14"] -> mkTuple 14
+                ["Tuple15"] -> mkTuple 15
+                ["Tuple16"] -> mkTuple 16
+                ["Tuple17"] -> mkTuple 17
+                ["Tuple18"] -> mkTuple 18
+                ["Tuple19"] -> mkTuple 19
+                ["Tuple20"] -> mkTuple 20
                 [name] ->
                     HsTyVar noExt NotPromoted $
                     noLoc $
@@ -742,6 +761,11 @@ convType env =
                 [noLoc $ convType env ty | (_fldName, ty) <- fls]
         LF.TNat n ->
             HsTyLit noExt (HsNumTy NoSourceText (LF.fromTypeLevelNat n))
+  where
+    mkTuple :: Int -> HsType GhcPs
+    mkTuple i =
+        HsTyVar noExt NotPromoted $
+        noLoc $ mkRdrUnqual $ occName $ tupleTyConName BoxedTuple i
 
 convBuiltInTy :: Bool -> LF.BuiltinType -> HsType GhcPs
 convBuiltInTy qualify =

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -357,7 +357,7 @@ packagingTests = testGroup "packaging"
         checkDarFile darFiles "B" "C.hi"
         checkDarFile darFiles "B" "C.hie"
 
-    , testCase "Imports from differen directories" $ withTempDir $ \projDir -> do
+    , testCase "Imports from different directories" $ withTempDir $ \projDir -> do
         -- Regression test for #2929
         createDirectory (projDir </> "A")
         writeFileUTF8 (projDir </> "A.daml") $ unlines
@@ -471,6 +471,26 @@ packagingTests = testGroup "packaging"
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
         assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
         withCurrentDirectory projDir $ callCommandQuiet "daml test --target 1.dev"
+
+    <> [ testCaseSteps "Source generation edge cases" $ \step -> withTempDir $ \tmpDir -> do
+      writeFileUTF8 (tmpDir </> "Foo.daml") $ unlines
+        [ "daml 1.2"
+        , "module Foo where"
+        , "template Bar"
+        , "   with"
+        , "     p : Party"
+        , "     t : (Text, Int)" -- check for correct tuple type generation
+        , "   where"
+        , "     signatory p"
+        ]
+      withCurrentDirectory tmpDir $ do
+        step "Compile source to dalf ..."
+        callCommandQuiet "daml damlc compile Foo.daml -o Foo.dalf"
+        step "Regenerate source ..."
+        callCommandQuiet "daml damlc generate-src Foo.dalf --srcdir gen"
+        step "Compile generated source ..."
+        callCommandQuiet "daml damlc compile --generated-src gen/Foo.daml"
+    ]
 
     <> [ testCaseSteps "Build migration package" $ \step -> withTempDir $ \tmpDir -> do
         -- it's important that we have fresh empty directories here!

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -489,7 +489,8 @@ packagingTests = testGroup "packaging"
         step "Regenerate source ..."
         callCommandQuiet "daml damlc generate-src Foo.dalf --srcdir gen"
         step "Compile generated source ..."
-        callCommandQuiet "daml damlc compile --generated-src gen/Foo.daml"
+        callCommandQuiet "daml damlc compile --generated-src gen/Foo.daml -o FooGen.dalf"
+        assertBool "FooGen.dalf was not created" =<< doesFileExist "FooGen.dalf"
     ]
 
     <> [ testCaseSteps "Build migration package" $ \step -> withTempDir $ \tmpDir -> do


### PR DESCRIPTION
We correct the source generation from dalfs containing TupleN data
types. A test is added to the integration tests of daml assistant and
the `generate-src` command is improved to make this test possible.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
