### PR TITLE
Add party to participant mappings as submission inputs

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
@@ -58,12 +58,6 @@ final case class NonEmptyInsertOrdSet[T](
 object InsertOrdSet {
   def empty[T] = EmptyInsertOrdSet.asInstanceOf[InsertOrdSet[T]]
 
-  def fromSet[T](s: Set[T]): InsertOrdSet[T] =
-    NonEmptyInsertOrdSet(
-      s.to[Queue],
-      s.to[HashSet]
-    )
-
   def fromSeq[T](s: Seq[T]): InsertOrdSet[T] =
     NonEmptyInsertOrdSet(Queue(s.reverse: _*), HashSet(s: _*))
 }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+
+/**
+  * Insert-ordered Set.
+  *
+  * Implemented as (Queue[T], HashSet[T]).
+  * Asymptotics:
+  *  get: O(1)
+  *  insert: O(1)
+  *  remove: O(n)
+  */
+import scala.collection.immutable.{HashSet, Set, Queue}
+
+sealed abstract class InsertOrdSet[T] extends Set[T] {
+  def _items: Queue[T]
+  def _hashSet: HashSet[T]
+
+  override def empty: InsertOrdSet[T] = InsertOrdSet.empty
+
+  override def size: Int = _hashSet.size
+
+  def iterator: Iterator[T] =
+    _items.reverseIterator
+
+  override def contains(elem: T): Boolean =
+    _hashSet.contains(elem)
+
+  override def +(elem: T): InsertOrdSet[T] =
+    if (_hashSet.contains(elem))
+      this
+    else
+      NonEmptyInsertOrdSet(
+        elem +: _items,
+        _hashSet + elem
+      )
+
+  override def -(elem: T): InsertOrdSet[T] =
+    NonEmptyInsertOrdSet(
+      _items.filter(elem2 => elem != elem2),
+      _hashSet - elem
+    )
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+final case object EmptyInsertOrdSet extends InsertOrdSet[Any] {
+  override def _items = Queue[Any]()
+  override def _hashSet = HashSet[Any]()
+}
+
+final case class NonEmptyInsertOrdSet[T](
+    override val _items: Queue[T],
+    override val _hashSet: HashSet[T])
+    extends InsertOrdSet[T]
+
+object InsertOrdSet {
+  def empty[T] = EmptyInsertOrdSet.asInstanceOf[InsertOrdSet[T]]
+
+  def fromSet[T](s: Set[T]): InsertOrdSet[T] =
+    NonEmptyInsertOrdSet(
+      s.to[Queue],
+      s.to[HashSet]
+    )
+
+  def fromSeq[T](s: Seq[T]): InsertOrdSet[T] =
+    NonEmptyInsertOrdSet(Queue(s.reverse: _*), HashSet(s: _*))
+}

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
@@ -14,7 +14,7 @@ package com.digitalasset.daml.lf.data
   */
 import scala.collection.immutable.{HashSet, Set, Queue}
 
-sealed abstract class InsertOrdSet[T] extends Set[T] {
+final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T]) extends Set[T] {
   def _items: Queue[T]
   def _hashSet: HashSet[T]
 
@@ -56,8 +56,9 @@ final case class NonEmptyInsertOrdSet[T](
     extends InsertOrdSet[T]
 
 object InsertOrdSet {
-  def empty[T] = EmptyInsertOrdSet.asInstanceOf[InsertOrdSet[T]]
+  private val Empty =  new InsertOrdSet(Queue.empty, HashSet.empty)
+  def empty[T] = Empty.asInstanceOf[InsertOrdSet[T]]
 
   def fromSeq[T](s: Seq[T]): InsertOrdSet[T] =
-    NonEmptyInsertOrdSet(Queue(s.reverse: _*), HashSet(s: _*))
+    new InsertOrdSet(Queue(s.reverse: _*), HashSet(s: _*))
 }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
@@ -13,13 +13,14 @@ package com.digitalasset.daml.lf.data
   *  remove: O(n)
   */
 import scala.collection.immutable.{HashSet, Set, Queue}
+import scala.collection.{SetLike, AbstractSet}
 
-final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T]) extends Set[T] {
-  def _items: Queue[T]
-  def _hashSet: HashSet[T]
-
+final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T])
+    extends AbstractSet[T]
+    with Set[T]
+    with SetLike[T, InsertOrdSet[T]]
+    with Serializable {
   override def empty: InsertOrdSet[T] = InsertOrdSet.empty
-
   override def size: Int = _hashSet.size
 
   def iterator: Iterator[T] =
@@ -32,31 +33,20 @@ final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T]) ext
     if (_hashSet.contains(elem))
       this
     else
-      NonEmptyInsertOrdSet(
+      new InsertOrdSet(
         elem +: _items,
         _hashSet + elem
       )
 
   override def -(elem: T): InsertOrdSet[T] =
-    NonEmptyInsertOrdSet(
+    new InsertOrdSet(
       _items.filter(elem2 => elem != elem2),
       _hashSet - elem
     )
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Any"))
-final case object EmptyInsertOrdSet extends InsertOrdSet[Any] {
-  override def _items = Queue[Any]()
-  override def _hashSet = HashSet[Any]()
-}
-
-final case class NonEmptyInsertOrdSet[T](
-    override val _items: Queue[T],
-    override val _hashSet: HashSet[T])
-    extends InsertOrdSet[T]
-
 object InsertOrdSet {
-  private val Empty =  new InsertOrdSet(Queue.empty, HashSet.empty)
+  private val Empty = new InsertOrdSet(Queue.empty, HashSet.empty)
   def empty[T] = Empty.asInstanceOf[InsertOrdSet[T]]
 
   def fromSeq[T](s: Seq[T]): InsertOrdSet[T] =

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/InsertOrdSetTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/InsertOrdSetTest.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.data
+
+import org.scalatest.{Matchers, WordSpec}
+
+class InsertOrdSetTest extends WordSpec with Matchers {
+  "toSeq" should {
+    "preserve order" in {
+      (InsertOrdSet.empty + "a" + "b").toSeq shouldEqual Seq("a", "b")
+      (InsertOrdSet.empty + "b" + "a").toSeq shouldEqual Seq("b", "a")
+    }
+  }
+
+  "fromSeq" should {
+    "preserve order" in {
+      InsertOrdSet.fromSeq(Seq("a", "b")).toSeq shouldEqual Seq("a", "b")
+      InsertOrdSet.fromSeq(Seq("b", "a")).toSeq shouldEqual Seq("b", "a")
+    }
+  }
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -6,6 +6,8 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1.SubmittedTransaction
+import com.digitalasset.daml.lf.data.InsertOrdSet
+import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import com.digitalasset.daml.lf.value.Value.{
@@ -47,38 +49,45 @@ private[kvutils] object InputsAndEffects {
     * and packages.
     */
   def computeInputs(tx: SubmittedTransaction): List[DamlStateKey] = {
-    val packageInputs: List[DamlStateKey] = tx.usedPackages.map { pkgId =>
-      DamlStateKey.newBuilder.setPackageId(pkgId).build
-    }.toList
+    val packageInputs: InsertOrdSet[DamlStateKey] =
+      InsertOrdSet fromSet
+        tx.usedPackages.map { pkgId =>
+          DamlStateKey.newBuilder.setPackageId(pkgId).build
+        }
 
-    def addContractInput(inputs: List[DamlStateKey], coid: ContractId): List[DamlStateKey] =
+    def contractInputs(coid: ContractId): InsertOrdSet[DamlStateKey] =
       coid match {
         case acoid: AbsoluteContractId =>
-          absoluteContractIdToStateKey(acoid) :: inputs
+          InsertOrdSet.empty + absoluteContractIdToStateKey(acoid)
         case _ =>
-          inputs
+          InsertOrdSet.empty
       }
 
-    tx.fold(GenTransaction.TopDown, packageInputs) {
-      case (stateInputs, (nodeId, node)) =>
-        node match {
-          case fetch: NodeFetch[ContractId] =>
-            addContractInput(stateInputs, fetch.coid)
-          case create: NodeCreate[ContractId, VersionedValue[ContractId]] =>
-            create.key.fold(stateInputs) { keyWithM =>
-              contractKeyToStateKey(GlobalKey(
-                create.coinst.template,
-                forceAbsoluteContractIds(keyWithM.key))) :: stateInputs
-            }
-          case exe: NodeExercises[_, ContractId, _] =>
-            addContractInput(stateInputs, exe.targetCoid)
-          case l: NodeLookupByKey[ContractId, Transaction.Value[ContractId]] =>
-            // We need both the contract key state and the contract state. The latter is used to verify
-            // that the submitter can access the contract.
-            contractKeyToStateKey(GlobalKey(l.templateId, forceAbsoluteContractIds(l.key.key))) ::
-              l.result.fold(stateInputs)(addContractInput(stateInputs, _))
-        }
-    }
+    def partyInputs(parties: Set[Party]): InsertOrdSet[DamlStateKey] =
+      InsertOrdSet fromSet parties.map(partyStateKey)
+
+    tx.fold(GenTransaction.TopDown, packageInputs: Set[DamlStateKey]) {
+        case (inputs, (nodeId, node)) =>
+          node match {
+            case fetch: NodeFetch[ContractId] =>
+              inputs ++ contractInputs(fetch.coid) ++ partyInputs(fetch.signatories) ++
+                partyInputs(fetch.stakeholders)
+            case create: NodeCreate[ContractId, VersionedValue[ContractId]] =>
+              create.key.fold(inputs) { keyWithM =>
+                inputs + contractKeyToStateKey(
+                  GlobalKey(create.coinst.template, forceAbsoluteContractIds(keyWithM.key)))
+              } ++ partyInputs(create.signatories) ++ partyInputs(create.stakeholders)
+            case exe: NodeExercises[_, ContractId, _] =>
+              inputs ++ contractInputs(exe.targetCoid) ++ partyInputs(exe.stakeholders) ++ partyInputs(
+                exe.signatories) ++ partyInputs(exe.controllers)
+            case l: NodeLookupByKey[ContractId, Transaction.Value[ContractId]] =>
+              // We need both the contract key state and the contract state. The latter is used to verify
+              // that the submitter can access the contract.
+              l.result.fold(inputs)(inputs ++ contractInputs(_)) +
+                contractKeyToStateKey(GlobalKey(l.templateId, forceAbsoluteContractIds(l.key.key)))
+          }
+      }
+      .toList
   }
 
   /** Compute the effects of a DAML transaction, that is, the created and consumed contracts. */


### PR DESCRIPTION
This adds party to participant mappings as inputs to kvutils submissions.
Needed when doing a privacy-aware transformation of the resulting log entry.

Also added InsertOrdSet and made sure all DamlSubmission inputs are in
deterministic order.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
