### PR TITLE
Fix conversion from Ledger API to Speedy in DAML triggers

### DIFF
--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -17,6 +17,7 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-lf/transaction",
@@ -45,11 +46,11 @@ genrule(
         "//triggers/daml:daml-trigger.dar",
         "//compiler/damlc",
     ],
-    outs = ["com/daml/trigger/TriggerPackageIds.scala"],
+    outs = ["com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
     cmd = """
       PACKAGE_ID=$$($(location //compiler/damlc) inspect-dar $(location //triggers/daml:daml-trigger.dar) | awk '/daml-trigger-0.0.1 / {print $$2}')
-      cat << EOF > $(location com/daml/trigger/TriggerPackageIds.scala)
-package com.daml
+      cat << EOF > $(location com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala)
+package com.digitalasset.daml.lf.engine
 
 import com.digitalasset.daml.lf.data.Ref.PackageId
 
@@ -62,8 +63,8 @@ EOF
 
 da_scala_binary(
     name = "trigger-runner",
-    main_class = "com.daml.trigger.RunnerMain",
-    tags = ["maven_coordinates=com.daml.triggers:runner:__VERSION__"],
+    main_class = "com.digitalasset.daml.lf.engine.trigger.RunnerMain",
+    tags = ["maven_coordinates=com.digitalasset.daml.lf.engine.trigger:runner:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [":trigger-runner-lib"],
 )

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.trigger
+package com.digitalasset.daml.lf.engine.trigger
 
 import akka.NotUsed
 import akka.stream._
@@ -51,7 +51,6 @@ class Runner(
     submit: SubmitRequest => Unit)
     extends StrictLogging {
 
-  private val converter = Converter.fromDar(dar)
   private val triggerIds = TriggerIds.fromDar(dar)
   if (triggerIds.triggerPackageId != EXPECTED_TRIGGER_PACKAGE_ID) {
     logger.warn(
@@ -61,6 +60,7 @@ class Runner(
   private val compiler = Compiler(darMap)
   private val compiledPackages =
     PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
+  private val converter = Converter.fromDar(dar, compiledPackages)
   // This is a map from the command ids used on the ledger API to the command ids used internally
   // in the trigger which are just incremented at each step.
   private var commandIdMap: Map[UUID, String] = Map.empty

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.trigger
+package com.digitalasset.daml.lf.engine.trigger
 
 import java.io.File
 import java.time.Duration

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.trigger
+package com.digitalasset.daml.lf.engine.trigger
 
 import akka.actor.ActorSystem
 import akka.stream._

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -25,6 +25,7 @@ genrule(
       cp -L $(location :daml/ACS.daml) $$TMP_DIR/daml
       cp -L $(location :daml/Retry.daml) $$TMP_DIR/daml
       cp -L $(location :daml/ExerciseByKey.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/Numeric.daml) $$TMP_DIR/daml
       cp -L $(location //docs:source/triggers/template-root/src/CopyTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
@@ -47,7 +48,7 @@ EOF
 da_scala_binary(
     name = "test_client",
     srcs = glob(["src/**/*.scala"]),
-    main_class = "com.daml.trigger.test.TestMain",
+    main_class = "com.digitalasset.daml.lf.engine.trigger.test.TestMain",
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",

--- a/triggers/tests/daml/Numeric.daml
+++ b/triggers/tests/daml/Numeric.daml
@@ -1,0 +1,25 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module Numeric where
+
+import Daml.Trigger.LowLevel
+
+test : Trigger Bool
+test = Trigger
+  { initialState = \party _ -> (False, [Commands (CommandId "mycreate1") [createCmd (T party 1.06)]])
+  , update = \msg s -> case (s, msg) of
+      (False, MTransaction (Transaction _ _ [CreatedEvent (fromCreated @T -> Some (_, _, t))])) ->
+      -- This verifies that t.v has the proper scale as otherwise the interpreter will
+      -- throw an assertion error
+        (True, [Commands (CommandId "mycreate2") [createCmd (t { v = t.v + 1.0 })]])
+      _ -> (s, [])
+  }
+
+template T
+  with
+    p : Party
+    v : Numeric 11
+  where
+    signatory p

--- a/triggers/tests/list-triggers.sh
+++ b/triggers/tests/list-triggers.sh
@@ -29,10 +29,11 @@ TRIGGER_EXE=$(rlocation "$TEST_WORKSPACE/$1")
 DAR=$(rlocation "$TEST_WORKSPACE/$2")
 OUTPUT="$($TRIGGER_EXE list --dar $DAR | tail -n '+2' | tr -d '\r')"
 EXPECTED="\
-  Retry:retryTrigger
-  ACS:test
   CopyTrigger:copyTrigger
-  ExerciseByKey:exerciseByKeyTrigger\
+  ExerciseByKey:exerciseByKeyTrigger
+  Numeric:test
+  Retry:retryTrigger
+  ACS:test\
 "
 
 if [ "$OUTPUT" != "$EXPECTED" ]; then

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -34,3 +34,5 @@ HEAD — ongoing
 - [JSON API - Experimental] Implement replay on database consistency violation, See issue #3387.
 - [JSON API - Experimental] Comparison/range queries supported.
   See `issue #2780 <https://github.com/digital-asset/daml/issues/2780>`__.
+- [DAML Triggers] Fix a bug where the use of Numeric caused triggers
+  to crash with an assertion error.


### PR DESCRIPTION
Previously, we use SValue.fromValue for the conversion. However, this
breaks in cases like Numeric where the scale information is lost. By
using the ValueTranslator instead, we avoid this issue.

There is a similar problem in DAML script but I’ll fix that in a
separate PR.

Since the ValueTranslator is package private, this PR moves the
triggers in the engine package.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
