### PR TITLE
ledger-api-test-tool-on-canton: Upgrade Canton to v0.4.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -986,14 +986,14 @@ dev_env_tool(
 
 http_archive(
     name = "canton",
-    build_file_content = '''
+    build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "lib",
     jars = glob(["lib/**"]),
 )
-''',
+""",
     sha256 = "9d0e8fd49410bc7061bdf85a51d0becb46eb9cdaf3bf2162d06285f4861684df",
     strip_prefix = "canton-0.4.0",
     urls = ["https://github.com/digital-asset/canton/releases/download/v0.4.0/canton-0.4.0.tar.gz"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -990,7 +990,7 @@ http_archive(
 package(default_visibility = ["//visibility:public"])
 filegroup(name="jars", srcs=glob(["lib/**"]))
 ''',
-    sha256 = "b67215655bdcfaf0f4b271ebd3f9ce8f887c3c81a53351f47165a9bf5b93e435",
-    strip_prefix = "canton-0.3.0",
-    urls = ["https://github.com/digital-asset/canton/releases/download/v0.3.0/canton-0.3.0.tar.gz"],
+    sha256 = "9d0e8fd49410bc7061bdf85a51d0becb46eb9cdaf3bf2162d06285f4861684df",
+    strip_prefix = "canton-0.4.0",
+    urls = ["https://github.com/digital-asset/canton/releases/download/v0.4.0/canton-0.4.0.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -988,7 +988,11 @@ http_archive(
     name = "canton",
     build_file_content = '''
 package(default_visibility = ["//visibility:public"])
-filegroup(name="jars", srcs=glob(["lib/**"]))
+
+java_import(
+    name = "lib",
+    jars = glob(["lib/**"]),
+)
 ''',
     sha256 = "9d0e8fd49410bc7061bdf85a51d0becb46eb9cdaf3bf2162d06285f4861684df",
     strip_prefix = "canton-0.4.0",

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -4,15 +4,10 @@
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
 load("@os_info//:os_info.bzl", "is_windows")
 
-java_import(
-    name = "canton-lib",
-    jars = ["@canton//:jars"],
-)
-
 java_binary(
     name = "canton",
     main_class = "com.digitalasset.canton.CantonApp",
-    runtime_deps = [":canton-lib"],
+    runtime_deps = ["@canton//:lib"],
 )
 
 # Disabled on Windows because `coreutils` and `grpcurl` aren't easily available.


### PR DESCRIPTION
Tests still pass.

I also moved the `java_library` definition `ledger-api-test-tool-on-canton` to the import of Canton itself, because exposing the `filegroup` seems like it's too low level.

I tried to move the definition of the `java_binary`, but it made things break. Didn't dig into it too much.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
