### PR TITLE
Update rules_haskell

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -671,10 +671,6 @@ hazel_repositories(
                 "eb2c732b3d4ab5f7b367c51eef845e597ade19da52c03ee11954d35b6cfc4128",
                 patch_args = ["-p1"],
                 patches = ["@com_github_digital_asset_daml//3rdparty/haskell:bzlib-conduit.patch"],
-            ) + hazel_hackage(
-                "hpp",
-                "0.6.1",
-                "d1a843f4383223f85de4d91759545966f33a139d0019ab30a2f766bf9a7d62bf",
             ),
         pkgs = packages,
     ),

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -737,6 +737,46 @@ hazel_custom_package_github(
     repo_sha = GHCIDE_REV,
 )
 
+http_archive(
+    name = "hpp",
+    build_file_content = """
+load("@rules_haskell//haskell:cabal.bzl", "haskell_cabal_binary")
+haskell_cabal_binary(
+    name = "hpp",
+    srcs = glob(["**"]),
+    deps = [
+        "@stackage//:base",
+        "@stackage//:directory",
+        "@stackage//:filepath",
+        "@stackage//:hpp",
+        "@stackage//:time",
+    ],
+    visibility = ["//visibility:public"],
+)
+    """,
+    sha256 = "d1a843f4383223f85de4d91759545966f33a139d0019ab30a2f766bf9a7d62bf",
+    strip_prefix = "hpp-0.6.1",
+    urls = ["http://hackage.haskell.org/package/hpp-0.6.1/hpp-0.6.1.tar.gz"],
+)
+
+load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
+
+stack_snapshot(
+    name = "stackage",
+    flags = {
+        "hashable": ["-integer-gmp"],
+        "text": ["integer-simple"],
+    } if not is_windows else {},
+    local_snapshot = "//:stack-snapshot.yaml",
+    packages = [
+        "base",
+        "directory",
+        "filepath",
+        "hpp",
+        "time",
+    ],
+)
+
 load("//bazel_tools:java.bzl", "java_home_runtime")
 
 java_home_runtime(name = "java_home")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,11 @@ ghc_dwarf(name = "ghc_dwarf")
 
 load("@ghc_dwarf//:ghc_dwarf.bzl", "enable_ghc_dwarf")
 
+# Configure msys2 POSIX toolchain provided by dadew.
+load("//bazel_tools/dev_env_tool:dev_env_tool.bzl", "dadew_sh_posix_configure")
+
+dadew_sh_posix_configure() if is_windows else None
+
 nixpkgs_local_repository(
     name = "nixpkgs",
     nix_file = "//nix:nixpkgs.nix",

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -173,7 +173,7 @@ toolchain(
 )
 """.format(
         commands = ",\n    ".join([
-            '{cmd} = r"{path}"'.format(cmd = cmd, path = cmd_path)
+            '{cmd} = r"{path}"'.format(cmd = cmd, path = cmd_path).replace("\\", "/")
             for (cmd, cmd_path) in commands.items()
             if cmd_path
         ]),

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
+load("@rules_sh//sh:posix.bzl", "posix")
 
 def _create_build_content(rule_name, tools, win_paths, nix_paths):
     content = """
@@ -140,3 +141,50 @@ dev_env_tool = repository_rule(
     configure = True,
     local = True,
 )
+
+def _dadew_sh_posix_config_impl(repository_ctx):
+    ps = repository_ctx.which("powershell")
+    dadew = _dadew_where(repository_ctx, ps)
+    msys2_usr_bin = _dadew_tool_home(dadew, "msys2") + "\\usr\\bin"
+    commands = {}
+    for cmd in posix.commands:
+        for ext in [".exe", ""]:
+            path = "%s\\%s%s" % (msys2_usr_bin, cmd, ext)
+            if repository_ctx.path(path).exists:
+                commands[cmd] = path
+    repository_ctx.file("BUILD.bazel", executable = False, content = """
+load("@rules_sh//sh:posix.bzl", "sh_posix_toolchain")
+sh_posix_toolchain(
+    name = "dadew_posix",
+    {commands}
+)
+toolchain(
+    name = "dadew_posix_toolchain",
+    toolchain = "dadew_posix",
+    toolchain_type = "@rules_sh//sh/posix:toolchain_type",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+)
+""".format(
+        commands = ",\n    ".join([
+            '{cmd} = r"{path}"'.format(cmd = cmd, path = cmd_path)
+            for (cmd, cmd_path) in commands.items()
+            if cmd_path
+        ]),
+    ))
+
+_dadew_sh_posix_config = repository_rule(
+    implementation = _dadew_sh_posix_config_impl,
+    configure = True,
+    local = True,
+)
+
+def dadew_sh_posix_configure(name = "dadew_sh_posix"):
+    _dadew_sh_posix_config(name = name)
+    native.register_toolchains("@%s//:dadew_posix_toolchain" % name)

--- a/bazel_tools/haskell-cabal-wrapper.patch
+++ b/bazel_tools/haskell-cabal-wrapper.patch
@@ -1,0 +1,28 @@
+Adding include paths to the GHC bindist upsets the Windows builds. GHC starts
+looking for ghcversion.h under too long paths and fails due to not finding it.
+diff --git a/haskell/cabal.bzl b/haskell/cabal.bzl
+index b2cc1e27..a48572ab 100644
+--- a/haskell/cabal.bzl
++++ b/haskell/cabal.bzl
+@@ -88,6 +88,12 @@ def _cabal_tool_flag(tool):
+ def _binary_paths(binaries):
+     return [binary.dirname for binary in binaries.to_list()]
+ 
++def _skip_ghc_bindist(path):
++    if path.find("rules_haskell_ghc_windows_amd64") != -1:
++        return None
++    else:
++        return path
++
+ def _prepare_cabal_inputs(hs, cc, posix, dep_info, cc_info, component, package_id, tool_inputs, tool_input_manifests, cabal, setup, srcs, flags, cabal_wrapper, package_database):
+     """Compute Cabal wrapper, arguments, inputs."""
+     with_profiling = is_profiling_enabled(hs)
+@@ -118,7 +124,7 @@ def _prepare_cabal_inputs(hs, cc, posix, dep_info, cc_info, component, package_i
+     args.add("--flags=" + " ".join(flags))
+     args.add("--")
+     args.add_all(package_databases, map_each = _dirname, format_each = "--package-db=%s")
+-    args.add_all(extra_include_dirs, format_each = "--extra-include-dirs=%s")
++    args.add_all(extra_include_dirs, map_each = _skip_ghc_bindist, format_each = "--extra-include-dirs=%s")
+     args.add_all(extra_lib_dirs, format_each = "--extra-lib-dirs=%s", uniquify = True)
+     if with_profiling:
+         args.add("--enable-profiling")

--- a/bazel_tools/haskell-ghci-grpc.patch
+++ b/bazel_tools/haskell-ghci-grpc.patch
@@ -65,7 +65,7 @@ index c0645cfa..a88bf2d0 100644
          static_lib = mangle_static_library(hs, posix, dynamic_lib, static_lib, fixed_lib_dir)
  
 +        if hs.toolchain.is_darwin and fixup_dir == "_ghci_libs" and dynamic_lib and get_lib_name(dynamic_lib) == "fat_cbits":
-+            dynamic_libs.append(symlink_dynamic_library(hs, dynamic_lib, fixup_dir))
++            dynamic_libs.append(symlink_dynamic_library(hs, posix, dynamic_lib, fixup_dir))
 +            continue
 +
          if static_lib and not (dynamic and dynamic_lib):

--- a/bazel_tools/haskell-ghci-grpc.patch
+++ b/bazel_tools/haskell-ghci-grpc.patch
@@ -1,13 +1,13 @@
 On MacOS GHCi fails to load grpc fat_cbits statically due to duplicate symbols.
 diff --git a/haskell/private/path_utils.bzl b/haskell/private/path_utils.bzl
-index 3956164a..037cc95a 100644
+index 7b6f3268..5ea67bf7 100644
 --- a/haskell/private/path_utils.bzl
 +++ b/haskell/private/path_utils.bzl
 @@ -135,6 +135,44 @@ def make_library_path(hs, libs, prefix = None):
  
      return join_path_list(hs, set.to_list(r))
  
-+def symlink_dynamic_library(hs, lib, outdir):
++def symlink_dynamic_library(hs, posix, lib, outdir):
 +    """Create a symbolic link for a dynamic library and fix the extension.
 +
 +    This function is used for two reasons:
@@ -42,14 +42,14 @@ index 3956164a..037cc95a 100644
 +    link = hs.actions.declare_file(
 +        paths.join(outdir, "lib" + get_lib_name(lib) + "." + extension),
 +    )
-+    ln(hs, lib, link)
++    ln(hs, posix, lib, link)
 +    return link
 +
- def mangle_static_library(hs, dynamic_lib, static_lib, outdir):
+ def mangle_static_library(hs, posix, dynamic_lib, static_lib, outdir):
      """Mangle a static library to match a dynamic library name.
  
 diff --git a/haskell/providers.bzl b/haskell/providers.bzl
-index 597e2c06..8549aed0 100644
+index c0645cfa..a88bf2d0 100644
 --- a/haskell/providers.bzl
 +++ b/haskell/providers.bzl
 @@ -14,6 +14,7 @@ load(
@@ -60,9 +60,9 @@ index 597e2c06..8549aed0 100644
      "target_unique_name",
  )
  
-@@ -275,6 +276,10 @@ def get_extra_libs(hs, cc_info, dynamic = False, pic = None, fixup_dir = "_libs"
+@@ -276,6 +277,10 @@ def get_extra_libs(hs, posix, cc_info, dynamic = False, pic = None, fixup_dir =
  
-         static_lib = mangle_static_library(hs, dynamic_lib, static_lib, fixed_lib_dir)
+         static_lib = mangle_static_library(hs, posix, dynamic_lib, static_lib, fixed_lib_dir)
  
 +        if hs.toolchain.is_darwin and fixup_dir == "_ghci_libs" and dynamic_lib and get_lib_name(dynamic_lib) == "fat_cbits":
 +            dynamic_libs.append(symlink_dynamic_library(hs, dynamic_lib, fixup_dir))

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -215,12 +215,12 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-prim \
             --format=Json \
-            --cpp $(location @haskell_hpp//:bin) \
+            --cpp $(location @hpp//:hpp) \
             $(locations //compiler/damlc/daml-prim-src)
     """,
     tools = [
         "//compiler/damlc",
-        "@haskell_hpp//:bin",
+        "@hpp",
     ],
     visibility = ["//visibility:public"],
 )
@@ -234,12 +234,12 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-stdlib \
             --format=Json \
-            --cpp $(location @haskell_hpp//:bin) \
+            --cpp $(location @hpp//:hpp) \
             $(locations //compiler/damlc/daml-stdlib-src)
     """,
     tools = [
         "//compiler/damlc",
-        "@haskell_hpp//:bin",
+        "@hpp",
     ],
     visibility = ["//visibility:public"],
 )

--- a/compiler/damlc/pkg-db/util.bzl
+++ b/compiler/damlc/pkg-db/util.bzl
@@ -172,7 +172,7 @@ daml_package_rule = rule(
             cfg = "host",
         ),
         "cpp": attr.label(
-            default = Label("@haskell_hpp//:bin"),
+            default = Label("@hpp//:hpp"),
             executable = True,
             cfg = "host",
         ),

--- a/deps.bzl
+++ b/deps.bzl
@@ -55,6 +55,9 @@ def daml_deps():
                 # This should be made configurable in rules_haskell.
                 # Remove this patch once that's available.
                 "@com_github_digital_asset_daml//bazel_tools:haskell-opt.patch",
+                # This should be fixed in rules_haskell.
+                # Remove this patch once that's available.
+                "@com_github_digital_asset_daml//bazel_tools:haskell-cabal-wrapper.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,

--- a/deps.bzl
+++ b/deps.bzl
@@ -30,9 +30,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 rules_scala_version = "0f89c210ade8f4320017daf718a61de3c1ac4773"
-rules_haskell_version = "f1323829e7e7cc1ea71013efe22466a6298a59b2"
-rules_haskell_sha256 = "addd6b4d8d63fd5c3ed1a4a2a72f071397203474dbb9a9fe0487c917ac219d55"
-rules_nixpkgs_version = "a169f54bfc48ad3ade9f46acac9fae7d493ad94b"
+rules_haskell_version = "b8f4b6d8f3847edbcfd122f633e3a90e7ec9349d"
+rules_haskell_sha256 = "6fe07580b3235d3abc7393b352d27b85919c66e4fe4deea920785ac5aee1fb6c"
+rules_nixpkgs_version = "33c50ba64c11dddb95823d12f6b1324083cc5c43"
+rules_nixpkgs_sha256 = "91fedd5151bbd9ef89efc39e2172921bd7036c68cff54712a5df8ddf62bd6922"
 
 def daml_deps():
     if "rules_haskell" not in native.existing_rules():
@@ -64,7 +65,7 @@ def daml_deps():
             name = "io_tweag_rules_nixpkgs",
             strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
-            sha256 = "fab1bb801ac5dcfa364e51b5bd825c809d6767f6bab6c48605d4348bba0fa4f4",
+            sha256 = rules_nixpkgs_sha256,
         )
 
     if "ai_formation_hazel" not in native.existing_rules():

--- a/deps.bzl
+++ b/deps.bzl
@@ -30,8 +30,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 rules_scala_version = "0f89c210ade8f4320017daf718a61de3c1ac4773"
-rules_haskell_version = "b8f4b6d8f3847edbcfd122f633e3a90e7ec9349d"
-rules_haskell_sha256 = "6fe07580b3235d3abc7393b352d27b85919c66e4fe4deea920785ac5aee1fb6c"
+rules_haskell_version = "c53f7cc0fa11eb8f8107cf7cd977a6835b9f9ad6"
+rules_haskell_sha256 = "d5d8361a1a5a67cf24f7f44035e8120a7993089bc8c05b2415cc0ecf16884a73"
 rules_nixpkgs_version = "33c50ba64c11dddb95823d12f6b1324083cc5c43"
 rules_nixpkgs_sha256 = "91fedd5151bbd9ef89efc39e2172921bd7036c68cff54712a5df8ddf62bd6922"
 

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -153,9 +153,9 @@ def _daml_doctest_impl(ctx):
       $DAMLC doctest {flags} --cpp $CPP --package-name {package_name}-`cat $(rlocation $TEST_WORKSPACE/{version_file})` $(rlocations "{files}")
     """.format(
         damlc = ctx.executable.damlc.short_path,
-        # we end up with "../haskell_hpp/bin" while we want "external/haskell_hpp/bin"
+        # we end up with "../hpp/hpp" while we want "external/hpp/hpp"
         # so we just do the replacement ourselves.
-        cpp = ctx.executable.cpp.short_path.replace("..", "external", 1),
+        cpp = ctx.executable.cpp.short_path.replace("..", "external"),
         package_name = ctx.attr.package_name,
         flags = " ".join(ctx.attr.flags),
         version_file = ctx.file.version.path,
@@ -199,7 +199,7 @@ daml_doc_test = rule(
             executable = True,
             cfg = "host",
             allow_files = True,
-            default = Label("@haskell_hpp//:bin"),
+            default = Label("@hpp//:hpp"),
         ),
         "flags": attr.string_list(
             default = [],

--- a/stack-snapshot.yaml
+++ b/stack-snapshot.yaml
@@ -1,0 +1,6 @@
+resolver: lts-14.1
+packages:
+  - hpp-0.6.1
+  # Core packages, need to be listed for integer-simple flags.
+  - integer-simple-0.1.1.1
+  - text-1.2.3.1


### PR DESCRIPTION
- Updates rules_haskell
  Now supports `rules_sh` POSIX toolchain to manage Unix shell commands.
  Allows to avoid `use_default_shell_env` to improve hermeticity and caching.
- Defines a Windows POSIX toolchain using dadew
- Replace `hpp` by a `stack_snapshot` provided version.
  This is to ensure that the POSIX toolchain, which is used by `haskell_cabal_library`, is working.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
