### PR TITLE
Choice instances for cross sdk

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -324,7 +324,6 @@ generateChoiceInstance env externPkgId template choice =
             , cid_overlap_mode = Nothing
             }
   where
-
     app :: LHsType GhcPs -> LHsType GhcPs -> LHsType GhcPs
     app t1 t2 = noLoc $ HsAppTy noExt t1 t2
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -158,15 +158,11 @@ choiceInstances env externPkgId =
     [ generateChoiceInstance env externPkgId templateDT choice
     | template <- NM.elems $ LF.moduleTemplates mod
     , choice <- NM.elems $ LF.tplChoices template
-    , not (specialArchiveChoice choice)
     , Just templateDT <-
       [NM.lookup (LF.tplTypeCon template) (LF.moduleDataTypes mod)]
     ]
   where
     mod = envMod env
-    specialArchiveChoice = \case
-      LF.TemplateChoice{chcName=LF.ChoiceName "Archive"} -> True
-      _ -> False
 
 generateGenInstancesPkgFromLf ::
        (LF.PackageRef -> UnitId)

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -112,8 +112,7 @@ generateTemplateInstanceModule env externPkgId
               map (showSDocForUser fakeDynFlags alwaysQualify . ppr) instances)
     | otherwise = Nothing
   where
-    instances = templInstances
-    templInstances = templateInstances env externPkgId
+    instances = templateInstances env externPkgId ++ choiceInstances env externPkgId
 
     mod = envMod env
     unitIdStr = unitIdString $ envGetUnitId env LF.PRSelf
@@ -138,6 +137,8 @@ generateTemplateInstanceModule env externPkgId
           modName <>
           " as X"
         , "import \"" <> packageName <> "\" " <> modName
+        , "import qualified Sdk.DA.Internal.LF"
+        , "import qualified Sdk.DA.Internal.Prelude"
         , "import qualified Sdk.DA.Internal.Template"
         , "import qualified GHC.Types"
         ]
@@ -151,6 +152,21 @@ templateInstances env externPkgId =
     ]
   where
     mod = envMod env
+
+choiceInstances :: Env -> LF.PackageId -> [HsDecl GhcPs]
+choiceInstances env externPkgId =
+    [ generateChoiceInstance env externPkgId templateDT choice
+    | template <- NM.elems $ LF.moduleTemplates mod
+    , choice <- NM.elems $ LF.tplChoices template
+    , not (specialArchiveChoice choice)
+    , Just templateDT <-
+      [NM.lookup (LF.tplTypeCon template) (LF.moduleDataTypes mod)]
+    ]
+  where
+    mod = envMod env
+    specialArchiveChoice = \case
+      LF.TemplateChoice{chcName=LF.ChoiceName "Archive"} -> True
+      _ -> False
 
 generateGenInstancesPkgFromLf ::
        (LF.PackageRef -> UnitId)
@@ -234,7 +250,7 @@ generateTemplateInstance ::
     -> [(LF.TypeVarName, LF.Kind)]
     -> LF.PackageId
     -> HsDecl GhcPs
-generateTemplateInstance env typeCon typeParams externPkgId =
+generateTemplateInstance env dataTypeCon dataParams externPkgId =
     InstD noExt $
     ClsInstD
         noExt
@@ -247,9 +263,9 @@ generateTemplateInstance env typeCon typeParams externPkgId =
                             noLoc $
                             HsAppTy noExt templateTy $
                             noLoc $
-                            convType env $ lfTemplateType typeCon typeParams
+                            convType env lfTemplateType
                       }
-            , cid_binds = listToBag $ map (classMethodStub typeCon) templateMethodNames
+            , cid_binds = listToBag $ map classMethodStub methodMapping
             , cid_sigs = []
             , cid_tyfam_insts = []
             , cid_datafam_insts = []
@@ -267,11 +283,19 @@ generateTemplateInstance env typeCon typeParams externPkgId =
         noLoc $
         mkRdrQual (mkModuleName "Sdk.DA.Internal.Template") $
         mkOccName varName "Template" :: LHsType GhcPs
-    lfTemplateType dataTypeCon dataParams =
+    lfTemplateType =
         LF.mkTApps
             (LF.TCon (LF.Qualified LF.PRSelf moduleName0 dataTypeCon))
             (map (LF.TVar . fst) dataParams)
-    templateMethodNames =
+    methodMapping =
+        map (\funName -> (funName, mkExternalString funName)) methodNames
+    mkExternalString :: T.Text -> String
+    mkExternalString funName =
+        (T.unpack $ LF.unPackageId externPkgId) <>
+        ":" <> moduleNameStr <>
+        ":" <> (T.unpack $ T.intercalate "." $ LF.unTypeConName dataTypeCon) <>
+        ":" <> T.unpack funName
+    methodNames =
         [ "signatory"
         , "observer"
         , "agreement"
@@ -283,86 +307,156 @@ generateTemplateInstance env typeCon typeParams externPkgId =
         , "fromAnyTemplate"
         , "_templateTypeRep"
         ]
-    classMethodStub :: LF.TypeConName -> T.Text -> LHsBindLR GhcPs GhcPs
-    classMethodStub templName funName =
-        noLoc $
-        FunBind
-            { fun_ext = noExt
-            , fun_id = mkRdrName funName
-            , fun_matches =
-                  MG
-                      { mg_ext = noExt
-                      , mg_alts =
-                            noLoc
-                                [ noLoc $
-                                  Match
-                                      { m_ext = noExt
-                                      , m_ctxt =
-                                            FunRhs
-                                                { mc_fun = mkRdrName funName
-                                                , mc_fixity = Prefix
-                                                , mc_strictness = NoSrcStrict
-                                                }
-                                      , m_pats =
-                                            [ noLoc $
-                                            VarPat noExt (mkRdrName "proxy")
-                                            | funName == "_templateTypeRep"
-                                            ] -- NOTE (drsk): we shouldn't need this pattern, but
-                                              -- somehow ghc insists on it. We want to fix this in ghc.
-                                      , m_rhs_sig = Nothing
-                                      , m_grhss =
-                                            GRHSs
-                                                { grhssExt = noExt
-                                                , grhssGRHSs =
-                                                      [ noLoc $
-                                                        GRHS
-                                                            noExt
-                                                            []
-                                                            (noLoc $
-                                                             HsAppType
-                                                                 noExt
-                                                                 (noLoc $
-                                                                  HsVar
-                                                                      noExt
-                                                                      (noLoc $
-                                                                       mkRdrQual
-                                                                           (mkModuleName
-                                                                                "GHC.Types")
-                                                                           (mkOccName
-                                                                                varName
-                                                                                "external")))
-                                                                 (HsWC
-                                                                      noExt
-                                                                      (noLoc $
-                                                                       HsTyLit noExt $
-                                                                       HsStrTy
-                                                                           NoSourceText $
-                                                                       mkFastString
-                                                                           ((T.unpack $
-                                                                             LF.unPackageId
-                                                                                 externPkgId) <>
-                                                                            ":" <>
-                                                                            moduleNameStr <>
-                                                                            ":" <>
-                                                                            (T.unpack $
-                                                                             T.intercalate
-                                                                                 "." $
-                                                                             LF.unTypeConName
-                                                                                 templName) <>
-                                                                            ":" <>
-                                                                            T.unpack
-                                                                                funName))))
-                                                      ]
-                                                , grhssLocalBinds =
-                                                      noLoc emptyLocalBinds
-                                                }
-                                      }
-                                ]
-                      , mg_origin = Generated
+
+-- | Generate a single choice instance for a given templateDT/choice
+generateChoiceInstance ::
+       Env
+    -> LF.PackageId
+    -> LF.DefDataType
+    -> LF.TemplateChoice
+    -> HsDecl GhcPs
+generateChoiceInstance env externPkgId templateDT choice =
+    InstD noExt $
+    ClsInstD
+        noExt
+        ClsInstDecl
+            { cid_ext = noExt
+            , cid_poly_ty =
+                  HsIB
+                      { hsib_ext = noExt
+                      , hsib_body = body
                       }
-            , fun_co_fn = WpHole
-            , fun_tick = []
+            , cid_binds = listToBag $ map classMethodStub methodMapping
+            , cid_sigs = []
+            , cid_tyfam_insts = []
+            , cid_datafam_insts = []
+            , cid_overlap_mode = Nothing
             }
+  where
+
+    app :: LHsType GhcPs -> LHsType GhcPs -> LHsType GhcPs
+    app t1 t2 = noLoc $ HsAppTy noExt t1 t2
+
+    body :: LHsType GhcPs =
+      choiceClass `app` arg1 `app` arg2 `app` arg3
+
+    choiceClass :: LHsType GhcPs =
+        noLoc $
+        HsTyVar noExt NotPromoted $
+        noLoc $
+        mkRdrQual (mkModuleName "DA.Internal.Template") $
+        mkOccName varName "Choice" :: LHsType GhcPs
+
+    arg1 :: LHsType GhcPs =
+      noLoc $ convType env lfTemplateType
+
+    arg2 :: LHsType GhcPs =
+      noLoc $ convType env lfChoiceType
+
+    arg3 :: LHsType GhcPs =
+      noLoc $ convType env lfChoiceReturnType
+
+    moduleNameStr = T.unpack $ LF.moduleNameString $ LF.moduleName $ envMod env
+    moduleName0 =
+        LF.ModuleName $
+        map T.pack $
+        splitOn "." moduleNameStr
+
+    lfTemplateType :: LF.Type =
+        LF.mkTApps
+          (LF.TCon (LF.Qualified LF.PRSelf moduleName0 dataTypeCon))
+          (map (LF.TVar . fst) dataParams)
+
+    lfChoiceType :: LF.Type =
+        LF.TCon (LF.Qualified LF.PRSelf moduleName0
+                  (LF.TypeConName{unTypeConName=[LF.unChoiceName chcName]}))
+
+    LF.DefDataType{dataTypeCon,dataParams} = templateDT
+    LF.TemplateChoice{chcName,chcReturnType=lfChoiceReturnType} = choice
+
+    methodMapping =
+      map (\funName -> (funName, mkExternalString funName)) methodNames
+
+    mkExternalString :: T.Text -> String
+    mkExternalString funName =
+      (T.unpack $ LF.unPackageId externPkgId) <>
+      ":" <> moduleNameStr <>
+      ":" <> (T.unpack $ T.intercalate "." $ LF.unTypeConName dataTypeCon) <>
+      ":" <> (T.unpack $ LF.unChoiceName chcName) <>
+      ":" <> T.unpack funName
+
+    methodNames =
+        [ "exercise"
+        , "_toAnyChoice"
+        , "_fromAnyChoice"
+        ]
+
+classMethodStub :: (T.Text,String) -> LHsBindLR GhcPs GhcPs
+classMethodStub (funName,xString) =
+    noLoc $
+    FunBind
+        { fun_ext = noExt
+        , fun_id = mkRdrName funName
+        , fun_matches =
+              MG
+                  { mg_ext = noExt
+                  , mg_alts =
+                        noLoc
+                            [ noLoc $
+                              Match
+                                  { m_ext = noExt
+                                  , m_ctxt =
+                                        FunRhs
+                                            { mc_fun = mkRdrName funName
+                                            , mc_fixity = Prefix
+                                            , mc_strictness = NoSrcStrict
+                                            }
+                                  , m_pats =
+                                        [ noLoc $
+                                        VarPat noExt (mkRdrName "proxy")
+                                        | funName == "_templateTypeRep"
+                                        ] -- NOTE (drsk): we shouldn't need this pattern, but
+                                          -- somehow ghc insists on it. We want to fix this in ghc.
+                                  , m_rhs_sig = Nothing
+                                  , m_grhss =
+                                        GRHSs
+                                            { grhssExt = noExt
+                                            , grhssGRHSs =
+                                                  [ noLoc $
+                                                    GRHS
+                                                        noExt
+                                                        []
+                                                        (noLoc $
+                                                         HsAppType
+                                                             noExt
+                                                             (noLoc $
+                                                              HsVar
+                                                                  noExt
+                                                                  (noLoc $
+                                                                   mkRdrQual
+                                                                       (mkModuleName
+                                                                            "GHC.Types")
+                                                                       (mkOccName
+                                                                            varName
+                                                                            "external")))
+                                                             (HsWC
+                                                                  noExt
+                                                                  (noLoc $
+                                                                   HsTyLit noExt $
+                                                                   HsStrTy
+                                                                       NoSourceText $
+                                                                   mkFastString xString)))
+                                                  ]
+                                            , grhssLocalBinds =
+                                                  noLoc emptyLocalBinds
+                                            }
+                                  }
+                            ]
+                  , mg_origin = Generated
+                  }
+        , fun_co_fn = WpHole
+        , fun_tick = []
+        }
 
 -- | Generate the full source for a daml-lf package.
 generateSrcPkgFromLf ::

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -244,7 +244,7 @@ generateTemplateInstance ::
     -> [(LF.TypeVarName, LF.Kind)]
     -> LF.PackageId
     -> HsDecl GhcPs
-generateTemplateInstance env dataTypeCon dataParams externPkgId =
+generateTemplateInstance env typeCon typeParams externPkgId =
     InstD noExt $
     ClsInstD
         noExt
@@ -279,15 +279,15 @@ generateTemplateInstance env dataTypeCon dataParams externPkgId =
         mkOccName varName "Template" :: LHsType GhcPs
     lfTemplateType =
         LF.mkTApps
-            (LF.TCon (LF.Qualified LF.PRSelf moduleName0 dataTypeCon))
-            (map (LF.TVar . fst) dataParams)
+            (LF.TCon (LF.Qualified LF.PRSelf moduleName0 typeCon))
+            (map (LF.TVar . fst) typeParams)
     methodMapping =
         map (\funName -> (funName, mkExternalString funName)) methodNames
     mkExternalString :: T.Text -> String
     mkExternalString funName =
         (T.unpack $ LF.unPackageId externPkgId) <>
         ":" <> moduleNameStr <>
-        ":" <> (T.unpack $ T.intercalate "." $ LF.unTypeConName dataTypeCon) <>
+        ":" <> (T.unpack $ T.intercalate "." $ LF.unTypeConName typeCon) <>
         ":" <> T.unpack funName
     methodNames =
         [ "signatory"

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -137,8 +137,8 @@ generateTemplateInstanceModule env externPkgId
           modName <>
           " as X"
         , "import \"" <> packageName <> "\" " <> modName
-        , "import qualified Sdk.DA.Internal.LF"
-        , "import qualified Sdk.DA.Internal.Prelude"
+        , "import qualified DA.Internal.LF"
+        , "import qualified DA.Internal.Prelude"
         , "import qualified Sdk.DA.Internal.Template"
         , "import qualified GHC.Types"
         ]
@@ -327,7 +327,7 @@ generateChoiceInstance env externPkgId template choice =
         noLoc $
         HsTyVar noExt NotPromoted $
         noLoc $
-        mkRdrQual (mkModuleName "DA.Internal.Template") $
+        mkRdrQual (mkModuleName "Sdk.DA.Internal.Template") $
         mkOccName varName "Choice" :: LHsType GhcPs
 
     arg1 :: LHsType GhcPs =

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -267,10 +267,7 @@ generateTemplateInstance env typeCon typeParams externPkgId =
             }
   where
     moduleNameStr = T.unpack $ LF.moduleNameString $ LF.moduleName $ envMod env
-    moduleName0 =
-        LF.ModuleName $
-        map T.pack $
-        splitOn "." moduleNameStr
+    moduleName0 = LF.moduleName $ envMod env
     templateTy =
         noLoc $
         HsTyVar noExt NotPromoted $
@@ -351,10 +348,7 @@ generateChoiceInstance env externPkgId template choice =
       noLoc $ convType env lfChoiceReturnType
 
     moduleNameStr = T.unpack $ LF.moduleNameString $ LF.moduleName $ envMod env
-    moduleName0 =
-        LF.ModuleName $
-        map T.pack $
-        splitOn "." moduleNameStr
+    moduleName0 = LF.moduleName $ envMod env
 
     lfTemplateType :: LF.Type =
         LF.mkTApps

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -363,12 +363,8 @@ generateChoiceInstance env externPkgId templateDT choice =
           (LF.TCon (LF.Qualified LF.PRSelf moduleName0 dataTypeCon))
           (map (LF.TVar . fst) dataParams)
 
-    lfChoiceType :: LF.Type =
-        LF.TCon (LF.Qualified LF.PRSelf moduleName0
-                  (LF.TypeConName{unTypeConName=[LF.unChoiceName chcName]}))
-
     LF.DefDataType{dataTypeCon,dataParams} = templateDT
-    LF.TemplateChoice{chcName,chcReturnType=lfChoiceReturnType} = choice
+    LF.TemplateChoice{chcArgBinder=(_,lfChoiceType),chcName,chcReturnType=lfChoiceReturnType} = choice
 
     methodMapping =
       map (\funName -> (funName, mkExternalString funName)) methodNames

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -354,13 +354,18 @@ generateChoiceInstance env externPkgId template choice =
           (LF.TCon (LF.Qualified LF.PRSelf moduleName0 dataTypeCon))
           (map (LF.TVar . fst) dataParams)
 
-    tycon :: LF.TypeConName = LF.tplTypeCon template
+    tycon :: LF.TypeConName =
+      LF.tplTypeCon template
+
     templateDT = case NM.lookup tycon (LF.moduleDataTypes (envMod env)) of
       Just x -> x
       Nothing -> error $ "Internal error: Could not find template definition for: " <> show tycon
 
     LF.DefDataType{dataTypeCon,dataParams} = templateDT
-    LF.TemplateChoice{chcArgBinder=(_,lfChoiceType),chcName,chcReturnType=lfChoiceReturnType} = choice
+    LF.TemplateChoice { chcArgBinder = (_, lfChoiceType)
+                      , chcName
+                      , chcReturnType = lfChoiceReturnType
+                      } = choice
 
     methodMapping =
       map (\funName -> (funName, mkExternalString funName)) methodNames
@@ -379,8 +384,8 @@ generateChoiceInstance env externPkgId template choice =
         , "_fromAnyChoice"
         ]
 
-classMethodStub :: (T.Text,String) -> LHsBindLR GhcPs GhcPs
-classMethodStub (funName,xString) =
+classMethodStub :: (T.Text, String) -> LHsBindLR GhcPs GhcPs
+classMethodStub (funName, xString) =
     noLoc $
     FunBind
         { fun_ext = noExt

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -139,6 +139,7 @@ generateTemplateInstanceModule env externPkgId
         , "import \"" <> packageName <> "\" " <> modName
         , "import qualified DA.Internal.LF"
         , "import qualified DA.Internal.Prelude"
+        , "import qualified DA.Internal.Template"
         , "import qualified Sdk.DA.Internal.Template"
         , "import qualified GHC.Types"
         ]

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -266,7 +266,7 @@ generateTemplateInstance env typeCon typeParams externPkgId =
             , cid_overlap_mode = Nothing
             }
   where
-    moduleNameStr = T.unpack $ LF.moduleNameString $ moduleName0
+    moduleNameStr = T.unpack $ LF.moduleNameString moduleName0
     moduleName0 = LF.moduleName $ envMod env
     templateTy =
         noLoc $
@@ -339,7 +339,7 @@ generateChoiceInstance env externPkgId template choice =
     arg3 :: LHsType GhcPs =
       noLoc $ convType env lfChoiceReturnType
 
-    moduleNameStr = T.unpack $ LF.moduleNameString $ moduleName0
+    moduleNameStr = T.unpack $ LF.moduleNameString moduleName0
     moduleName0 = LF.moduleName $ envMod env
     lfTemplateType = mkLfTemplateType moduleName0 dataTypeCon dataParams
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1668,11 +1668,11 @@ convertExternal env stdlibRef primId lfType
         let mod = ModuleName $ map T.pack $ splitOn "." modStr
         let qualify tconName = Qualified { qualPackage = pkgRef , qualModule = mod , qualObject = tconName}
         let templateDataType = TCon . qualify
-        let (choiceArg, choiceArgType) = chcArgBinder
+        let (choiceArg, _) = chcArgBinder
         case method of
           "exercise" -> do
             ETmLam (chcSelfBinder, TApp (TBuiltin BTContractId) (templateDataType tplTypeCon)) $
-              ETmLam (choiceArg, choiceArgType) $
+              ETmLam chcArgBinder $
                 EUpdate $ UExercise (qualify tplTypeCon) choice (EVar chcSelfBinder) Nothing (EVar choiceArg)
           "_toAnyChoice" ->
             -- TODO: envLfVersion env `supports` featureAnyType

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -47,6 +47,13 @@ main = do
             , dataTypeCon = TypeConName ["Choice"]
             , dataSerializable = IsSerializable True
             , dataParams = []
+            , dataCons = DataVariant [(VariantConName "Choice", TUnit)]
+            }
+    let chcArg2 = DefDataType
+            { dataLocation = Nothing
+            , dataTypeCon = TypeConName ["Choice2"]
+            , dataSerializable = IsSerializable True
+            , dataParams = []
             , dataCons = DataRecord [ (FieldName "choiceArg", TUnit) ]
             }
     let emptyRec = DefDataType
@@ -63,6 +70,16 @@ main = do
             , chcControllers = tplParties
             , chcSelfBinder = ExprVarName "this"
             , chcArgBinder = (ExprVarName "self", TCon (modRef (dataTypeCon chcArg)))
+            , chcReturnType = TUnit
+            , chcUpdate = EUpdate $ UPure TUnit EUnit
+            }
+    let chc2 = TemplateChoice
+            { chcLocation = Nothing
+            , chcName = ChoiceName "Choice2"
+            , chcConsuming = True
+            , chcControllers = tplParties
+            , chcSelfBinder = ExprVarName "this"
+            , chcArgBinder = (ExprVarName "self", TCon (modRef (dataTypeCon chcArg2)))
             , chcReturnType = TUnit
             , chcUpdate = EUpdate $ UPure TUnit EUnit
             }
@@ -84,14 +101,14 @@ main = do
             , tplSignatories = tplParties
             , tplObservers = ENil TParty
             , tplAgreement = mkEmptyText
-            , tplChoices = NM.fromList ([chc] <> [arc | withArchiveChoice])
+            , tplChoices = NM.fromList ([chc,chc2] <> [arc | withArchiveChoice])
             , tplKey = Nothing
             }
     let mod = Module
             { moduleName = ModuleName ["Module"]
             , moduleSource = Nothing
             , moduleFeatureFlags = FeatureFlags{forbidPartyLiterals = True}
-            , moduleDataTypes = NM.fromList ([tplRec, chcArg] <> [emptyRec | withArchiveChoice])
+            , moduleDataTypes = NM.fromList ([tplRec, chcArg, chcArg2] <> [emptyRec | withArchiveChoice])
             , moduleValues = NM.empty
             , moduleTemplates = NM.fromList [tpl]
             }

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -47,7 +47,7 @@ main = do
             , dataTypeCon = TypeConName ["Choice"]
             , dataSerializable = IsSerializable True
             , dataParams = []
-            , dataCons = DataVariant [(VariantConName "Choice", TUnit)]
+            , dataCons = DataRecord [ (FieldName "choiceArg", TUnit) ]
             }
     let emptyRec = DefDataType
             { dataLocation = Nothing
@@ -58,7 +58,7 @@ main = do
             }
     let chc = TemplateChoice
             { chcLocation = Nothing
-            , chcName = ChoiceName "NotChoice"
+            , chcName = ChoiceName "Choice"
             , chcConsuming = True
             , chcControllers = tplParties
             , chcSelfBinder = ExprVarName "this"

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -58,7 +58,7 @@ main = do
             }
     let chc = TemplateChoice
             { chcLocation = Nothing
-            , chcName = ChoiceName "Choice"
+            , chcName = ChoiceName "NotChoice"
             , chcConsuming = True
             , chcControllers = tplParties
             , chcSelfBinder = ExprVarName "this"

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -329,7 +329,7 @@ dataDependencyTests damlc = testGroup "Data Dependencies" $
             , "  assert $ signatory t1 == [bob, bob]"
             , "  let anyTemplate = toAnyTemplate t1"
             , "  let (Some t2 : Optional Module.Template) = fromAnyTemplate anyTemplate"
-            , "  submit bob $ exercise coid1 Module.Choice with choiceArg = ()"
+            , "  submit bob $ exercise coid1 Module.Choice2 with choiceArg = ()"
             , "  pure ()"
             ]
         withCurrentDirectory projDir $

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -329,6 +329,7 @@ dataDependencyTests damlc = testGroup "Data Dependencies" $
             , "  assert $ signatory t1 == [bob, bob]"
             , "  let anyTemplate = toAnyTemplate t1"
             , "  let (Some t2 : Optional Module.Template) = fromAnyTemplate anyTemplate"
+            , "  submit bob $ exercise coid1 Module.Choice with choiceArg = ()"
             , "  pure ()"
             ]
         withCurrentDirectory projDir $


### PR DESCRIPTION

`Upgrade.hs`
- Generate instances for template choices
- generate new 5-element format for `external` strings

`LFConversion.hs`
- (aside: fix text in existing "is not supported" messages)
- support `external` strings: `[pkgId, modStr, templName, choiceName, method]`

`GenerateSimpleDalf.hs`
- fix generation of `Choice` to be well-formed:
    - (1) Name of choice matches name of datatype
    - (2) datatype is a record (not a variant!)

`IntegrationTests.hs`
- refactor to split `packagingTests` into `packagingTests` / `crossSdkTests` / `migrationTests`
- Extend `crossSdkTests` to test choice-exercise:
    `submit bob $ exercise coid1 Module.Choice with choiceArg`



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
