### PR TITLE
release instructions: add label to PR

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -87,6 +87,7 @@
    for all releases since the last public release, convert them to
    markdown and insert them in the textbox, then uncheck the `This is
    a pre-release` checkbox at the bottom.
+1. On the release PR, add the `Standard-Change` label.
 1. Leave a comment like "All manual tests have passed" on the release PR on
    GitHub.
 1. Finally, announce the release in the relevant Slack channels.


### PR DESCRIPTION
The Security team has requested that every PR that represents significant, risky or unusual change be labeled with the `Standard-Change` label (as opposed to other changes which are qualified as "routine changes" and do not need a specific label).

We have agreed to define "standard change" as any PR that either is a release PR or touches the `/infra` folder.