### PR TITLE
ledger-api-test-tool-on-canton: Disable tests unless run explicitly.

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -64,4 +64,5 @@ conformance_test(
         5021,
     ],
     server = ":canton-test-runner-with-dependencies",
+    tags = ["manual"],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool/conformance.bzl
+++ b/ledger/ledger-api-test-tool/conformance.bzl
@@ -7,7 +7,14 @@ load(
 )
 load("@os_info//:os_info.bzl", "is_windows")
 
-def conformance_test(name, server, server_args = [], extra_data = [], ports = [6865], test_tool_args = []):
+def conformance_test(
+        name,
+        server,
+        server_args = [],
+        extra_data = [],
+        ports = [6865],
+        test_tool_args = [],
+        tags = []):
     client_server_test(
         name = name,
         timeout = "long",
@@ -24,7 +31,7 @@ def conformance_test(name, server, server_args = [], extra_data = [], ports = [6
         tags = [
             "dont-run-on-darwin",
             "exclusive",
-        ],
+        ] + tags,
     ) if not is_windows else None
 
 def server_conformance_test(name, servers, server_args = [], test_tool_args = []):


### PR DESCRIPTION
They're flickering on CI, which is not helpful. Let's run them manually until we feel they're stable.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
