### PR TITLE
Map CommandIds in MTransaction

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -212,16 +212,16 @@ class Runner(
             // This happens for invalid UUIDs which we might get for completions not emitted by the trigger.
             case e: IllegalArgumentException => List()
           }
-        case msg @ TransactionMsg(t) =>
+        case TransactionMsg(t) =>
           try {
             commandIdMap.get(UUID.fromString(t.commandId)) match {
-              case None => List(msg)
+              case None => List(TransactionMsg(t.copy(commandId = "")))
               case Some(internalCommandId) =>
                 List(TransactionMsg(t.copy(commandId = internalCommandId)))
             }
           } catch {
             // This happens for invalid UUIDs which we might get for transactions not emitted by the trigger.
-            case e: IllegalArgumentException => List(msg)
+            case e: IllegalArgumentException => List(TransactionMsg(t.copy(commandId = "")))
           }
       })
       .toMat(Sink.fold[SExpr, TriggerMsg](SEValue(evaluatedInitialState))((state, message) => {

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -26,6 +26,7 @@ genrule(
       cp -L $(location :daml/Retry.daml) $$TMP_DIR/daml
       cp -L $(location :daml/ExerciseByKey.daml) $$TMP_DIR/daml
       cp -L $(location :daml/Numeric.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/CommandId.daml) $$TMP_DIR/daml
       cp -L $(location //docs:source/triggers/template-root/src/CopyTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml

--- a/triggers/tests/daml/CommandId.daml
+++ b/triggers/tests/daml/CommandId.daml
@@ -1,0 +1,25 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module CommandId where
+
+import Daml.Trigger.LowLevel
+
+test : Trigger [Text]
+test = Trigger
+  { initialState = \party _ ->
+      ([], [Commands (CommandId "mycreateid") [createCmd (T party)]])
+  , update = \msg s -> case (s, msg) of
+      (cmdIds, MTransaction (Transaction _ (Some (CommandId cmdId)) [CreatedEvent (fromCreated @T -> Some (_, cid, _))])) ->
+        (cmdId :: cmdIds, [Commands (CommandId "myexerciseid") [exerciseCmd cid Archive]])
+      (cmdIds, MTransaction (Transaction _ (Some (CommandId cmdId)) [ArchivedEvent (fromArchived @T -> Some _)])) ->
+        (cmdId :: cmdIds, [])
+      _ -> (s, [])
+  }
+
+template T
+  with
+    p : Party
+  where
+    signatory p

--- a/triggers/tests/daml/ExerciseByKey.daml
+++ b/triggers/tests/daml/ExerciseByKey.daml
@@ -24,7 +24,8 @@ retryRule party acs commandsInFlight allowedRetries
   | [] <- getContracts @T acs = do
     dedupCreate T { p = party }
   | ((_, T { p = party' } ) :: _) <- getContracts @T acs
-  , party == party' =
+  , [] <- getContracts @T_ acs
+  , party == party' = do
     dedupExerciseByKey @T party C
   | otherwise = pure ()
 
@@ -36,7 +37,7 @@ template T
     key p : Party
     maintainer key
 
-    choice C : ContractId T_
+    nonconsuming choice C : ContractId T_
       controller p
       do create T_ { p }
 

--- a/triggers/tests/list-triggers.sh
+++ b/triggers/tests/list-triggers.sh
@@ -29,6 +29,7 @@ TRIGGER_EXE=$(rlocation "$TEST_WORKSPACE/$1")
 DAR=$(rlocation "$TEST_WORKSPACE/$2")
 OUTPUT="$($TRIGGER_EXE list --dar $DAR | tail -n '+2' | tr -d '\r')"
 EXPECTED="\
+  CommandId:test
   CopyTrigger:copyTrigger
   ExerciseByKey:exerciseByKeyTrigger
   Numeric:test

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
@@ -670,7 +670,7 @@ case class ExerciseByKeyTests(dar: Dar[(PackageId, Package)], runner: TestRunner
       // 1 for exerciseByKey
       // 1 for corresponding completion
       NumMessages(4),
-      numT = 0,
+      numT = 1,
       numTPrime = 1,
     )
   }


### PR DESCRIPTION
Closes #3485

- Apply the trigger runner's CommandId mapping on transaction messages same as on completion messages.
- Adapt the `ExerciseByKey` test
- Add regression test for #3485 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
