### PR TITLE
language: make only needed packages visible for cross sdk imports

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -138,7 +138,7 @@ generateTemplateInstanceModule env externPkgId
           modName <>
           " as X"
         , "import \"" <> packageName <> "\" " <> modName
-        , "import qualified DA.Internal.Template"
+        , "import qualified DA.Internal.TemplateThisSdk"
         , "import qualified GHC.Types"
         ]
 
@@ -265,7 +265,7 @@ generateTemplateInstance env typeCon typeParams externPkgId =
         noLoc $
         HsTyVar noExt NotPromoted $
         noLoc $
-        mkRdrQual (mkModuleName "DA.Internal.Template") $
+        mkRdrQual (mkModuleName "DA.Internal.TemplateThisSdk") $
         mkOccName varName "Template" :: LHsType GhcPs
     lfTemplateType dataTypeCon dataParams =
         LF.mkTApps

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Upgrade.hs
@@ -138,7 +138,7 @@ generateTemplateInstanceModule env externPkgId
           modName <>
           " as X"
         , "import \"" <> packageName <> "\" " <> modName
-        , "import qualified DA.Internal.TemplateThisSdk"
+        , "import qualified Sdk.DA.Internal.Template"
         , "import qualified GHC.Types"
         ]
 
@@ -265,7 +265,7 @@ generateTemplateInstance env typeCon typeParams externPkgId =
         noLoc $
         HsTyVar noExt NotPromoted $
         noLoc $
-        mkRdrQual (mkModuleName "DA.Internal.TemplateThisSdk") $
+        mkRdrQual (mkModuleName "Sdk.DA.Internal.Template") $
         mkOccName varName "Template" :: LHsType GhcPs
     lfTemplateType dataTypeCon dataParams =
         LF.mkTApps

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -42,8 +42,9 @@ data Options = Options
     -- ^ alternative directory to write interface files to. Default is <current working dir>.daml/interfaces.
   , optHideAllPkgs :: Bool
     -- ^ hide all imported packages
-  , optPackageImports :: [(String, [(String, String)])]
-    -- ^ list of explicit package imports and modules with aliases
+  , optPackageImports :: [(String, Bool, [(String, String)])]
+    -- ^ list of explicit package imports and modules with aliases. The boolean flag controls
+    -- whether modules without given alias are visible.
   , optShakeProfiling :: Maybe FilePath
     -- ^ enable shake profiling
   , optThreads :: Int

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -688,8 +688,8 @@ execMigrate projectOpts inFile1_ inFile2_ mbDir =
                   (NM.names $ LF.packageModules lfPkg2)
           let eqModNamesStr = map (T.unpack . LF.moduleNameString) eqModNames
           let buildOptions =
-                  [ "'--package=" <> show ("instances-" <> pkgName1, [(m, m ++ "A") | m <- eqModNamesStr]) <> "'"
-                  , "'--package=" <> show ("instances-" <> pkgName2, [(m, m ++ "B") | m <- eqModNamesStr]) <> "'"
+                  [ "'--package=" <> show ("instances-" <> pkgName1, True, [(m, m ++ "A") | m <- eqModNamesStr]) <> "'"
+                  , "'--package=" <> show ("instances-" <> pkgName2, True, [(m, m ++ "B") | m <- eqModNamesStr]) <> "'"
                   ]
           forM_ eqModNames $ \m@(LF.ModuleName modName) -> do
               let upgradeModPath =

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -291,7 +291,7 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                         , optPackageImports =
                               ("daml-prim", True, []) :
                               (unitIdStr, True, []) :
-                              -- we need the standart library from the current sdk for the
+                              -- we need the standard library from the current sdk for the
                               -- definition of the template class.
                               [ ( damlStdlib
                                 , False

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -47,6 +47,7 @@ import DA.Daml.LF.Reader
 import DA.Daml.Options.Types
 import DA.Daml.Project.Consts
 import qualified DA.Pretty
+import SdkVersion
 
 -- | Create the project package database containing the given dar packages.
 createProjectPackageDb ::
@@ -211,10 +212,11 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                 , optIsGenerated = True
                 , optDflagCheck = False
                 , optMbPackageName = Just unitIdStr
-                , optHideAllPkgs = False
+                , optHideAllPkgs = True
                 , optGhcCustomOpts = []
-                , optPackageImports = []
-                , optImportPath = workDir : optImportPath opts
+                , optPackageImports =
+                      ("daml-prim", True, []) :
+                      [(takeBaseName dep, True, []) | dep <- deps] ++ optPackageImports opts
                 }
 
         _ <- withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
@@ -285,8 +287,17 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                         , optIsGenerated = True
                         , optDflagCheck = False
                         , optMbPackageName = Just instancesUnitIdStr
-                        , optHideAllPkgs = False
-                        , optPackageImports = [(unitIdStr, []) | pkgName /= "daml-stdlib"]
+                        , optHideAllPkgs = True
+                        , optPackageImports =
+                              ("daml-prim", True, []) :
+                              (unitIdStr, True, []) :
+                              -- we need the standart library from the current sdk for the
+                              -- definition of the template class.
+                              [ ( damlStdlib
+                                , False
+                                , [("DA.Internal.Template", "DA.Internal.TemplateThisSdk")])
+                              ] ++
+                              [(takeBaseName dep, True, []) | dep <- deps] ++ optPackageImports opts
                         }
                 mbDar <-
                     withDamlIdeState opts' loggerH diagnosticsLogger $ \ide ->
@@ -413,4 +424,3 @@ getEntry fp dar =
 
 lfVersionString :: LF.Version -> String
 lfVersionString = DA.Pretty.renderPretty
-

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -286,7 +286,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
           help "Whether to write interface files during type checking, required for building a package such as daml-prim" <>
           long "write-iface"
 
-    optPackage :: Parser (String, [(String, String)])
+    optPackage :: Parser (String, Bool, [(String, String)])
     optPackage =
       option auto $
       metavar "PACKAGE" <>

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -84,7 +84,7 @@ tests damlc = testGroup "Packaging"
             , "  - daml-stdlib"
             , "  - " <> aDar
             , "build-options:"
-            , "- '--package=(\"a-1.0\", [(\"A\", \"C\")])'"
+            , "- '--package=(\"a-1.0\", True, [(\"A\", \"C\")])'"
             ]
             -- the last option checks that module aliases work and modules imported without aliases
             -- are still exposed.
@@ -285,7 +285,7 @@ dataDependencyTests damlc = testGroup "Data Dependencies" $
           , "dependencies: [daml-prim, daml-stdlib]"
           , "data-dependencies: [simple-dalf-0.0.0.dalf]"
           , "build-options:"
-          , "- --generated-src"
+          , "- '--package=(\"daml-stdlib-" <> sdkVersion <> "\", True, [])'"
           ]
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "daml 1.2"
@@ -334,7 +334,7 @@ dataDependencyTests damlc = testGroup "Data Dependencies" $
         withCurrentDirectory projDir $
             callProcessSilent genSimpleDalf $
             ["--with-archive-choice" | withArchiveChoice ] <> ["simple-dalf-0.0.0.dalf"]
-        withCurrentDirectory projDir $ callProcessSilent damlc ["build", "--target=1.dev"]
+        withCurrentDirectory projDir $ callProcessSilent damlc ["build", "--target=1.dev", "--generated-src"]
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
         assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
         callProcessSilent damlc ["test", "--target=1.dev", "--project-root", projDir, "--generated-src"]


### PR DESCRIPTION
This gives us more control over what packages are visible in the package
database during cross sdk imports and makes sure we're not accidentally
picking up the wrong one.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
