### PR TITLE
Improve Numeric type inference and safety by adding a scale constraint.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -781,9 +781,9 @@ convertExpr env0 e = do
                 pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x2 x1, args)
     go env (VarIn GHC_Real "fromRational") (LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalDecimal env top bot
-    go env (VarIn GHC_Real "fromRational") (LType (isNumLitTy -> Just n) : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+    go env (VarIn GHC_Real "fromRational") (LType (isNumLitTy -> Just n) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalNumericMono env n top bot
-    go env (VarIn GHC_Real "fromRational") (LType scaleTyCoRep : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+    go env (VarIn GHC_Real "fromRational") (LType scaleTyCoRep : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = unsupported "Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (1.2345 : Numeric 10)" ()
     go env (VarIn GHC_Num "negate") (tyInt : LExpr (VarIs "$fAdditiveInt") : LExpr (untick -> VarIs "fromInteger" `App` Lit (LitNumber _ x _)) : args)
         = fmap (, args) $ convertInt64 (negate x)

--- a/compiler/damlc/daml-prim-src/GHC/Classes.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Classes.daml
@@ -51,6 +51,10 @@ module GHC.Classes(
 
     -- * Functions over Bool
     (&&), (||), not,
+
+    #ifdef DAML_NUMERIC
+    NumericScale (numericScale),
+    #endif
  ) where
 
 import GHC.Base
@@ -58,6 +62,7 @@ import GHC.Prim
 import GHC.Tuple
 import GHC.CString (unpackCString#)
 import GHC.Types
+import GHC.Integer.Type
 import DA.Types
 
 infix  4  ==, /=, <, <=, >=, >
@@ -365,3 +370,71 @@ False || x              =  x
 not                     : Bool -> Bool
 not True                =  False
 not False               =  True
+
+
+#ifdef DAML_NUMERIC
+
+-- | Is this a valid scale for the `Numeric` type?
+--
+-- This typeclass is used to prevent the creation of Numeric values
+-- with too large a scale. The scale controls the number of digits available
+-- after the decimal point, and it must be between 0 and 37 inclusive.
+--
+-- Thus the only available instances of this typeclass are `NumericScale 0`
+-- through `NumericScale 37`. This cannot be extended without additional
+-- compiler and runtime support. You cannot implement a custom instance
+-- of this typeclass.
+--
+-- If you have an error message in your code of the form "No instance for
+-- `(NumericScale n)`", this is probably caused by having a numeric literal
+-- whose scale cannot be inferred by the compiler. You can usually fix this
+-- by adding a type signature to the definition, or annotating the numeric
+-- literal directly (for example, instead of writing `3.14159` you can write
+-- `(3.14159 : Numeric 5)`).
+class NumericScale (n : Nat) where
+    -- | Get the scale of a `Numeric` as an integer. For example,
+    -- `numericScale (3.14159 : Numeric 5)` equals `5`.
+    numericScale : proxy n -> Int
+
+    -- | HIDE
+    numericScalePrivate : proxy n -> ()
+
+instance NumericScale 0 where numericScale _ = 0; numericScalePrivate _ = ()
+instance NumericScale 1 where numericScale _ = 1; numericScalePrivate _ = ()
+instance NumericScale 2 where numericScale _ = 2; numericScalePrivate _ = ()
+instance NumericScale 3 where numericScale _ = 3; numericScalePrivate _ = ()
+instance NumericScale 4 where numericScale _ = 4; numericScalePrivate _ = ()
+instance NumericScale 5 where numericScale _ = 5; numericScalePrivate _ = ()
+instance NumericScale 6 where numericScale _ = 6; numericScalePrivate _ = ()
+instance NumericScale 7 where numericScale _ = 7; numericScalePrivate _ = ()
+instance NumericScale 8 where numericScale _ = 8; numericScalePrivate _ = ()
+instance NumericScale 9 where numericScale _ = 9; numericScalePrivate _ = ()
+instance NumericScale 10 where numericScale _ = 10; numericScalePrivate _ = ()
+instance NumericScale 11 where numericScale _ = 11; numericScalePrivate _ = ()
+instance NumericScale 12 where numericScale _ = 12; numericScalePrivate _ = ()
+instance NumericScale 13 where numericScale _ = 13; numericScalePrivate _ = ()
+instance NumericScale 14 where numericScale _ = 14; numericScalePrivate _ = ()
+instance NumericScale 15 where numericScale _ = 15; numericScalePrivate _ = ()
+instance NumericScale 16 where numericScale _ = 16; numericScalePrivate _ = ()
+instance NumericScale 17 where numericScale _ = 17; numericScalePrivate _ = ()
+instance NumericScale 18 where numericScale _ = 18; numericScalePrivate _ = ()
+instance NumericScale 19 where numericScale _ = 19; numericScalePrivate _ = ()
+instance NumericScale 20 where numericScale _ = 20; numericScalePrivate _ = ()
+instance NumericScale 21 where numericScale _ = 21; numericScalePrivate _ = ()
+instance NumericScale 22 where numericScale _ = 22; numericScalePrivate _ = ()
+instance NumericScale 23 where numericScale _ = 23; numericScalePrivate _ = ()
+instance NumericScale 24 where numericScale _ = 24; numericScalePrivate _ = ()
+instance NumericScale 25 where numericScale _ = 25; numericScalePrivate _ = ()
+instance NumericScale 26 where numericScale _ = 26; numericScalePrivate _ = ()
+instance NumericScale 27 where numericScale _ = 27; numericScalePrivate _ = ()
+instance NumericScale 28 where numericScale _ = 28; numericScalePrivate _ = ()
+instance NumericScale 29 where numericScale _ = 29; numericScalePrivate _ = ()
+instance NumericScale 30 where numericScale _ = 30; numericScalePrivate _ = ()
+instance NumericScale 31 where numericScale _ = 31; numericScalePrivate _ = ()
+instance NumericScale 32 where numericScale _ = 32; numericScalePrivate _ = ()
+instance NumericScale 33 where numericScale _ = 33; numericScalePrivate _ = ()
+instance NumericScale 34 where numericScale _ = 34; numericScalePrivate _ = ()
+instance NumericScale 35 where numericScale _ = 35; numericScalePrivate _ = ()
+instance NumericScale 36 where numericScale _ = 36; numericScalePrivate _ = ()
+instance NumericScale 37 where numericScale _ = 37; numericScalePrivate _ = ()
+#endif

--- a/compiler/damlc/daml-prim-src/GHC/Real.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Real.daml
@@ -11,17 +11,19 @@ module GHC.Real where
 
 import GHC.Integer.Type
 import GHC.Types
+#ifdef DAML_NUMERIC
+import GHC.Classes
+#endif
 
 data Ratio a = !a :% !a
 
 type Rational = Ratio Integer
 
 #ifdef DAML_NUMERIC
-fromRational : Rational -> Numeric n
+fromRational : NumericScale n => Rational -> Numeric n
 #else
 fromRational : Rational -> Decimal
 #endif
-
 fromRational = magic @"fromRational"
 
 {-# NOINLINE fromRational #-}

--- a/compiler/damlc/daml-stdlib-src/DA/Numeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Numeric.daml
@@ -12,32 +12,32 @@ module DA.Numeric where
 -- different scales, unlike `(*)` which forces all numeric scales
 -- to be the same. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-mul : Numeric n1 -> Numeric n2 -> Numeric n3
+mul : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 mul = primitive @"BEMulNumeric"
 
 -- | Divide two numerics. Both inputs and the output may have
 -- different scales, unlike `(/)` which forces all numeric scales
 -- to be the same. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-div : Numeric n1 -> Numeric n2 -> Numeric n3
+div : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 div = primitive @"BEDivNumeric"
 
 -- | Cast a Numeric. Raises an error on overflow or loss of precision.
-cast : Numeric n1 -> Numeric n2
+cast : NumericScale n2 => Numeric n1 -> Numeric n2
 cast = primitive @"BECastNumeric"
 
 -- | Cast a Numeric. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-castAndRound : Numeric n1 -> Numeric n2
+castAndRound : NumericScale n2 => Numeric n1 -> Numeric n2
 castAndRound = mul (1.0 : Numeric 0)
 
 -- | Move the decimal point left or right by multiplying the numeric
 -- value by 10^(n2 - n1). Does not overflow or underflow.
-shift : Numeric n1 -> Numeric n2
+shift : NumericScale n2 => Numeric n1 -> Numeric n2
 shift = primitive @"BEShiftNumeric"
 
 -- | The number pi.
-pi : Numeric n
+pi : NumericScale n => Numeric n
 pi = castAndRound (3.14159_26535_89793_23846_26433_83279_50288_41 : Numeric 37)
 
 #else

--- a/compiler/damlc/tests/daml-test-files/NumericLit.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLit.daml
@@ -3,7 +3,7 @@
 
 -- Test numeric literals.
 --
--- @SINCE-LF 1.dev
+-- @SINCE-LF 1.7
 
 daml 1.2
 

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
@@ -1,15 +1,16 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- Test numeric literal errors.
+-- Ensure numeric literal cannot be out of bounds thanks to
+-- `NumericScale` constraint.
 --
--- @SINCE-LF 1.dev
--- @ERROR scale is out of bounds
+-- @SINCE-LF 1.7
+-- @ERROR No instance for (NumericScale 38)
 
 daml 1.2
 
 module NumericLitMonoScaleOOB where
 
--- Scale out of bounds for monomorphic literal.
+-- Scale out of bounds for numeric literal.
 scaleOOB : Numeric 38
 scaleOOB = 0.00001

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Ensure numeric literal cannot be out of bounds even if we
+-- condition on `NumericScale 38`. That is, we still get a
+-- conversion error even if we try to be clever.
+--
+-- @SINCE-LF 1.7
+-- @ERROR type-level natural outside of supported range [0, 37]
+
+daml 1.2
+
+module NumericLitMonoScaleOOB2 where
+
+-- Scale out of bounds for numeric literal.
+scaleOOB : NumericScale 38 => Numeric 38
+scaleOOB = 0.00001

--- a/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
@@ -1,15 +1,19 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- Test numeric literal errors.
+-- Ensure numeric literal must have a fixed scale, even if we
+-- condition on `NumericScale n`. That is, we still get a
+-- conversion error even if we try to be clever.
 --
--- @SINCE-LF 1.dev
+-- @SINCE-LF 1.7
 -- @ERROR Polymorphic numeric literal
 
 daml 1.2
 
 module NumericLitPoly where
 
--- Polymorphic numeric literals are not allowed.
-polyLit : Numeric n
+-- Polymorphic numeric literals are not allowed. To get a polymorphic
+-- numeric value, you need to import DA.Numeric and use `cast` or
+-- `castAndRound` explicitly.
+polyLit : NumericScale n => Numeric n
 polyLit = 1.2345

--- a/compiler/damlc/tests/daml-test-files/NumericScalePropagation.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericScalePropagation.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Test that numeric scale information propagates automatically when working
+-- with numeric literals.
+--
+-- @SINCE-LF 1.7
+
+daml 1.2
+
+module NumericScalePropagation where
+
+scalePropWhere : Numeric 10
+scalePropWhere = a + b
+    where
+        a = 0.1
+        b = 0.2
+
+scalePropLet : Numeric 15
+scalePropLet =
+    let x = 0.1
+        y = 0.2
+    in x*x + y*y

--- a/unreleased.rst
+++ b/unreleased.rst
@@ -9,4 +9,4 @@ This page contains release notes for the SDK.
 HEAD — ongoing
 --------------
 
-
+- [DAML Stdlib] Added the ``NumericScale`` typeclass, which improves the type inference for Numeric literals, and helps catch the creation of out-of-bound Numerics earlier in the compilation process.


### PR DESCRIPTION
This PR introduces a typeclass `NumericScale (n : Nat)` in the stdlib, which is only implemented for valid scales `0` through `37`. This is added as a condition to `fromRational`, meaning you can only construct `Numeric n` literal if there is a `NumericScale n` instance. The typeclass cannot be extended by users (it does not export all its members).

The primary intent of this change is to improve type inference around numeric literals: by adding the constraint on `fromRational`, GHC is forced to propagate scale information because of `MonoLocalBinds`. This means that we can now write things like

```
foo : Numeric 20
foo = x*x + y*y
  where
    a = 3.14159
    b = 2.71828      
```

where previously we would need to give specific types for `a` and `b`. The same goes for `let` clauses. See the new test `NumericScalePropagation.daml`.

A second benefit of this change is that the typechecker can now prevent the creation of `Numeric` values with an invalid scale. I added the `NumericScale n` constraint only to operations that create a `Numeric n` without first consuming a `Numeric n` -- this is limited to `fromRational`, and the various multi-scale functions exported in `DA.Numeric`.

This also decouples the range of `Nat` from the numeric scale, so if we want to implement type-level naturals greater than 37 at any point, we can.
