### PR TITLE
Upload proto and deploy jars to maven

### DIFF
--- a/bazel_tools/java.bzl
+++ b/bazel_tools/java.bzl
@@ -4,6 +4,7 @@
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
 load("@com_github_google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+load("//bazel_tools:pkg.bzl", "pkg_empty_zip")
 
 _java_home_runtime_build_template = """
 java_runtime(
@@ -86,6 +87,18 @@ def da_java_binary(name, **kwargs):
         visibility = ["//visibility:public"],
     )
 
+    # Create empty javadoc JAR for uploading deploy jars to Maven Central
+    pkg_empty_zip(
+        name = name + "_javadoc",
+        out = name + "_javadoc.jar",
+    )
+
+    # Create empty src JAR for uploading deploy jars to Maven Central
+    pkg_empty_zip(
+        name = name + "_src",
+        out = name + "_src.jar",
+    )
+
 def da_java_proto_library(name, **kwargs):
     _wrap_rule(native.java_proto_library, name, **kwargs)
     pom_file(
@@ -93,3 +106,12 @@ def da_java_proto_library(name, **kwargs):
         target = ":" + name,
         visibility = ["//visibility:public"],
     )
+
+    # Create empty javadoc JAR for uploading proto jars to Maven Central
+    pkg_empty_zip(
+        name = name + "_javadoc",
+        out = name + "_javadoc.jar",
+    )
+
+    # we don't need to create an empty zip for sources, because java_proto_library
+    # creates a sources jar as a side effect automatically

--- a/bazel_tools/pkg.bzl
+++ b/bazel_tools/pkg.bzl
@@ -262,3 +262,12 @@ def pkg_tar(**kwargs):
                       "Consider renaming it in your BUILD file.")
                 kwargs["srcs"] = kwargs.pop("files")
     _real_pkg_tar(**kwargs)
+
+def pkg_empty_zip(name, out):
+    native.genrule(
+        name = name,
+        srcs = [],
+        outs = [out],
+        # minimal empty zip file in Base64 encoding
+        cmd = "echo UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA== | base64 -d > $@",
+    )

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -16,6 +16,7 @@ load(
 )
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
+load("//bazel_tools:pkg.bzl", "pkg_empty_zip")
 
 # This file defines common Scala compiler flags and plugins used throughout
 # this repository. The initial set of flags is taken from the ledger-client
@@ -466,6 +467,18 @@ def da_scala_binary(name, **kwargs):
                 pom_file(
                     name = name + "_pom",
                     target = ":" + name,
+                )
+
+                # Create empty Sources JAR for uploading to Maven Central
+                pkg_empty_zip(
+                    name = name + "_src",
+                    out = name + "_src.jar",
+                )
+
+                # Create empty javadoc JAR for uploading deploy jars to Maven Central
+                pkg_empty_zip(
+                    name = name + "_javadoc",
+                    out = name + "_javadoc.jar",
                 )
                 break
 

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -124,6 +124,7 @@ da_scala_binary(
         # We release this as a fat jar so this tag ensures that the dependencies in the generated
         # POM file are set correctly.
         "fat_jar",
+        "no_scala_version_suffix",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -47,10 +47,13 @@
   platformDependent: True
 - target: //daml-lf/transaction:value_java_proto
   type: jar-proto
+  mavenUpload: true
 - target: //daml-lf/transaction:transaction_java_proto
   type: jar-proto
+  mavenUpload: true
 - target: //daml-lf/transaction:blindinginfo_java_proto
   type: jar-proto
+  mavenUpload: true
 - target: //daml-lf/transaction:transaction
   type: jar-scala
   mavenUpload: True
@@ -139,6 +142,7 @@
   type: jar-scala
 - target: //ledger/ledger-api-test-tool:ledger-api-test-tool
   type: jar-deploy
+  mavenUpload: true
 - target: //language-support/scala/codegen:codegen
   type: jar-scala
   mavenUpload: true
@@ -172,8 +176,10 @@
   mavenUpload: True
 - target: //ledger/participant-state/kvutils:daml_kvutils_java_proto
   type: jar-proto
+  mavenUpload: true
 - target: //ledger/participant-state/kvutils:kvutils
   type: jar-scala
+  mavenUpload: true
 - target: //ledger-service/lf-value-json:lf-value-json
   type: jar-scala
 - target: //ledger-service/utils:utils


### PR DESCRIPTION
- Add helper to produce an empty zip files.
  This is used to generate empty sources and javadoc jars for deploy jars later on.
- Create empty auxilliary jars.
  - da_java_binary:
    - empty javadoc jar
    - empty sources jar
  - da_java_proto_library:
    - empty javadoc jar
    - the sources jar is automatically generated by java_proto_library as a side effect
  - da_scala_binary:
    - empty javadoc jar
    - empty sources jar

- Support maven upload for jar-deploy and jar-proto
  For jar-deploy targets we don't check for internal dependencies, because these should already be contained in the (fat-)jar itself.
  Additionally, the release program now uploads javadocs and sources for jar-proto and jar-deploy as well to comply with maven central.
-  Upload ledger-api-test-tool and kvutils + dependencies to maven central.
  This is the diff running the output of the release without and with these changes. A few artifacts now also get their javadoc and sources uploaded (mostly to bintray, but now they are ready for a maven central upload).
  ledger-api-test-tool has the scala version removed from the artifact as it is a deploy jar and nobody should care which specific scala version is used.
```
Only in release/com/daml/ledger/participant-state-kvutils-java-proto/100.13.35: participant-state-kvutils-java-proto-100.13.35-javadoc.jar
Only in release/com/daml/ledger/participant-state-kvutils-java-proto/100.13.35: participant-state-kvutils-java-proto-100.13.35-sources.jar
Only in release/com/daml/ledger/testtool: ledger-api-test-tool
Only in release-before/com/daml/ledger/testtool: ledger-api-test-tool_2.12
Only in release/com/digitalasset/daml/lf/engine/trigger/runner_2.12/100.13.35: runner_2.12-100.13.35-javadoc.jar
Only in release/com/digitalasset/daml/lf/engine/trigger/runner_2.12/100.13.35: runner_2.12-100.13.35-sources.jar
Only in release/com/digitalasset/daml-lf-blindinginfo-java-proto/100.13.35: daml-lf-blindinginfo-java-proto-100.13.35-javadoc.jar
Only in release/com/digitalasset/daml-lf-blindinginfo-java-proto/100.13.35: daml-lf-blindinginfo-java-proto-100.13.35-sources.jar
Only in release/com/digitalasset/daml-lf-transaction-java-proto/100.13.35: daml-lf-transaction-java-proto-100.13.35-javadoc.jar
Only in release/com/digitalasset/daml-lf-transaction-java-proto/100.13.35: daml-lf-transaction-java-proto-100.13.35-sources.jar
Only in release/com/digitalasset/daml-lf-value-java-proto/100.13.35: daml-lf-value-java-proto-100.13.35-javadoc.jar
Only in release/com/digitalasset/daml-lf-value-java-proto/100.13.35: daml-lf-value-java-proto-100.13.35-sources.jar
Only in release/com/digitalasset/damlc/100.13.35: damlc-100.13.35-javadoc.jar
Only in release/com/digitalasset/damlc/100.13.35: damlc-100.13.35-sources.jar
Only in release/com/digitalasset/extractor/100.13.35: extractor-100.13.35-javadoc.jar
Only in release/com/digitalasset/extractor/100.13.35: extractor-100.13.35-sources.jar
Only in release/com/digitalasset/ledger-service/http-json-deploy/100.13.35: http-json-deploy-100.13.35-javadoc.jar
Only in release/com/digitalasset/ledger-service/http-json-deploy/100.13.35: http-json-deploy-100.13.35-sources.jar
Only in release/com/digitalasset/navigator/100.13.35: navigator-100.13.35-javadoc.jar
Only in release/com/digitalasset/navigator/100.13.35: navigator-100.13.35-sources.jar
```



### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
