### PR TITLE
Expose conversion from Ast.Type to iface.Type

### DIFF
--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -197,7 +197,7 @@ object InterfaceReader {
       case (fieldName, typ) => toIfaceType(ctx, typ).map(x => fieldName -> x)
     }
 
-  def toIfaceType(
+  private[lf] def toIfaceType(
       ctx: QualifiedName,
       a: Ast.Type,
       args: FrontStack[Type] = FrontStack.empty

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -160,7 +160,7 @@ class Runner(
         scriptTy match {
           case TApp(TApp(TBuiltin(BTArrow), param), result) => {
             assertScriptTy(result)
-            val paramIface = Converter.toIfaceType(param) match {
+            val paramIface = Converter.toIfaceType(scriptId.qualifiedName, param) match {
               case Left(s) => throw new ConverterException(s"Failed to convert $result: $s")
               case Right(ty) => ty
             }


### PR DESCRIPTION
This allows me to get rid of the duplicated conversion logic for DAML
script. The reason for why I can’t use the higher level APIs provided
by the interface reader is that the type of the script identifier can
be a function which is not serializable and therefore does not show up
in the interface. However, I only want to translate the type of the
argument of that function which is serializable.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
