### PR TITLE
Fix protobuf zlib reference

### DIFF
--- a/bazel_tools/proto-zlib-url.patch
+++ b/bazel_tools/proto-zlib-url.patch
@@ -1,0 +1,28 @@
+From 516f8b15603b7f7613e2fb957c55bc56a36b64a6 Mon Sep 17 00:00:00 2001
+From: Keith Smiley <keithbsmiley@gmail.com>
+Date: Wed, 28 Aug 2019 21:41:02 -0700
+Subject: [PATCH] bazel: Change zlib URL to GitHub
+
+We've notice significant issues downloading from zlib.net. Since there
+are already other archives coming from GitHub, this shouldn't negatively
+affect reliability.
+---
+ protobuf_deps.bzl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/protobuf_deps.bzl b/protobuf_deps.bzl
+index e5117d167d..9209b1c5a3 100644
+--- a/protobuf_deps.bzl
++++ b/protobuf_deps.bzl
+@@ -17,7 +17,7 @@ def protobuf_deps():
+         http_archive(
+             name = "zlib",
+             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
++            sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+             strip_prefix = "zlib-1.2.11",
+-            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
++            urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+         )
+
+     if not native.existing_rule("six"):

--- a/deps.bzl
+++ b/deps.bzl
@@ -131,6 +131,10 @@ def daml_deps():
             sha256 = "1e622ce4b84b88b6d2cdf1db38d1a634fe2392d74f0b7b74ff98f3a51838ee53",
             strip_prefix = "protobuf-3.8.0",
             urls = ["https://github.com/google/protobuf/archive/v3.8.0.zip"],
+            patches = [
+                "@com_github_digital_asset_daml//bazel_tools:proto-zlib-url.patch",
+            ],
+            patch_args = ["-p1"],
         )
 
     if "io_bazel_skydoc" not in native.existing_rules():


### PR DESCRIPTION
Apparently the other URL is broken on CI atm.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
