### PR TITLE
Add metrics to Ledger API Server

### DIFF
--- a/ledger/README.md
+++ b/ledger/README.md
@@ -2,40 +2,19 @@
 
 Home of our reference ledger implementation (Sandbox) and various ledger related libraries.
 
-## v1 gRPC API
-
-The v1 gRPC API is described [here](API.md)
-
 ## Logging
 
 ### Logging Configuration
 
-Ledger Server uses [Logback](https://logback.qos.ch/) for logging configuration.
+The Sandbox and Ledger API Server use [Logback](https://logback.qos.ch/) for logging configuration.
 
 #### Log Files
 
-By [default our log configuration](https://github.com/DACH-NY/da/blob/master/ledger/platform-deployment/src/main/resources/logback.xml) creates two log files:
-- a plaintext file `logs/ledger.log`
-- a json file `logs/ledger.json.log` (for Logstash type log processors)
-
-The path the file is stored in can be adjusted by setting `-Dlogging.location=some/other/path`.
-The filename used can be adjusted by setting `-Dlogging.file=my-process-logs`.
-
-By default no output is sent to stdout (beyond logs from the logging setup itself).
-
-#### standard streams logging
-
-For development and testing it can be useful to send all logs to stdout & stderr rather than files (for instance to use the IntelliJ console or getting useful output from docker containers).
-
-We [ship a logging configuration for this](https://github.com/DACH-NY/da/blob/master/ledger/platform-deployment/src/main/resources/logback-standard.xml) which can be enabled by using `-Dlogback.configurationFile=classpath:logback-standard.xml -Dlogging.config=classpath:logback-standard.xml`.
-
-INFO level and below goes to stdout. WARN and above goes to stderr.
-
-_Note: always use both `-Dlogback.configurationFile` and `-Dlogging.config`. Logback is first initialized with the configuration file from `logback.configurationFile`. When the Spring framework boots it recreates logback and uses the configuration specified in `logging.config`.
+The Sandbox logs at `INFO` level to standard out and to the file `sandbox.log` in the current working directory.
 
 ### Log levels
 
-As most Java libraries and frameworks, ledger server uses INFO as the default logging level. This level is for minimal 
+As most Java libraries and frameworks, the Sandbox and Ledger API Server use INFO as the default logging level. This level is for minimal 
 and important information (usually only startup and normal shutdown events). INFO level logging should not produce
 increasing volume of logging during normal operation.
 
@@ -43,6 +22,41 @@ WARN level should be used for transition between healthy/unhealthy state, or in 
 
 DEBUG level should be turned on only when investigating issues in the system, and usually that means we want the trail
 loggers. Normal loggers at DEBUG level can be useful sometimes (e.g. DAML interpretation).
+
+## Metrics
+
+Sandbox and Ledger API Server provide a couple of useful metrics:
+
+### Sandbox and Ledger API Server
+
+The Ledger API Server exposes basic metrics for all gRPC services and some additional ones.
+<table>
+<thead><tr><td>Metric Name</td><td>Description</td></tr>
+<tbody>
+<tr><td><pre>LedgerApi.com.digitalasset.ledger.api.v1.$SERVICE.$METHOD</pre></td><td>A <i>meter</i> that tracks the number of calls to the respective service and method.
+<tr><td><pre>CommandSubmission.failedCommandInterpretations</pre></td><td>A <i>meter</i> that tracks the failed command interpretations.
+<tr><td><pre>CommandSubmission.submittedTransactions</pre></td><td>A <i>timer</i> that tracks the commands submitted to the backing ledger. 
+</tbody>
+</table>
+
+### Indexer
+<table>
+<thead><tr><td>Metric Name</td><td>Description</td></tr></thead>
+<tbody>
+<tr><td><pre>JdbcIndexer.processedStateUpdates</pre></td><td>A <i>timer</i> that tracks duration of state update processing.</td></tr>
+<tr><td><pre>JdbcIndexer.lastReceivedRecordTime</pre></td><td>A <i>gauge</i> that returns the last received record time in milliseconds since EPOCH.</td></tr>
+<tr><td><pre>JdbcIndexer.lastReceivedOffset</pre></td><td>A <i>gauge</i> that returns that last received offset from the ledger.</td></tr>
+<tr><td><pre>JdbcIndexer.currentRecordTimeLag</pre></td><td>A <i>gauge</i> that returns the difference between the Indexer's wallclock time and the last received record time in milliseconds.</td></tr>
+</tbody>
+</table>
+
+The following JMX domains are used:
+
+* Sandbox: `com.digitalasset.platform.sandbox`
+* Ledger API Server: `com.digitalasset.platform.ledger-api-server.$PARTICIPANT_ID`
+* Indexer Server: `com.digitalasset.platform.indexer.$PARTICIPANT_ID`
+
+`$PARTICIPANT_ID` is provided via CLI parameters.
 
 ## gRPC and back-pressure
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
@@ -21,6 +21,7 @@ import com.digitalasset.ledger.api.v1.command_completion_service.CompletionEndRe
 import com.digitalasset.ledger.client.services.commands.CommandSubmissionFlow
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.sandbox.config.CommandConfiguration
+import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.services._
 import com.digitalasset.platform.sandbox.services.admin.{
   ApiPackageManagementService,
@@ -68,7 +69,8 @@ object ApiServices {
       timeModel: TimeModel,
       commandConfig: CommandConfiguration,
       optTimeServiceBackend: Option[TimeServiceBackend],
-      loggerFactory: NamedLoggerFactory)(
+      loggerFactory: NamedLoggerFactory,
+      metricsManager: MetricsManager)(
       implicit mat: ActorMaterializer,
       esf: ExecutionSequencerFactory): Future[ApiServices] = {
     implicit val ec: ExecutionContext = mat.system.dispatcher
@@ -92,7 +94,8 @@ object ApiServices {
           timeModel,
           timeProvider,
           new CommandExecutorImpl(engine, packagesService.getLfPackage),
-          loggerFactory
+          loggerFactory,
+          metricsManager,
         )
 
       loggerFactory.getLogger(this.getClass).info(EngineInfo.show)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem
 import akka.stream._
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.{Done, NotUsed}
+import com.codahale.metrics.Gauge
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.Update._
 import com.daml.ledger.participant.state.v1._
@@ -92,7 +93,7 @@ class JdbcIndexerFactory[Status <: InitStatus] private (loggerFactory: NamedLogg
       ledgerEnd <- ledgerDao.lookupLedgerEnd()
       externalOffset <- ledgerDao.lookupExternalLedgerEnd()
     } yield {
-      new JdbcIndexer(ledgerEnd, externalOffset, ledgerDao)(materializer) {
+      new JdbcIndexer(ledgerEnd, externalOffset, ledgerDao, metricsManager)(materializer) {
         override def close(): Unit = {
           super.close()
           materializer.shutdown()
@@ -162,12 +163,57 @@ class JdbcIndexerFactory[Status <: InitStatus] private (loggerFactory: NamedLogg
 class JdbcIndexer private[index] (
     initialInternalOffset: Long,
     beginAfterExternalOffset: Option[LedgerString],
-    ledgerDao: LedgerDao)(implicit mat: Materializer)
+    ledgerDao: LedgerDao,
+    metricsManager: MetricsManager)(implicit mat: Materializer)
     extends Indexer
     with AutoCloseable {
 
   @volatile
   private var headRef = initialInternalOffset
+
+  @volatile
+  private var lastReceivedRecordTime = Instant.now()
+
+  @volatile
+  private var lastReceivedOffset: LedgerString = _
+
+  object Metrics {
+    val stateUpdateProcessingTimer =
+      metricsManager.metrics.timer("JdbcIndexer:processedStateUpdates")
+
+    private[JdbcIndexer] def setup(): Unit = {
+      val lastReceivedRecordTimeName = "JdbcIndexer:lastReceivedRecordTime"
+      val lastReceivedOffsetName = "JdbcIndexer:lastReceivedOffset"
+      val currentRecordTimeLagName = "JdbcIndexer:currentRecordTimeLag"
+
+      metricsManager.metrics.remove(lastReceivedRecordTimeName)
+      metricsManager.metrics.remove(lastReceivedOffsetName)
+      metricsManager.metrics.remove(currentRecordTimeLagName)
+
+      metricsManager.metrics.gauge(
+        lastReceivedRecordTimeName,
+        () =>
+          new Gauge[Long] {
+            override def getValue: Long = lastReceivedRecordTime.toEpochMilli
+        })
+
+      metricsManager.metrics.gauge(
+        lastReceivedOffsetName,
+        () =>
+          new Gauge[LedgerString] {
+            override def getValue: LedgerString = lastReceivedOffset
+        })
+
+      metricsManager.metrics.gauge(
+        currentRecordTimeLagName,
+        () =>
+          new Gauge[Long] {
+            override def getValue: Long =
+              Instant.now().toEpochMilli - lastReceivedRecordTime.toEpochMilli
+        })
+      ()
+    }
+  }
 
   /**
     * Subscribes to an instance of ReadService.
@@ -176,10 +222,16 @@ class JdbcIndexer private[index] (
     * @return a handle of IndexFeedHandle or a failed Future
     */
   override def subscribe(readService: ReadService): Future[IndexFeedHandle] = {
+    Metrics.setup()
+
     val (killSwitch, completionFuture) = readService
       .stateUpdates(beginAfterExternalOffset.map(Offset.assertFromString))
       .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
-      .mapAsync(1)((handleStateUpdate _).tupled)
+      .mapAsync(1)({
+        case (offset, update) =>
+          metricsManager
+            .timedFuture(Metrics.stateUpdateProcessingTimer, handleStateUpdate(offset, update))
+      })
       .toMat(Sink.ignore)(Keep.both)
       .run()
 
@@ -187,6 +239,9 @@ class JdbcIndexer private[index] (
   }
 
   private def handleStateUpdate(offset: Offset, update: Update): Future[Unit] = {
+    lastReceivedOffset = offset.toLedgerString
+    stateUpdateRecordTime(update).foreach(lastReceivedRecordTime = _)
+
     val externalOffset = Some(offset.toLedgerString)
     update match {
       case Heartbeat(recordTime) =>
@@ -286,6 +341,17 @@ class JdbcIndexer private[index] (
           .map(_ => headRef = headRef + 1)(DEC)
     }
   }
+
+  private def stateUpdateRecordTime(update: Update): Option[Instant] =
+    (update match {
+      case Heartbeat(recordTime) => Some(recordTime)
+      case PartyAddedToParticipant(_, _, _, recordTime) => Some(recordTime)
+      case PublicPackageUploaded(_, _, _, recordTime) => Some(recordTime)
+      case TransactionAccepted(_, _, _, _, recordTime, _) => Some(recordTime)
+      case ConfigurationChanged(_, _) => None
+      case ConfigurationChangeRejected(_, _) => None
+      case CommandRejected(_, _) => None
+    }) map (_.toInstant)
 
   private def toDomainRejection(
       submitterInfo: SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -179,12 +179,12 @@ class JdbcIndexer private[index] (
 
   object Metrics {
     val stateUpdateProcessingTimer =
-      metricsManager.metrics.timer("JdbcIndexer:processedStateUpdates")
+      metricsManager.metrics.timer("JdbcIndexer.processedStateUpdates")
 
     private[JdbcIndexer] def setup(): Unit = {
-      val lastReceivedRecordTimeName = "JdbcIndexer:lastReceivedRecordTime"
-      val lastReceivedOffsetName = "JdbcIndexer:lastReceivedOffset"
-      val currentRecordTimeLagName = "JdbcIndexer:currentRecordTimeLag"
+      val lastReceivedRecordTimeName = "JdbcIndexer.lastReceivedRecordTime"
+      val lastReceivedOffsetName = "JdbcIndexer.lastReceivedOffset"
+      val currentRecordTimeLagName = "JdbcIndexer.currentRecordTimeLag"
 
       metricsManager.metrics.remove(lastReceivedRecordTimeName)
       metricsManager.metrics.remove(lastReceivedOffsetName)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -74,10 +74,13 @@ class JdbcIndexerFactory[Status <: InitStatus] private (loggerFactory: NamedLogg
     this.asInstanceOf[JdbcIndexerFactory[Initialized]]
   }
 
-  def create(actorSystem: ActorSystem, readService: ReadService, jdbcUrl: String)(
-      implicit x: Status =:= Initialized): Future[JdbcIndexer] = {
+  def create(
+      participantId: String,
+      actorSystem: ActorSystem,
+      readService: ReadService,
+      jdbcUrl: String)(implicit x: Status =:= Initialized): Future[JdbcIndexer] = {
     val materializer: ActorMaterializer = ActorMaterializer()(actorSystem)
-    val metricsManager = MetricsManager(false)
+    val metricsManager = MetricsManager(s"com.digitalasset.platform.indexer.$participantId")
 
     implicit val ec: ExecutionContext = DEC
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -176,7 +176,8 @@ class StandaloneIndexServer(
         None,
         loggerFactory,
         config.tlsConfig.flatMap(_.server),
-        List(AuthorizationInterceptor(authService, ec))
+        List(AuthorizationInterceptor(authService, ec)),
+        mm
       )
       apiServerState = ApiServerState(
         domain.LedgerId(cond.ledgerId),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -198,7 +198,10 @@ class StandaloneIndexServer(
   def start(): Future[SandboxState] = {
     val actorSystem = ActorSystem(actorSystemName)
     val infrastructure =
-      Infrastructure(actorSystem, ActorMaterializer()(actorSystem), MetricsManager(false))
+      Infrastructure(
+        actorSystem,
+        ActorMaterializer()(actorSystem),
+        MetricsManager(s"com.digitalasset.platform.ledger-api-server.$participantId"))
     implicit val ec: ExecutionContext = infrastructure.executionContext
     val apiState = buildAndStartApiServer(infrastructure)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -168,7 +168,8 @@ class StandaloneIndexServer(
               cond.config.timeModel,
               SandboxConfig.defaultCommandConfig,
               timeServiceBackendO,
-              loggerFactory
+              loggerFactory,
+              mm
             )(am, esf),
         config.port,
         config.maxInboundMessageSize,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -50,7 +50,7 @@ object StandaloneIndexerServer {
         indexer.start { () =>
           {
             val createF = initializedIndexerFactory
-              .create(actorSystem, readService, config.jdbcUrl)
+              .create(config.participantId, actorSystem, readService, config.jdbcUrl)
             // signal when ready
             createF.map(_ => {
               promise.trySuccess(())

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -300,7 +300,10 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
   private def start(): SandboxState = {
     val actorSystem = ActorSystem(actorSystemName)
     val infrastructure =
-      Infrastructure(actorSystem, ActorMaterializer()(actorSystem), MetricsManager())
+      Infrastructure(
+        actorSystem,
+        ActorMaterializer()(actorSystem),
+        MetricsManager("com.digitalasset.platform.sandbox"))
     val packageStore = loadDamlPackages
     val apiState = buildAndStartApiServer(infrastructure, packageStore)
     SandboxState(apiState, infrastructure, packageStore)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -270,6 +270,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
           AuthorizationInterceptor(authService, ec),
           resetService(ledgerId, authorizer, loggerFactory)
         ),
+        mm
       ),
       asyncTolerance
     )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -256,7 +256,8 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
                     _,
                     indexAndWriteService.publishHeartbeat
                   )),
-              loggerFactory
+              loggerFactory,
+              mm
             )(am, esf)
             .map(_.withServices(List(resetService(ledgerId, authorizer, loggerFactory)))),
         // NOTE(JM): Re-use the same port after reset.

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.platform.sandbox.metrics
 
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
@@ -1,0 +1,25 @@
+package com.digitalasset.platform.sandbox.metrics
+
+import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
+
+/**
+  * An interceptor that counts all incoming calls by method.
+  * The metrics generated will be of the following schema:
+  * <pre>LedgerApi.&lt;service-name&gt;.&lt;method-name&gt;</pre>
+  * <br/>
+  * For example:
+  * <pre>LedgerApi.com.digitalasset.ledger.api.v1.TransactionService.GetTransactionTrees</pre>
+  */
+class MetricsInterceptor(metricsManager: MetricsManager) extends ServerInterceptor {
+  override def interceptCall[ReqT, RespT](
+      call: ServerCall[ReqT, RespT],
+      headers: Metadata,
+      next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    // The service name and method name are separated by a '/'.
+    // Converting it to a '.' makes it easier for downstream tools to
+    // put the metrics into a hierarchy.
+    val serviceName = call.getMethodDescriptor.getFullMethodName.replace('/', '.')
+    metricsManager.metrics.meter(s"LedgerApi.$serviceName").mark()
+    next.startCall(call, headers)
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsManager.scala
@@ -17,13 +17,13 @@ import scala.concurrent.Future
   * <br/><br/>
   * Note that metrics are in general light-weight and add negligible overhead. They are not visible to everyday
   * users so they can be safely enabled all the time. */
-final class MetricsManager(enableJmxReporter: Boolean) extends AutoCloseable {
+final class MetricsManager(jmxDomain: String, enableJmxReporter: Boolean) extends AutoCloseable {
 
   val metrics = new MetricRegistry()
 
   private lazy val jmxReporter = JmxReporter
     .forRegistry(metrics)
-    .inDomain("com.digitalasset.platform.sandbox")
+    .inDomain(jmxDomain)
     .build
 
   private val slf4jReporter = Slf4jReporter
@@ -54,6 +54,6 @@ final class MetricsManager(enableJmxReporter: Boolean) extends AutoCloseable {
 }
 
 object MetricsManager {
-  def apply(enableJmxReporter: Boolean = true): MetricsManager =
-    new MetricsManager(enableJmxReporter)
+  def apply(jmxDomain: String, enableJmxReporter: Boolean = true): MetricsManager =
+    new MetricsManager(jmxDomain, enableJmxReporter)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
@@ -7,9 +7,9 @@ import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.index.v2.ContractStore
 import com.daml.ledger.participant.state.v1.SubmissionResult.{
   Acknowledged,
+  InternalError,
   NotSupported,
-  Overloaded,
-  InternalError
+  Overloaded
 }
 import com.daml.ledger.participant.state.v1.{
   SubmissionResult,
@@ -27,12 +27,12 @@ import com.digitalasset.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.digitalasset.ledger.api.messages.command.submission.SubmitRequest
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.api.grpc.GrpcApiService
+import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ledger.{CommandExecutor, ErrorCause}
 import com.digitalasset.platform.server.api.services.domain.CommandSubmissionService
 import com.digitalasset.platform.server.api.services.grpc.GrpcCommandSubmissionService
 import com.digitalasset.platform.server.api.validation.ErrorFactories
 import com.digitalasset.platform.server.services.command.time.TimeModelValidator
-
 import io.grpc.Status
 import scalaz.syntax.tag._
 
@@ -51,7 +51,8 @@ object ApiSubmissionService {
       timeModel: TimeModel,
       timeProvider: TimeProvider,
       commandExecutor: CommandExecutor,
-      loggerFactory: NamedLoggerFactory)(implicit ec: ExecutionContext, mat: ActorMaterializer)
+      loggerFactory: NamedLoggerFactory,
+      metricsManager: MetricsManager)(implicit ec: ExecutionContext, mat: ActorMaterializer)
     : GrpcCommandSubmissionService with GrpcApiService with CommandSubmissionServiceLogging =
     new GrpcCommandSubmissionService(
       new ApiSubmissionService(
@@ -60,7 +61,8 @@ object ApiSubmissionService {
         timeModel,
         timeProvider,
         commandExecutor,
-        loggerFactory),
+        loggerFactory,
+        metricsManager),
       ledgerId
     ) with CommandSubmissionServiceLogging
 
@@ -76,7 +78,8 @@ class ApiSubmissionService private (
     timeModel: TimeModel,
     timeProvider: TimeProvider,
     commandExecutor: CommandExecutor,
-    loggerFactory: NamedLoggerFactory)(implicit ec: ExecutionContext, mat: ActorMaterializer)
+    loggerFactory: NamedLoggerFactory,
+    metricsManager: MetricsManager)(implicit ec: ExecutionContext, mat: ActorMaterializer)
     extends CommandSubmissionService
     with ErrorFactories
     with AutoCloseable {
@@ -146,17 +149,27 @@ class ApiSubmissionService private (
       submissionResult <- handleResult(res)
     } yield submissionResult
 
+  private val failedInterpretationsMeter =
+    metricsManager.metrics.meter("CommandSubmission:failedCommandInterpretations")
+
+  private val submittedTransactionsTimer =
+    metricsManager.metrics.timer("CommandSubmission:submittedTransactions")
+
   private def handleResult(
       res: scala.Either[ErrorCause, (SubmitterInfo, TransactionMeta, Transaction.Transaction)]) =
     res match {
       case Right((submitterInfo, transactionMeta, transaction)) =>
-        FutureConverters.toScala(
-          writeService.submitTransaction(
-            submitterInfo,
-            transactionMeta,
-            transaction
-          ))
-      case Left(err) => Future.failed(grpcError(toStatus(err)))
+        metricsManager.timedFuture(
+          submittedTransactionsTimer,
+          FutureConverters.toScala(
+            writeService.submitTransaction(
+              submitterInfo,
+              transactionMeta,
+              transaction
+            )))
+      case Left(err) =>
+        failedInterpretationsMeter.mark()
+        Future.failed(grpcError(toStatus(err)))
     }
 
   private def toStatus(errorCause: ErrorCause) = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -37,26 +37,26 @@ private class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, mm: MetricsManager)
   override def lookupContract(
       contractId: Value.AbsoluteContractId,
       forParty: Party): Future[Option[Contract]] =
-    mm.timedFuture("Ledger:lookupContract", ledger.lookupContract(contractId, forParty))
+    mm.timedFuture("Ledger.lookupContract", ledger.lookupContract(contractId, forParty))
 
   override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =
-    mm.timedFuture("Ledger:lookupKey", ledger.lookupKey(key, forParty))
+    mm.timedFuture("Ledger.lookupKey", ledger.lookupKey(key, forParty))
 
   override def lookupTransaction(
       transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =
-    mm.timedFuture("Ledger:lookupTransaction", ledger.lookupTransaction(transactionId))
+    mm.timedFuture("Ledger.lookupTransaction", ledger.lookupTransaction(transactionId))
 
   override def parties: Future[List[PartyDetails]] =
-    mm.timedFuture("Ledger:parties", ledger.parties)
+    mm.timedFuture("Ledger.parties", ledger.parties)
 
   override def listLfPackages(): Future[Map[PackageId, PackageDetails]] =
-    mm.timedFuture("Ledger:listLfPackages", ledger.listLfPackages())
+    mm.timedFuture("Ledger.listLfPackages", ledger.listLfPackages())
 
   override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
-    mm.timedFuture("Ledger:getLfArchive", ledger.getLfArchive(packageId))
+    mm.timedFuture("Ledger.getLfArchive", ledger.getLfArchive(packageId))
 
   override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
-    mm.timedFuture("Ledger:getLfPackage", ledger.getLfPackage(packageId))
+    mm.timedFuture("Ledger.getLfPackage", ledger.getLfPackage(packageId))
 
   override def close(): Unit = {
     ledger.close()
@@ -73,27 +73,27 @@ private class MeteredLedger(ledger: Ledger, mm: MetricsManager)
     with Ledger {
 
   override def publishHeartbeat(time: Instant): Future[Unit] =
-    mm.timedFuture("Ledger:publishHeartbeat", ledger.publishHeartbeat(time))
+    mm.timedFuture("Ledger.publishHeartbeat", ledger.publishHeartbeat(time))
 
   override def publishTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction): Future[SubmissionResult] =
     mm.timedFuture(
-      "Ledger:publishTransaction",
+      "Ledger.publishTransaction",
       ledger.publishTransaction(submitterInfo, transactionMeta, transaction))
 
   override def allocateParty(
       party: Party,
       displayName: Option[String]): Future[PartyAllocationResult] =
-    mm.timedFuture("Ledger:addParty", ledger.allocateParty(party, displayName))
+    mm.timedFuture("Ledger.addParty", ledger.allocateParty(party, displayName))
 
   override def uploadPackages(
       knownSince: Instant,
       sourceDescription: Option[String],
       payload: List[Archive]): Future[UploadPackagesResult] =
     mm.timedFuture(
-      "Ledger:uploadPackages",
+      "Ledger.uploadPackages",
       ledger.uploadPackages(knownSince, sourceDescription, payload))
 
   override def close(): Unit = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
@@ -25,32 +25,32 @@ private class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, mm: MetricsManager)
     extends LedgerReadDao
     with AutoCloseable {
   override def lookupLedgerId(): Future[Option[LedgerId]] =
-    mm.timedFuture("LedgerDao:lookupLedgerId", ledgerDao.lookupLedgerId())
+    mm.timedFuture("LedgerDao.lookupLedgerId", ledgerDao.lookupLedgerId())
 
   override def lookupLedgerEnd(): Future[Long] =
-    mm.timedFuture("LedgerDao:lookupLedgerEnd", ledgerDao.lookupLedgerEnd())
+    mm.timedFuture("LedgerDao.lookupLedgerEnd", ledgerDao.lookupLedgerEnd())
 
   override def lookupExternalLedgerEnd(): Future[Option[LedgerString]] =
-    mm.timedFuture("LedgerDao:lookupExternalLedgerEnd", ledgerDao.lookupExternalLedgerEnd())
+    mm.timedFuture("LedgerDao.lookupExternalLedgerEnd", ledgerDao.lookupExternalLedgerEnd())
 
   override def lookupActiveOrDivulgedContract(
       contractId: Value.AbsoluteContractId,
       forParty: Party): Future[Option[Contract]] =
     mm.timedFuture(
-      "LedgerDao:lookupActiveContract",
+      "LedgerDao.lookupActiveContract",
       ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty))
 
   override def lookupLedgerEntry(offset: Long): Future[Option[LedgerEntry]] =
-    mm.timedFuture("LedgerDao:lookupLedgerEntry", ledgerDao.lookupLedgerEntry(offset))
+    mm.timedFuture("LedgerDao.lookupLedgerEntry", ledgerDao.lookupLedgerEntry(offset))
 
   override def lookupTransaction(
       transactionId: TransactionId): Future[Option[(LedgerOffset, LedgerEntry.Transaction)]] =
-    mm.timedFuture("LedgerDao:lookupTransaction", ledgerDao.lookupTransaction(transactionId))
+    mm.timedFuture("LedgerDao.lookupTransaction", ledgerDao.lookupTransaction(transactionId))
 
   override def lookupKey(
       key: Node.GlobalKey,
       forParty: Party): Future[Option[Value.AbsoluteContractId]] =
-    mm.timedFuture("LedgerDao:lookupKey", ledgerDao.lookupKey(key, forParty))
+    mm.timedFuture("LedgerDao.lookupKey", ledgerDao.lookupKey(key, forParty))
 
   override def getActiveContractSnapshot(untilExclusive: LedgerOffset, filter: TemplateAwareFilter)(
       implicit mat: Materializer): Future[LedgerSnapshot] =
@@ -62,13 +62,13 @@ private class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, mm: MetricsManager)
     ledgerDao.getLedgerEntries(startInclusive, endExclusive)
 
   override def getParties: Future[List[PartyDetails]] =
-    mm.timedFuture("getParties", ledgerDao.getParties)
+    mm.timedFuture("LedgerDao.getParties", ledgerDao.getParties)
 
   override def listLfPackages: Future[Map[PackageId, PackageDetails]] =
-    mm.timedFuture("listLfPackages", ledgerDao.listLfPackages)
+    mm.timedFuture("LedgerDao.listLfPackages", ledgerDao.listLfPackages)
 
   override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
-    mm.timedFuture("getLfArchive", ledgerDao.getLfArchive(packageId))
+    mm.timedFuture("LedgerDao.getLfArchive", ledgerDao.getLfArchive(packageId))
 
   override def close(): Unit = {
     ledgerDao.close()
@@ -84,7 +84,7 @@ private class MeteredLedgerDao(ledgerDao: LedgerDao, mm: MetricsManager)
       externalOffset: Option[ExternalOffset],
       ledgerEntry: PersistenceEntry): Future[PersistenceResponse] =
     mm.timedFuture(
-      "storeLedgerEntry",
+      "LedgerDao.storeLedgerEntry",
       ledgerDao.storeLedgerEntry(offset, newLedgerEnd, externalOffset, ledgerEntry))
 
   override def storeInitialState(
@@ -93,7 +93,7 @@ private class MeteredLedgerDao(ledgerDao: LedgerDao, mm: MetricsManager)
       newLedgerEnd: LedgerOffset
   ): Future[Unit] =
     mm.timedFuture(
-      "storeInitialState",
+      "LedgerDao.storeInitialState",
       ledgerDao.storeInitialState(activeContracts, ledgerEntries, newLedgerEnd))
 
   override def initializeLedger(ledgerId: LedgerId, ledgerEnd: LedgerOffset): Future[Unit] =
@@ -103,20 +103,20 @@ private class MeteredLedgerDao(ledgerDao: LedgerDao, mm: MetricsManager)
     ledgerDao.reset()
 
   override def getParties: Future[List[PartyDetails]] =
-    mm.timedFuture("getParties", ledgerDao.getParties)
+    mm.timedFuture("LedgerDao.getParties", ledgerDao.getParties)
 
   override def storeParty(
       party: Party,
       displayName: Option[String],
       externalOffset: Option[ExternalOffset]): Future[PersistenceResponse] =
-    mm.timedFuture("storeParty", ledgerDao.storeParty(party, displayName, externalOffset))
+    mm.timedFuture("LedgerDao.storeParty", ledgerDao.storeParty(party, displayName, externalOffset))
 
   override def uploadLfPackages(
       uploadId: String,
       packages: List[(Archive, PackageDetails)],
       externalOffset: Option[ExternalOffset]): Future[Map[PersistenceResponse, Int]] =
     mm.timedFuture(
-      "uploadLfPackages",
+      "LedgerDao.uploadLfPackages",
       ledgerDao.uploadLfPackages(uploadId, packages, externalOffset))
 
   override def close(): Unit = {

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
@@ -13,7 +13,7 @@ trait MetricsAround extends BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    metricsManager = MetricsManager()
+    metricsManager = MetricsManager("MetricsAround")
   }
 
   override protected def afterAll(): Unit = {

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -76,7 +76,8 @@ trait TestHelpers {
       TimeModel.reasonableDefault,
       timeProvider,
       new CommandExecutorImpl(Engine(), packageStore.getLfPackage),
-      NamedLoggerFactory.forParticipant(participantId)
+      NamedLoggerFactory.forParticipant(participantId),
+      mm
     )(ec, mat)
   }
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/TestHelpers.scala
@@ -52,7 +52,7 @@ trait TestHelpers {
       toleranceWindow: ToleranceWindow,
       authService: AuthService)(implicit ec: ExecutionContext, mat: ActorMaterializer) = {
 
-    implicit val mm: MetricsManager = MetricsManager()
+    implicit val mm: MetricsManager = MetricsManager("test")
 
     val ledgerId = LedgerId("sandbox-ledger")
     val participantId: ParticipantId = Ref.LedgerString.assertFromString("sandbox-participant")

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -86,7 +86,12 @@ class JdbcLedgerDaoSpec
     super.beforeAll()
     val loggerFactory = NamedLoggerFactory(JdbcLedgerDaoSpec.getClass)
     FlywayMigrations(postgresFixture.jdbcUrl, loggerFactory).migrate()
-    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4, loggerFactory, MetricsManager())
+    dbDispatcher = DbDispatcher(
+      postgresFixture.jdbcUrl,
+      4,
+      4,
+      loggerFactory,
+      MetricsManager("JdbcLedgerDaoSpec"))
     ledgerDao = JdbcLedgerDao(
       dbDispatcher,
       ContractSerializer,


### PR DESCRIPTION
Add metrics to track commands

    - Meter: CommandSubmission.failedCommandInterpretations
    - Timer: CommandSubmission:submittedTransactions

Add metrics to JdbcIndexer

    - Gauge: JdbcIndexer:lastReceivedRecordTime
    - Gauge: JdbcIndexer:lastReceivedOffset
    - Gauge: JdbcIndexer:currentRecordTimeLag
    - Timer: JdbcIndexer:processedStateUpdates

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
