### PR TITLE
add error codes for overloaded and internal error to participant state

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -40,6 +40,9 @@ trait ErrorFactories {
   def permissionDenied(description: String): StatusRuntimeException =
     grpcError(Status.PERMISSION_DENIED.withDescription(description))
 
+  def resourceExhausted: StatusRuntimeException =
+    grpcError(Status.RESOURCE_EXHAUSTED)
+
   def grpcError(status: Status) = new ApiException(status)
 
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -40,8 +40,8 @@ trait ErrorFactories {
   def permissionDenied(description: String): StatusRuntimeException =
     grpcError(Status.PERMISSION_DENIED.withDescription(description))
 
-  def resourceExhausted: StatusRuntimeException =
-    grpcError(Status.RESOURCE_EXHAUSTED)
+  def resourceExhausted(description: String): StatusRuntimeException =
+    grpcError(Status.RESOURCE_EXHAUSTED.withDescription(description))
 
   def grpcError(status: Status) = new ApiException(status)
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -28,7 +28,8 @@ object PartyAllocationResult {
 
   /** Submission ended up with internal error */
   final case class InternalError(reason: String) extends PartyAllocationResult {
-    override def description: String = "Party allocation failed with an internal error, reason=" + reason
+    override def description: String =
+      "Party allocation failed with an internal error, reason=" + reason
   }
 
   /** The requested party name already exists */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -29,7 +29,7 @@ object PartyAllocationResult {
   /** Submission ended up with internal error */
   final case class InternalError(reason: String) extends PartyAllocationResult {
     override def description: String =
-      "Party allocation failed with an internal error, reason=" + reason
+      s"Party allocation failed with an internal error, reason=$reason"
   }
 
   /** The requested party name already exists */
@@ -39,7 +39,7 @@ object PartyAllocationResult {
 
   /** The requested party name is not valid */
   final case class InvalidName(details: String) extends PartyAllocationResult {
-    override def description: String = "Party name is invalid, details=" + details
+    override def description: String = s"Party name is invalid, details=$details"
   }
 
   /** The participant was not authorized to submit the allocation request */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -38,7 +38,7 @@ object PartyAllocationResult {
 
   /** The requested party name is not valid */
   final case class InvalidName(details: String) extends PartyAllocationResult {
-    override def description: String = "Party name is invalid, error=" + details
+    override def description: String = "Party name is invalid, details=" + details
   }
 
   /** The participant was not authorized to submit the allocation request */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -16,9 +16,19 @@ object PartyAllocationResult {
     override def description: String = "Party successfully allocated"
   }
 
+  /** The system is overloaded, clients should back off exponentially */
+  final case object Overloaded extends PartyAllocationResult {
+    override def description: String = "System is overloaded, please try again later"
+  }
+
   /** Synchronous party allocation is not supported */
   final case object NotSupported extends PartyAllocationResult {
     override def description: String = "Party allocation not supported"
+  }
+
+  /** Submission ended up with internal error */
+  final case class InternalError(reason: String) extends PartyAllocationResult {
+    override def description: String = "Party allocation failed with an internal error, reason=" + reason
   }
 
   /** The requested party name already exists */
@@ -28,7 +38,7 @@ object PartyAllocationResult {
 
   /** The requested party name is not valid */
   final case class InvalidName(details: String) extends PartyAllocationResult {
-    override def description: String = "Party name is invalid: " + details
+    override def description: String = "Party name is invalid, error=" + details
   }
 
   /** The participant was not authorized to submit the allocation request */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/PartyAllocationResult.scala
@@ -17,13 +17,13 @@ object PartyAllocationResult {
   }
 
   /** The system is overloaded, clients should back off exponentially */
-  final case object Overloaded extends PartyAllocationResult {
-    override def description: String = "System is overloaded, please try again later"
+  case object Overloaded extends PartyAllocationResult {
+    override val description: String = "System is overloaded, please try again later"
   }
 
   /** Synchronous party allocation is not supported */
-  final case object NotSupported extends PartyAllocationResult {
-    override def description: String = "Party allocation not supported"
+  case object NotSupported extends PartyAllocationResult {
+    override val description: String = "Party allocation not supported"
   }
 
   /** Submission ended up with internal error */
@@ -33,8 +33,8 @@ object PartyAllocationResult {
   }
 
   /** The requested party name already exists */
-  final case object AlreadyExists extends PartyAllocationResult {
-    override def description: String = "Party already exists"
+  case object AlreadyExists extends PartyAllocationResult {
+    override val description: String = "Party already exists"
   }
 
   /** The requested party name is not valid */
@@ -43,7 +43,7 @@ object PartyAllocationResult {
   }
 
   /** The participant was not authorized to submit the allocation request */
-  final case object ParticipantNotAuthorized extends PartyAllocationResult {
-    override def description: String = "Participant is not authorized to allocate a party"
+  case object ParticipantNotAuthorized extends PartyAllocationResult {
+    override val description: String = "Participant is not authorized to allocate a party"
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -27,12 +27,12 @@ object UploadPackagesResult {
   /** Submission ended up with internal error */
   final case class InternalError(reason: String) extends UploadPackagesResult {
     override def description: String =
-      "Party allocation failed with an internal error, reason=" + reason
+      s"Party allocation failed with an internal error, reason=$reason"
   }
 
   /** One of the uploaded packages is not valid */
   final case class InvalidPackage(reason: String) extends UploadPackagesResult {
-    override def description: String = "Uploaded packages were invalid, details=" + reason
+    override def description: String = s"Uploaded packages were invalid, details=$reason"
   }
 
   /** The participant was not authorized to submit the upload request */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -10,18 +10,18 @@ sealed abstract class UploadPackagesResult extends Product with Serializable {
 object UploadPackagesResult {
 
   /** The packages were successfully uploaded */
-  final case object Ok extends UploadPackagesResult {
-    override def description: String = "Packages successfully uploaded"
+  case object Ok extends UploadPackagesResult {
+    override val description: String = "Packages successfully uploaded"
   }
 
   /** The system is overloaded, clients should back off exponentially */
-  final case object Overloaded extends UploadPackagesResult {
-    override def description: String = "System is overloaded, please try again later"
+  case object Overloaded extends UploadPackagesResult {
+    override val description: String = "System is overloaded, please try again later"
   }
 
   /** Synchronous package upload is not supported */
-  final case object NotSupported extends UploadPackagesResult {
-    override def description: String = "Packages upload not supported"
+  case object NotSupported extends UploadPackagesResult {
+    override val description: String = "Packages upload not supported"
   }
 
   /** Submission ended up with internal error */
@@ -36,7 +36,7 @@ object UploadPackagesResult {
   }
 
   /** The participant was not authorized to submit the upload request */
-  final case object ParticipantNotAuthorized extends UploadPackagesResult {
-    override def description: String = "Participant is not authorized to upload packages"
+  case object ParticipantNotAuthorized extends UploadPackagesResult {
+    override val description: String = "Participant is not authorized to upload packages"
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -26,7 +26,8 @@ object UploadPackagesResult {
 
   /** Submission ended up with internal error */
   final case class InternalError(reason: String) extends UploadPackagesResult {
-    override def description: String = "Party allocation failed with an internal error, reason=" + reason
+    override def description: String =
+      "Party allocation failed with an internal error, reason=" + reason
   }
 
   /** One of the uploaded packages is not valid */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -31,7 +31,7 @@ object UploadPackagesResult {
 
   /** One of the uploaded packages is not valid */
   final case class InvalidPackage(reason: String) extends UploadPackagesResult {
-    override def description: String = "Uploaded packages were invalid: " + reason
+    override def description: String = "Uploaded packages were invalid, details=" + reason
   }
 
   /** The participant was not authorized to submit the upload request */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/UploadPackagesResult.scala
@@ -14,9 +14,19 @@ object UploadPackagesResult {
     override def description: String = "Packages successfully uploaded"
   }
 
+  /** The system is overloaded, clients should back off exponentially */
+  final case object Overloaded extends UploadPackagesResult {
+    override def description: String = "System is overloaded, please try again later"
+  }
+
   /** Synchronous package upload is not supported */
   final case object NotSupported extends UploadPackagesResult {
     override def description: String = "Packages upload not supported"
+  }
+
+  /** Submission ended up with internal error */
+  final case class InternalError(reason: String) extends UploadPackagesResult {
+    override def description: String = "Party allocation failed with an internal error, reason=" + reason
   }
 
   /** One of the uploaded packages is not valid */

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -76,6 +76,10 @@ class ApiPackageManagementService(
           .flatMap {
             case UploadPackagesResult.Ok =>
               Future.successful(UploadDarFileResponse())
+            case r @ UploadPackagesResult.Overloaded =>
+              Future.failed(ErrorFactories.resourceExhausted)
+            case r @ UploadPackagesResult.InternalError(_) =>
+              Future.failed(ErrorFactories.internal(r.reason))
             case r @ UploadPackagesResult.InvalidPackage(_) =>
               Future.failed(ErrorFactories.invalidArgument(r.description))
             case r @ UploadPackagesResult.ParticipantNotAuthorized =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -77,7 +77,7 @@ class ApiPackageManagementService(
             case UploadPackagesResult.Ok =>
               Future.successful(UploadDarFileResponse())
             case r @ UploadPackagesResult.Overloaded =>
-              Future.failed(ErrorFactories.resourceExhausted)
+              Future.failed(ErrorFactories.resourceExhausted(r.description))
             case r @ UploadPackagesResult.InternalError(_) =>
               Future.failed(ErrorFactories.internal(r.reason))
             case r @ UploadPackagesResult.InvalidPackage(_) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -90,8 +90,12 @@ class ApiPartyManagementService private (
       .flatMap {
         case PartyAllocationResult.Ok(details) =>
           Future.successful(AllocatePartyResponse(Some(mapPartyDetails(details))))
+        case r @ PartyAllocationResult.Overloaded =>
+          Future.failed(ErrorFactories.resourceExhausted)
         case r @ PartyAllocationResult.AlreadyExists =>
           Future.failed(ErrorFactories.invalidArgument(r.description))
+        case r @ PartyAllocationResult.InternalError(_) =>
+          Future.failed(ErrorFactories.internal(r.reason))
         case r @ PartyAllocationResult.InvalidName(_) =>
           Future.failed(ErrorFactories.invalidArgument(r.description))
         case r @ PartyAllocationResult.ParticipantNotAuthorized =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -91,7 +91,7 @@ class ApiPartyManagementService private (
         case PartyAllocationResult.Ok(details) =>
           Future.successful(AllocatePartyResponse(Some(mapPartyDetails(details))))
         case r @ PartyAllocationResult.Overloaded =>
-          Future.failed(ErrorFactories.resourceExhausted)
+          Future.failed(ErrorFactories.resourceExhausted(r.description))
         case r @ PartyAllocationResult.AlreadyExists =>
           Future.failed(ErrorFactories.invalidArgument(r.description))
         case r @ PartyAllocationResult.InternalError(_) =>


### PR DESCRIPTION
The overloaded and internal error codes currently missing from the participant state API. Unfortunately, these two are quite common errors for gRPC based ledger implementations, where back pressure can result in overloaded and any 3rd party library crash will result in internal error being raised.

These error codes will very soon be replaced by SubmissionResult in a separate PR, which already contains the correct codes.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
