### PR TITLE
Implement support for RSA-signed JWT tokens

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -11,6 +11,7 @@ def install_java_deps():
             "ch.qos.logback:logback-classic:1.2.3",
             "ch.qos.logback:logback-core:1.2.3",
             "com.auth0:java-jwt:3.8.1",
+            "com.auth0:jwks-rsa:0.9.0",
             "com.chuusai:shapeless_2.12:2.3.2",
             "com.fasterxml.jackson.core:jackson-annotations:2.9.8",
             "com.fasterxml.jackson.core:jackson-core:2.9.8",

--- a/ledger-service/jwt/BUILD.bazel
+++ b/ledger-service/jwt/BUILD.bazel
@@ -15,6 +15,8 @@ hj_scalacopts = [
 
 jwt_deps = [
     "@maven//:com_auth0_java_jwt",
+    "@maven//:com_auth0_jwks_rsa",
+    "@maven//:com_google_guava_guava",
     "@maven//:ch_qos_logback_logback_classic",
     "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     "@maven//:org_scalaz_scalaz_core_2_12",

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwksVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwksVerifier.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.jwt
+
+import java.net.{URI, URL}
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.TimeUnit
+
+import com.auth0.jwk.UrlJwkProvider
+import com.digitalasset.jwt.JwtVerifier.Error
+import com.google.common.cache.{Cache, CacheBuilder}
+import scalaz.{-\/, Show, \/}
+import scalaz.syntax.show._
+
+/**
+  * A JWK verifier, where the public keys are automatically fetched from the given JWKS URL.
+  *
+  */
+class JwksVerifier(url: URL) extends JwtVerifierBase {
+  private[this] val http = new UrlJwkProvider(url)
+
+  private[this] val cache: Cache[String, JwtVerifier] = CacheBuilder
+    .newBuilder()
+    .maximumSize(10)
+    .expireAfterWrite(10, TimeUnit.HOURS)
+    .build()
+
+  private[this] def getVerifier(keyId: String): Error \/ JwtVerifier = {
+    val jwk = http.get(keyId)
+    val publicKey = jwk.getPublicKey.asInstanceOf[RSAPublicKey]
+    RSA256Verifier(publicKey)
+  }
+
+  /** Looks up the verifier for the given keyId from the local cache.
+    * On a cache miss, creates a new verifier by fetching the public key from the JWKS URL. */
+  private[this] def getCachedVerifier(keyId: String): Error \/ JwtVerifier = {
+    if (keyId == null)
+      -\/(Error('getCachedVerifier, "No Key ID found"))
+    else
+      \/.fromTryCatchNonFatal(
+        cache.get(keyId, () => getVerifier(keyId).fold(e => sys.error(e.shows), x => x))
+      ).leftMap(e => Error('getCachedVerifier, e.getMessage))
+  }
+
+  def verify(jwt: domain.Jwt): Error \/ domain.DecodedJwt[String] = {
+    for {
+      keyId <- \/.fromTryCatchNonFatal(com.auth0.jwt.JWT.decode(jwt.value).getKeyId)
+        .leftMap(e => Error('verify, e.getMessage))
+      verifier <- getCachedVerifier(keyId)
+      decoded <- verifier.verify(jwt)
+    } yield decoded
+  }
+}
+
+object JwksVerifier {
+  def apply(url: String) = new JwksVerifier(new URI(url).toURL)
+
+  final case class Error(what: Symbol, message: String)
+
+  object Error {
+    implicit val showInstance: Show[Error] =
+      Show.shows(e => s"JwksVerifier.Error: ${e.what}, ${e.message}")
+  }
+}

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwksVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwksVerifier.scala
@@ -18,7 +18,14 @@ import scalaz.syntax.show._
   *
   */
 class JwksVerifier(url: URL) extends JwtVerifierBase {
-  private[this] val http = new UrlJwkProvider(url)
+
+  /** Timeout for connecting to the JWKS URL, in milliseconds */
+  private[this] val connectionTimeoutMs = 10000
+
+  /** Timeout for reading from the JWKS URL, in milliseconds */
+  private[this] val readTimeoutMs = 10000
+  private[this] val http =
+    new UrlJwkProvider(url, new Integer(connectionTimeoutMs), new Integer(readTimeoutMs))
 
   private[this] val cache: Cache[String, JwtVerifier] = CacheBuilder
     .newBuilder()

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtSigner.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtSigner.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.jwt
 
 import java.nio.charset.Charset
+import java.security.interfaces.RSAPrivateKey
 
 import com.auth0.jwt.algorithms.Algorithm
 import scalaz.syntax.traverse._
@@ -24,6 +25,24 @@ object JwtSigner {
 
         signature <- \/.fromTryCatchNonFatal(algorithm.sign(base64Jwt.header, base64Jwt.payload))
           .leftMap(e => Error(Symbol("HMAC256.sign"), e.getMessage))
+
+        base64Signature <- base64Encode(signature)
+
+      } yield
+        domain.Jwt(
+          s"${str(base64Jwt.header): String}.${str(base64Jwt.payload)}.${str(base64Signature): String}")
+  }
+
+  object RSA256 {
+    def sign(jwt: domain.DecodedJwt[String], privateKey: RSAPrivateKey): Error \/ domain.Jwt =
+      for {
+        base64Jwt <- base64Encode(jwt)
+
+        algorithm <- \/.fromTryCatchNonFatal(Algorithm.RSA256(null, privateKey))
+          .leftMap(e => Error(Symbol("RSA256.sign"), e.getMessage))
+
+        signature <- \/.fromTryCatchNonFatal(algorithm.sign(base64Jwt.header, base64Jwt.payload))
+          .leftMap(e => Error(Symbol("RSA256.sign"), e.getMessage))
 
         base64Signature <- base64Encode(signature)
 

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
@@ -80,15 +80,16 @@ object RSA256Verifier extends StrictLogging {
 
   /**
     * Create a RSA256 validator with the key loaded from the given file.
-    * The file is assumed to be a X509 encoded RSA public key in a PEM container.
+    * The file is assumed to be a X509 encoded certificate.
+    * These typically have the .crt file extension.
     */
-  def fromX509PemFile(path: String): Error \/ JwtVerifier = {
+  def fromCrtFile(path: String): Error \/ JwtVerifier = {
     for {
       rsaKey <- \/.fromEither(
         KeyUtils
           .readRSAPublicKeyFromCrt(new File(path))
           .toEither)
-        .leftMap(e => Error('fromX509PemFile, e.getMessage))
+        .leftMap(e => Error('fromCrtFile, e.getMessage))
       verfier <- RSA256Verifier.apply(rsaKey)
     } yield verfier
   }

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
@@ -3,15 +3,23 @@
 
 package com.digitalasset.jwt
 
+import java.io.File
+import java.security.interfaces.RSAPublicKey
+
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.RSAKeyProvider
 import com.digitalasset.jwt.JwtVerifier.Error
 import com.typesafe.scalalogging.StrictLogging
 import scalaz.{Show, \/}
 import scalaz.syntax.show._
 import scalaz.syntax.traverse._
 
-class JwtVerifier(verifier: com.auth0.jwt.interfaces.JWTVerifier) {
+abstract class JwtVerifierBase {
+  def verify(jwt: domain.Jwt): Error \/ domain.DecodedJwt[String]
+}
+
+class JwtVerifier(verifier: com.auth0.jwt.interfaces.JWTVerifier) extends JwtVerifierBase {
 
   def verify(jwt: domain.Jwt): Error \/ domain.DecodedJwt[String] = {
     // The auth0 library verification already fails if the token has expired,
@@ -44,7 +52,7 @@ object HMAC256Verifier extends StrictLogging {
   def apply(secret: String): Error \/ JwtVerifier =
     \/.fromTryCatchNonFatal {
       logger.warn(
-        "HMAC256 JWT Validator is NOT recommended for production env, please use RSA256 (WIP)!!!")
+        "HMAC256 JWT Validator is NOT recommended for production environments, please use RSA256!!!")
 
       val algorithm = Algorithm.HMAC256(secret)
       val verifier = JWT.require(algorithm).build()
@@ -52,4 +60,39 @@ object HMAC256Verifier extends StrictLogging {
     }.leftMap(e => Error('HMAC256, e.getMessage))
 }
 
-// TODO(Leo) RSA256 validator
+// RSA256 validator factory
+object RSA256Verifier extends StrictLogging {
+  def apply(publicKey: RSAPublicKey): Error \/ JwtVerifier =
+    \/.fromTryCatchNonFatal {
+
+      val algorithm = Algorithm.RSA256(publicKey, null)
+      val verifier = JWT.require(algorithm).build()
+      new JwtVerifier(verifier)
+    }.leftMap(e => Error('RSA256, e.getMessage))
+
+  def apply(keyProvider: RSAKeyProvider): Error \/ JwtVerifier =
+    \/.fromTryCatchNonFatal {
+
+      val algorithm = Algorithm.RSA256(keyProvider)
+      val verifier = JWT.require(algorithm).build()
+      new JwtVerifier(verifier)
+    }.leftMap(e => Error('RSA256, e.getMessage))
+
+  /**
+    * Create a RSA256 validator with the key loaded from the given file.
+    * The file is assumed to be a X509 encoded RSA public key in a PEM container.
+    */
+  def fromX509PemFile(path: String): Error \/ JwtVerifier = {
+    for {
+      rsaKey <- \/.fromEither(
+        KeyUtils
+          .readRSAPublicKeyFromCrt(new File(path))
+          .toEither)
+        .leftMap(e => Error('fromX509PemFile, e.getMessage))
+      verfier <- RSA256Verifier.apply(rsaKey)
+    } yield verfier
+  }
+
+  /** Create a RSA256 validator with the key loaded from the given JWK server */
+  def fromJwk(url: String): Error \/ JwtVerifier = ???
+}

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
@@ -92,7 +92,4 @@ object RSA256Verifier extends StrictLogging {
       verfier <- RSA256Verifier.apply(rsaKey)
     } yield verfier
   }
-
-  /** Create a RSA256 validator with the key loaded from the given JWK server */
-  def fromJwk(url: String): Error \/ JwtVerifier = ???
 }

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.jwt
+
+import java.io.{File, FileInputStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.cert.CertificateFactory
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.KeyFactory
+
+import com.digitalasset.daml.lf.data.TryOps.Bracket.bracket
+import scalaz.Show
+import scalaz.syntax.show._
+
+import scala.util.Try
+
+object KeyUtils {
+  final case class Error(what: Symbol, message: String)
+
+  object Error {
+    implicit val showInstance: Show[Error] =
+      Show.shows(e => s"PemUtils.Error: ${e.what}, ${e.message}")
+  }
+
+  private val mimeCharSet = StandardCharsets.ISO_8859_1
+
+  /**
+    * Reads an RSA public key from a X509 encoded file.
+    * These usually have the .crt file extension.
+    */
+  def readRSAPublicKeyFromCrt(file: File): Try[RSAPublicKey] = {
+    bracket(Try(new FileInputStream(file)))(is => Try(is.close())).flatMap { istream =>
+      Try(
+        CertificateFactory
+          .getInstance("X.509")
+          .generateCertificate(istream)
+          .getPublicKey
+          .asInstanceOf[RSAPublicKey])
+    }
+  }
+
+  /**
+    * Reads a RSA private key from a PEM/PKCS#8 file.
+    * These usually have the .pem file extension.
+    */
+  def readRSAPrivateKeyFromPem(file: File): Try[RSAPrivateKey] = {
+    bracket(Try(new FileInputStream(file)))(is => Try(is.close())).flatMap { istream =>
+      for {
+        fileContent <- Try(Files.readAllBytes(file.toPath))
+
+        // Remove PEM container header and footer
+        pemContent <- Try(
+          new String(fileContent, mimeCharSet)
+            .replaceFirst("-----BEGIN ([A-Z ])*-----\n", "")
+            .replaceFirst("\n-----END ([A-Z ])*-----\n", "")
+            .replace("\r", "")
+            .replace("\n", "")
+        )
+
+        // Base64-decode the PEM container content
+        decoded <- Base64
+          .decode(pemContent)
+          .leftMap(e => new RuntimeException(e.shows))
+          .toEither
+          .toTry
+
+        // Interpret the container content as PKCS#8
+        key <- Try {
+          val kf = KeyFactory.getInstance("RSA")
+          val keySpec = new PKCS8EncodedKeySpec(decoded.getBytes)
+          kf.generatePrivate(keySpec).asInstanceOf[RSAPrivateKey]
+        }
+      } yield key
+    }
+  }
+
+  /**
+    * Reads a RSA private key from a binary file (PKCS#8, DER)
+    * openssl pkcs8 -topk8 -inform PEM -outform DER -in private-key.pem -nocrypt > private-key.der
+    */
+  def readRSAPrivateKeyFromDer(file: File): Try[RSAPrivateKey] = {
+    bracket(Try(new FileInputStream(file)))(is => Try(is.close())).flatMap { istream =>
+      for {
+        fileContent <- Try(Files.readAllBytes(file.toPath))
+
+        // Interpret the container content as PKCS#8
+        key <- Try {
+          val kf = KeyFactory.getInstance("RSA")
+          val keySpec = new PKCS8EncodedKeySpec(fileContent)
+          kf.generatePrivate(keySpec).asInstanceOf[RSAPrivateKey]
+        }
+      } yield key
+    }
+  }
+
+  /**
+    * Generates a JWKS JSON object for the given map of KeyID->Key
+    *
+    * Note: this uses the same format as Google OAuth, see https://www.googleapis.com/oauth2/v3/certs
+    */
+  def generateJwks(keys: Map[String, RSAPublicKey]): String = {
+    def generateKeyEntry(keyId: String, key: RSAPublicKey): String =
+      s"""    {
+         |      "kid": "$keyId",
+         |      "kty": "RSA",
+         |      "alg": "RS256",
+         |      "use": "sig",
+         |      "e": "${java.util.Base64.getUrlEncoder
+           .encodeToString(key.getPublicExponent.toByteArray)}",
+         |      "n": "${java.util.Base64.getUrlEncoder.encodeToString(key.getModulus.toByteArray)}"
+         |    }""".stripMargin
+
+    s"""
+       |{
+       |  "keys": [
+       |${keys.toList.map { case (keyId, key) => generateKeyEntry(keyId, key) }.mkString(",\n")}
+       |  ]
+       |}
+    """.stripMargin
+  }
+}

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
@@ -78,7 +78,8 @@ object KeyUtils {
   }
 
   /**
-    * Reads a RSA private key from a binary file (PKCS#8, DER)
+    * Reads a RSA private key from a binary file (PKCS#8, DER).
+    * To generate this file from a .pem file, use the following command:
     * openssl pkcs8 -topk8 -inform PEM -outform DER -in private-key.pem -nocrypt > private-key.der
     */
   def readRSAPrivateKeyFromDer(file: File): Try[RSAPrivateKey] = {

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
@@ -22,7 +22,7 @@ object KeyUtils {
 
   object Error {
     implicit val showInstance: Show[Error] =
-      Show.shows(e => s"PemUtils.Error: ${e.what}, ${e.message}")
+      Show.shows(e => s"KeyUtils.Error: ${e.what}, ${e.message}")
   }
 
   private val mimeCharSet = StandardCharsets.ISO_8859_1

--- a/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
+++ b/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
@@ -1,0 +1,110 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.jwt
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.security.KeyPairGenerator
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+
+import com.digitalasset.jwt.domain.DecodedJwt
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.syntax.show._
+
+/** Helper to create a HTTP server that serves a constant response on the "/result" URL */
+object SimpleHttpServer {
+  def start(response: String): HttpServer = {
+    val server = HttpServer.create(null, 0)
+    server.createContext("/result", new HttpResultHandler(response))
+    server.setExecutor(null)
+    server.start()
+    server
+  }
+
+  def responseUrl(server: HttpServer) =
+    s"http://${server.getAddress.getHostName}:${server.getAddress.getPort}/result"
+
+  def stop(server: HttpServer): Unit =
+    server.stop(0)
+
+  private[this] class HttpResultHandler(response: String) extends HttpHandler {
+    def handle(t: HttpExchange): Unit = {
+      t.sendResponseHeaders(200, response.getBytes().length.toLong)
+      val os = t.getResponseBody
+      os.write(response.getBytes)
+      os.close()
+    }
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+class JwksSpec extends FlatSpec with Matchers {
+
+  private def generateToken(keyId: String, privateKey: RSAPrivateKey) = {
+    val jwtPayload = s"""{"test": "JwksSpec"}"""
+    val jwtHeader = s"""{"alg": "RS256", "typ": "JWT", "kid": "$keyId"}"""
+    JwtSigner.RSA256.sign(DecodedJwt(jwtHeader, jwtPayload), privateKey)
+  }
+
+  it should "correctly verify JWT tokens using a JWKS server" in {
+    // Generate some RSA key pairs
+    val keySize = 2048
+    val kpg = KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(keySize)
+
+    val keyPair1 = kpg.generateKeyPair()
+    val publicKey1 = keyPair1.getPublic.asInstanceOf[RSAPublicKey]
+    val privateKey1 = keyPair1.getPrivate.asInstanceOf[RSAPrivateKey]
+
+    val keyPair2 = kpg.generateKeyPair()
+    val publicKey2 = keyPair2.getPublic.asInstanceOf[RSAPublicKey]
+    val privateKey2 = keyPair2.getPrivate.asInstanceOf[RSAPrivateKey]
+
+    // Start a JWKS server and create a verifier using the JWKS server
+    val jwks = KeyUtils.generateJwks(
+      Map(
+        "test-key-1" -> publicKey1,
+        "test-key-2" -> publicKey2
+      ))
+
+    val server = SimpleHttpServer.start(jwks)
+    val url = SimpleHttpServer.responseUrl(server)
+
+    val verifier = JwksVerifier(url)
+
+    // Test 1: Success
+    val token1 = generateToken("test-key-1", privateKey1)
+      .fold(e => fail("Failed to generate signed token: " + e.shows), x => x)
+    val result1 = verifier.verify(token1)
+
+    assert(
+      result1.isRight,
+      s"The correctly signed token should successfully verify, but the result was ${result1.leftMap(
+        e => e.shows)}"
+    )
+
+    // Test 2: Failure - unknown key ID
+    val token2 = generateToken("test-key-unknown", privateKey1)
+      .fold(e => fail("Failed to generate signed token: " + e.shows), x => x)
+    val result2 = verifier.verify(token1)
+
+    assert(
+      result1.isLeft,
+      s"The token with an unknown key ID should not successfully verify"
+    )
+
+    // Test 3: Failure - wrong public key
+    val token3 = generateToken("test-key-1", privateKey2)
+      .fold(e => fail("Failed to generate signed token: " + e.shows), x => x)
+    val result3 = verifier.verify(token1)
+
+    assert(
+      result3.isLeft,
+      s"The token with a mismatching public key should not successfully verify"
+    )
+
+    SimpleHttpServer.stop(server)
+
+    ()
+  }
+}

--- a/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
+++ b/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
@@ -3,6 +3,8 @@
 
 package com.digitalasset.jwt
 
+import java.net.InetSocketAddress
+
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import java.security.KeyPairGenerator
 import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
@@ -14,7 +16,7 @@ import scalaz.syntax.show._
 /** Helper to create a HTTP server that serves a constant response on the "/result" URL */
 object SimpleHttpServer {
   def start(response: String): HttpServer = {
-    val server = HttpServer.create(null, 0)
+    val server = HttpServer.create(new InetSocketAddress(0), 0)
     server.createContext("/result", new HttpResultHandler(response))
     server.setExecutor(null)
     server.start()
@@ -22,7 +24,7 @@ object SimpleHttpServer {
   }
 
   def responseUrl(server: HttpServer) =
-    s"http://${server.getAddress.getHostName}:${server.getAddress.getPort}/result"
+    s"http://localhost:${server.getAddress.getPort}/result"
 
   def stop(server: HttpServer): Unit =
     server.stop(0)
@@ -86,17 +88,17 @@ class JwksSpec extends FlatSpec with Matchers {
     // Test 2: Failure - unknown key ID
     val token2 = generateToken("test-key-unknown", privateKey1)
       .fold(e => fail("Failed to generate signed token: " + e.shows), x => x)
-    val result2 = verifier.verify(token1)
+    val result2 = verifier.verify(token2)
 
     assert(
-      result1.isLeft,
+      result2.isLeft,
       s"The token with an unknown key ID should not successfully verify"
     )
 
     // Test 3: Failure - wrong public key
     val token3 = generateToken("test-key-1", privateKey2)
       .fold(e => fail("Failed to generate signed token: " + e.shows), x => x)
-    val result3 = verifier.verify(token1)
+    val result3 = verifier.verify(token3)
 
     assert(
       result3.isLeft,

--- a/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
+++ b/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/JwksSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scalaz.syntax.show._
 
 /** Helper to create a HTTP server that serves a constant response on the "/result" URL */
-object SimpleHttpServer {
+private object SimpleHttpServer {
   def start(response: String): HttpServer = {
     val server = HttpServer.create(new InetSocketAddress(0), 0)
     server.createContext("/result", new HttpResultHandler(response))

--- a/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/SignatureSpec.scala
+++ b/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/SignatureSpec.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.jwt
+
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+
+import org.scalatest.{Matchers, WordSpec}
+import scalaz.syntax.show._
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+class SignatureSpec extends WordSpec with Matchers {
+
+  "Jwt" when {
+
+    "using HMAC256 signatures" should {
+
+      "work with a valid secret" in {
+        val secret = "secret key"
+        val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
+        val jwtPayload = """{"dummy":"dummy"}"""
+        val jwt = domain.DecodedJwt[String](jwtHeader, jwtPayload)
+
+        val success = for {
+          signedJwt <- JwtSigner.HMAC256
+            .sign(jwt, secret)
+            .leftMap(e => fail(e.shows))
+          verifier <- HMAC256Verifier(secret)
+            .leftMap(e => fail(e.shows))
+          verifiedJwt <- verifier
+            .verify(signedJwt)
+            .leftMap(e => fail(e.shows))
+        } yield verifiedJwt
+
+        success.isRight shouldBe true
+      }
+
+      "fail with an invalid secret" in {
+        val secret = "secret key"
+        val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
+        val jwtPayload = """{"dummy":"dummy"}"""
+        val jwt = domain.DecodedJwt[String](jwtHeader, jwtPayload)
+
+        val success = for {
+          signedJwt <- JwtSigner.HMAC256
+            .sign(jwt, secret)
+            .leftMap(e => fail(e.shows))
+          verifier <- HMAC256Verifier("invalid " + secret)
+            .leftMap(e => fail(e.shows))
+          error <- verifier
+            .verify(signedJwt)
+            .swap
+            .leftMap(jwt => fail(s"JWT $jwt was unexpectedly verified"))
+        } yield error
+
+        success.isRight shouldBe true
+      }
+    }
+
+    "using RSA256 signatures" should {
+
+      "work with a valid key" in {
+        val kpg = java.security.KeyPairGenerator.getInstance("RSA")
+        kpg.initialize(2048)
+        val keyPair = kpg.generateKeyPair()
+        val privateKey = keyPair.getPrivate.asInstanceOf[RSAPrivateKey]
+        val publicKey = keyPair.getPublic.asInstanceOf[RSAPublicKey]
+
+        val jwtHeader = """{"alg": "RS256", "typ": "JWT"}"""
+        val jwtPayload = """{"dummy":"dummy"}"""
+        val jwt = domain.DecodedJwt[String](jwtHeader, jwtPayload)
+
+        val success = for {
+          signedJwt <- JwtSigner.RSA256
+            .sign(jwt, privateKey)
+            .leftMap(e => fail(e.shows))
+          verifier <- RSA256Verifier(publicKey)
+            .leftMap(e => fail(e.shows))
+          verifiedJwt <- verifier
+            .verify(signedJwt)
+            .leftMap(e => fail(e.shows))
+        } yield verifiedJwt
+
+        success.isRight shouldBe true
+      }
+
+      "fail with an invalid key" in {
+        val kpg = java.security.KeyPairGenerator.getInstance("RSA")
+        kpg.initialize(2048)
+        val keyPair1 = kpg.generateKeyPair()
+        val privateKey = keyPair1.getPrivate.asInstanceOf[RSAPrivateKey]
+
+        val keyPair2 = kpg.generateKeyPair()
+        val publicKey = keyPair2.getPublic.asInstanceOf[RSAPublicKey]
+
+        val jwtHeader = """{"alg": "RS256", "typ": "JWT"}"""
+        val jwtPayload = """{"dummy":"dummy"}"""
+        val jwt = domain.DecodedJwt[String](jwtHeader, jwtPayload)
+
+        val success = for {
+          signedJwt <- JwtSigner.RSA256
+            .sign(jwt, privateKey)
+            .leftMap(e => fail(e.shows))
+          verifier <- RSA256Verifier(publicKey)
+            .leftMap(e => fail(e.shows))
+          error <- verifier
+            .verify(signedJwt)
+            .swap
+            .leftMap(jwt => fail(s"JWT $jwt was unexpectedly verified"))
+        } yield error
+
+        success.isRight shouldBe true
+      }
+    }
+  }
+}

--- a/ledger/ledger-api-auth/BUILD.bazel
+++ b/ledger/ledger-api-auth/BUILD.bazel
@@ -3,9 +3,35 @@
 
 load(
     "//bazel_tools:scala.bzl",
+    "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
 )
+
+ledger_api_auth_deps = [
+    "//daml-lf/data",
+    "//ledger-api/grpc-definitions:ledger-api-scalapb",
+    "//ledger-api/rs-grpc-akka",
+    "//ledger-api/rs-grpc-bridge",
+    "//ledger-service/jwt",
+    "//ledger/ledger-api-akka",
+    "//ledger/ledger-api-client",
+    "//ledger/ledger-api-common",
+    "//ledger/ledger-api-domain",
+    "//ledger/ledger-api-scala-logging",
+    "@maven//:com_auth0_java_jwt",
+    "@maven//:com_github_scopt_scopt_2_12",
+    "@maven//:com_typesafe_akka_akka_actor_2_12",
+    "@maven//:com_typesafe_akka_akka_stream_2_12",
+    "@maven//:io_grpc_grpc_api",
+    "@maven//:io_grpc_grpc_context",
+    "@maven//:io_grpc_grpc_core",
+    "@maven//:io_grpc_grpc_services",
+    "@maven//:io_spray_spray_json_2_12",
+    "@maven//:org_scala_lang_modules_scala_java8_compat_2_12",
+    "@maven//:org_scalaz_scalaz_core_2_12",
+    "@maven//:org_slf4j_slf4j_api",
+]
 
 da_scala_library(
     name = "ledger-api-auth",
@@ -16,29 +42,14 @@ da_scala_library(
         "//visibility:public",
     ],
     runtime_deps = [],
-    deps = [
-        "//daml-lf/data",
-        "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "//ledger-api/rs-grpc-akka",
-        "//ledger-api/rs-grpc-bridge",
-        "//ledger-service/jwt",
-        "//ledger/ledger-api-akka",
-        "//ledger/ledger-api-client",
-        "//ledger/ledger-api-common",
-        "//ledger/ledger-api-domain",
-        "//ledger/ledger-api-scala-logging",
-        "@maven//:com_auth0_java_jwt",
-        "@maven//:com_typesafe_akka_akka_actor_2_12",
-        "@maven//:com_typesafe_akka_akka_stream_2_12",
-        "@maven//:io_grpc_grpc_api",
-        "@maven//:io_grpc_grpc_context",
-        "@maven//:io_grpc_grpc_core",
-        "@maven//:io_grpc_grpc_services",
-        "@maven//:io_spray_spray_json_2_12",
-        "@maven//:org_scala_lang_modules_scala_java8_compat_2_12",
-        "@maven//:org_scalaz_scalaz_core_2_12",
-        "@maven//:org_slf4j_slf4j_api",
-    ],
+    deps = ledger_api_auth_deps,
+)
+
+da_scala_binary(
+    name = "ledger-api-auth-bin",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    main_class = "com.digitalasset.ledger.api.auth.Main",
+    deps = [":ledger-api-auth"] + ledger_api_auth_deps,
 )
 
 da_scala_test_suite(

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
@@ -6,7 +6,7 @@ package com.digitalasset.ledger.api.auth
 import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.jwt.JwtVerifier
+import com.digitalasset.jwt.{JwtVerifier, JwtVerifierBase}
 import com.digitalasset.ledger.api.auth.AuthServiceJWT.Error
 import io.grpc.Metadata
 import org.slf4j.{Logger, LoggerFactory}
@@ -18,7 +18,7 @@ import scala.util.Try
 /** An AuthService that reads a JWT token from a `Authorization: Bearer` HTTP header.
   * The token is expected to use the format as defined in [[AuthServiceJWTPayload]]:
   */
-class AuthServiceJWT(verifier: JwtVerifier) extends AuthService {
+class AuthServiceJWT(verifier: JwtVerifierBase) extends AuthService {
 
   protected val logger: Logger = LoggerFactory.getLogger(AuthServiceJWT.getClass)
 
@@ -86,6 +86,6 @@ object AuthServiceJWT {
   def apply(verifier: com.auth0.jwt.interfaces.JWTVerifier) =
     new AuthServiceJWT(new JwtVerifier(verifier))
 
-  def apply(verifier: JwtVerifier) =
+  def apply(verifier: JwtVerifierBase) =
     new AuthServiceJWT(verifier)
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Main.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Main.scala
@@ -1,0 +1,244 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.ledger.api.auth
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.interfaces.RSAPublicKey
+import java.time.Instant
+
+import com.digitalasset.jwt.domain.{DecodedJwt, Jwt}
+import com.digitalasset.jwt.{JwtSigner, KeyUtils}
+import scalaz.syntax.show._
+
+object Main {
+
+  object ErrorCodes {
+    val InvalidUsage = 100
+    val GenerateTokensError = 101
+  }
+
+  final case class Config(
+      command: Option[Command] = None
+  )
+
+  sealed abstract class Command
+
+  final case class GenerateJwks(
+      output: Option[File] = None,
+      publicKeys: List[File] = List(),
+  ) extends Command
+
+  final case class GenerateToken(
+      output: Option[File] = None,
+      signingKey: Option[File] = None,
+      ledgerId: Option[String] = None,
+      applicationId: Option[String] = None,
+      exp: Option[Instant] = None,
+      kid: Option[String] = None,
+      parties: List[String] = List(),
+      readOnly: Boolean = false,
+      admin: Boolean = false
+  ) extends Command
+
+  /** By default, RSA key Ids are generated from their file name. */
+  private[this] def defaultKeyId(file: File): String = {
+    val fileName = file.getName
+    val pos = fileName.lastIndexOf(".")
+    if (pos > 0 && pos < (fileName.length - 1)) {
+      fileName.substring(0, pos)
+    } else {
+      fileName
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    parseConfig(args) match {
+      case Some(Config(Some(config @ GenerateJwks(Some(outputFile), publicKeys)))) =>
+        // Load RSA keys. They ID of each key is its file name.
+        val keys: Map[String, RSAPublicKey] = publicKeys
+          .map(
+            f =>
+              defaultKeyId(f) -> KeyUtils
+                .readRSAPublicKeyFromCrt(f)
+                .fold(
+                  t =>
+                    handleGenerateTokensError(
+                      "Error loading RSA public key from a X509 certificate file.")(t.getMessage),
+                  x => x))
+          .toMap
+
+        // Generate and write JWKS for all keys
+        val jwks = KeyUtils.generateJwks(keys)
+        Files.write(outputFile.toPath, jwks.getBytes(StandardCharsets.UTF_8))
+
+        ()
+
+      case Some(
+          Config(
+            Some(
+              GenerateToken(
+                Some(outputFile),
+                Some(signingKeyFile),
+                ledgerIdO,
+                applicationIdO,
+                exp,
+                kid,
+                parties,
+                readOnly,
+                admin)))) =>
+        import JwtSigner.Error.showInstance
+
+        val keyId = kid.getOrElse(defaultKeyId(signingKeyFile))
+
+        val payload = AuthServiceJWTPayload(
+          ledgerIdO,
+          None,
+          applicationIdO,
+          exp,
+          admin,
+          parties,
+          parties,
+        )
+        val signingKey = KeyUtils
+          .readRSAPrivateKeyFromDer(signingKeyFile)
+          .fold(
+            t =>
+              handleGenerateTokensError(
+                "Error loading RSA private key from a PKCS8/DER file. Use the following command to convert a PEM encoded private key: openssl pkcs8 -topk8 -inform PEM -outform DER -in private-key.pem -nocrypt > private-key.der.")(
+                t.getMessage),
+            x => x
+          )
+        val jwtPayload = AuthServiceJWTCodec.compactPrint(payload)
+        val jwtHeader = s"""{"alg": "RS256", "typ": "JWT", "kid": "$keyId"}"""
+        val signed: Jwt = JwtSigner.RSA256
+          .sign(DecodedJwt(jwtHeader, jwtPayload), signingKey)
+          .valueOr(e => handleGenerateTokensError("Error signing JWT token")(e.shows))
+
+        def changeExtension(file: File, extension: String): File = {
+          val filename = file.getName
+
+          val baseName =
+            if (filename.contains("."))
+              filename.substring(0, filename.lastIndexOf('.'))
+            else
+              filename
+
+          new File(file.getParentFile, filename + extension)
+        }
+
+        Files.write(outputFile.toPath, signed.value.getBytes(StandardCharsets.UTF_8))
+
+        Files.write(
+          changeExtension(outputFile, "-bearer.txt").toPath,
+          s"Bearer ${signed.value}".getBytes(StandardCharsets.UTF_8))
+
+        Files.write(
+          changeExtension(outputFile, "-payload.json").toPath,
+          jwtPayload.getBytes(StandardCharsets.UTF_8))
+
+        Files.write(
+          changeExtension(outputFile, "-header.json").toPath,
+          jwtHeader.getBytes(StandardCharsets.UTF_8))
+
+        ()
+      case Some(_) =>
+        configParser.showUsage()
+        sys.exit(ErrorCodes.InvalidUsage)
+      case None =>
+        sys.exit(ErrorCodes.InvalidUsage)
+    }
+  }
+
+  private def handleGenerateTokensError(message: String)(details: String): Nothing = {
+    Console.println(s"$message. Details: $details")
+    sys.exit(ErrorCodes.GenerateTokensError)
+  }
+
+  private def parseConfig(args: Seq[String]): Option[Config] = {
+    configParser.parse(args, Config())
+  }
+
+  private val configParser = new scopt.OptionParser[Config]("ledger-api-auth") {
+    cmd("generate-jwks")
+      .text("Generate a JWKS JSON object for the given set of RSA public keys")
+      .action((_, c) => c.copy(command = Some(GenerateJwks())))
+      .children(
+        opt[File]("output")
+          .required()
+          .text("The output file")
+          .valueName("<paths>")
+          .action((x, c) =>
+            c.copy(command = c.command.map(_.asInstanceOf[GenerateJwks].copy(output = Some(x))))),
+        opt[Seq[File]]("keys")
+          .required()
+          .text("List of RSA certificates (.crt)")
+          .valueName("<paths>")
+          .action((x, c) =>
+            c.copy(
+              command = c.command.map(_.asInstanceOf[GenerateJwks].copy(publicKeys = x.toList)))),
+      )
+
+    cmd("generate-token")
+      .text("Generate a signed access token for the DAML ledger API")
+      .action((_, c) => c.copy(command = Some(GenerateToken())))
+      .children(
+        opt[File]("output")
+          .required()
+          .text("The output file")
+          .valueName("<paths>")
+          .action((x, c) =>
+            c.copy(command = c.command.map(_.asInstanceOf[GenerateToken].copy(output = Some(x))))),
+        opt[File]("key")
+          .required()
+          .text("The RSA private key (.der)")
+          .valueName("<path>")
+          .action((x, c) =>
+            c.copy(
+              command = c.command.map(_.asInstanceOf[GenerateToken].copy(signingKey = Some(x))))),
+        opt[Seq[String]]("parties")
+          .required()
+          .text("Parties to generate tokens for")
+          .valueName("<list of parties>")
+          .action((x, c) =>
+            c.copy(
+              command = c.command.map(_.asInstanceOf[GenerateToken].copy(parties = x.toList)))),
+        opt[String]("ledgerId")
+          .optional()
+          .text("Restrict validity of the token to this ledger ID. Default: None, token is valid for all ledgers.")
+          .action((x, c) =>
+            c.copy(
+              command = c.command.map(_.asInstanceOf[GenerateToken].copy(ledgerId = Some(x))))),
+        opt[String]("applicationId")
+          .optional()
+          .text("Restrict validity of the token to this application ID. Default: None, token is valid for all applications.")
+          .action((x, c) =>
+            c.copy(command =
+              c.command.map(_.asInstanceOf[GenerateToken].copy(applicationId = Some(x))))),
+        opt[String]("exp")
+          .optional()
+          .text("Token expiration date, in ISO 8601 format. Default: no expiration date.")
+          .action((x, c) =>
+            c.copy(command =
+              c.command.map(_.asInstanceOf[GenerateToken].copy(exp = Some(Instant.parse(x)))))),
+        opt[String]("kid")
+          .optional()
+          .text("The key id, as used in JWKS. Default: the file name of the RSA private key.")
+          .action((x, c) =>
+            c.copy(command =
+              c.command.map(_.asInstanceOf[GenerateToken].copy(exp = Some(Instant.parse(x)))))),
+        opt[Boolean]("admin")
+          .optional()
+          .text("If set, authorizes the bearer to use admin endpoints. Default: false")
+          .action((x, c) =>
+            c.copy(command = c.command.map(_.asInstanceOf[GenerateToken].copy(admin = x)))),
+        opt[Boolean]("readonly")
+          .optional()
+          .text("If set, prevents the bearer from acting on the ledger. Default: false")
+          .action((x, c) =>
+            c.copy(command = c.command.map(_.asInstanceOf[GenerateToken].copy(admin = x)))),
+      )
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -165,8 +165,8 @@ object Cli {
     opt[String]("auth-jwt-rs256-crt")
       .optional()
       .validate(v => Either.cond(v.length > 0, (), "Public key file path must be a non-empty string"))
-      .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given X509 certificate file")
-      .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(RSA256Verifier.fromX509PemFile(path).valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
+      .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given X509 certificate file (.crt)")
+      .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(RSA256Verifier.fromCrtFile(path).valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
 
     opt[String]("auth-jwt-rs256-jwks")
       .optional()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -164,7 +164,7 @@ object Cli {
 
     opt[String]("auth-jwt-rs256-crt")
       .optional()
-      .validate(v => Either.cond(v.length > 0, (), "Public key file path must be a non-empty string"))
+      .validate(v => Either.cond(v.length > 0, (), "Certificate file path must be a non-empty string"))
       .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given X509 certificate file (.crt)")
       .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(RSA256Verifier.fromCrtFile(path).valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 
 import ch.qos.logback.classic.Level
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.jwt.HMAC256Verifier
+import com.digitalasset.jwt.{HMAC256Verifier, JwksVerifier, RSA256Verifier}
 import com.digitalasset.ledger.api.auth.AuthServiceJWT
 import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.common.LedgerIdMode
@@ -160,7 +160,19 @@ object Cli {
       .hidden()
       .validate(v => Either.cond(v.length > 0, (), "HMAC secret must be a non-empty string"))
       .text("[UNSAFE] Enables JWT-based authorization with shared secret HMAC256 signing: USE THIS EXCLUSIVELY FOR TESTING")
-      .action( (secret, config) => config.copy(authService = Some(AuthServiceJWT(HMAC256Verifier(secret).getOrElse(sys.error("Failed to create HMAC256 verifier"))))))
+      .action( (secret, config) => config.copy(authService = Some(AuthServiceJWT(HMAC256Verifier(secret).valueOr(err => sys.error(s"Failed to create HMAC256 verifier: $err"))))))
+
+    opt[String]("auth-jwt-rs256-crt")
+      .optional()
+      .validate(v => Either.cond(v.length > 0, (), "Public key file path must be a non-empty string"))
+      .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given X509 certificate file")
+      .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(RSA256Verifier.fromX509PemFile(path).valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
+
+    opt[String]("auth-jwt-rs256-jwks")
+      .optional()
+      .validate(v => Either.cond(v.length > 0, (), "JWK server URL must be a non-empty string"))
+      .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given JWKS URL")
+      .action( (url, config) => config.copy(authService = Some(AuthServiceJWT(JwksVerifier(url)))))
 
     help("help").text("Print the usage text")
 

--- a/maven_install.json
+++ b/maven_install.json
@@ -233,12 +233,12 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-databind:2.9.8",
-                    "commons-codec:commons-codec:1.12"
+                    "commons-codec:commons-codec:1.13"
                 ],
                 "dependencies": [
+                    "commons-codec:commons-codec:1.13",
                     "com.fasterxml.jackson.core:jackson-databind:2.9.8",
                     "com.fasterxml.jackson.core:jackson-core:2.9.8",
-                    "commons-codec:commons-codec:1.12",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.8"
                 ],
                 "url": "https://repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1.jar",
@@ -252,19 +252,75 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
-                    "commons-codec:commons-codec:jar:sources:1.12"
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
                     "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
-                    "commons-codec:commons-codec:jar:sources:1.12"
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "url": "https://repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar",
                 "mirror_urls": [
                     "https://repo1.maven.org/maven2/com/auth0/java-jwt/3.8.1/java-jwt-3.8.1-sources.jar"
                 ],
                 "sha256": "73e99e54327508ef5ecd96b4369e1b5932f3abc96a45b13cefdac1e9c3cbb6f8"
+            },
+            {
+                "coord": "com.auth0:jwks-rsa:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.google.guava:guava:24.0-jre",
+                    "commons-codec:commons-codec:1.13",
+                    "commons-io:commons-io:2.5"
+                ],
+                "dependencies": [
+                    "org.checkerframework:checker-compat-qual:2.0.0",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.8",
+                    "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
+                    "commons-io:commons-io:2.5",
+                    "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+                    "com.google.j2objc:j2objc-annotations:1.1",
+                    "com.google.guava:guava:24.0-jre",
+                    "com.fasterxml.jackson.core:jackson-annotations:2.9.8",
+                    "com.google.errorprone:error_prone_annotations:2.3.2",
+                    "com.fasterxml.jackson.core:jackson-core:2.9.8"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0.jar"
+                ],
+                "sha256": "81daf61d045996ee96c8372c8493904319d2a1f57cf0d4082181d2abb8d6482a"
+            },
+            {
+                "coord": "com.auth0:jwks-rsa:jar:sources:0.9.0",
+                "file": "v1/https/repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0-sources.jar",
+                "directDependencies": [
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "commons-codec:commons-codec:jar:sources:1.13",
+                    "commons-io:commons-io:jar:sources:2.5"
+                ],
+                "dependencies": [
+                    "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.8",
+                    "org.checkerframework:checker-compat-qual:jar:sources:2.0.0",
+                    "org.codehaus.mojo:animal-sniffer-annotations:jar:sources:1.17",
+                    "com.google.guava:guava:jar:sources:24.0-jre",
+                    "commons-io:commons-io:jar:sources:2.5",
+                    "com.google.j2objc:j2objc-annotations:jar:sources:1.1",
+                    "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.8",
+                    "commons-codec:commons-codec:jar:sources:1.13",
+                    "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.8",
+                    "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
+                ],
+                "url": "https://repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/com/auth0/jwks-rsa/0.9.0/jwks-rsa-0.9.0-sources.jar"
+                ],
+                "sha256": "431bfb54c1c7cd720f8be2e10e6ed771ed4973f3daf7698586eafb0d4c2d3258"
             },
             {
                 "coord": "com.beust:jcommander:1.12",
@@ -3475,26 +3531,26 @@
                 "sha256": "a66fc818710bc62c3fe19accc933f234dcec7bb58ac7cb36518d46ff57a6c666"
             },
             {
-                "coord": "commons-codec:commons-codec:1.12",
-                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar",
+                "coord": "commons-codec:commons-codec:1.13",
+                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar",
+                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar"
+                    "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13.jar"
                 ],
-                "sha256": "23df58fae9c83d1bcd277b99f9429e9d8c134f0600b73e2e86b2385ed793c81e"
+                "sha256": "61f7a3079e92b9fdd605238d0295af5fd11ac411a0a0af48deace1f6c5ffa072"
             },
             {
-                "coord": "commons-codec:commons-codec:jar:sources:1.12",
-                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar",
+                "coord": "commons-codec:commons-codec:jar:sources:1.13",
+                "file": "v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13-sources.jar",
                 "directDependencies": [],
                 "dependencies": [],
-                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar",
+                "url": "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12-sources.jar"
+                    "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13-sources.jar"
                 ],
-                "sha256": "9938b259c2ec37cf0d25c4ea2b400b7b6636e6628189a6ef1852895dce7d2e2a"
+                "sha256": "09a72795a920c1a9c0209cfb8395f8d97089832d249cba8c0938a3423b3ed1d1"
             },
             {
                 "coord": "commons-collections:commons-collections:3.0",
@@ -5584,13 +5640,13 @@
                 "coord": "org.apache.httpcomponents:httpclient:4.5.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:1.12",
+                    "commons-codec:commons-codec:1.13",
                     "commons-logging:commons-logging:1.2",
                     "org.apache.httpcomponents:httpcore:4.4.6"
                 ],
                 "dependencies": [
+                    "commons-codec:commons-codec:1.13",
                     "commons-logging:commons-logging:1.2",
-                    "commons-codec:commons-codec:1.12",
                     "org.apache.httpcomponents:httpcore:4.4.6"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
@@ -5603,14 +5659,14 @@
                 "coord": "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "org.apache.httpcomponents:httpcore:jar:sources:4.4.6"
                 ],
                 "dependencies": [
                     "org.apache.httpcomponents:httpcore:jar:sources:4.4.6",
-                    "commons-codec:commons-codec:jar:sources:1.12",
-                    "commons-logging:commons-logging:jar:sources:1.2"
+                    "commons-logging:commons-logging:jar:sources:1.2",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3-sources.jar",
                 "mirror_urls": [
@@ -12539,9 +12595,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -12554,10 +12610,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -12580,7 +12636,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-chrome-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -12591,10 +12646,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -12610,6 +12665,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar",
@@ -12623,9 +12679,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -12638,10 +12694,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -12664,7 +12720,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-edge-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -12675,10 +12730,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -12694,6 +12749,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar",
@@ -12707,9 +12763,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -12722,10 +12778,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -12748,7 +12804,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -12759,10 +12814,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -12778,6 +12833,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar",
@@ -12791,9 +12847,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -12806,10 +12862,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -12832,7 +12888,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-ie-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -12843,10 +12898,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -12862,6 +12917,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar",
@@ -12876,9 +12932,9 @@
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.seleniumhq.selenium:selenium-opera-driver:3.12.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "org.seleniumhq.selenium:selenium-chrome-driver:3.12.0",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-edge-driver:3.12.0",
@@ -12898,10 +12954,10 @@
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.seleniumhq.selenium:selenium-opera-driver:3.12.0",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "org.seleniumhq.selenium:selenium-chrome-driver:3.12.0",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-edge-driver:3.12.0",
@@ -12930,7 +12986,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-java:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -12948,10 +13003,10 @@
                     "org.seleniumhq.selenium:selenium-chrome-driver:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "org.seleniumhq.selenium:selenium-firefox-driver:jar:sources:3.12.0",
@@ -12974,6 +13029,7 @@
                     "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar",
@@ -12987,9 +13043,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -13002,10 +13058,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -13028,7 +13084,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-opera-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -13039,10 +13094,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -13058,6 +13113,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar",
@@ -13071,8 +13127,8 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -13085,9 +13141,9 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -13110,7 +13166,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -13120,10 +13175,10 @@
                     "org.apache.commons:commons-exec:jar:sources:1.3",
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
-                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -13138,6 +13193,7 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.12.0/selenium-remote-driver-3.12.0-sources.jar",
@@ -13151,9 +13207,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -13166,10 +13222,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -13192,7 +13248,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-safari-driver:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -13203,10 +13258,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -13222,6 +13277,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar",
@@ -13235,9 +13291,9 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0.jar",
                 "directDependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "com.squareup.okio:okio:1.13.0",
@@ -13250,10 +13306,10 @@
                 "dependencies": [
                     "com.squareup.okhttp3:okhttp:3.9.1",
                     "org.checkerframework:checker-compat-qual:2.0.0",
-                    "commons-codec:commons-codec:1.12",
                     "org.seleniumhq.selenium:selenium-remote-driver:3.12.0",
                     "commons-logging:commons-logging:1.2",
                     "com.google.code.findbugs:jsr305:3.0.2",
+                    "commons-codec:commons-codec:1.13",
                     "net.bytebuddy:byte-buddy:1.9.7",
                     "org.seleniumhq.selenium:selenium-api:3.12.0",
                     "org.codehaus.mojo:animal-sniffer-annotations:1.17",
@@ -13276,7 +13332,6 @@
                 "coord": "org.seleniumhq.selenium:selenium-support:jar:sources:3.12.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0-sources.jar",
                 "directDependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
                     "net.bytebuddy:byte-buddy:jar:sources:1.9.7",
@@ -13287,10 +13342,10 @@
                     "com.google.code.gson:gson:jar:sources:2.8.2",
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
-                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0"
+                    "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13"
                 ],
                 "dependencies": [
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "com.google.code.findbugs:jsr305:jar:sources:3.0.2",
                     "com.squareup.okhttp3:okhttp:jar:sources:3.9.1",
                     "commons-logging:commons-logging:jar:sources:1.2",
@@ -13306,6 +13361,7 @@
                     "org.apache.httpcomponents:httpclient:jar:sources:4.5.3",
                     "org.seleniumhq.selenium:selenium-api:jar:sources:3.12.0",
                     "org.seleniumhq.selenium:selenium-remote-driver:jar:sources:3.12.0",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "com.google.errorprone:error_prone_annotations:jar:sources:2.3.2"
                 ],
                 "url": "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.12.0/selenium-support-3.12.0-sources.jar",
@@ -13536,10 +13592,10 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:5.0.4",
-                    "commons-codec:commons-codec:1.12",
                     "org.ow2.asm:asm-tree:5.0.3",
                     "com.github.jnr:jffi:1.2.15",
                     "org.rnorth:tcp-unix-socket-proxy:1.0.1",
+                    "commons-codec:commons-codec:1.13",
                     "org.slf4j:slf4j-api:1.7.26",
                     "commons-lang:commons-lang:2.6",
                     "junit:junit:4.12",
@@ -13580,7 +13636,6 @@
                 ],
                 "dependencies": [
                     "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "org.slf4j:slf4j-ext:jar:sources:1.7.25",
                     "org.jetbrains:annotations:jar:sources:13.0",
                     "org.apache.commons:commons-compress:jar:sources:1.12",
@@ -13604,6 +13659,7 @@
                     "org.scijava:native-lib-loader:jar:sources:2.0.2",
                     "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
                     "log4j:log4j:jar:sources:1.2.17",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
                     "junit:junit:jar:sources:4.12",
                     "org.ow2.asm:asm-util:jar:sources:5.0.3",
@@ -13623,10 +13679,10 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:5.0.4",
-                    "commons-codec:commons-codec:1.12",
                     "org.ow2.asm:asm-tree:5.0.3",
                     "com.github.jnr:jffi:1.2.15",
                     "org.rnorth:tcp-unix-socket-proxy:1.0.1",
+                    "commons-codec:commons-codec:1.13",
                     "org.slf4j:slf4j-api:1.7.26",
                     "commons-lang:commons-lang:2.6",
                     "junit:junit:4.12",
@@ -13668,7 +13724,6 @@
                 ],
                 "dependencies": [
                     "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "org.slf4j:slf4j-ext:jar:sources:1.7.25",
                     "org.jetbrains:annotations:jar:sources:13.0",
                     "org.apache.commons:commons-compress:jar:sources:1.12",
@@ -13693,6 +13748,7 @@
                     "org.testcontainers:jdbc:jar:sources:1.4.2",
                     "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
                     "log4j:log4j:jar:sources:1.2.17",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
                     "junit:junit:jar:sources:4.12",
                     "org.ow2.asm:asm-util:jar:sources:5.0.3",
@@ -13709,10 +13765,10 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/testcontainers/1.4.2/testcontainers-1.4.2.jar",
                 "directDependencies": [
                     "org.ow2.asm:asm:5.0.4",
-                    "commons-codec:commons-codec:1.12",
                     "org.ow2.asm:asm-tree:5.0.3",
                     "com.github.jnr:jffi:1.2.15",
                     "org.rnorth:tcp-unix-socket-proxy:1.0.1",
+                    "commons-codec:commons-codec:1.13",
                     "org.slf4j:slf4j-api:1.7.26",
                     "commons-lang:commons-lang:2.6",
                     "junit:junit:4.12",
@@ -13739,10 +13795,10 @@
                 ],
                 "dependencies": [
                     "org.ow2.asm:asm:5.0.4",
-                    "commons-codec:commons-codec:1.12",
                     "org.ow2.asm:asm-tree:5.0.3",
                     "com.github.jnr:jffi:1.2.15",
                     "org.rnorth:tcp-unix-socket-proxy:1.0.1",
+                    "commons-codec:commons-codec:1.13",
                     "org.slf4j:slf4j-api:1.7.26",
                     "commons-lang:commons-lang:2.6",
                     "junit:junit:4.12",
@@ -13779,7 +13835,6 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/testcontainers/testcontainers/1.4.2/testcontainers-1.4.2-sources.jar",
                 "directDependencies": [
                     "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "org.slf4j:slf4j-ext:jar:sources:1.7.25",
                     "org.jetbrains:annotations:jar:sources:13.0",
                     "org.apache.commons:commons-compress:jar:sources:1.12",
@@ -13802,13 +13857,13 @@
                     "org.ow2.asm:asm:jar:sources:5.0.4",
                     "org.scijava:native-lib-loader:jar:sources:2.0.2",
                     "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
                     "junit:junit:jar:sources:4.12",
                     "org.ow2.asm:asm-util:jar:sources:5.0.3"
                 ],
                 "dependencies": [
                     "com.github.jnr:jnr-ffi:jar:sources:2.1.4",
-                    "commons-codec:commons-codec:jar:sources:1.12",
                     "org.slf4j:slf4j-ext:jar:sources:1.7.25",
                     "org.jetbrains:annotations:jar:sources:13.0",
                     "org.apache.commons:commons-compress:jar:sources:1.12",
@@ -13832,6 +13887,7 @@
                     "org.scijava:native-lib-loader:jar:sources:2.0.2",
                     "com.github.jnr:jnr-x86asm:jar:sources:1.0.2",
                     "log4j:log4j:jar:sources:1.2.17",
+                    "commons-codec:commons-codec:jar:sources:1.13",
                     "org.ow2.asm:asm-analysis:jar:sources:5.0.3",
                     "junit:junit:jar:sources:4.12",
                     "org.ow2.asm:asm-util:jar:sources:5.0.3"
@@ -14520,6 +14576,6 @@
             }
         ],
         "version": "0.1.0",
-        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -1052568063
+        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -1437003746
     }
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -294,7 +294,8 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
       case DumpGraphQLSchema =>
         dumpGraphQLSchema()
       case CreateConfig =>
-        userFacingLogger.info(s"Creating a configuration template file at $navigatorConfigFile")
+        userFacingLogger.info(
+          s"Creating a configuration template file at ${navigatorConfigFile.toAbsolutePath()}")
         Config.writeTemplateToPath(navigatorConfigFile, args.useDatabase)
       case RunServer =>
         Config.load(navigatorConfigFile, args.useDatabase) match {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -287,7 +287,8 @@ class PlatformStore(
         maxParallelSubmissions,
         overrideTtl = false,
         Duration.ofSeconds(30)),
-      sslContext
+      sslContext,
+      token
     )
 
     val result =


### PR DESCRIPTION
Fixes #3155.

This PR adds:
- Two new CLI options to the sandbox that can be used to configure JWT-based authentication with RSA signatures (with public keys loaded from a file or a JWKS URL).
- An executable version of the `ledger-api-auth` library that can be used to generate SDK-compatible JWT tokens from the command line.
- A fix for an issue where the `--access-token-file` option in Navigator would not work.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
