### PR TITLE
Change title of release notes tab

### DIFF
--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -138,7 +138,7 @@ async function showReleaseNotes(version: string) {
         if (result.ok) {
             const panel = vscode.window.createWebviewPanel(
                 'releaseNotes', // Identifies the type of the webview. Used internally
-                `DAML SDK ${version} Available`, // Title of the panel displayed to the user
+                `New DAML SDK ${version} Available`, // Title of the panel displayed to the user
                 vscode.ViewColumn.One, // Editor column to show the new webview panel in
                 {} // No webview options for now
             );

--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -138,7 +138,7 @@ async function showReleaseNotes(version: string) {
         if (result.ok) {
             const panel = vscode.window.createWebviewPanel(
                 'releaseNotes', // Identifies the type of the webview. Used internally
-                `Release Notes for DAML SDK ${version}`, // Title of the panel displayed to the user
+                `DAML SDK ${version} Available`, // Title of the panel displayed to the user
                 vscode.ViewColumn.One, // Editor column to show the new webview panel in
                 {} // No webview options for now
             );


### PR DESCRIPTION
This suggests that a new release is available, but not necessarily
installed. We do this for the case that the extension is updated
(which triggers the tab to open) but the actual SDK is not.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
