### PR TITLE
EXPERIMENT: fromAnyContract ignores template type

### DIFF
--- a/compiler/damlc/tests/daml-test-files/AnyContractKey.daml
+++ b/compiler/damlc/tests/daml-test-files/AnyContractKey.daml
@@ -15,6 +15,15 @@ template T1
     key p : Party
     maintainer key
 
+template T1'
+  with
+    x : Int
+    p : Party
+  where
+    signatory p
+    key p : Party
+    maintainer key
+
 template T2
   with
     y : Text
@@ -40,6 +49,8 @@ main = scenario do
   p <- getParty "alice"
   fromAnyContractKey @T1 (toAnyContractKey @T1 p) === Some p
   fromAnyContractKey @T2 (toAnyContractKey @T2 (p, "foobar")) === Some (p, "foobar")
+
+  fromAnyContractKey @T1' (toAnyContractKey @T1 p) === None
 
   fromAnyContractKey @T2 (toAnyContractKey @T1 p) === None
   fromAnyContractKey @T1 (toAnyContractKey @T2 (p, "foobar")) === None


### PR DESCRIPTION
@moritzkiefer-da, is this test expected to fail? Is it possible that template's type is taken into consideration and actually fail to produce ContractKey when it was serialized from different original template?

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
