### PR TITLE
Split rw claims

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
@@ -70,6 +70,9 @@ class AuthServiceJWT(verifier: JwtVerifier) extends AuthService {
     payload.actAs
       .foreach(party => claims.append(ClaimActAsParty(Ref.Party.assertFromString(party))))
 
+    payload.readAs
+      .foreach(party => claims.append(ClaimReadAsParty(Ref.Party.assertFromString(party))))
+
     Claims(claims.toList, payload.exp)
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -44,51 +44,67 @@ final class Authorizer(now: () => Instant) {
   def requireNotExpired[Req, Res](call: Req => Future[Res]): Req => Future[Res] =
     wrapSingleCall(_.notExpired(now()), call)
 
-  /** Wraps a streaming call to verify whether some Claims authorize to act as all parties
+  /** Wraps a streaming call to verify whether some Claims authorize to read as all parties
     * of the given set. Authorization is always granted for an empty collection of parties.
     */
-  def requireClaimsForAllPartiesOnStream[Req, Res](
+  def requireReadClaimsForAllPartiesOnStream[Req, Res](
       parties: Iterable[String],
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    wrapStream(c => c.notExpired(now()) && parties.forall(p => c.canActAs(p)), call)
+    wrapStream(c => c.notExpired(now()) && parties.forall(p => c.canReadAs(p)), call)
+
+  /** Wraps a single call to verify whether some Claims authorize to read as all parties
+    * of the given set. Authorization is always granted for an empty collection of parties.
+    */
+  def requireReadClaimsForAllParties[Req, Res](
+      parties: Iterable[String],
+      call: Req => Future[Res]): Req => Future[Res] =
+    wrapSingleCall(c => c.notExpired(now()) && parties.forall(p => c.canReadAs(p)), call)
 
   /** Wraps a single call to verify whether some Claims authorize to act as all parties
     * of the given set. Authorization is always granted for an empty collection of parties.
     */
-  def requireClaimsForAllParties[Req, Res](
-      parties: Iterable[String],
-      call: Req => Future[Res]): Req => Future[Res] =
+  def requireActClaimsForAllParties[Req, Res](
+    parties: Iterable[String],
+    call: Req => Future[Res]): Req => Future[Res] =
     wrapSingleCall(c => c.notExpired(now()) && parties.forall(p => c.canActAs(p)), call)
 
-  /** Checks whether the current Claims authorize to act as the given party, if any.
-    * Note: An missing party does NOT result in an authorization error.
+  /** Checks whether the current Claims authorize to read as the given party, if any.
+    * Note: A missing party does NOT result in an authorization error.
     */
-  def requireClaimsForPartyOnStream[Req, Res](
+  def requireReadClaimsForPartyOnStream[Req, Res](
       party: Option[String],
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    requireClaimsForAllPartiesOnStream(party.toList, call)
+    requireReadClaimsForAllPartiesOnStream(party.toList, call)
+
+  /** Checks whether the current Claims authorize to read as the given party, if any.
+    * Note: A missing party does NOT result in an authorization error.
+    */
+  def requireReadClaimsForParty[Req, Res](
+      party: Option[String],
+      call: Req => Future[Res]): Req => Future[Res] =
+    requireReadClaimsForAllParties(party.toList, call)
 
   /** Checks whether the current Claims authorize to act as the given party, if any.
     * Note: A missing party does NOT result in an authorization error.
     */
-  def requireClaimsForParty[Req, Res](
-      party: Option[String],
-      call: Req => Future[Res]): Req => Future[Res] =
-    requireClaimsForAllParties(party.toList, call)
+  def requireActClaimsForParty[Req, Res](
+    party: Option[String],
+    call: Req => Future[Res]): Req => Future[Res] =
+    requireActClaimsForAllParties(party.toList, call)
 
   /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
-  def requireClaimsForTransactionFilterOnStream[Req, Res](
+  def requireReadClaimsForTransactionFilterOnStream[Req, Res](
       filter: Option[TransactionFilter],
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    requireClaimsForAllPartiesOnStream(
+    requireReadClaimsForAllPartiesOnStream(
       filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet),
       call)
 
   /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
-  def requireClaimsForTransactionFilter[Req, Res](
+  def requireReadClaimsForTransactionFilter[Req, Res](
       filter: Option[TransactionFilter],
       call: Req => Future[Res]): Req => Future[Res] =
-    requireClaimsForAllParties(filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet), call)
+    requireReadClaimsForAllParties(filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet), call)
 
   private def assertServerCall[A](observer: StreamObserver[A]): ServerCallStreamObserver[A] =
     observer match {

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -64,8 +64,8 @@ final class Authorizer(now: () => Instant) {
     * of the given set. Authorization is always granted for an empty collection of parties.
     */
   def requireActClaimsForAllParties[Req, Res](
-    parties: Iterable[String],
-    call: Req => Future[Res]): Req => Future[Res] =
+      parties: Iterable[String],
+      call: Req => Future[Res]): Req => Future[Res] =
     wrapSingleCall(c => c.notExpired(now()) && parties.forall(p => c.canActAs(p)), call)
 
   /** Checks whether the current Claims authorize to read as the given party, if any.
@@ -88,8 +88,8 @@ final class Authorizer(now: () => Instant) {
     * Note: A missing party does NOT result in an authorization error.
     */
   def requireActClaimsForParty[Req, Res](
-    party: Option[String],
-    call: Req => Future[Res]): Req => Future[Res] =
+      party: Option[String],
+      call: Req => Future[Res]): Req => Future[Res] =
     requireActClaimsForAllParties(party.toList, call)
 
   /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
@@ -104,7 +104,9 @@ final class Authorizer(now: () => Instant) {
   def requireReadClaimsForTransactionFilter[Req, Res](
       filter: Option[TransactionFilter],
       call: Req => Future[Res]): Req => Future[Res] =
-    requireReadClaimsForAllParties(filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet), call)
+    requireReadClaimsForAllParties(
+      filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet),
+      call)
 
   private def assertServerCall[A](observer: StreamObserver[A]): ServerCallStreamObserver[A] =
     observer match {

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -43,7 +43,7 @@ final case class ClaimActAsParty(name: Ref.Party) extends Claim
 
 /** Authorized to read all data for the given party.
   *
-  * Does NOT authorize to modify the ledger in any way.
+  * Does NOT authorize to issue commands.
   */
 final case class ClaimReadAsParty(name: Ref.Party) extends Claim
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -47,7 +47,6 @@ final case class ClaimActAsParty(name: Ref.Party) extends Claim
   */
 final case class ClaimReadAsParty(name: Ref.Party) extends Claim
 
-
 /**
   * [[Claims]] define what actions an authenticated user can perform on the Ledger API.
   *

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ActiveContractsServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ActiveContractsServiceAuthorization.scala
@@ -26,7 +26,7 @@ final class ActiveContractsServiceAuthorization(
   override def getActiveContracts(
       request: GetActiveContractsRequest,
       responseObserver: StreamObserver[GetActiveContractsResponse]): Unit =
-    authorizer.requireClaimsForTransactionFilterOnStream(
+    authorizer.requireReadClaimsForTransactionFilterOnStream(
       request.filter,
       service.getActiveContracts)(request, responseObserver)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
@@ -29,7 +29,7 @@ final class CommandCompletionServiceAuthorization(
   override def completionStream(
       request: CompletionStreamRequest,
       responseObserver: StreamObserver[CompletionStreamResponse]): Unit =
-    authorizer.requireClaimsForAllPartiesOnStream(request.parties, service.completionStream)(
+    authorizer.requireReadClaimsForAllPartiesOnStream(request.parties, service.completionStream)(
       request,
       responseObserver)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -25,7 +25,8 @@ final class CommandServiceAuthorization(
     with GrpcApiService {
 
   override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
-    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submitAndWait)(request)
+    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submitAndWait)(
+      request)
 
   override def submitAndWaitForTransaction(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] =

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -25,23 +25,23 @@ final class CommandServiceAuthorization(
     with GrpcApiService {
 
   override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
-    authorizer.requireClaimsForParty(request.commands.map(_.party), service.submitAndWait)(request)
+    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submitAndWait)(request)
 
   override def submitAndWaitForTransaction(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] =
-    authorizer.requireClaimsForParty(
+    authorizer.requireActClaimsForParty(
       request.commands.map(_.party),
       service.submitAndWaitForTransaction)(request)
 
   override def submitAndWaitForTransactionId(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionIdResponse] =
-    authorizer.requireClaimsForParty(
+    authorizer.requireActClaimsForParty(
       request.commands.map(_.party),
       service.submitAndWaitForTransactionId)(request)
 
   override def submitAndWaitForTransactionTree(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] =
-    authorizer.requireClaimsForParty(
+    authorizer.requireActClaimsForParty(
       request.commands.map(_.party),
       service.submitAndWaitForTransactionTree)(request)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
@@ -22,7 +22,7 @@ final class CommandSubmissionServiceAuthorization(
     with GrpcApiService {
 
   override def submit(request: SubmitRequest): Future[Empty] =
-    authorizer.requireClaimsForParty(request.commands.map(_.party), service.submit)(request)
+    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submit)(request)
 
   override def bindService(): ServerServiceDefinition =
     CommandSubmissionServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
@@ -25,38 +25,38 @@ final class TransactionServiceAuthorization(
   override def getTransactions(
       request: transaction_service.GetTransactionsRequest,
       responseObserver: StreamObserver[GetTransactionsResponse]): Unit =
-    authorizer.requireClaimsForTransactionFilterOnStream(request.filter, service.getTransactions)(
+    authorizer.requireReadClaimsForTransactionFilterOnStream(request.filter, service.getTransactions)(
       request,
       responseObserver)
 
   override def getTransactionTrees(
       request: transaction_service.GetTransactionsRequest,
       responseObserver: StreamObserver[GetTransactionTreesResponse]): Unit =
-    authorizer.requireClaimsForTransactionFilterOnStream(
+    authorizer.requireReadClaimsForTransactionFilterOnStream(
       request.filter,
       service.getTransactionTrees)(request, responseObserver)
 
   override def getTransactionByEventId(
       request: transaction_service.GetTransactionByEventIdRequest): Future[GetTransactionResponse] =
-    authorizer.requireClaimsForAllParties(
+    authorizer.requireReadClaimsForAllParties(
       request.requestingParties,
       service.getTransactionByEventId)(request)
 
   override def getTransactionById(
       request: transaction_service.GetTransactionByIdRequest): Future[GetTransactionResponse] =
-    authorizer.requireClaimsForAllParties(request.requestingParties, service.getTransactionById)(
+    authorizer.requireReadClaimsForAllParties(request.requestingParties, service.getTransactionById)(
       request)
 
   override def getFlatTransactionByEventId(
       request: transaction_service.GetTransactionByEventIdRequest)
     : Future[GetFlatTransactionResponse] =
-    authorizer.requireClaimsForAllParties(
+    authorizer.requireReadClaimsForAllParties(
       request.requestingParties,
       service.getFlatTransactionByEventId)(request)
 
   override def getFlatTransactionById(
       request: transaction_service.GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
-    authorizer.requireClaimsForAllParties(
+    authorizer.requireReadClaimsForAllParties(
       request.requestingParties,
       service.getFlatTransactionById)(request)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
@@ -25,9 +25,9 @@ final class TransactionServiceAuthorization(
   override def getTransactions(
       request: transaction_service.GetTransactionsRequest,
       responseObserver: StreamObserver[GetTransactionsResponse]): Unit =
-    authorizer.requireReadClaimsForTransactionFilterOnStream(request.filter, service.getTransactions)(
-      request,
-      responseObserver)
+    authorizer.requireReadClaimsForTransactionFilterOnStream(
+      request.filter,
+      service.getTransactions)(request, responseObserver)
 
   override def getTransactionTrees(
       request: transaction_service.GetTransactionsRequest,
@@ -44,8 +44,9 @@ final class TransactionServiceAuthorization(
 
   override def getTransactionById(
       request: transaction_service.GetTransactionByIdRequest): Future[GetTransactionResponse] =
-    authorizer.requireReadClaimsForAllParties(request.requestingParties, service.getTransactionById)(
-      request)
+    authorizer.requireReadClaimsForAllParties(
+      request.requestingParties,
+      service.getTransactionById)(request)
 
   override def getFlatTransactionByEventId(
       request: transaction_service.GetTransactionByEventIdRequest)


### PR DESCRIPTION
This PR introduces read-only `Claims`. Fixes #3398.

- The existing `ClaimActAsParty` can read and write
- The new `ClaimReadAsParty` can only read
- There is not write-only claim (as that does not make any sense, IMO)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
