### PR TITLE
Java-codegen: add support for Generic Maps.

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -538,7 +538,9 @@ containers method ``toOptional``. This method expects a function to
 convert back the value possibiy contains in the container.
 
 .. code-block:: java
-
+  
+  Attribute<Optional<Long>> idAttribute2 =
+    serializedId.toOptional(v -> v.asInt64().orElseThrow(() -> new IllegalArgumentException("Expected Int64 element")));
   
 Convert Collection values
 """""""""""""""""""""""""
@@ -562,7 +564,7 @@ functions to convert back the container's entries.
 
 .. code-block:: java
 
-  Attribute<List<String>> authorsAttribute =
+  Attribute<List<String>> authorsAttribute2 =
       Attribute.<List<String>>fromValue(
           serializedAuthors,
           f0 -> f0.asList().orElseThrow(() -> new IllegalArgumentException("Expected DamlList field"))
@@ -570,7 +572,7 @@ functions to convert back the container's entries.
                    f1 -> f1.asText().orElseThrow(() -> new IllegalArgumentException("Expected Text element"))
                         .getValue()
                )
-      )
+      );
 
 
 .. _Value: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -149,7 +149,7 @@ DAML built-in types are translated to the following equivalent types in Java:
 +--------------------------------+--------------------------------------------+------------------------+
 | ``List`` or ``[]``             | ``java.util.List``                         | `DamlList`_            |
 +--------------------------------+--------------------------------------------+------------------------+
-| ``TextMap``                    | ``java.util.Map``                          | `TextMap`_             |
+| ``TextMap``                    | ``java.util.Map``                          | `DamlMap`_             |
 |                                | Restricted to using ``String`` keys.       |                        |
 +--------------------------------+--------------------------------------------+------------------------+
 | ``Optional``                   | ``java.util.Optional``                     | `DamlOptional`_        |
@@ -528,7 +528,7 @@ The conversion of the Java ``List`` and ``Optional`` types requires multiple ste
 
   Attribute<List<String>> authorsAttribute = new Attribute<List<String>>(Arrays.asList("Homer", "Ovid", "Vergil"));
 
-  Value serializedAuthors = authorsAttribute.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
+  Value serializedAuthors = authorsAttribute.toValue(f -> DamlList.of(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
 
 The conversion of the Java ``List`` and ``Optional`` types similarly require that the Java Bindings types `DamlList`_ and `DamlOptional`_ are converted to it's Java equivalent and then all the contained elements are converted to Java types.
 
@@ -549,7 +549,7 @@ The conversion of the Java ``List`` and ``Optional`` types similarly require tha
 .. _Date: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Date.html
 .. _Timestamp: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Timestamp.html
 .. _DamlList: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlList.html
-.. _TextMap: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/TextMap.html
+.. _DamlMap: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamLMap.html
 .. _DamlOptional: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
 .. _Unit: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
 .. _ContractId: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -519,10 +519,10 @@ Non-exposed parameterized types
 
 If the parameterized type is contained in a type where the *actual* type is specified (as in the ``BookAttributes`` type above), then the conversion methods of the enclosing type provides the required conversion function parameters automatically.
 
-Convert List and Optional values
-""""""""""""""""""""""""""""""""
+Convert Container values
+""""""""""""""""""""""""
 
-The conversion of the Java ``List`` and ``Optional`` types requires multiple steps to first convert the list elements or the value inside the optional creating the `DamlList`_ or `DamlOptional`_ value.
+The conversion of the Java types Container types such as ``Optional``, ``List`` or ``Map`` requires multiple steps to first convert the container elements creating the Daml conatiner value.
 
 .. code-block:: java
 
@@ -530,7 +530,7 @@ The conversion of the Java ``List`` and ``Optional`` types requires multiple ste
 
   Value serializedAuthors = authorsAttribute.toValue(f -> DamlList.of(f.stream().map(Text::new).collect(Collectors.<Value>toList())));
 
-The conversion of the Java ``List`` and ``Optional`` types similarly require that the Java Bindings types `DamlList`_ and `DamlOptional`_ are converted to it's Java equivalent and then all the contained elements are converted to Java types.
+The conversion of the Daml containers types such `DamlOptional`_, `DamlList`_, `DamlMap`_ similarly requires that the type is converted to it's Java equivalent and then all the contained elements are converted to Java types.
 
 .. code-block:: java
 
@@ -541,15 +541,16 @@ The conversion of the Java ``List`` and ``Optional`` types similarly require tha
 
 
 .. _Value: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/Value.html
+.. _Unit: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
+.. _Bool: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Bool.html
 .. _Int64: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Int64.html
 .. _Decimal: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Decimal.html
-.. _Text: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Text.html
-.. _Bool: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Bool.html
-.. _Party: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Party.html
 .. _Date: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Date.html
 .. _Timestamp: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Timestamp.html
+.. _Text: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Text.html
+.. _Party: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Party.html
+.. _ContractId: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html
+.. _DamlOptional: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
 .. _DamlList: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlList.html
 .. _DamlMap: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamLMap.html
-.. _DamlOptional: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamlOptional.html
-.. _Unit: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/Unit.html
-.. _ContractId: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/ContractId.html
+.. _DamlCollectors: /app-dev/bindings-java/javadocs/com/daml/ledger/javaapi/data/DamLCollectors.html

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -143,7 +143,7 @@ object TransactionGenerator {
       (elementsSize, newHeight) <- splitSizeAndHeight(height)
       elements <- Gen.listOfN(elementsSize, valueGen(newHeight))
       (scalaElements, javaElements) = elements.unzip
-    } yield (Sum.List(value.List(scalaElements)), new data.DamlList(javaElements.asJava))
+    } yield (Sum.List(value.List(scalaElements)), data.DamlList.of(javaElements.asJava))
 
   val int64ValueGen: Gen[(Sum.Int64, data.Int64)] = Arbitrary.arbLong.arbitrary.map { int64 =>
     (Sum.Int64(int64), new data.Int64(int64))

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlCollectors.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlCollectors.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+public final class DamlCollectors {
+
+    public static <T> Collector<T, ArrayList<Value>, DamlList> toDamlList(Function<T, Value> valueMapper) {
+        return Collector.of(
+                ArrayList::new,
+                (acc, entry) -> acc.add(valueMapper.apply(entry)),
+                (left, right) -> { left.addAll(right); return left; },
+                DamlList::fromPrivateList
+        );
+    }
+
+    public static <T> Collector<T, Map<String, Value>, DamlMap> toDamlMap(
+            Function<T, String> keyMapper,
+            Function<T, Value> valueMapper) {
+
+        return Collector.of(
+                HashMap::new,
+                (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
+                (left, right) -> { left.putAll(right); return left; },
+                DamlMap::fromPrivateMap
+        );
+    }
+
+    public static <T> Collector<T, Map<Value, Value>, DamlGenMap> toDamlGenMap(
+            Function<T, Value> keyMapper,
+            Function<T, Value> valueMapper) {
+
+        return Collector.of(
+                LinkedHashMap::new,
+                (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
+                (left, right) -> { left.putAll(right); return left; },
+                DamlGenMap::fromPrivateMap
+        );
+    }
+
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlCollectors.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlCollectors.java
@@ -3,16 +3,13 @@
 
 package com.daml.ledger.javaapi.data;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
 public final class DamlCollectors {
 
-    public static <T> Collector<T, ArrayList<Value>, DamlList> toDamlList(Function<T, Value> valueMapper) {
+    public static <T> Collector<T, List<Value>, DamlList> toDamlList(Function<T, Value> valueMapper) {
         return Collector.of(
                 ArrayList::new,
                 (acc, entry) -> acc.add(valueMapper.apply(entry)),
@@ -21,7 +18,11 @@ public final class DamlCollectors {
         );
     }
 
-    public static <T> Collector<T, Map<String, Value>, DamlMap> toDamlMap(
+    public static Collector<Value, List<Value>, DamlList> toDamlList(){
+        return toDamlList(Function.identity());
+    }
+
+    public static <T> Collector<T, Map<String, Value>, DamlTextMap> toDamlTextMap(
             Function<T, String> keyMapper,
             Function<T, Value> valueMapper) {
 
@@ -29,8 +30,12 @@ public final class DamlCollectors {
                 HashMap::new,
                 (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
                 (left, right) -> { left.putAll(right); return left; },
-                DamlMap::fromPrivateMap
+                DamlTextMap::fromPrivateMap
         );
+    }
+
+    public static Collector<Map.Entry<String, Value>, Map<String, Value>, DamlTextMap> toDamlTextMap(){
+        return toDamlTextMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
     public static <T> Collector<T, Map<Value, Value>, DamlGenMap> toDamlGenMap(
@@ -43,6 +48,10 @@ public final class DamlCollectors {
                 (left, right) -> { left.putAll(right); return left; },
                 DamlGenMap::fromPrivateMap
         );
+    }
+
+    public static Collector<Map.Entry<Value, Value>, Map<Value, Value>, DamlGenMap> toMap(){
+        return toDamlGenMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
@@ -6,7 +6,6 @@ package com.daml.ledger.javaapi.data;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -23,7 +22,7 @@ public final class DamlGenMap extends Value {
         this.map = value;
     }
 
-    private static @Nonnull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
+    private static @NonNull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
         return new DamlGenMap(Collections.unmodifiableMap(map));
     }
 
@@ -45,7 +44,7 @@ public final class DamlGenMap extends Value {
         );
     }
 
-    public @Nonnull Map<@NonNull Value, @NonNull Value> getMap() { return map; }
+    public @NonNull Map<@NonNull Value, @NonNull Value> getMap() { return map; }
 
     @Override
     public boolean equals(Object o) {
@@ -68,7 +67,7 @@ public final class DamlGenMap extends Value {
     }
 
     @Override
-    public @Nonnull ValueOuterClass.Value toProto() {
+    public ValueOuterClass.Value toProto() {
         ValueOuterClass.GenMap.Builder mb = ValueOuterClass.GenMap.newBuilder();
         map.forEach((key, value) ->
                 mb.addEntries(ValueOuterClass.GenMap.Entry.newBuilder()
@@ -78,7 +77,7 @@ public final class DamlGenMap extends Value {
         return ValueOuterClass.Value.newBuilder().setGenMap(mb).build();
     }
 
-    public static @Nonnull DamlGenMap fromProto(@Nonnull ValueOuterClass.GenMap map){
+    public static @NonNull DamlGenMap fromProto(ValueOuterClass.GenMap map){
         return map.getEntriesList().stream().collect(collector(
                 entry -> fromProto(entry.getKey()),
                 entry -> fromProto(entry.getValue())

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
-final public class DamlGenMap extends Value {
+public final class DamlGenMap extends Value {
 
     private static DamlGenMap EMPTY = new DamlGenMap(Collections.EMPTY_MAP);
 
@@ -28,10 +28,7 @@ final public class DamlGenMap extends Value {
         return Collector.of(
                 LinkedHashMap::new,
                 (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
-                (left, right) -> {
-                    left.putAll(right);
-                    return left;
-                },
+                (left, right) -> { left.putAll(right); return left; },
                 DamlGenMap::new
         );
     }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
@@ -7,22 +7,21 @@ import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public final class DamlGenMap extends Value {
 
     private final Map<Value, Value> map;
 
-    /**
-     * The map that is passed to this constructor must not be changed
-     * once passed.
-     */
     private DamlGenMap(@NonNull Map<@NonNull Value, @NonNull Value> value) {
         this.map = value;
     }
 
-    private static @NonNull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
+    /**
+     * The map that is passed to this constructor must not be changed
+     * once passed.
+     */
+    protected static @NonNull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
         return new DamlGenMap(Collections.unmodifiableMap(map));
     }
 
@@ -30,18 +29,6 @@ public final class DamlGenMap extends Value {
 
     public static DamlGenMap of(@NonNull Map<@NonNull Value, @NonNull Value> map){
        return new DamlGenMap(new LinkedHashMap<>(map));
-    }
-
-    public static <T> Collector<T, Map<Value, Value>, DamlGenMap> collector(
-            Function<T, Value> keyMapper,
-            Function<T, Value> valueMapper) {
-
-        return Collector.of(
-                LinkedHashMap::new,
-                (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
-                (left, right) -> { left.putAll(right); return left; },
-                DamlGenMap::fromPrivateMap
-        );
     }
 
     public @NonNull Map<@NonNull Value, @NonNull Value> getMap() { return map; }
@@ -78,7 +65,7 @@ public final class DamlGenMap extends Value {
     }
 
     public static @NonNull DamlGenMap fromProto(ValueOuterClass.GenMap map){
-        return map.getEntriesList().stream().collect(collector(
+        return map.getEntriesList().stream().collect(DamlCollectors.toDamlGenMap(
                 entry -> fromProto(entry.getKey()),
                 entry -> fromProto(entry.getValue())
         ));

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlGenMap.java
@@ -23,7 +23,7 @@ public final class DamlGenMap extends Value {
     /**
      * The map that is passed to this constructor must not be changed once passed.
      */
-    protected static @NonNull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
+    static @NonNull DamlGenMap fromPrivateMap(@NonNull Map<@NonNull Value, @NonNull Value> map){
         return new DamlGenMap(Collections.unmodifiableMap(map));
     }
 
@@ -32,9 +32,6 @@ public final class DamlGenMap extends Value {
     public static DamlGenMap of(@NonNull Map<@NonNull Value, @NonNull Value> map){
        return fromPrivateMap(new LinkedHashMap<>(map));
     }
-
-    @Deprecated // use DamlGenMap::stream or DamlGenMap::toMap
-    public @NonNull Map<@NonNull Value, @NonNull Value> getMap() { return map; }
 
     public Stream<Map.Entry<Value, Value>> stream(){
         return map.entrySet().stream();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -7,6 +7,9 @@ import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class DamlList extends Value {
 
@@ -45,21 +48,17 @@ public final class DamlList extends Value {
         this(Arrays.asList(values));
     }
 
+    @Deprecated // use DamlMap::stream or DamlMap::toListf
     public @NonNull List<@NonNull Value> getValues() {
         return values;
     }
 
-    @Override
-    public ValueOuterClass.Value toProto() {
-        ValueOuterClass.List.Builder builder = ValueOuterClass.List.newBuilder();
-        for (Value value : this.values) {
-            builder.addElements(value.toProto());
-        }
-        return ValueOuterClass.Value.newBuilder().setList(builder.build()).build();
+    public @NonNull Stream<Value> stream(){
+        return values.stream();
     }
 
-    public static @NonNull DamlList fromProto(ValueOuterClass.List list) {
-        return list.getElementsList().stream().collect(DamlCollectors.toDamlList(Value::fromProto));
+    public @NonNull <T> List<T> toList(Function<Value, T> valueMapper) {
+        return stream().map(valueMapper).collect(Collectors.toList());
     }
 
     @Override
@@ -81,4 +80,18 @@ public final class DamlList extends Value {
                 "values=" + values +
                 '}';
     }
+
+    @Override
+    public ValueOuterClass.Value toProto() {
+        ValueOuterClass.List.Builder builder = ValueOuterClass.List.newBuilder();
+        for (Value value : this.values) {
+            builder.addElements(value.toProto());
+        }
+        return ValueOuterClass.Value.newBuilder().setList(builder.build()).build();
+    }
+
+    public static @NonNull DamlList fromProto(ValueOuterClass.List list) {
+        return list.getElementsList().stream().collect(DamlCollectors.toDamlList(Value::fromProto));
+    }
+
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -20,7 +20,7 @@ public final class DamlList extends Value {
     /**
      * The list that is passed to this constructor must not be change once passed.
      */
-    protected static DamlList fromPrivateList(@NonNull List<@NonNull Value> values){
+    static @NonNull DamlList fromPrivateList(@NonNull List<@NonNull Value> values){
         DamlList damlList = new DamlList();
         damlList.values =  Collections.unmodifiableList(values);
         return damlList;
@@ -50,7 +50,7 @@ public final class DamlList extends Value {
 
     @Deprecated // use DamlMap::stream or DamlMap::toListf
     public @NonNull List<@NonNull Value> getValues() {
-        return values;
+        return toList(Function.identity());
     }
 
     public @NonNull Stream<Value> stream(){

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -7,7 +7,6 @@ import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
-import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
@@ -59,7 +58,7 @@ public final class DamlList extends Value {
     }
 
     @Override
-    public @Nonnull ValueOuterClass.Value toProto() {
+    public ValueOuterClass.Value toProto() {
         ValueOuterClass.List.Builder builder = ValueOuterClass.List.newBuilder();
         for (Value value : this.values) {
             builder.addElements(value.toProto());
@@ -67,7 +66,7 @@ public final class DamlList extends Value {
         return ValueOuterClass.Value.newBuilder().setList(builder.build()).build();
     }
 
-    public static @Nonnull DamlList fromProto(@Nonnull ValueOuterClass.List list) {
+    public static @NonNull DamlList fromProto(ValueOuterClass.List list) {
         return list.getElementsList().stream().collect(collector(Value::fromProto));
     }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -6,7 +6,6 @@ package com.daml.ledger.javaapi.data;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.lang.reflect.Array;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -36,10 +35,7 @@ public final class DamlList extends Value {
         return Collector.of(
                 ArrayList::new,
                 (acc, entry) -> acc.add(valueMapper.apply(entry)),
-                (left, right) -> {
-                    left.addAll(right);
-                    return left;
-                },
+                (left, right) -> { left.addAll(right); return left; },
                 DamlList::new
         );
     }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlList.java
@@ -7,8 +7,6 @@ import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collector;
 
 public final class DamlList extends Value {
 
@@ -16,7 +14,10 @@ public final class DamlList extends Value {
 
     private DamlList(){ }
 
-    private static DamlList fromPrivateList(@NonNull List<@NonNull Value> values){
+    /**
+     * The list that is passed to this constructor must not be change once passed.
+     */
+    protected static DamlList fromPrivateList(@NonNull List<@NonNull Value> values){
         DamlList damlList = new DamlList();
         damlList.values =  Collections.unmodifiableList(values);
         return damlList;
@@ -48,15 +49,6 @@ public final class DamlList extends Value {
         return values;
     }
 
-    public static <T> Collector<T, ArrayList<Value>, DamlList> collector(Function<T, Value> valueMapper) {
-        return Collector.of(
-                ArrayList::new,
-                (acc, entry) -> acc.add(valueMapper.apply(entry)),
-                (left, right) -> { left.addAll(right); return left; },
-                DamlList::fromPrivateList
-        );
-    }
-
     @Override
     public ValueOuterClass.Value toProto() {
         ValueOuterClass.List.Builder builder = ValueOuterClass.List.newBuilder();
@@ -67,7 +59,7 @@ public final class DamlList extends Value {
     }
 
     public static @NonNull DamlList fromProto(ValueOuterClass.List list) {
-        return list.getElementsList().stream().collect(collector(Value::fromProto));
+        return list.getElementsList().stream().collect(DamlCollectors.toDamlList(Value::fromProto));
     }
 
     @Override

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
@@ -6,7 +6,6 @@ package com.daml.ledger.javaapi.data;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -46,7 +45,7 @@ public final class DamlMap extends Value {
         );
     }
 
-    public @Nonnull Map<@NonNull String, @NonNull Value> getMap() { return value; }
+    public @NonNull Map<@NonNull String, @NonNull Value> getMap() { return value; }
 
     @Override
     public boolean equals(Object o) {
@@ -69,7 +68,7 @@ public final class DamlMap extends Value {
     }
 
     @Override
-    public @Nonnull ValueOuterClass.Value toProto() {
+    public ValueOuterClass.Value toProto() {
         ValueOuterClass.Map.Builder mb = ValueOuterClass.Map.newBuilder();
         value.forEach((k, v) ->
                 mb.addEntries(ValueOuterClass.Map.Entry.newBuilder()
@@ -81,7 +80,7 @@ public final class DamlMap extends Value {
         return ValueOuterClass.Value.newBuilder().setMap(mb).build();
     }
 
-    public static @Nonnull DamlMap fromProto(ValueOuterClass.Map map) {
+    public static @NonNull DamlMap fromProto(ValueOuterClass.Map map) {
         return map.getEntriesList().stream().collect(collector(
                 ValueOuterClass.Map.Entry::getKey,
                 entry -> fromProto(entry.getValue())

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
-public class DamlMap extends Value {
+public final class DamlMap extends Value {
 
     private static DamlMap EMPTY = new DamlMap(Collections.emptyMap());
 
@@ -28,10 +28,7 @@ public class DamlMap extends Value {
         return Collector.of(
                 HashMap::new,
                 (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
-                (left, right) -> {
-                    left.putAll(right);
-                    return left;
-                },
+                (left, right) -> { left.putAll(right); return left; },
                 DamlMap::new
         );
     }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
@@ -7,8 +7,6 @@ import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collector;
 
 public final class DamlMap extends Value {
 
@@ -16,7 +14,7 @@ public final class DamlMap extends Value {
 
     private DamlMap(){ }
 
-    private static DamlMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
+    protected static DamlMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
         DamlMap damlMap = new DamlMap();
         damlMap.value = Collections.unmodifiableMap(value);
         return damlMap;
@@ -31,18 +29,6 @@ public final class DamlMap extends Value {
     @Deprecated // use DamlMap:of
     public DamlMap(Map<String, Value> value) {
         this.value = Collections.unmodifiableMap(new HashMap<>(value));
-    }
-
-    public static <T> Collector<T, Map<String, Value>, DamlMap> collector(
-            Function<T, String> keyMapper,
-            Function<T, Value> valueMapper) {
-
-        return Collector.of(
-                HashMap::new,
-                (acc, entry) -> acc.put(keyMapper.apply(entry), valueMapper.apply(entry)),
-                (left, right) -> { left.putAll(right); return left; },
-                DamlMap::fromPrivateMap
-        );
     }
 
     public @NonNull Map<@NonNull String, @NonNull Value> getMap() { return value; }
@@ -81,7 +67,7 @@ public final class DamlMap extends Value {
     }
 
     public static @NonNull DamlMap fromProto(ValueOuterClass.Map map) {
-        return map.getEntriesList().stream().collect(collector(
+        return map.getEntriesList().stream().collect(DamlCollectors.toDamlMap(
                 ValueOuterClass.Map.Entry::getKey,
                 entry -> fromProto(entry.getValue())
         ));

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlMap.java
@@ -3,73 +3,15 @@
 
 package com.daml.ledger.javaapi.data;
 
-import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.*;
 
-public final class DamlMap extends Value {
+@Deprecated // Use DamlTextMap
+public class DamlMap extends DamlTextMap{
 
-    private Map<String, Value> value;
-
-    private DamlMap(){ }
-
-    protected static DamlMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
-        DamlMap damlMap = new DamlMap();
-        damlMap.value = Collections.unmodifiableMap(value);
-        return damlMap;
+    public DamlMap(Map<@NonNull String, @NonNull Value> value) {
+        super(Collections.unmodifiableMap(new HashMap<>(value)));
     }
 
-    private static @NonNull DamlMap EMPTY = fromPrivateMap(Collections.emptyMap());
-
-    public static DamlMap of(@NonNull Map<@NonNull String, @NonNull Value> value){
-        return fromPrivateMap(new HashMap<>(value));
-    }
-
-    @Deprecated // use DamlMap:of
-    public DamlMap(Map<String, Value> value) {
-        this.value = Collections.unmodifiableMap(new HashMap<>(value));
-    }
-
-    public @NonNull Map<@NonNull String, @NonNull Value> getMap() { return value; }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DamlMap optional = (DamlMap) o;
-        return Objects.equals(value, optional.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
-
-    @Override
-    public @NonNull String toString() {
-        StringJoiner sj = new StringJoiner(", ", "Map{", "}");
-        value.forEach((k, v) -> sj.add(k + "->" + v.toString()));
-        return sj.toString();
-    }
-
-    @Override
-    public ValueOuterClass.Value toProto() {
-        ValueOuterClass.Map.Builder mb = ValueOuterClass.Map.newBuilder();
-        value.forEach((k, v) ->
-                mb.addEntries(ValueOuterClass.Map.Entry.newBuilder()
-                        .setKey(k)
-                        .setValue(v.toProto())
-                )
-        );
-
-        return ValueOuterClass.Value.newBuilder().setMap(mb).build();
-    }
-
-    public static @NonNull DamlMap fromProto(ValueOuterClass.Map map) {
-        return map.getEntriesList().stream().collect(DamlCollectors.toDamlMap(
-                ValueOuterClass.Map.Entry::getKey,
-                entry -> fromProto(entry.getValue())
-        ));
-    }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlOptional.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlOptional.java
@@ -57,7 +57,7 @@ public class DamlOptional extends Value {
     }
 
     public static @Nonnull DamlOptional empty() {
-        return (DamlOptional) EMPTY;
+        return EMPTY;
     }
 
     @Override
@@ -67,5 +67,14 @@ public class DamlOptional extends Value {
         return ValueOuterClass.Value.newBuilder()
                 .setOptional(ob.build())
                 .build();
+    }
+
+    public static DamlOptional fromProto(ValueOuterClass.Optional optional) {
+        if (optional.hasValue()) {
+            return new DamlOptional(fromProto(optional.getValue()));
+        }
+        else {
+            return EMPTY;
+        }
     }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlOptional.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlOptional.java
@@ -6,26 +6,42 @@ package com.daml.ledger.javaapi.data;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import javax.annotation.Nonnull;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Function;
 
-public class DamlOptional extends Value {
+public final class DamlOptional extends Value {
 
-    private static DamlOptional EMPTY = new DamlOptional(java.util.Optional.empty());
+    public static DamlOptional EMPTY = new DamlOptional(Optional.empty());
 
     private final Value value;
 
-    private DamlOptional(Value value) {
+    DamlOptional(Value value) {
         this.value = value;
     }
 
-    public DamlOptional(java.util.Optional<Value> value) {
-        this.value = value.orElse(null);
+    @Deprecated // use DamlOptional.of
+    public DamlOptional(Optional<@NonNull Value> value) {
+        this(value.orElse(null));
     }
 
-    public @Nonnull
-    java.util.Optional<Value> getValue() {
+
+    static public DamlOptional of(@NonNull Optional<@NonNull Value> value) {
+        if (value.isPresent())
+            return new DamlOptional((value.get()));
+        else
+            return EMPTY;
+    }
+
+    static public DamlOptional of(Value value){
+        return new DamlOptional(value);
+    }
+
+    public java.util.Optional<Value> getValue() {
         return java.util.Optional.ofNullable(value);
+    }
+
+    public @NonNull <V> Optional<V> toOptional(Function<@NonNull Value, @NonNull V> valueMapper){
+        return  (value == null) ? Optional.empty() : Optional.of(valueMapper.apply(value));
     }
 
     @Override
@@ -52,16 +68,13 @@ public class DamlOptional extends Value {
                 '}';
     }
 
-    public static @Nonnull  DamlOptional of(Value value) {
-        return value == null ? EMPTY : new DamlOptional(value);
-    }
-
-    public static @Nonnull DamlOptional empty() {
+    @Deprecated  // use DamlOptional::EMPTY
+    public static @NonNull DamlOptional empty() {
         return EMPTY;
     }
 
     @Override
-    public @Nonnull ValueOuterClass.Value toProto() {
+    public ValueOuterClass.Value toProto() {
         ValueOuterClass.Optional.Builder ob = ValueOuterClass.Optional.newBuilder();
         if (value != null) ob.setValue(value.toProto());
         return ValueOuterClass.Value.newBuilder()
@@ -70,11 +83,6 @@ public class DamlOptional extends Value {
     }
 
     public static DamlOptional fromProto(ValueOuterClass.Optional optional) {
-        if (optional.hasValue()) {
-            return new DamlOptional(fromProto(optional.getValue()));
-        }
-        else {
-            return EMPTY;
-        }
+        return (optional.hasValue()) ? new DamlOptional(fromProto(optional.getValue())) : EMPTY;
     }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlTextMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlTextMap.java
@@ -23,7 +23,7 @@ public class DamlTextMap extends Value {
     /**
      * The map that is passed to this constructor must not be changed once passed.
      */
-    static DamlTextMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
+    static @NonNull DamlTextMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
         return new DamlTextMap(Collections.unmodifiableMap(value));
     }
 
@@ -34,7 +34,9 @@ public class DamlTextMap extends Value {
     }
 
     @Deprecated // use DamlTextMap::toMap or DamlTextMap::stream
-    public final @NonNull Map<@NonNull String, @NonNull Value> getMap() { return map; }
+    public final @NonNull Map<@NonNull String, @NonNull Value> getMap() {
+        return toMap(Function.identity());
+    }
 
     public Stream<Map.Entry<String, Value>> stream(){
         return map.entrySet().stream();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlTextMap.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/DamlTextMap.java
@@ -1,0 +1,97 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.digitalasset.ledger.api.v1.ValueOuterClass;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DamlTextMap extends Value {
+
+    private final Map<String, Value> map;
+
+    DamlTextMap(Map<String, Value> map){
+        this.map = map;
+    }
+
+    /**
+     * The map that is passed to this constructor must not be changed once passed.
+     */
+    static DamlTextMap fromPrivateMap(Map<@NonNull String, @NonNull Value> value){
+        return new DamlTextMap(Collections.unmodifiableMap(value));
+    }
+
+    private static @NonNull DamlTextMap EMPTY = fromPrivateMap(Collections.emptyMap());
+
+    public static DamlTextMap of(@NonNull Map<@NonNull String, @NonNull Value> value){
+        return fromPrivateMap(new HashMap<>(value));
+    }
+
+    @Deprecated // use DamlTextMap::toMap or DamlTextMap::stream
+    public final @NonNull Map<@NonNull String, @NonNull Value> getMap() { return map; }
+
+    public Stream<Map.Entry<String, Value>> stream(){
+        return map.entrySet().stream();
+    }
+
+    public final @NonNull <K, V> Map< K,  V> toMap(
+            @NonNull Function<@NonNull String, @NonNull K> keyMapper,
+            @NonNull Function<@NonNull Value, @NonNull V> valueMapper
+    ){
+        return stream().collect(Collectors.toMap(
+                e -> keyMapper.apply(e.getKey()),
+                e -> valueMapper.apply(e.getValue())
+        ));
+    }
+
+    public final @NonNull <V> Map<@NonNull String,@NonNull V> toMap(
+            @NonNull Function<@NonNull Value, @NonNull V> valueMapper
+    ){
+        return toMap(Function.identity(), valueMapper);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DamlTextMap other = (DamlTextMap) o;
+        return Objects.equals(map, other.map);
+    }
+
+    @Override
+    public final int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public final @NonNull String toString() {
+        StringJoiner sj = new StringJoiner(", ", "TextMap{", "}");
+        map.forEach((key, value) -> sj.add(key + "->" + value.toString()));
+        return sj.toString();
+    }
+
+    @Override
+    public final ValueOuterClass.Value toProto() {
+        ValueOuterClass.Map.Builder mb = ValueOuterClass.Map.newBuilder();
+        map.forEach((k, v) ->
+                mb.addEntries(ValueOuterClass.Map.Entry.newBuilder()
+                        .setKey(k)
+                        .setValue(v.toProto())
+                )
+        );
+        return ValueOuterClass.Value.newBuilder().setMap(mb).build();
+    }
+
+    public static @NonNull DamlTextMap fromProto(ValueOuterClass.Map map) {
+        return map.getEntriesList().stream().collect(DamlCollectors.toDamlTextMap(
+                ValueOuterClass.Map.Entry::getKey,
+                entry -> fromProto(entry.getValue())
+        ));
+    }
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Decimal.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Decimal.java
@@ -9,7 +9,6 @@ import java.math.BigDecimal;
 
 @Deprecated
 public class Decimal extends Numeric {
-
     public Decimal(@NonNull BigDecimal value) {
         super(value);
     }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
@@ -6,6 +6,8 @@ package com.daml.ledger.javaapi.data;
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public abstract class Value {
@@ -39,19 +41,11 @@ public abstract class Value {
             case DATE:
                 return new Date(value.getDate());
             case OPTIONAL:
-                if (value.getOptional().hasValue()) {
-                    Value inner = fromProto(value.getOptional().getValue());
-                    return DamlOptional.of(inner);
-                }
-                else {
-                    return DamlOptional.empty();
-                }
+                return DamlOptional.fromProto(value.getOptional());
             case MAP:
-                HashMap<String, Value> map = new HashMap<String, Value>();
-                for(ValueOuterClass.Map.Entry e: value.getMap().getEntriesList()){
-                    map.put(e.getKey(), fromProto(e.getValue()));
-                }
-                return new DamlMap(map);
+               return DamlMap.fromProto(value.getMap());
+            case GEN_MAP:
+                return DamlGenMap.fromProto(value.getGenMap());
             case SUM_NOT_SET:
                 throw new SumNotSetException(value);
             default:

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
@@ -5,9 +5,6 @@ package com.daml.ledger.javaapi.data;
 
 import com.digitalasset.ledger.api.v1.ValueOuterClass;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
 
 public abstract class Value {
@@ -43,7 +40,7 @@ public abstract class Value {
             case OPTIONAL:
                 return DamlOptional.fromProto(value.getOptional());
             case MAP:
-               return DamlMap.fromProto(value.getMap());
+               return DamlTextMap.fromProto(value.getMap());
             case GEN_MAP:
                 return DamlGenMap.fromProto(value.getGenMap());
             case SUM_NOT_SET:
@@ -116,9 +113,15 @@ public abstract class Value {
                 Optional.empty();
     }
 
-    public final Optional<DamlMap> asMap() {
-        return (this instanceof DamlMap) ? Optional.of((DamlMap) this) : Optional.empty();
+    public final Optional<DamlTextMap> asTextMap() {
+        return (this instanceof DamlTextMap) ? Optional.of((DamlTextMap) this) : Optional.empty();
     }
+
+    @Deprecated // Use Value::asTextMap
+    public final Optional<DamlTextMap> asMap() {
+        return (this instanceof DamlTextMap) ? Optional.of((DamlTextMap) this) : Optional.empty();
+    }
+
 
     public final Optional<DamlGenMap> asGenMap() {
         return (this instanceof DamlGenMap) ? Optional.of((DamlGenMap) this) : Optional.empty();

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Value.java
@@ -119,9 +119,8 @@ public abstract class Value {
 
     @Deprecated // Use Value::asTextMap
     public final Optional<DamlTextMap> asMap() {
-        return (this instanceof DamlTextMap) ? Optional.of((DamlTextMap) this) : Optional.empty();
+        return asTextMap();
     }
-
 
     public final Optional<DamlGenMap> asGenMap() {
         return (this instanceof DamlGenMap) ? Optional.of((DamlGenMap) this) : Optional.empty();

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -135,6 +135,46 @@ object Generators {
   def listValueGen: Gen[ValueOuterClass.Value] =
     listGen.map(ValueOuterClass.Value.newBuilder().setList(_).build())
 
+  def textMapGen: Gen[ValueOuterClass.Map] =
+    Gen
+      .sized(
+        height =>
+          for {
+            size <- Gen.size.flatMap(maxSize =>
+              if (maxSize >= 1) Gen.chooseNum(1, maxSize) else Gen.const(1))
+            newHeight = height / size
+            keys <- Gen.listOfN(size, Arbitrary.arbString.arbitrary)
+            if keys.distinct == keys
+            values <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
+          } yield
+            (keys zip values).map {
+              case (k, v) => ValueOuterClass.Map.Entry.newBuilder().setKey(k).setValue(v).build()
+          })
+      .map(x => ValueOuterClass.Map.newBuilder().addAllEntries(x.asJava).build())
+
+  def textMapValueGen: Gen[ValueOuterClass.Value] =
+    textMapGen.map(ValueOuterClass.Value.newBuilder().setMap(_).build())
+
+  def genMapGen: Gen[ValueOuterClass.GenMap] =
+    Gen
+      .sized(
+        height =>
+          for {
+            size <- Gen.size.flatMap(maxSize =>
+              if (maxSize >= 1) Gen.chooseNum(1, maxSize) else Gen.const(1))
+            newHeight = height / size
+            keys <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
+            if keys.distinct == keys
+            values <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
+          } yield
+            (keys zip values).map {
+              case (k, v) => ValueOuterClass.GenMap.Entry.newBuilder().setKey(k).setValue(v).build()
+          })
+      .map(x => ValueOuterClass.GenMap.newBuilder().addAllEntries(x.asJava).build())
+
+  def genMapValueGen: Gen[ValueOuterClass.Value] =
+    genMapGen.map(ValueOuterClass.Value.newBuilder().setGenMap(_).build())
+
   def int64ValueGen: Gen[ValueOuterClass.Value] =
     Arbitrary.arbLong.arbitrary.map(ValueOuterClass.Value.newBuilder().setInt64(_).build())
 

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -164,7 +164,6 @@ object Generators {
               if (maxSize >= 1) Gen.chooseNum(1, maxSize) else Gen.const(1))
             newHeight = height / size
             keys <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
-            if keys.distinct == keys
             values <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
           } yield
             (keys zip values).map {

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
@@ -37,7 +37,9 @@ class ValueSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyCheck
     SumCase.TIMESTAMP -> (((_: Value).asTimestamp(), "asTimestamp")),
     SumCase.UNIT -> (((_: Value).asUnit(), "asUnit")),
     SumCase.VARIANT -> (((_: Value).asVariant(), "asVariant")),
-    SumCase.OPTIONAL -> (((_: Value).asOptional(), "asOptional"))
+    SumCase.OPTIONAL -> (((_: Value).asOptional(), "asOptional")),
+    SumCase.MAP -> (((_: Value).asTextMap(), "asTextMap")),
+    SumCase.GEN_MAP -> (((_: Value).asGenMap(), "asGenMap")),
   )
 
   def assertConversions[T <: Value](sumCase: SumCase, expected: T): scala.Unit = {
@@ -76,6 +78,8 @@ class ValueSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyCheck
   assertConversions(SumCase.UNIT, Value.fromProto(unitValueGen.sample.get))
   assertConversions(SumCase.VARIANT, Value.fromProto(variantValueGen.sample.get))
   assertConversions(SumCase.OPTIONAL, Value.fromProto(optionalValueGen.sample.get))
+  assertConversions(SumCase.MAP, Value.fromProto(textMapValueGen.sample.get))
+  assertConversions(SumCase.GEN_MAP, Value.fromProto(genMapValueGen.sample.get))
 
   "Timestamp" should
     "be constructed from Instant" in forAll(Gen.posNum[Long]) { micros =>

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
@@ -10,11 +10,15 @@ import java.util.concurrent.TimeUnit
 import com.daml.ledger.javaapi.data.Generators._
 import com.digitalasset.ledger.api.v1.ValueOuterClass.Value.SumCase
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, TableDrivenPropertyChecks}
 import org.scalatest.{FlatSpec, Matchers}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class ValueSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class ValueSpec
+    extends FlatSpec
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with TableDrivenPropertyChecks {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSize = 1, sizeRange = 3)

--- a/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/ListTest.java
@@ -219,7 +219,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlCollectors.toDamlList(Text::new))), dataRecord);
     }
 
 }

--- a/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/ListTest.java
@@ -219,8 +219,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList()))), dataRecord);
-
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
     }
 
 }

--- a/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/OptionalTest.java
+++ b/language-support/java/codegen/src/it/java-1.0/com/digitalasset/lf_1_0/OptionalTest.java
@@ -62,7 +62,7 @@ public class OptionalTest {
         Record record = new Record(
                 new Record.Field(
                         new Variant("Some",
-                                new DamlList(new Int64(42))
+                                DamlList.of(new Int64(42))
                         )
                 )
         );
@@ -76,7 +76,7 @@ public class OptionalTest {
     @Test
     void listOfOptionals() {
         Record record = new Record(
-                new Record.Field(new DamlList(new Variant("Some", new Int64(42))))
+                new Record.Field(DamlList.of(new Variant("Some", new Int64(42))))
         );
 
         MyListOfOptionalsRecord fromValue = MyListOfOptionalsRecord.fromValue(record);

--- a/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/ListTest.java
@@ -218,7 +218,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlCollectors.toDamlList(Text::new))), dataRecord);
     }
 
 }

--- a/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.1/com/digitalasset/lf_1_1/ListTest.java
@@ -13,7 +13,6 @@ import tests.listtest.*;
 import tests.listtest.color.Green;
 import tests.listtest.color.Red;
 import tests.listtest.listitem.Node;
-import tests.varianttest.variantitem.ParameterizedRecordVariant;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -219,8 +218,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList()))), dataRecord);
-
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
     }
 
 }

--- a/language-support/java/codegen/src/it/java-1.5/com/digitalasset/lf_1_5/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.5/com/digitalasset/lf_1_5/ListTest.java
@@ -219,7 +219,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlCollectors.toDamlList(Text::new))), dataRecord);
 
     }
 

--- a/language-support/java/codegen/src/it/java-1.5/com/digitalasset/lf_1_5/ListTest.java
+++ b/language-support/java/codegen/src/it/java-1.5/com/digitalasset/lf_1_5/ListTest.java
@@ -219,7 +219,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList()))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
 
     }
 

--- a/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/ListTest.java
+++ b/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/ListTest.java
@@ -216,7 +216,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> new DamlList(f.stream().map(Text::new).collect(Collectors.<Value>toList()))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
 
     }
 

--- a/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/ListTest.java
+++ b/language-support/java/codegen/src/it/java-latest/com/digitalasset/lf_latest/ListTest.java
@@ -216,7 +216,7 @@ public class ListTest {
         ));
 
         assertEquals(fromValue, fromConstructor);
-        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlList.collector(Text::new))), dataRecord);
+        assertEquals(fromConstructor.toValue(f -> f.stream().collect(DamlCollectors.toDamlList(Text::new))), dataRecord);
 
     }
 

--- a/language-support/java/codegen/src/it/java/com/digitalasset/RecordTest.java
+++ b/language-support/java/codegen/src/it/java/com/digitalasset/RecordTest.java
@@ -55,7 +55,7 @@ public class RecordTest {
         Timestamp timestamp = new Timestamp(timestampMicrosValue);
         DamlList list = DamlList.of(Unit.getInstance(), Unit.getInstance());
         DamlList nestedList =
-                nestedListValue.stream().collect(DamlList.collector(ns -> ns.stream().collect(DamlList.collector(Int64::new))));
+                nestedListValue.stream().collect(DamlCollectors.toDamlList(ns -> ns.stream().collect(DamlCollectors.toDamlList(Int64::new))));
         Record nestedRecord = new Record(new Record.Field("value", new Int64(42)));
         Variant nestedVariant = new Variant("Nested", new Int64(42));
         ArrayList<Record.Field> fieldsList = new ArrayList<>(10);

--- a/language-support/java/codegen/src/it/java/com/digitalasset/RecordTest.java
+++ b/language-support/java/codegen/src/it/java/com/digitalasset/RecordTest.java
@@ -53,8 +53,9 @@ public class RecordTest {
         Party party = new Party(partyValue);
         Date date = new Date(dateValue);
         Timestamp timestamp = new Timestamp(timestampMicrosValue);
-        DamlList list = new DamlList(Unit.getInstance(), Unit.getInstance());
-        DamlList nestedList = new DamlList(nestedListValue.stream().map(ns -> new DamlList(ns.stream().map(n -> new Int64(n)).collect(Collectors.toList()))).collect(Collectors.toList()));
+        DamlList list = DamlList.of(Unit.getInstance(), Unit.getInstance());
+        DamlList nestedList =
+                nestedListValue.stream().collect(DamlList.collector(ns -> ns.stream().collect(DamlList.collector(Int64::new))));
         Record nestedRecord = new Record(new Record.Field("value", new Int64(42)));
         Variant nestedVariant = new Variant("Nested", new Int64(42));
         ArrayList<Record.Field> fieldsList = new ArrayList<>(10);

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/Types.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/Types.scala
@@ -22,6 +22,7 @@ object Types {
   val apiContractId = ClassName.get(classOf[javaapi.data.ContractId])
   val apiMap = ClassName.get(classOf[javaapi.data.DamlMap])
   val apiGenMap = ClassName.get(classOf[javaapi.data.DamlGenMap])
+  val apiCollectors = ClassName.get(classOf[javaapi.data.DamlCollectors])
 
   // All the types part of the Java platform to which API types will be mapped to
   val javaNativeBoolean = TypeName.get(java.lang.Boolean.TYPE)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/Types.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/Types.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.lf.codegen.backend.java
 
 import com.daml.ledger.javaapi
+import com.daml.ledger.javaapi.data.DamlTextMap
 import com.squareup.javapoet.{ClassName, TypeName}
 
 object Types {
@@ -20,7 +21,7 @@ object Types {
   val apiOptional = ClassName.get(classOf[javaapi.data.DamlOptional])
   val apiUnit = ClassName.get(classOf[javaapi.data.Unit])
   val apiContractId = ClassName.get(classOf[javaapi.data.ContractId])
-  val apiMap = ClassName.get(classOf[javaapi.data.DamlMap])
+  val apiTextMap = ClassName.get(classOf[DamlTextMap])
   val apiGenMap = ClassName.get(classOf[javaapi.data.DamlGenMap])
   val apiCollectors = ClassName.get(classOf[javaapi.data.DamlCollectors])
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -106,9 +106,7 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L", arg), args, packagePrefixes)
         val extractor = CodeBlock.of("$L -> $L", arg, wrapped)
         CodeBlock.of(
-          // new DamlOptional(jutilOptionalParamName.map(i -> new Int64(i)))
-          //       $T        (        $L            .map(       $L        ))
-          "new $T($L.map($L))",
+          "$T.of($L.map($L))",
           apiOptional,
           accessor,
           extractor
@@ -122,7 +120,7 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L.getValue()", arg), args, packagePrefixes)
         )
         CodeBlock.of(
-          "$L.entrySet().stream().collect($T.toDamlMap($T::getKey, $L)) ",
+          "$L.entrySet().stream().collect($T.toDamlTextMap($T::getKey, $L)) ",
           accessor,
           apiCollectors,
           classOf[java.util.Map.Entry[_, _]],

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.codegen.backend.java.inner
-import java.util.stream.Collectors
 
 import com.daml.ledger.javaapi
 import com.digitalasset.daml.lf.codegen.backend.java.{JavaEscaper, Types}
@@ -95,11 +94,10 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L", arg), args, packagePrefixes)
         )
         CodeBlock.of(
-          "new $T($L.stream().map($L).collect($T.<Value>toList()))",
-          apiList,
+          "$L.stream().collect($T.collector($L))",
           accessor,
+          apiList,
           extractor,
-          classOf[Collectors]
         )
 
       case TypePrim(PrimTypeOptional, ImmArraySeq(param)) =>
@@ -124,12 +122,9 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L.getValue()", arg), args, packagePrefixes)
         )
         CodeBlock.of(
-          "new $T($L.entrySet().stream().collect($T.<$T<String,$L>,String,Value>toMap($T::getKey, $L)))",
-          apiMap,
+          "$L.entrySet().stream().collect($T.collector($T::getKey, $L)) ",
           accessor,
-          classOf[Collectors],
-          classOf[java.util.Map.Entry[_, _]],
-          toJavaTypeName(param, packagePrefixes),
+          apiMap,
           classOf[java.util.Map.Entry[_, _]],
           extractor
         )
@@ -151,13 +146,9 @@ object ToValueGenerator {
             packagePrefixes)
         )
         CodeBlock.of(
-          "new $T($L.entrySet().stream().collect($T.<$T<$L,$L>,Value,Value>toMap($L, $L)))",
-          apiGenMap,
+          "$L.entrySet().stream().collect($T.collector($L, $L))",
           accessor,
-          classOf[Collectors],
-          classOf[java.util.Map.Entry[_, _]],
-          toJavaTypeName(keyType, packagePrefixes),
-          toJavaTypeName(valueType, packagePrefixes),
+          apiGenMap,
           keyExtractor,
           valueExtractor
         )

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -94,9 +94,9 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L", arg), args, packagePrefixes)
         )
         CodeBlock.of(
-          "$L.stream().collect($T.collector($L))",
+          "$L.stream().collect($T.toDamlList($L))",
           accessor,
-          apiList,
+          apiCollectors,
           extractor,
         )
 
@@ -122,9 +122,9 @@ object ToValueGenerator {
           generateToValueConverter(param, CodeBlock.of("$L.getValue()", arg), args, packagePrefixes)
         )
         CodeBlock.of(
-          "$L.entrySet().stream().collect($T.collector($T::getKey, $L)) ",
+          "$L.entrySet().stream().collect($T.toDamlMap($T::getKey, $L)) ",
           accessor,
-          apiMap,
+          apiCollectors,
           classOf[java.util.Map.Entry[_, _]],
           extractor
         )
@@ -146,9 +146,9 @@ object ToValueGenerator {
             packagePrefixes)
         )
         CodeBlock.of(
-          "$L.entrySet().stream().collect($T.collector($L, $L))",
+          "$L.entrySet().stream().collect($T.toDamlGenMap($L, $L))",
           accessor,
-          apiGenMap,
+          apiCollectors,
           keyExtractor,
           valueExtractor
         )

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -7,7 +7,7 @@ import java.util
 
 import com.daml.ledger.javaapi
 import com.daml.ledger.javaapi.data.codegen.ContractId
-import com.daml.ledger.javaapi.data.{DamlGenMap, DamlList, DamlMap, DamlOptional}
+import com.daml.ledger.javaapi.data.{DamlGenMap, DamlList, DamlTextMap, DamlOptional}
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.digitalasset.daml.lf.iface._
@@ -105,7 +105,7 @@ package object inner {
       case TypePrim(PrimTypeOptional, _) =>
         ClassName.get(classOf[DamlOptional])
       case TypePrim(PrimTypeMap, _) =>
-        ClassName.get(classOf[DamlMap])
+        ClassName.get(classOf[DamlTextMap])
       case TypePrim(PrimTypeGenMap, _) =>
         ClassName.get(classOf[DamlGenMap])
       case TypePrim(PrimTypeUnit, _) =>

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
@@ -12,11 +12,12 @@ import test.genmapmod.Box;
 import test.recordmod.Pair;
 import test.variantmod.Either;
 import test.variantmod.either.*;
+
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @RunWith(JUnitPlatform.class)
@@ -95,11 +96,9 @@ public class GenMapTestFor1_dev {
     @Test
     void fromValuePreservesOrder(){
         Record b = value();
-        Object[] keys = b.getFieldsMap().get("x").asGenMap().get().getMap().keySet().toArray();
-        assertEquals(keys.length, 3);
-        assertEquals(keys[0], pairValue1());
-        assertEquals(keys[1], pairValue2());
-        assertEquals(keys[2], pairValue3());
+        Object[] keys = b.getFieldsMap().get("x").asGenMap().get().stream().map(Map.Entry::getKey).toArray();
+        Object[] expected = {pairValue1(), pairValue2(), pairValue3()};
+        assertArrayEquals(keys, expected);
     }
 
 

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
@@ -79,7 +79,7 @@ public class GenMapTestFor1_dev {
         value.put(pairValue1(), left(1L));
         value.put(pairValue2(), right(bg2()));
         value.put(pairValue3(), left(3L));
-        Value map = new DamlGenMap(value);
+        Value map = DamlGenMap.of(value);
         return new Record(
                 new Record.Field("x", map),
                 new Record.Field("party", new Party("alice"))

--- a/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
+++ b/language-support/java/codegen/src/test/java/com/digitalasset/testing/GenMapTestFor1_dev.java
@@ -14,6 +14,7 @@ import test.variantmod.Either;
 import test.variantmod.either.*;
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,18 +22,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @RunWith(JUnitPlatform.class)
 public class GenMapTestFor1_dev {
 
-    private BigDecimal bg1 = new BigDecimal("1.0000000000");
-    private BigDecimal bg2 = new BigDecimal("-2.2222222222");
-    private BigDecimal bg3 = new BigDecimal("3.3333333333");
+    private BigDecimal bg1() { return new BigDecimal("1.0000000000"); }
+    private BigDecimal bg2() { return new BigDecimal("-2.2222222222"); }
+    private BigDecimal bg3() { return new BigDecimal("3.3333333333"); }
+    private Pair<Long, BigDecimal> pair1() { return new Pair<>(1L, bg1()); }
+    private Pair<Long, BigDecimal> pair2() { return new Pair<>(2L, bg2()); }
+    private Pair<Long, BigDecimal> pair3() { return new Pair<>(3L, bg3()); }
+
+
+    private Box box() {
+        Map<Pair<Long, BigDecimal>, Either<Long, BigDecimal>> map = new LinkedHashMap<>();
+        map.put(pair1(), new Right<>(bg1()));
+        map.put(pair2(), new Left<>(2L));
+        map.put(pair3(), new Right<>(bg3()));
+        return new Box(map, "alice");
+    }
+
 
     @Test
     void genMap2Value2GenMap() {
-        HashMap<Pair<Long, BigDecimal>, Either<Long, BigDecimal>> map = new HashMap<>();
-        map.put(new Pair<>(1L, bg1), new Right<>(bg1));
-        map.put(new Pair<>(2L, bg2), new Left<>(2L));
-        map.put(new Pair<>(3L, bg3), new Right<>(bg3));
-        Box b = new Box(map, "alice");
+        Box b = box();
         assertEquals(Box.fromValue(b.toValue()), b);
+    }
+
+    @Test
+    void toValuePreservesOrder(){
+        Box b = box();
+        Object[] keys = b.x.keySet().toArray();
+        assertEquals(keys.length, 3);
+        assertEquals(keys[0], pair1());
+        assertEquals(keys[1], pair2());
+        assertEquals(keys[2], pair3());
     }
 
     private Record pair(Long fst, BigDecimal snd) {
@@ -50,18 +70,37 @@ public class GenMapTestFor1_dev {
         return new Variant("Right", new Numeric(r));
     }
 
-    @Test
-    void value2GenMap2value() {
-        Map<Value, Value> value = new HashMap<Value, Value>();
-        value.put(pair(1L, bg1), left(1L));
-        value.put(pair(-2L,bg2 ), right(bg2));
-        value.put(pair(3L, bg3), left(3L));
+    private Record pairValue1() { return pair(1L, bg1());   }
+    private Record pairValue2() { return pair(-2L, bg2());  }
+    private Record pairValue3() { return pair(3L, bg3());   }
+
+    private Record value() {
+        Map<Value, Value> value = new LinkedHashMap<>();
+        value.put(pairValue1(), left(1L));
+        value.put(pairValue2(), right(bg2()));
+        value.put(pairValue3(), left(3L));
         Value map = new DamlGenMap(value);
-        Record b = new Record(
+        return new Record(
                 new Record.Field("x", map),
                 new Record.Field("party", new Party("alice"))
         );
+    }
+
+    @Test
+    void value2GenMap2value() {
+        Record b = value();
         assertEquals(Box.fromValue(b).toValue(), b);
     }
+
+    @Test
+    void fromValuePreservesOrder(){
+        Record b = value();
+        Object[] keys = b.getFieldsMap().get("x").asGenMap().get().getMap().keySet().toArray();
+        assertEquals(keys.length, 3);
+        assertEquals(keys[0], pairValue1());
+        assertEquals(keys[1], pairValue2());
+        assertEquals(keys[2], pairValue3());
+    }
+
 
 }


### PR DESCRIPTION
This PR advances the state of Generic Maps #2256.

In this PR we use `LinkedHashMap` instead `HashMap` in the java bindings. 
Hence we can preserves order of map entries,  when (un)serializing value in protobuf.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Add a line to the [release notes](https://github.com/digital-asset/daml/blob/master/unreleased.rst), if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
