### PR TITLE
Implement GenericSetTemplate and ImmutableSetFactory for InsertOrdSet

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/InsertOrdSet.scala
@@ -14,11 +14,18 @@ package com.digitalasset.daml.lf.data
   */
 import scala.collection.immutable.{HashSet, Set, Queue}
 import scala.collection.{SetLike, AbstractSet}
+import scala.collection.generic.{
+  ImmutableSetFactory,
+  GenericCompanion,
+  CanBuildFrom,
+  GenericSetTemplate
+}
 
 final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T])
     extends AbstractSet[T]
     with Set[T]
     with SetLike[T, InsertOrdSet[T]]
+    with GenericSetTemplate[T, InsertOrdSet]
     with Serializable {
   override def empty: InsertOrdSet[T] = InsertOrdSet.empty
   override def size: Int = _hashSet.size
@@ -43,12 +50,20 @@ final class InsertOrdSet[T] private (_items: Queue[T], _hashSet: HashSet[T])
       _items.filter(elem2 => elem != elem2),
       _hashSet - elem
     )
+
+  override def companion: GenericCompanion[InsertOrdSet] = InsertOrdSet
+
 }
 
-object InsertOrdSet {
+object InsertOrdSet extends ImmutableSetFactory[InsertOrdSet] {
   private val Empty = new InsertOrdSet(Queue.empty, HashSet.empty)
-  def empty[T] = Empty.asInstanceOf[InsertOrdSet[T]]
+  override def empty[T] = Empty.asInstanceOf[InsertOrdSet[T]]
+  def emptyInstance: InsertOrdSet[Any] = empty[Any]
 
   def fromSeq[T](s: Seq[T]): InsertOrdSet[T] =
     new InsertOrdSet(Queue(s.reverse: _*), HashSet(s: _*))
+
+  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, InsertOrdSet[A]] =
+    setCanBuildFrom[A]
+
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/InsertOrdSetTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/InsertOrdSetTest.scala
@@ -5,6 +5,7 @@ package com.digitalasset.daml.lf.data
 
 import org.scalatest.{Matchers, WordSpec}
 
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
 class InsertOrdSetTest extends WordSpec with Matchers {
   "toSeq" should {
     "preserve order" in {
@@ -20,4 +21,11 @@ class InsertOrdSetTest extends WordSpec with Matchers {
     }
   }
 
+  "use CanBuildFrom of InsertOrdSet" should {
+    "preserve type" in {
+      val ios: InsertOrdSet[String] = InsertOrdSet.fromSeq(Seq("a", "b"))
+      ios.map(x => x) shouldBe ios
+      ios.map(x => x + "x") shouldBe a[InsertOrdSet[_]]
+    }
+  }
 }


### PR DESCRIPTION
This ensures we retain InsertOrdSet when transforming it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
