### PR TITLE
checkout current sha after daily docs

### DIFF
--- a/ci/cron/run.sh
+++ b/ci/cron/run.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+SHA=$(git log -n1 --format=%H)
+
+revert_sha () {
+    git checkout $SHA
+}
+trap revert_sha EXIT
+
 cd "$(dirname "$0")"/../..
 
 eval "$(dev-env/bin/dade assist)"


### PR DESCRIPTION
Currently if the docs script fails, the Slack message we get mentions the commit title of the docs version that failed to build, which is not super useful. This ensures we get back to the current commit regardless of what happens with the Haskell script.