### PR TITLE
Remove runtime-based coloring from LATT reports

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -65,13 +65,7 @@ object Reporter {
             s.print(cyan(s"- $test ... "))
             result match {
               case Result.Succeeded(duration) =>
-                val durationString = s"${duration.toMillis} ms"
-                val highlightedDurationString = duration.toMillis match {
-                  case d if d > 1000 => red(durationString)
-                  case d if d > 100 => yellow(durationString)
-                  case _ => green(durationString)
-                }
-                s.println(s"${green("Success")} ($highlightedDurationString)")
+                s.println(green(s"Success (${duration.toMillis} ms)"))
               case Result.TimedOut => s.println(red(s"Timeout"))
               case Result.Skipped(reason) =>
                 s.println(yellow(s"Skipped (reason: $reason)"))


### PR DESCRIPTION
Main reasoning: the spectrum of acceptable timing for each test is very wide and using arbitrary times can lead the user to derive misleading information out of the test run.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
