### PR TITLE
Fix unreleased.sh

### DIFF
--- a/unreleased.sh
+++ b/unreleased.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2019 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-for SHA in $(git log --format=%H "$1"); do git log --format=%b "$SHA" | awk '/^$/{next} toupper($0) ~ /CHANGELOG_END/{flag=0; next} toupper($0) ~ /CHANGELOG_BEGIN/{flag=1; next} flag'; done
+for SHA in $(git log --format=%H "$1"); do git show --quiet --format=%b "$SHA" | awk '/^$/{next} toupper($0) ~ /CHANGELOG_END/{flag=0; next} toupper($0) ~ /CHANGELOG_BEGIN/{flag=1; next} flag'; done

--- a/unreleased.sh
+++ b/unreleased.sh
@@ -2,4 +2,7 @@
 # Copyright (c) 2019 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-for SHA in $(git log --format=%H "$1"); do git show --quiet --format=%b "$SHA" | awk '/^$/{next} toupper($0) ~ /CHANGELOG_END/{flag=0; next} toupper($0) ~ /CHANGELOG_BEGIN/{flag=1; next} flag'; done
+for SHA in $(git log --format=%H "$1"); do
+  git show --quiet --format=%b "$SHA" \
+    | awk '/^$/{next} toupper($0) ~ /CHANGELOG_END/{flag=0; next} toupper($0) ~ /CHANGELOG_BEGIN/{flag=1; next} flag'
+done


### PR DESCRIPTION
The usage of `git log` to avoid printing the diff of each commit turned
out to cause the commit to be interpreted as a revision range reachable
from said commit, which breaks unreleased.sh. This commit reverts to
using `git show` but with `--quiet` to avoid printing the diff, as
originally planned.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
