### PR TITLE
Replace MetricsManager with MetricRegistry

### DIFF
--- a/ledger/README.md
+++ b/ledger/README.md
@@ -50,13 +50,12 @@ The Ledger API Server exposes basic metrics for all gRPC services and some addit
 </tbody>
 </table>
 
-The following JMX domains are used:
+### Metrics Reporting
 
-* Sandbox: `com.digitalasset.platform.sandbox`
-* Ledger API Server: `com.digitalasset.platform.ledger-api-server.$PARTICIPANT_ID`
-* Indexer Server: `com.digitalasset.platform.indexer.$PARTICIPANT_ID`
+The Sandbox automatically makes all metrics available via JMX under the JMX domain `com.digitalasset.platform.sandbox`. 
 
-`$PARTICIPANT_ID` is provided via CLI parameters.
+When building an Indexer or Ledger API Server the implementer/ledger integrator is responsible to set up 
+a `MetricRegistry` and a suitable metric reporting strategy that fits their needs.
 
 ## gRPC and back-pressure
 

--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -50,6 +50,7 @@ da_scala_binary(
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_netty_netty_handler",
         "@maven//:io_netty_netty_tcnative_boringssl_static",
         "@maven//:org_slf4j_slf4j_api",

--- a/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/ledger/server/apiserver/ApiServices.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.ledger.server.apiserver
 
 import akka.stream.ActorMaterializer
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2.{
   IdentityProvider,
   IndexActiveContractsService,
@@ -21,7 +22,6 @@ import com.digitalasset.ledger.api.v1.command_completion_service.CompletionEndRe
 import com.digitalasset.ledger.client.services.commands.CommandSubmissionFlow
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.sandbox.config.CommandConfiguration
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.services._
 import com.digitalasset.platform.sandbox.services.admin.{
   ApiPackageManagementService,
@@ -70,7 +70,7 @@ object ApiServices {
       commandConfig: CommandConfiguration,
       optTimeServiceBackend: Option[TimeServiceBackend],
       loggerFactory: NamedLoggerFactory,
-      metricsManager: MetricsManager)(
+      metrics: MetricRegistry)(
       implicit mat: ActorMaterializer,
       esf: ExecutionSequencerFactory): Future[ApiServices] = {
     implicit val ec: ExecutionContext = mat.system.dispatcher
@@ -95,7 +95,7 @@ object ApiServices {
           timeProvider,
           new CommandExecutorImpl(engine, packagesService.getLfPackage),
           loggerFactory,
-          metricsManager,
+          metrics,
         )
 
       loggerFactory.getLogger(this.getClass).info(EngineInfo.show)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -95,7 +95,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
 
   private val metrics = new MetricRegistry
   private val metricsReporting =
-    new MetricsReporting(metrics, "com.digitalasset.platform.sandbox", true)
+    new MetricsReporting(metrics, "com.digitalasset.platform.sandbox")
 
   case class ApiServerState(
       ledgerId: LedgerId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
@@ -22,7 +23,7 @@ import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.sandbox.SandboxServer.{asyncTolerance, createInitialState, logger}
 import com.digitalasset.platform.sandbox.banner.Banner
 import com.digitalasset.platform.sandbox.config.SandboxConfig
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
+import com.digitalasset.platform.sandbox.metrics.MetricsReporting
 import com.digitalasset.platform.sandbox.services.SandboxResetService
 import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
 import com.digitalasset.platform.sandbox.stores.ledger._
@@ -92,6 +93,10 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
 
   private val authService: AuthService = config.authService.getOrElse(AuthServiceWildcard)
 
+  private val metrics = new MetricRegistry
+  private val metricsReporting =
+    new MetricsReporting(metrics, "com.digitalasset.platform.sandbox", true)
+
   case class ApiServerState(
       ledgerId: LedgerId,
       apiServer: ApiServer,
@@ -105,17 +110,14 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
     }
   }
 
-  case class Infrastructure(
-      actorSystem: ActorSystem,
-      materializer: ActorMaterializer,
-      metricsManager: MetricsManager)
+  case class Infrastructure(actorSystem: ActorSystem, materializer: ActorMaterializer)
       extends AutoCloseable {
     def executionContext: ExecutionContext = materializer.executionContext
 
     override def close: Unit = {
       materializer.shutdown()
       Await.result(actorSystem.terminate(), asyncTolerance)
-      metricsManager.close()
+      ()
     }
   }
 
@@ -177,8 +179,6 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
     implicit val mat = infra.materializer
     implicit val ec: ExecutionContext = infra.executionContext
 
-    val mm: MetricsManager = infra.metricsManager
-
     val ledgerId = config.ledgerIdMode match {
       case LedgerIdMode.Static(id) => id
       case LedgerIdMode.Dynamic() => LedgerIdGenerator.generateRandomId()
@@ -212,7 +212,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
           config.commandConfig.maxCommandsInFlight * 2, // we can get commands directly as well on the submission service
           packageStore,
           loggerFactory,
-          mm
+          metrics
         )
 
       case None =>
@@ -225,7 +225,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
             acs,
             ledgerEntries,
             packageStore,
-            mm
+            metrics
           ))
     }
 
@@ -257,7 +257,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
                     indexAndWriteService.publishHeartbeat
                   )),
               loggerFactory,
-              mm
+              metrics
             )(am, esf)
             .map(_.withServices(List(resetService(ledgerId, authorizer, loggerFactory)))),
         // NOTE(JM): Re-use the same port after reset.
@@ -270,7 +270,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
           AuthorizationInterceptor(authService, ec),
           resetService(ledgerId, authorizer, loggerFactory)
         ),
-        mm
+        metrics
       ),
       asyncTolerance
     )
@@ -301,10 +301,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
   private def start(): SandboxState = {
     val actorSystem = ActorSystem(actorSystemName)
     val infrastructure =
-      Infrastructure(
-        actorSystem,
-        ActorMaterializer()(actorSystem),
-        MetricsManager("com.digitalasset.platform.sandbox"))
+      Infrastructure(actorSystem, ActorMaterializer()(actorSystem))
     val packageStore = loadDamlPackages
     val apiState = buildAndStartApiServer(infrastructure, packageStore)
     SandboxState(apiState, infrastructure, packageStore)
@@ -321,7 +318,10 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
       .fold({ case (err, file) => sys.error(s"Could not load package $file: $err") }, identity)
   }
 
-  override def close(): Unit = sandboxState.close()
+  override def close(): Unit = {
+    metricsReporting.close()
+    sandboxState.close()
+  }
 
   private def writePortFile(port: Int): Unit = {
     config.portFile.foreach { f =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsInterceptor.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.platform.sandbox.metrics
 
+import com.codahale.metrics.MetricRegistry
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
 
 /**
@@ -13,7 +14,7 @@ import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
   * For example:
   * <pre>LedgerApi.com.digitalasset.ledger.api.v1.TransactionService.GetTransactionTrees</pre>
   */
-class MetricsInterceptor(metricsManager: MetricsManager) extends ServerInterceptor {
+class MetricsInterceptor(metrics: MetricRegistry) extends ServerInterceptor {
   override def interceptCall[ReqT, RespT](
       call: ServerCall[ReqT, RespT],
       headers: Metadata,
@@ -22,7 +23,7 @@ class MetricsInterceptor(metricsManager: MetricsManager) extends ServerIntercept
     // Converting it to a '.' makes it easier for downstream tools to
     // put the metrics into a hierarchy.
     val serviceName = call.getMethodDescriptor.getFullMethodName.replace('/', '.')
-    metricsManager.metrics.meter(s"LedgerApi.$serviceName").mark()
+    metrics.meter(s"LedgerApi.$serviceName").mark()
     next.startCall(call, headers)
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsReporting.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsReporting.scala
@@ -14,13 +14,14 @@ import com.codahale.metrics.{MetricRegistry, Slf4jReporter}
   * <br/><br/>
   * Note that metrics are in general light-weight and add negligible overhead. They are not visible to everyday
   * users so they can be safely enabled all the time. */
-final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String, enableJmxReporter: Boolean)
+final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String)
     extends AutoCloseable {
 
-  private lazy val jmxReporter = JmxReporter
+  private val jmxReporter = JmxReporter
     .forRegistry(metrics)
     .inDomain(jmxDomain)
     .build
+  jmxReporter.start()
 
   private val slf4jReporter = Slf4jReporter
     .forRegistry(metrics)
@@ -29,18 +30,9 @@ final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String, enableJ
     .withLoggingLevel(LoggingLevel.DEBUG)
     .build()
 
-  if (enableJmxReporter) jmxReporter.start()
 
   override def close(): Unit = {
     slf4jReporter.report()
-    if (enableJmxReporter) jmxReporter.close()
+    jmxReporter.close()
   }
-}
-
-object MetricsReporting {
-  def apply(
-      metrics: MetricRegistry,
-      jmxDomain: String,
-      enableJmxReporter: Boolean = true): MetricsReporting =
-    new MetricsReporting(metrics, jmxDomain, enableJmxReporter)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsReporting.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/MetricsReporting.scala
@@ -14,8 +14,7 @@ import com.codahale.metrics.{MetricRegistry, Slf4jReporter}
   * <br/><br/>
   * Note that metrics are in general light-weight and add negligible overhead. They are not visible to everyday
   * users so they can be safely enabled all the time. */
-final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String)
-    extends AutoCloseable {
+final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String) extends AutoCloseable {
 
   private val jmxReporter = JmxReporter
     .forRegistry(metrics)
@@ -29,7 +28,6 @@ final class MetricsReporting(metrics: MetricRegistry, jmxDomain: String)
     .convertDurationsTo(TimeUnit.MILLISECONDS)
     .withLoggingLevel(LoggingLevel.DEBUG)
     .build()
-
 
   override def close(): Unit = {
     slf4jReporter.report()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/metrics/package.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox
+
+import com.codahale.metrics.Timer
+import com.digitalasset.platform.common.util.DirectExecutionContext
+
+import scala.concurrent.Future
+
+package object metrics {
+  def timedFuture[T](timer: Timer, f: => Future[T]): Future[T] = {
+    val ctx = timer.time()
+    val res = f
+    res.onComplete(_ => ctx.stop())(DirectExecutionContext)
+    res
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.api.util.TimeProvider
@@ -21,7 +22,6 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.Contract
 import com.digitalasset.platform.sandbox.stores.{InMemoryActiveLedgerState, InMemoryPackageStore}
 import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
@@ -130,7 +130,7 @@ object Ledger {
       queueDepth: Int,
       startMode: SqlStartMode,
       loggerFactory: NamedLoggerFactory,
-      mm: MetricsManager
+      metrics: MetricRegistry
   )(implicit mat: Materializer): Future[Ledger] =
     SqlLedger(
       jdbcUrl,
@@ -142,7 +142,7 @@ object Ledger {
       queueDepth,
       startMode,
       loggerFactory,
-      mm)
+      metrics)
 
   /**
     * Creates a JDBC backed read only ledger
@@ -155,15 +155,15 @@ object Ledger {
       jdbcUrl: String,
       ledgerId: LedgerId,
       loggerFactory: NamedLoggerFactory,
-      mm: MetricsManager
+      metrics: MetricRegistry
   )(implicit mat: Materializer): Future[ReadOnlyLedger] =
-    ReadOnlySqlLedger(jdbcUrl, Some(ledgerId), loggerFactory, mm)
+    ReadOnlySqlLedger(jdbcUrl, Some(ledgerId), loggerFactory, metrics)
 
   /** Wraps the given Ledger adding metrics around important calls */
-  def metered(ledger: Ledger, mm: MetricsManager): Ledger = MeteredLedger(ledger, mm)
+  def metered(ledger: Ledger, metrics: MetricRegistry): Ledger = MeteredLedger(ledger, metrics)
 
   /** Wraps the given Ledger adding metrics around important calls */
-  def meteredReadOnly(ledger: ReadOnlyLedger, mm: MetricsManager): ReadOnlyLedger =
-    MeteredReadOnlyLedger(ledger, mm)
+  def meteredReadOnly(ledger: ReadOnlyLedger, metrics: MetricRegistry): ReadOnlyLedger =
+    MeteredReadOnlyLedger(ledger, metrics)
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/LedgerDao.scala
@@ -6,6 +6,7 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql.dao
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1.{AbsoluteContractInst, TransactionId}
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party}
@@ -18,7 +19,6 @@ import com.digitalasset.ledger._
 import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
 import com.digitalasset.platform.common.util.DirectExecutionContext
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.{ActiveContract, Contract}
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry.Transaction
@@ -229,7 +229,7 @@ trait LedgerDao extends LedgerReadDao with LedgerWriteDao {
 object LedgerDao {
 
   /** Wraps the given LedgerDao adding metrics around important calls */
-  def metered(dao: LedgerDao, mm: MetricsManager): LedgerDao = MeteredLedgerDao(dao, mm)
-  def meteredRead(dao: LedgerReadDao, mm: MetricsManager): LedgerReadDao =
-    new MeteredLedgerReadDao(dao, mm)
+  def metered(dao: LedgerDao, metrics: MetricRegistry): LedgerDao = MeteredLedgerDao(dao, metrics)
+  def meteredRead(dao: LedgerReadDao, metrics: MetricRegistry): LedgerReadDao =
+    new MeteredLedgerReadDao(dao, metrics)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -8,9 +8,9 @@ import java.util.concurrent.Executors
 
 import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
+import com.codahale.metrics.MetricRegistry
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.common.util.DirectExecutionContext
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
@@ -47,13 +47,13 @@ private class DbDispatcherImpl(
     val noOfShortLivedConnections: Int,
     noOfStreamingConnections: Int,
     loggerFactory: NamedLoggerFactory,
-    mm: MetricsManager)
+    metrics: MetricRegistry)
     extends DbDispatcher {
 
   private val logger = loggerFactory.getLogger(getClass)
   private val connectionProvider =
     HikariJdbcConnectionProvider(jdbcUrl, noOfShortLivedConnections, noOfStreamingConnections)
-  private val sqlExecutor = SqlExecutor(noOfShortLivedConnections, loggerFactory, mm)
+  private val sqlExecutor = SqlExecutor(noOfShortLivedConnections, loggerFactory, metrics)
 
   private val connectionGettingThreadPool = ExecutionContext.fromExecutorService(
     Executors.newSingleThreadExecutor(
@@ -104,12 +104,12 @@ object DbDispatcher {
       noOfShortLivedConnections: Int,
       noOfStreamingConnections: Int,
       loggerFactory: NamedLoggerFactory,
-      mm: MetricsManager): DbDispatcher =
+      metrics: MetricRegistry): DbDispatcher =
     new DbDispatcherImpl(
       jdbcUrl,
       noOfShortLivedConnections,
       noOfStreamingConnections,
       loggerFactory,
-      mm
+      metrics
     )
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -4,9 +4,9 @@
 package com.digitalasset.platform.sandbox
 
 import akka.stream.Materializer
+import com.codahale.metrics.MetricRegistry
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.ledger.api.testing.utils.Resource
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.persistence.{PostgresFixture, PostgresResource}
 import com.digitalasset.platform.sandbox.stores.{InMemoryActiveLedgerState, InMemoryPackageStore}
 import com.digitalasset.platform.sandbox.stores.ledger.sql.SqlStartMode
@@ -48,7 +48,7 @@ object LedgerResource {
   def postgres(
       ledgerId: LedgerId,
       timeProvider: TimeProvider,
-      mm: MetricsManager,
+      metrics: MetricRegistry,
       packages: InMemoryPackageStore = InMemoryPackageStore.empty)(implicit mat: Materializer) = {
     new Resource[Ledger] {
       @volatile
@@ -75,7 +75,7 @@ object LedgerResource {
               128,
               SqlStartMode.AlwaysReset,
               NamedLoggerFactory(Tag.unwrap(ledgerId)),
-              mm
+              metrics
           ))
         ledger.setup()
       }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/MetricsAround.scala
@@ -3,21 +3,20 @@
 
 package com.digitalasset.platform.sandbox
 
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
+import com.codahale.metrics.MetricRegistry
 import org.scalatest.BeforeAndAfterAll
 
 trait MetricsAround extends BeforeAndAfterAll {
   self: org.scalatest.Suite =>
 
-  @volatile protected var metricsManager: MetricsManager = _
+  @volatile protected var metrics: MetricRegistry = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    metricsManager = MetricsManager("MetricsAround")
+    metrics = new MetricRegistry
   }
 
   override protected def afterAll(): Unit = {
-    metricsManager.close()
     super.afterAll()
   }
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -82,7 +82,7 @@ class ImplicitPartyAdditionIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
-        LedgerResource.postgres(ledgerId, timeProvider, metricsManager)
+        LedgerResource.postgres(ledgerId, timeProvider, metrics)
     }
 
   private def publishSingleNodeTx(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -62,7 +62,7 @@ class TransactionMRTComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
-        LedgerResource.postgres(ledgerId, timeProvider, metricsManager)
+        LedgerResource.postgres(ledgerId, timeProvider, metrics)
     }
 
   val LET = Instant.EPOCH.plusSeconds(2)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -9,12 +9,13 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.stream.scaladsl.{Sink, Source}
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.Offset
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.archive.DarReader
-import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
+import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Node.{
@@ -42,7 +43,6 @@ import com.digitalasset.ledger.api.domain.{
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.participant.util.EventFilter
-import com.digitalasset.platform.sandbox.metrics.MetricsManager
 import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.ActiveContract
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry
@@ -86,12 +86,7 @@ class JdbcLedgerDaoSpec
     super.beforeAll()
     val loggerFactory = NamedLoggerFactory(JdbcLedgerDaoSpec.getClass)
     FlywayMigrations(postgresFixture.jdbcUrl, loggerFactory).migrate()
-    dbDispatcher = DbDispatcher(
-      postgresFixture.jdbcUrl,
-      4,
-      4,
-      loggerFactory,
-      MetricsManager("JdbcLedgerDaoSpec"))
+    dbDispatcher = DbDispatcher(postgresFixture.jdbcUrl, 4, 4, loggerFactory, new MetricRegistry)
     ledgerDao = JdbcLedgerDao(
       dbDispatcher,
       ContractSerializer,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -46,7 +46,7 @@ class SqlLedgerSpec
         queueDepth,
         startMode = SqlStartMode.ContinueIfExists,
         loggerFactory,
-        metricsManager
+        metrics
       )
 
       ledgerF.map { ledger =>
@@ -65,7 +65,7 @@ class SqlLedgerSpec
         queueDepth,
         startMode = SqlStartMode.ContinueIfExists,
         loggerFactory,
-        metricsManager
+        metrics
       )
 
       ledgerF.map { ledger =>
@@ -86,7 +86,7 @@ class SqlLedgerSpec
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
           loggerFactory,
-          metricsManager
+          metrics
         )
 
         ledger2 <- SqlLedger(
@@ -99,7 +99,7 @@ class SqlLedgerSpec
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
           loggerFactory,
-          metricsManager
+          metrics
         )
 
         ledger3 <- SqlLedger(
@@ -112,7 +112,7 @@ class SqlLedgerSpec
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
           loggerFactory,
-          metricsManager
+          metrics
         )
 
       } yield {
@@ -135,7 +135,7 @@ class SqlLedgerSpec
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
           loggerFactory,
-          metricsManager
+          metrics
         )
         _ <- SqlLedger(
           jdbcUrl = postgresFixture.jdbcUrl,
@@ -147,7 +147,7 @@ class SqlLedgerSpec
           queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
           loggerFactory,
-          metricsManager
+          metrics
         )
       } yield (())
 


### PR DESCRIPTION
Instead of passing around MetricsManager just for the timedFuture
method, we pass the underlying MetricRegistry directly and use
the timedFuture function as an actual function (passing in a timer metric).

The Sandbox still starts the JmxReporter, but the integrator of the Indexer
and the Ledger API Server needs to enable the reporting facilities themselves.

Contributes to #3513.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
