### PR TITLE
Add template id filtering to triggers

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -104,6 +104,7 @@ To create a trigger you need to define a value of type ``Trigger s`` where ``s``
       { initialize : ACS -> s
       , updateState : ACS -> Message -> s -> s
       , rule : Party -> ACS -> Map CommandId [Command] -> s -> TriggerA ()
+      , registeredTemplates : RegisteredTemplates
       }
 
 The ``initialize`` function is called on startup and allows you to
@@ -115,13 +116,20 @@ the ACS and the transaction or completion. Since our DAML trigger does
 not have any interesting user-defined state, we will not go into
 details here.
 
-Finally, the ``rule`` function is the core of a DAML trigger. It
+The ``rule`` function is the core of a DAML trigger. It
 defines which commands need to be sent to the ledger based on the
 party the trigger is executed at, the current state of the ACS, the
 commands in flight and the user defined state. The type ``TriggerA``
 allows you to emit commands that are then sent to the ledger. Like
 ``Scenario`` or ``Update``, you can use ``do`` notation with
 ``TriggerA``.
+
+Finally, we can specify the templates that our trigger will operate
+on. In our case, we will simply specify ``AllInDar`` which means that
+the trigger will receive events for all template types defined in the
+DAR. It is also possible to specify an explicit list of templates,
+e.g., ``RegisteredTemplates [registeredTemplate @Original, registeredTemplate @Subscriber, registeredTemplate @Copy]``.
+This is mainly useful for performance reasons if your DAR contains many templates that are not relevant for your trigger.
 
 For our DAML trigger, the definition looks as follows:
 

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -54,6 +54,7 @@ copyTrigger = Trigger
   { initialize = \_acs -> ()
   , updateState = \_acs _message () -> ()
   , rule = copyRule
+  , registeredTemplates = AllInDar
   }
 -- TRIGGER_END
 

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -74,7 +74,7 @@ data Trigger s = Trigger
   -- and the user-defined state, you can send commands to the ledger using
   -- `emitCommands` to change the ACS.
   , registeredTemplates : RegisteredTemplates
-  -- The templates the trigger will receive events for.
+  -- ^ The templates the trigger will receive events for.
   }
 
 -- | TriggerA is the type used in the `rule` of a DAML trigger.

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -25,6 +25,8 @@ module Daml.Trigger
  , Completion(..)
  , Transaction(..)
  , CompletionStatus(..)
+ , RegisteredTemplates(..)
+ , registeredTemplate
  ) where
 
 import DA.Action
@@ -71,6 +73,8 @@ data Trigger s = Trigger
   -- Given the party your trigger is running as, the ACS, the commands in flight
   -- and the user-defined state, you can send commands to the ledger using
   -- `emitCommands` to change the ACS.
+  , registeredTemplates : RegisteredTemplates
+  -- The templates the trigger will receive events for.
   }
 
 -- | TriggerA is the type used in the `rule` of a DAML trigger.
@@ -152,6 +156,7 @@ runTrigger : Trigger s -> LowLevel.Trigger (TriggerState s)
 runTrigger userTrigger = LowLevel.Trigger
   { initialState = initialState
   , update = update
+  , registeredTemplates = userTrigger.registeredTemplates
   }
   where
     initialState party (ActiveContracts createdEvents) =

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -21,7 +21,6 @@ module Daml.Trigger.LowLevel
   , Trigger(..)
   , ActiveContracts(..)
   , Commands(..)
-  , TemplateId(..)
   , Command(..)
   , createCmd
   , exerciseCmd
@@ -29,6 +28,8 @@ module Daml.Trigger.LowLevel
   , fromCreate
   , fromExercise
   , fromExerciseByKey
+  , RegisteredTemplates(..)
+  , registeredTemplate
   ) where
 
 import DA.Next.Map (MapKey(..))
@@ -138,14 +139,22 @@ data ActiveContracts = ActiveContracts { activeContracts : [Created] }
 data Trigger s = Trigger
   { initialState : Party -> ActiveContracts -> (s, [Commands])
   , update : Message -> s -> (s, [Commands])
+  , registeredTemplates : RegisteredTemplates
   }
 
--- | We implicitly assume that the package id corresponds to the package the trigger is part of.
--- This type is temporary until we have a builtin in LF for identifiers.
-data TemplateId = TemplateId
-  { moduleName : Text
-  , entityName : Text
-  }
+-- | A template that the trigger will receive events for.
+newtype RegisteredTemplate = RegisteredTemplate TemplateTypeRep
+
+-- This controls which templates the trigger will receive events for.
+-- `AllInDar` is a safe default but for performance reasons you might
+-- want to limit it to limit the templates that the trigger will receive
+-- events for.
+data RegisteredTemplates
+  = AllInDar -- ^ Listen to events for all templates in the given DAR.
+  | RegisteredTemplates [RegisteredTemplate]
+
+registeredTemplate : forall t. Template t => RegisteredTemplate
+registeredTemplate = RegisteredTemplate (templateTypeRep @t)
 
 -- | A ledger API command. To construct a command use `createCmd` and `exerciseCmd`.
 data Command

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -28,6 +28,7 @@ genrule(
       cp -L $(location :daml/Numeric.daml) $$TMP_DIR/daml
       cp -L $(location :daml/CommandId.daml) $$TMP_DIR/daml
       cp -L $(location :daml/PendingSet.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/TemplateIdFilter.daml) $$TMP_DIR/daml
       cp -L $(location //docs:source/triggers/template-root/src/CopyTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -35,6 +35,7 @@ test : Trigger TriggerState
 test = Trigger
   { initialState = \party acs -> (initState party acs, [])
   , update = update
+  , registeredTemplates = AllInDar
   }
   where
     update : Message -> TriggerState -> (TriggerState, [Commands])

--- a/triggers/tests/daml/CommandId.daml
+++ b/triggers/tests/daml/CommandId.daml
@@ -16,6 +16,7 @@ test = Trigger
       (cmdIds, MTransaction (Transaction _ (Some (CommandId cmdId)) [ArchivedEvent (fromArchived @T -> Some _)])) ->
         (cmdId :: cmdIds, [])
       _ -> (s, [])
+  , registeredTemplates = AllInDar
   }
 
 template T

--- a/triggers/tests/daml/ExerciseByKey.daml
+++ b/triggers/tests/daml/ExerciseByKey.daml
@@ -16,6 +16,7 @@ exerciseByKeyTrigger = Trigger
         | Failed {} <- c.status -> allowedFail - 1
       _ -> allowedFail
   , rule = retryRule
+  , registeredTemplates = AllInDar
   }
 
 -- Create one T template and then call a choice by key to create T_.

--- a/triggers/tests/daml/Numeric.daml
+++ b/triggers/tests/daml/Numeric.daml
@@ -15,6 +15,7 @@ test = Trigger
       -- throw an assertion error
         (True, [Commands (CommandId "mycreate2") [createCmd (t { v = t.v + 1.0 })]])
       _ -> (s, [])
+  , registeredTemplates = AllInDar
   }
 
 template T

--- a/triggers/tests/daml/PendingSet.daml
+++ b/triggers/tests/daml/PendingSet.daml
@@ -39,6 +39,7 @@ booTrigger = Trigger with
   initialize = \acs -> ()
   updateState = \acs _ s -> s
   rule = booRule
+  registeredTemplates = AllInDar
 
 booRule : Party -> ACS -> Map CommandId [Command] -> () -> TriggerA ()
 booRule party acs _commandsInFlight _userState = do

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -16,6 +16,7 @@ retryTrigger = Trigger
         | Failed {} <- c.status -> allowedFail - 1
       _ -> allowedFail
   , rule = retryRule
+  , registeredTemplates = AllInDar
   }
 
 -- We first create a T template, then we try to exercise C 3 times until allowedRetries is 0

--- a/triggers/tests/daml/TemplateIdFilter.daml
+++ b/triggers/tests/daml/TemplateIdFilter.daml
@@ -1,0 +1,51 @@
+-- Copyright (c) 2019 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module TemplateIdFilter where
+
+import Prelude hiding (test)
+import Daml.Trigger
+
+test : RegisteredTemplates -> Trigger ()
+test registered = Trigger
+  { initialize = \_acs -> ()
+  , updateState = \_acs _message () -> ()
+  , registeredTemplates = registered
+  , rule = \party acs _inFlight () -> do
+      let ones = getContracts @One acs
+      let twos = getContracts @Two acs
+      let doneOnes = getContracts @DoneOne acs
+      let doneTwos = getContracts @DoneTwo acs
+      case (ones, twos) of
+        ([_], []) | null doneOnes -> dedupCreate DoneOne with p = party
+        ([], [_]) | null doneTwos -> dedupCreate DoneTwo with p = party
+        _ -> pure ()
+  }
+
+testOne = test $ RegisteredTemplates [registeredTemplate @One, registeredTemplate @DoneOne]
+testTwo = test $ RegisteredTemplates [registeredTemplate @Two, registeredTemplate @DoneTwo]
+
+template One
+  with
+    p : Party
+  where
+    signatory p
+
+template Two
+  with
+    p : Party
+  where
+    signatory p
+
+template DoneOne
+  with
+    p : Party
+  where
+    signatory p
+
+template DoneTwo
+  with
+    p : Party
+  where
+    signatory p

--- a/triggers/tests/list-triggers.sh
+++ b/triggers/tests/list-triggers.sh
@@ -35,7 +35,9 @@ EXPECTED="\
   ExerciseByKey:exerciseByKeyTrigger
   Numeric:test
   Retry:retryTrigger
-  ACS:test\
+  ACS:test
+  TemplateIdFilter:testOne
+  TemplateIdFilter:testTwo\
 "
 
 if [ "$OUTPUT" != "$EXPECTED" ]; then


### PR DESCRIPTION
CHANGELOG_BEGIN
- [Daml Triggers - Experimental] DAML triggers now allow you to specify which templates you want to listen for which can improve performance.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
