### PR TITLE
Support exerciseByKey in DAML script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -1,6 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-
+{-# LANGUAGE AllowAmbiguousTypes #-}
 daml 1.2
 module Daml.Script
   ( Script
@@ -11,6 +11,7 @@ module Daml.Script
   , Commands
   , createCmd
   , exerciseCmd
+  , exerciseByKeyCmd
   ) where
 
 import Prelude hiding (submit, submitMustFail)
@@ -53,6 +54,7 @@ instance Applicative (Ap f) where
 data CommandsF a
   = Create { argC : AnyTemplate, continueC : ContractId () -> a }
   | Exercise { tplId : TemplateTypeRep, cId : ContractId (), argE : AnyChoice, continueE : LedgerValue -> a }
+  | ExerciseByKey { tplId : TemplateTypeRep, keyE : AnyContractKey, argE : AnyChoice, continueE : LedgerValue -> a }
   deriving Functor
 
 -- | This is used to build up the commands send as part of `submit`.
@@ -132,3 +134,7 @@ createCmd arg = Commands $ Ap (\f -> f (Create (toAnyTemplate arg) identity) (pu
 -- | Exercise a choice on the given contract.
 exerciseCmd : forall t c r. Choice t c r => ContractId t -> c -> Commands r
 exerciseCmd cId arg = Commands $ Ap (\f -> f (Exercise (templateTypeRep @t) (coerceContractId cId) (toAnyChoice @t arg) identity) (pure fromLedgerValue))
+
+-- | Exercise a choice on the contract with the given key.
+exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> Commands r
+exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg) identity) (pure fromLedgerValue))

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -50,6 +50,18 @@ template NumericTpl
       controller p
       do pure v
 
+template WithKey
+  with
+    p : Party
+  where
+    signatory p
+    key p : Party
+    maintainer key
+
+    nonconsuming choice GetCid : ContractId WithKey
+      controller p
+      do pure self
+
 test0 : Script (Party, Party, [T], [TProposal], [C])
 test0 = do
   alice <- allocateParty "alice"
@@ -94,4 +106,11 @@ test4 = do
   alice <- allocateParty "alice"
   cid <- submit alice $ createCmd (C alice 42)
   [(cid', _)] <- query @C alice
+  pure (cid, cid')
+
+testKey : Script (ContractId WithKey, ContractId WithKey)
+testKey = do
+  alice <- allocateParty "alice"
+  cid <- submit alice $ createCmd (WithKey alice)
+  cid' <- submit alice $ exerciseByKeyCmd @WithKey alice GetCid
   pure (cid, cid')

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestMain.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestMain.scala
@@ -260,6 +260,24 @@ case class Test4(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
+case class TestKey(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testKey"))
+  def runTests() = {
+    runner.genericTest(
+      "testKey",
+      dar,
+      scriptId,
+      None,
+      result =>
+        result match {
+          case SRecord(_, _, vals) if vals.size == 2 =>
+            TestRunner.assertEqual(vals.get(0), vals.get(1), "ContractIds")
+          case v => Left(s"Expected record with 2 fields but got $v")
+      }
+    )
+  }
+}
+
 // Runs the example from the docs to make sure it doesn’t produce a runtime error.
 case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptExample:test"))
@@ -317,6 +335,7 @@ object TestMain {
         Test2(dar, runner).runTests()
         Test3(dar, runner).runTests()
         Test4(dar, runner).runTests()
+        TestKey(dar, runner).runTests()
         ScriptExample(dar, runner).runTests()
     }
   }


### PR DESCRIPTION
CHANGELOG_BEGIN
- [DAML Script - Experimental] Expose the Ledger API exerciseByKey command
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
