### PR TITLE
DAML-LF: rename ValueMap to ValueTextMap

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -655,7 +655,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
           case Some(v) => optionalBuilder.setValue(convertValue(v))
         }
         builder.setOptional(optionalBuilder)
-      case V.ValueMap(map) =>
+      case V.ValueTextMap(map) =>
         val mapBuilder = v1.Map.newBuilder
         map.toImmArray.foreach {
           case (k, v) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -147,7 +147,7 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
             ls.toImmArray.traverseU(go(newNesting, elemType, _)).map(es => SList(FrontStack(es)))
 
           // map
-          case (TMap(elemType), ValueMap(map)) =>
+          case (TMap(elemType), ValueTextMap(map)) =>
             map.toImmArray
               .traverseU {
                 case (key0, value0) => go(newNesting, elemType, value0).map(key0 -> _)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -65,7 +65,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
       TList(TText) ->
         ValueList(FrontStack(ValueText("a"), ValueText("b"))),
       TMap(TBool) ->
-        ValueMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
+        ValueTextMap(SortedLookupList(Map("0" -> ValueTrue, "1" -> ValueFalse))),
       TOptional(TText) ->
         ValueOptional(Some(ValueText("text"))),
       TTyCon(recordCon) ->

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -413,7 +413,7 @@ object Pretty {
       case ValueParty(p) => char('\'') + str(p) + char('\'')
       case ValueOptional(Some(v1)) => text("Option(") + prettyValue(verbose)(v1) + char(')')
       case ValueOptional(None) => text("None")
-      case ValueMap(map) =>
+      case ValueTextMap(map) =>
         val list = map.toImmArray.map {
           case (k, v) => text(k) + text(" -> ") + prettyValue(verbose)(v)
         }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -63,7 +63,7 @@ sealed trait SValue {
       case SOptional(mbV) =>
         V.ValueOptional(mbV.map(_.toValue))
       case SMap(mVal) =>
-        V.ValueMap(SortedLookupList(mVal).mapValue(_.toValue))
+        V.ValueTextMap(SortedLookupList(mVal).mapValue(_.toValue))
       case SGenMap(values) =>
         V.ValueGenMap(ImmArray(values.map { case (k, v) => k.v.toValue -> v.toValue }))
       case SContractId(coid) =>
@@ -270,7 +270,7 @@ object SValue {
       case V.ValueOptional(mbV) =>
         SOptional(mbV.map(fromValue))
 
-      case V.ValueMap(map) =>
+      case V.ValueTextMap(map) =>
         SMap(map.mapValue(fromValue).toHashMap)
 
       case V.ValueGenMap(value) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -971,7 +971,7 @@ object Ledger {
           coids += coid
         case _: ValueCidlessLeaf => ()
         case ValueOptional(mbV) => mbV.foreach(collect)
-        case ValueMap(map) => map.values.foreach(collect)
+        case ValueTextMap(map) => map.values.foreach(collect)
         case ValueGenMap(entries) =>
           entries.foreach {
             case (k, v) =>
@@ -1015,7 +1015,7 @@ object Ledger {
           ValueContractId(acoid)
         case vlit: ValueCidlessLeaf => vlit
         case ValueOptional(mbV) => ValueOptional(mbV.map(rewrite))
-        case ValueMap(map) => ValueMap(map.mapValue(rewrite))
+        case ValueTextMap(map) => ValueTextMap(map.mapValue(rewrite))
         case ValueGenMap(entries) =>
           ValueGenMap(entries.map { case (k, v) => rewrite(k) -> rewrite(v) })
       }

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
@@ -141,9 +141,9 @@ object TypedValueGenerators {
       type Inj[Cid] = SortedLookupList[elt.Inj[Cid]]
       override val t = TypePrim(PT.Map, ImmArraySeq(elt.t))
       override def inj[Cid] =
-        (sll: SortedLookupList[elt.Inj[Cid]]) => ValueMap(sll map elt.inj)
+        (sll: SortedLookupList[elt.Inj[Cid]]) => ValueTextMap(sll map elt.inj)
       override def prj[Cid] = {
-        case ValueMap(sll) => sll traverse elt.prj
+        case ValueTextMap(sll) => sll traverse elt.prj
         case _ => None
       }
       override def injarb[Cid: Arbitrary] = {

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -193,8 +193,8 @@ object ValueGenerators {
       list <- Gen.listOf(for {
         k <- Gen.asciiPrintableStr; v <- Gen.lzy(valueGen(nesting))
       } yield k -> v)
-    } yield ValueMap[ContractId](SortedLookupList(Map(list: _*)))
-  def valueMapGen: Gen[ValueMap[ContractId]] = valueMapGen(0)
+    } yield ValueTextMap[ContractId](SortedLookupList(Map(list: _*)))
+  def valueMapGen: Gen[ValueTextMap[ContractId]] = valueMapGen(0)
 
   def coidGen: Gen[ContractId] = {
     val genRel: Gen[ContractId] =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -41,7 +41,7 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
       case ValueList(vs) =>
         ValueList(vs.map(_.mapContractId(f)))
       case ValueOptional(x) => ValueOptional(x.map(_.mapContractId(f)))
-      case ValueMap(x) => ValueMap(x.mapValue(_.mapContractId(f)))
+      case ValueTextMap(x) => ValueTextMap(x.mapValue(_.mapContractId(f)))
       case ValueGenMap(x) =>
         ValueGenMap(x.map { case (k, v) => k.mapContractId(f) -> v.mapContractId(f) })
     }
@@ -116,7 +116,7 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
             } else {
               go(exceededNesting, errs, ImmArray(x.toList.map(v => (v, nesting + 1))) ++: vs)
             }
-          case ValueMap(value) =>
+          case ValueTextMap(value) =>
             if (nesting + 1 > MAXIMUM_NESTING) {
               if (exceededNesting) {
                 // we already exceeded the nesting, do not output again
@@ -207,7 +207,7 @@ object Value {
   }
   case object ValueUnit extends ValueCidlessLeaf
   final case class ValueOptional[+Cid](value: Option[Value[Cid]]) extends Value[Cid]
-  final case class ValueMap[+Cid](value: SortedLookupList[Value[Cid]]) extends Value[Cid]
+  final case class ValueTextMap[+Cid](value: SortedLookupList[Value[Cid]]) extends Value[Cid]
   final case class ValueGenMap[+Cid](value: ImmArray[(Value[Cid], Value[Cid])]) extends Value[Cid]
   // this is present here just because we need it in some internal code --
   // specifically the scenario interpreter converts committed values to values and
@@ -250,8 +250,8 @@ object Value {
           case ValueTuple(fields2) =>
             fields === fields2
         }
-        case ValueMap(map1) => {
-          case ValueMap(map2) =>
+        case ValueTextMap(map1) => {
+          case ValueTextMap(map2) =>
             map1 === map2
         }
         case ValueGenMap(_) => {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -388,7 +388,7 @@ object ValueCoder {
                 err => throw Err(err),
                 identity
               )
-            ValueMap(map)
+            ValueTextMap(map)
 
           case proto.Value.SumCase.SUM_NOT_SET =>
             throw Err(s"Value not set")
@@ -501,7 +501,7 @@ object ValueCoder {
             mbV.foreach(v => protoOption.setValue(go(newNesting, v)))
             builder.setOptional(protoOption).build()
 
-          case ValueMap(map) =>
+          case ValueTextMap(map) =>
             val protoMap = proto.Map.newBuilder()
             map.toImmArray.foreach {
               case (key, value) =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -54,7 +54,7 @@ object ValueVersions
                 go(maxVV(minNumeric, currentVersion), values)
               case ValueOptional(x) =>
                 go(maxVV(minOptional, currentVersion), ImmArray(x.toList) ++: values)
-              case ValueMap(map) =>
+              case ValueTextMap(map) =>
                 go(maxVV(minMap, currentVersion), map.values ++: values)
               case ValueEnum(_, _) =>
                 go(maxVV(minEnum, currentVersion), values)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -138,7 +138,7 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
     }
 
     "do maps" in {
-      forAll(valueMapGen) { v: ValueMap[ContractId] =>
+      forAll(valueMapGen) { v: ValueTextMap[ContractId] =>
         testRoundTrip(v)
       }
     }

--- a/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
@@ -50,7 +50,7 @@ object JsonConverters {
   implicit val variantEncoder: Encoder[OfCid[V.ValueVariant]] = valueEncoder
 
   implicit val mapEncoder: Encoder[SortedLookupList[LedgerValue]] =
-    valueEncoder.contramap(V.ValueMap(_))
+    valueEncoder.contramap(V.ValueTextMap(_))
 
   implicit val idKeyEncoder: KeyEncoder[Identifier] = id => s"${id.packageId}@${id.name}"
   implicit val idKeyDecoder: KeyDecoder[Identifier] = StringEncodedIdentifier.unapply

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
@@ -87,14 +87,14 @@ object LedgerValue {
   private def convertOptional(apiOptional: api.value.Optional) =
     apiOptional.value traverseU (_.convert) map (V.ValueOptional(_))
 
-  private def convertMap(apiMap: api.value.Map): String \/ OfCid[V.ValueMap] =
+  private def convertMap(apiMap: api.value.Map): String \/ OfCid[V.ValueTextMap] =
     for {
       entries <- apiMap.entries.toList.traverseU {
         case api.value.Map.Entry(_, None) => -\/("value must be defined")
         case api.value.Map.Entry(k, Some(v)) => v.sum.convert.map(k -> _)
       }
       map <- SortedLookupList.fromImmArray(ImmArray(entries)).disjunction
-    } yield V.ValueMap(map)
+    } yield V.ValueTextMap(map)
 
   private def convertIdentifier(
       apiIdentifier: api.value.Identifier): String \/ Option[Ref.Identifier] = {

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -309,7 +309,7 @@ object Queries {
         case V.ValueParty(value) => Fragment("?", value: String)
         case V.ValueUnit => Fragment.const("FALSE")
         case V.ValueDate(LfTime.Date(days)) => Fragment("?", LocalDate.ofEpochDay(days.toLong))
-        case V.ValueMap(m) =>
+        case V.ValueTextMap(m) =>
           Fragment(
             "?::jsonb",
             toJsonString(m)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -43,7 +43,7 @@ sealed abstract class ValuePredicate extends Product with Serializable {
       case MapMatch(q) =>
         val cq = (q mapValue go).toImmArray;
         {
-          case V.ValueMap(v) if cq.length == v.toImmArray.length =>
+          case V.ValueTextMap(v) if cq.length == v.toImmArray.length =>
             // the sort-by-key is the same for cq and v, so if equal, the keys
             // are at equal indices
             cq.iterator zip v.toImmArray.iterator forall {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -83,7 +83,7 @@ object ApiValueToLfValueConverterTest {
       value1 === value2
     case (V.ValueTuple(fields), V.ValueTuple(fields2)) =>
       fields === fields2
-    case (V.ValueMap(map1), V.ValueMap(map2)) =>
+    case (V.ValueTextMap(map1), V.ValueTextMap(map2)) =>
       map1.toImmArray === map2.toImmArray
     case _ =>
       false

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -56,7 +56,7 @@ abstract class ApiCodecCompressed[Cid](
         case V.ValueOptional(Some(_)) => JsArray(apiValueToJsValue(v))
         case _ => apiValueToJsValue(v)
       }
-    case v: V.ValueMap[Cid] =>
+    case v: V.ValueTextMap[Cid] =>
       apiMapToJsValue(v)
     case _: V.ValueGenMap[Cid] =>
       // FIXME https://github.com/digital-asset/daml/issues/2256
@@ -88,7 +88,7 @@ abstract class ApiCodecCompressed[Cid](
         }: _*)
     }
 
-  private[this] def apiMapToJsValue(value: V.ValueMap[Cid]): JsValue =
+  private[this] def apiMapToJsValue(value: V.ValueTextMap[Cid]): JsValue =
     JsObject(
       value.value.toImmArray
         .map { case (k, v) => k -> apiValueToJsValue(v) }
@@ -145,7 +145,7 @@ abstract class ApiCodecCompressed[Cid](
         }
       case Model.DamlLfPrimType.Map => {
         case JsObject(a) =>
-          V.ValueMap(SortedLookupList(a.transform { (_, v) =>
+          V.ValueTextMap(SortedLookupList(a.transform { (_, v) =>
             jsValueToApiValue(v, prim.typArgs.head, defs)
           }))
       }

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
@@ -97,7 +97,7 @@ trait NavigatorModelAliases[Cid] {
   type ApiVariant = OfCid[V.ValueVariant]
   type ApiList = OfCid[V.ValueList]
   type ApiOptional = OfCid[V.ValueOptional]
-  type ApiMap = OfCid[V.ValueMap]
+  type ApiMap = OfCid[V.ValueTextMap]
   type ApiGenMap = OfCid[V.ValueGenMap]
   type ApiImpossible = OfCid[V.ValueTuple]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
@@ -105,7 +105,7 @@ object ValueValidator {
       for {
         entries <- map
         map <- SortedLookupList.fromImmArray(entries.toImmArray).left.map(invalidArgument)
-      } yield Lf.ValueMap(map)
+      } yield Lf.ValueTextMap(map)
 
     case Sum.GenMap(genMap0) =>
       val genMap = genMap0.entries

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -84,7 +84,7 @@ object LfEngineToApi {
           Right(api.Value(api.Value.Sum.Optional(api.Optional.defaultInstance))))(v =>
           lfValueToApiValue(verbose, v).map(c =>
             api.Value(api.Value.Sum.Optional(api.Optional(Some(c))))))
-      case Lf.ValueMap(m) =>
+      case Lf.ValueTextMap(m) =>
         m.toImmArray.reverse
           .foldLeft[Either[String, List[api.Map.Entry]]](Right(List.empty)) {
             case (Right(list), (k, v)) =>

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -502,7 +502,7 @@ class SubmitRequestValidatorTest
     "validating map values" should {
       "convert empty maps" in {
         val input = Value(Sum.Map(ApiMap(List.empty)))
-        val expected = Lf.ValueMap(SortedLookupList.empty)
+        val expected = Lf.ValueTextMap(SortedLookupList.empty)
         validateValue(input) shouldEqual Right(expected)
       }
 
@@ -516,7 +516,7 @@ class SubmitRequestValidatorTest
         val input = Value(Sum.Map(ApiMap(apiEntries.toSeq)))
         val lfEntries = entries.map { case (k, v) => k -> Lf.ValueInt64(v) }
         val expected =
-          Lf.ValueMap(SortedLookupList.fromImmArray(lfEntries).getOrElse(unexpectedError))
+          Lf.ValueTextMap(SortedLookupList.fromImmArray(lfEntries).getOrElse(unexpectedError))
 
         validateValue(input) shouldEqual Right(expected)
       }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
@@ -92,7 +92,7 @@ object KeyHasher extends KeyHasher {
         op(z2, HashTokenCollectionEnd())
 
       // Map: [CollectionBegin(), (Text(key), Token(value))*, CollectionEnd()]
-      case ValueMap(xs) =>
+      case ValueTextMap(xs) =>
         val arr = xs.toImmArray
         val z1 = op(z, HashTokenCollectionBegin(arr.length))
         val z2 = arr.foldLeft[T](z1)((t, v) => {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/KeyHasherSpec.scala
@@ -49,7 +49,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
         None -> ValueText("field1"),
         None -> ValueText("field2")
       ))
-    builder += None -> ValueMap(
+    builder += None -> ValueTextMap(
       SortedLookupList(
         Map(
           "keyA" -> ValueText("valueA"),
@@ -201,7 +201,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     "not produce collision in Map keys" in {
       val value1 = VersionedValue(
         ValueVersion("4"),
-        ValueMap(
+        ValueTextMap(
           SortedLookupList(
             Map(
               "A" -> ValueInt64(0),
@@ -209,7 +209,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
             ))))
       val value2 = VersionedValue(
         ValueVersion("4"),
-        ValueMap(
+        ValueTextMap(
           SortedLookupList(
             Map(
               "A" -> ValueInt64(0),
@@ -227,7 +227,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
     "not produce collision in Map values" in {
       val value1 = VersionedValue(
         ValueVersion("4"),
-        ValueMap(
+        ValueTextMap(
           SortedLookupList(
             Map(
               "A" -> ValueInt64(0),
@@ -235,7 +235,7 @@ class KeyHasherSpec extends WordSpec with Matchers {
             ))))
       val value2 = VersionedValue(
         ValueVersion("4"),
-        ValueMap(
+        ValueTextMap(
           SortedLookupList(
             Map(
               "A" -> ValueInt64(0),

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/Pretty.scala
@@ -244,7 +244,7 @@ object Pretty {
     case V.ValueUnit => PrettyPrimitive("<unit>")
     case V.ValueOptional(None) => PrettyPrimitive("<none>")
     case V.ValueOptional(Some(v)) => PrettyObject(PrettyField("value", argument(v)))
-    case V.ValueMap(map) =>
+    case V.ValueTextMap(map) =>
       PrettyObject(map.toImmArray.toList.map {
         case (key, value) => PrettyField(key, argument(arg))
       })

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
@@ -164,7 +164,7 @@ object ApiCodecVerbose {
           case v => V.ValueOptional(Some(jsValueToApiValue(v)))
         }
       case `tagMap` =>
-        V.ValueMap(
+        V.ValueTextMap(
           SortedLookupList
             .fromImmArray(ImmArray(arrayField(value, propValue, "ApiMap").map(jsValueToMapEntry)))
             .fold(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -330,7 +330,7 @@ case object LedgerApiV1 {
         case _ => Left(GenericConversionError(s"Cannot read $map as $typ"))
       }
       values <- map.value traverseU (fillInTypeInfo(_, elementType, ctx))
-    } yield V.ValueMap(values)
+    } yield V.ValueTextMap(values)
 
   private def fillInOptionalTI(
       opt: Model.ApiOptional,

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -64,7 +64,7 @@ case object DamlConstants {
   val simpleDateV = V.ValueDate.fromIso8601("2019-01-28")
   val simpleTimestampV = V.ValueTimestamp.fromIso8601("2019-01-28T12:44:33.22Z")
   val simpleOptionalV = V.ValueOptional(Some(V.ValueText("foo")))
-  val simpleMapV = V.ValueMap(
+  val simpleMapV = V.ValueTextMap(
     SortedLookupList(Map("1" -> V.ValueInt64(1), "2" -> V.ValueInt64(2), "3" -> V.ValueInt64(3))))
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -243,7 +243,7 @@ case object DamlConstants {
       ("fOptOptText", V.ValueOptional(Some(V.ValueOptional(Some(V.ValueText("foo")))))),
       (
         "fMap",
-        V.ValueMap(
+        V.ValueTextMap(
           SortedLookupList(
             Map("1" -> V.ValueInt64(1), "2" -> V.ValueInt64(2), "3" -> V.ValueInt64(3))))),
       ("fVariant", simpleVariantV),


### PR DESCRIPTION
This PR advances the state of Generic Maps implementation #2256.

Here we rename the value `ValueMap` to `ValueTextMap` to avoid confusion between legacy `TextMap` and the new `GenMap`

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
