### PR TITLE
Set Sdk-Version in DAR Manifest to compiler SDK version.

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -30,6 +30,7 @@ da_haskell_library(
         "time",
         "transformers",
         "utf8-string",
+        "yaml",
         "zip",
     ],
     src_strip_prefix = "src",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -85,7 +85,7 @@ newtype FromDalf = FromDalf
 
 newtype PackageSdkVersion = PackageSdkVersion
     { unPackageSdkVersion :: String
-    } deriving (Y.FromJSON)
+    } deriving (Eq, Y.FromJSON)
 
 -- | daml.yaml config fields specific to packaging.
 data PackageConfigFields = PackageConfigFields

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -46,6 +46,7 @@ import qualified Development.IDE.Types.Logger as IdeLogger
 import SdkVersion
 import System.Directory.Extra
 import System.FilePath
+import qualified Data.Yaml as Y
 
 import GHC
 import MkIface
@@ -83,7 +84,8 @@ newtype FromDalf = FromDalf
     }
 
 newtype PackageSdkVersion = PackageSdkVersion
-    { unPackageSdkVersion :: String }
+    { unPackageSdkVersion :: String
+    } deriving (Y.FromJSON)
 
 -- | daml.yaml config fields specific to packaging.
 data PackageConfigFields = PackageConfigFields

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -4,6 +4,7 @@ module DA.Daml.Compiler.Dar
     ( buildDar
     , FromDalf(..)
     , breakAt72Bytes
+    , PackageSdkVersion(..)
     , PackageConfigFields(..)
     , pkgNameVersion
     , getSrcRoot
@@ -81,6 +82,9 @@ newtype FromDalf = FromDalf
     { unFromDalf :: Bool
     }
 
+newtype PackageSdkVersion = PackageSdkVersion
+    { unPackageSdkVersion :: String }
+
 -- | daml.yaml config fields specific to packaging.
 data PackageConfigFields = PackageConfigFields
     { pName :: String
@@ -89,8 +93,7 @@ data PackageConfigFields = PackageConfigFields
     , pVersion :: Maybe String
     , pDependencies :: [String]
     , pDataDependencies :: [String]
-    , pSdkVersion :: String
-    , cliOpts :: Maybe [String]
+    , pSdkVersion :: PackageSdkVersion
     }
 
 buildDar ::
@@ -338,7 +341,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies srcRoot fileD
         map (breakAt72Bytes . BSLUTF8.fromString)
             [ "Manifest-Version: 1.0"
             , "Created-By: damlc"
-            , "Sdk-Version: " <> pSdkVersion
+            , "Sdk-Version: " <> unPackageSdkVersion pSdkVersion
             , "Main-Dalf: " <> toPosixFilePath location
             , "Dalfs: " <> intercalate ", " (map toPosixFilePath dalfs)
             , "Format: daml-lf"

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -481,10 +481,11 @@ overrideSdkVersion pkgConfig = do
                     , sdkVersion
                     , "from"
                     , sdkVersionEnvVar
-                    , "instead of DAML SDK version"
+                    , "enviroment variable instead of DAML SDK version"
                     , unPackageSdkVersion (pSdkVersion pkgConfig)
                     , "from"
                     , projectConfigName
+                    , "config file."
                     ]
             pure pkgConfig { pSdkVersion = PackageSdkVersion sdkVersion }
 

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -51,7 +51,7 @@ import SdkVersion
 
 -- | Create the project package database containing the given dar packages.
 createProjectPackageDb ::
-       Options -> String -> [FilePath] -> [FilePath] -> IO ()
+       Options -> PackageSdkVersion -> [FilePath] -> [FilePath] -> IO ()
 createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
     let dbPath = projectPackageDatabase </> (lfVersionString $ optDamlLfVersion opts)
     let
@@ -78,7 +78,7 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
           in mapM expand
     deps <- handleSdkPackages $ filter (`notElem` basePackages) deps0
     depsExtracted <- mapM extractDar deps
-    let uniqSdkVersions = nubSort $ filter (/= "0.0.0") $ thisSdkVer : map edSdkVersions depsExtracted
+    let uniqSdkVersions = nubSort $ filter (/= "0.0.0") $ unPackageSdkVersion thisSdkVer : map edSdkVersions depsExtracted
     -- we filter the 0.0.0 version because otherwise integration tests fail that import SDK packages
     unless (length uniqSdkVersions <= 1) $
            fail $
@@ -238,8 +238,7 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                         , pVersion = mbPkgVersion
                         , pDependencies = deps
                         , pDataDependencies = []
-                        , pSdkVersion = "unknown"
-                        , cliOpts = Nothing
+                        , pSdkVersion = PackageSdkVersion "unknown"
                         }
                     (map T.unpack $ LF.packageModuleNames dalf)
                     pkgIdStr
@@ -280,7 +279,6 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                             , pDependencies = (unitIdStr <.> "dalf") : deps
                             , pDataDependencies = []
                             , pSdkVersion = thisSdkVer
-                            , cliOpts = Nothing
                             }
                 opts' <-
                     mkOptions $

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -232,6 +232,7 @@ da_haskell_test(
         "extra",
         "filepath",
         "process",
+        "safe-exceptions",
         "tasty",
         "tasty-hunit",
         "zip-archive",

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
@@ -17,6 +17,7 @@ module DA.Daml.Project.Consts
     , getProjectPath
     , getSdkPath
     , getSdkVersion
+    , getSdkVersionMaybe
     , getDamlAssistant
     , ProjectCheck(..)
     , withProjectRoot
@@ -129,8 +130,12 @@ getSdkPath = getEnv sdkPathEnvVar
 --
 -- This will throw an `IOException` if the environment has not been setup by
 -- the assistant.
-getSdkVersion  :: IO String
+getSdkVersion :: IO String
 getSdkVersion = getEnv sdkVersionEnvVar
+
+-- | Returns the current SDK version if set, or Nothing.
+getSdkVersionMaybe :: IO (Maybe String)
+getSdkVersionMaybe = lookupEnv sdkVersionEnvVar
 
 -- | Returns the absolute path to the assistant.
 --


### PR DESCRIPTION
CHANGELOG_BEGIN

- [DAML Compiler] Bugfix: The Sdk-Version field in a DAR manifest file
now matches the SDK version of the compiler, not the sdk-version field
from daml.yaml. These are usually the same, but they could be different
if you set the DAML_SDK_VERSION environment variable before running
``daml init`` or ``daml build``.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
