### PR TITLE
Manually run stack update

### DIFF
--- a/.dadew
+++ b/.dadew
@@ -12,6 +12,7 @@
         "nodejs-10.16.3",
         "python-3.6.7",
         "nsis-3.04",
-        "maven-3.6.1"
+        "maven-3.6.1",
+        "stack"
     ]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -27,6 +27,17 @@ if (Test-Path -Path $env:appdata\stack\pantry\hackage\hackage-security-lock) {
     Remove-Item -ErrorAction Continue -Force -Recurse -Path $env:appdata\stack
 }
 
+# rules_haskell can automatically install stack if it is not in $PATH,
+# yet. However, if the index has not been updated before building. Then
+# multiple parallel invocations of `stack` will both attempt to update
+# the index during build. This will fail with the following error.
+#
+#   user error (hTryLock: lock already exists: C:\Users\VssAdministrator\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
+#
+# To avoid this issue we added stack to dadew and update the index beforehand.
+# See https://github.com/tweag/stackage-head/issues/29.
+stack update
+
 function bazel() {
     Write-Output ">> bazel $args"
     $global:lastexitcode = 0

--- a/dev-env/windows/manifests/stack.json
+++ b/dev-env/windows/manifests/stack.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://docs.haskellstack.org/en/stable/README/",
+  "version": "2.1.3",
+  "bin": "stack.exe",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-windows-x86_64.zip",
+      "hash": "415fb140c7497c4771b84e45a38b65ad47f50b9adc06499b03c4f5a8899aa32a"
+    }
+  }
+}


### PR DESCRIPTION
- Add stack to Windows dev-env
- Manually run stack update before build to avoid 
    ```
    user error (hTryLock: lock already exists: C:\Users\VssAdministrator\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
    ```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
