### PR TITLE
Windows: Take stack from dadew

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ register_toolchains(
     "//:c2hs-toolchain",
 )
 
-load("//bazel_tools/dev_env_tool:dev_env_tool.bzl", "dev_env_tool")
+load("//bazel_tools/dev_env_tool:dev_env_tool.bzl", "dadew", "dev_env_tool")
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",
@@ -44,6 +44,8 @@ load(
 load("//bazel_tools:os_info.bzl", "os_info")
 
 os_info(name = "os_info")
+
+dadew(name = "dadew")
 
 load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 load("//bazel_tools:ghc_dwarf.bzl", "ghc_dwarf")

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -14,6 +14,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@os_info//:os_info.bzl", "is_windows")
+load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
 GHCIDE_REV = "78aa9745798cfd730861e8c037cc481aa6b0dd43"
@@ -292,6 +293,20 @@ cc_library(name = "libgpr", linkstatic = 1, srcs = [":gpr"])
     )
 
     #
+    # Stack binary
+    #
+
+    # On Windows the stack binary is provisioned using dadew.
+    if is_windows:
+        native.new_local_repository(
+            name = "stack_windows",
+            build_file_content = """
+exports_files(["stack.exe"], visibility = ["//visibility:public"])
+""",
+            path = dadew_tool_home("stack"),
+        )
+
+    #
     # Stack Snapshots
     #
 
@@ -309,6 +324,7 @@ cc_library(name = "libgpr", linkstatic = 1, srcs = [":gpr"])
             "filepath",
             "language-c",
         ],
+        stack = "@stack_windows//:stack.exe" if is_windows else None,
         tools = [
             "@alex",
             "@happy",
@@ -492,6 +508,7 @@ cc_library(name = "libgpr", linkstatic = 1, srcs = [":gpr"])
             "zlib",
             "zlib-bindings",
         ] + (["unix"] if not is_windows else ["Win32"]),
+        stack = "@stack_windows//:stack.exe" if is_windows else None,
         tools = [
             "@alex",
             "@c2hs",

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -71,6 +71,29 @@ def _symlink_files_recursive(ctx, find, source, dest):
     for f in files:
         ctx.symlink("%s/%s" % (source, f), "%s/%s" % (dest, f))
 
+def _dadew_impl(ctx):
+    ctx.file("BUILD.bazel", executable = False)
+    if get_cpu_value(ctx) == "x64_windows":
+        ps = ctx.which("powershell")
+        dadew = _dadew_where(ctx, ps)
+        ctx.file("dadew.bzl", executable = False, content = """
+dadew = r"{dadew}"
+def dadew_tool_home(tool):
+    return r"%s\\scoop\\apps\\%s\\current" % (dadew, tool)
+""".format(dadew = dadew))
+    else:
+        ctx.file("dadew.bzl", executable = False, content = """
+dadew = None
+def dadew_tool_home(tool):
+    return None
+""")
+
+dadew = repository_rule(
+    implementation = _dadew_impl,
+    configure = True,
+    local = True,
+)
+
 def _dev_env_tool_impl(ctx):
     if get_cpu_value(ctx) == "x64_windows":
         ps = ctx.which("powershell")


### PR DESCRIPTION
`rules_haskell` looks for stack in `PATH`. On Windows `stack` is provided by `dadew` (i.e. `scoop`). `rules_haskell` creates a symbolic link (a copy on Windows) to the found stack binary. Unfortunately, this breaks with scoop as the shim file is then not found. The corresponding error reads:

```
ERROR: Analysis of target '//:c2hs-toolchain-impl' failed; build aborted: no such package '@c2hs_deps//': Traceback (most recent call last):
	File "C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/rules_haskell/haskell/cabal.bzl", line 809
		_compute_dependency_graph(<6 more arguments>)
	File "C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/rules_haskell/haskell/cabal.bzl", line 649, in _compute_dependency_graph
		_stack_version_check(<2 more arguments>)
	File "C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/rules_haskell/haskell/cabal.bzl", line 609, in _stack_version_check
		_execute_or_fail_loudly(<2 more arguments>)
	File "C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/rules_haskell/haskell/private/workspace_utils.bzl", line 18, in _execute_or_fail_loudly
		fail(<1 more arguments>)
Command failed: C:/users/vssadministrator/_bazel_vssadministrator/w3d6ug6o/external/rules_haskell_stack/stack --numeric-version
Couldn't find stack.shim in C:\users\vssadministrator\_bazel_vssadministrator\w3d6ug6o\external\rules_haskell_stack

```

This PR works around this by importing `stack.exe` from the scoop install directory using `new_local_repository`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
