### PR TITLE
Ledger api test tool canton run config fix

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -28,6 +28,10 @@ canton {
       admin-api {
         port = 5012
       }
+
+      party-change-notification {
+        type = via-domain
+      }
     }
 
     participant_2 {
@@ -41,6 +45,10 @@ canton {
 
       admin-api {
         port = 5022
+      }
+
+      party-change-notification {
+        type = via-domain
       }
     }
   }


### PR DESCRIPTION
Configuring Canton to send party change notification events only once domain is ready was 
missing from 15a7f72eaec1f2b82192d04b3c60b60b029db7bd

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
