### PR TITLE
Properly drop invalid actor name chars in standalone indexer actor name

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -85,6 +85,8 @@ SERVERS = {
             # "db_close_delay=-1" is needed so that the in-memory database is not closed
             # (and therefore lost) after the flyway migration
             "--jdbc-url=jdbc:h2:mem:daml_on_x;db_close_delay=-1;db_close_on_exit=false",
+            # participant-id contains special colon (:) character allowed in LfStrings
+            "--participant-id=participant:h2database",
         ],
     },
     "postgres": {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexerServer.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.platform.index
 
-import java.net.URLEncoder
-
 import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.ReadService
@@ -25,10 +23,9 @@ object StandaloneIndexerServer {
       loggerFactory: NamedLoggerFactory,
       metrics: MetricRegistry): Future[AutoCloseable] = {
 
-    // encode ActorSystem name not allowed to contain daml-lf LedgerString characters ".:#/ "
+    // ActorSystem name not allowed to contain daml-lf LedgerString characters ".:#/ "
     val actorSystem = ActorSystem(
-      "StandaloneIndexerServer-" + URLEncoder.encode(config.participantId, "UTF-8"))
-
+      "StandaloneIndexerServer-" + config.participantId.filterNot(".:#/ ".toSet))
     val asyncTolerance: FiniteDuration = 10.seconds
     val indexerFactory = JdbcIndexerFactory(metrics, loggerFactory)
     val indexer =


### PR DESCRIPTION
Closes #3327

CHANGELOG_BEGIN

[Ledger]
  * Allow non-alphanumeric characters in ledger api server participant ids (space, colon, hash, slash, dot). Proper fix for change originally attempted in v0.13.36. See issue `issue #3327 <https://github.com/digital-asset/daml/issues/3327>`__.

CHANGELOG_END

Proper fix replacing f39bf7fc5a007d4c2de8ffc55955a202ecb34234 which does not work

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
