### PR TITLE
ledger-api-test-tool: Use the default Akka execution context.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -131,6 +131,10 @@ final class LedgerTestSuiteRunner(
       .recover { case NonFatal(e) => throw LedgerTestSuiteRunner.UncaughtExceptionError(e) }
       .onComplete { result =>
         participantSessionManager.closeAll()
+        materializer.shutdown()
+        system.terminate().failed.foreach { throwable =>
+          logger.error("The actor system failed to terminate.", throwable)
+        }
         completionCallback(result)
       }
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import java.util.concurrent.{ExecutionException, Executors, TimeoutException}
+import java.util.concurrent.{ExecutionException, TimeoutException}
 import java.util.{Timer, TimerTask}
 
 import akka.actor.ActorSystem
@@ -15,7 +15,7 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessio
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Try}
 
@@ -104,13 +104,9 @@ final class LedgerTestSuiteRunner(
     result(start(test, session))
 
   private def run(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
-    implicit val executionContext: ExecutionContextExecutorService =
-      ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
-    val system: ActorSystem =
-      ActorSystem(
-        classOf[LedgerTestSuiteRunner].getSimpleName,
-        defaultExecutionContext = Some(executionContext))
+    val system: ActorSystem = ActorSystem(classOf[LedgerTestSuiteRunner].getSimpleName)
     implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
+    implicit val executionContext: ExecutionContext = materializer.executionContext
 
     val participantSessionManager = new ParticipantSessionManager
     val ledgerSession = new LedgerSession(config, participantSessionManager)
@@ -136,7 +132,6 @@ final class LedgerTestSuiteRunner(
       .onComplete { result =>
         participantSessionManager.closeAll()
         completionCallback(result)
-        executionContext.shutdown()
       }
   }
 


### PR DESCRIPTION
Akka will use the global fork-join pool by default, which is fine for
our purposes. There's no longer a need to use a specific execution
context, because we no longer use it to limit the work in progress.
That's now done by the parallelism parameter to Akka Streams'
`mapAsyncUnordered`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
