### PR TITLE
Obscure shared-secret-based authenticated sandbox

### DIFF
--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -64,7 +64,7 @@ Running with authentication
 
 By default, Sandbox does not use any authentication and accepts all valid ledger API requests.
 
-To start Sandbox with authentication based on `JWT <https://jwt.io/>`_, run ``daml sandbox --auth-jwt-hs256=<secret>`` where ``<secret>`` is the secret used to sign the token with the HMAC256 algorithm.
+To start Sandbox with authentication based on `JWT <https://jwt.io/>`_, run ``daml sandbox --auth-jwt-hs256-unsafe=<secret>`` where ``<secret>`` is the secret used to sign the token with the HMAC256 algorithm. Please note that this option is there _exclusively_ for testing: for production use cases you are advised to use asymmetric key signing, which is currently being worked on.
 
 The JWT payload has the following schema:
 

--- a/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Sandbox.hs
@@ -36,7 +36,7 @@ sandboxProcess SandboxSpec{dar,maybeAuth} portFile = do
       where
         authOpts = case maybeAuth of
           Nothing -> []
-          Just AuthSpec{sharedSecret} -> ["--auth-jwt-hs256=" <> sharedSecret]
+          Just AuthSpec{sharedSecret} -> ["--auth-jwt-hs256-unsafe=" <> sharedSecret]
 
 startSandboxProcess :: SandboxSpec -> FilePath -> IO (ProcessHandle,Maybe Handle)
 startSandboxProcess spec portFile = withDevNull $ \devNull -> do

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -155,10 +155,11 @@ object Cli {
         .text("The maximum TTL allowed for commands in seconds")
         .action( (maxTtl, config) => config.copy(timeModel = config.timeModel.copy(maxTtl = Duration.ofSeconds(maxTtl))))
 
-    opt[String]("auth-jwt-hs256")
+    opt[String]("auth-jwt-hs256-unsafe")
       .optional()
+      .hidden()
       .validate(v => Either.cond(v.length > 0, (), "HMAC secret must be a non-empty string"))
-      .text("Enables JWT-based authorization, where the JWT is signed by HMAC256 with the given secret")
+      .text("[UNSAFE] Enables JWT-based authorization with shared secret HMAC256 signing: USE THIS EXCLUSIVELY FOR TESTING")
       .action( (secret, config) => config.copy(authService = Some(AuthServiceJWT(HMAC256Verifier(secret).getOrElse(sys.error("Failed to create HMAC256 verifier"))))))
 
     help("help").text("Print the usage text")


### PR DESCRIPTION
The shared-secret-based authentication is there exclusively for testing,
this PR makes sure that this is correctly reported through the CLI and
hides this until further notice.

Makes sure that the flag clearly says that this option is not meant for
production use cases.

A warning is already printed when this feature is used, both at startup
and every time this verifier is used.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
