### PR TITLE
DAML-LF iface reader: rename Map to TextMap

### DIFF
--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Type.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Type.scala
@@ -141,7 +141,7 @@ sealed abstract class PrimType extends TypeConNameOrPrimType {
       case List => list
       case Unit => unit
       case Optional => optional
-      case Map => map
+      case TextMap => map
       case GenMap => genMap
     }
   }
@@ -158,7 +158,9 @@ object PrimType {
   final val List = PrimTypeList
   final val Unit = PrimTypeUnit
   final val Optional = PrimTypeOptional
-  final val Map = PrimTypeMap
+  final val TextMap = PrimTypeTextMap
+  @deprecated("Use TextMap", since = "0.13.38")
+  final val Map = TextMap
   final val GenMap = PrimTypeGenMap
 }
 
@@ -172,7 +174,7 @@ case object PrimTypeContractId extends PrimType
 case object PrimTypeList extends PrimType
 case object PrimTypeUnit extends PrimType
 case object PrimTypeOptional extends PrimType
-case object PrimTypeMap extends PrimType
+case object PrimTypeTextMap extends PrimType
 case object PrimTypeGenMap extends PrimType
 
 trait PrimTypeVisitor[+Z] {

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/package.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/package.scala
@@ -12,6 +12,10 @@ import scala.collection.TraversableLike
 
 // Types to be used internally
 package object iface {
+
+  @deprecated("Use TextMap", since = "0.13.38")
+  val PrimTypeMap = PrimTypeTextMap
+
   type FieldWithType = (Ref.Name, Type)
 
   private[iface] def lfprintln(

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -238,7 +238,7 @@ object InterfaceReader {
         case Ast.BTContractId => \/-((1, PrimType.ContractId))
         case Ast.BTList => \/-((1, PrimType.List))
         case Ast.BTOptional => \/-((1, PrimType.Optional))
-        case Ast.BTTextMap => \/-((1, PrimType.Map))
+        case Ast.BTTextMap => \/-((1, PrimType.TextMap))
         case Ast.BTGenMap => \/-((2, PrimType.GenMap))
         case Ast.BTNumeric =>
           unserializableDataType(

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -58,7 +58,7 @@ class TypeSpec extends WordSpec with Matchers {
           case Pkg.BTList =>
             TypePrim(PrimTypeList, ImmArraySeq(assertOneArg(args)))
           case Pkg.BTTextMap =>
-            TypePrim(PrimTypeMap, ImmArraySeq(assertOneArg(args)))
+            TypePrim(PrimTypeTextMap, ImmArraySeq(assertOneArg(args)))
           case Pkg.BTGenMap =>
             // FIXME https://github.com/digital-asset/daml/issues/2256
             sys.error("GenMap not supported in interface type")

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReaderSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReaderSpec.scala
@@ -136,13 +136,11 @@ class InterfaceReaderSpec extends WordSpec with Matchers with Inside {
     val actual = InterfaceReader.foldModule(wrappInModule(dnfs("MapRecord"), dataType))
     val expectedResult = Map(
       Ref.QualifiedName(moduleName, dnfs("MapRecord")) ->
-        iface.InterfaceType.Normal(
-          DefDataType(
-            ImmArray.empty.toSeq,
-            Record(
-              ImmArraySeq[(Ref.Name, TypePrim)](
-                ("map", TypePrim(PrimTypeMap, ImmArraySeq(TypePrim(PrimTypeInt64, ImmArraySeq()))))
-              ))))
+        iface.InterfaceType.Normal(DefDataType(
+          ImmArray.empty.toSeq,
+          Record(ImmArraySeq[(Ref.Name, TypePrim)](
+            ("map", TypePrim(PrimTypeTextMap, ImmArraySeq(TypePrim(PrimTypeInt64, ImmArraySeq()))))
+          ))))
     )
 
     actual.typeDecls shouldBe expectedResult

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/TypedValueGenerators.scala
@@ -139,7 +139,7 @@ object TypedValueGenerators {
 
     def map(elt: ValueAddend): Aux[Compose[SortedLookupList, elt.Inj, ?]] = new ValueAddend {
       type Inj[Cid] = SortedLookupList[elt.Inj[Cid]]
-      override val t = TypePrim(PT.Map, ImmArraySeq(elt.t))
+      override val t = TypePrim(PT.TextMap, ImmArraySeq(elt.t))
       override def inj[Cid] =
         (sll: SortedLookupList[elt.Inj[Cid]]) => ValueTextMap(sll map elt.inj)
       override def prj[Cid] = {

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/MultiTableDataFormat.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/MultiTableDataFormat.scala
@@ -257,7 +257,7 @@ class MultiTableDataFormat(
         case iface.PrimTypeText => "TEXT"
         case iface.PrimTypeDate => "DATE"
         case iface.PrimTypeOptional => "JSONB"
-        case iface.PrimTypeMap => "JSONB"
+        case iface.PrimTypeTextMap => "JSONB"
         case iface.PrimTypeGenMap => "JSONB"
       }
     case TypeCon(_, _, true) => "TEXT"

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
@@ -205,7 +205,7 @@ private[inner] object FromValueGenerator extends StrictLogging {
           accessor,
           orElseThrow(apiType, field))
 
-      case TypePrim(PrimTypeMap, ImmArraySeq(param)) =>
+      case TypePrim(PrimTypeTextMap, ImmArraySeq(param)) =>
         val optMapArg = args.next()
         val entryArg = args.next()
         CodeBlock.of(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -112,7 +112,7 @@ object ToValueGenerator {
           extractor
         )
 
-      case TypePrim(PrimTypeMap, ImmArraySeq(param)) =>
+      case TypePrim(PrimTypeTextMap, ImmArraySeq(param)) =>
         val arg = args.next()
         val extractor = CodeBlock.of(
           "$L -> $L",

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -74,7 +74,7 @@ package object inner {
           .get(
             ClassName.get(classOf[java.util.Optional[_]]),
             typeParameters.map(toJavaTypeName(_, packagePrefixes)): _*)
-      case TypePrim(PrimTypeMap, typeParameters) =>
+      case TypePrim(PrimTypeTextMap, typeParameters) =>
         ParameterizedTypeName
           .get(
             ClassName.get(classOf[java.util.Map[String, _]]),
@@ -104,7 +104,7 @@ package object inner {
         ClassName.get(classOf[DamlList])
       case TypePrim(PrimTypeOptional, _) =>
         ClassName.get(classOf[DamlOptional])
-      case TypePrim(PrimTypeMap, _) =>
+      case TypePrim(PrimTypeTextMap, _) =>
         ClassName.get(classOf[DamlTextMap])
       case TypePrim(PrimTypeGenMap, _) =>
         ClassName.get(classOf[DamlGenMap])

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
@@ -85,7 +85,7 @@ final case class LFUtil(
         case PT.Date => q"$primitiveObject.Date"
         case PT.Timestamp => q"$primitiveObject.Timestamp"
         case PT.Unit => q"$primitiveObject.Unit"
-        case PT.List | PT.ContractId | PT.Optional | PT.Map | PT.GenMap =>
+        case PT.List | PT.ContractId | PT.Optional | PT.TextMap | PT.GenMap =>
           throw UnsupportedDamlTypeException(
             s"type $refType should not occur in a Data-kinded position; this is an invalid input LF")
         case TypeConName(tyCon) =>
@@ -103,7 +103,7 @@ final case class LFUtil(
       case TypePrim(PT.Optional, ImmArraySeq(typ)) =>
         val optType = genTypeToScalaType(typ)
         q"$primitiveObject.Optional[$optType]"
-      case TypePrim(PT.Map, ImmArraySeq(typ)) =>
+      case TypePrim(PT.TextMap, ImmArraySeq(typ)) =>
         val optType = genTypeToScalaType(typ)
         q"$primitiveObject.Map[$optType]"
       case TypePrim(PT.GenMap, ImmArraySeq(_, _)) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -215,7 +215,7 @@ object ValuePredicate {
             val elemTy = soleTypeArg("Optional")
             fromOptional(q, elemTy)
         }
-        case Map => {
+        case TextMap => {
           case JsObject(q) =>
             val elemTy = soleTypeArg("Map")
             MapMatch(SortedLookupList(q) mapValue (fromValue(_, elemTy)))

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -143,7 +143,7 @@ abstract class ApiCodecCompressed[Cid](
             }
           case _ if !useArray => V.ValueOptional(Some(jsValueToApiValue(value, typArg, defs)))
         }
-      case Model.DamlLfPrimType.Map => {
+      case Model.DamlLfPrimType.TextMap => {
         case JsObject(a) =>
           V.ValueTextMap(SortedLookupList(a.transform { (_, v) =>
             jsValueToApiValue(v, prim.typArgs.head, defs)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/DamlLfCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/DamlLfCodec.scala
@@ -90,7 +90,7 @@ object DamlLfCodec {
     case Model.DamlLfPrimType.Text => JsString(tagTypeText)
     case Model.DamlLfPrimType.Timestamp => JsString(tagTypeTimestamp)
     case Model.DamlLfPrimType.Optional => JsString(tagTypeOptional)
-    case Model.DamlLfPrimType.Map => JsString(tagTypeMap)
+    case Model.DamlLfPrimType.TextMap => JsString(tagTypeMap)
     case Model.DamlLfPrimType.GenMap =>
       // FIXME https://github.com/digital-asset/daml/issues/2256
       serializationError("GenMap not supported")
@@ -174,7 +174,7 @@ object DamlLfCodec {
     case `tagTypeTimestamp` => Model.DamlLfPrimType.Timestamp
     case `tagTypeUnit` => Model.DamlLfPrimType.Unit
     case `tagTypeOptional` => Model.DamlLfPrimType.Optional
-    case `tagTypeMap` => Model.DamlLfPrimType.Map
+    case `tagTypeMap` => Model.DamlLfPrimType.TextMap
   }
 
   def jsValueToDamlLfDataType(value: JsValue): Model.DamlLfDataType =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -325,7 +325,7 @@ case object LedgerApiV1 {
   ): Result[Model.ApiMap] =
     for {
       elementType <- typ match {
-        case Model.DamlLfTypePrim(Model.DamlLfPrimType.Map, Seq(t)) =>
+        case Model.DamlLfTypePrim(Model.DamlLfPrimType.TextMap, Seq(t)) =>
           Right(t)
         case _ => Left(GenericConversionError(s"Cannot read $map as $typ"))
       }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
@@ -84,7 +84,7 @@ package object filter {
           Right(checkContained("contractid", expectedValue))
         case DamlLfTypePrim(DamlLfPrimType.Optional, _) =>
           Right(checkContained("optional", expectedValue))
-        case DamlLfTypePrim(DamlLfPrimType.Map, _) =>
+        case DamlLfTypePrim(DamlLfPrimType.TextMap, _) =>
           Right(checkContained("map", expectedValue))
         case DamlLfTypePrim(DamlLfPrimType.GenMap, _) =>
           // FIXME https://github.com/digital-asset/daml/issues/2256

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/project/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/project/package.scala
@@ -94,7 +94,7 @@ object project {
         case DamlLfTypePrim(DamlLfPrimType.List, _) => Right(StringValue("list"))
         case DamlLfTypePrim(DamlLfPrimType.ContractId, _) => Right(StringValue("contractid"))
         case DamlLfTypePrim(DamlLfPrimType.Optional, _) => Right(StringValue("optional"))
-        case DamlLfTypePrim(DamlLfPrimType.Map, _) => Right(StringValue("map"))
+        case DamlLfTypePrim(DamlLfPrimType.TextMap, _) => Right(StringValue("map"))
         case DamlLfTypePrim(DamlLfPrimType.GenMap, _) =>
           // FIXME https://github.com/digital-asset/daml/issues/2256
           sys.error("GenMap not supported")

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -55,7 +55,8 @@ case object DamlConstants {
     DamlLfTypePrim(DamlLfPrimType.Optional, DamlLfImmArraySeq(typ))
   def simpleListT(typ: DamlLfIface.Type) =
     DamlLfTypePrim(DamlLfPrimType.List, DamlLfImmArraySeq(typ))
-  def simpleMapT(typ: DamlLfIface.Type) = DamlLfTypePrim(DamlLfPrimType.Map, DamlLfImmArraySeq(typ))
+  def simpleMapT(typ: DamlLfIface.Type) =
+    DamlLfTypePrim(DamlLfPrimType.TextMap, DamlLfImmArraySeq(typ))
 
   val simpleTextV = V.ValueText("foo")
   val simpleInt64V = V.ValueInt64(100)


### PR DESCRIPTION
This PR advances the state of Generic Map #2256.

In order to avoid confusion with Generic Map, we rename Map to TextMap in the interface reader.


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
