### PR TITLE
Move DamlLedgerClient to builder-based constructors

### DIFF
--- a/docs/source/app-dev/bindings-java/index.rst
+++ b/docs/source/app-dev/bindings-java/index.rst
@@ -174,10 +174,9 @@ Before any ledger services can be accessed, a connection to the ledger must be e
 Connecting securely
 ===================
 
-The Java bindings library lets you connect to a DAML Ledger via a secure connection. The factory methods
-``DamlLedgerClient.forLedgerIdAndHost`` and ``DamlLedgerClient.forHostWithLedgerIdDiscovery`` accept a parameter of type ``Optional<SslContext>``.
-If the value of that optional parameter is not present (i.e. by passing ``Optional.empty()``), a plain text / insecure connection will be established.
-This is useful when connecting to a locally running Sandbox.
+The Java bindings library lets you connect to a DAML Ledger via a secure connection. The builders created by
+``DamlLedgerClient.newBuilder`` default to a plaintext connection, but you can invoke ``withSslContext` to pass an ``SslContext``.
+Using the default plaintext connection is useful only when connecting to a locally running Sandbox for development purposes.
 
 Secure connections to a DAML Ledger must be configured to use client authentication certificates, which can be provided by a Ledger Operator.
 
@@ -188,7 +187,7 @@ For information on how to set up an ``SslContext`` with the provided certificate
 Advanced connection settings
 ============================
 
-Sometimes the default settings for gRPC connections/channels are not suitable for a given situation. These usecases are supported by creating a a custom `ManagedChannel <https://grpc.io/grpc-java/javadoc/io/grpc/ManagedChannel.html>`_ object via `ManagedChannelBuilder <https://grpc.io/grpc-java/javadoc/io/grpc/ManagedChannelBuilder.html>`_  or `NettyChannelBuilder <https://grpc.io/grpc-java/javadoc/io/grpc/netty/NettyChannelBuilder.html>`_ and passing the channel instance to the constructor of `DamlLedgerClient <javadocs/com/daml/ledger/rxjava/DamlLedgerClient.html>`_.
+Sometimes the default settings for gRPC connections/channels are not suitable for a given situation. These use cases are supported by creating a a custom `NettyChannelBuilder <https://grpc.github.io/grpc-java/javadoc/io/grpc/netty/NettyChannelBuilder.html>`_ object and passing the it to the ``newBuilder`` static method defined over `DamlLedgerClient <javadocs/com/daml/ledger/rxjava/DamlLedgerClient.html>`_.
 
 Example project
 ***************

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.rxjava
 
 import java.time.Instant
-import java.util.Optional
 import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.javaapi.data.LedgerOffset.Absolute
@@ -36,19 +35,17 @@ class DamlLedgerClientTest extends FlatSpec with Matchers with OptionValues with
 
   it should "connect to an existing ledger-api grpc service with the correct ledgerId and pass the ledgerId to the clients" in {
     withFakeLedgerServer() { (server, impls) =>
-      val damlLedgerClient = DamlLedgerClient.forLedgerIdAndHost(
-        ledgerServices.ledgerId,
-        "localhost",
-        server.getPort,
-        Optional.empty())
+      val damlLedgerClient = DamlLedgerClient
+        .newBuilder("localhost", server.getPort)
+        .withExpectedLedgerId(ledgerServices.ledgerId)
+        .build()
       testDamlLedgerClient(damlLedgerClient, impls)
     }
   }
 
   it should "connect to an existing ledger-api grpc service, autodiscover the ledgerId and pass it to the clients" in {
     withFakeLedgerServer() { (server, impls) =>
-      val damlLedgerClient =
-        DamlLedgerClient.forHostWithLedgerIdDiscovery("localhost", server.getPort, Optional.empty())
+      val damlLedgerClient = DamlLedgerClient.newBuilder("localhost", server.getPort).build()
       testDamlLedgerClient(damlLedgerClient, impls)
     }
   }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -389,7 +389,7 @@ class BotTest extends FlatSpec with Matchers with DataLayerHelpers {
       Future.successful(scalaAPI.package_service.GetPackageStatusResponse.defaultInstance)
     ) { (server, _) =>
       val client =
-        DamlLedgerClient.forHostWithLedgerIdDiscovery("localhost", server.getPort, Optional.empty())
+        DamlLedgerClient.newBuilder("localhost", server.getPort).build()
       client.connect()
 
       /* The bot is wired here and inside wire is where the race condition can happen. We catch the possible


### PR DESCRIPTION
With the intent of adding more functionality to the Java bindings, in
particular authentication, this PR deprecates existing constructors in
favor of a more flexible builder based approach.

CHANGELOG_BEGIN

- [Java Bindings] Deprecated existing constructors for
``DamlLedgerClient``, please use the static ``newBuilder`` method to
instantiate a builder and use it to create the client, starting from
either a ``NettyChannelBuilder`` or a plain host/port pair.

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
