### PR TITLE
kvutils: Clean up the InMemoryKVParticipantState integration tests a little.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
@@ -95,7 +95,7 @@ object InMemoryKVParticipantState {
   */
 class InMemoryKVParticipantState(
     val participantId: ParticipantId,
-    val ledgerId: LedgerString.T = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
+    val ledgerId: LedgerString = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
     file: Option[File] = None,
     openWorld: Boolean = true)(implicit system: ActorSystem, mat: Materializer)
     extends ReadService

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantStateIT.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantStateIT.scala
@@ -377,6 +377,7 @@ class InMemoryKVParticipantStateIT
             maxRecordTime = rt.addMicros(1000000),
             submissionId = "test2",
             config = lic.config.copy(
+              generation = lic.config.generation + 1,
               timeModel = TimeModel(
                 Duration.ofSeconds(123),
                 Duration.ofSeconds(123),


### PR DESCRIPTION
Mostly as an exercise to help me understand how kvutils works a little better.

Probably easiest to review per-commit. Each one is quite small and self-contained.

I tried to:

- fix warnings
- write more idiomatic Scala
- move helpers to the bottom
- remove duplication
- improve a couple of test cases where I saw an easy win

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
