### PR TITLE
language: upgrades: prefix stdlib imports everywhere.

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -788,7 +788,7 @@ execGenerateSrc opts dalfFp mbOutDir = Command GenerateSrc effect
                         (pkgId, _pkg) <- decode dalfBS
                         pure (pkgId, stringToUnitId $ takeFileName dalfFp)
         let pkgMap = MS.insert pkgId unitId pkgMap0
-        let genSrcs = generateSrcPkgFromLf (getUnitId unitId pkgMap) pkgId pkg
+        let genSrcs = generateSrcPkgFromLf (getUnitId unitId pkgMap) (Just "Sdk") pkg
         forM_ genSrcs $ \(path, src) -> do
             let fp = fromMaybe "" mbOutDir </> fromNormalizedFilePath path
             createDirectoryIfMissing True $ takeDirectory fp
@@ -823,7 +823,7 @@ execGenerateGenSrc darFp mbQual outDir = Command GenerateGenerics effect
         (mainPkgId, mainLfPkg) <-
             decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
         let getUid = getUnitId unitId pkgMap
-        let genSrcs = generateGenInstancesPkgFromLf getUid mainPkgId mainLfPkg (fromMaybe "" mbQual)
+        let genSrcs = generateGenInstancesPkgFromLf getUid Nothing mainPkgId mainLfPkg (fromMaybe "" mbQual)
         forM_ genSrcs $ \(path, src) -> do
             let fp = fromMaybe "" outDir </> fromNormalizedFilePath path
             createDirectoryIfMissing True $ takeDirectory fp

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -121,10 +121,11 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                         | LF.PRImport pid <- toListOf packageRefs dalf
                         ]
                 let getUid = getUnitId unitId pkgMap
-                let src = generateSrcPkgFromLf getUid pkgId dalf
+                let src = generateSrcPkgFromLf getUid (Just "Sdk") dalf
                 let templInstSrc =
                         generateTemplateInstancesPkgFromLf
                             getUid
+                            (Just "Sdk")
                             pkgId
                             dalf
                 pure
@@ -216,10 +217,13 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                 , optGhcCustomOpts = []
                 , optPackageImports =
                       ("daml-prim", True, []) :
-                      -- the following is for the edge case, when there is no standard library
-                      -- dependency, but the dalf still uses builtins or builtin types like Party.
-                      -- In this case, we use the current daml-stdlib as their origin.
-                      [(damlStdlib, True, []) | not $ hasStdlibDep deps]  ++
+                      [ ( damlStdlib
+                        , False
+                        , [ ("DA.Internal.Template", "Sdk.DA.Internal.Template")
+                          , ("DA.Internal.LF", "Sdk.DA.Internal.LF")
+                          , ("DA.Internal.Prelude", "Sdk.DA.Internal.Prelude")
+                          ])
+                      ] ++
                       [(takeBaseName dep, True, []) | dep <- deps]
                 }
 
@@ -297,7 +301,10 @@ createProjectPackageDb opts thisSdkVer deps0 dataDeps = do
                               -- definition of the template class.
                               [ ( damlStdlib
                                 , False
-                                , [("DA.Internal.Template", "Sdk.DA.Internal.Template") ])
+                                , [ ("DA.Internal.Template", "Sdk.DA.Internal.Template")
+                                  , ("DA.Internal.LF", "Sdk.DA.Internal.LF")
+                                  , ("DA.Internal.Prelude", "Sdk.DA.Internal.Prelude")
+                                  ])
                               ] ++
                               -- the following is for the edge case, when there is no standard
                               -- library dependency, but the dalf still uses builtins or builtin

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -405,7 +405,16 @@ dataDependencyTests damlc = testGroup "Data Dependencies" $
         step "Regenerate source ..."
         callProcessSilent damlc ["generate-src", "Foo.dalf", "--srcdir=gen"]
         step "Compile generated source ..."
-        callProcessSilent damlc ["compile", "--generated-src", "gen/Foo.daml", "-o", "FooGen.dalf"]
+        callProcessSilent
+            damlc
+            [ "compile"
+            , "--generated-src"
+            , "gen/Foo.daml"
+            , "-o"
+            , "FooGen.dalf"
+            , "--package=(" <> show damlStdlib <>
+              ", False, [(\"DA.Internal.LF\", \"Sdk.DA.Internal.LF\"), (\"DA.Internal.Prelude\", \"Sdk.DA.Internal.Prelude\")])"
+            ]
         assertBool "FooGen.dalf was not created" =<< doesFileExist "FooGen.dalf"
     ]
 


### PR DESCRIPTION
This fixes an issue where builtins were pointing to the wrong standard library when importing a package compiled with an older sdk. We also drop the generation of DA.Internal.LF types and refer always to the current sdk.
I'm trying to find a way how to test this in the meantime.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
