### PR TITLE
Add support for authenticated ledger

### DIFF
--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -9,7 +9,7 @@ import akka.stream.{ActorMaterializer, KillSwitches}
 import com.digitalasset.extractor.Types._
 import com.digitalasset.extractor.config.{ExtractorConfig, SnapshotEndSetting}
 import com.digitalasset.extractor.helpers.FutureUtil.toFuture
-import com.digitalasset.extractor.helpers.{TemplateIds, TokenHolder, TransactionTreeTrimmer}
+import com.digitalasset.extractor.helpers.{TemplateIds, TransactionTreeTrimmer}
 import com.digitalasset.extractor.ledger.types.TransactionTree
 import com.digitalasset.extractor.ledger.types.TransactionTree._
 import com.digitalasset.extractor.writers.Writer
@@ -22,7 +22,7 @@ import com.digitalasset.ledger.api.{v1 => api}
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.configuration._
 import com.digitalasset.ledger.client.services.pkg.PackageClient
-import com.digitalasset.ledger.service.LedgerReader
+import com.digitalasset.ledger.service.{LedgerReader, TokenHolder}
 import com.digitalasset.ledger.service.LedgerReader.PackageStore
 import com.digitalasset.timer.RetryStrategy
 import com.typesafe.scalalogging.StrictLogging

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -85,6 +85,7 @@ da_scala_test(
         "//ledger/sandbox:sandbox-scala-tests-lib",
         "//ledger/participant-state",
         "//bazel_tools/runfiles:scala_runfiles",
+        "//ledger/ledger-api-auth",
     ] + http_json_deps,
 )
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.http
 
 import java.io.File
+import java.nio.file.Path
 
 import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
 import scalaz.{Show, \/}
@@ -23,6 +24,7 @@ private[http] final case class Config(
     maxInboundMessageSize: Int = HttpService.DefaultMaxInboundMessageSize,
     jdbcConfig: Option[JdbcConfig] = None,
     staticContentConfig: Option[StaticContentConfig] = None,
+    accessTokenFile: Option[Path] = None,
 )
 
 private[http] object Config {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -3,6 +3,8 @@
 
 package com.digitalasset.http
 
+import java.nio.file.Paths
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.ActorMaterializer
@@ -47,6 +49,7 @@ object Main extends StrictLogging {
         s", maxInboundMessageSize=${config.maxInboundMessageSize: Int}" +
         s", jdbcConfig=${config.jdbcConfig.shows}" +
         s", staticContentConfig=${config.staticContentConfig.shows}" +
+        s", accessTokenFile=${config.accessTokenFile.toString}" +
         ")")
 
     implicit val asys: ActorSystem = ActorSystem("http-json-ledger-api")
@@ -82,6 +85,7 @@ object Main extends StrictLogging {
         config.applicationId,
         config.address,
         config.httpPort,
+        config.accessTokenFile,
         contractDao,
         config.staticContentConfig,
         config.packageReloadInterval,
@@ -185,5 +189,11 @@ object Main extends StrictLogging {
         .valueName(StaticContentConfig.usage)
         .text(s"DEV MODE ONLY (not recommended for production). Optional static content configuration string. "
           + StaticContentConfig.help)
+
+      opt[String]("access-token-file")
+        .text(
+          s"provide the path from which the access token will be read, required to interact with an authenticated ledger, no default")
+        .action((path, arguments) => arguments.copy(accessTokenFile = Some(Paths.get(path))))
+        .optional()
     }
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AuthorizationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AuthorizationTest.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http
+
+import java.nio.file.Files
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.digitalasset.daml.bazeltools.BazelRunfiles.rlocation
+import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.digitalasset.http.util.TestUtil.requiredFile
+import com.digitalasset.ledger.api.auth.{AuthServiceStatic, Claim, ClaimPublic, Claims}
+import com.digitalasset.ledger.client.LedgerClient
+import com.digitalasset.ledger.service.TokenHolder
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+final class AuthorizationTest extends AsyncFlatSpec with BeforeAndAfterAll with Matchers {
+
+  private val dar = requiredFile(rlocation("docs/quickstart-model.dar"))
+    .fold(e => throw new IllegalStateException(e), identity)
+
+  private val testId: String = this.getClass.getSimpleName
+
+  implicit val asys: ActorSystem = ActorSystem(testId)
+  implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val aesf: ExecutionSequencerFactory = new AkkaExecutionSequencerPool(testId)(asys)
+  implicit val ec: ExecutionContext = asys.dispatcher
+
+  private val publicToken = "public"
+  private val emptyToken = "empty"
+  private val mockedAuthService = Option(AuthServiceStatic {
+    case `publicToken` => Claims(Seq[Claim](ClaimPublic))
+    case `emptyToken` => Claims(Nil)
+  })
+
+  private val accessTokenFile = Files.createTempFile("Extractor", "AuthSpec")
+  private val tokenHolder = Option(new TokenHolder(accessTokenFile))
+
+  private def setToken(string: String): Unit = {
+    val _ = Files.write(accessTokenFile, string.getBytes())
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    try {
+      Files.delete(accessTokenFile)
+    } catch {
+      case NonFatal(e) =>
+        LoggerFactory
+          .getLogger(classOf[AuthorizationTest])
+          .warn("Unable to delete temporary token file", e)
+    }
+  }
+
+  protected def withLedger[A] =
+    HttpServiceTestFixture.withLedger[A](dar, testId, Option(publicToken), mockedAuthService) _
+
+  private def packageService(client: LedgerClient): PackageService =
+    new PackageService(HttpService.loadPackageStoreUpdates(client.packageClient, tokenHolder))
+
+  behavior of "PackageService against an authenticated sandbox"
+
+  it should "fail immediately if the authorization is insufficient" in withLedger { client =>
+    setToken(emptyToken)
+    packageService(client).reload.failed.map(_ => succeed)
+  }
+
+  it should "succeed if the authorization is sufficient" in withLedger { client =>
+    setToken(publicToken)
+    packageService(client).reload.map(_ => succeed)
+  }
+
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
@@ -16,6 +16,7 @@ import com.digitalasset.http.util.FutureUtil
 import com.digitalasset.http.util.FutureUtil.toFuture
 import com.digitalasset.http.util.IdentifierConverters.apiLedgerId
 import com.digitalasset.http.util.TestUtil.findOpenPort
+import com.digitalasset.ledger.api.auth.AuthService
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
 import com.digitalasset.ledger.client.LedgerClient
@@ -72,6 +73,7 @@ object HttpServiceTestFixture {
           applicationId,
           "localhost",
           httpPort,
+          None,
           contractDao,
           staticContentConfig,
           doNotReloadPackages))
@@ -102,7 +104,11 @@ object HttpServiceTestFixture {
     fa
   }
 
-  def withLedger[A](dar: File, testName: String)(testFn: LedgerClient => Future[A])(
+  def withLedger[A](
+      dar: File,
+      testName: String,
+      token: Option[String] = None,
+      authService: Option[AuthService] = None)(testFn: LedgerClient => Future[A])(
       implicit aesf: ExecutionSequencerFactory,
       ec: ExecutionContext): Future[A] = {
 
@@ -111,12 +117,12 @@ object HttpServiceTestFixture {
 
     val ledgerF: Future[(SandboxServer, Int)] = for {
       port <- toFuture(findOpenPort())
-      ledger <- Future(SandboxServer(ledgerConfig(port, dar, ledgerId)))
+      ledger <- Future(SandboxServer(ledgerConfig(port, dar, ledgerId, authService)))
     } yield (ledger, port)
 
     val clientF: Future[LedgerClient] = for {
       (_, ledgerPort) <- ledgerF
-      client <- LedgerClient.singleHost("localhost", ledgerPort, clientConfig(applicationId))
+      client <- LedgerClient.singleHost("localhost", ledgerPort, clientConfig(applicationId, token))
     } yield client
 
     val fa: Future[A] = for {
@@ -131,27 +137,35 @@ object HttpServiceTestFixture {
     fa
   }
 
-  private def ledgerConfig(ledgerPort: Int, dar: File, ledgerId: LedgerId): SandboxConfig =
+  private def ledgerConfig(
+      ledgerPort: Int,
+      dar: File,
+      ledgerId: LedgerId,
+      authService: Option[AuthService] = None): SandboxConfig =
     SandboxConfig.default.copy(
       port = ledgerPort,
       damlPackages = List(dar),
       timeProviderType = TimeProviderType.WallClock,
       ledgerIdMode = LedgerIdMode.Static(ledgerId),
+      authService = authService
     )
 
-  private def clientConfig[A](applicationId: ApplicationId): LedgerClientConfiguration =
+  private def clientConfig[A](
+      applicationId: ApplicationId,
+      token: Option[String] = None): LedgerClientConfiguration =
     LedgerClientConfiguration(
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
       commandClient = CommandClientConfiguration.default,
-      sslContext = None
+      sslContext = None,
+      token = token
     )
 
   def jsonCodecs(client: LedgerClient)(
       implicit ec: ExecutionContext): Future[(DomainJsonEncoder, DomainJsonDecoder)] = {
     val ledgerId = apiLedgerId(client.ledgerId)
     val packageService = new PackageService(
-      HttpService.loadPackageStoreUpdates(client.packageClient, token = None))
+      HttpService.loadPackageStoreUpdates(client.packageClient, tokenHolder = None))
     packageService
       .reload(ec)
       .flatMap(x => FutureUtil.toFuture(x))

--- a/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/TokenHolder.scala
+++ b/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/TokenHolder.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.extractor.helpers
+package com.digitalasset.ledger.service
 
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicReference


### PR DESCRIPTION
Closes #3627

- Pass a token at startup to read packages
- Re-read the token every time new packages are fetched to ensure token
freshness
- If the token is expired, new packages will not be retrieved

CHANGELOG_BEGIN

- [JSON API] Accept a path to a file containing a token at startup for
package retrieval. See `issue #3627 <https://github.com/digital-asset/daml/issues/3627>`__.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
