### PR TITLE
DAML-LF: type synonyms are also taken into account for collisions

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -1364,17 +1364,19 @@ name* construct as follows:
   in the module ``Mod`` is ``Mod.T``.
 * The *fully resolved name* of a variant type constructor ``T``
   defined in the module ``Mod`` is ``Mod.T``.
-* The *fully resolved name* of a enum type constructor ``T``
-  defined in the module ``Mod`` is ``Mod.T``.
+* The *fully resolved name* of a enum type constructor ``T`` defined
+  in the module ``Mod`` is ``Mod.T``.
+* The *fully resolved name* of a type synonym ``S`` defined in the
+  module ``Mod`` is ``Mod.S``.
 * The *fully resolved name* of a field ``fᵢ`` of a record type
-  definition ``'record' T …  ↦ { …, fᵢ: τᵢ, … }`` defined in the module
-  ``Mod`` is ``Mod.T.fᵢ``
+  definition ``'record' T …  ↦ { …, fᵢ: τᵢ, … }`` defined in the
+  module ``Mod`` is ``Mod.T.fᵢ``
 * The *fully resolved name* of a variant constructor ``Vᵢ`` of a
-  variant type definition ``'variant' T … ↦ …  | Vᵢ: τᵢ | …`` defined in
-  the module ``Mod`` is ``Mod.T.Vᵢ``.
-* The *fully resolved name* of a enum constructor ``Eᵢ`` of a enum type
-   definition ``'enum' T ↦ …  | Eᵢ | …`` defined in the module ``Mod``
-   is ``Mod.T.Eᵢ``.
+  variant type definition ``'variant' T … ↦ …  | Vᵢ: τᵢ | …`` defined
+  in the module ``Mod`` is ``Mod.T.Vᵢ``.
+* The *fully resolved name* of a enum constructor ``Eᵢ`` of a enum
+   type definition ``'enum' T ↦ …  | Eᵢ | …`` defined in the module
+   ``Mod`` is ``Mod.T.Eᵢ``.
 * The *fully resolved name* of a choice ``Ch`` of a template
   definition ``'tpl' (x : T) ↦ { …, 'choices' { …, 'choice' ChKind Ch
   … ↦ …, … } }`` defined in the module ``Mod`` is ``Mod.T.Ch``.


### PR DESCRIPTION
This PR advance the state of #3616.

Here we specify that name synonym collide in the same way as other definitions.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
