### PR TITLE
Use scalafmt's diff mode

### DIFF
--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -5,4 +5,4 @@
 set -eu -o pipefail
 
 cd "${0%/*}"
-scalafmt --git true --config .scalafmt.conf "$@"
+scalafmt --git true --diff --config .scalafmt.conf "$@"


### PR DESCRIPTION
Limits the set of files scalafmt will run on to those in the
git diff with master. This should greatly speed up language
agnostic checks, especially for developers to test them before
the contribution hits CI.

Worth mentioning: we use scalafmt 1.5.x, scalafmt latest release
is 2.2.x and the option is deprecated in favor of `--mode diff`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
