### PR TITLE
Rename daml lf tuples

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -177,9 +177,9 @@ data Type
     , forallBody   :: !Type
       -- ^ Type of the body of the type abstraction.
     }
-  -- | Type for strocts aka structural records. Parameterized by the names of the
+  -- | Type for structs aka structural records. Parameterized by the names of the
   -- fields and their types.
-  | TStroct      ![(FieldName, Type)]
+  | TStruct      ![(FieldName, Type)]
   -- | Type-level natural numbers
   | TNat !TypeLevelNat
   deriving (Eq, Data, Generic, NFData, Ord, Show)
@@ -358,25 +358,25 @@ data Expr
     , enumDataCon :: !VariantConName
       -- ^ Data constructor of the enum type.
     }
-  -- | Stroct construction.
-  | EStroctCon
-    { stroctFields :: ![(FieldName, Expr)]
+  -- | Struct construction.
+  | EStructCon
+    { structFields :: ![(FieldName, Expr)]
       -- ^ Fields together with the expressions to assign to them.
     }
-  -- | Stroct projection.
-  | EStroctProj
-    { stroctField :: !FieldName
+  -- | Struct projection.
+  | EStructProj
+    { structField :: !FieldName
       -- ^ Field to project to.
-    , stroctExpr  :: !Expr
+    , structExpr  :: !Expr
       -- ^ Expression to project from.
     }
-  -- | Non-destructive stroct update.
-  | EStroctUpd
-    { stroctField :: !FieldName
+  -- | Non-destructive struct update.
+  | EStructUpd
+    { structField :: !FieldName
       -- ^ Field to update.
-    , stroctExpr :: !Expr
+    , structExpr :: !Expr
       -- ^ Expression to update the field in.
-    , stroctUpdate :: !Expr
+    , structUpdate :: !Expr
       -- ^ Expression to update the field with.
     }
   -- | (Expression) application.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -177,9 +177,9 @@ data Type
     , forallBody   :: !Type
       -- ^ Type of the body of the type abstraction.
     }
-  -- | Type for tuples aka structural records. Parameterized by the names of the
+  -- | Type for strocts aka structural records. Parameterized by the names of the
   -- fields and their types.
-  | TTuple      ![(FieldName, Type)]
+  | TStroct      ![(FieldName, Type)]
   -- | Type-level natural numbers
   | TNat !TypeLevelNat
   deriving (Eq, Data, Generic, NFData, Ord, Show)
@@ -358,25 +358,25 @@ data Expr
     , enumDataCon :: !VariantConName
       -- ^ Data constructor of the enum type.
     }
-  -- | Tuple construction.
-  | ETupleCon
-    { tupFields :: ![(FieldName, Expr)]
+  -- | Stroct construction.
+  | EStroctCon
+    { stroctFields :: ![(FieldName, Expr)]
       -- ^ Fields together with the expressions to assign to them.
     }
-  -- | Tuple projection.
-  | ETupleProj
-    { tupField :: !FieldName
+  -- | Stroct projection.
+  | EStroctProj
+    { stroctField :: !FieldName
       -- ^ Field to project to.
-    , tupExpr  :: !Expr
+    , stroctExpr  :: !Expr
       -- ^ Expression to project from.
     }
-  -- | Non-destructive tuple update.
-  | ETupleUpd
-    { tupField :: !FieldName
+  -- | Non-destructive stroct update.
+  | EStroctUpd
+    { stroctField :: !FieldName
       -- ^ Field to update.
-    , tupExpr :: !Expr
+    , stroctExpr :: !Expr
       -- ^ Expression to update the field in.
-    , tupUpdate :: !Expr
+    , stroctUpdate :: !Expr
       -- ^ Expression to update the field with.
     }
   -- | (Expression) application.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -100,7 +100,7 @@ builtinType f =
         TApp s t -> TApp <$> builtinType f s <*> builtinType f t
         TBuiltin x -> TBuiltin <$> f x
         TForall b body -> TForall b <$> builtinType f body
-        TTuple fs -> TTuple <$> (traverse . _2) (builtinType f) fs
+        TStroct fs -> TStroct <$> (traverse . _2) (builtinType f) fs
         TNat n -> pure $ TNat n
 
 type ModuleRef = (PackageRef, ModuleName)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -100,7 +100,7 @@ builtinType f =
         TApp s t -> TApp <$> builtinType f s <*> builtinType f t
         TBuiltin x -> TBuiltin <$> f x
         TForall b body -> TForall b <$> builtinType f body
-        TStroct fs -> TStroct <$> (traverse . _2) (builtinType f) fs
+        TStruct fs -> TStruct <$> (traverse . _2) (builtinType f) fs
         TNat n -> pure $ TNat n
 
 type ModuleRef = (PackageRef, ModuleName)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -145,9 +145,9 @@ prettyRecord lvl sept fields =
   where
     prettyField (name, thing) = hang (pretty name <-> sept) 2 (pPrintPrec lvl 0 thing)
 
-prettyTuple :: (Pretty a) =>
+prettyStroct :: (Pretty a) =>
   PrettyLevel -> Doc ann -> [(FieldName, a)] -> Doc ann
-prettyTuple lvl sept fields =
+prettyStroct lvl sept fields =
   "<" <> sep (punctuate ";" (map prettyField fields)) <> ">"
   where
     prettyField (name, thing) = hang (pretty name <-> sept) 2 (pPrintPrec lvl 0 thing)
@@ -168,7 +168,7 @@ instance Pretty Type where
       in  maybeParens (prec > precTForall)
             (prettyForall <-> hsep (map (prettyAndKind lvl) vs) <> "."
              <-> pPrintPrec lvl precTForall t1)
-    TTuple fields -> prettyTuple lvl prettyHasType fields
+    TStroct fields -> prettyStroct lvl prettyHasType fields
     TNat n -> integer (fromTypeLevelNat n)
 
 precEApp, precEAbs :: Rational
@@ -417,14 +417,14 @@ instance Pretty Expr where
         (map TyArg targs ++ [TmArg arg])
     EEnumCon tcon con ->
       pretty tcon <> ":" <> pretty con
-    ETupleCon fields ->
-      prettyTuple lvl "=" fields
-    ETupleProj field expr -> pPrintPrec lvl precHighest expr <> "." <> pretty field
-    ETupleUpd field tuple update ->
+    EStroctCon fields ->
+      prettyStroct lvl "=" fields
+    EStroctProj field expr -> pPrintPrec lvl precHighest expr <> "." <> pretty field
+    EStroctUpd field stroct update ->
           "<" <> updDoc <> ">"
       where
         updDoc = sep
-          [ pPrintPrec lvl 0 tuple
+          [ pPrintPrec lvl 0 stroct
           , keyword_ "with"
           , hang (pretty field <-> "=") 2 (pPrintPrec lvl 0 update)
           ]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -145,9 +145,9 @@ prettyRecord lvl sept fields =
   where
     prettyField (name, thing) = hang (pretty name <-> sept) 2 (pPrintPrec lvl 0 thing)
 
-prettyStroct :: (Pretty a) =>
+prettyStruct :: (Pretty a) =>
   PrettyLevel -> Doc ann -> [(FieldName, a)] -> Doc ann
-prettyStroct lvl sept fields =
+prettyStruct lvl sept fields =
   "<" <> sep (punctuate ";" (map prettyField fields)) <> ">"
   where
     prettyField (name, thing) = hang (pretty name <-> sept) 2 (pPrintPrec lvl 0 thing)
@@ -168,7 +168,7 @@ instance Pretty Type where
       in  maybeParens (prec > precTForall)
             (prettyForall <-> hsep (map (prettyAndKind lvl) vs) <> "."
              <-> pPrintPrec lvl precTForall t1)
-    TStroct fields -> prettyStroct lvl prettyHasType fields
+    TStruct fields -> prettyStruct lvl prettyHasType fields
     TNat n -> integer (fromTypeLevelNat n)
 
 precEApp, precEAbs :: Rational
@@ -417,14 +417,14 @@ instance Pretty Expr where
         (map TyArg targs ++ [TmArg arg])
     EEnumCon tcon con ->
       pretty tcon <> ":" <> pretty con
-    EStroctCon fields ->
-      prettyStroct lvl "=" fields
-    EStroctProj field expr -> pPrintPrec lvl precHighest expr <> "." <> pretty field
-    EStroctUpd field stroct update ->
+    EStructCon fields ->
+      prettyStruct lvl "=" fields
+    EStructProj field expr -> pPrintPrec lvl precHighest expr <> "." <> pretty field
+    EStructUpd field struct update ->
           "<" <> updDoc <> ">"
       where
         updDoc = sep
-          [ pPrintPrec lvl 0 stroct
+          [ pPrintPrec lvl 0 struct
           , keyword_ "with"
           , hang (pretty field <-> "=") 2 (pPrintPrec lvl 0 update)
           ]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -27,9 +27,9 @@ data ExprF expr
   | ERecUpdF     !TypeConApp !FieldName !expr !expr
   | EVariantConF !TypeConApp !VariantConName !expr
   | EEnumConF    !(Qualified TypeConName) !VariantConName
-  | EStroctConF  ![(FieldName, expr)]
-  | EStroctProjF !FieldName !expr
-  | EStroctUpdF  !FieldName !expr !expr
+  | EStructConF  ![(FieldName, expr)]
+  | EStructProjF !FieldName !expr
+  | EStructUpdF  !FieldName !expr !expr
   | ETmAppF      !expr !expr
   | ETyAppF      !expr !Type
   | ETmLamF      !(ExprVarName, Type) !expr
@@ -159,9 +159,9 @@ instance Recursive Expr where
     ERecUpd   a b c d -> ERecUpdF     a b c d
     EVariantCon a b c -> EVariantConF   a b c
     EEnumCon    a b   -> EEnumConF      a b
-    EStroctCon  a     -> EStroctConF    a
-    EStroctProj a b   -> EStroctProjF   a b
-    EStroctUpd  a b c -> EStroctUpdF    a b c
+    EStructCon  a     -> EStructConF    a
+    EStructProj a b   -> EStructProjF   a b
+    EStructUpd  a b c -> EStructUpdF    a b c
     ETmApp      a b   -> ETmAppF        a b
     ETyApp      a b   -> ETyAppF        a b
     ETmLam      a b   -> ETmLamF        a b
@@ -189,9 +189,9 @@ instance Corecursive Expr where
     ERecUpdF   a b c d -> ERecUpd     a b c d
     EVariantConF a b c -> EVariantCon   a b c
     EEnumConF    a b   -> EEnumCon      a b
-    EStroctConF  a     -> EStroctCon    a
-    EStroctProjF a b   -> EStroctProj   a b
-    EStroctUpdF  a b c -> EStroctUpd    a b c
+    EStructConF  a     -> EStructCon    a
+    EStructProjF a b   -> EStructProj   a b
+    EStructUpdF  a b c -> EStructUpd    a b c
     ETmAppF      a b   -> ETmApp        a b
     ETyAppF      a b   -> ETyApp        a b
     ETmLamF      a b   -> ETmLam        a b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -27,9 +27,9 @@ data ExprF expr
   | ERecUpdF     !TypeConApp !FieldName !expr !expr
   | EVariantConF !TypeConApp !VariantConName !expr
   | EEnumConF    !(Qualified TypeConName) !VariantConName
-  | ETupleConF   ![(FieldName, expr)]
-  | ETupleProjF  !FieldName !expr
-  | ETupleUpdF   !FieldName !expr !expr
+  | EStroctConF  ![(FieldName, expr)]
+  | EStroctProjF !FieldName !expr
+  | EStroctUpdF  !FieldName !expr !expr
   | ETmAppF      !expr !expr
   | ETyAppF      !expr !Type
   | ETmLamF      !(ExprVarName, Type) !expr
@@ -159,9 +159,9 @@ instance Recursive Expr where
     ERecUpd   a b c d -> ERecUpdF     a b c d
     EVariantCon a b c -> EVariantConF   a b c
     EEnumCon    a b   -> EEnumConF      a b
-    ETupleCon   a     -> ETupleConF     a
-    ETupleProj  a b   -> ETupleProjF    a b
-    ETupleUpd   a b c -> ETupleUpdF     a b c
+    EStroctCon  a     -> EStroctConF    a
+    EStroctProj a b   -> EStroctProjF   a b
+    EStroctUpd  a b c -> EStroctUpdF    a b c
     ETmApp      a b   -> ETmAppF        a b
     ETyApp      a b   -> ETyAppF        a b
     ETmLam      a b   -> ETmLamF        a b
@@ -189,9 +189,9 @@ instance Corecursive Expr where
     ERecUpdF   a b c d -> ERecUpd     a b c d
     EVariantConF a b c -> EVariantCon   a b c
     EEnumConF    a b   -> EEnumCon      a b
-    ETupleConF   a     -> ETupleCon     a
-    ETupleProjF  a b   -> ETupleProj    a b
-    ETupleUpdF   a b c -> ETupleUpd     a b c
+    EStroctConF  a     -> EStroctCon    a
+    EStroctProjF a b   -> EStroctProj   a b
+    EStroctUpdF  a b c -> EStroctUpd    a b c
     ETmAppF      a b   -> ETmApp        a b
     ETyAppF      a b   -> ETyApp        a b
     ETmLamF      a b   -> ETmLam        a b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -30,7 +30,7 @@ freeVars e = go Set.empty e Set.empty
         TApp s1 s2 -> go boundVars s1 $ go boundVars s2 acc
         TBuiltin _ -> acc
         TForall (v, _k) s -> go (Set.insert v boundVars) s acc
-        TStroct fs -> foldl' (\acc (_, t) -> go boundVars t acc) acc fs
+        TStruct fs -> foldl' (\acc (_, t) -> go boundVars t acc) acc fs
         TNat _ -> Set.empty
 
 -- | Auxiliary data structure to track bound variables in the test for alpha
@@ -68,7 +68,7 @@ alphaEquiv = go (AlphaEnv 0 Map.empty Map.empty)
               , binderDepthRhs = Map.insert v2 currentDepth binderDepthRhs
               }
         in  k1 == k2 && go env1 t1 t2
-      (TStroct fs1, TStroct fs2)
+      (TStruct fs1, TStruct fs2)
         | Just bs <- zipWithExactMay agree (sortOn fst fs1) (sortOn fst fs2) ->
             and bs
         where
@@ -105,7 +105,7 @@ substitute subst = go (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.emp
                 subst1 = Map.insert v0 (TVar v1) subst0
             in  TForall (v1, k) (go fvSubst1 subst1 t)
         | otherwise -> TForall (v0, k) (go fvSubst0 (Map.delete v0 subst0) t)
-      TStroct fs -> TStroct (map (second go0) fs)
+      TStruct fs -> TStruct (map (second go0) fs)
       TNat n -> TNat n
       where
         go0 = go fvSubst0 subst0

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -30,7 +30,7 @@ freeVars e = go Set.empty e Set.empty
         TApp s1 s2 -> go boundVars s1 $ go boundVars s2 acc
         TBuiltin _ -> acc
         TForall (v, _k) s -> go (Set.insert v boundVars) s acc
-        TTuple fs -> foldl' (\acc (_, t) -> go boundVars t acc) acc fs
+        TStroct fs -> foldl' (\acc (_, t) -> go boundVars t acc) acc fs
         TNat _ -> Set.empty
 
 -- | Auxiliary data structure to track bound variables in the test for alpha
@@ -68,7 +68,7 @@ alphaEquiv = go (AlphaEnv 0 Map.empty Map.empty)
               , binderDepthRhs = Map.insert v2 currentDepth binderDepthRhs
               }
         in  k1 == k2 && go env1 t1 t2
-      (TTuple fs1, TTuple fs2)
+      (TStroct fs1, TStroct fs2)
         | Just bs <- zipWithExactMay agree (sortOn fst fs1) (sortOn fst fs2) ->
             and bs
         where
@@ -105,7 +105,7 @@ substitute subst = go (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.emp
                 subst1 = Map.insert v0 (TVar v1) subst0
             in  TForall (v1, k) (go fvSubst1 subst1 t)
         | otherwise -> TForall (v0, k) (go fvSubst0 (Map.delete v0 subst0) t)
-      TTuple fs -> TTuple (map (second go0) fs)
+      TStroct fs -> TStroct (map (second go0) fs)
       TNat n -> TNat n
       where
         go0 = go fvSubst0 subst0

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -182,7 +182,7 @@ pattern TGenMap :: Type -> Type -> Type
 pattern TGenMap t1 t2 = TApp (TApp (TBuiltin BTGenMap) t1) t2
 
 pattern TTextMapEntry :: Type -> Type
-pattern TTextMapEntry a = TStroct [(FieldName "key", TText), (FieldName "value", a)]
+pattern TTextMapEntry a = TStruct [(FieldName "key", TText), (FieldName "value", a)]
 
 pattern TConApp :: Qualified TypeConName -> [Type] -> Type
 pattern TConApp tcon targs <- (view (leftSpine _TApp) -> (TCon tcon, targs))

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -182,7 +182,7 @@ pattern TGenMap :: Type -> Type -> Type
 pattern TGenMap t1 t2 = TApp (TApp (TBuiltin BTGenMap) t1) t2
 
 pattern TTextMapEntry :: Type -> Type
-pattern TTextMapEntry a = TTuple [(FieldName "key", TText), (FieldName "value", a)]
+pattern TTextMapEntry a = TStroct [(FieldName "key", TText), (FieldName "value", a)]
 
 pattern TConApp :: Qualified TypeConName -> [Type] -> Type
 pattern TConApp tcon targs <- (view (leftSpine _TApp) -> (TCon tcon, targs))

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -466,18 +466,18 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     EEnumCon
       <$> mayDecode "Expr_EnumConTycon" mbTypeCon decodeTypeConName
       <*> decodeName VariantConName dataCon
-  LF1.ExprSumTupleCon (LF1.Expr_TupleCon fields) ->
-    ETupleCon
+  LF1.ExprSumStroctCon (LF1.Expr_StroctCon fields) ->
+    EStroctCon
       <$> mapM decodeFieldWithExpr (V.toList fields)
-  LF1.ExprSumTupleProj (LF1.Expr_TupleProj field mbTuple) ->
-    ETupleProj
+  LF1.ExprSumStroctProj (LF1.Expr_StroctProj field mbStroct) ->
+    EStroctProj
       <$> decodeName FieldName field
-      <*> mayDecode "Expr_TupleProjTuple" mbTuple decodeExpr
-  LF1.ExprSumTupleUpd (LF1.Expr_TupleUpd field mbTuple mbUpdate) ->
-    ETupleUpd
+      <*> mayDecode "Expr_StroctProjStroct" mbStroct decodeExpr
+  LF1.ExprSumStroctUpd (LF1.Expr_StroctUpd field mbStroct mbUpdate) ->
+    EStroctUpd
       <$> decodeName FieldName field
-      <*> mayDecode "Expr_TupleUpdTuple" mbTuple decodeExpr
-      <*> mayDecode "Expr_TupleUpdUpdate" mbUpdate decodeExpr
+      <*> mayDecode "Expr_StroctUpdStroct" mbStroct decodeExpr
+      <*> mayDecode "Expr_StroctUpdUpdate" mbUpdate decodeExpr
   LF1.ExprSumApp (LF1.Expr_App mbFun args) -> do
     fun <- mayDecode "Expr_AppFun" mbFun decodeExpr
     foldl' ETmApp fun <$> mapM decodeExpr (V.toList args)
@@ -720,8 +720,8 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumForall (LF1.Type_Forall binders mbBody) -> do
     body <- mayDecode "type_ForAllBody" mbBody decodeType
     foldr TForall body <$> traverse decodeTypeVarWithKind (V.toList binders)
-  LF1.TypeSumTuple (LF1.Type_Tuple flds) ->
-    TTuple <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
+  LF1.TypeSumStroct (LF1.Type_Stroct flds) ->
+    TStroct <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
   where
     decodeWithArgs :: V.Vector LF1.Type -> Decode Type -> Decode Type
     decodeWithArgs args fun = foldl TApp <$> fun <*> traverse decodeType args

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -466,18 +466,18 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     EEnumCon
       <$> mayDecode "Expr_EnumConTycon" mbTypeCon decodeTypeConName
       <*> decodeName VariantConName dataCon
-  LF1.ExprSumStroctCon (LF1.Expr_StroctCon fields) ->
-    EStroctCon
+  LF1.ExprSumStructCon (LF1.Expr_StructCon fields) ->
+    EStructCon
       <$> mapM decodeFieldWithExpr (V.toList fields)
-  LF1.ExprSumStroctProj (LF1.Expr_StroctProj field mbStroct) ->
-    EStroctProj
+  LF1.ExprSumStructProj (LF1.Expr_StructProj field mbStruct) ->
+    EStructProj
       <$> decodeName FieldName field
-      <*> mayDecode "Expr_StroctProjStroct" mbStroct decodeExpr
-  LF1.ExprSumStroctUpd (LF1.Expr_StroctUpd field mbStroct mbUpdate) ->
-    EStroctUpd
+      <*> mayDecode "Expr_StructProjStruct" mbStruct decodeExpr
+  LF1.ExprSumStructUpd (LF1.Expr_StructUpd field mbStruct mbUpdate) ->
+    EStructUpd
       <$> decodeName FieldName field
-      <*> mayDecode "Expr_StroctUpdStroct" mbStroct decodeExpr
-      <*> mayDecode "Expr_StroctUpdUpdate" mbUpdate decodeExpr
+      <*> mayDecode "Expr_StructUpdStruct" mbStruct decodeExpr
+      <*> mayDecode "Expr_StructUpdUpdate" mbUpdate decodeExpr
   LF1.ExprSumApp (LF1.Expr_App mbFun args) -> do
     fun <- mayDecode "Expr_AppFun" mbFun decodeExpr
     foldl' ETmApp fun <$> mapM decodeExpr (V.toList args)
@@ -720,8 +720,8 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumForall (LF1.Type_Forall binders mbBody) -> do
     body <- mayDecode "type_ForAllBody" mbBody decodeType
     foldr TForall body <$> traverse decodeTypeVarWithKind (V.toList binders)
-  LF1.TypeSumStroct (LF1.Type_Stroct flds) ->
-    TStroct <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
+  LF1.TypeSumStruct (LF1.Type_Struct flds) ->
+    TStruct <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
   where
     decodeWithArgs :: V.Vector LF1.Type -> Decode Type -> Decode Type
     decodeWithArgs args fun = foldl TApp <$> fun <*> traverse decodeType args

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -298,16 +298,16 @@ encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
         type_ForallVars <- encodeTypeVarsWithKinds binders
         type_ForallBody <- encodeType body
         pure $ P.TypeSumForall P.Type_Forall{..}
-    (TStroct flds, []) -> do
-        type_StroctFields <- encodeFieldsWithTypes unFieldName flds
-        pure $ P.TypeSumStroct P.Type_Stroct{..}
+    (TStruct flds, []) -> do
+        type_StructFields <- encodeFieldsWithTypes unFieldName flds
+        pure $ P.TypeSumStruct P.Type_Struct{..}
 
     (TNat n, _) ->
         pure $ P.TypeSumNat (fromTypeLevelNat n)
 
     (TApp{}, _) -> error "TApp after unwinding TApp"
     -- NOTE(MH): The following case is ill-kinded.
-    (TStroct{}, _:_) -> error "Application of TStroct"
+    (TStruct{}, _:_) -> error "Application of TStruct"
     -- NOTE(MH): The following case requires impredicative polymorphism,
     -- which we don't support.
     (TForall{}, _:_) -> error "Application of TForall"
@@ -514,18 +514,18 @@ encodeExpr' = \case
         expr_EnumConTycon <- encodeQualTypeConName enumTypeCon
         expr_EnumConEnumCon <- encodeName unVariantConName enumDataCon
         pureExpr $ P.ExprSumEnumCon P.Expr_EnumCon{..}
-    EStroctCon{..} -> do
-        expr_StroctConFields <- encodeFieldsWithExprs unFieldName stroctFields
-        pureExpr $ P.ExprSumStroctCon P.Expr_StroctCon{..}
-    EStroctProj{..} -> do
-        expr_StroctProjField <- encodeName unFieldName stroctField
-        expr_StroctProjStroct <- encodeExpr stroctExpr
-        pureExpr $ P.ExprSumStroctProj P.Expr_StroctProj{..}
-    EStroctUpd{..} -> do
-        expr_StroctUpdField <- encodeName unFieldName stroctField
-        expr_StroctUpdStroct <- encodeExpr stroctExpr
-        expr_StroctUpdUpdate <- encodeExpr stroctUpdate
-        pureExpr $ P.ExprSumStroctUpd P.Expr_StroctUpd{..}
+    EStructCon{..} -> do
+        expr_StructConFields <- encodeFieldsWithExprs unFieldName structFields
+        pureExpr $ P.ExprSumStructCon P.Expr_StructCon{..}
+    EStructProj{..} -> do
+        expr_StructProjField <- encodeName unFieldName structField
+        expr_StructProjStruct <- encodeExpr structExpr
+        pureExpr $ P.ExprSumStructProj P.Expr_StructProj{..}
+    EStructUpd{..} -> do
+        expr_StructUpdField <- encodeName unFieldName structField
+        expr_StructUpdStruct <- encodeExpr structExpr
+        expr_StructUpdUpdate <- encodeExpr structUpdate
+        pureExpr $ P.ExprSumStructUpd P.Expr_StructUpd{..}
     e@ETmApp{} -> do
         let (fun, args) = e ^. _ETmApps
         expr_AppFun <- encodeExpr fun

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -298,16 +298,16 @@ encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
         type_ForallVars <- encodeTypeVarsWithKinds binders
         type_ForallBody <- encodeType body
         pure $ P.TypeSumForall P.Type_Forall{..}
-    (TTuple flds, []) -> do
-        type_TupleFields <- encodeFieldsWithTypes unFieldName flds
-        pure $ P.TypeSumTuple P.Type_Tuple{..}
+    (TStroct flds, []) -> do
+        type_StroctFields <- encodeFieldsWithTypes unFieldName flds
+        pure $ P.TypeSumStroct P.Type_Stroct{..}
 
     (TNat n, _) ->
         pure $ P.TypeSumNat (fromTypeLevelNat n)
 
     (TApp{}, _) -> error "TApp after unwinding TApp"
     -- NOTE(MH): The following case is ill-kinded.
-    (TTuple{}, _:_) -> error "Application of TTuple"
+    (TStroct{}, _:_) -> error "Application of TStroct"
     -- NOTE(MH): The following case requires impredicative polymorphism,
     -- which we don't support.
     (TForall{}, _:_) -> error "Application of TForall"
@@ -514,18 +514,18 @@ encodeExpr' = \case
         expr_EnumConTycon <- encodeQualTypeConName enumTypeCon
         expr_EnumConEnumCon <- encodeName unVariantConName enumDataCon
         pureExpr $ P.ExprSumEnumCon P.Expr_EnumCon{..}
-    ETupleCon{..} -> do
-        expr_TupleConFields <- encodeFieldsWithExprs unFieldName tupFields
-        pureExpr $ P.ExprSumTupleCon P.Expr_TupleCon{..}
-    ETupleProj{..} -> do
-        expr_TupleProjField <- encodeName unFieldName tupField
-        expr_TupleProjTuple <- encodeExpr tupExpr
-        pureExpr $ P.ExprSumTupleProj P.Expr_TupleProj{..}
-    ETupleUpd{..} -> do
-        expr_TupleUpdField <- encodeName unFieldName tupField
-        expr_TupleUpdTuple <- encodeExpr tupExpr
-        expr_TupleUpdUpdate <- encodeExpr tupUpdate
-        pureExpr $ P.ExprSumTupleUpd P.Expr_TupleUpd{..}
+    EStroctCon{..} -> do
+        expr_StroctConFields <- encodeFieldsWithExprs unFieldName stroctFields
+        pureExpr $ P.ExprSumStroctCon P.Expr_StroctCon{..}
+    EStroctProj{..} -> do
+        expr_StroctProjField <- encodeName unFieldName stroctField
+        expr_StroctProjStroct <- encodeExpr stroctExpr
+        pureExpr $ P.ExprSumStroctProj P.Expr_StroctProj{..}
+    EStroctUpd{..} -> do
+        expr_StroctUpdField <- encodeName unFieldName stroctField
+        expr_StroctUpdStroct <- encodeExpr stroctExpr
+        expr_StroctUpdUpdate <- encodeExpr stroctUpdate
+        pureExpr $ P.ExprSumStroctUpd P.Expr_StroctUpd{..}
     e@ETmApp{} -> do
         let (fun, args) = e ^. _ETmApps
         expr_AppFun <- encodeExpr fun

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
@@ -48,8 +48,8 @@ instance EitherLike TL.Text Int32 P.DefTemplateParam
 instance EitherLike TL.Text Int32 P.Expr_EnumConEnumCon
 instance EitherLike TL.Text Int32 P.Expr_RecProjField
 instance EitherLike TL.Text Int32 P.Expr_RecUpdField
-instance EitherLike TL.Text Int32 P.Expr_StroctProjField
-instance EitherLike TL.Text Int32 P.Expr_StroctUpdField
+instance EitherLike TL.Text Int32 P.Expr_StructProjField
+instance EitherLike TL.Text Int32 P.Expr_StructUpdField
 instance EitherLike TL.Text Int32 P.Expr_VariantConVariantCon
 instance EitherLike TL.Text Int32 P.FieldWithExprField
 instance EitherLike TL.Text Int32 P.FieldWithTypeField

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Util.hs
@@ -48,8 +48,8 @@ instance EitherLike TL.Text Int32 P.DefTemplateParam
 instance EitherLike TL.Text Int32 P.Expr_EnumConEnumCon
 instance EitherLike TL.Text Int32 P.Expr_RecProjField
 instance EitherLike TL.Text Int32 P.Expr_RecUpdField
-instance EitherLike TL.Text Int32 P.Expr_TupleProjField
-instance EitherLike TL.Text Int32 P.Expr_TupleUpdField
+instance EitherLike TL.Text Int32 P.Expr_StroctProjField
+instance EitherLike TL.Text Int32 P.Expr_StroctUpdField
 instance EitherLike TL.Text Int32 P.Expr_VariantConVariantCon
 instance EitherLike TL.Text Int32 P.FieldWithExprField
 instance EitherLike TL.Text Int32 P.FieldWithTypeField

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -44,9 +44,9 @@ freeVarsStep = \case
   ERecUpdF _ _ s1 s2 -> s1 <> s2
   EVariantConF _ _ s -> s
   EEnumConF _ _ -> Set.empty
-  ETupleConF fs -> foldMap snd fs
-  ETupleProjF _ s -> s
-  ETupleUpdF _ s1 s2 -> s1 <> s2
+  EStroctConF fs -> foldMap snd fs
+  EStroctProjF _ s -> s
+  EStroctUpdF _ s1 s2 -> s1 <> s2
   ETmAppF s1 s2 -> s1 <> s2
   ETyAppF s _ -> s
   ETmLamF (x, _) s -> x `Set.delete` s
@@ -188,9 +188,9 @@ safetyStep = \case
   ERecUpdF _ _ s1 s2 -> s1 `min` s2 `min` Safe 0
   EVariantConF _ _ s -> s `min` Safe 0
   EEnumConF _ _ -> Safe 0
-  ETupleConF fs -> minimum (Safe 0 : map snd fs)
-  ETupleProjF _ s -> s `min` Safe 0
-  ETupleUpdF _ s1 s2 -> s1 `min` s2 `min` Safe 0
+  EStroctConF fs -> minimum (Safe 0 : map snd fs)
+  EStroctProjF _ s -> s `min` Safe 0
+  EStroctUpdF _ s1 s2 -> s1 `min` s2 `min` Safe 0
   ETmAppF s1 s2 ->
     case s2 of
       Unsafe -> Unsafe
@@ -236,7 +236,7 @@ simplifyExpr = fst . cata go
     go :: ExprF (Expr, Info) -> (Expr, Info)
     go = \case
       -- <...; f = e; ...>.f    ==>    e
-      ETupleProjF f (ETupleCon fes, s)
+      EStroctProjF f (EStroctCon fes, s)
         -- NOTE(MH): We're deliberately overapproximating the potential of
         -- bottoms and the set of free variables below to avoid recomputing
         -- them.
@@ -251,20 +251,20 @@ simplifyExpr = fst . cata go
         | x == x' -> e
 
       -- let x = <...; f = e; ...> in x.f    ==>    e
-      ELetF (BindingF (x, _) (ETupleCon fes, s)) (ETupleProj f (EVar x'), _)
+      ELetF (BindingF (x, _) (EStroctCon fes, s)) (EStroctProj f (EVar x'), _)
         -- NOTE(MH): See NOTE above on @s@.
         | x == x', Safe _ <- safety s, Just e <- f `lookup` fes -> (e, s)
 
       -- let x = <f1 = e1; ...; fn = en> in T {f1 = x.f1; ...; fn = x.fn}
       -- ==>
       -- T {f1 = e1; ...; fn = en}
-      ELetF (BindingF (x1, _) (ETupleCon fes1, s)) (ERecCon t fes2, _)
+      ELetF (BindingF (x1, _) (EStroctCon fes1, s)) (ERecCon t fes2, _)
         | Just bs <- Safe.zipWithExactMay matchField fes1 fes2
         , and bs ->
             (ERecCon t fes1, s)
         where
           matchField (f1, _) (f2, e2)
-            | f1 == f2, ETupleProj f3 (EVar x3) <- e2, f1 == f3, x1 == x3 = True
+            | f1 == f2, EStroctProj f3 (EVar x3) <- e2, f1 == f3, x1 == x3 = True
             | otherwise = False
 
       -- let x = e1 in e2    ==>    e2, if e1 cannot be bottom and x is not free in e2
@@ -278,8 +278,8 @@ simplifyExpr = fst . cata go
       --   `fv(e2) ⊆ V ∪ {x}`.
       -- - If `let x = e1 in e2` is k-safe, then `e1` is 0-safe and `e2` is
       --   k-safe.
-      ETupleProjF f (ELet (Binding (x, t) e1) e2, Info fv sf) ->
-        go $ ELetF (BindingF (x, t) (e1, s1)) (go $ ETupleProjF f (e2, s2))
+      EStroctProjF f (ELet (Binding (x, t) e1) e2, Info fv sf) ->
+        go $ ELetF (BindingF (x, t) (e1, s1)) (go $ EStroctProjF f (e2, s2))
         where
           s1 = Info fv (sf `min` Safe 0)
           s2 = Info (Set.insert x fv) sf

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -141,7 +141,7 @@ kindOf = \case
     pure resKind
   TBuiltin btype -> pure (kindOfBuiltin btype)
   TForall (v, k) t1 -> introTypeVar v k $ checkType t1 KStar $> KStar
-  TTuple recordType -> checkRecordType recordType $> KStar
+  TStroct recordType -> checkRecordType recordType $> KStar
   TNat _ -> pure KNat
 
 typeOfBuiltin :: MonadGamma m => BuiltinExpr -> m Type
@@ -278,22 +278,22 @@ typeOfRecUpd typ0 field record update = do
   checkExpr update fieldType
   pure typ1
 
-typeOfTupleCon :: MonadGamma m => [(FieldName, Expr)] -> m Type
-typeOfTupleCon recordExpr = do
+typeOfStroctCon :: MonadGamma m => [(FieldName, Expr)] -> m Type
+typeOfStroctCon recordExpr = do
   checkUnique EDuplicateField (map fst recordExpr)
-  TTuple <$> (traverse . _2) typeOf recordExpr
+  TStroct <$> (traverse . _2) typeOf recordExpr
 
-typeOfTupleProj :: MonadGamma m => FieldName -> Expr -> m Type
-typeOfTupleProj field expr = do
+typeOfStroctProj :: MonadGamma m => FieldName -> Expr -> m Type
+typeOfStroctProj field expr = do
   typ <- typeOf expr
-  tupleType <- match _TTuple (EExpectedTupleType typ) typ
-  match _Just (EUnknownField field) (lookup field tupleType)
+  stroctType <- match _TStroct (EExpectedStroctType typ) typ
+  match _Just (EUnknownField field) (lookup field stroctType)
 
-typeOfTupleUpd :: MonadGamma m => FieldName -> Expr -> Expr -> m Type
-typeOfTupleUpd field tuple update = do
-  typ <- typeOf tuple
-  tupleType <- match _TTuple (EExpectedTupleType typ) typ
-  fieldType <- match _Just (EUnknownField field) (lookup field tupleType)
+typeOfStroctUpd :: MonadGamma m => FieldName -> Expr -> Expr -> m Type
+typeOfStroctUpd field stroct update = do
+  typ <- typeOf stroct
+  stroctType <- match _TStroct (EExpectedStroctType typ) typ
+  fieldType <- match _Just (EUnknownField field) (lookup field stroctType)
   checkExpr update fieldType
   pure typ
 
@@ -456,7 +456,7 @@ typeOfUpdate = \case
     return (TUpdate typ)
   UFetchByKey retrieveByKey -> do
     (cidType, contractType) <- checkRetrieveByKey retrieveByKey
-    return (TUpdate (TTuple [(FieldName "contractId", cidType), (FieldName "contract", contractType)]))
+    return (TUpdate (TStroct [(FieldName "contractId", cidType), (FieldName "contract", contractType)]))
   ULookupByKey retrieveByKey -> do
     (cidType, _contractType) <- checkRetrieveByKey retrieveByKey
     return (TUpdate (TOptional cidType))
@@ -498,9 +498,9 @@ typeOf = \case
   ERecUpd typ field record update -> typeOfRecUpd typ field record update
   EVariantCon typ con arg -> checkVariantCon typ con arg $> typeConAppToType typ
   EEnumCon typ con -> checkEnumCon typ con $> TCon typ
-  ETupleCon recordExpr -> typeOfTupleCon recordExpr
-  ETupleProj field expr -> typeOfTupleProj field expr
-  ETupleUpd field tuple update -> typeOfTupleUpd field tuple update
+  EStroctCon recordExpr -> typeOfStroctCon recordExpr
+  EStroctProj field expr -> typeOfStroctProj field expr
+  EStroctUpd field stroct update -> typeOfStroctUpd field stroct update
   ETmApp fun arg -> typeOfTmApp fun arg
   ETyApp expr typ -> typeOfTyApp expr typ
   ETmLam binder body -> typeOfTmLam binder body

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -49,7 +49,7 @@ data UnserializabilityReason
   | URForall  -- ^ It has higher rank.
   | URUpdate  -- ^ It contains an update action.
   | URScenario  -- ^ It contains a scenario action.
-  | URTuple  -- ^ It contains a structural record.
+  | URStroct  -- ^ It contains a structural record.
   | URList  -- ^ It contains an unapplied list type constructor.
   | UROptional  -- ^ It contains an unapplied optional type constructor.
   | URMap  -- ^ It contains an unapplied map type constructor.
@@ -82,7 +82,7 @@ data Error
   | EExpectedEnumType      !(Qualified TypeConName)
   | EUnknownDataCon        !VariantConName
   | EUnknownField          !FieldName
-  | EExpectedTupleType     !Type
+  | EExpectedStroctType     !Type
   | EKindMismatch          {foundKind :: !Kind, expectedKind :: !Kind}
   | ETypeMismatch          {foundType :: !Type, expectedType :: !Type, expr :: !(Maybe Expr)}
   | EExpectedHigherKind    !Kind
@@ -156,7 +156,7 @@ instance Pretty UnserializabilityReason where
     URForall -> "higher-ranked type"
     URUpdate -> "Update"
     URScenario -> "Scenario"
-    URTuple -> "structual record"
+    URStroct -> "structual record"
     URList -> "unapplied List"
     UROptional -> "unapplied Optional"
     URMap -> "unapplied Map"
@@ -205,8 +205,8 @@ instance Pretty Error where
     EExpectedEnumType qname -> "expected enum type: " <> pretty qname
     EUnknownDataCon name -> "unknown data constructor: " <> pretty name
     EUnknownField name -> "unknown field: " <> pretty name
-    EExpectedTupleType foundType ->
-      "expected tuple type, but found: " <> pretty foundType
+    EExpectedStroctType foundType ->
+      "expected stroct type, but found: " <> pretty foundType
 
     ETypeMismatch{foundType, expectedType, expr} ->
       vcat $

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -49,7 +49,7 @@ data UnserializabilityReason
   | URForall  -- ^ It has higher rank.
   | URUpdate  -- ^ It contains an update action.
   | URScenario  -- ^ It contains a scenario action.
-  | URStroct  -- ^ It contains a structural record.
+  | URStruct  -- ^ It contains a structural record.
   | URList  -- ^ It contains an unapplied list type constructor.
   | UROptional  -- ^ It contains an unapplied optional type constructor.
   | URMap  -- ^ It contains an unapplied map type constructor.
@@ -82,7 +82,7 @@ data Error
   | EExpectedEnumType      !(Qualified TypeConName)
   | EUnknownDataCon        !VariantConName
   | EUnknownField          !FieldName
-  | EExpectedStroctType     !Type
+  | EExpectedStructType     !Type
   | EKindMismatch          {foundKind :: !Kind, expectedKind :: !Kind}
   | ETypeMismatch          {foundType :: !Type, expectedType :: !Type, expr :: !(Maybe Expr)}
   | EExpectedHigherKind    !Kind
@@ -156,7 +156,7 @@ instance Pretty UnserializabilityReason where
     URForall -> "higher-ranked type"
     URUpdate -> "Update"
     URScenario -> "Scenario"
-    URStroct -> "structual record"
+    URStruct -> "structual record"
     URList -> "unapplied List"
     UROptional -> "unapplied Optional"
     URMap -> "unapplied Map"
@@ -205,8 +205,8 @@ instance Pretty Error where
     EExpectedEnumType qname -> "expected enum type: " <> pretty qname
     EUnknownDataCon name -> "unknown data constructor: " <> pretty name
     EUnknownField name -> "unknown field: " <> pretty name
-    EExpectedStroctType foundType ->
-      "expected stroct type, but found: " <> pretty foundType
+    EExpectedStructType foundType ->
+      "expected struct type, but found: " <> pretty foundType
 
     ETypeMismatch{foundType, expectedType, expr} ->
       vcat $

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -102,7 +102,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTAny -> Left URAny
         BTTypeRep -> Left URTypeRep
       TForall{} -> Left URForall
-      TTuple{} -> Left URTuple
+      TStroct{} -> Left URStroct
 
 -- | Determine whether a data type preserves serializability. When a module
 -- name is given, -- data types in this module are returned rather than lookup

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -102,7 +102,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTAny -> Left URAny
         BTTypeRep -> Left URTypeRep
       TForall{} -> Left URForall
-      TStroct{} -> Left URStroct
+      TStruct{} -> Left URStruct
 
 -- | Determine whether a data type preserves serializability. When a module
 -- name is given, -- data types in this module are returned rather than lookup

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -553,7 +553,7 @@ convType env =
                 [mkUserTyVar $ LF.unTypeVarName $ fst forallBinder]
                 (noLoc $ convType env forallBody)
         -- TODO (drsk): Is this the correct tuple type? What about the field names?
-        LF.TTuple fls ->
+        LF.TStroct fls ->
             HsTupleTy
                 noExt
                 HsBoxedTuple

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -553,7 +553,7 @@ convType env =
                 [mkUserTyVar $ LF.unTypeVarName $ fst forallBinder]
                 (noLoc $ convType env forallBody)
         -- TODO (drsk): Is this the correct tuple type? What about the field names?
-        LF.TStroct fls ->
+        LF.TStruct fls ->
             HsTupleTy
                 noExt
                 HsBoxedTuple

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -359,10 +359,10 @@ convertGenericTemplate env x
                         let tupleType = TypeConApp tupleTyCon [TContractId polyType, polyType]
                         let fetchByKey =
                                 ETmLam (mkVar "key", keyType) $
-                                EUpdate $ UBind (Binding (res, TStroct [(selfField, TContractId monoType), (thisField, monoType)]) $ EUpdate $ UFetchByKey $ RetrieveByKey monoTyCon $ EVar $ mkVar "key") $
+                                EUpdate $ UBind (Binding (res, TStruct [(selfField, TContractId monoType), (thisField, monoType)]) $ EUpdate $ UFetchByKey $ RetrieveByKey monoTyCon $ EVar $ mkVar "key") $
                                 EUpdate $ UPure (typeConAppToType tupleType) $ ERecCon tupleType
-                                    [ (FieldName "_1", unwrapCid $ EStroctProj selfField $ EVar res)
-                                    , (FieldName "_2", unwrapTpl $ EStroctProj thisField $ EVar res)
+                                    [ (FieldName "_1", unwrapCid $ EStructProj selfField $ EVar res)
+                                    , (FieldName "_2", unwrapTpl $ EStructProj thisField $ EVar res)
                                     ]
                         let lookupByKey =
                                 ETmLam (mkVar "key", keyType) $
@@ -748,9 +748,9 @@ convertExpr env0 e = do
             let fields = [(mkField f1, t1), (mkField f2, t2)]
             tupleTyCon <- qDA_Types env $ mkTypeCon ["Tuple" <> T.pack (show $ length fields)]
             let tupleType = TypeConApp tupleTyCon (map snd fields)
-            pure $ ETmLam (varV1, TStroct fields) $ ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields
+            pure $ ETmLam (varV1, TStruct fields) $ ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields
         where
-            mkFieldProj i (name, _typ) = (mkField ("_" <> T.pack (show i)), EStroctProj name (EVar varV1))
+            mkFieldProj i (name, _typ) = (mkField ("_" <> T.pack (show i)), EStructProj name (EVar varV1))
     go env (VarIn GHC_Types "primitive") (LType (isStrLitTy -> Just y) : LType t : args)
         = fmap (, args) $ convertPrim (envLfVersion env) (unpackFS y) <$> convertType env t
     go env (VarIn GHC_Types "external") (LType (isStrLitTy -> Just y) : LType t : args)
@@ -1418,7 +1418,7 @@ convertType env o@(TypeCon t ts)
     , [StrLitTy f1, StrLitTy f2, t1, t2] <- ts = do
         t1 <- convertType env t1
         t2 <- convertType env t2
-        pure $ TStroct [(mkField f1, t1), (mkField f2, t2)]
+        pure $ TStruct [(mkField f1, t1), (mkField f2, t2)]
     | tyConFlavour t == TypeSynonymFlavour = convertType env $ expandTypeSynonyms o
     | otherwise = mkTApps <$> convertTyCon env t <*> mapM (convertType env) ts
 convertType env t | Just (v, t') <- splitForAllTy_maybe t

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -596,7 +596,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
             )
             .build
         )
-      case V.ValueTuple(fields) =>
+      case V.ValueStroct(fields) =>
         builder.setTuple(
           Tuple.newBuilder
             .addAllFields(

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -596,7 +596,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
             )
             .build
         )
-      case V.ValueStroct(fields) =>
+      case V.ValueStruct(fields) =>
         builder.setTuple(
           Tuple.newBuilder
             .addAllFields(

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -346,8 +346,8 @@ message Type {
     Type body = 2;
   }
 
-  // Tuple type
-  message Tuple {
+  // Stroct type
+  message Stroct {
     // name of the field with their types.
     repeated FieldWithType fields = 1;
   }
@@ -358,7 +358,7 @@ message Type {
     Prim prim = 3; // FixMe: renamed
     Fun fun = 4;
     Forall forall = 5;
-    Tuple tuple = 7;
+    Stroct stroct = 7;
     // *Available in versions >= 1.7*
     // *Must be between 0 and 37 (bounds inclusive)*
     // use standard signed long for future usage.
@@ -656,14 +656,14 @@ message Expr {
     }
   }
 
-  // Tuple Construction ('ExpTupleCon')
-  message TupleCon {
+  // Stroct Construction ('ExpStroctCon')
+  message StroctCon {
     // Field names and their associated values.
     repeated FieldWithExpr fields = 1;
   }
 
-  // Tuple Projection ('ExpTupleProj')
-  message TupleProj {
+  // Stroct Projection ('ExpStroctProj')
+  message StroctProj {
 
     // Name of the field to be projected on.
     oneof field {
@@ -674,12 +674,12 @@ message Expr {
       int32 field_interned_str = 3; // *Available in versions >= 1.7*
     }
 
-    // tuple to be projected.
-    Expr tuple = 2;
+    // stroct to be projected.
+    Expr stroct = 2;
   }
 
-  // Tuple update ('ExpTuplUpdate')
-  message TupleUpd {
+  // Stroct update ('ExpTuplUpdate')
+  message StroctUpd {
 
     // Name of the updated field.
     oneof field {
@@ -690,8 +690,8 @@ message Expr {
       int32 field_interned_str = 4; // *Available in versions >= 1.7*
     }
 
-    // Actual tuple being updated.
-    Expr tuple = 2;
+    // Actual stroct being updated.
+    Expr stroct = 2;
 
     // Value to which the record is udpated.
     Expr update = 3;
@@ -838,14 +838,14 @@ message Expr {
     // Enum construction ('ExpEnumCon')
     EnumCon enum_con = 28; // *Available in versions >= 1.6*
 
-    // Tuple construction ('ExpTupleCon')
-    TupleCon tuple_con = 9;
+    // Stroct construction ('ExpStroctCon')
+    StroctCon stroct_con = 9;
 
-    // Tuple project ('ExpTupleProj')
-    TupleProj tuple_proj = 10;
+    // Stroct project ('ExpStroctProj')
+    StroctProj stroct_proj = 10;
 
-    // Tuple update ('ExpTupleUpdate')
-    TupleUpd tuple_upd = 23;
+    // Stroct update ('ExpStroctUpdate')
+    StroctUpd stroct_upd = 23;
 
     // Application ('ExpApp')
     App app = 11;

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -346,8 +346,8 @@ message Type {
     Type body = 2;
   }
 
-  // Stroct type
-  message Stroct {
+  // Struct type
+  message Struct {
     // name of the field with their types.
     repeated FieldWithType fields = 1;
   }
@@ -358,7 +358,7 @@ message Type {
     Prim prim = 3; // FixMe: renamed
     Fun fun = 4;
     Forall forall = 5;
-    Stroct stroct = 7;
+    Struct struct = 7;
     // *Available in versions >= 1.7*
     // *Must be between 0 and 37 (bounds inclusive)*
     // use standard signed long for future usage.
@@ -656,14 +656,14 @@ message Expr {
     }
   }
 
-  // Stroct Construction ('ExpStroctCon')
-  message StroctCon {
+  // Struct Construction ('ExpStructCon')
+  message StructCon {
     // Field names and their associated values.
     repeated FieldWithExpr fields = 1;
   }
 
-  // Stroct Projection ('ExpStroctProj')
-  message StroctProj {
+  // Struct Projection ('ExpStructProj')
+  message StructProj {
 
     // Name of the field to be projected on.
     oneof field {
@@ -674,12 +674,12 @@ message Expr {
       int32 field_interned_str = 3; // *Available in versions >= 1.7*
     }
 
-    // stroct to be projected.
-    Expr stroct = 2;
+    // struct to be projected.
+    Expr struct = 2;
   }
 
-  // Stroct update ('ExpTuplUpdate')
-  message StroctUpd {
+  // Struct update ('ExpTuplUpdate')
+  message StructUpd {
 
     // Name of the updated field.
     oneof field {
@@ -690,8 +690,8 @@ message Expr {
       int32 field_interned_str = 4; // *Available in versions >= 1.7*
     }
 
-    // Actual stroct being updated.
-    Expr stroct = 2;
+    // Actual struct being updated.
+    Expr struct = 2;
 
     // Value to which the record is udpated.
     Expr update = 3;
@@ -838,14 +838,14 @@ message Expr {
     // Enum construction ('ExpEnumCon')
     EnumCon enum_con = 28; // *Available in versions >= 1.6*
 
-    // Stroct construction ('ExpStroctCon')
-    StroctCon stroct_con = 9;
+    // Struct construction ('ExpStructCon')
+    StructCon struct_con = 9;
 
-    // Stroct project ('ExpStroctProj')
-    StroctProj stroct_proj = 10;
+    // Struct project ('ExpStructProj')
+    StructProj struct_proj = 10;
 
-    // Stroct update ('ExpStroctUpdate')
-    StroctUpd stroct_upd = 23;
+    // Struct update ('ExpStructUpdate')
+    StructUpd struct_upd = 23;
 
     // Application ('ExpApp')
     App app = 11;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -556,11 +556,11 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           assertNonEmpty(vars, "vars")
           (vars :\ decodeType(tForall.getBody))((binder, acc) =>
             TForall(decodeTypeVarWithKind(binder), acc))
-        case PLF.Type.SumCase.STROCT =>
-          val stroct = lfType.getStroct
-          val fields = stroct.getFieldsList.asScala
+        case PLF.Type.SumCase.STRUCT =>
+          val struct = lfType.getStruct
+          val fields = struct.getFieldsList.asScala
           assertNonEmpty(fields, "fields")
-          TStroct(fields.map(decodeFieldWithType)(breakOut))
+          TStruct(fields.map(decodeFieldWithType)(breakOut))
 
         case PLF.Type.SumCase.SUM_NOT_SET =>
           throw ParseError("Type.SUM_NOT_SET")
@@ -723,39 +723,39 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             )
           )
 
-        case PLF.Expr.SumCase.STROCT_CON =>
-          val stroctCon = lfExpr.getStroctCon
-          EStroctCon(
-            ImmArray(stroctCon.getFieldsList.asScala).map(decodeFieldWithExpr(_, definition))
+        case PLF.Expr.SumCase.STRUCT_CON =>
+          val structCon = lfExpr.getStructCon
+          EStructCon(
+            ImmArray(structCon.getFieldsList.asScala).map(decodeFieldWithExpr(_, definition))
           )
 
-        case PLF.Expr.SumCase.STROCT_PROJ =>
-          val stroctProj = lfExpr.getStroctProj
-          EStroctProj(
+        case PLF.Expr.SumCase.STRUCT_PROJ =>
+          val structProj = lfExpr.getStructProj
+          EStructProj(
             field = handleInternedName(
-              stroctProj.getFieldCase,
-              PLF.Expr.StroctProj.FieldCase.FIELD_STR,
-              stroctProj.getFieldStr,
-              PLF.Expr.StroctProj.FieldCase.FIELD_INTERNED_STR,
-              stroctProj.getFieldInternedStr,
-              "Expr.StroctProj.field.field"
+              structProj.getFieldCase,
+              PLF.Expr.StructProj.FieldCase.FIELD_STR,
+              structProj.getFieldStr,
+              PLF.Expr.StructProj.FieldCase.FIELD_INTERNED_STR,
+              structProj.getFieldInternedStr,
+              "Expr.StructProj.field.field"
             ),
-            stroct = decodeExpr(stroctProj.getStroct, definition)
+            struct = decodeExpr(structProj.getStruct, definition)
           )
 
-        case PLF.Expr.SumCase.STROCT_UPD =>
-          val stroctUpd = lfExpr.getStroctUpd
-          EStroctUpd(
+        case PLF.Expr.SumCase.STRUCT_UPD =>
+          val structUpd = lfExpr.getStructUpd
+          EStructUpd(
             field = handleInternedName(
-              stroctUpd.getFieldCase,
-              PLF.Expr.StroctUpd.FieldCase.FIELD_STR,
-              stroctUpd.getFieldStr,
-              PLF.Expr.StroctUpd.FieldCase.FIELD_INTERNED_STR,
-              stroctUpd.getFieldInternedStr,
-              "Expr.StroctUpd.field.field"
+              structUpd.getFieldCase,
+              PLF.Expr.StructUpd.FieldCase.FIELD_STR,
+              structUpd.getFieldStr,
+              PLF.Expr.StructUpd.FieldCase.FIELD_INTERNED_STR,
+              structUpd.getFieldInternedStr,
+              "Expr.StructUpd.field.field"
             ),
-            stroct = decodeExpr(stroctUpd.getStroct, definition),
-            update = decodeExpr(stroctUpd.getUpdate, definition)
+            struct = decodeExpr(structUpd.getStruct, definition),
+            update = decodeExpr(structUpd.getUpdate, definition)
           )
 
         case PLF.Expr.SumCase.APP =>

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -556,11 +556,11 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           assertNonEmpty(vars, "vars")
           (vars :\ decodeType(tForall.getBody))((binder, acc) =>
             TForall(decodeTypeVarWithKind(binder), acc))
-        case PLF.Type.SumCase.TUPLE =>
-          val tuple = lfType.getTuple
-          val fields = tuple.getFieldsList.asScala
+        case PLF.Type.SumCase.STROCT =>
+          val stroct = lfType.getStroct
+          val fields = stroct.getFieldsList.asScala
           assertNonEmpty(fields, "fields")
-          TTuple(fields.map(decodeFieldWithType)(breakOut))
+          TStroct(fields.map(decodeFieldWithType)(breakOut))
 
         case PLF.Type.SumCase.SUM_NOT_SET =>
           throw ParseError("Type.SUM_NOT_SET")
@@ -723,39 +723,39 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             )
           )
 
-        case PLF.Expr.SumCase.TUPLE_CON =>
-          val tupleCon = lfExpr.getTupleCon
-          ETupleCon(
-            ImmArray(tupleCon.getFieldsList.asScala).map(decodeFieldWithExpr(_, definition))
+        case PLF.Expr.SumCase.STROCT_CON =>
+          val stroctCon = lfExpr.getStroctCon
+          EStroctCon(
+            ImmArray(stroctCon.getFieldsList.asScala).map(decodeFieldWithExpr(_, definition))
           )
 
-        case PLF.Expr.SumCase.TUPLE_PROJ =>
-          val tupleProj = lfExpr.getTupleProj
-          ETupleProj(
+        case PLF.Expr.SumCase.STROCT_PROJ =>
+          val stroctProj = lfExpr.getStroctProj
+          EStroctProj(
             field = handleInternedName(
-              tupleProj.getFieldCase,
-              PLF.Expr.TupleProj.FieldCase.FIELD_STR,
-              tupleProj.getFieldStr,
-              PLF.Expr.TupleProj.FieldCase.FIELD_INTERNED_STR,
-              tupleProj.getFieldInternedStr,
-              "Expr.TupleProj.field.field"
+              stroctProj.getFieldCase,
+              PLF.Expr.StroctProj.FieldCase.FIELD_STR,
+              stroctProj.getFieldStr,
+              PLF.Expr.StroctProj.FieldCase.FIELD_INTERNED_STR,
+              stroctProj.getFieldInternedStr,
+              "Expr.StroctProj.field.field"
             ),
-            tuple = decodeExpr(tupleProj.getTuple, definition)
+            stroct = decodeExpr(stroctProj.getStroct, definition)
           )
 
-        case PLF.Expr.SumCase.TUPLE_UPD =>
-          val tupleUpd = lfExpr.getTupleUpd
-          ETupleUpd(
+        case PLF.Expr.SumCase.STROCT_UPD =>
+          val stroctUpd = lfExpr.getStroctUpd
+          EStroctUpd(
             field = handleInternedName(
-              tupleUpd.getFieldCase,
-              PLF.Expr.TupleUpd.FieldCase.FIELD_STR,
-              tupleUpd.getFieldStr,
-              PLF.Expr.TupleUpd.FieldCase.FIELD_INTERNED_STR,
-              tupleUpd.getFieldInternedStr,
-              "Expr.TupleUpd.field.field"
+              stroctUpd.getFieldCase,
+              PLF.Expr.StroctUpd.FieldCase.FIELD_STR,
+              stroctUpd.getFieldStr,
+              PLF.Expr.StroctUpd.FieldCase.FIELD_INTERNED_STR,
+              stroctUpd.getFieldInternedStr,
+              "Expr.StroctUpd.field.field"
             ),
-            tuple = decodeExpr(tupleUpd.getTuple, definition),
-            update = decodeExpr(tupleUpd.getUpdate, definition)
+            stroct = decodeExpr(stroctUpd.getStroct, definition),
+            update = decodeExpr(stroctUpd.getUpdate, definition)
           )
 
         case PLF.Expr.SumCase.APP =>

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -239,9 +239,9 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           expect(args.isEmpty)
           builder.setForall(
             PLF.Type.Forall.newBuilder().accumulateLeft(binders)(_ addVars _).setBody(body))
-        case TStroct(fields) =>
+        case TStruct(fields) =>
           expect(args.isEmpty)
-          builder.setStroct(PLF.Type.Stroct.newBuilder().accumulateLeft(fields)(_ addFields _))
+          builder.setStruct(PLF.Type.Struct.newBuilder().accumulateLeft(fields)(_ addFields _))
       }
     }
 
@@ -502,19 +502,19 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           val b = PLF.Expr.EnumCon.newBuilder().setTycon(tyCon)
           setString(con, b.setEnumConStr, b.setEnumConInternedStr)
           builder.setEnumCon(b.build())
-        case EStroctCon(fields) =>
-          builder.setStroctCon(PLF.Expr.StroctCon.newBuilder().accumulateLeft(fields)(_ addFields _))
-        case EStroctProj(field, expr) =>
-          val b = PLF.Expr.StroctProj.newBuilder()
+        case EStructCon(fields) =>
+          builder.setStructCon(PLF.Expr.StructCon.newBuilder().accumulateLeft(fields)(_ addFields _))
+        case EStructProj(field, expr) =>
+          val b = PLF.Expr.StructProj.newBuilder()
           setString(field, b.setFieldStr, b.setFieldInternedStr)
-          b.setStroct(expr)
-          builder.setStroctProj(b)
-        case EStroctUpd(field, stroct, update) =>
-          val b = PLF.Expr.StroctUpd.newBuilder()
+          b.setStruct(expr)
+          builder.setStructProj(b)
+        case EStructUpd(field, struct, update) =>
+          val b = PLF.Expr.StructUpd.newBuilder()
           setString(field, b.setFieldStr, b.setFieldInternedStr)
-          b.setStroct(stroct)
+          b.setStruct(struct)
           b.setUpdate(update)
-          builder.setStroctUpd(b)
+          builder.setStructUpd(b)
         case EApps(fun, args) =>
           builder.setApp(PLF.Expr.App.newBuilder().setFun(fun).accumulateLeft(args)(_ addArgs _))
         case ETyApps(expr, typs1) =>

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -239,9 +239,9 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           expect(args.isEmpty)
           builder.setForall(
             PLF.Type.Forall.newBuilder().accumulateLeft(binders)(_ addVars _).setBody(body))
-        case TTuple(fields) =>
+        case TStroct(fields) =>
           expect(args.isEmpty)
-          builder.setTuple(PLF.Type.Tuple.newBuilder().accumulateLeft(fields)(_ addFields _))
+          builder.setStroct(PLF.Type.Stroct.newBuilder().accumulateLeft(fields)(_ addFields _))
       }
     }
 
@@ -502,19 +502,19 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           val b = PLF.Expr.EnumCon.newBuilder().setTycon(tyCon)
           setString(con, b.setEnumConStr, b.setEnumConInternedStr)
           builder.setEnumCon(b.build())
-        case ETupleCon(fields) =>
-          builder.setTupleCon(PLF.Expr.TupleCon.newBuilder().accumulateLeft(fields)(_ addFields _))
-        case ETupleProj(field, expr) =>
-          val b = PLF.Expr.TupleProj.newBuilder()
+        case EStroctCon(fields) =>
+          builder.setStroctCon(PLF.Expr.StroctCon.newBuilder().accumulateLeft(fields)(_ addFields _))
+        case EStroctProj(field, expr) =>
+          val b = PLF.Expr.StroctProj.newBuilder()
           setString(field, b.setFieldStr, b.setFieldInternedStr)
-          b.setTuple(expr)
-          builder.setTupleProj(b)
-        case ETupleUpd(field, tuple, update) =>
-          val b = PLF.Expr.TupleUpd.newBuilder()
+          b.setStroct(expr)
+          builder.setStroctProj(b)
+        case EStroctUpd(field, stroct, update) =>
+          val b = PLF.Expr.StroctUpd.newBuilder()
           setString(field, b.setFieldStr, b.setFieldInternedStr)
-          b.setTuple(tuple)
+          b.setStroct(stroct)
           b.setUpdate(update)
-          builder.setTupleUpd(b)
+          builder.setStroctUpd(b)
         case EApps(fun, args) =>
           builder.setApp(PLF.Expr.App.newBuilder().setFun(fun).accumulateLeft(args)(_ addArgs _))
         case ETyApps(expr, typs1) =>

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -503,7 +503,8 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           setString(con, b.setEnumConStr, b.setEnumConInternedStr)
           builder.setEnumCon(b.build())
         case EStructCon(fields) =>
-          builder.setStructCon(PLF.Expr.StructCon.newBuilder().accumulateLeft(fields)(_ addFields _))
+          builder.setStructCon(
+            PLF.Expr.StructCon.newBuilder().accumulateLeft(fields)(_ addFields _))
         case EStructProj(field, expr) =>
           val b = PLF.Expr.StructProj.newBuilder()
           setString(field, b.setFieldStr, b.setFieldInternedStr)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -62,9 +62,9 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
           case forall: TForall =>
             fail(
               s"Unexpected forall when replacing parameters in command translation -- all types should be serializable, and foralls are not: $forall")
-          case tuple: TTuple =>
+          case stroct: TStroct =>
             fail(
-              s"Unexpected tuple when replacing parameters in command translation -- all types should be serializable, and tuples are not: $tuple")
+              s"Unexpected stroct when replacing parameters in command translation -- all types should be serializable, and strocts are not: $stroct")
         }
 
       go(typ0)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -62,9 +62,9 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
           case forall: TForall =>
             fail(
               s"Unexpected forall when replacing parameters in command translation -- all types should be serializable, and foralls are not: $forall")
-          case stroct: TStroct =>
+          case struct: TStruct =>
             fail(
-              s"Unexpected stroct when replacing parameters in command translation -- all types should be serializable, and strocts are not: $stroct")
+              s"Unexpected struct when replacing parameters in command translation -- all types should be serializable, and structs are not: $struct")
         }
 
       go(typ0)

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -217,7 +217,7 @@ object InterfaceReader {
       case Ast.TApp(tyfun, arg) =>
         toIfaceType(ctx, arg, FrontStack.empty) flatMap (tArg =>
           toIfaceType(ctx, tyfun, tArg +: args))
-      case Ast.TForall(_, _) | Ast.TTuple(_) | Ast.TNat(_) =>
+      case Ast.TForall(_, _) | Ast.TStroct(_) | Ast.TNat(_) =>
         unserializableDataType(ctx, s"unserializable data type: ${a.pretty}")
     }
 

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -217,7 +217,7 @@ object InterfaceReader {
       case Ast.TApp(tyfun, arg) =>
         toIfaceType(ctx, arg, FrontStack.empty) flatMap (tArg =>
           toIfaceType(ctx, tyfun, tArg +: args))
-      case Ast.TForall(_, _) | Ast.TStroct(_) | Ast.TNat(_) =>
+      case Ast.TForall(_, _) | Ast.TStruct(_) | Ast.TNat(_) =>
         unserializableDataType(ctx, s"unserializable data type: ${a.pretty}")
     }
 

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -78,7 +78,7 @@ class TypeSpec extends WordSpec with Matchers {
         }
       case Pkg.TTyCon(tycon) => TypeCon(TypeConName(tycon), args.toImmArray.toSeq)
       case Pkg.TNat(_) => sys.error("cannot use nat type in interface type")
-      case _: Pkg.TStroct => sys.error("cannot use strocts in interface type")
+      case _: Pkg.TStruct => sys.error("cannot use structs in interface type")
       case _: Pkg.TForall => sys.error("cannot use forall in interface type")
     }
 

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -78,7 +78,7 @@ class TypeSpec extends WordSpec with Matchers {
         }
       case Pkg.TTyCon(tycon) => TypeCon(TypeConName(tycon), args.toImmArray.toSeq)
       case Pkg.TNat(_) => sys.error("cannot use nat type in interface type")
-      case _: Pkg.TTuple => sys.error("cannot use tuples in interface type")
+      case _: Pkg.TStroct => sys.error("cannot use strocts in interface type")
       case _: Pkg.TForall => sys.error("cannot use forall in interface type")
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -369,16 +369,16 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
           translate(update)
         )
 
-      case ETupleCon(fields) =>
-        SEApp(SEBuiltin(SBTupleCon(Name.Array(fields.map(_._1).toSeq: _*))), fields.iterator.map {
+      case EStroctCon(fields) =>
+        SEApp(SEBuiltin(SBStroctCon(Name.Array(fields.map(_._1).toSeq: _*))), fields.iterator.map {
           case (_, e) => translate(e)
         }.toArray)
 
-      case ETupleProj(field, tuple) =>
-        SBTupleProj(field)(translate(tuple))
+      case EStroctProj(field, stroct) =>
+        SBStroctProj(field)(translate(stroct))
 
-      case ETupleUpd(field, tuple, update) =>
-        SBTupleUpd(field)(translate(tuple), translate(update))
+      case EStroctUpd(field, stroct, update) =>
+        SBStroctUpd(field)(translate(stroct), translate(update))
 
       case ECase(scrut, alts) =>
         SECase(
@@ -584,7 +584,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
                       observers,
                       SEVar(3) // token
                     )
-                  ) in SBTupleCon(Name.Array(contractIdFieldName, contractFieldName))(
+                  ) in SBStroctCon(Name.Array(contractIdFieldName, contractFieldName))(
                     SEVar(3), // contract id
                     SEVar(2) // contract
                   )
@@ -1062,7 +1062,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         case SVariant(_, _, value) => goV(value)
         case SEnum(_, _) => ()
         case SAny(_, v) => goV(v)
-        case _: SPAP | SToken | STuple(_, _) =>
+        case _: SPAP | SToken | SStroct(_, _) =>
           throw CompileError("validate: unexpected SEValue")
       }
     }
@@ -1163,7 +1163,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         case Some(tmplKey) =>
           SELet(translate(tmplKey.body)) in
             SBSome(
-              SBTupleCon(Name.Array(keyFieldName, maintainersFieldName))(
+              SBStroctCon(Name.Array(keyFieldName, maintainersFieldName))(
                 SEVar(1), // key
                 SEApp(translate(tmplKey.maintainers), Array(SEVar(1) /* key */ ))))
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -369,16 +369,16 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
           translate(update)
         )
 
-      case EStroctCon(fields) =>
-        SEApp(SEBuiltin(SBStroctCon(Name.Array(fields.map(_._1).toSeq: _*))), fields.iterator.map {
+      case EStructCon(fields) =>
+        SEApp(SEBuiltin(SBStructCon(Name.Array(fields.map(_._1).toSeq: _*))), fields.iterator.map {
           case (_, e) => translate(e)
         }.toArray)
 
-      case EStroctProj(field, stroct) =>
-        SBStroctProj(field)(translate(stroct))
+      case EStructProj(field, struct) =>
+        SBStructProj(field)(translate(struct))
 
-      case EStroctUpd(field, stroct, update) =>
-        SBStroctUpd(field)(translate(stroct), translate(update))
+      case EStructUpd(field, struct, update) =>
+        SBStructUpd(field)(translate(struct), translate(update))
 
       case ECase(scrut, alts) =>
         SECase(
@@ -584,7 +584,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
                       observers,
                       SEVar(3) // token
                     )
-                  ) in SBStroctCon(Name.Array(contractIdFieldName, contractFieldName))(
+                  ) in SBStructCon(Name.Array(contractIdFieldName, contractFieldName))(
                     SEVar(3), // contract id
                     SEVar(2) // contract
                   )
@@ -1062,7 +1062,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         case SVariant(_, _, value) => goV(value)
         case SEnum(_, _) => ()
         case SAny(_, v) => goV(v)
-        case _: SPAP | SToken | SStroct(_, _) =>
+        case _: SPAP | SToken | SStruct(_, _) =>
           throw CompileError("validate: unexpected SEValue")
       }
     }
@@ -1163,7 +1163,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         case Some(tmplKey) =>
           SELet(translate(tmplKey.body)) in
             SBSome(
-              SBStroctCon(Name.Array(keyFieldName, maintainersFieldName))(
+              SBStructCon(Name.Array(keyFieldName, maintainersFieldName))(
                 SEVar(1), // key
                 SEApp(translate(tmplKey.maintainers), Array(SEVar(1) /* key */ ))))
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -369,7 +369,7 @@ object Pretty {
               text("<no-label>") & char('=') & prettyValue(true)(v)
           }) &
           char('}')
-      case ValueTuple(fs) =>
+      case ValueStroct(fs) =>
         char('{') &
           fill(text(", "), fs.toList.map {
             case (k, v) => text(k) & char('=') & prettyValue(true)(v)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -369,7 +369,7 @@ object Pretty {
               text("<no-label>") & char('=') & prettyValue(true)(v)
           }) &
           char('}')
-      case ValueStroct(fs) =>
+      case ValueStruct(fs) =>
         char('{') &
           fill(text(", "), fs.toList.map {
             case (k, v) => text(k) & char('=') & prettyValue(true)(v)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -446,7 +446,7 @@ object SBuiltin {
       val args = new util.ArrayList[SValue](2)
       args.add(SText(key))
       args.add(value)
-      SStroct(entryFields, args)
+      SStruct(entryFields, args)
     }
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
@@ -725,37 +725,37 @@ object SBuiltin {
     }
   }
 
-  /** $tcon[fields] :: a -> b -> ... -> Stroct */
-  final case class SBStroctCon(fields: Array[Name])
+  /** $tcon[fields] :: a -> b -> ... -> Struct */
+  final case class SBStructCon(fields: Array[Name])
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SStroct(fields, args))
+      machine.ctrl = CtrlValue(SStruct(fields, args))
     }
   }
 
-  /** $tproj[field] :: Stroct -> a */
-  final case class SBStroctProj(field: FieldName) extends SBuiltin(1) {
+  /** $tproj[field] :: Struct -> a */
+  final case class SBStructProj(field: FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
-        case SStroct(fields, values) =>
+        case SStruct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
-          crash(s"StroctProj on non-stroct: $v")
+          crash(s"StructProj on non-struct: $v")
       })
     }
   }
 
-  /** $tupd[field] :: Stroct -> a -> Stroct */
-  final case class SBStroctUpd(field: FieldName) extends SBuiltin(2) {
+  /** $tupd[field] :: Struct -> a -> Struct */
+  final case class SBStructUpd(field: FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
-        case SStroct(fields, values) =>
+        case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
-          SStroct(fields, values2)
+          SStruct(fields, values2)
         case v =>
-          crash(s"StroctUpd on non-stroct: $v")
+          crash(s"StructUpd on non-struct: $v")
       })
     }
   }
@@ -819,7 +819,7 @@ object SBuiltin {
       val obs = extractParties(args.get(3))
       val key = args.get(4) match {
         case SOptional(None) => None
-        case SOptional(Some(SStroct(flds, vals)))
+        case SOptional(Some(SStruct(flds, vals)))
             if flds.length == 2 && flds(0) == "key" && flds(1) == "maintainers" =>
           asVersionedValue(vals.get(0).toValue) match {
             case Left(err) => crash(err)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -446,7 +446,7 @@ object SBuiltin {
       val args = new util.ArrayList[SValue](2)
       args.add(SText(key))
       args.add(value)
-      STuple(entryFields, args)
+      SStroct(entryFields, args)
     }
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
@@ -725,37 +725,37 @@ object SBuiltin {
     }
   }
 
-  /** $tcon[fields] :: a -> b -> ... -> Tuple */
-  final case class SBTupleCon(fields: Array[Name])
+  /** $tcon[fields] :: a -> b -> ... -> Stroct */
+  final case class SBStroctCon(fields: Array[Name])
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(STuple(fields, args))
+      machine.ctrl = CtrlValue(SStroct(fields, args))
     }
   }
 
-  /** $tproj[field] :: Tuple -> a */
-  final case class SBTupleProj(field: FieldName) extends SBuiltin(1) {
+  /** $tproj[field] :: Stroct -> a */
+  final case class SBStroctProj(field: FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
-        case STuple(fields, values) =>
+        case SStroct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
-          crash(s"TupleProj on non-tuple: $v")
+          crash(s"StroctProj on non-stroct: $v")
       })
     }
   }
 
-  /** $tupd[field] :: Tuple -> a -> Tuple */
-  final case class SBTupleUpd(field: FieldName) extends SBuiltin(2) {
+  /** $tupd[field] :: Stroct -> a -> Stroct */
+  final case class SBStroctUpd(field: FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
-        case STuple(fields, values) =>
+        case SStroct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
-          STuple(fields, values2)
+          SStroct(fields, values2)
         case v =>
-          crash(s"TupleUpd on non-tuple: $v")
+          crash(s"StroctUpd on non-stroct: $v")
       })
     }
   }
@@ -819,7 +819,7 @@ object SBuiltin {
       val obs = extractParties(args.get(3))
       val key = args.get(4) match {
         case SOptional(None) => None
-        case SOptional(Some(STuple(flds, vals)))
+        case SOptional(Some(SStroct(flds, vals)))
             if flds.length == 2 && flds(0) == "key" && flds(1) == "maintainers" =>
           asVersionedValue(vals.get(0).toValue) match {
             case Left(err) => crash(err)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -37,8 +37,8 @@ sealed trait SValue {
       case SBool(x) => V.ValueBool(x)
       case SUnit => V.ValueUnit
       case SDate(x) => V.ValueDate(x)
-      case SStroct(fields, svalues) =>
-        V.ValueStroct(
+      case SStruct(fields, svalues) =>
+        V.ValueStruct(
           ImmArray(
             fields.toSeq
               .zip(svalues.asScala)
@@ -94,8 +94,8 @@ sealed trait SValue {
         SPAP(prim2, args2, arity)
       case SRecord(tycon, fields, values) =>
         SRecord(tycon, fields, mapArrayList(values, v => v.mapContractId(f)))
-      case SStroct(fields, values) =>
-        SStroct(fields, mapArrayList(values, v => v.mapContractId(f)))
+      case SStruct(fields, values) =>
+        SStruct(fields, mapArrayList(values, v => v.mapContractId(f)))
       case SVariant(tycon, variant, value) =>
         SVariant(tycon, variant, value.mapContractId(f))
       case SList(lst) =>
@@ -137,7 +137,7 @@ object SValue {
       extends SValue
 
   @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
-  final case class SStroct(fields: Array[Name], values: util.ArrayList[SValue]) extends SValue
+  final case class SStruct(fields: Array[Name], values: util.ArrayList[SValue]) extends SValue
 
   final case class SVariant(id: Identifier, variant: VariantConName, value: SValue) extends SValue
 
@@ -251,7 +251,7 @@ object SValue {
       case V.ValueRecord(None, _) =>
         throw SErrorCrash("SValue.fromValue: record missing identifier")
 
-      case V.ValueStroct(fs) =>
+      case V.ValueStruct(fs) =>
         val fields = Name.Array.ofDim(fs.length)
         val values = new util.ArrayList[SValue](fields.length)
         fs.foreach {
@@ -259,7 +259,7 @@ object SValue {
             fields(values.size) = k
             val _ = values.add(fromValue(v))
         }
-        SStroct(fields, values)
+        SStruct(fields, values)
 
       case V.ValueVariant(None, _variant @ _, _value @ _) =>
         throw SErrorCrash("SValue.fromValue: variant without identifier")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -37,8 +37,8 @@ sealed trait SValue {
       case SBool(x) => V.ValueBool(x)
       case SUnit => V.ValueUnit
       case SDate(x) => V.ValueDate(x)
-      case STuple(fields, svalues) =>
-        V.ValueTuple(
+      case SStroct(fields, svalues) =>
+        V.ValueStroct(
           ImmArray(
             fields.toSeq
               .zip(svalues.asScala)
@@ -94,8 +94,8 @@ sealed trait SValue {
         SPAP(prim2, args2, arity)
       case SRecord(tycon, fields, values) =>
         SRecord(tycon, fields, mapArrayList(values, v => v.mapContractId(f)))
-      case STuple(fields, values) =>
-        STuple(fields, mapArrayList(values, v => v.mapContractId(f)))
+      case SStroct(fields, values) =>
+        SStroct(fields, mapArrayList(values, v => v.mapContractId(f)))
       case SVariant(tycon, variant, value) =>
         SVariant(tycon, variant, value.mapContractId(f))
       case SList(lst) =>
@@ -137,7 +137,7 @@ object SValue {
       extends SValue
 
   @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
-  final case class STuple(fields: Array[Name], values: util.ArrayList[SValue]) extends SValue
+  final case class SStroct(fields: Array[Name], values: util.ArrayList[SValue]) extends SValue
 
   final case class SVariant(id: Identifier, variant: VariantConName, value: SValue) extends SValue
 
@@ -251,7 +251,7 @@ object SValue {
       case V.ValueRecord(None, _) =>
         throw SErrorCrash("SValue.fromValue: record missing identifier")
 
-      case V.ValueTuple(fs) =>
+      case V.ValueStroct(fs) =>
         val fields = Name.Array.ofDim(fs.length)
         val values = new util.ArrayList[SValue](fields.length)
         fs.foreach {
@@ -259,7 +259,7 @@ object SValue {
             fields(values.size) = k
             val _ = values.add(fromValue(v))
         }
-        STuple(fields, values)
+        SStroct(fields, values)
 
       case V.ValueVariant(None, _variant @ _, _value @ _) =>
         throw SErrorCrash("SValue.fromValue: variant without identifier")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -508,7 +508,7 @@ object Speedy {
             }
           }
         case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | SStroct(_, _) | SMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
+            STimestamp(_) | SStruct(_, _) | SMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
             STypeRep(_) | STNat(_) | _: SPAP | SToken =>
           crash("Match on non-matchable value")
       }
@@ -537,7 +537,7 @@ object Speedy {
   /** Store the evaluated value in the 'SEVal' from which the expression came from.
     * This in principle makes top-level values lazy. It is a useful optimization to
     * allow creation of large constants (for example records) that are repeatedly
-    * accessed. In older compilers which did not use the builtin record and stroct
+    * accessed. In older compilers which did not use the builtin record and struct
     * updates this solves the blow-up which would happen when a large record is
     * updated multiple times. */
   final case class KCacheVal(v: SEVal, stack_trace: List[Location]) extends Kont {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -508,7 +508,7 @@ object Speedy {
             }
           }
         case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | STuple(_, _) | SMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
+            STimestamp(_) | SStroct(_, _) | SMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
             STypeRep(_) | STNat(_) | _: SPAP | SToken =>
           crash("Match on non-matchable value")
       }
@@ -537,7 +537,7 @@ object Speedy {
   /** Store the evaluated value in the 'SEVal' from which the expression came from.
     * This in principle makes top-level values lazy. It is a useful optimization to
     * allow creation of large constants (for example records) that are repeatedly
-    * accessed. In older compilers which did not use the builtin record and tuple
+    * accessed. In older compilers which did not use the builtin record and stroct
     * updates this solves the blow-up which would happen when a large record is
     * updated multiple times. */
   final case class KCacheVal(v: SEVal, stack_trace: List[Location]) extends Kont {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -58,7 +58,7 @@ private[lf] object Equality {
               val keys = map1.keys
               equality(zipAndPush(keys.iterator.map(map1), keys.iterator.map(map2), stack))
             }
-          case (SStroct(fields1, args1), SStroct(fields2, args2)) =>
+          case (SStruct(fields1, args1), SStruct(fields2, args2)) =>
             (fields1 sameElements fields2) && equality(
               zipAndPush(args1.iterator().asScala, args2.iterator().asScala, stack))
           case (SAny(t1, v1), SAny(t2, v2)) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -58,7 +58,7 @@ private[lf] object Equality {
               val keys = map1.keys
               equality(zipAndPush(keys.iterator.map(map1), keys.iterator.map(map2), stack))
             }
-          case (STuple(fields1, args1), STuple(fields2, args2)) =>
+          case (SStroct(fields1, args1), SStroct(fields2, args2)) =>
             (fields1 sameElements fields2) && equality(
               zipAndPush(args1.iterator().asScala, args2.iterator().asScala, stack))
           case (SAny(t1, v1), SAny(t2, v2)) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
@@ -72,7 +72,7 @@ private[speedy] object Hasher {
                 loop(pushOrderedValues(values.iterator().asScala, cmdsRest), stack)
               case SVariant(_, variant, value) =>
                 loop(Value(value) :: Mix(variant.hashCode) :: cmdsRest, stack)
-              case SStroct(_, values) =>
+              case SStruct(_, values) =>
                 loop(pushOrderedValues(values.iterator().asScala, cmdsRest), stack)
               case SOptional(opt) =>
                 loop(pushOrderedValues(opt.iterator, cmdsRest), stack)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
@@ -72,7 +72,7 @@ private[speedy] object Hasher {
                 loop(pushOrderedValues(values.iterator().asScala, cmdsRest), stack)
               case SVariant(_, variant, value) =>
                 loop(Value(value) :: Mix(variant.hashCode) :: cmdsRest, stack)
-              case STuple(_, values) =>
+              case SStroct(_, values) =>
                 loop(pushOrderedValues(values.iterator().asScala, cmdsRest), stack)
               case SOptional(opt) =>
                 loop(pushOrderedValues(opt.iterator, cmdsRest), stack)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -959,7 +959,7 @@ object Ledger {
           fs.foreach {
             case (_, v) => collect(v)
           }
-        case ValueTuple(fs) =>
+        case ValueStroct(fs) =>
           fs.foreach {
             case (_, v) => collect(v)
           }
@@ -1003,8 +1003,8 @@ object Ledger {
           ValueRecord(tycon, fs.map[(Option[Name], Value[AbsoluteContractId])] {
             case (k, v) => (k, rewrite(v))
           })
-        case ValueTuple(fs) =>
-          ValueTuple(fs.map[(Name, Value[AbsoluteContractId])] {
+        case ValueStroct(fs) =>
+          ValueStroct(fs.map[(Name, Value[AbsoluteContractId])] {
             case (k, v) => (k, rewrite(v))
           })
         case ValueVariant(tycon, variant, value) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -959,7 +959,7 @@ object Ledger {
           fs.foreach {
             case (_, v) => collect(v)
           }
-        case ValueStroct(fs) =>
+        case ValueStruct(fs) =>
           fs.foreach {
             case (_, v) => collect(v)
           }
@@ -1003,8 +1003,8 @@ object Ledger {
           ValueRecord(tycon, fs.map[(Option[Name], Value[AbsoluteContractId])] {
             case (k, v) => (k, rewrite(v))
           })
-        case ValueStroct(fs) =>
-          ValueStroct(fs.map[(Name, Value[AbsoluteContractId])] {
+        case ValueStruct(fs) =>
+          ValueStruct(fs.map[(Name, Value[AbsoluteContractId])] {
             case (k, v) => (k, rewrite(v))
           })
         case ValueVariant(tycon, variant, value) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1380,7 +1380,7 @@ object SBuiltinTest {
     val args = new util.ArrayList[SValue](2)
     args.add(SText(k))
     args.add(v)
-    STuple(entryFields, args)
+    SStroct(entryFields, args)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1380,7 +1380,7 @@ object SBuiltinTest {
     val args = new util.ArrayList[SValue](2)
     args.add(SText(k))
     args.add(v)
-    SStroct(entryFields, args)
+    SStruct(entryFields, args)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -69,7 +69,7 @@ class SpeedyTest extends WordSpec with Matchers {
       eval(e"Matcher:list @Int64 ${intList()}", pkgs) shouldEqual Right(SOptional(None))
       eval(e"Matcher:list @Int64 ${intList(7, 11, 13)}", pkgs) shouldEqual Right(
         SOptional(
-          Some(SStroct(
+          Some(SStruct(
             Ref.Name.Array(n"x1", n"x2"),
             ArrayList(SInt64(7), SList(FrontStack(SInt64(11), SInt64(13))))))))
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -69,7 +69,7 @@ class SpeedyTest extends WordSpec with Matchers {
       eval(e"Matcher:list @Int64 ${intList()}", pkgs) shouldEqual Right(SOptional(None))
       eval(e"Matcher:list @Int64 ${intList(7, 11, 13)}", pkgs) shouldEqual Right(
         SOptional(
-          Some(STuple(
+          Some(SStroct(
             Ref.Name.Array(n"x1", n"x2"),
             ArrayList(SInt64(7), SList(FrontStack(SInt64(11), SInt64(13))))))))
     }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -81,14 +81,14 @@ object Ast {
   /** Variant construction. */
   final case class EEnumCon(tyConName: TypeConName, con: EnumConName) extends Expr
 
-  /** Tuple construction. */
-  final case class ETupleCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
+  /** Stroct construction. */
+  final case class EStroctCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
 
-  /** Tuple projection. */
-  final case class ETupleProj(field: FieldName, tuple: Expr) extends Expr
+  /** Stroct projection. */
+  final case class EStroctProj(field: FieldName, stroct: Expr) extends Expr
 
-  /** Non-destructive tuple update. */
-  final case class ETupleUpd(field: FieldName, tuple: Expr, update: Expr) extends Expr
+  /** Non-destructive stroct update. */
+  final case class EStroctUpd(field: FieldName, stroct: Expr, update: Expr) extends Expr
 
   /** Expression application. Function can be an abstraction or a builtin function. */
   final case class EApp(fun: Expr, arg: Expr) extends Expr
@@ -221,7 +221,7 @@ object Ast {
             prettyType(fun, precTApp) + " " + prettyType(arg, precTApp + 1))
         case TForall((v, _), body) =>
           maybeParens(prec > precTForall, "∀" + v + prettyForAll(body))
-        case TTuple(fields) =>
+        case TStroct(fields) =>
           "(" + fields
             .map { case (n, t) => n + ": " + prettyType(t, precTForall) }
             .toSeq
@@ -262,13 +262,13 @@ object Ast {
   /** Universally quantified type. */
   final case class TForall(binder: (TypeVarName, Kind), body: Type) extends Type
 
-  /** Tuples */
-  final case class TTuple private (sortedFields: ImmArray[(FieldName, Type)]) extends Type
+  /** Strocts */
+  final case class TStroct private (sortedFields: ImmArray[(FieldName, Type)]) extends Type
 
-  object TTuple extends (ImmArray[(FieldName, Type)] => TTuple) {
+  object TStroct extends (ImmArray[(FieldName, Type)] => TStroct) {
     // should be dropped once the compiler sort fields.
-    def apply(fields: ImmArray[(FieldName, Type)]): TTuple =
-      new TTuple(ImmArray(fields.toSeq.sortBy(_._1: String)))
+    def apply(fields: ImmArray[(FieldName, Type)]): TStroct =
+      new TStroct(ImmArray(fields.toSeq.sortBy(_._1: String)))
   }
 
   sealed abstract class BuiltinType extends Product with Serializable
@@ -360,7 +360,7 @@ object Ast {
   final case object BTextMapInsert extends BuiltinFunction(3) // : ∀ a. Text -> a -> TextMap a -> TextMap a
   final case object BTextMapLookup extends BuiltinFunction(2) // : ∀ a. Text -> TextMap a -> Optional a
   final case object BTextMapDelete extends BuiltinFunction(2) // : ∀ a. Text -> TextMap a -> TextMap a
-  final case object BTextMapToList extends BuiltinFunction(1) // : ∀ a. TextMap a -> [Tuple("key":Text, "value":a)]
+  final case object BTextMapToList extends BuiltinFunction(1) // : ∀ a. TextMap a -> [Stroct("key":Text, "value":a)]
   final case object BTextMapSize extends BuiltinFunction(1) // : ∀ a. TextMap a -> Int64
 
   // Generic Maps

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -81,14 +81,14 @@ object Ast {
   /** Variant construction. */
   final case class EEnumCon(tyConName: TypeConName, con: EnumConName) extends Expr
 
-  /** Stroct construction. */
-  final case class EStroctCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
+  /** Struct construction. */
+  final case class EStructCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
 
-  /** Stroct projection. */
-  final case class EStroctProj(field: FieldName, stroct: Expr) extends Expr
+  /** Struct projection. */
+  final case class EStructProj(field: FieldName, struct: Expr) extends Expr
 
-  /** Non-destructive stroct update. */
-  final case class EStroctUpd(field: FieldName, stroct: Expr, update: Expr) extends Expr
+  /** Non-destructive struct update. */
+  final case class EStructUpd(field: FieldName, struct: Expr, update: Expr) extends Expr
 
   /** Expression application. Function can be an abstraction or a builtin function. */
   final case class EApp(fun: Expr, arg: Expr) extends Expr
@@ -221,7 +221,7 @@ object Ast {
             prettyType(fun, precTApp) + " " + prettyType(arg, precTApp + 1))
         case TForall((v, _), body) =>
           maybeParens(prec > precTForall, "∀" + v + prettyForAll(body))
-        case TStroct(fields) =>
+        case TStruct(fields) =>
           "(" + fields
             .map { case (n, t) => n + ": " + prettyType(t, precTForall) }
             .toSeq
@@ -262,13 +262,13 @@ object Ast {
   /** Universally quantified type. */
   final case class TForall(binder: (TypeVarName, Kind), body: Type) extends Type
 
-  /** Strocts */
-  final case class TStroct private (sortedFields: ImmArray[(FieldName, Type)]) extends Type
+  /** Structs */
+  final case class TStruct private (sortedFields: ImmArray[(FieldName, Type)]) extends Type
 
-  object TStroct extends (ImmArray[(FieldName, Type)] => TStroct) {
+  object TStruct extends (ImmArray[(FieldName, Type)] => TStruct) {
     // should be dropped once the compiler sort fields.
-    def apply(fields: ImmArray[(FieldName, Type)]): TStroct =
-      new TStroct(ImmArray(fields.toSeq.sortBy(_._1: String)))
+    def apply(fields: ImmArray[(FieldName, Type)]): TStruct =
+      new TStruct(ImmArray(fields.toSeq.sortBy(_._1: String)))
   }
 
   sealed abstract class BuiltinType extends Product with Serializable
@@ -360,7 +360,7 @@ object Ast {
   final case object BTextMapInsert extends BuiltinFunction(3) // : ∀ a. Text -> a -> TextMap a -> TextMap a
   final case object BTextMapLookup extends BuiltinFunction(2) // : ∀ a. Text -> TextMap a -> Optional a
   final case object BTextMapDelete extends BuiltinFunction(2) // : ∀ a. Text -> TextMap a -> TextMap a
-  final case object BTextMapToList extends BuiltinFunction(1) // : ∀ a. TextMap a -> [Stroct("key":Text, "value":a)]
+  final case object BTextMapToList extends BuiltinFunction(1) // : ∀ a. TextMap a -> [Struct("key":Text, "value":a)]
   final case object BTextMapSize extends BuiltinFunction(1) // : ∀ a. TextMap a -> Int64
 
   // Generic Maps

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -58,8 +58,8 @@ private[digitalasset] class AstRewriter(
           TApp(apply(tyfun), apply(arg))
         case TForall(binder, body) =>
           TForall(binder, apply(body))
-        case TTuple(fields) =>
-          TTuple(fields.map(apply))
+        case TStroct(fields) =>
+          TStroct(fields.map(apply))
       }
 
   def apply(nameWithType: (Name, Type)): (Name, Type) = nameWithType match {
@@ -89,14 +89,14 @@ private[digitalasset] class AstRewriter(
           EVariantCon(apply(tycon), variant, apply(arg))
         case EEnumCon(tyCon, cons) =>
           EEnumCon(apply(tyCon), cons)
-        case ETupleCon(fields) =>
-          ETupleCon(fields.transform { (_, x) =>
+        case EStroctCon(fields) =>
+          EStroctCon(fields.transform { (_, x) =>
             apply(x)
           })
-        case ETupleProj(field, tuple) =>
-          ETupleProj(field, apply(tuple))
-        case ETupleUpd(field, tuple, update) =>
-          ETupleUpd(field, apply(tuple), apply(update))
+        case EStroctProj(field, stroct) =>
+          EStroctProj(field, apply(stroct))
+        case EStroctUpd(field, stroct, update) =>
+          EStroctUpd(field, apply(stroct), apply(update))
         case EApp(fun, arg) =>
           EApp(apply(fun), apply(arg))
         case ETyApp(expr, typ) =>

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -58,8 +58,8 @@ private[digitalasset] class AstRewriter(
           TApp(apply(tyfun), apply(arg))
         case TForall(binder, body) =>
           TForall(binder, apply(body))
-        case TStroct(fields) =>
-          TStroct(fields.map(apply))
+        case TStruct(fields) =>
+          TStruct(fields.map(apply))
       }
 
   def apply(nameWithType: (Name, Type)): (Name, Type) = nameWithType match {
@@ -89,14 +89,14 @@ private[digitalasset] class AstRewriter(
           EVariantCon(apply(tycon), variant, apply(arg))
         case EEnumCon(tyCon, cons) =>
           EEnumCon(apply(tyCon), cons)
-        case EStroctCon(fields) =>
-          EStroctCon(fields.transform { (_, x) =>
+        case EStructCon(fields) =>
+          EStructCon(fields.transform { (_, x) =>
             apply(x)
           })
-        case EStroctProj(field, stroct) =>
-          EStroctProj(field, apply(stroct))
-        case EStroctUpd(field, stroct, update) =>
-          EStroctUpd(field, apply(stroct), apply(update))
+        case EStructProj(field, struct) =>
+          EStructProj(field, apply(struct))
+        case EStructUpd(field, struct, update) =>
+          EStructUpd(field, apply(struct), apply(update))
         case EApp(fun, arg) =>
           EApp(apply(fun), apply(arg))
         case ETyApp(expr, typ) =>

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -26,9 +26,9 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eRecProj |
       eRecUpd |
       eVariantOrEnumCon |
-      eStroctCon |
-      eStroctUpd |
-      eStroctProj |
+      eStructCon |
+      eStructUpd |
+      eStructProj |
       eAbs |
       eTyAbs |
       eLet |
@@ -138,17 +138,17 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
         EEnumCon(tName, vName)
     }
 
-  private lazy val eStroctCon: Parser[Expr] =
-    `<` ~> fieldInits <~ `>` ^^ EStroctCon
+  private lazy val eStructCon: Parser[Expr] =
+    `<` ~> fieldInits <~ `>` ^^ EStructCon
 
-  private lazy val eStroctProj: Parser[Expr] =
+  private lazy val eStructProj: Parser[Expr] =
     (`(` ~> expr <~ `)` ~ `.`) ~! id ^^ {
-      case stroct ~ fName => EStroctProj(fName, stroct)
+      case struct ~ fName => EStructProj(fName, struct)
     }
 
-  private lazy val eStroctUpd: Parser[Expr] =
+  private lazy val eStructUpd: Parser[Expr] =
     `<` ~> expr ~ (`with` ~>! fieldInit) <~ `>` ^^ {
-      case stroct ~ ((fName, value)) => EStroctUpd(fName, stroct, value)
+      case struct ~ ((fName, value)) => EStructUpd(fName, struct, value)
     }
 
   private[parser] lazy val varBinder: Parser[(Name, Type)] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -26,9 +26,9 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eRecProj |
       eRecUpd |
       eVariantOrEnumCon |
-      eTupleCon |
-      eTupleUpd |
-      eTupleProj |
+      eStroctCon |
+      eStroctUpd |
+      eStroctProj |
       eAbs |
       eTyAbs |
       eLet |
@@ -138,17 +138,17 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
         EEnumCon(tName, vName)
     }
 
-  private lazy val eTupleCon: Parser[Expr] =
-    `<` ~> fieldInits <~ `>` ^^ ETupleCon
+  private lazy val eStroctCon: Parser[Expr] =
+    `<` ~> fieldInits <~ `>` ^^ EStroctCon
 
-  private lazy val eTupleProj: Parser[Expr] =
+  private lazy val eStroctProj: Parser[Expr] =
     (`(` ~> expr <~ `)` ~ `.`) ~! id ^^ {
-      case tuple ~ fName => ETupleProj(fName, tuple)
+      case stroct ~ fName => EStroctProj(fName, stroct)
     }
 
-  private lazy val eTupleUpd: Parser[Expr] =
+  private lazy val eStroctUpd: Parser[Expr] =
     `<` ~> expr ~ (`with` ~>! fieldInit) <~ `>` ^^ {
-      case tuple ~ ((fName, value)) => ETupleUpd(fName, tuple, value)
+      case stroct ~ ((fName, value)) => EStroctUpd(fName, stroct, value)
     }
 
   private[parser] lazy val varBinder: Parser[(Name, Type)] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -56,14 +56,14 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
   private lazy val fieldType: Parser[(FieldName, Type)] =
     id ~ `:` ~ typ ^^ { case name ~ _ ~ t => name -> t }
 
-  private lazy val tTuple: Parser[Type] =
-    `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TTuple(ImmArray(fs)))
+  private lazy val tStroct: Parser[Type] =
+    `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TStroct(ImmArray(fs)))
 
   lazy val typ0: Parser[Type] =
     `(` ~> typ <~ `)` |
       tNat |
       tForall |
-      tTuple |
+      tStroct |
       (id ^? builtinTypes) ^^ TBuiltin |
       fullIdentifier ^^ TTyCon.apply |
       id ^^ TVar.apply

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -56,14 +56,14 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
   private lazy val fieldType: Parser[(FieldName, Type)] =
     id ~ `:` ~ typ ^^ { case name ~ _ ~ t => name -> t }
 
-  private lazy val tStroct: Parser[Type] =
-    `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TStroct(ImmArray(fs)))
+  private lazy val tStruct: Parser[Type] =
+    `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TStruct(ImmArray(fs)))
 
   lazy val typ0: Parser[Type] =
     `(` ~> typ <~ `)` |
       tNat |
       tForall |
-      tStroct |
+      tStruct |
       (id ^? builtinTypes) ^^ TBuiltin |
       fullIdentifier ^^ TTyCon.apply |
       id ^^ TVar.apply

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -96,7 +96,7 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "a -> b" -> TApp(TApp(TBuiltin(BTArrow), α), β),
         "a -> b -> a" -> TApp(TApp(TBuiltin(BTArrow), α), TApp(TApp(TBuiltin(BTArrow), β), α)),
         "forall (a: *). Mod:T a" -> TForall((α.name, KStar), TApp(T, α)),
-        "<f1: a, f2: Bool, f3:Mod:T>" -> TTuple(
+        "<f1: a, f2: Bool, f3:Mod:T>" -> TStroct(
           ImmArray[(FieldName, Type)](n"f1" -> α, n"f2" -> TBuiltin(BTBool), n"f3" -> T))
       )
 
@@ -262,9 +262,9 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "Mod:R:C" ->
           EEnumCon(R.tycon, n"C"),
         "< f1 =2, f2=False >" ->
-          ETupleCon(ImmArray(n"f1" -> e"2", n"f2" -> e"False")),
+          EStroctCon(ImmArray(n"f1" -> e"2", n"f2" -> e"False")),
         "(x).f1" ->
-          ETupleProj(n"f1", e"x"),
+          EStroctProj(n"f1", e"x"),
         "x y" ->
           EApp(e"x", e"y"),
         "x y z" ->

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -96,7 +96,7 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "a -> b" -> TApp(TApp(TBuiltin(BTArrow), α), β),
         "a -> b -> a" -> TApp(TApp(TBuiltin(BTArrow), α), TApp(TApp(TBuiltin(BTArrow), β), α)),
         "forall (a: *). Mod:T a" -> TForall((α.name, KStar), TApp(T, α)),
-        "<f1: a, f2: Bool, f3:Mod:T>" -> TStroct(
+        "<f1: a, f2: Bool, f3:Mod:T>" -> TStruct(
           ImmArray[(FieldName, Type)](n"f1" -> α, n"f2" -> TBuiltin(BTBool), n"f3" -> T))
       )
 
@@ -262,9 +262,9 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
         "Mod:R:C" ->
           EEnumCon(R.tycon, n"C"),
         "< f1 =2, f2=False >" ->
-          EStroctCon(ImmArray(n"f1" -> e"2", n"f2" -> e"False")),
+          EStructCon(ImmArray(n"f1" -> e"2", n"f2" -> e"False")),
         "(x).f1" ->
-          EStroctProj(n"f1", e"x"),
+          EStructProj(n"f1", e"x"),
         "x y" ->
           EApp(e"x", e"y"),
         "x y z" ->

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -310,7 +310,7 @@ object Repl {
           prettyType(fun, precTApp) + " " + prettyType(arg, precTApp + 1))
       case TForall((v, _), body) =>
         maybeParens(prec > precTForall, "∀" + v + prettyForAll(body))
-      case TStroct(fields) =>
+      case TStruct(fields) =>
         "(" + fields
           .map { case (n, t) => n + ": " + prettyType(t, precTForall) }
           .toSeq

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -310,7 +310,7 @@ object Repl {
           prettyType(fun, precTApp) + " " + prettyType(arg, precTApp + 1))
       case TForall((v, _), body) =>
         maybeParens(prec > precTForall, "∀" + v + prettyForAll(body))
-      case TTuple(fields) =>
+      case TStroct(fields) =>
         "(" + fields
           .map { case (n, t) => n + ": " + prettyType(t, precTForall) }
           .toSeq

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -31,8 +31,8 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
         ValueRecord(id, fs.map({
           case (lbl, value) => (lbl, value.mapContractId(f))
         }))
-      case ValueStroct(fs) =>
-        ValueStroct(fs.map[(Name, Value[Cid2])] {
+      case ValueStruct(fs) =>
+        ValueStruct(fs.map[(Name, Value[Cid2])] {
           case (lbl, value) => (lbl, value.mapContractId(f))
         })
       case ValueVariant(id, variant, value) =>
@@ -66,8 +66,8 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
         val newNesting = nesting + 1
 
         v match {
-          case tpl: ValueStroct[Cid] =>
-            go(exceededNesting, errs :+ s"contains stroct $tpl", vs)
+          case tpl: ValueStruct[Cid] =>
+            go(exceededNesting, errs :+ s"contains struct $tpl", vs)
           case ValueRecord(_, flds) =>
             if (newNesting > MAXIMUM_NESTING) {
               if (exceededNesting) {
@@ -223,8 +223,8 @@ object Value {
   final case class ValueGenMap[+Cid](entries: ImmArray[(Value[Cid], Value[Cid])]) extends Value[Cid]
   // this is present here just because we need it in some internal code --
   // specifically the scenario interpreter converts committed values to values and
-  // currently those can be strocts, although we should probably ban that.
-  final case class ValueStroct[+Cid](fields: ImmArray[(Name, Value[Cid])]) extends Value[Cid]
+  // currently those can be structs, although we should probably ban that.
+  final case class ValueStruct[+Cid](fields: ImmArray[(Name, Value[Cid])]) extends Value[Cid]
 
   // Order of GenMap entries is relevant for this equality.
   implicit def `Value Equal instance`[Cid: Equal]: Equal[Value[Cid]] =
@@ -259,8 +259,8 @@ object Value {
           case ValueOptional(value2) =>
             value === value2
         }
-        case ValueStroct(fields) => {
-          case ValueStroct(fields2) =>
+        case ValueStruct(fields) => {
+          case ValueStruct(fields2) =>
             fields === fields2
         }
         case ValueTextMap(map1) => {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -31,8 +31,8 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
         ValueRecord(id, fs.map({
           case (lbl, value) => (lbl, value.mapContractId(f))
         }))
-      case ValueTuple(fs) =>
-        ValueTuple(fs.map[(Name, Value[Cid2])] {
+      case ValueStroct(fs) =>
+        ValueStroct(fs.map[(Name, Value[Cid2])] {
           case (lbl, value) => (lbl, value.mapContractId(f))
         })
       case ValueVariant(id, variant, value) =>
@@ -66,8 +66,8 @@ sealed abstract class Value[+Cid] extends Product with Serializable {
         val newNesting = nesting + 1
 
         v match {
-          case tpl: ValueTuple[Cid] =>
-            go(exceededNesting, errs :+ s"contains tuple $tpl", vs)
+          case tpl: ValueStroct[Cid] =>
+            go(exceededNesting, errs :+ s"contains stroct $tpl", vs)
           case ValueRecord(_, flds) =>
             if (newNesting > MAXIMUM_NESTING) {
               if (exceededNesting) {
@@ -223,8 +223,8 @@ object Value {
   final case class ValueGenMap[+Cid](entries: ImmArray[(Value[Cid], Value[Cid])]) extends Value[Cid]
   // this is present here just because we need it in some internal code --
   // specifically the scenario interpreter converts committed values to values and
-  // currently those can be tuples, although we should probably ban that.
-  final case class ValueTuple[+Cid](fields: ImmArray[(Name, Value[Cid])]) extends Value[Cid]
+  // currently those can be strocts, although we should probably ban that.
+  final case class ValueStroct[+Cid](fields: ImmArray[(Name, Value[Cid])]) extends Value[Cid]
 
   // Order of GenMap entries is relevant for this equality.
   implicit def `Value Equal instance`[Cid: Equal]: Equal[Value[Cid]] =
@@ -259,8 +259,8 @@ object Value {
           case ValueOptional(value2) =>
             value === value2
         }
-        case ValueTuple(fields) => {
-          case ValueTuple(fields2) =>
+        case ValueStroct(fields) => {
+          case ValueStroct(fields2) =>
             fields === fields2
         }
         case ValueTextMap(map1) => {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -535,8 +535,8 @@ object ValueCoder {
             }
             builder.setGenMap(protoMap).build()
 
-          case ValueStroct(fields) =>
-            throw Err(s"Trying to serialize stroct, which are not serializable. Fields: $fields")
+          case ValueStruct(fields) =>
+            throw Err(s"Trying to serialize struct, which are not serializable. Fields: $fields")
         }
       }
     }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -535,8 +535,8 @@ object ValueCoder {
             }
             builder.setGenMap(protoMap).build()
 
-          case ValueTuple(fields) =>
-            throw Err(s"Trying to serialize tuple, which are not serializable. Fields: $fields")
+          case ValueStroct(fields) =>
+            throw Err(s"Trying to serialize stroct, which are not serializable. Fields: $fields")
         }
       }
     }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -64,9 +64,9 @@ object ValueVersions
                 go(maxVV(minGenMap, currentVersion), newValues)
               case ValueEnum(_, _) =>
                 go(maxVV(minEnum, currentVersion), values)
-              // strocts are a no-no
-              case ValueStroct(fields) =>
-                Left(s"Got stroct when trying to assign version. Fields: $fields")
+              // structs are a no-no
+              case ValueStruct(fields) =>
+                Left(s"Got struct when trying to assign version. Fields: $fields")
             }
         }
       }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -64,9 +64,9 @@ object ValueVersions
                 go(maxVV(minGenMap, currentVersion), newValues)
               case ValueEnum(_, _) =>
                 go(maxVV(minEnum, currentVersion), values)
-              // tuples are a no-no
-              case ValueTuple(fields) =>
-                Left(s"Got tuple when trying to assign version. Fields: $fields")
+              // strocts are a no-no
+              case ValueStroct(fields) =>
+                Left(s"Got stroct when trying to assign version. Fields: $fields")
             }
         }
       }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -161,9 +161,9 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
       }
     }
 
-    "don't tuple" in {
-      val tuple = ValueTuple(ImmArray((Ref.Name.assertFromString("foo"), ValueInt64(42))))
-      val res = ValueCoder.encodeValue[ContractId](defaultCidEncode, defaultValueVersion, tuple)
+    "don't stroct" in {
+      val stroct = ValueStroct(ImmArray((Ref.Name.assertFromString("foo"), ValueInt64(42))))
+      val res = ValueCoder.encodeValue[ContractId](defaultCidEncode, defaultValueVersion, stroct)
       res.left.get.errorMessage should include("serializable")
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -161,9 +161,9 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
       }
     }
 
-    "don't stroct" in {
-      val stroct = ValueStroct(ImmArray((Ref.Name.assertFromString("foo"), ValueInt64(42))))
-      val res = ValueCoder.encodeValue[ContractId](defaultCidEncode, defaultValueVersion, stroct)
+    "don't struct" in {
+      val struct = ValueStruct(ImmArray((Ref.Name.assertFromString("foo"), ValueInt64(42))))
+      val res = ValueCoder.encodeValue[ContractId](defaultCidEncode, defaultValueVersion, struct)
       res.left.get.errorMessage should include("serializable")
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -12,8 +12,8 @@ import org.scalatest.{FreeSpec, Matchers}
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrivenPropertyChecks {
   "serialize" - {
-    val emptyTuple = ValueTuple(ImmArray.empty)
-    val emptyTupleError = "contains tuple ValueTuple(ImmArray())"
+    val emptyStroct = ValueStroct(ImmArray.empty)
+    val emptyStroctError = "contains stroct ValueStroct(ImmArray())"
     val exceedsNesting = (1 to MAXIMUM_NESTING + 1).foldRight[Value[Nothing]](ValueInt64(42)) {
       case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
     }
@@ -22,12 +22,12 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
       case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
     }
 
-    "rejects tuple" in {
-      emptyTuple.serializable shouldBe ImmArray(emptyTupleError)
+    "rejects stroct" in {
+      emptyStroct.serializable shouldBe ImmArray(emptyStroctError)
     }
 
-    "rejects nested tuple" in {
-      ValueList(FrontStack(emptyTuple)).serializable shouldBe ImmArray(emptyTupleError)
+    "rejects nested stroct" in {
+      ValueList(FrontStack(emptyStroct)).serializable shouldBe ImmArray(emptyStroctError)
     }
 
     "rejects excessive nesting" in {
@@ -39,8 +39,8 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
     }
 
     "outputs both error messages, without duplication" in {
-      ValueList(FrontStack(exceedsNesting, ValueTuple(ImmArray.empty), exceedsNesting)).serializable shouldBe
-        ImmArray(exceedsNestingError, emptyTupleError)
+      ValueList(FrontStack(exceedsNesting, ValueStroct(ImmArray.empty), exceedsNesting)).serializable shouldBe
+        ImmArray(exceedsNestingError, emptyStroctError)
     }
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -12,8 +12,8 @@ import org.scalatest.{FreeSpec, Matchers}
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrivenPropertyChecks {
   "serialize" - {
-    val emptyStroct = ValueStroct(ImmArray.empty)
-    val emptyStroctError = "contains stroct ValueStroct(ImmArray())"
+    val emptyStruct = ValueStruct(ImmArray.empty)
+    val emptyStructError = "contains struct ValueStruct(ImmArray())"
     val exceedsNesting = (1 to MAXIMUM_NESTING + 1).foldRight[Value[Nothing]](ValueInt64(42)) {
       case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
     }
@@ -22,12 +22,12 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
       case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
     }
 
-    "rejects stroct" in {
-      emptyStroct.serializable shouldBe ImmArray(emptyStroctError)
+    "rejects struct" in {
+      emptyStruct.serializable shouldBe ImmArray(emptyStructError)
     }
 
-    "rejects nested stroct" in {
-      ValueList(FrontStack(emptyStroct)).serializable shouldBe ImmArray(emptyStroctError)
+    "rejects nested struct" in {
+      ValueList(FrontStack(emptyStruct)).serializable shouldBe ImmArray(emptyStructError)
     }
 
     "rejects excessive nesting" in {
@@ -39,8 +39,8 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
     }
 
     "outputs both error messages, without duplication" in {
-      ValueList(FrontStack(exceedsNesting, ValueStroct(ImmArray.empty), exceedsNesting)).serializable shouldBe
-        ImmArray(exceedsNestingError, emptyStroctError)
+      ValueList(FrontStack(exceedsNesting, ValueStruct(ImmArray.empty), exceedsNesting)).serializable shouldBe
+        ImmArray(exceedsNestingError, emptyStructError)
     }
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
@@ -30,7 +30,7 @@ private[validation] object AlphaEquiv {
             binderDepthLhs + (varName1 -> currentDepth),
             binderDepthRhs + (varName2 -> currentDepth)
           ).alphaEquiv(b1, b2)
-      case (TTuple(fs1), TTuple(fs2)) =>
+      case (TStroct(fs1), TStroct(fs2)) =>
         (fs1.keys sameElements fs1.keys) &&
           (fs1.values zip fs2.values).forall((alphaEquiv _).tupled)
       case _ => false

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
@@ -30,7 +30,7 @@ private[validation] object AlphaEquiv {
             binderDepthLhs + (varName1 -> currentDepth),
             binderDepthRhs + (varName2 -> currentDepth)
           ).alphaEquiv(b1, b2)
-      case (TStroct(fs1), TStroct(fs2)) =>
+      case (TStruct(fs1), TStruct(fs2)) =>
         (fs1.keys sameElements fs1.keys) &&
           (fs1.values zip fs2.values).forall((alphaEquiv _).tupled)
       case _ => false

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -107,8 +107,8 @@ private[validation] object Serializability {
         }
       case TForall(_, _) =>
         unserializable(URForall)
-      case TStroct(_) =>
-        unserializable(URStroct)
+      case TStruct(_) =>
+        unserializable(URStruct)
     }
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -107,8 +107,8 @@ private[validation] object Serializability {
         }
       case TForall(_, _) =>
         unserializable(URForall)
-      case TTuple(_) =>
-        unserializable(URTuple)
+      case TStroct(_) =>
+        unserializable(URStroct)
     }
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -24,8 +24,8 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       } else
         v -> TypeSubst(map - v)
       TForall((v1, k), subst1(t))
-    case TStroct(ts) =>
-      TStroct(ts.transform { (_, x) =>
+    case TStruct(ts) =>
+      TStruct(ts.transform { (_, x) =>
         apply(x)
       })
   }
@@ -127,14 +127,14 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       ERecUpd(apply(tycon), field, apply(record), apply(update))
     case EVariantCon(tycon, variant, arg) =>
       EVariantCon(apply(tycon), variant, apply(arg))
-    case EStroctCon(fields) =>
-      EStroctCon(fields.transform { (_, x) =>
+    case EStructCon(fields) =>
+      EStructCon(fields.transform { (_, x) =>
         apply(x)
       })
-    case EStroctProj(field, stroct) =>
-      EStroctProj(field, apply(stroct))
-    case EStroctUpd(field, stroct, update) =>
-      EStroctUpd(field, apply(stroct), apply(update))
+    case EStructProj(field, struct) =>
+      EStructProj(field, apply(struct))
+    case EStructUpd(field, struct, update) =>
+      EStructUpd(field, apply(struct), apply(update))
     case EApp(fun, arg) =>
       EApp(apply(fun), apply(arg))
     case ETyApp(expr, typ) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -24,8 +24,8 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       } else
         v -> TypeSubst(map - v)
       TForall((v1, k), subst1(t))
-    case TTuple(ts) =>
-      TTuple(ts.transform { (_, x) =>
+    case TStroct(ts) =>
+      TStroct(ts.transform { (_, x) =>
         apply(x)
       })
   }
@@ -127,14 +127,14 @@ private[validation] case class TypeSubst(map: Map[TypeVarName, Type], private va
       ERecUpd(apply(tycon), field, apply(record), apply(update))
     case EVariantCon(tycon, variant, arg) =>
       EVariantCon(apply(tycon), variant, apply(arg))
-    case ETupleCon(fields) =>
-      ETupleCon(fields.transform { (_, x) =>
+    case EStroctCon(fields) =>
+      EStroctCon(fields.transform { (_, x) =>
         apply(x)
       })
-    case ETupleProj(field, tuple) =>
-      ETupleProj(field, apply(tuple))
-    case ETupleUpd(field, tuple, update) =>
-      ETupleUpd(field, apply(tuple), apply(update))
+    case EStroctProj(field, stroct) =>
+      EStroctProj(field, apply(stroct))
+    case EStroctUpd(field, stroct, update) =>
+      EStroctUpd(field, apply(stroct), apply(update))
     case EApp(fun, arg) =>
       EApp(apply(fun), apply(arg))
     case ETyApp(expr, typ) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -120,7 +120,7 @@ private[validation] object Typing {
         TForall(
           alpha.name -> KStar,
           TTextMap(alpha) ->: TList(
-            TTuple(ImmArray(keyFieldName -> TText, valueFieldName -> alpha)))
+            TStroct(ImmArray(keyFieldName -> TText, valueFieldName -> alpha)))
         ),
       BTextMapSize ->
         TForall(
@@ -431,7 +431,7 @@ private[validation] object Typing {
       case TForall((v, k), b) =>
         introTypeVar(v, k).checkType(b, KStar)
         KStar
-      case TTuple(recordType) =>
+      case TStroct(recordType) =>
         checkRecordType(recordType)
         KStar
     }
@@ -486,27 +486,27 @@ private[validation] object Typing {
           throw EExpectedRecordType(ctx, typ0)
       }
 
-    private def typeOfTupleCon(fields: ImmArray[(FieldName, Expr)]): Type = {
+    private def typeOfStroctCon(fields: ImmArray[(FieldName, Expr)]): Type = {
       checkUniq[FieldName](fields.keys, EDuplicateField(ctx, _))
-      TTuple(fields.transform { (_, x) =>
+      TStroct(fields.transform { (_, x) =>
         typeOf(x)
       })
     }
 
-    private def typeOfTupleProj(field: FieldName, expr: Expr): Type = typeOf(expr) match {
-      case TTuple(tupleType) =>
-        tupleType.lookup(field, EUnknownField(ctx, field))
+    private def typeOfStroctProj(field: FieldName, expr: Expr): Type = typeOf(expr) match {
+      case TStroct(stroctType) =>
+        stroctType.lookup(field, EUnknownField(ctx, field))
       case typ =>
-        throw EExpectedTupleType(ctx, typ)
+        throw EExpectedStroctType(ctx, typ)
     }
 
-    private def typeOfTupleUpd(field: FieldName, tuple: Expr, update: Expr): Type =
-      typeOf(tuple) match {
-        case typ @ TTuple(tupleType) =>
-          checkExpr(update, tupleType.lookup(field, EUnknownField(ctx, field)))
+    private def typeOfStroctUpd(field: FieldName, stroct: Expr, update: Expr): Type =
+      typeOf(stroct) match {
+        case typ @ TStroct(stroctType) =>
+          checkExpr(update, stroctType.lookup(field, EUnknownField(ctx, field)))
           typ
         case typ =>
-          throw EExpectedTupleType(ctx, typ)
+          throw EExpectedStroctType(ctx, typ)
       }
 
     private def typeOfTmApp(fun: Expr, arg: Expr): Type = typeOf(fun) match {
@@ -729,7 +729,7 @@ private[validation] object Typing {
         checkRetrieveByKey(retrieveByKey)
         // fetches return the contract id and the contract itself
         TUpdate(
-          TTuple(
+          TStroct(
             ImmArray(
               (contractIdFieldName, TContractId(TTyCon(retrieveByKey.templateId))),
               (contractFieldName, TTyCon(retrieveByKey.templateId)))))
@@ -813,12 +813,12 @@ private[validation] object Typing {
       case EEnumCon(tyCon, constructor) =>
         checkEnumCon(tyCon, constructor)
         TTyCon(tyCon)
-      case ETupleCon(fields) =>
-        typeOfTupleCon(fields)
-      case ETupleProj(field, tuple) =>
-        typeOfTupleProj(field, tuple)
-      case ETupleUpd(field, tuple, update) =>
-        typeOfTupleUpd(field, tuple, update)
+      case EStroctCon(fields) =>
+        typeOfStroctCon(fields)
+      case EStroctProj(field, stroct) =>
+        typeOfStroctProj(field, stroct)
+      case EStroctUpd(field, stroct, update) =>
+        typeOfStroctUpd(field, stroct, update)
       case EApp(fun, arg) =>
         typeOfTmApp(fun, arg)
       case ETyApp(expr, typ) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -120,7 +120,7 @@ private[validation] object Typing {
         TForall(
           alpha.name -> KStar,
           TTextMap(alpha) ->: TList(
-            TStroct(ImmArray(keyFieldName -> TText, valueFieldName -> alpha)))
+            TStruct(ImmArray(keyFieldName -> TText, valueFieldName -> alpha)))
         ),
       BTextMapSize ->
         TForall(
@@ -431,7 +431,7 @@ private[validation] object Typing {
       case TForall((v, k), b) =>
         introTypeVar(v, k).checkType(b, KStar)
         KStar
-      case TStroct(recordType) =>
+      case TStruct(recordType) =>
         checkRecordType(recordType)
         KStar
     }
@@ -486,27 +486,27 @@ private[validation] object Typing {
           throw EExpectedRecordType(ctx, typ0)
       }
 
-    private def typeOfStroctCon(fields: ImmArray[(FieldName, Expr)]): Type = {
+    private def typeOfStructCon(fields: ImmArray[(FieldName, Expr)]): Type = {
       checkUniq[FieldName](fields.keys, EDuplicateField(ctx, _))
-      TStroct(fields.transform { (_, x) =>
+      TStruct(fields.transform { (_, x) =>
         typeOf(x)
       })
     }
 
-    private def typeOfStroctProj(field: FieldName, expr: Expr): Type = typeOf(expr) match {
-      case TStroct(stroctType) =>
-        stroctType.lookup(field, EUnknownField(ctx, field))
+    private def typeOfStructProj(field: FieldName, expr: Expr): Type = typeOf(expr) match {
+      case TStruct(structType) =>
+        structType.lookup(field, EUnknownField(ctx, field))
       case typ =>
-        throw EExpectedStroctType(ctx, typ)
+        throw EExpectedStructType(ctx, typ)
     }
 
-    private def typeOfStroctUpd(field: FieldName, stroct: Expr, update: Expr): Type =
-      typeOf(stroct) match {
-        case typ @ TStroct(stroctType) =>
-          checkExpr(update, stroctType.lookup(field, EUnknownField(ctx, field)))
+    private def typeOfStructUpd(field: FieldName, struct: Expr, update: Expr): Type =
+      typeOf(struct) match {
+        case typ @ TStruct(structType) =>
+          checkExpr(update, structType.lookup(field, EUnknownField(ctx, field)))
           typ
         case typ =>
-          throw EExpectedStroctType(ctx, typ)
+          throw EExpectedStructType(ctx, typ)
       }
 
     private def typeOfTmApp(fun: Expr, arg: Expr): Type = typeOf(fun) match {
@@ -729,7 +729,7 @@ private[validation] object Typing {
         checkRetrieveByKey(retrieveByKey)
         // fetches return the contract id and the contract itself
         TUpdate(
-          TStroct(
+          TStruct(
             ImmArray(
               (contractIdFieldName, TContractId(TTyCon(retrieveByKey.templateId))),
               (contractFieldName, TTyCon(retrieveByKey.templateId)))))
@@ -813,12 +813,12 @@ private[validation] object Typing {
       case EEnumCon(tyCon, constructor) =>
         checkEnumCon(tyCon, constructor)
         TTyCon(tyCon)
-      case EStroctCon(fields) =>
-        typeOfStroctCon(fields)
-      case EStroctProj(field, stroct) =>
-        typeOfStroctProj(field, stroct)
-      case EStroctUpd(field, stroct, update) =>
-        typeOfStroctUpd(field, stroct, update)
+      case EStructCon(fields) =>
+        typeOfStructCon(fields)
+      case EStructProj(field, struct) =>
+        typeOfStructProj(field, struct)
+      case EStructUpd(field, struct, update) =>
+        typeOfStructUpd(field, struct, update)
       case EApp(fun, arg) =>
         typeOfTmApp(fun, arg)
       case ETyApp(expr, typ) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -108,7 +108,7 @@ case object URUpdate extends UnserializabilityReason {
 case object URScenario extends UnserializabilityReason {
   def pretty: String = "Scenario"
 }
-case object URStroct extends UnserializabilityReason {
+case object URStruct extends UnserializabilityReason {
   def pretty: String = "structural record"
 }
 case object URNumeric extends UnserializabilityReason {
@@ -218,8 +218,8 @@ final case class EUnknownEnumCon(context: Context, conName: EnumConName) extends
 final case class EUnknownField(context: Context, fieldName: FieldName) extends ValidationError {
   protected def prettyInternal: String = s"unknown field: $fieldName"
 }
-final case class EExpectedStroctType(context: Context, typ: Type) extends ValidationError {
-  protected def prettyInternal: String = s"expected stroct type, but found: ${typ.pretty}"
+final case class EExpectedStructType(context: Context, typ: Type) extends ValidationError {
+  protected def prettyInternal: String = s"expected struct type, but found: ${typ.pretty}"
 }
 final case class EKindMismatch(context: Context, foundKind: Kind, expectedKind: Kind)
     extends ValidationError {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -108,7 +108,7 @@ case object URUpdate extends UnserializabilityReason {
 case object URScenario extends UnserializabilityReason {
   def pretty: String = "Scenario"
 }
-case object URTuple extends UnserializabilityReason {
+case object URStroct extends UnserializabilityReason {
   def pretty: String = "structural record"
 }
 case object URNumeric extends UnserializabilityReason {
@@ -218,8 +218,8 @@ final case class EUnknownEnumCon(context: Context, conName: EnumConName) extends
 final case class EUnknownField(context: Context, fieldName: FieldName) extends ValidationError {
   protected def prettyInternal: String = s"unknown field: $fieldName"
 }
-final case class EExpectedTupleType(context: Context, typ: Type) extends ValidationError {
-  protected def prettyInternal: String = s"expected tuple type, but found: ${typ.pretty}"
+final case class EExpectedStroctType(context: Context, typ: Type) extends ValidationError {
+  protected def prettyInternal: String = s"expected stroct type, but found: ${typ.pretty}"
 }
 final case class EKindMismatch(context: Context, foundKind: Kind, expectedKind: Kind)
     extends ValidationError {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -25,12 +25,12 @@ private[validation] object ExprTraversable {
         f(update)
       case EVariantCon(tycon @ _, variant @ _, arg) =>
         f(arg)
-      case ETupleCon(fields) =>
+      case EStroctCon(fields) =>
         fields.values.foreach(f)
-      case ETupleProj(field @ _, tuple) =>
-        f(tuple)
-      case ETupleUpd(field @ _, tuple, update) =>
-        f(tuple)
+      case EStroctProj(field @ _, stroct) =>
+        f(stroct)
+      case EStroctUpd(field @ _, stroct, update) =>
+        f(stroct)
         f(update)
       case EApp(fun, arg) =>
         f(fun)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -25,12 +25,12 @@ private[validation] object ExprTraversable {
         f(update)
       case EVariantCon(tycon @ _, variant @ _, arg) =>
         f(arg)
-      case EStroctCon(fields) =>
+      case EStructCon(fields) =>
         fields.values.foreach(f)
-      case EStroctProj(field @ _, stroct) =>
-        f(stroct)
-      case EStroctUpd(field @ _, stroct, update) =>
-        f(stroct)
+      case EStructProj(field @ _, struct) =>
+        f(struct)
+      case EStructUpd(field @ _, struct, update) =>
+        f(struct)
         f(update)
       case EApp(fun, arg) =>
         f(fun)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -23,7 +23,7 @@ private[validation] object TypeTraversable {
       case TForall(binder @ _, body) =>
         f(body)
         ()
-      case TStroct(fields) =>
+      case TStruct(fields) =>
         fields.values.foreach(f)
     }
 
@@ -79,7 +79,7 @@ private[validation] object TypeTraversable {
       case EScenario(s) =>
         foreach(s, f)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
-          ELocation(_, _) | EStroctCon(_) | EStroctProj(_, _) | EStroctUpd(_, _, _) | ETyAbs(_, _) =>
+          ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) | ETyAbs(_, _) =>
         ExprTraversable.foreach(expr0, foreach(_, f))
     }
     ()

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -79,7 +79,8 @@ private[validation] object TypeTraversable {
       case EScenario(s) =>
         foreach(s, f)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
-          ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) | ETyAbs(_, _) =>
+          ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) |
+          ETyAbs(_, _) =>
         ExprTraversable.foreach(expr0, foreach(_, f))
     }
     ()

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -23,7 +23,7 @@ private[validation] object TypeTraversable {
       case TForall(binder @ _, body) =>
         f(body)
         ()
-      case TTuple(fields) =>
+      case TStroct(fields) =>
         fields.values.foreach(f)
     }
 
@@ -79,7 +79,7 @@ private[validation] object TypeTraversable {
       case EScenario(s) =>
         foreach(s, f)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
-          ELocation(_, _) | ETupleCon(_) | ETupleProj(_, _) | ETupleUpd(_, _, _) | ETyAbs(_, _) =>
+          ELocation(_, _) | EStroctCon(_) | EStroctProj(_, _) | EStroctUpd(_, _, _) | ETyAbs(_, _) =>
         ExprTraversable.foreach(expr0, foreach(_, f))
     }
     ()

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -181,22 +181,22 @@ object Converter {
   def toApFields(
       compiledPackages: CompiledPackages,
       fun: SValue): Either[String, (SValue, SValue)] = {
-    val extractTuple = SEMakeClo(
+    val extractStroct = SEMakeClo(
       Array(),
       2,
       SEApp(
-        SEBuiltin(SBTupleCon(Name.Array(Name.assertFromString("a"), Name.assertFromString("b")))),
+        SEBuiltin(SBStroctCon(Name.Array(Name.assertFromString("a"), Name.assertFromString("b")))),
         Array(SEVar(2), SEVar(1))))
     val machine =
-      Speedy.Machine.fromSExpr(SEApp(SEValue(fun), Array(extractTuple)), false, compiledPackages)
+      Speedy.Machine.fromSExpr(SEApp(SEValue(fun), Array(extractStroct)), false, compiledPackages)
     @tailrec
     def iter(): Either[String, (SValue, SValue)] = {
       if (machine.isFinal) {
         machine.toSValue match {
-          case STuple(_, values) if values.size == 2 => {
+          case SStroct(_, values) if values.size == 2 => {
             Right((values.get(0), values.get(1)))
           }
-          case v => Left(s"Expected STuple but got $v")
+          case v => Left(s"Expected SStroct but got $v")
         }
       } else {
         machine.step() match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -181,22 +181,22 @@ object Converter {
   def toApFields(
       compiledPackages: CompiledPackages,
       fun: SValue): Either[String, (SValue, SValue)] = {
-    val extractStroct = SEMakeClo(
+    val extractStruct = SEMakeClo(
       Array(),
       2,
       SEApp(
-        SEBuiltin(SBStroctCon(Name.Array(Name.assertFromString("a"), Name.assertFromString("b")))),
+        SEBuiltin(SBStructCon(Name.Array(Name.assertFromString("a"), Name.assertFromString("b")))),
         Array(SEVar(2), SEVar(1))))
     val machine =
-      Speedy.Machine.fromSExpr(SEApp(SEValue(fun), Array(extractStroct)), false, compiledPackages)
+      Speedy.Machine.fromSExpr(SEApp(SEValue(fun), Array(extractStruct)), false, compiledPackages)
     @tailrec
     def iter(): Either[String, (SValue, SValue)] = {
       if (machine.isFinal) {
         machine.toSValue match {
-          case SStroct(_, values) if values.size == 2 => {
+          case SStruct(_, values) if values.size == 2 => {
             Right((values.get(0), values.get(1)))
           }
-          case v => Left(s"Expected SStroct but got $v")
+          case v => Left(s"Expected SStruct but got $v")
         }
       } else {
         machine.step() match {

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -317,9 +317,9 @@ object Queries {
         case V.ValueGenMap(_) =>
           // FIXME https://github.com/digital-asset/daml/issues/2256
           throw new IllegalArgumentException(s"Gen Map are not supported")
-        case stroct @ V.ValueStroct(_) =>
+        case struct @ V.ValueStruct(_) =>
           throw new IllegalArgumentException(
-            s"stroct should not be present in contract, as raw strocts are not serializable: $stroct")
+            s"struct should not be present in contract, as raw structs are not serializable: $struct")
       }
     }
   }

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -317,9 +317,9 @@ object Queries {
         case V.ValueGenMap(_) =>
           // FIXME https://github.com/digital-asset/daml/issues/2256
           throw new IllegalArgumentException(s"Gen Map are not supported")
-        case tuple @ V.ValueTuple(_) =>
+        case stroct @ V.ValueStroct(_) =>
           throw new IllegalArgumentException(
-            s"tuple should not be present in contract, as raw tuples are not serializable: $tuple")
+            s"stroct should not be present in contract, as raw strocts are not serializable: $stroct")
       }
     }
   }

--- a/language-support/ts/codegen/src/Main.hs
+++ b/language-support/ts/codegen/src/Main.hs
@@ -215,7 +215,7 @@ genType curModName = go
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"
-        TTuple{} -> error "IMPOSSIBLE: structural record not serializable"
+        TStroct{} -> error "IMPOSSIBLE: structural record not serializable"
         TNat{} -> error "IMPOSSIBLE: standalone type level natural not serializable"
 
 genTypeCon :: ModuleName -> Qualified TypeConName -> (T.Text, T.Text)

--- a/language-support/ts/codegen/src/Main.hs
+++ b/language-support/ts/codegen/src/Main.hs
@@ -215,7 +215,7 @@ genType curModName = go
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"
-        TStroct{} -> error "IMPOSSIBLE: structural record not serializable"
+        TStruct{} -> error "IMPOSSIBLE: structural record not serializable"
         TNat{} -> error "IMPOSSIBLE: standalone type level natural not serializable"
 
 genTypeCon :: ModuleName -> Qualified TypeConName -> (T.Text, T.Text)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -81,7 +81,7 @@ object ApiValueToLfValueConverterTest {
       values.toImmArray === values2.toImmArray
     case (V.ValueOptional(value1), V.ValueOptional(value2)) =>
       value1 === value2
-    case (V.ValueTuple(fields), V.ValueTuple(fields2)) =>
+    case (V.ValueStroct(fields), V.ValueStroct(fields2)) =>
       fields === fields2
     case (V.ValueTextMap(map1), V.ValueTextMap(map2)) =>
       map1.toImmArray === map2.toImmArray

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -81,7 +81,7 @@ object ApiValueToLfValueConverterTest {
       values.toImmArray === values2.toImmArray
     case (V.ValueOptional(value1), V.ValueOptional(value2)) =>
       value1 === value2
-    case (V.ValueStroct(fields), V.ValueStroct(fields2)) =>
+    case (V.ValueStruct(fields), V.ValueStruct(fields2)) =>
       fields === fields2
     case (V.ValueTextMap(map1), V.ValueTextMap(map2)) =>
       map1.toImmArray === map2.toImmArray

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -61,7 +61,7 @@ abstract class ApiCodecCompressed[Cid](
     case _: V.ValueGenMap[Cid] =>
       // FIXME https://github.com/digital-asset/daml/issues/2256
       serializationError("GenMap are not not supported.")
-    case _: V.ValueStroct[Cid] => serializationError("impossible! strocts are not serializable")
+    case _: V.ValueStruct[Cid] => serializationError("impossible! structs are not serializable")
   }
 
   @throws[SerializationException]

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -61,7 +61,7 @@ abstract class ApiCodecCompressed[Cid](
     case _: V.ValueGenMap[Cid] =>
       // FIXME https://github.com/digital-asset/daml/issues/2256
       serializationError("GenMap are not not supported.")
-    case _: V.ValueTuple[Cid] => serializationError("impossible! tuples are not serializable")
+    case _: V.ValueStroct[Cid] => serializationError("impossible! strocts are not serializable")
   }
 
   @throws[SerializationException]

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
@@ -99,7 +99,7 @@ trait NavigatorModelAliases[Cid] {
   type ApiOptional = OfCid[V.ValueOptional]
   type ApiMap = OfCid[V.ValueTextMap]
   type ApiGenMap = OfCid[V.ValueGenMap]
-  type ApiImpossible = OfCid[V.ValueStroct]
+  type ApiImpossible = OfCid[V.ValueStruct]
 }
 
 object NavigatorModelAliases extends NavigatorModelAliases[String]

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
@@ -99,7 +99,7 @@ trait NavigatorModelAliases[Cid] {
   type ApiOptional = OfCid[V.ValueOptional]
   type ApiMap = OfCid[V.ValueTextMap]
   type ApiGenMap = OfCid[V.ValueGenMap]
-  type ApiImpossible = OfCid[V.ValueTuple]
+  type ApiImpossible = OfCid[V.ValueStroct]
 }
 
 object NavigatorModelAliases extends NavigatorModelAliases[String]

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -103,7 +103,7 @@ object LfEngineToApi {
               } yield api.GenMap.Entry(Some(key), Some(value)) :: tail
           }
           .map(list => api.Value(api.Value.Sum.GenMap(api.GenMap(list))))
-      case Lf.ValueStroct(_) => Left("strocts not allowed")
+      case Lf.ValueStruct(_) => Left("structs not allowed")
       case Lf.ValueList(vs) =>
         vs.toImmArray.toSeq.traverseEitherStrictly(lfValueToApiValue(verbose, _)) map { xs =>
           api.Value(api.Value.Sum.List(api.List(xs)))

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -103,7 +103,7 @@ object LfEngineToApi {
               } yield api.GenMap.Entry(Some(key), Some(value)) :: tail
           }
           .map(list => api.Value(api.Value.Sum.GenMap(api.GenMap(list))))
-      case Lf.ValueTuple(_) => Left("tuples not allowed")
+      case Lf.ValueStroct(_) => Left("strocts not allowed")
       case Lf.ValueList(vs) =>
         vs.toImmArray.toSeq.traverseEitherStrictly(lfValueToApiValue(verbose, _)) map { xs =>
           api.Value(api.Value.Sum.List(api.List(xs)))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
@@ -105,9 +105,9 @@ object KeyHasher extends KeyHasher {
         val z2 = entries.foldLeft[T](z1) { case (t, (k, v)) => foldLeft(k, foldLeft(v, t, op), op) }
         op(z2, HashTokenCollectionEnd())
 
-      // Stroct: should never be encountered
-      case ValueStroct(_) =>
-        sys.error("Hashing of stroct values is not supported")
+      // Struct: should never be encountered
+      case ValueStruct(_) =>
+        sys.error("Hashing of struct values is not supported")
     }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/KeyHasher.scala
@@ -105,9 +105,9 @@ object KeyHasher extends KeyHasher {
         val z2 = entries.foldLeft[T](z1) { case (t, (k, v)) => foldLeft(k, foldLeft(v, t, op), op) }
         op(z2, HashTokenCollectionEnd())
 
-      // Tuple: should never be encountered
-      case ValueTuple(_) =>
-        sys.error("Hashing of tuple values is not supported")
+      // Stroct: should never be encountered
+      case ValueStroct(_) =>
+        sys.error("Hashing of stroct values is not supported")
     }
   }
 


### PR DESCRIPTION
Rename DAML-LF structural records as `struct`s. Previously these were known (confusingly) as tuples!

- `tuple` -> `struct`
- `Tuple` ->`Struct`
- `TUPLE` -> `STRUCT`
- `tup` prefix used in haskell field name -> `struct`

The change affects `.proto`, `.scala` and `.haskell` files. A following PR will update doc.
- `.proto` : message types & field names
- `scala` : types (classes/objects)
- `haskell`: data constructor names & field names
- everywhere: local variable names & comments

`.proto`
- message `Tuple`
- message `TupleCon`
- message `TupleProj`
- message `TupleUpd`

`Scala`
- class `ETupleCon`
- class `ETupleProj`
- class `ETupleUpd`
- class `TTuple`
- class `ValueTuple`
- class `EExpectedTupleType`
- class `SBTupleCon`
- class `SBTupleProj`
- class `SBTupleUpd`
- class `STuple`
- object `TTuple`
- object `URTuple`

Haskell:
- `TTuple`
- `ETupleCon`
- `ETupleProj`
- `ETupleUpd`
- `ETupleConF`
- `ETupleProjF`
- `ETupleUpdF`
- `URTuple`
- `EExpectedTupleType`



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
