### PR TITLE
scala-protoc-plugins: Don't use two versions of scalapb.

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -204,26 +204,6 @@ def daml_deps():
             urls = ["https://github.com/johnynek/bazel_jar_jar/archive/20dbf71f09b1c1c2a8575a42005a968b38805519.zip"],  # Latest commit SHA as at 2019/02/13
         )
 
-    if "com_github_scalapb_scalapb" not in native.existing_rules():
-        http_archive(
-            name = "com_github_scalapb_scalapb",
-            url = "https://github.com/scalapb/ScalaPB/releases/download/v0.8.0/scalapbc-0.8.0.zip",
-            sha256 = "bda0b44b50f0a816342a52c34e6a341b1a792f2a6d26f4f060852f8f10f5d854",
-            strip_prefix = "scalapbc-0.8.0/lib",
-            build_file_content = """
-java_import(
-    name = "compilerplugin",
-    jars = ["com.thesamet.scalapb.compilerplugin-0.8.0.jar"],
-    visibility = ["//visibility:public"],
-)
-java_import(
-    name = "scala-library",
-    jars = ["org.scala-lang.scala-library-2.11.12.jar"],
-    visibility = ["//visibility:public"],
-)
-            """,
-        )
-
         if "com_github_googleapis_googleapis" not in native.existing_rules():
             http_archive(
                 name = "com_github_googleapis_googleapis",

--- a/scala-protoc-plugins/scala-akka/BUILD.bazel
+++ b/scala-protoc-plugins/scala-akka/BUILD.bazel
@@ -8,9 +8,6 @@ da_scala_binary(
     srcs = glob(["*.scala"]),
     main_class = "com.digitalasset.protoc.plugins.akka.AkkaStreamCompilerPlugin",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        "@com_github_scalapb_scalapb//:scala-library",
-    ],
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_thesamet_scalapb_compilerplugin_2_12",

--- a/scala-protoc-plugins/scala-logging/BUILD.bazel
+++ b/scala-protoc-plugins/scala-logging/BUILD.bazel
@@ -8,9 +8,6 @@ da_scala_binary(
     srcs = ["LoggingCompilerPlugin.scala"],
     main_class = "com.digitalasset.protoc.plugins.logging.LoggingCompilerPlugin",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        "@com_github_scalapb_scalapb//:scala-library",
-    ],
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_thesamet_scalapb_compilerplugin_2_12",

--- a/scala-protoc-plugins/scalapb/BUILD.bazel
+++ b/scala-protoc-plugins/scalapb/BUILD.bazel
@@ -8,9 +8,6 @@ da_scala_binary(
     srcs = glob(["*.scala"]),
     main_class = "com.digitalasset.protoc.plugins.scalapb.ScalaPbCompilerPlugin",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        "@com_github_scalapb_scalapb//:scala-library",
-    ],
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_thesamet_scalapb_compilerplugin_2_12",


### PR DESCRIPTION
This really confuses IntelliJ, because it's importing two versions of
scala-library-*.jar.

Turns out it's not being used anyway.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
