### PR TITLE
Don't break long party names in scenario view weirdly

### DIFF
--- a/compiler/daml-extension/src/webview.css
+++ b/compiler/daml-extension/src/webview.css
@@ -1,0 +1,43 @@
+/* Copyright (c) 2019 The DAML Authors. All rights reserved.  */
+/* SPDX-License-Identifier: Apache-2.0  */
+
+table, th, td {
+  border: 1px solid;
+  border-collapse: collapse;
+}
+th, td {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+body.hide_archived .archived {
+  display: none;
+}
+body.hide_table .table {
+  display: none;
+}
+body.hide_transaction .transaction {
+  display: none;
+}
+body.hide_note .note {
+  display: none;
+}
+tr.archived td {
+  text-decoration: line-through;
+}
+td.disclosure {
+  max-width: 1em;
+  text-align: center;
+}
+tr.archived td.disclosure {
+  text-decoration: none;
+}
+th {
+  vertical-align: bottom;
+}
+div.observer {
+  max-width: 1em;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  white-space: nowrap;
+}
+

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -848,8 +848,8 @@ renderScenarioResult world res = TL.toStrict $ Blaze.renderHtml $ do
     H.docTypeHtml $ do
         H.head $ do
             H.style $ H.text Pretty.highlightStylesheet
-            H.style $ H.text stylesheet
             H.script "" H.! A.src "$webviewSrc"
+            H.link H.! A.rel "stylesheet" H.! A.href "$webviewCss"
         let tableView = renderTableView world res
         let transView = renderTransactionView world res
         let noteView = H.div H.! A.class_ "note" H.! A.id "note" $ H.toHtml $ T.pack " "
@@ -869,48 +869,6 @@ renderScenarioResult world res = TL.toStrict $ Blaze.renderHtml $ do
                 noteView
                 tbl
                 transView
-
-stylesheet :: T.Text
-stylesheet = T.unlines
-  [ "table, th, td {"
-  , "  border: 1px solid;"
-  , "  border-collapse: collapse;"
-  , "}"
-  , "th, td {"
-  , "  padding-left: 2px;"
-  , "  padding-right: 2px;"
-  , "}"
-  , "body.hide_archived .archived {"
-  , "  display: none;"
-  , "}"
-  , "body.hide_table .table {"
-  , "  display: none;"
-  , "}"
-  , "body.hide_transaction .transaction {"
-  , "  display: none;"
-  , "}"
-  , "body.hide_note .note {"
-  , "  display: none;"
-  , "}"
-  , "tr.archived td {"
-  , "  text-decoration: line-through;"
-  , "}"
-  , "td.disclosure {"
-  , "  max-width: 1em;"
-  , "  text-align: center;"
-  , "}"
-  , "tr.archived td.disclosure {"
-  , "  text-decoration: none;"
-  , "}"
-  , "th {"
-  , "  vertical-align: bottom;"
-  , "}"
-  , "div.observer {"
-  , "  max-width: 1em;"
-  , "  writing-mode: vertical-rl;"
-  , "  transform: rotate(180deg);"
-  , "}"
-  ]
 
 scenarioNotInFileNote :: T.Text -> T.Text
 scenarioNotInFileNote file = htmlNote $ T.pack $


### PR DESCRIPTION
Until now, we broke long party names in the table view in the scenario at
spaces. This looked quite ugly.

Now, we don't break them at spaces. At the same time we also moved the CSS
into a file rather than having it in the code to make changes like this one
easier in the future.

This fixes #3642.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3669)
<!-- Reviewable:end -->
