### PR TITLE
Update DataDependencies.hs for GenMap

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -225,7 +225,6 @@ generateSrcFromLf env = noLoc mod
             LF.BTOptional -> (damlStdlibUnitId, sdkInternalPrelude)
             LF.BTTextMap -> (damlStdlibUnitId, sdkDaInternalLf)
             LF.BTGenMap -> (damlStdlibUnitId, sdkDaInternalLf)
-                -- GENMAP TODO (#2256): Verify module name once GenMap implemented in stdlib.
             LF.BTArrow -> (primUnitId, translateModName funTyCon)
             LF.BTNumeric -> (primUnitId, LF.ModuleName ["GHC", "Types"])
             LF.BTAny -> (damlStdlibUnitId, sdkDaInternalLf)
@@ -555,8 +554,7 @@ convBuiltInTy env =
         LF.BTContractId -> mkLfInternalType env "ContractId"
         LF.BTOptional -> mkLfInternalPrelude env "Optional"
         LF.BTTextMap -> mkLfInternalType env "TextMap"
-        LF.BTGenMap -> mkLfInternalType env "GenMap"
-            -- GENMAP TODO  (#2256): Verify type name once implemented in stdlib.
+        LF.BTGenMap -> mkLfInternalType env "Map"
         LF.BTArrow -> mkTyConTypeUnqual funTyCon
         LF.BTNumeric -> mkGhcType "Numeric"
         LF.BTAny -> mkLfInternalType env "Any"
@@ -807,4 +805,3 @@ generateGenInstanceModule env externPkgId qual
         [ "import qualified " <> modNameQual
         , "import qualified DA.Generics"
         ]
-


### PR DESCRIPTION
Now that `GenMap` is added in the stdlib as `Map` in `DA.Internal.LF`, it's necessary to update these references.