### PR TITLE
Improve the error message for polymorphic numeric literals

### DIFF
--- a/compiler/damlc/daml-lf-conversion/BUILD.bazel
+++ b/compiler/damlc/daml-lf-conversion/BUILD.bazel
@@ -13,6 +13,7 @@ da_haskell_library(
         "base",
         "bytestring",
         "containers",
+        "Decimal",
         "directory",
         "extra",
         "filepath",

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -97,6 +97,7 @@ import           DA.Daml.LF.Ast as LF
 import           DA.Daml.LF.Ast.Type as LF
 import           DA.Daml.LF.Ast.Numeric
 import           Data.Data hiding (TyCon)
+import qualified Data.Decimal as Decimal
 import           Data.Foldable (foldlM)
 import           Data.Int
 import           Data.List.Extra
@@ -789,7 +790,7 @@ convertExpr env0 e = do
     go env (VarIn GHC_Real "fromRational") (LType (isNumLitTy -> Just n) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalNumericMono env n top bot
     go env (VarIn GHC_Real "fromRational") (LType scaleTyCoRep : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
-        = unsupported "Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (1.2345 : Numeric 10)" ()
+        = unsupported ("Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (" ++ show (fromRational (top % bot) :: Decimal.Decimal) ++ " : Numeric 10)") ()
     go env (VarIn GHC_Num "negate") (tyInt : LExpr (VarIs "$fAdditiveInt") : LExpr (untick -> VarIs "fromInteger" `App` Lit (LitNumber _ x _)) : args)
         = fmap (, args) $ convertInt64 (negate x)
     go env (VarIn GHC_Integer_Type "fromInteger") (LExpr (Lit (LitNumber _ x _)) : args)

--- a/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
@@ -6,7 +6,7 @@
 -- conversion error even if we try to be clever.
 --
 -- @SINCE-LF 1.7
--- @ERROR Polymorphic numeric literal
+-- @ERROR Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (2.71828 : Numeric 10)
 
 daml 1.2
 
@@ -16,4 +16,4 @@ module NumericLitPoly where
 -- numeric value, you need to import DA.Numeric and use `cast` or
 -- `castAndRound` explicitly.
 polyLit : NumericScale n => Numeric n
-polyLit = 1.2345
+polyLit = 2.71828


### PR DESCRIPTION
Display the actual number the user tried to use instead of 1.2345.

The logic to display the number is not perfect but definitely better than
we have now. If somebody knows a _simple_ way to do this better, please
tell me about it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3672)
<!-- Reviewable:end -->
