### PR TITLE
Don't make UndecidableSuperClasses a default extension for DAML

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -160,7 +160,7 @@ xExtensionsSet =
   , ConstraintKinds
     -- type classes
   , MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, TypeSynonymInstances
-  , DefaultSignatures, StandaloneDeriving, FunctionalDependencies, DeriveFunctor, UndecidableSuperClasses
+  , DefaultSignatures, StandaloneDeriving, FunctionalDependencies, DeriveFunctor
     -- let generalization
   , MonoLocalBinds
     -- replacing primitives


### PR DESCRIPTION
We needed this for our generic template hacks. Since they are gone now,
I'm very much in favour of removing this extension since "undecidable"
always sounds a bit scary, even if it is only at compile time.

CHANGELOG_BEGIN

- [DAML Compiler] Don't make `UndecidableSuperClasses` a default language
  extension for DAML anymore. If you really need this feature for a module,
  you can reenable it using a `LANGUAGE` pragma at the top.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3673)
<!-- Reviewable:end -->
