### PR TITLE
Add support for type-synonyms in DAML-LF .proto and Haskell AST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -670,6 +670,8 @@ data DataCons
   | DataVariant ![(VariantConName, Type)]
   -- | An enum type given by the name of its constructors.
   | DataEnum ![VariantConName]
+  -- | A type synonym
+  | DataSynonym !Type
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 newtype HasNoPartyLiterals = HasNoPartyLiterals{getHasNoPartyLiterals :: Bool}

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -92,6 +92,7 @@ dataConsType f = \case
   DataRecord  fs -> DataRecord  <$> (traverse . _2) f fs
   DataVariant cs -> DataVariant <$> (traverse . _2) f cs
   DataEnum cs -> pure $ DataEnum cs
+  DataSynonym t -> DataSynonym <$> f t
 
 builtinType :: Traversal' Type BuiltinType
 builtinType f =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -463,6 +463,8 @@ instance Pretty Expr where
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =
     withSourceLoc mbLoc $ case dataCons of
+    DataSynonym typ ->
+      (keyword_ "synonym" <-> lhsDoc) $$ nest 2 (pPrintPrec lvl 0 typ)
     DataRecord fields ->
       hang (keyword_ "record" <-> lhsDoc) 2 (prettyRecord lvl prettyHasType fields)
     DataVariant variants ->

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -208,6 +208,8 @@ decodeDefDataType LF1.DefDataType{..} =
 
 decodeDataCons :: LF1.DefDataTypeDataCons -> Decode DataCons
 decodeDataCons = \case
+  LF1.DefDataTypeDataConsSynonym ty ->
+    DataSynonym <$> decodeType ty
   LF1.DefDataTypeDataConsRecord (LF1.DefDataType_Fields fs) ->
     DataRecord <$> mapM (decodeFieldWithType FieldName) (V.toList fs)
   LF1.DefDataTypeDataConsVariant (LF1.DefDataType_Fields fs) ->

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -712,6 +712,9 @@ encodeDefDataType DefDataType{..} = do
     defDataTypeName <- encodeDottedName unTypeConName dataTypeCon
     defDataTypeParams <- encodeTypeVarsWithKinds dataParams
     defDataTypeDataCons <- fmap Just $ case dataCons of
+        DataSynonym typ -> do
+            t <- encodeType' typ
+            pure $ P.DefDataTypeDataConsSynonym t
         DataRecord fs -> do
             defDataType_FieldsFields <- encodeFieldsWithTypes unFieldName fs
             pure $ P.DefDataTypeDataConsRecord P.DefDataType_Fields{..}

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -563,6 +563,8 @@ checkDefDataType (DefDataType _loc _name _serializable params dataCons) = do
       DataEnum names -> do
         unless (null params) $ throwWithContext EEnumTypeWithParams
         checkUnique EDuplicateConstructor names
+      DataSynonym typ -> do -- TODO(NICK): check for cycles
+        typ `checkType` KStar
 
 checkDefValue :: MonadGamma m => DefValue -> m ()
 checkDefValue (DefValue _loc (_, typ) _noParties (IsTest isTest) expr) = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -147,7 +147,8 @@ checkDataType moduleName DefDataType{..} =
             forM_ constrs $ \vconName -> do
                 checkName (NEnumCon moduleName dataTypeCon vconName)
 
-        DataSynonym _ -> return ()
+        DataSynonym _ ->
+            checkName (NEnumType moduleName dataTypeCon)
 
 checkTemplate :: MonadGamma m => ModuleName -> Template -> S.StateT NCState m ()
 checkTemplate moduleName Template{..} = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -147,6 +147,8 @@ checkDataType moduleName DefDataType{..} =
             forM_ constrs $ \vconName -> do
                 checkName (NEnumCon moduleName dataTypeCon vconName)
 
+        DataSynonym _ -> return ()
+
 checkTemplate :: MonadGamma m => ModuleName -> Template -> S.StateT NCState m ()
 checkTemplate moduleName Template{..} = do
     forM_ tplChoices $ \TemplateChoice{..} ->

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -108,6 +108,9 @@ generateSrcFromLf env = noLoc mod
 
     convDataCons :: T.Text -> LF.DataCons -> [LConDecl GhcPs]
     convDataCons dataTypeCon0 = \case
+            LF.DataSynonym _ ->
+              [] -- TODO(NICK) write the Haskell type synonym
+
             LF.DataRecord fields ->
                 [ noLoc $
                   ConDeclH98

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -235,6 +235,7 @@ typeConFieldsNames _ (LF.FieldName fName, _) = [fName]
 typeConFields :: LF.Qualified LF.TypeConName -> LF.World -> [T.Text]
 typeConFields qName world = case LF.lookupDataType qName world of
   Right dataType -> case LF.dataCons dataType of
+    LF.DataSynonym _ -> [""] -- TODO(NICK)
     LF.DataRecord re -> concatMap (typeConFieldsNames world) re
     LF.DataVariant _ -> [""]
     LF.DataEnum _ -> [""]

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -104,6 +104,13 @@ main = do
             , tplChoices = NM.fromList ([chc,chc2] <> [arc | withArchiveChoice])
             , tplKey = Nothing
             }
+    let _syn = DefDataType -- TODO(NICK) make use of this synonym
+            { dataLocation = Nothing
+            , dataTypeCon = TypeConName ["Syn"]
+            , dataSerializable = IsSerializable True
+            , dataParams = []
+            , dataCons = DataSynonym TUnit
+            }
     let mod = Module
             { moduleName = ModuleName ["Module"]
             , moduleSource = Nothing

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -1309,6 +1309,7 @@ message DefDataType {
     Fields record = 3; // Records without fields are explicitly allowed.
     Fields variant = 4; // Variants without constructors are explicitly allowed.
     EnumConstructors enum = 7; // *Available in versions >= 1.6*
+    Type synonym = 9; // *Available in versions >= 1.dev*
   }
 
   // If true, this data type preserves serializability in the sense that when

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -248,6 +248,9 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         lfDataType.getSerializable,
         ImmArray(params).map(decodeTypeVarWithKind),
         lfDataType.getDataConsCase match {
+          case PLF.DefDataType.DataConsCase.SYNONYM =>
+            //assertSince(LV.Features.type_syn, "DefDataType.DataCons.Synonym") //TODO(NICK)
+            throw ParseError("DefDataType.DataCons.Synonym") //TODO(NICK)
           case PLF.DefDataType.DataConsCase.RECORD =>
             DataRecord(decodeFields(ImmArray(lfDataType.getRecord.getFieldsList.asScala)), None)
           case PLF.DefDataType.DataConsCase.VARIANT =>

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -249,6 +249,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         ImmArray(params).map(decodeTypeVarWithKind),
         lfDataType.getDataConsCase match {
           case PLF.DefDataType.DataConsCase.SYNONYM =>
+            // FIXME https://github.com/digital-asset/daml/issues/3616
             //assertSince(LV.Features.type_syn, "DefDataType.DataCons.Synonym") //TODO(NICK)
             throw ParseError("DefDataType.DataCons.Synonym") //TODO(NICK)
           case PLF.DefDataType.DataConsCase.RECORD =>

--- a/language-support/ts/codegen/src/Main.hs
+++ b/language-support/ts/codegen/src/Main.hs
@@ -114,6 +114,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
     [] -> error "IMPOSSIBLE: empty type constructor name"
     _:_:_ -> error "TODO(MH): multi-part type constructor names"
     [conName] -> case dataCons def of
+        DataSynonym{} -> ((makeType ["unknown;"], makeSer ["jtv.unknownJson,"]), Set.empty)  -- TODO(NICK)
         DataVariant{} -> ((makeType ["unknown;"], makeSer ["jtv.unknownJson,"]), Set.empty)  -- TODO(MH): make variants type safe
         DataEnum{} -> ((makeType ["unknown;"], makeSer ["jtv.unknownJson,"]), Set.empty)  -- TODO(MH): make enum types type safe
         DataRecord fields ->


### PR DESCRIPTION
Add support for type synonym (step 1)
- extend .proto defs
- extend Haskell AST
- fixup haskell code (leaving some TODO makers)
- fix `Decode.scala` to : `throw ParseError("DefDataType.DataCons.Synonym")`

This PR does not extende scala AST, or make any other changes on the scala side.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
