### PR TITLE
Remove component version from damlc output

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -138,12 +138,10 @@ genrule(
     outs = ["SdkVersion.hs"],
     cmd = """
         SDK_VERSION=$$(cat $(location VERSION))
-        COMPONENT_VERSION=$$(cat $(location :component-version))
         cat > $@ <<EOF
 module SdkVersion where
-sdkVersion, componentVersion, damlStdlib :: String
+sdkVersion, damlStdlib :: String
 sdkVersion = "$$SDK_VERSION"
-componentVersion = "$$COMPONENT_VERSION"
 damlStdlib = "daml-stdlib-" ++ sdkVersion
 EOF
     """,

--- a/compiler/damlc/lib/DA/Cli/Damlc/BuildInfo.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/BuildInfo.hs
@@ -11,7 +11,4 @@ import Data.Monoid ((<>))
 import SdkVersion
 
 buildInfo :: PP.Doc
-buildInfo = PP.vcat
-    [ "Compiler Version: " <> PP.text componentVersion
-    , "SDK Version: " <> PP.text sdkVersion
-    ]
+buildInfo = "SDK Version: " <> PP.text sdkVersion


### PR DESCRIPTION
The component version is a relic from before we went to a mono repo.
It's completely useless now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3709)
<!-- Reviewable:end -->
