### PR TITLE
Fix RST in DAML script docs

### DIFF
--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -83,7 +83,7 @@ script so that we can easily swap them out.
    :end-before: -- LEDGER_PARTIES_END
 
 Let us now write a function to initialize the ledger with 3
-``CoinProposal``s and accept 2 of them. This function takes the
+``CoinProposal`` contracts and accept 2 of them. This function takes the
 ``LedgerParties`` as an argument and return something of type ``Script
 ()`` which is DAML script’s equivalent of ``Scenario ()``.
 


### PR DESCRIPTION
RST doesn’t like having a word character after an inline code block.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
