### PR TITLE
Support CreateAndExercise in DAML script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -13,6 +13,7 @@ module Daml.Script
   , createCmd
   , exerciseCmd
   , exerciseByKeyCmd
+  , createAndExerciseCmd
   ) where
 
 import Prelude hiding (submit, submitMustFail)
@@ -56,6 +57,7 @@ data CommandsF a
   = Create { argC : AnyTemplate, continueC : ContractId () -> a }
   | Exercise { tplId : TemplateTypeRep, cId : ContractId (), argE : AnyChoice, continueE : LedgerValue -> a }
   | ExerciseByKey { tplId : TemplateTypeRep, keyE : AnyContractKey, argE : AnyChoice, continueE : LedgerValue -> a }
+  | CreateAndExercise { tplArgCE : AnyTemplate, choiceArgCE : AnyChoice, continueE : LedgerValue -> a }
   deriving Functor
 
 -- | This is used to build up the commands send as part of `submit`.
@@ -145,3 +147,7 @@ exerciseCmd cId arg = Commands $ Ap (\f -> f (Exercise (templateTypeRep @t) (coe
 -- | Exercise a choice on the contract with the given key.
 exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> Commands r
 exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg) identity) (pure fromLedgerValue))
+
+-- | Create a contract and exercise a choice on it in the same transacton.
+createAndExerciseCmd : forall t c r. Choice t c r => t -> c -> Commands r
+createAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) identity) (pure fromLedgerValue))

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -39,6 +39,10 @@ template C
       controller p
       do assert False
 
+    choice GetCValue : Int
+      controller p
+      do pure v
+
 template NumericTpl
   with
     p : Party
@@ -114,3 +118,16 @@ testKey = do
   cid <- submit alice $ createCmd (WithKey alice)
   cid' <- submit alice $ exerciseByKeyCmd @WithKey alice GetCid
   pure (cid, cid')
+
+testCreateAndExercise : Script Int
+testCreateAndExercise = do
+  alice <- allocateParty "alice"
+  cid <- submit alice $ createCmd (C alice 41)
+  -- We send a couple of commands to make sure that we properly handle the fact that
+  -- we get two event results from a CreateAndExercise
+  (_, r, _) <- submit alice $
+    (,,)
+      <$> createCmd (C alice 42)
+      <*> createAndExerciseCmd (C alice 42) GetCValue
+      <*> exerciseCmd cid GetCValue
+  pure r

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -170,6 +170,19 @@ case class TestKey(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
+case class TestCreateAndExercise(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId =
+    Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testCreateAndExercise"))
+  def runTests() = {
+    runner.genericTest(
+      "testKey",
+      scriptId,
+      None,
+      result => TestRunner.assertEqual(SInt64(42), result, "Exercise result")
+    )
+  }
+}
+
 // Runs the example from the docs to make sure it doesn’t produce a runtime error.
 case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptExample:test"))
@@ -230,6 +243,7 @@ object SingleParticipant {
         Test3(dar, runner).runTests()
         Test4(dar, runner).runTests()
         TestKey(dar, runner).runTests()
+        TestCreateAndExercise(dar, runner).runTests()
         ScriptExample(dar, runner).runTests()
     }
   }


### PR DESCRIPTION
CHANGELOG_BEGIN

- [DAML Script - Experimental] Add createAndExerciseCmd matching the
Ledger API command of the same name.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
