### PR TITLE
Avoid running navigator from a temporary directory in `daml ledger na…

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -902,10 +902,9 @@ runLedgerNavigator flags remainingArguments = do
 
         writeFileUTF8 navigatorConfPath (T.unpack $ navigatorConfig partyDetails)
         unsetEnv "DAML_PROJECT" -- necessary to prevent config contamination
-        withCurrentDirectory confDir $ do
-            withJar damlSdkJar [] ("navigator":navigatorArgs) $ \ph -> do
-                exitCode <- waitExitCode ph
-                exitWith exitCode
+        withJar damlSdkJar [] ("navigator" : navigatorArgs ++ ["-c", confDir </> "ui-backend.conf"]) $ \ph -> do
+            exitCode <- waitExitCode ph
+            exitWith exitCode
 
   where
     navigatorConfig :: [PartyDetails] -> T.Text

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -286,7 +286,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
     Arguments.parse(rawArgs, defaultConfigFile) foreach run
 
   private def run(args: Arguments): Unit = {
-    val navigatorConfigFile = args.configFile.getOrElse(defaultConfigFile)
+    val navigatorConfigFile = args.configFile.fold[ConfigOption](DefaultConfig(defaultConfigFile))(ExplicitConfig(_))
 
     args.command match {
       case ShowUsage =>
@@ -295,8 +295,8 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
         dumpGraphQLSchema()
       case CreateConfig =>
         userFacingLogger.info(
-          s"Creating a configuration template file at ${navigatorConfigFile.toAbsolutePath()}")
-        Config.writeTemplateToPath(navigatorConfigFile, args.useDatabase)
+          s"Creating a configuration template file at ${navigatorConfigFile.path.toAbsolutePath()}")
+        Config.writeTemplateToPath(navigatorConfigFile.path, args.useDatabase)
       case RunServer =>
         Config.load(navigatorConfigFile, args.useDatabase) match {
           case Left(ConfigNotFound(_)) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
@@ -39,6 +39,12 @@ final case class ConfigNotFound(reason: String) extends ConfigReadError
 final case class ConfigInvalid(reason: String) extends ConfigReadError
 final case class ConfigParseFailed(reason: String) extends ConfigReadError
 
+sealed abstract class ConfigOption {
+  def path: Path
+}
+final case class DefaultConfig(path: Path) extends ConfigOption
+final case class ExplicitConfig(path: Path) extends ConfigOption
+
 @SuppressWarnings(
   Array(
     "org.wartremover.warts.Any",
@@ -48,16 +54,22 @@ object Config {
 
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
 
-  def load(configFile: Path, useDatabase: Boolean): Either[ConfigReadError, Config] = {
-    loadSdkConfig(useDatabase).left
-      .flatMap {
-        case ConfigNotFound(_) =>
-          logger.warn("SDK config does not exist. Falling back to Navigator config file.")
-          loadNavigatorConfig(configFile, useDatabase)
-        case e: ConfigReadError =>
-          logger.warn(s"SDK config exists, but is not usable: ${e.reason}")
-          Left(e)
-      }
+  def load(configOpt: ConfigOption, useDatabase: Boolean): Either[ConfigReadError, Config] = {
+    configOpt match {
+      case ExplicitConfig(configFile) =>
+        // If users specified a config file explicitly, we ignore the SDK config.
+        loadNavigatorConfig(configFile, useDatabase)
+      case DefaultConfig(configFile) =>
+        loadSdkConfig(useDatabase).left
+          .flatMap {
+            case ConfigNotFound(_) =>
+              logger.warn("SDK config does not exist. Falling back to Navigator config file.")
+              loadNavigatorConfig(configFile, useDatabase)
+            case e: ConfigReadError =>
+              logger.warn(s"SDK config exists, but is not usable: ${e.reason}")
+              Left(e)
+          }
+    }
   }
 
   def loadNavigatorConfig(


### PR DESCRIPTION
…vigator`

This makes sure that navigator picks up things such as
`frontend-config.js` which is needed for custom tabs.

To get there, this PR does two things:

1. Change navigator such that it prefers a config file specified
explicitly via -c over the SDK config file.
2. Change daml-helper to pass in the config file via -c instead of
changing the directory

CHANGELOG_BEGIN

- [DAML Assistant] ``daml ledger navigator`` now loads
``frontend-config.js`` properly.

- [Navigator] Explicit config files passed via ``-c`` are preferred
over ``daml.yaml``.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
