### PR TITLE
Upgrade Canton to 0.5.0 with flaky test fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -793,7 +793,7 @@ java_import(
     jars = glob(["lib/**"]),
 )
 """,
-    sha256 = "e475dd93a165bd8299eb67684e99c7c5a82dc149cd92829a2103768cff1214ec",
-    strip_prefix = "canton-0.4.1",
-    urls = ["https://www.canton.io/releases/canton-0.4.1.tar.gz"],
+    sha256 = "05123af62ff02d7b6a7661d57c60666f6c7006ab9a7bb01ec976b0fc4402b5a6",
+    strip_prefix = "canton-0.5.0",
+    urls = ["https://www.canton.io/releases/canton-0.5.0.tar.gz"],
 )


### PR DESCRIPTION
This release contains a canton flakiness fix to prevent the
occurrence of `Disputed: Failed to select first domain: The
following parti(es) are not available on any connected domain`
during SemanticTest runs.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
