### PR TITLE
Add tracing info to participant state interface

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.server.damlonx.reference.v2
 
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.ActorSystem
@@ -10,6 +11,7 @@ import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import com.codahale.metrics.SharedMetricRegistries
 import com.daml.ledger.api.server.damlonx.reference.v2.cli.Cli
 import com.daml.ledger.participant.state.kvutils.InMemoryKVParticipantState
+import com.daml.ledger.participant.state.v1.TracingInfo
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.auth.AuthServiceWildcard
@@ -53,7 +55,7 @@ object ReferenceServer extends App {
     for {
       dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
         .readArchiveFromFile(file)
-    } yield ledger.uploadPackages(dar.all, None)
+    } yield ledger.uploadPackages(dar.all, None, TracingInfo(UUID.randomUUID().toString))
   }
 
   val participantF: Future[(AutoCloseable, StandaloneIndexServer#SandboxState)] = for {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InMemoryKVParticipantState.scala
@@ -428,7 +428,8 @@ class InMemoryKVParticipantState(
   override def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): CompletionStage[SubmissionResult] =
+      transaction: SubmittedTransaction,
+      tracingInfo: TracingInfo): CompletionStage[SubmissionResult] =
     CompletableFuture.completedFuture({
       // Construct a [[DamlSubmission]] message using the key-value utilities.
       // [[DamlSubmission]] contains the serialized transaction and metadata such as
@@ -451,7 +452,8 @@ class InMemoryKVParticipantState(
   /** Allocate a party on the ledger */
   override def allocateParty(
       hint: Option[String],
-      displayName: Option[String]): CompletionStage[PartyAllocationResult] = {
+      displayName: Option[String],
+      tracingInfo: TracingInfo): CompletionStage[PartyAllocationResult] = {
 
     hint.map(p => Party.fromString(p)) match {
       case None =>
@@ -484,7 +486,8 @@ class InMemoryKVParticipantState(
   /** Upload DAML-LF packages to the ledger */
   override def uploadPackages(
       archives: List[Archive],
-      sourceDescription: Option[String]): CompletionStage[UploadPackagesResult] = {
+      sourceDescription: Option[String],
+      tracingInfo: TracingInfo): CompletionStage[UploadPackagesResult] = {
     val sId = submissionIdSource.getAndIncrement().toString
     val cf = new CompletableFuture[UploadPackagesResult]
     matcherActorRef ! AddPackageUploadRequest(sId, cf)
@@ -560,7 +563,8 @@ class InMemoryKVParticipantState(
   override def submitConfiguration(
       maxRecordTime: Timestamp,
       submissionId: String,
-      config: Configuration): CompletionStage[SubmissionResult] =
+      config: Configuration,
+      tracingInfo: TracingInfo): CompletionStage[SubmissionResult] =
     CompletableFuture.completedFuture({
       val submission =
         KeyValueSubmission

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -51,7 +51,8 @@ object KeyValueConsumption {
               Some(entry.getPackageUploadEntry.getSourceDescription)
             else None,
             parseLedgerString("ParticipantId")(entry.getPackageUploadEntry.getParticipantId),
-            recordTime
+            recordTime,
+            TracingInfo("")
           )
         }(breakOut)
 
@@ -63,7 +64,12 @@ object KeyValueConsumption {
         val party = parseParty(pae.getParty)
         val participantId = parseLedgerString("ParticipantId")(pae.getParticipantId)
         List(
-          Update.PartyAddedToParticipant(party, pae.getDisplayName, participantId, recordTime)
+          Update.PartyAddedToParticipant(
+            party,
+            pae.getDisplayName,
+            participantId,
+            recordTime,
+            TracingInfo(""))
         )
 
       case DamlLogEntry.PayloadCase.PARTY_ALLOCATION_REJECTION_ENTRY =>
@@ -84,7 +90,8 @@ object KeyValueConsumption {
             recordTime,
             configEntry.getSubmissionId,
             participantId,
-            newConfig
+            newConfig,
+            TracingInfo("")
           )
         )
 
@@ -115,7 +122,8 @@ object KeyValueConsumption {
                 s"Configuration change request timed out: $mrt > $rt"
               case DamlConfigurationRejectionEntry.ReasonCase.REASON_NOT_SET =>
                 "Unknown reason"
-            }
+            },
+            TracingInfo("")
           ))
 
       case DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY =>
@@ -225,7 +233,8 @@ object KeyValueConsumption {
           )
         case DamlTransactionRejectionEntry.ReasonCase.REASON_NOT_SET =>
           throw Err.InternalError("transactionRejectionEntryToUpdate: REASON_NOT_SET!")
-      }
+      },
+      TracingInfo("")
     )
 
   private def partyRejectionEntryToAsyncResponse(
@@ -282,7 +291,8 @@ object KeyValueConsumption {
       transaction = makeCommittedTransaction(entryId, relTx),
       transactionId = hexTxId,
       recordTime = recordTime,
-      divulgedContracts = List.empty
+      divulgedContracts = List.empty,
+      TracingInfo("")
     )
   }
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TracingInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TracingInfo.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+/** Information allowing tracing of the requests across different distributed components
+  *
+  * TracingInfo is used in all the ReadService and WriteService calls
+  *
+  * @param correlationId The unique identifier of the request, assigned by the ledger api server
+  *                      upon receipt of a client command
+  *
+  */
+final case class TracingInfo(correlationId: String)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteConfigService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteConfigService.scala
@@ -23,11 +23,13 @@ trait WriteConfigService {
     * @param maxRecordTime: The maximum record time after which the request is rejected.
     * @param submissionId: Client picked submission identifier for matching the responses with the request.
     * @param config: The new ledger configuration.
+    * @param tracingInfo: The information allowing tracing of the request across the distributed stack.
     * @return an async result of a SubmissionResult
     */
   def submitConfiguration(
       maxRecordTime: Timestamp,
       submissionId: String,
-      config: Configuration
+      config: Configuration,
+      tracingInfo: TracingInfo
   ): CompletionStage[SubmissionResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
@@ -39,10 +39,13 @@ trait WritePackagesService {
     *
     * @param payload           : DAML-LF archives to be uploaded to the ledger.
     *
+    * @param tracingInfo       : The information allowing tracing of the request across the distributed stack.
+    *
     * @return an async result of a [[UploadPackagesResult]]
     */
   def uploadPackages(
       payload: List[Archive],
-      sourceDescription: Option[String]
+      sourceDescription: Option[String],
+      tracingInfo: TracingInfo
   ): CompletionStage[UploadPackagesResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
@@ -32,10 +32,13 @@ trait WritePartyService {
     *
     * @param displayName  : A human readable name of the new party
     *
+    * @param tracingInfo  : The information allowing tracing of the request across the distributed stack.
+    *
     * @return an async result of a PartyAllocationResult
     */
   def allocateParty(
       hint: Option[String],
-      displayName: Option[String]
+      displayName: Option[String],
+      tracingInfo: TracingInfo
   ): CompletionStage[PartyAllocationResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
@@ -95,11 +95,13 @@ trait WriteService
     *                        This typically happens after a transaction has been assigned a
     *                        globally unique id, as then the contract-ids can be derived from that
     *                        transaction id.
+    * @param tracingInfo     : the information allowing tracing of the request across distributed stack.
     *
     * @return an async result of a SubmissionResult
     */
   def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): CompletionStage[SubmissionResult]
+      transaction: SubmittedTransaction,
+      tracingInfo: TracingInfo): CompletionStage[SubmissionResult]
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndexer.scala
@@ -258,10 +258,10 @@ class JdbcIndexer private[index] (
             PersistenceEntry.Checkpoint(LedgerEntry.Checkpoint(recordTime.toInstant)))
           .map(_ => headRef = headRef + 1)(DEC)
 
-      case PartyAddedToParticipant(party, displayName, _, _) =>
+      case PartyAddedToParticipant(party, displayName, _, _, tracingInfo) =>
         ledgerDao.storeParty(party, Some(displayName), externalOffset).map(_ => ())(DEC)
 
-      case PublicPackageUploaded(archive, sourceDescription, _, _) =>
+      case PublicPackageUploaded(archive, sourceDescription, _, _, tracingInfo) =>
         val uploadId = UUID.randomUUID().toString
         val uploadInstant = Instant.now() // TODO: use PublicPackageUploaded.recordTime for multi-ledgers (#2635)
         val packages: List[(DamlLf.Archive, v2.PackageDetails)] = List(
@@ -279,7 +279,8 @@ class JdbcIndexer private[index] (
           transaction,
           transactionId,
           recordTime,
-          divulgedContracts) =>
+          divulgedContracts,
+          tracingInfo) =>
         val toAbsCoid: ContractId => AbsoluteContractId =
           SandboxEventIdFormatter.makeAbsCoid(transactionId)
 
@@ -347,7 +348,7 @@ class JdbcIndexer private[index] (
           )
           .map(_ => headRef = headRef + 1)(DEC)
 
-      case CommandRejected(recordTime, submitterInfo, reason) =>
+      case CommandRejected(recordTime, submitterInfo, reason, tracingInfo) =>
         val rejection = PersistenceEntry.Rejection(
           LedgerEntry.Rejection(
             recordTime.toInstant,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -14,12 +14,6 @@ import com.daml.ledger.participant.state.v1.TimeModel
 
 import scala.concurrent.duration._
 
-final case class TlsServerConfiguration(
-    enabled: Boolean,
-    keyCertChainFile: File,
-    keyFile: File,
-    trustCertCollectionFile: File)
-
 /**
   * Defines the basic configuration for running sandbox
   */

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/ApiSubmissionService.scala
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.platform.sandbox.services
+import java.util.UUID
+
 import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceLogging
 import akka.stream.ActorMaterializer
 import com.codahale.metrics.MetricRegistry
@@ -168,8 +170,11 @@ class ApiSubmissionService private (
             writeService.submitTransaction(
               submitterInfo,
               transactionMeta,
-              transaction
-            )))
+              transaction,
+              // TODO: Push generation of the UUID to the start of the request handling
+              TracingInfo(UUID.randomUUID.toString)
+            ))
+        )
       case Left(err) =>
         Metrics.failedInterpretationsMeter.mark()
         Future.failed(grpcError(toStatus(err)))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPackageManagementService.scala
@@ -4,12 +4,17 @@
 package com.digitalasset.platform.sandbox.services.admin
 
 import java.io.ByteArrayInputStream
+import java.util.UUID
 import java.util.zip.ZipInputStream
 
 import akka.actor.Scheduler
 import akka.stream.ActorMaterializer
 import com.daml.ledger.participant.state.index.v2.IndexPackagesService
-import com.daml.ledger.participant.state.v1.{UploadPackagesResult, WritePackagesService}
+import com.daml.ledger.participant.state.v1.{
+  TracingInfo,
+  UploadPackagesResult,
+  WritePackagesService
+}
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc.PackageManagementService
@@ -19,7 +24,6 @@ import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.common.util.{DirectExecutionContext => DE}
 import com.digitalasset.platform.server.api.validation.ErrorFactories
 import com.google.protobuf.timestamp.Timestamp
-
 import io.grpc.ServerServiceDefinition
 import org.slf4j.Logger
 
@@ -60,13 +64,14 @@ class ApiPackageManagementService(
   }
 
   override def uploadDarFile(request: UploadDarFileRequest): Future[UploadDarFileResponse] = {
+    val tracingInfo = TracingInfo(UUID.randomUUID.toString)
     val resultT = for {
       dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
         .readArchive(
           "package-upload",
           new ZipInputStream(new ByteArrayInputStream(request.darFile.toByteArray)))
     } yield {
-      (packagesWrite.uploadPackages(dar.all, None), dar.all.map(_.getHash))
+      (packagesWrite.uploadPackages(dar.all, None, tracingInfo), dar.all.map(_.getHash))
     }
     resultT.fold(
       err => Future.failed(ErrorFactories.invalidArgument(err.getMessage)),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -416,12 +416,14 @@ class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider) exten
   override def submitTransaction(
       submitterInfo: ParticipantState.SubmitterInfo,
       transactionMeta: ParticipantState.TransactionMeta,
-      transaction: SubmittedTransaction): CompletionStage[ParticipantState.SubmissionResult] =
+      transaction: SubmittedTransaction,
+      tracingInfo: TracingInfo): CompletionStage[ParticipantState.SubmissionResult] =
     FutureConverters.toJava(ledger.publishTransaction(submitterInfo, transactionMeta, transaction))
 
   override def allocateParty(
       hint: Option[String],
-      displayName: Option[String]): CompletionStage[PartyAllocationResult] = {
+      displayName: Option[String],
+      tracingInfo: TracingInfo): CompletionStage[PartyAllocationResult] = {
     // In the sandbox, the hint is used as-is.
     // If hint is not a valid and unallocated party name, the call fails
     hint.map(p => Party.fromString(p)) match {
@@ -437,7 +439,8 @@ class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider) exten
   // WritePackagesService
   override def uploadPackages(
       payload: List[Archive],
-      sourceDescription: Option[String]
+      sourceDescription: Option[String],
+      tracingInfo: TracingInfo
   ): CompletionStage[UploadPackagesResult] =
     FutureConverters.toJava(
       ledger.uploadPackages(timeProvider.getCurrentTime, sourceDescription, payload))
@@ -446,6 +449,7 @@ class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider) exten
   override def submitConfiguration(
       maxRecordTime: Time.Timestamp,
       submissionId: String,
-      config: Configuration): CompletionStage[SubmissionResult] =
+      config: Configuration,
+      tracingInfo: TracingInfo): CompletionStage[SubmissionResult] =
     FutureConverters.toJava(ledger.publishConfiguration(maxRecordTime, submissionId, config))
 }


### PR DESCRIPTION
- Introduce correlationIds to all the Write- and Read- Service calls
- Tracing functionality is purposely separate from the business logic to allow for divergent evolution paths. A good mental model to have for this is that the two domains should be fairly separate and should not intertwine. For instance, tracing info should not be stored in the db tables together with the business logic data.
- TracingInfo is a structure, so that it can be extended
- Only an interface with stub implementations has been introduced at this point, proper implementations will follow.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
