### PR TITLE
Support authentication in DAML triggers

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -254,6 +254,9 @@ have created as ``Alice``. Once you archive the ``Subscriber``
 contract, you can see that the ``Copy`` contract will also be
 archived.
 
+When using DAML triggers against a Ledger with authentication, you can
+pass ``--access-token-file token.jwt`` to ``daml trigger`` which will
+read the token from the file ``token.jwt``.
 
 When not to use DAML triggers
 =============================

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/utils",
         "//ledger/ledger-api-common",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -3,13 +3,13 @@
 
 package com.digitalasset.daml.lf.engine.trigger
 
-import java.io.File
+import java.nio.file.{Path, Paths}
 import java.time.Duration
 
 import com.digitalasset.platform.services.time.TimeProviderType
 
 case class RunnerConfig(
-    darPath: File,
+    darPath: Path,
     // If true, we will only list the triggers in the DAR and exit.
     listTriggers: Boolean,
     triggerIdentifier: String,
@@ -18,15 +18,16 @@ case class RunnerConfig(
     ledgerParty: String,
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
+    accessTokenFile: Option[Path],
 )
 
 object RunnerConfig {
   private val parser = new scopt.OptionParser[RunnerConfig]("trigger-runner") {
     head("trigger-runner")
 
-    opt[File]("dar")
+    opt[String]("dar")
       .required()
-      .action((f, c) => c.copy(darPath = f))
+      .action((f, c) => c.copy(darPath = Paths.get(f)))
       .text("Path to the dar file containing the trigger")
 
     opt[String]("trigger-name")
@@ -56,6 +57,12 @@ object RunnerConfig {
         c.copy(commandTtl = Duration.ofSeconds(t))
       }
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
+
+    opt[String]("access-token-file")
+      .action { (f, c) =>
+        c.copy(accessTokenFile = Some(Paths.get(f)))
+      }
+      .text("File from which the access token will be read, required to interact with an authenticated ledger")
 
     cmd("list")
       .action((_, c) => c.copy(listTriggers = true))
@@ -93,6 +100,7 @@ object RunnerConfig {
         ledgerParty = null,
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
+        accessTokenFile = None,
       )
     )
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -70,7 +70,6 @@ object RunnerMain {
         implicit val ec: ExecutionContext = system.dispatcher
 
         val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
-        println(tokenHolder.flatMap(_.token))
         // We probably want to refresh the token at some point but given that triggers
         // are expected to be written such that they can be killed and restarted at
         // any time it would in principle also be fine to just have the auth failure due

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -118,8 +118,11 @@ client_server_test(
     name = "test_static_time_authenticated",
     timeout = "long",
     client = ":test_client",
-    client_args = ["--access-token-file=$(rootpath :test-auth-token.jwt)"],
-    client_files = ["$(rootpath :acs.dar)"],
+    client_args = ["--access-token-file"],
+    client_files = [
+        "$(rootpath :test-auth-token.jwt)",
+        "$(rootpath :acs.dar)",
+    ],
     data = [
         ":acs.dar",
         ":test-auth-token.jwt",

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -63,6 +63,7 @@ da_scala_binary(
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/utils",
         "//ledger/ledger-api-common",
         "//triggers/runner:trigger-runner-lib",
         "@maven//:com_github_scopt_scopt_2_12",
@@ -93,6 +94,40 @@ client_server_test(
     server_args = [
         "-w",
         "--port=0",
+    ],
+    server_files = ["$(rootpath :acs.dar)"],
+)
+
+AUTH_TOKEN = "I_CAN_HAZ_AUTH"
+
+# This is a genrule so we can replace it by something nicer that actually generates the token
+# from some readable input so we can change it more easily.
+# For now, this corresponds to a token that has admin set to false
+# and actAs to Alice1, …, Alice100
+genrule(
+    name = "test-auth-token",
+    outs = ["test-auth-token.jwt"],
+    cmd = """
+      cat <<EOF > $(location test-auth-token.jwt)
+Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY3RBcyI6WyJBbGljZTEiLCJBbGljZTIiLCJBbGljZTMiLCJBbGljZTQiLCJBbGljZTUiLCJBbGljZTYiLCJBbGljZTciLCJBbGljZTgiLCJBbGljZTkiLCJBbGljZTEwIiwiQWxpY2UxMSIsIkFsaWNlMTIiLCJBbGljZTEzIiwiQWxpY2UxNCIsIkFsaWNlMTUiLCJBbGljZTE2IiwiQWxpY2UxNyIsIkFsaWNlMTgiLCJBbGljZTE5IiwiQWxpY2UyMCIsIkFsaWNlMjEiLCJBbGljZTIyIiwiQWxpY2UyMyIsIkFsaWNlMjQiLCJBbGljZTI1IiwiQWxpY2UyNiIsIkFsaWNlMjciLCJBbGljZTI4IiwiQWxpY2UyOSIsIkFsaWNlMzAiLCJBbGljZTMxIiwiQWxpY2UzMiIsIkFsaWNlMzMiLCJBbGljZTM0IiwiQWxpY2UzNSIsIkFsaWNlMzYiLCJBbGljZTM3IiwiQWxpY2UzOCIsIkFsaWNlMzkiLCJBbGljZTQwIiwiQWxpY2U0MSIsIkFsaWNlNDIiLCJBbGljZTQzIiwiQWxpY2U0NCIsIkFsaWNlNDUiLCJBbGljZTQ2IiwiQWxpY2U0NyIsIkFsaWNlNDgiLCJBbGljZTQ5IiwiQWxpY2U1MCIsIkFsaWNlNTEiLCJBbGljZTUyIiwiQWxpY2U1MyIsIkFsaWNlNTQiLCJBbGljZTU1IiwiQWxpY2U1NiIsIkFsaWNlNTciLCJBbGljZTU4IiwiQWxpY2U1OSIsIkFsaWNlNjAiLCJBbGljZTYxIiwiQWxpY2U2MiIsIkFsaWNlNjMiLCJBbGljZTY0IiwiQWxpY2U2NSIsIkFsaWNlNjYiLCJBbGljZTY3IiwiQWxpY2U2OCIsIkFsaWNlNjkiLCJBbGljZTcwIiwiQWxpY2U3MSIsIkFsaWNlNzIiLCJBbGljZTczIiwiQWxpY2U3NCIsIkFsaWNlNzUiLCJBbGljZTc2IiwiQWxpY2U3NyIsIkFsaWNlNzgiLCJBbGljZTc5IiwiQWxpY2U4MCIsIkFsaWNlODEiLCJBbGljZTgyIiwiQWxpY2U4MyIsIkFsaWNlODQiLCJBbGljZTg1IiwiQWxpY2U4NiIsIkFsaWNlODciLCJBbGljZTg4IiwiQWxpY2U4OSIsIkFsaWNlOTAiLCJBbGljZTkxIiwiQWxpY2U5MiIsIkFsaWNlOTMiLCJBbGljZTk0IiwiQWxpY2U5NSIsIkFsaWNlOTYiLCJBbGljZTk3IiwiQWxpY2U5OCIsIkFsaWNlOTkiLCJBbGljZTEwMCJdfQ.p78Bgrx0kX2tPwXoc2p5Uz22HifzfELjnmf7XwmCI4k
+EOF
+    """,
+)
+
+client_server_test(
+    name = "test_static_time_authenticated",
+    timeout = "long",
+    client = ":test_client",
+    client_args = ["--access-token-file=$(rootpath :test-auth-token.jwt)"],
+    client_files = ["$(rootpath :acs.dar)"],
+    data = [
+        ":acs.dar",
+        ":test-auth-token.jwt",
+    ],
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "--port=0",
+        "--auth-jwt-hs256-unsafe={}".format(AUTH_TOKEN),
     ],
     server_files = ["$(rootpath :acs.dar)"],
 )


### PR DESCRIPTION
fixes #3259

CHANGELOG_BEGIN

- [DAML Triggers - Experimental] DAML triggers can now be run against
an authenticated ledger.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
