### PR TITLE
daml-lf: add hook for experimental builtins

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -326,15 +326,6 @@ data BuiltinExpr
   | BEEqualContractId            -- :: forall a. ContractId a -> ContractId a -> Bool
   | BECoerceContractId           -- :: forall a b. ContractId a -> ContractId b
 
-  -- Experimental Text Primitives
-  | BETextToUpper                -- :: Text -> Text
-  | BETextToLower                -- :: Text -> Text
-  | BETextSlice                  -- :: Int -> Int -> Text -> Text
-  | BETextSliceIndex             -- :: Text -> Text -> Optional Int64
-  | BETextContainsOnly           -- :: Text -> Text -> Bool
-  | BETextReplicate              -- :: Int64 -> Text -> Text
-  | BETextSplitOn                -- :: Text -> Text -> [Text]
-  | BETextIntercalate            -- :: Text -> [Text] -> Text
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 
@@ -506,6 +497,8 @@ data Expr
   | EScenario !Scenario
   -- | An expression annotated with a source location.
   | ELocation !SourceLoc !Expr
+  -- | EExperimentalBuiltin (only use in dev)
+  | EExperimentalBuiltin !T.Text !Type
   deriving (Eq, Data, Generic, NFData, Ord, Show)
 
 -- | Pattern matching alternative.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -25,6 +25,7 @@ import Control.Lens.Ast
 import Control.Lens.MonoTraversal
 import Data.Functor.Foldable (cata, embed)
 import qualified Data.NameMap as NM
+import qualified Data.Text as T
 
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.TypeLevelNat
@@ -118,6 +119,7 @@ instance MonoTraversable ModuleRef (Qualified a) where
   monoTraverse f (Qualified pkg0 mod0 x) =
     (\(pkg1, mod1) -> Qualified pkg1 mod1 x) <$> f (pkg0, mod0)
 
+instance MonoTraversable ModuleRef T.Text where monoTraverse _ = pure
 instance MonoTraversable ModuleRef ChoiceName where monoTraverse _ = pure
 instance MonoTraversable ModuleRef ExprValName where monoTraverse _ = pure
 instance MonoTraversable ModuleRef ExprVarName where monoTraverse _ = pure

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -276,14 +276,6 @@ instance Pretty BuiltinExpr where
     BETextToCodePoints -> "TEXT_TO_CODE_POINTS"
     BETextFromCodePoints -> "TEXT_FROM_CODE_POINTS"
     BECoerceContractId -> "COERCE_CONTRACT_ID"
-    BETextToUpper -> "TEXT_TO_UPPER"
-    BETextToLower -> "TEXT_TO_LOWER"
-    BETextSlice -> "TEXT_SLICE"
-    BETextSliceIndex -> "TEXT_SLICE_INDEX"
-    BETextContainsOnly -> "TEXT_CONTAINS_ONLY"
-    BETextReplicate -> "TEXT_REPLICATE"
-    BETextSplitOn -> "TEXT_SPLIT_ON"
-    BETextIntercalate -> "TEXT_INTERCALATE"
 
     where
       epochToText fmt secs =
@@ -478,6 +470,7 @@ instance Pretty Expr where
     EToAny ty body -> prettyAppKeyword lvl prec "to_any" [TyArg ty, TmArg body]
     EFromAny ty body -> prettyAppKeyword lvl prec "from_any" [TyArg ty, TmArg body]
     ETypeRep ty -> prettyAppKeyword lvl prec "type_rep" [TyArg ty]
+    EExperimentalBuiltin name _ -> pretty name
 
 instance Pretty DefTypeSyn where
   pPrintPrec lvl _prec (DefTypeSyn mbLoc syn params typ) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -15,6 +15,7 @@ module DA.Daml.LF.Ast.Recursive(
     ) where
 
 import Data.Functor.Foldable
+import qualified Data.Text as T
 
 import DA.Daml.LF.Ast.Base
 
@@ -46,6 +47,7 @@ data ExprF expr
   | EToAnyF !Type !expr
   | EFromAnyF !Type !expr
   | ETypeRepF !Type
+  | EExperimentalBuiltinF !T.Text !Type
   deriving (Foldable, Functor, Traversable)
 
 data BindingF expr = BindingF !(ExprVarName, Type) !expr
@@ -178,6 +180,7 @@ instance Recursive Expr where
     EToAny a b  -> EToAnyF a b
     EFromAny a b -> EFromAnyF a b
     ETypeRep a -> ETypeRepF a
+    EExperimentalBuiltin a b -> EExperimentalBuiltinF a b
 
 instance Corecursive Expr where
   embed = \case
@@ -208,3 +211,4 @@ instance Corecursive Expr where
     EToAnyF a b  -> EToAny a b
     EFromAnyF a b -> EFromAny a b
     ETypeRepF a -> ETypeRep a
+    EExperimentalBuiltinF a b -> EExperimentalBuiltin a b

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -448,15 +448,6 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_CONTRACT_ID -> BEEqualContractId
   LF1.BuiltinFunctionCOERCE_CONTRACT_ID -> BECoerceContractId
 
-  LF1.BuiltinFunctionTEXT_TO_UPPER -> BETextToUpper
-  LF1.BuiltinFunctionTEXT_TO_LOWER -> BETextToLower
-  LF1.BuiltinFunctionTEXT_SLICE -> BETextSlice
-  LF1.BuiltinFunctionTEXT_SLICE_INDEX -> BETextSliceIndex
-  LF1.BuiltinFunctionTEXT_CONTAINS_ONLY -> BETextContainsOnly
-  LF1.BuiltinFunctionTEXT_REPLICATE -> BETextReplicate
-  LF1.BuiltinFunctionTEXT_SPLIT_ON -> BETextSplitOn
-  LF1.BuiltinFunctionTEXT_INTERCALATE -> BETextIntercalate
-
 decodeLocation :: LF1.Location -> Decode SourceLoc
 decodeLocation (LF1.Location mbModRef mbRange) = do
   mbModRef' <- traverse decodeModuleRef mbModRef
@@ -568,9 +559,9 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     return (EFromAny type' expr)
   LF1.ExprSumTypeRep typ ->
     ETypeRep <$> decodeType typ
-  LF1.ExprSumExperimentalBuiltin _ ->
-  -- FIXME: https://github.com/digital-asset/daml/issues/3710
-    error "Experimental builtin not supported"
+  LF1.ExprSumExperimentalBuiltin (LF1.Expr_ExperimentalBuiltin name mbType) -> do
+    type' <- mayDecode "expr_ExperimentalBuiltin" mbType decodeType
+    return (EExperimentalBuiltin (decodeString name) type')
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -568,6 +568,9 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     return (EFromAny type' expr)
   LF1.ExprSumTypeRep typ ->
     ETypeRep <$> decodeType typ
+  LF1.ExprSumExperimentalBuiltin _ ->
+  -- FIXME: https://github.com/digital-asset/daml/issues/3710
+    error "Experimental builtin not supported"
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -497,15 +497,6 @@ encodeBuiltinExpr = \case
     BEEqualContractId -> builtin P.BuiltinFunctionEQUAL_CONTRACT_ID
     BECoerceContractId -> builtin P.BuiltinFunctionCOERCE_CONTRACT_ID
 
-    BETextToUpper -> builtin P.BuiltinFunctionTEXT_TO_UPPER
-    BETextToLower -> builtin P.BuiltinFunctionTEXT_TO_LOWER
-    BETextSlice -> builtin P.BuiltinFunctionTEXT_SLICE
-    BETextSliceIndex -> builtin P.BuiltinFunctionTEXT_SLICE_INDEX
-    BETextContainsOnly -> builtin P.BuiltinFunctionTEXT_CONTAINS_ONLY
-    BETextReplicate -> builtin P.BuiltinFunctionTEXT_REPLICATE
-    BETextSplitOn -> builtin P.BuiltinFunctionTEXT_SPLIT_ON
-    BETextIntercalate -> builtin P.BuiltinFunctionTEXT_INTERCALATE
-
     where
       builtin = pure . P.ExprSumBuiltin . P.Enumerated . Right
       lit = P.ExprSumPrimLit . P.PrimLit . Just
@@ -619,7 +610,11 @@ encodeExpr' = \case
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
     ETypeRep ty -> do
         expr . P.ExprSumTypeRep <$> encodeType' ty
-  where
+    EExperimentalBuiltin name typ -> do
+        expr_ExperimentalBuiltinName <- pure $ encodeString name
+        expr_ExperimentalBuiltinType <- encodeType typ
+        pureExpr $ P.ExprSumExperimentalBuiltin P.Expr_ExperimentalBuiltin{..}
+    where
     expr = P.Expr Nothing . Just
     pureExpr = pure . expr
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -82,6 +82,7 @@ freeVarsStep = \case
       SGetPartyF s -> s
       SEmbedExprF _ s -> s
   ELocationF _ e -> e
+  EExperimentalBuiltinF _ _ -> mempty
   where
     fvBinding :: BindingF VarSet -> VarSet -> VarSet
     fvBinding (BindingF (x, _) s1) s2 = s1 <> (x `Set.delete` s2)
@@ -188,14 +189,6 @@ safetyStep = \case
       BEDecimalFromText -> Safe 1
       BETextToCodePoints -> Safe 1
       BECoerceContractId -> Safe 1
-      BETextToUpper -> Safe 1
-      BETextToLower -> Safe 1
-      BETextSlice -> Safe 3
-      BETextSliceIndex -> Safe 2
-      BETextContainsOnly -> Safe 2
-      BETextReplicate -> Safe 2
-      BETextSplitOn -> Safe 2
-      BETextIntercalate -> Safe 2
 
   ERecConF _ fs -> minimum (Safe 0 : map snd fs)
   ERecProjF _ _ s -> s `min` Safe 0
@@ -239,6 +232,7 @@ safetyStep = \case
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
   ETypeRepF _ -> Safe 0
+  EExperimentalBuiltinF _ _ -> Unsafe
 
 
 infoStep :: ExprF Info -> Info

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -275,15 +275,6 @@ typeOfBuiltin = \case
   BECoerceContractId -> do
     pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TContractId tAlpha :-> TContractId tBeta
 
-  BETextToUpper -> pure (TText :-> TText)
-  BETextToLower -> pure (TText :-> TText)
-  BETextSlice -> pure (TInt64 :-> TInt64 :-> TText :-> TText)
-  BETextSliceIndex -> pure (TText :-> TText :-> TOptional TInt64)
-  BETextContainsOnly -> pure (TText :-> TText :-> TBool)
-  BETextReplicate -> pure (TInt64 :-> TText :-> TText)
-  BETextSplitOn -> pure (TText :-> TText :-> TList TText)
-  BETextIntercalate -> pure (TText :-> TList TText :-> TText)
-
   where
     tComparison btype = TBuiltin btype :-> TBuiltin btype :-> TBool
     tBinop typ = typ :-> typ :-> typ
@@ -576,6 +567,7 @@ typeOf' = \case
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf' expr
+  EExperimentalBuiltin _ typ -> pure typ
 
 typeOf :: MonadGamma m => Expr -> m Type
 typeOf expr = do

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -13,6 +13,7 @@ import           DA.Daml.LFConversion.UtilLF
 import           DA.Daml.LF.Ast
 import           DA.Pretty (renderPretty)
 import qualified Data.Text as T
+import qualified Data.List as L
 
 convertPrim :: Version -> String -> Type -> Expr
 -- Update
@@ -261,14 +262,8 @@ convertPrim _ "BENumericFromText" (TText :-> TOptional (TNumeric n)) =
     ETyApp (EBuiltin BENumericFromText) n
 
 -- Experimental text primitives.
-convertPrim _ "BETextToUpper" (TText :-> TText) = EBuiltin BETextToUpper
-convertPrim _ "BETextToLower" (TText :-> TText) = EBuiltin BETextToLower
-convertPrim _ "BETextSlice" (TInt64 :-> TInt64 :-> TText :-> TText) = EBuiltin BETextSlice
-convertPrim _ "BETextSliceIndex" (TText :-> TText :-> TOptional TInt64) = EBuiltin BETextSliceIndex
-convertPrim _ "BETextContainsOnly" (TText :-> TText :-> TBool) = EBuiltin BETextContainsOnly
-convertPrim _ "BETextReplicate" (TInt64 :-> TText :-> TText) = EBuiltin BETextReplicate
-convertPrim _ "BETextSplitOn" (TText :-> TText :-> TList TText) = EBuiltin BETextSplitOn
-convertPrim _ "BETextIntercalate" (TText :-> TList TText :-> TText) = EBuiltin BETextIntercalate
+convertPrim (V1 PointDev) (L.stripPrefix "Experimental" -> Just builtin) typ =
+    EExperimentalBuiltin (T.pack builtin) typ
 
 -- Template Desugaring.
 

--- a/compiler/damlc/daml-stdlib-src/DA/Text.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Text.daml
@@ -343,13 +343,13 @@ fromCodePoints = primitive @"BETextFromCodePoints"
 #ifdef DAML_UNSTABLE
 
 unstableToUpper : Text -> Text
-unstableToUpper = primitive @"BETextToUpper"
+unstableToUpper = primitive @"ExperimentalTEXT_TO_UPPER"
 
 unstableToLower : Text -> Text
-unstableToLower = primitive @"BETextToLower"
+unstableToLower = primitive @"ExperimentalTEXT_TO_LOWER"
 
 unstableSlice : Int -> Int -> Text -> Text
-unstableSlice = primitive @"BETextSlice"
+unstableSlice = primitive @"ExperimentalTEXT_SLICE"
 
 unstableTake : Int -> Text -> Text
 unstableTake = unstableSlice 0
@@ -361,7 +361,7 @@ unstableSplitAt : Int -> Text -> (Text, Text)
 unstableSplitAt n x = (unstableTake n x, unstableDrop n x)
 
 unstableSliceIndex : Text -> Text -> Optional Int
-unstableSliceIndex = primitive @"BETextSliceIndex"
+unstableSliceIndex = primitive @"ExperimentalTEXT_SLICE_INDEX"
 
 unstableBreakOn : Text -> Text -> (Text, Text)
 unstableBreakOn k x =
@@ -375,15 +375,15 @@ unstableStripInfix k x = do
     Some (unstableTake i x, unstableDrop (i + DA.Text.length k) x)
 
 unstableContainsOnly : Text -> Text -> Bool
-unstableContainsOnly = primitive @"BETextContainsOnly"
+unstableContainsOnly = primitive @"ExperimentalTEXT_CONTAINS_ONLY"
 
 unstableReplicate : Int -> Text -> Text
-unstableReplicate = primitive @"BETextReplicate"
+unstableReplicate = primitive @"ExperimentalTEXT_REPLICATE"
 
 unstableSplitOn : Text -> Text -> [Text]
-unstableSplitOn = primitive @"BETextSplitOn"
+unstableSplitOn = primitive @"ExperimentalTEXT_SPLIT_ON"
 
 unstableIntercalate : Text -> [Text] -> Text
-unstableIntercalate = primitive @"BETextIntercalate"
+unstableIntercalate = primitive @"ExperimentalTEXT_INTERCALATE"
 
 #endif

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -563,6 +563,12 @@ enum BuiltinFunction {
   TEXT_INTERCALATE = 9908; // *Available in versions >= 1.dev*
 }
 
+// *Available only in 1.dev*
+message ExperimentalBuiltinFunction{
+  string name = 1;
+  Type type = 2;
+}
+
 // Builtin literals
 // FixMe: Renamed
 message PrimLit {
@@ -945,6 +951,10 @@ message Expr {
     // A type representation
     // *Available in versions >= 1.7*
     Type type_rep = 32;
+
+    // Hook to add quickly a builtin for testing purpose
+    // *Available in versions 1.dev*
+    ExperimentalBuiltinFunction experimental_builtin = 536870911;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -854,6 +854,12 @@ message Expr {
     Expr expr = 2;
   }
 
+  // *Available only in 1.dev*
+  message ExperimentalBuiltin {
+    string name = 1;
+    Type type = 2;
+  }
+
   // Location of the expression in the DAML code source.
   // Optional
   Location location = 25;
@@ -954,7 +960,7 @@ message Expr {
 
     // Hook to add quickly a builtin for testing purpose
     // *Available in versions 1.dev*
-    ExperimentalBuiltinFunction experimental_builtin = 536870911;
+    ExperimentalBuiltin experimental_builtin = 536870911;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1640,14 +1640,6 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId, maxVersion = Some(genMap)),
       BuiltinFunctionInfo(TRACE, BTrace),
       BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId, minVersion = coerceContractId),
-      BuiltinFunctionInfo(TEXT_TO_UPPER, BTextToUpper, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_TO_LOWER, BTextToLower, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_SLICE, BTextSlice, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_SLICE_INDEX, BTextSliceIndex, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_CONTAINS_ONLY, BTextContainsOnly, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_REPLICATE, BTextReplicate, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_SPLIT_ON, BTextSplitOn, minVersion = unstable),
-      BuiltinFunctionInfo(TEXT_INTERCALATE, BTextIntercalate, minVersion = unstable)
     )
   }
 

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -932,6 +932,11 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           assertSince(LV.Features.typeRep, "Expr.type_rep")
           ETypeRep(decodeType(lfExpr.getTypeRep))
 
+        case PLF.Expr.SumCase.EXPERIMENTAL_BUILTIN =>
+          assertDev("Expr.experimental_builtin")
+          val lfBuiltin = lfExpr.getExperimentalBuiltin
+          EExperimentalBuiltin(lfBuiltin.getName, decodeType(lfBuiltin.getType))
+
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
       }
@@ -1254,6 +1259,13 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
   private[this] def assertSince(minVersion: LV, description: => String): Unit =
     if (versionIsOlderThan(minVersion))
       throw ParseError(s"$description is not supported by DAML-LF 1.$minor")
+
+  private[this] def assertDev(description: => String): Unit =
+    languageVersion match {
+      case LV(_, LV.Minor.Dev) =>
+      case _ =>
+        throw ParseError(s"$description is only supported by DAML-LF 1.dev")
+    }
 
   private def assertUndefined(i: Int, description: => String): Unit =
     if (i != 0)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -583,6 +583,9 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
 
       case ETypeRep(typ) =>
         SEValue(STypeRep(typ))
+
+      case EExperimentalBuiltin(name, typ) =>
+        SEExperimentalBuiltin(name, typ)
     }
 
   @tailrec

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -301,16 +301,6 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
               case BGenMapValues => SBGenMapValues
               case BGenMapSize => SBGenMapSize
 
-              // Unstable Text Primitives
-              case BTextToUpper => SBTextToUpper
-              case BTextToLower => SBTextToLower
-              case BTextSlice => SBTextSlice
-              case BTextSliceIndex => SBTextSliceIndex
-              case BTextContainsOnly => SBTextContainsOnly
-              case BTextReplicate => SBTextReplicate
-              case BTextSplitOn => SBTextSplitOn
-              case BTextIntercalate => SBTextIntercalate
-
               // Implemented using normal SExpr
               case BFoldl | BFoldr | BCoerceContractId | BEqual | BEqualList | BLessEq | BLess |
                   BGreaterEq | BGreater | BLessNumeric | BLessEqNumeric | BGreaterNumeric |

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -416,16 +416,6 @@ object Ast {
 
   final case object BCoerceContractId extends BuiltinFunction(1) // : ∀a b. ContractId a -> ContractId b
 
-  // Unstable Text Primitives
-  final case object BTextToUpper extends BuiltinFunction(1) // Text → Text
-  final case object BTextToLower extends BuiltinFunction(1) // : Text → Text
-  final case object BTextSlice extends BuiltinFunction(3) // : Int64 → Int64 → Text → Text
-  final case object BTextSliceIndex extends BuiltinFunction(2) // : Text → Text → Optional Int64
-  final case object BTextContainsOnly extends BuiltinFunction(2) // : Text → Text → Bool
-  final case object BTextReplicate extends BuiltinFunction(2) // : Int64 → Text → Text
-  final case object BTextSplitOn extends BuiltinFunction(2) // : Text → Text → List Text
-  final case object BTextIntercalate extends BuiltinFunction(2) // : Text → List Text → Text
-
   //
   // Update expressions
   //

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -140,6 +140,9 @@ object Ast {
   /** Unique textual representation of template Id **/
   final case class ETypeRep(typ: Type) extends Expr
 
+  /** Experimental builtin function  */
+  final case class EExperimentalBuiltin(name: String, typ: Type) extends Expr
+
   //
   // Kinds
   //

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -67,12 +67,6 @@ object LanguageVersion {
     val genMap = v1_dev
     val scenarioMustFailAtMsg = v1_dev
 
-    /** Unstable, experimental features. This should stay in 1.dev forever.
-      * Features implemented with this flag should be moved to a separate
-      * feature flag once the decision to add them permanently has been made.
-      */
-    val unstable = v1_dev
-
     /** See <https://github.com/digital-asset/daml/issues/1866>. To not break backwards
       * compatibility, we introduce a new DAML-LF version where this restriction is in
       * place, and then:

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -29,6 +29,12 @@ object Util {
   object TFun extends ((Type, Type) => Type) {
     def apply(targ: Type, tres: Type) =
       TApp(TApp(TBuiltin(BTArrow), targ), tres)
+
+    def unapply(arg: Type): Option[(Type, Type)] =
+      arg match {
+        case TApp(TApp(TBuiltin(BTArrow), targ), tres) => Some(targ -> tres)
+        case _ => None
+      }
   }
 
   class ParametricType1(bType: BuiltinType) {

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -129,6 +129,8 @@ private[digitalasset] class AstRewriter(
           EToAny(ty, apply(body))
         case EFromAny(ty, body) =>
           EFromAny(ty, apply(body))
+        case EExperimentalBuiltin(name, typ) =>
+          EExperimentalBuiltin(name, apply(typ))
       }
 
   def apply(x: TypeConApp): TypeConApp = x match {

--- a/daml-lf/spec/contract-identifier.rst
+++ b/daml-lf/spec/contract-identifier.rst
@@ -1,0 +1,175 @@
+.. Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Copyright © 2020, `Digital Asset (Switzerland) GmbH
+<https://www.digitalasset.com/>`_ and/or its affiliates.  All rights
+reserved.
+
+
+Contract ID V1 allocation scheme
+================================
+
+Contract IDs are may of two parts.
+
+* A *discriminator* is like a random UUID, but generated from an
+  initial seed using a deterministic random bit generator (DRBG) via a
+  fixed derivation scheme that supports validation (see below).
+* To guard against the submitter choosing low-entropy initial seeds
+  for the discriminators, Contract IDs are formed by extending the
+  discriminators with a *suffix*.  The suffix depends on the
+  particular ledger and ensures that contract IDs are universally
+  unique even with a malicious submitter who controls the seed.
+
+
+
+
+  
+During interpretation for submission, keep track of all seen discriminators. They can appear in the following places:
+
+
+
+
+* 32 bytes for the discriminator
+* upto 96 bytes for the so-called suffix.
+
+
+
+
+
+
+Replace relative contract IDs in the transaction tree by discriminators. A discriminator is like a random UUID, but generated from an initial seed using a deterministic random bit generator (DRBG) via a fixed derivation scheme that supports validation (see below).
+To guard against the submitter choosing low-entropy initial seeds for the discriminators, absolute contract IDs are formed by extending the discriminators with a transaction ID. The transaction ID depends on the particular ledger and ensures that contract IDs are universally unique even with a malicious submitter who controls the seed.
+During interpretation for submission, keep track of all seen discriminators. They can appear in the following places:
+The discriminators of created contracts
+The IDs of an input contract
+In the command
+In template arguments of an input contract
+If the discriminators of created contracts are not disjoint from the others, abort the interpretation. The submitter (e.g., the command service) can restart the interpretation with another seed.
+This ensures that only the discriminators, not the transaction IDs are needed to order the contract IDs of created contract w.r.t. other contract IDs.
+If interpretation succeeds, the output is a raw transaction.
+Every ledger provides a function that takes a raw transaction, the commands, and metadata (ledger-effective time, submitter, command ID, application ID) and produces a transaction ID.
+All discriminator-only contract IDs in the raw transaction are suffixed with the transaction ID. This yields the ready transaction. The finished transaction is then sent to the ledger on the write path, along with the transaction ID and the seed.
+Re-interpretation during validation takes the transaction ID and the seed as inputs. When a contract ID must be allocated, the discriminator is computed in the same way, but the transaction ID is immediately added. Accordingly, no check for discriminator clashes is needed.
+
+
+Goals
+^^^^^
+
+*
+
+
+Transaction Seed
+
+Submission Seed
+
+
+
+Goals
+^^^^^
+
+* Do not leak information
+
+Requirements
+^^^^^^^^^^^^
+
+* Executability: DAML engine can determine the contract IDs before it hands out the transaction to the write service.
+Validation: The allocation scheme commutes with transaction projection. That is, the contract IDs for contracts created in the projection of a transaction to a set of parties can be computed solely from the projection and input seeds.
+* Unlinkability: It is computationally infeasible to link the contract contents to the contract ID unless the create node is witnessed. The contract contents include the contract instance, the template ID, the stakeholders / signatories / maintainers, and the contract key.
+* Freshness: It is computationally infeasible to find contracts C1 and C2 with the same contract ID such that one of the following holds:
+* The contracts are instances of different templates
+The contracts have different signatories, observers, or maintainers.
+The contracts are created by different transactions.
+The contracts are created by different subactions of the same transaction forest where the seeds are pairwise different.
+Distinctness: The ledger can enforce that the seeds are pairwise different.
+
+Suggested approach: Discriminators instead of indices
+Replace relative contract IDs in the transaction tree by discriminators. A discriminator is like a random UUID, but generated from an initial seed using a deterministic random bit generator (DRBG) via a fixed derivation scheme that supports validation (see below).
+To guard against the submitter choosing low-entropy initial seeds for the discriminators, absolute contract IDs are formed by extending the discriminators with a transaction ID. The transaction ID depends on the particular ledger and ensures that contract IDs are universally unique even with a malicious submitter who controls the seed.
+During interpretation for submission, keep track of all seen discriminators. They can appear in the following places:
+The discriminators of created contracts
+The IDs of an input contract
+In the command
+In template arguments of an input contract
+If the discriminators of created contracts are not disjoint from the others, abort the interpretation. The submitter (e.g., the command service) can restart the interpretation with another seed.
+This ensures that only the discriminators, not the transaction IDs are needed to order the contract IDs of created contract w.r.t. other contract IDs.
+If interpretation succeeds, the output is a raw transaction.
+Every ledger provides a function that takes a raw transaction, the commands, and metadata (ledger-effective time, submitter, command ID, application ID) and produces a transaction ID.
+All discriminator-only contract IDs in the raw transaction are suffixed with the transaction ID. This yields the ready transaction. The finished transaction is then sent to the ledger on the write path, along with the transaction ID and the seed.
+Re-interpretation during validation takes the transaction ID and the seed as inputs. When a contract ID must be allocated, the discriminator is computed in the same way, but the transaction ID is immediately added. Accordingly, no check for discriminator clashes is needed.
+
+Allocation scheme for discriminators
+From an initial seed, seeds for all nodes in the transaction tree are derived as they are computed. We propose the following scheme, inspired by NIST’s HMAC_DRBG construction. It assumes a hash-based MAC function HMAC, and defines for each natural number n the derived seed
+deriveSeed(seed, n) := HMAC(seed, n)
+Initial seed construction:
+Any random number with sufficient entropy works as initial seed init_seed (256 bit entropy)
+Canton currently uses the HMAC with the submitting participant’s private HMAC key on the following pieces
+submitting party
+command Id
+application Id
+domain
+ledger-effective time
+I recommend a SHA256 HMAC of the following pieces
+submitting party
+command Id
+application Id
+submitting participant ID
+a counter that is incremented if interpretation fails because of discriminator clashes
+HMAC key: a random nonce (256 bit randomness) or the private key of the submitting participant
+Derivation of seeds for root nodes of the transaction:
+For each root node of the transaction, a root seed is computed from the initial seed as follows:
+root_seed_i = deriveSeed(init_seed, i)
+Derivation of seeds for the children of exercise nodes:
+For an exercise node with seed seed, the seeds child_seed_i for the children are derived as follows:
+child_seed_i = deriveSeed(seed, i)
+Contract ID allocation scheme
+Given the seed of a create node, the discriminator for the created contract ID is given as follows:
+discriminator =
+  hash(DISCRIMINATOR_TAG ++ seed ++ hashed_contract_instance)
+where
+hash is a collision-resistant hash function (e.g., SHA-256)
+DISCRIMINATOR_TAG is a tag that marks this hash as being a discriminator
+hashed_contract_instance is the collision-resistant hash of the contract instance, as given by the DAML-LF hash function for values.
+Transaction ID generation
+How transaction IDs are generated depends on the particular ledgers.
+Sandbox / DAML on SQL: A counter for transactions.
+Canton: A cryptographic hash of the following pieces:
+the ledger effective time,
+the domain (determined by the multi-domain dispatcher based on the transaction’s input contracts, the domain topology, and topology hints such as namespaces and workflow IDs)
+the command ID, the application ID, the submitter
+kvutils: Currently picked by the ledger integration. Sawtooth picks a UUID at submission time, VMware uses a counter.
+Corda: The transaction ID is generated by
+Corda
+A transaction builder is signed by the initial party to return a signed transaction which is distributed to other parties and the notary for further signing as required.
+fun signInitialTransaction(builder: TransactionBuilder): SignedTransaction
+The signed transaction contains an id which is a Corda SecureHash.  This is 256bit (32 byte) SHA256 hash of the transaction payload.  This transaction may contain a number of output contracts.  These are identified by a Corda StateRef:
+StateRef(val txhash: SecureHash, val index: Int)
+It is these StateRef objects which are mapped onto AbsoluteContractId (and the other way around).  This is possible because we ensure that each output state we add has a reference of its associated NodeId.
+Analysis
+Executability
+If command interpretation takes init_seed as input, it can derive all the salts and discriminators and detect clashes between discriminators. The raw transaction is transformed into the ready transaction only once before it hits the write service. (In that sense, Canton’s multi-domain dispatcher is not part of the write service.)
+Validation
+For validation, the transaction ID is known before re-interpretation starts (as it can be distributed along with the ready transaction). So the reinterpretation function can take the transaction Id and the seed as additional parameters.
+reinterpret: txId -> seed -> node -> transaction
+It can internally then derive the same seeds for the children and outputs the same subtransaction as what the submitter has computed. In particular, it does not contain IDs with discriminators only. Ledgers no longer need to map or store relative contract IDs.
+In particular, every validator can check that the seeds have been correctly derived within the projection it sees. Sub-transactions with invalid derivations are considered invalid and must be rejected.
+Unlinkability
+For unlinkability, we assume that the submitter chooses high-quality randomness for the initial seed. (For if it is dishonest, it could just publish the contents of the contracts directly.)
+The seed derivation using the DRBG spreads this randomness to the seeds of all create nodes. These seeds become salts that blind the hash of the contract instance. Therefore, a discriminator can be linked only to a contract instance if the salt is known.
+The seeds in one subtree are pseudo-independent from those in a different subtree. Therefore, if a participant learns the seeds of its projection, it does not learn anything about the salts in the subtrees outside of its projection. It therefore cannot link the discriminators in those trees with the contract instances.
+The unlinkability guarantee depends on the randomness quality of the initial seed. This is why the initial seed construction includes the nonce or is based on a private key of the submitting participant.
+Freshness
+We now consider a malicious submitter that can choose the initial seed arbitrarily, rather than randomly. Moreover, we also assume that the ledger ensures that transaction IDs are unique with overwhelming probability under the appropriate trust assumptions. Let C1 and C2 be two different contracts on the ledger. We want to show that the contracts have different IDs with overwhelming probability.
+If C1 and C2 are instances of different templates, then those templates will affect the hashed_contract_instance and therefore lead to different discriminators.
+If C1 and C2 have different signatories, observers, or stakeholders, then their contract instances must be different, as they are derived from the template parameters. Like in the previous case, hashed_contract_instance will produce a different hash and therefore lead to different discriminators.
+If C1 and C2 are created by different transactions, then the transaction IDs are different with overwhelming probability. Since these IDs are suffixes of the contract IDs, the contract IDs are also different.
+So let C1 and C2 are created by different subactions of the same transaction on the ledger, with the same template and contract instances. Let A1 and A2 be the root actions of the transaction that contain C1 and C2, respectively. By definition, the seeds in A1 and A2 have been derived from seeds seed1 and seed2 as described above.
+If A1 = A2, then the nodes creating C1 and C2 have different seeds by the collision resistance of the seed derivation scheme.
+If A1 ≠ A2, then by distinctness below, we can assume seed1 ≠ seed2. Again, by collision resistance, C1 and C2 have different IDs.
+Distinctness
+Different ledgers enforce distinctness of seeds differently:
+Ledgers with a centralized committer (kvutils, DAML-on-SQL):
+The committer checks that the seeds at the root of the transaction are unique.
+Canton
+The mediator checks that the seeds are pairwise different.
+Corda
+The validating notaries check that the seeds are pairwise different.

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -893,6 +893,8 @@ private[validation] object Typing {
       case ETypeRep(typ) =>
         checkGroundType(typ)
         TTypeRep
+      case EExperimentalBuiltin(_, typ) =>
+        typ
     }
 
     def checkExpr(expr: Expr, typ0: Type): Type = {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -210,15 +210,6 @@ private[validation] object Typing {
         TForall(
           alpha.name -> KStar,
           TForall(beta.name -> KStar, TContractId(alpha) ->: TContractId(beta))),
-      // Unstable text functions
-      BTextToUpper -> (TText ->: TText),
-      BTextToLower -> (TText ->: TText),
-      BTextSlice -> (TInt64 ->: TInt64 ->: TText ->: TText),
-      BTextSliceIndex -> (TText ->: TText ->: TOptional(TInt64)),
-      BTextContainsOnly -> (TText ->: TText ->: TBool),
-      BTextReplicate -> (TInt64 ->: TText ->: TText),
-      BTextSplitOn -> (TText ->: TText ->: TList(TText)),
-      BTextIntercalate -> (TText ->: TList(TText) ->: TText),
     )
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -13,7 +13,7 @@ private[validation] object ExprTraversable {
   private[traversable] def foreach[U](x: Expr, f: Expr => U): Unit = {
     x match {
       case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EEnumCon(_, _) | ETypeRep(
-            _) =>
+            _) | EExperimentalBuiltin(_, _) =>
       case ELocation(_, expr) =>
         f(expr)
       case ERecCon(tycon @ _, fields) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -78,6 +78,8 @@ private[validation] object TypeTraversable {
         foreach(u, f)
       case EScenario(s) =>
         foreach(s, f)
+      case EExperimentalBuiltin(_, t) =>
+        f(t)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
           ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) |
           ETyAbs(_, _) =>


### PR DESCRIPTION
This PR advance the state of #3710

Here we add a hook in daml-lf archive to quickly add new experimental built-in without having to update the archive decoder nor the type checker. 

`take :: Int64 -> Text -> Text` is provided as example.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
