### PR TITLE
Publish the thin trigger library instead of the fat jar

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -121,7 +121,7 @@ lf_scalacopts = [
     "-Ywarn-unused",
 ]
 
-def _wrap_rule(rule, name = "", scalacopts = [], plugins = [], **kwargs):
+def _wrap_rule(rule, name = "", scalacopts = [], plugins = [], generated_srcs = [], **kwargs):
     rule(
         name = name,
         scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
@@ -284,7 +284,7 @@ def _scaladoc_jar_impl(ctx):
     srcFiles = [
         src.path
         for src in ctx.files.srcs
-        if src.is_source
+        if src.is_source or src in ctx.files.generated_srcs
     ]
 
     if srcFiles != []:
@@ -361,6 +361,8 @@ scaladoc_jar = rule(
         "doctitle": attr.string(default = ""),
         "plugins": attr.label_list(default = []),
         "srcs": attr.label_list(allow_files = True),
+        # generated source files that should still be included.
+        "generated_srcs": attr.label_list(allow_files = True),
         "scalacopts": attr.string_list(),
         "_zipper": attr.label(
             default = Label("@bazel_tools//tools/zip:zipper"),
@@ -402,6 +404,7 @@ def _create_scaladoc_jar(**kwargs):
             plugins = plugins,
             srcs = kwargs["srcs"],
             scalacopts = kwargs.get("scalacopts", []),
+            generated_srcs = kwargs.get("generated_srcs", []),
         )
 
 def da_scala_library(name, **kwargs):

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -206,8 +206,8 @@
   type: jar-scala
 - target: //ledger-service/http-json:http-json-binary
   type: jar-deploy
-- target: //triggers/runner:trigger-runner
-  type: jar-deploy
+- target: //triggers/runner:trigger-runner-lib
+  type: jar-scala
   mavenUpload: true
 - target: //daml-assistant/scala-daml-project-config:scala-daml-project-config
   type: jar-scala

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -9,11 +9,11 @@ load(
 
 da_scala_library(
     name = "trigger-runner-lib",
-    srcs = glob(["src/main/scala/**/*.scala"]),
-    resources = glob(["src/main/resources/**/*"]),
+    srcs = glob(["src/main/scala/**/*.scala"]) + [":src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
+    generated_srcs = [":src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
+    tags = ["maven_coordinates=com.digitalasset.daml.lf.engine.trigger:runner:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
-        ":trigger-package-id-lib",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
@@ -33,12 +33,6 @@ da_scala_library(
     ],
 )
 
-da_scala_library(
-    name = "trigger-package-id-lib",
-    srcs = [":trigger-package-id"],
-    deps = ["//daml-lf/data"],
-)
-
 # This genrule generates a Scala file containing the package id of the trigger library
 # at build time. We use that to detect mismatches and warn the user about it.
 genrule(
@@ -47,10 +41,10 @@ genrule(
         "//triggers/daml:daml-trigger.dar",
         "//compiler/damlc",
     ],
-    outs = ["com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
+    outs = ["src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
     cmd = """
       PACKAGE_ID=$$($(location //compiler/damlc) inspect-dar $(location //triggers/daml:daml-trigger.dar) | awk '/daml-trigger-0.0.1-([a..f]|[0..9])*/ {print $$2}')
-      cat << EOF > $(location com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala)
+      cat << EOF > $(location src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala)
 package com.digitalasset.daml.lf.engine
 
 import com.digitalasset.daml.lf.data.Ref.PackageId
@@ -65,7 +59,9 @@ EOF
 da_scala_binary(
     name = "trigger-runner",
     main_class = "com.digitalasset.daml.lf.engine.trigger.RunnerMain",
-    tags = ["maven_coordinates=com.digitalasset.daml.lf.engine.trigger:runner:__VERSION__"],
+    resources = ["src/main/resources/logback.xml"],
     visibility = ["//visibility:public"],
     deps = [":trigger-runner-lib"],
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -53,6 +53,7 @@ da_scala_binary(
     name = "test_client",
     srcs = glob(["src/**/*.scala"]),
     main_class = "com.digitalasset.daml.lf.engine.trigger.test.TestMain",
+    resources = ["//triggers/runner:src/main/resources/logback.xml"],
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",


### PR DESCRIPTION
This still contains the main class so you can use it like you would
use the fat jar but publishing fat jars to maven central is apparently
bad practise and some peple have asked for the library.

This includes some slight tweaks to the scala_docs rule to make it
capable of coping with the generated source file and a hack in the
release script to avoid it complaining about the scenario proto
library not being published to Maven even though it is included in the
transitive deps.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
