### PR TITLE
Change range of snippet to be displayed

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -94,7 +94,7 @@ The following snippet is an excerpt from the ``pom.xml`` that is part of the :re
 
   .. literalinclude:: ../../getting-started/quickstart/template-root/pom.xml
     :language: xml
-    :lines: 47-79,95-96
+    :lines: 47-78,94-95
     :dedent: 12
 
 


### PR DESCRIPTION
Fixes #3745 

Adapt range of snippet so the shown code is conformant XML (correctly matching opening / closing tags)