### PR TITLE
daml-assistant: Add a 2s timeout to the version check

### DIFF
--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -114,7 +114,7 @@ getDefaultSdkVersion damlPath = do
 -- of versions.
 getAvailableSdkVersions :: IO [SdkVersion]
 getAvailableSdkVersions = wrapErr "Fetching list of available SDK versions" $ do
-    response <- requiredAny "HTTPS connection to docs.daml.com failed" $ do
+    response <- requiredAny "HTTP connection to docs.daml.com failed" $ do
         request <- parseRequest "GET http://docs.daml.com/versions.json"
         httpBS request { responseTimeout = responseTimeoutMicro 2000000 }
 


### PR DESCRIPTION
This PR sets a 2s timeout (as opposed to the default 30s timeout) to the request that fetches the list of available versions from docs.daml.com.

Fixes #3037 indirectly, because even if the request isn't running in the background, the 2s timeout prevents the update-check from being a showstopper. (Happy to reopen that issue if this turns out to be insufficient.)