### PR TITLE
Increase party allocation timeout and mark test as flaky

### DIFF
--- a/ledger/ledger-api-test-tool/conformance.bzl
+++ b/ledger/ledger-api-test-tool/conformance.bzl
@@ -14,7 +14,8 @@ def conformance_test(
         extra_data = [],
         ports = [6865],
         test_tool_args = [],
-        tags = []):
+        tags = [],
+        flaky = False):
     client_server_test(
         name = name,
         timeout = "long",
@@ -32,9 +33,10 @@ def conformance_test(
             "dont-run-on-darwin",
             "exclusive",
         ] + tags,
+        flaky = flaky,
     ) if not is_windows else None
 
-def server_conformance_test(name, servers, server_args = [], test_tool_args = []):
+def server_conformance_test(name, servers, server_args = [], test_tool_args = [], flaky = False):
     for server_name, server in servers.items():
         test_name = "-".join([segment for segment in [name, server_name] if segment])
         conformance_test(
@@ -43,4 +45,5 @@ def server_conformance_test(name, servers, server_args = [], test_tool_args = []
             server = server["binary"],
             server_args = server.get("server_args", []) + server_args,
             test_tool_args = server.get("test_tool_args", []) + test_tool_args,
+            flaky = flaky,
         )

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -250,6 +250,7 @@ server_conformance_test(
 
 server_conformance_test(
     name = "conformance-test-lots-of-parties",
+    flaky = True,
     server_args = [
         "--static-time",
     ],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/services/admin/ApiPartyManagementService.scala
@@ -80,7 +80,7 @@ class ApiPartyManagementService private (
         case entry @ AllocationAccepted(Some(`submissionId`), _, _) => entry
         case entry @ AllocationRejected(`submissionId`, _, _) => entry
       }
-      .completionTimeout(10.seconds)
+      .completionTimeout(30.seconds)
       .runWith(Sink.head)(materializer)
   }
 


### PR DESCRIPTION
The timeout for witnessing the party allocation is now increased
to 30 seconds (from 10 seconds). Additionally the LotsOfParties
conformance test is marked as flaky.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
