### PR TITLE
Perform name collision check against other names in package.

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -180,7 +180,8 @@ checkModuleFully m = do
 
 isAscendant :: ModuleName -> ModuleName -> Bool
 isAscendant (ModuleName xs) (ModuleName ys) =
-    (length xs < length ys) && and (zipWith (==) xs ys)
+    (length xs < length ys) && and (zipWith sameish xs ys)
+    where sameish a b = T.toLower a == T.toLower b
 
 -- | Check whether a module satisfies the name collision condition.
 --

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -185,8 +185,7 @@ isAscendant (ModuleName xs) (ModuleName ys) =
 -- | Check whether a module satisfies the name collision condition.
 --
 -- This involves not only checking the current module, but also
--- the module's parent and grandparent for potential collisions,
--- and the name of the module's children and grandchildren as well.
+-- the module's ascendants and descendants for potential collisions.
 checkModule :: MonadGamma m => Module -> m ()
 checkModule mod0 = do
     world <- getWorld

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -26,6 +26,7 @@ data Name
     | NRecordType ModuleName TypeConName
     | NVariantType ModuleName TypeConName
     | NEnumType ModuleName TypeConName
+    | NTypeSynonym ModuleName TypeConName
     | NVariantCon ModuleName TypeConName VariantConName
     | NEnumCon ModuleName TypeConName VariantConName
     | NField ModuleName TypeConName FieldName
@@ -42,6 +43,8 @@ displayName = \case
         T.concat ["variant ", dot m, ":", dot t]
     NEnumType (ModuleName m) (TypeConName t) ->
         T.concat ["enum ", dot m, ":", dot t]
+    NTypeSynonym (ModuleName m) (TypeConName t) ->
+        T.concat ["synonym ", dot m, ":", dot t]
     NVariantCon (ModuleName m) (TypeConName t) (VariantConName v) ->
         T.concat ["variant constructor ", dot m, ":", dot t, ".", v]
     NEnumCon (ModuleName m) (TypeConName t) (VariantConName v) ->
@@ -88,6 +91,8 @@ fullyResolve = FRName . map T.toLower . \case
     NVariantType (ModuleName m) (TypeConName t) ->
         m ++ t
     NEnumType (ModuleName m) (TypeConName t) ->
+        m ++ t
+    NTypeSynonym (ModuleName m) (TypeConName t) ->
         m ++ t
     NVariantCon (ModuleName m) (TypeConName t) (VariantConName v) ->
         m ++ t ++ [v]
@@ -149,7 +154,7 @@ checkDataType moduleName DefDataType{..} =
                 checkName (NEnumCon moduleName dataTypeCon vconName)
 
         DataSynonym _ ->
-            checkName (NEnumType moduleName dataTypeCon)
+            checkName (NTypeSynonym moduleName dataTypeCon)
 
 checkTemplate :: MonadGamma m => ModuleName -> Template -> S.StateT NCState m ()
 checkTemplate moduleName Template{..} = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/NameCollision.hs
@@ -178,6 +178,8 @@ checkModuleFully m = do
     checkModuleName m
     checkModuleTypes m
 
+-- | Is the first module an ascendant of the second? This check
+-- is case-insensitive because name collisions are case-insensitive.
 isAscendant :: ModuleName -> ModuleName -> Bool
 isAscendant (ModuleName xs) (ModuleName ys) =
     (length xs < length ys) && and (zipWith sameish xs ys)


### PR DESCRIPTION
This PR advances #3252 by checking the current module's names against the type names from ascendant modules, and against module names from descendent modules.

I ran this change against a very large DAML codebase and the difference was insignificant (it was actually 0.9% faster, i.e. up to random variation).

It also cleans up the handling of type synonyms in the name collision checker.