### PR TITLE
Sandbox: Perform JDBC health checks on a timer.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
@@ -3,16 +3,20 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql.dao
 
-import java.sql.Connection
+import java.sql.{Connection, SQLTransientConnectionException}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Timer, TimerTask}
 
 import com.codahale.metrics.MetricRegistry
+import com.digitalasset.ledger.api.health.{HealthStatus, Healthy, ReportsHealth, Unhealthy}
+import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider._
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.control.NonFatal
 
 /** A helper to run JDBC queries using a pool of managed connections */
-trait JdbcConnectionProvider extends AutoCloseable {
+trait JdbcConnectionProvider extends AutoCloseable with ReportsHealth {
 
   /** Blocks are running in a single transaction as the commit happens when the connection
     * is returned to the pool.
@@ -49,7 +53,29 @@ object HikariConnection {
   }
 }
 
-class HikariJdbcConnectionProvider(dataSource: HikariDataSource) extends JdbcConnectionProvider {
+class HikariJdbcConnectionProvider(dataSource: HikariDataSource, healthPoller: Timer)
+    extends JdbcConnectionProvider {
+  private val transientFailureCount = new AtomicInteger(0)
+
+  private val checkHealth = new TimerTask {
+    override def run(): Unit = {
+      try {
+        dataSource.getConnection().close()
+        transientFailureCount.set(0)
+      } catch {
+        case _: SQLTransientConnectionException =>
+          val _ = transientFailureCount.incrementAndGet()
+      }
+    }
+  }
+
+  healthPoller.schedule(checkHealth, 0, HealthPollingSchedule.toMillis)
+
+  override def currentHealth(): HealthStatus =
+    if (transientFailureCount.get() < MaxTransientFailureCount)
+      Healthy
+    else
+      Unhealthy
 
   override def runSQL[T](block: Connection => T): T = {
     val conn = dataSource.getConnection()
@@ -59,6 +85,9 @@ class HikariJdbcConnectionProvider(dataSource: HikariDataSource) extends JdbcCon
       conn.commit()
       res
     } catch {
+      case e: SQLTransientConnectionException =>
+        transientFailureCount.incrementAndGet()
+        throw e
       case NonFatal(t) =>
         // Log the error in the caller with access to more logging context (such as the sql statement description)
         conn.rollback()
@@ -69,11 +98,15 @@ class HikariJdbcConnectionProvider(dataSource: HikariDataSource) extends JdbcCon
   }
 
   override def close(): Unit = {
+    healthPoller.cancel()
     dataSource.close()
   }
 }
 
 object HikariJdbcConnectionProvider {
+  private val MaxTransientFailureCount: Int = 5
+  private val HealthPollingSchedule: FiniteDuration = 1.second
+
   def start(
       jdbcUrl: String,
       maxConnections: Int,
@@ -88,6 +121,8 @@ object HikariJdbcConnectionProvider {
       250.millis,
       Some(metrics),
     )
-    new HikariJdbcConnectionProvider(dataSource)
+    val healthPoller: Timer =
+      new Timer(s"${classOf[HikariJdbcConnectionProvider].getName}#healthPoller")
+    new HikariJdbcConnectionProvider(dataSource, healthPoller)
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -111,8 +111,7 @@ object DbDispatcher {
   ): DbDispatcher = {
     val logger = loggerFactory.getLogger(classOf[DbDispatcher])
 
-    val connectionProvider =
-      new HikariJdbcConnectionProvider(jdbcUrl, maxConnections, metrics)
+    val connectionProvider = HikariJdbcConnectionProvider.start(jdbcUrl, maxConnections, metrics)
 
     lazy val sqlExecutor =
       Executors.newFixedThreadPool(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -3,15 +3,13 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql.util
 
-import java.sql.{Connection, SQLTransientConnectionException}
-import java.util.concurrent.atomic.AtomicInteger
+import java.sql.Connection
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 
 import com.codahale.metrics.{MetricRegistry, Timer}
-import com.digitalasset.ledger.api.health.{HealthStatus, Healthy, ReportsHealth, Unhealthy}
+import com.digitalasset.ledger.api.health.{HealthStatus, ReportsHealth}
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao.HikariJdbcConnectionProvider
-import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.slf4j.Logger
 
@@ -28,18 +26,12 @@ final class DbDispatcher(
     with ReportsHealth {
   private val sqlExecution = ExecutionContext.fromExecutorService(sqlExecutor)
 
-  private val transientFailureCount: AtomicInteger = new AtomicInteger(0)
-
   object Metrics {
     val waitAllTimer: Timer = metrics.timer("sql_all_wait")
     val execAllTimer: Timer = metrics.timer("sql_all_exec")
   }
 
-  override def currentHealth(): HealthStatus =
-    if (transientFailureCount.get() < MaxTransientFailureCount)
-      Healthy
-    else
-      Unhealthy
+  override def currentHealth(): HealthStatus = connectionProvider.currentHealth()
 
   /** Runs an SQL statement in a dedicated Executor. The whole block will be run in a single database transaction.
     *
@@ -62,12 +54,8 @@ final class DbDispatcher(
       try {
         // Actual execution
         val result = connectionProvider.runSQL(sql)
-        transientFailureCount.set(0)
         result
       } catch {
-        case e: SQLTransientConnectionException =>
-          transientFailureCount.incrementAndGet()
-          throw e
         case NonFatal(e) =>
           logger.error(
             s"$description: Got an exception while executing a SQL query. Rolled back the transaction.",
@@ -101,8 +89,6 @@ final class DbDispatcher(
 }
 
 object DbDispatcher {
-  val MaxTransientFailureCount: Int = 3
-
   def start(
       jdbcUrl: String,
       maxConnections: Int,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
@@ -13,8 +13,11 @@ class PostgresIT extends WordSpec with Matchers with PostgresAroundAll {
 
   private val loggerFactory = NamedLoggerFactory("PostgresIT")
 
-  private lazy val connectionProvider =
-    new HikariJdbcConnectionProvider(postgresFixture.jdbcUrl, 4, new MetricRegistry)
+  private lazy val connectionProvider = HikariJdbcConnectionProvider.start(
+    postgresFixture.jdbcUrl,
+    maxConnections = 4,
+    new MetricRegistry,
+  )
 
   "Postgres" when {
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.platform.sandbox.stores.ledger.sql
 
-import java.sql.SQLException
-
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
@@ -35,7 +33,7 @@ class SqlLedgerSpec
 
   override val timeLimit: Span = scaled(Span(1, Minute))
   implicit override val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = scaled(Span(5, Seconds)))
+    PatienceConfig(timeout = scaled(Span(10, Seconds)))
 
   private val queueDepth = 128
 
@@ -109,7 +107,6 @@ class SqlLedgerSpec
           ()
         }
 
-        listPackages()
         withClue("before shutting down postgres,") {
           ledger.currentHealth() should be(Healthy)
         }
@@ -117,7 +114,6 @@ class SqlLedgerSpec
         stopPostgres()
 
         eventually {
-          assertThrows[SQLException](listPackages())
           withClue("after shutting down postgres,") {
             ledger.currentHealth() should be(Unhealthy)
           }
@@ -126,7 +122,6 @@ class SqlLedgerSpec
         startPostgres()
 
         eventually {
-          listPackages()
           withClue("after starting up postgres,") {
             ledger.currentHealth() should be(Healthy)
           }


### PR DESCRIPTION
The problem with hooking into existing requests is that if the Sandbox is running in a load balancer and reports itself as unhealthy, it might be taken out of the load balancer. Without any requests going through, it'll never realize it's healthy again, and so will remain thinking it's unhealthy forever.

Part of #2733.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
