### PR TITLE
Check ledger and participant ID in claims

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
@@ -44,7 +44,9 @@ final class LedgerServices(val ledgerId: String) {
 
   val executionContext: ExecutionContext = global
   private val esf: ExecutionSequencerFactory = new SingleThreadExecutionSequencerPool(ledgerId)
-  private val authorizer = new Authorizer(() => Clock.systemUTC().instant())
+  private val participantId = "LedgerServicesParticipant"
+  private val authorizer =
+    new Authorizer(() => Clock.systemUTC().instant(), ledgerId, participantId)
 
   def newServerBuilder(): NettyServerBuilder = NettyServerBuilder.forAddress(nextAddress())
 

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
@@ -23,7 +23,8 @@ package object rxjava {
   private[rxjava] def untestedEndpoint: Nothing =
     throw new UnsupportedOperationException("Untested endpoint, implement if needed")
 
-  private[rxjava] val authorizer = new Authorizer(() => Clock.systemUTC().instant())
+  private[rxjava] val authorizer =
+    new Authorizer(() => Clock.systemUTC().instant(), "testLedgerId", "testParticipantId")
 
   private[rxjava] val emptyToken = "empty"
   private[rxjava] val publicToken = "public"

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
@@ -73,7 +73,12 @@ class AuthServiceJWT(verifier: JwtVerifierBase) extends AuthService {
     payload.readAs
       .foreach(party => claims.append(ClaimReadAsParty(Ref.Party.assertFromString(party))))
 
-    Claims(claims.toList, payload.exp)
+    Claims(
+      claims = claims.toList,
+      expiration = payload.exp,
+      ledgerId = payload.ledgerId,
+      participantId = payload.participantId,
+    )
   }
 }
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -53,11 +53,6 @@ final case class ClaimReadAsParty(name: Ref.Party) extends Claim
   * They also optionally specify an expiration epoch time that statically specifies the
   * time on or after which the token will no longer be considered valid by the Ledger API.
   *
-  * @param claims         List of [[Claim]]s describing the authorization this object describes (see table below).
-  * @param ledgerId       If set, the claims will only be valid on the given ledger.
-  * @param participantId  If set, the claims will only be valid on the given participant.
-  * @param expiration     If set, the claims will cease to be valid at the given time.
-  *
   * The following is a full list of services and the corresponding required claims:
   * +-------------------------------------+----------------------------+------------------------------------------+
   * | Ledger API service                  | Method                     | Access with                              |
@@ -78,6 +73,11 @@ final case class ClaimReadAsParty(name: Ref.Party) extends Claim
   * | TransactionService                  | LedgerEnd                  | isPublic                                 |
   * | TransactionService                  | *                          | for each requested party p: canReadAs(p) |
   * +-------------------------------------+----------------------------+------------------------------------------+
+  *
+  * @param claims         List of [[Claim]]s describing the authorization this object describes.
+  * @param ledgerId       If set, the claims will only be valid on the given ledger.
+  * @param participantId  If set, the claims will only be valid on the given participant.
+  * @param expiration     If set, the claims will cease to be valid at the given time.
   */
 final case class Claims(
     claims: Seq[Claim],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/StandaloneIndexServer.scala
@@ -128,10 +128,12 @@ class StandaloneIndexServer(
     val packageStore = loadDamlPackages()
     preloadPackages(packageStore)
 
-    val authorizer = new Authorizer(() => java.time.Clock.systemUTC.instant())
-
     for {
       cond <- readService.getLedgerInitialConditions().runWith(Sink.head)
+      authorizer = new Authorizer(
+        () => java.time.Clock.systemUTC.instant(),
+        cond.ledgerId,
+        participantId)
       indexService <- JdbcIndex(
         readService,
         domain.LedgerId(cond.ledgerId),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -238,7 +238,10 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
         sys.error(msg)
       }, identity)
 
-    val authorizer = new Authorizer(() => java.time.Clock.systemUTC.instant())
+    val authorizer = new Authorizer(
+      () => java.time.Clock.systemUTC.instant(),
+      LedgerId.unwrap(ledgerId),
+      participantId)
 
     val healthChecks = new HealthChecks(
       "index" -> indexAndWriteService.indexService,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/AdminServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/AdminServiceCallAuthTests.scala
@@ -28,4 +28,17 @@ trait AdminServiceCallAuthTests extends ServiceCallAuthTests {
     expectSuccess(serviceCallWithToken(canReadAsAdmin))
   }
 
+  it should "allow calls with the correct ledger ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsAdminActualLedgerId))
+  }
+  it should "deny calls with a random ledger ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsAdminRandomLedgerId))
+  }
+  it should "allow calls with the correct participant ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsAdminActualParticipantId))
+  }
+  it should "deny calls with a random participant ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsAdminRandomParticipantId))
+  }
+
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/PublicServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/PublicServiceCallAuthTests.scala
@@ -35,4 +35,16 @@ trait PublicServiceCallAuthTests extends ServiceCallAuthTests {
     expectSuccess(serviceCallWithToken(canReadAsAdmin))
   }
 
+  it should "allow calls with the correct ledger ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsRandomPartyActualLedgerId))
+  }
+  it should "deny calls with a random ledger ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsRandomPartyRandomLedgerId))
+  }
+  it should "allow calls with the correct participant ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsRandomPartyActualParticipantId))
+  }
+  it should "deny calls with a random participant ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsRandomPartyRandomParticipantId))
+  }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
@@ -36,15 +36,15 @@ trait ReadOnlyServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   }
 
   it should "allow calls with the correct ledger ID" in {
-    expectSuccess(serviceCallWithToken(canActAsMainActorActualLedgerId))
+    expectSuccess(serviceCallWithToken(canReadAsMainActorActualLedgerId))
   }
   it should "deny calls with a random ledger ID" in {
-    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomLedgerId))
+    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomLedgerId))
   }
   it should "allow calls with the correct participant ID" in {
-    expectSuccess(serviceCallWithToken(canActAsMainActorActualParticipantId))
+    expectSuccess(serviceCallWithToken(canReadAsMainActorActualParticipantId))
   }
   it should "deny calls with a random participant ID" in {
-    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomParticipantId))
+    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomParticipantId))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
@@ -35,4 +35,16 @@ trait ReadOnlyServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
     successfulBehavior(serviceCallWithToken(canActAsMainActor))
   }
 
+  it should "allow calls with the correct ledger ID" in {
+    expectSuccess(serviceCallWithToken(canActAsMainActorActualLedgerId))
+  }
+  it should "deny calls with a random ledger ID" in {
+    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomLedgerId))
+  }
+  it should "allow calls with the correct participant ID" in {
+    expectSuccess(serviceCallWithToken(canActAsMainActorActualParticipantId))
+  }
+  it should "deny calls with a random participant ID" in {
+    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomParticipantId))
+  }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
@@ -36,13 +36,13 @@ trait ReadOnlyServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   }
 
   it should "allow calls with the correct ledger ID" in {
-    expectSuccess(serviceCallWithToken(canReadAsMainActorActualLedgerId))
+    successfulBehavior(serviceCallWithToken(canReadAsMainActorActualLedgerId))
   }
   it should "deny calls with a random ledger ID" in {
     expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomLedgerId))
   }
   it should "allow calls with the correct participant ID" in {
-    expectSuccess(serviceCallWithToken(canReadAsMainActorActualParticipantId))
+    successfulBehavior(serviceCallWithToken(canReadAsMainActorActualParticipantId))
   }
   it should "deny calls with a random participant ID" in {
     expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomParticipantId))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -23,15 +23,15 @@ trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   }
 
   it should "allow calls with the correct ledger ID" in {
-    expectSuccess(serviceCallWithToken(canReadAsMainActorActualLedgerId))
+    expectSuccess(serviceCallWithToken(canActAsMainActorActualLedgerId))
   }
   it should "deny calls with a random ledger ID" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomLedgerId))
+    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomLedgerId))
   }
   it should "allow calls with the correct participant ID" in {
-    expectSuccess(serviceCallWithToken(canReadAsMainActorActualParticipantId))
+    expectSuccess(serviceCallWithToken(canActAsMainActorActualParticipantId))
   }
   it should "deny calls with a random participant ID" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomParticipantId))
+    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomParticipantId))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -22,4 +22,16 @@ trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
     expectPermissionDenied(serviceCallWithToken(canReadAsMainActor))
   }
 
+  it should "allow calls with the correct ledger ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsMainActorActualLedgerId))
+  }
+  it should "deny calls with a random ledger ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomLedgerId))
+  }
+  it should "allow calls with the correct participant ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsMainActorActualParticipantId))
+  }
+  it should "deny calls with a random participant ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomParticipantId))
+  }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
@@ -74,4 +74,26 @@ trait ServiceCallAuthTests
     Option(toHeader(expiringIn(Duration.ofDays(-1), adminToken)))
   protected val canReadAsAdminExpiresTomorrow = Option(
     toHeader(expiringIn(Duration.ofDays(1), adminToken)))
+
+  // Note: lazy val, because the ledger ID is only known after the sandbox start
+  protected lazy val canReadAsRandomPartyActualLedgerId =
+    Option(toHeader(forLedgerId(unwrappedLedgerId, readOnlyToken(UUID.randomUUID.toString))))
+  protected val canReadAsRandomPartyRandomLedgerId =
+    Option(toHeader(forLedgerId(UUID.randomUUID.toString, readOnlyToken(UUID.randomUUID.toString))))
+  protected val canReadAsRandomPartyActualParticipantId =
+    Option(
+      toHeader(forParticipantId("sandbox-participant", readOnlyToken(UUID.randomUUID.toString))))
+  protected val canReadAsRandomPartyRandomParticipantId =
+    Option(
+      toHeader(forParticipantId(UUID.randomUUID.toString, readOnlyToken(UUID.randomUUID.toString))))
+
+  // Note: lazy val, because the ledger ID is only known after the sandbox start
+  protected lazy val canReadAsAdminActualLedgerId =
+    Option(toHeader(forLedgerId(unwrappedLedgerId, adminToken)))
+  protected val canReadAsAdminRandomLedgerId =
+    Option(toHeader(forLedgerId(UUID.randomUUID.toString, adminToken)))
+  protected val canReadAsAdminActualParticipantId =
+    Option(toHeader(forParticipantId("sandbox-participant", adminToken)))
+  protected val canReadAsAdminRandomParticipantId =
+    Option(toHeader(forParticipantId(UUID.randomUUID.toString, adminToken)))
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -37,4 +37,22 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
   protected val canActAsMainActorExpiresTomorrow =
     Option(toHeader(expiringIn(Duration.ofDays(1), readWriteToken(mainActor))))
 
+  protected lazy val canReadAsMainActorActualLedgerId =
+    Option(toHeader(forLedgerId(unwrappedLedgerId, readOnlyToken(mainActor))))
+  protected val canReadAsMainActorRandomLedgerId =
+    Option(toHeader(forLedgerId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
+  protected val canReadAsMainActorActualParticipantId =
+    Option(toHeader(forParticipantId("sandbox-participant", readOnlyToken(mainActor))))
+  protected val canReadAsMainActorRandomParticipantId =
+    Option(toHeader(forParticipantId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
+
+  protected lazy val canActAsMainActorActualLedgerId =
+    Option(toHeader(forLedgerId(unwrappedLedgerId, readWriteToken(mainActor))))
+  protected val canActAsMainActorRandomLedgerId =
+    Option(toHeader(forLedgerId(UUID.randomUUID.toString, readWriteToken(mainActor))))
+  protected val canActAsMainActorActualParticipantId =
+    Option(toHeader(forParticipantId("sandbox-participant", readWriteToken(mainActor))))
+  protected val canActAsMainActorRandomParticipantId =
+    Option(toHeader(forParticipantId(UUID.randomUUID.toString, readWriteToken(mainActor))))
+
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -37,6 +37,7 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
   protected val canActAsMainActorExpiresTomorrow =
     Option(toHeader(expiringIn(Duration.ofDays(1), readWriteToken(mainActor))))
 
+  // Note: lazy val, because the ledger ID is only known after the sandbox start
   protected lazy val canReadAsMainActorActualLedgerId =
     Option(toHeader(forLedgerId(unwrappedLedgerId, readOnlyToken(mainActor))))
   protected val canReadAsMainActorRandomLedgerId =
@@ -46,6 +47,7 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
   protected val canReadAsMainActorRandomParticipantId =
     Option(toHeader(forParticipantId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
 
+  // Note: lazy val, because the ledger ID is only known after the sandbox start
   protected lazy val canActAsMainActorActualLedgerId =
     Option(toHeader(forLedgerId(unwrappedLedgerId, readWriteToken(mainActor))))
   protected val canActAsMainActorRandomLedgerId =

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixtureWithAuth.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixtureWithAuth.scala
@@ -36,6 +36,15 @@ trait SandboxFixtureWithAuth extends SandboxFixture { self: Suite =>
   def expiringIn(t: Duration, p: AuthServiceJWTPayload): AuthServiceJWTPayload =
     p.copy(exp = Option(Instant.now().plusNanos(t.toNanos)))
 
+  def forLedgerId(id: String, p: AuthServiceJWTPayload): AuthServiceJWTPayload =
+    p.copy(ledgerId = Some(id))
+
+  def forParticipantId(id: String, p: AuthServiceJWTPayload): AuthServiceJWTPayload =
+    p.copy(participantId = Some(id))
+
+  def forApplicationId(id: String, p: AuthServiceJWTPayload): AuthServiceJWTPayload =
+    p.copy(applicationId = Some(id))
+
   override protected def config: SandboxConfig =
     super.config.copy(
       authService = Some(


### PR DESCRIPTION
This PR adds support for restricting access tokens to a single ledger or participant node.

The sandbox now respects the `ledgerId` and `participantId` fields of the JWT payload.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
