### PR TITLE
ledger-api-scala-logging: Fix errors in IntelliJ IDEA.

### DIFF
--- a/ledger/ledger-api-auth/BUILD.bazel
+++ b/ledger/ledger-api-auth/BUILD.bazel
@@ -18,6 +18,7 @@ ledger_api_auth_deps = [
     "//ledger/ledger-api-client",
     "//ledger/ledger-api-common",
     "//ledger/ledger-api-domain",
+    "//ledger/ledger-api-scala-logging:ledger-api-scala-logging-base",
     "//ledger/ledger-api-scala-logging",
     "@maven//:com_auth0_java_jwt",
     "@maven//:com_github_scopt_scopt_2_12",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -34,6 +34,7 @@ da_scala_library(
         "//ledger/ledger-api-domain",
         "//ledger/ledger-api-health",
         "//ledger/ledger-api-scala-logging",
+        "//ledger/ledger-api-scala-logging:ledger-api-scala-logging-base",
         "//ledger/participant-state",
         "//ledger/participant-state-index",
         "@maven//:com_github_blemale_scaffeine_2_12",

--- a/ledger/ledger-api-integration-tests/BUILD.bazel
+++ b/ledger/ledger-api-integration-tests/BUILD.bazel
@@ -51,6 +51,7 @@ dependencies = [
     "//ledger/ledger-api-common",
     "//ledger/ledger-api-common:ledger-api-common-scala-tests-lib",
     "//ledger/ledger-api-domain",
+    "//ledger/ledger-api-scala-logging:ledger-api-scala-logging-base",
     "//ledger/ledger-api-scala-logging",
     "//ledger/sandbox",
     "//ledger/sandbox:sandbox-scala-tests-lib",

--- a/ledger/ledger-api-scala-logging/BUILD.bazel
+++ b/ledger/ledger-api-scala-logging/BUILD.bazel
@@ -21,31 +21,45 @@ proto_gen(
 )
 
 da_scala_library(
-    name = "ledger-api-scala-logging",
-    srcs = [":ledger-api-scala-logging-srcs"] + glob(["src/main/scala/**/*.scala"]),
-    tags = ["maven_coordinates=com.digitalasset.ledger-api:ledger-api-scala-logging:__VERSION__"],
+    name = "ledger-api-scala-logging-base",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    tags = ["maven_coordinates=com.digitalasset.ledger-api:ledger-api-scala-logging-base:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],
     deps = [
-        "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "//scala-protoc-plugins/scala-logging:scala-logging-lib",
+        "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )
 
+da_scala_library(
+    name = "ledger-api-scala-logging",
+    srcs = [":ledger-api-scala-logging-srcs"],
+    tags = ["maven_coordinates=com.digitalasset.ledger-api:ledger-api-scala-logging:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":ledger-api-scala-logging-base",
+        "//ledger-api/grpc-definitions:ledger-api-scalapb",
+        "//scala-protoc-plugins/scala-logging:scala-logging-lib",
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)
+
 testDependencies = [
+    ":ledger-api-scala-logging-base",
+    ":ledger-api-scala-logging",
+    "//ledger-api/grpc-definitions:ledger-api-scalapb",
+    "@maven//:ch_qos_logback_logback_classic",
+    "@maven//:ch_qos_logback_logback_core",
     "@maven//:io_grpc_grpc_core",
     "@maven//:io_grpc_grpc_stub",
-    "//ledger-api/grpc-definitions:ledger-api-scalapb",
-    "//scala-protoc-plugins/scala-logging:scala-logging-lib",
-    ":ledger-api-scala-logging",
     "@maven//:org_scalactic_scalactic_2_12",
     "@maven//:org_scalatest_scalatest_2_12",
     "@maven//:org_slf4j_slf4j_api",
-    "@maven//:ch_qos_logback_logback_classic",
-    "@maven//:ch_qos_logback_logback_core",
 ]
 
 da_scala_library(

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -33,6 +33,7 @@ compileDependencies = [
     "//ledger/ledger-api-common",
     "//ledger/ledger-api-domain",
     "//ledger/ledger-api-health",
+    "//ledger/ledger-api-scala-logging:ledger-api-scala-logging-base",
     "//ledger/ledger-api-scala-logging",
     "//ledger/participant-state",
     "//ledger/participant-state-index:participant-state-index",

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -129,6 +129,9 @@
 - target: //ledger/ledger-api-scala-logging:ledger-api-scala-logging
   type: jar-scala
   mavenUpload: true
+- target: //ledger/ledger-api-scala-logging:ledger-api-scala-logging-base
+  type: jar-scala
+  mavenUpload: true
 - target: //ledger/ledger-api-client:ledger-api-client
   type: jar-scala
   mavenUpload: true


### PR DESCRIPTION
The Bazel plugin for IntelliJ doesn't seem to be smart enough to be able
to handle a Scala library that is part `src` directory and part
generated code from another Bazel rule. It just ignores the second part.
This means that IntelliJ cannot find the *ServiceLogging classes, as
they're not represented on the Bazel-generated classpath, and so
complains with lots of errors when working on the equivalent Api*Service
files.

To fix this, we can split these in two, compiling the base traits to
`ledger-api-scala-logging-base` and then the generated code separately.

It does result in an extra Bazel dependency for the users of
ledger-api-scala-logging, as Bazel doesn't realise transitive
dependencies for us.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
