### PR TITLE
Move the bazel aliases for yarn and java to the root BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -193,6 +193,16 @@ alias(
     actual = "//language-support/java/bindings:bindings-java",
 )
 
+alias(
+    name = "yarn",
+    actual = "@nodejs//:bin/yarn.cmd" if is_windows else "@nodejs//:bin/yarn",
+)
+
+alias(
+    name = "java",
+    actual = "@local_jdk//:bin/java.exe" if is_windows else "@local_jdk//:bin/java",
+)
+
 exports_files([
     ".scalafmt.conf",
 ])

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -3,8 +3,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@os_info//:os_info.bzl", "is_windows")
-
 filegroup(
     name = "json-files",
     srcs = glob([
@@ -71,14 +69,6 @@ genrule(
     """,
 )
 
-# This is needed to be able to call `$(location ...)` in the vsix rule.
-# Otherwise I have not found a way to express the conditional within the
-# `$(location ...)` substitution.
-alias(
-    name = "yarn",
-    actual = "@nodejs//:bin/yarn.cmd" if is_windows else "@nodejs//:bin/yarn",
-)
-
 genrule(
     name = "vsix",
     srcs = glob([
@@ -109,12 +99,12 @@ genrule(
         tar xzf $$DIR/$(location :node_deps_cache)
         sed -i "s/__VERSION__/$$VERSION/" package.json
         sed -i 's/"name": "daml"/"name": "daml-bundled"/' package.json
-        $$DIR/$(location :yarn)
-        $$DIR/$(location :yarn) compile
+        $$DIR/$(location //:yarn)
+        $$DIR/$(location //:yarn) compile
         $$DIR/$(location @daml_extension_deps//vsce/bin:vsce) package -o $$DIR/$@
     """,
     tools = [
-        ":yarn",
+        "//:yarn",
         "@daml_extension_deps//vsce/bin:vsce",
     ],
 )

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules_daml:daml.bzl", "daml_compile")
-load("@os_info//:os_info.bzl", "is_windows")
 
 daml_compile(
     name = "daml2ts-test",
@@ -10,25 +9,12 @@ daml_compile(
     main_src = "daml/Main.daml",
 )
 
-# This is needed to be able to call `$(location ...)` in rules.
-# Otherwise I have not found a way to express the conditional within the
-# `$(location ...)` substitution.
-alias(
-    name = "yarn",
-    actual = "@nodejs//:bin/yarn.cmd" if is_windows else "@nodejs//:bin/yarn",
-)
-
-alias(
-    name = "java",
-    actual = "@local_jdk//:bin/java.exe" if is_windows else "@local_jdk//:bin/java",
-)
-
 sh_test(
     name = "build-and-lint",
     srcs = ["build-and-lint.sh"],
     args = [
-        "$(location :java)",
-        "$(location :yarn)",
+        "$(location //:java)",
+        "$(location //:yarn)",
         "$(location //:daml2ts)",
         "$(location //ledger/sandbox:sandbox-binary_deploy.jar)",
         "$(location //ledger-service/http-json:http-json-binary_deploy.jar)",
@@ -36,8 +22,8 @@ sh_test(
         "$(location ts/package.json)",
     ],
     data = [
-        ":java",
-        ":yarn",
+        "//:java",
+        "//:yarn",
         "//:daml2ts",
         "//ledger/sandbox:sandbox-binary_deploy.jar",
         "//ledger-service/http-json:http-json-binary_deploy.jar",


### PR DESCRIPTION
Replicating the yarn alias in multiple places doesn't make sense.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3786)
<!-- Reviewable:end -->
