### PR TITLE
Ensure the access token is initialized when constructing a client

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -19,14 +19,14 @@ import java.util.concurrent.TimeUnit;
  * an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}:
  * <ol>
  *     <li>Create an instance of a {@link Builder} using {@link DamlLedgerClient#newBuilder(String, int)}
- *     <li>Specify and expected ledger identifier, {@link SslContext}, and/or access token, depending on your need</li>
+ *     <li>Specify and expected ledger identifier, {@link SslContext}, and/or access token, depending on your needs</li>
  *     <li>Invoke {@link Builder#build()} to finalize and construct a {@link DamlLedgerClient}</li>
  *     <li>Call the method {@link DamlLedgerClient#connect()} to initialize the clients for that particular ledger</li>
  *     <li>Retrieve one of the clients by using a getter, e.g. {@link DamlLedgerClient#getActiveContractSetClient()}</li>
  * </ol>
  *
  * Alternatively to {@link DamlLedgerClient#newBuilder(String, int)}, you can use {@link DamlLedgerClient#newBuilder(NettyChannelBuilder)}
- * to make sure you can ensure additional properties for the channel you're building, such as the maximum inbound message size.
+ * to make sure you can specify additional properties for the channel you're building, such as the maximum inbound message size.
  *
  * For information on how to set up an {@link SslContext} object for mutual authentication please refer to
  * the <a href="https://github.com/grpc/grpc-java/blob/master/SECURITY.md">section on security</a> in the grpc-java documentation.

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -18,12 +18,16 @@ import java.util.concurrent.TimeUnit;
  * A {@link LedgerClient} implementation that connects to
  * an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}:
  * <ol>
- *     <li>Create an instance of {@link DamlLedgerClient} using {@link DamlLedgerClient#forLedgerIdAndHost(String, String, int, Optional)},
- *     {@link DamlLedgerClient#forHostWithLedgerIdDiscovery(String, int, Optional)} or {@link DamlLedgerClient#DamlLedgerClient(Optional, ManagedChannel)}</li>
- *     <li>When ready to use the clients, call the method {@link DamlLedgerClient#connect()} to initialize the clients
- *     for that particular Ledger</li>
+ *     <li>Create an instance of a {@link Builder} using {@link DamlLedgerClient#newBuilder(String, int)}
+ *     <li>Specify and expected ledger identifier, {@link SslContext}, and/or access token, depending on your need</li>
+ *     <li>Invoke {@link Builder#build()} to finalize and construct a {@link DamlLedgerClient}</li>
+ *     <li>Call the method {@link DamlLedgerClient#connect()} to initialize the clients for that particular ledger</li>
  *     <li>Retrieve one of the clients by using a getter, e.g. {@link DamlLedgerClient#getActiveContractSetClient()}</li>
  * </ol>
+ *
+ * Alternatively to {@link DamlLedgerClient#newBuilder(String, int)}, you can use {@link DamlLedgerClient#newBuilder(NettyChannelBuilder)}
+ * to make sure you can ensure additional properties for the channel you're building, such as the maximum inbound message size.
+ *
  * For information on how to set up an {@link SslContext} object for mutual authentication please refer to
  * the <a href="https://github.com/grpc/grpc-java/blob/master/SECURITY.md">section on security</a> in the grpc-java documentation.
  *
@@ -147,6 +151,7 @@ public final class DamlLedgerClient implements LedgerClient {
     public DamlLedgerClient(Optional<String> expectedLedgerId, @NonNull ManagedChannel channel) {
         this.channel = channel;
         this.expectedLedgerId = expectedLedgerId.orElse(null);
+        this.accessToken = Optional.empty();
     }
 
     /**


### PR DESCRIPTION
CHANGELOG_BEGIN
- [Java Client] Ensure the access token is initialized when using a
deprecated constructor.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
