### PR TITLE
fix docs live-preview.sh script

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -134,7 +134,10 @@ in rec {
     yapf = pkgs.python37Packages.yapf;
 
     pex = pkgs.python37Packages.pex;
-    pipenv = pkgs.pipenv;
+    pipenv = import ./tools/pipenv {
+      lib = pkgs.stdenv.lib;
+      python3 = python3;
+    };
 
     sphinx            = pkgs.python37.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]);
     sphinx-build      = sphinx;

--- a/nix/tools/pipenv/default.nix
+++ b/nix/tools/pipenv/default.nix
@@ -1,0 +1,59 @@
+# copied from
+# https://raw.githubusercontent.com/NixOS/nixpkgs/1c406512eb6331ca4d75e0d63298c5e0e7009fdd/pkgs/development/tools/pipenv/default.nix
+# then modified to disable check phase (line 46)
+
+{ lib
+, python3
+}:
+
+with python3.pkgs;
+
+let
+
+  runtimeDeps = [
+    certifi
+    setuptools
+    pip
+    virtualenv
+    virtualenv-clone
+  ];
+
+  pythonEnv = python3.withPackages(ps: with ps; [ virtualenv ]);
+
+in buildPythonApplication rec {
+  pname = "pipenv";
+  version = "2018.11.26";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ip8zsrwmhrankrix0shig9g8q2knmr7b63sh7lqa8a5x03fcwx6";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+
+  postPatch = ''
+    # pipenv invokes python in a subprocess to create a virtualenv
+    # it uses sys.executable which will point in our case to a python that
+    # does not have virtualenv.
+    substituteInPlace pipenv/core.py \
+      --replace "vistir.compat.Path(sys.executable).absolute().as_posix()" "vistir.compat.Path('${pythonEnv.interpreter}').absolute().as_posix()"
+  '';
+
+  nativeBuildInputs = [ invoke parver ];
+
+  propagatedBuildInputs = runtimeDeps;
+
+  doCheck = false;
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    cp -r --no-preserve=mode ${wheel.src} $HOME/wheel-src
+    $out/bin/pipenv install $HOME/wheel-src
+  '';
+
+  meta = with lib; {
+    description = "Python Development Workflow for Humans";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ berdario ];
+  };
+}


### PR DESCRIPTION
pipenv is broken on current master as of #3366, as it invokes a Python
in a subshell that does not have access to virtualenv.