### PR TITLE
Workaround and test for #3777

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -195,10 +195,12 @@ envLookupAlias x = MS.lookup x . envAliases
 
 -- | Bind a type var without shadowing its LF name.
 envBindTypeVar :: Var -> Env -> (TypeVarName, Env)
-envBindTypeVar x env = try 1 (TypeVarName prefix)
+envBindTypeVar x env = try 1 (TypeVarName (prefix <> suffix))
     where
         prefix = getOccText x
-        nameFor i = TypeVarName (prefix <> T.pack (show i))
+        suffix = "_" <> T.pack (show (varUnique x))
+            -- NOTE: Workaround for #3777. Remove suffix once issue fixed.
+        nameFor i = TypeVarName (prefix <> T.pack (show i) <> suffix)
 
         try :: Int -> TypeVarName -> (TypeVarName, Env)
         try !i name =
@@ -433,14 +435,14 @@ convertSimpleRecordDef env tycon = do
     let fields = zipExact labels (map sanitize fieldTypes)
         tconName = mkTypeCon [getOccText tycon]
         typeDef = defDataType tconName tyVars (DataRecord fields)
-        workerDef = defNewtypeWorker env tycon tconName con tyVars fields
+        workerDef = defNewtypeWorker (envLFModuleName env) tycon tconName con tyVars fields
     pure $ typeDef : [workerDef | flavour == NewtypeFlavour]
 
-defNewtypeWorker :: NamedThing a => Env -> a -> TypeConName -> DataCon
+defNewtypeWorker :: NamedThing a => LF.ModuleName -> a -> TypeConName -> DataCon
     -> [(TypeVarName, LF.Kind)] -> [(FieldName, LF.Type)] -> Definition
-defNewtypeWorker env loc tconName con tyVars fields =
+defNewtypeWorker lfModuleName loc tconName con tyVars fields =
     let tcon = TypeConApp
-            (Qualified PRSelf (envLFModuleName env) tconName)
+            (Qualified PRSelf lfModuleName tconName)
             (map (TVar . fst) tyVars)
         workerName = mkWorkerName (getOccText con)
         workerType = mkTForalls tyVars $ mkTFuns (map snd fields) $ typeConAppToType tcon

--- a/compiler/damlc/tests/daml-test-files/TypeVarShadowing2.daml
+++ b/compiler/damlc/tests/daml-test-files/TypeVarShadowing2.daml
@@ -1,0 +1,10 @@
+daml 1.2
+
+-- | Minimal example of issue #3777
+module TypeVarShadowing2 where
+
+baz : (a1 -> a2) -> (b1 -> b2) -> (b1 -> b2)
+baz f g = bar f g
+
+bar : (b1 -> b2) -> (a1 -> a2) -> (a1 -> a2)
+bar f g = g


### PR DESCRIPTION
This PR adds a small workaround for #3777 and a test. 

(Also includes an unrelated refactoring of `defNewtypeWorker` because we shouldn't pass a (stale) env around when we can just pass the LF module name it needs directly.)