### PR TITLE
Move all datatypes out of daml-prim

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1425,7 +1425,7 @@ qualify env m x = do
 qDA_Types :: Env -> a -> ConvertM (Qualified a)
 qDA_Types env a = do
   pkgRef <- packageNameToPkgRef env "daml-prim"
-  pure $ Qualified pkgRef (mkModName ["DA", "Types"]) a
+  pure $ rewriteStableQualified env $ Qualified pkgRef (mkModName ["DA", "Types"]) a
 
 -- | Rewrite an a qualified name into a reference into one of the hardcoded
 -- stable packages if there is one.

--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -27,10 +27,14 @@ genrule(
     outs = [
         "daml-prim/GHC-Types.dalf",
         "daml-prim/GHC-Prim.dalf",
+        "daml-prim/GHC-Tuple.dalf",
+        "daml-prim/DA-Types.dalf",
     ],
     cmd = """
       $(location :generate-stable-package) --module GHC.Types -o $(location daml-prim/GHC-Types.dalf)
       $(location :generate-stable-package) --module GHC.Prim -o $(location daml-prim/GHC-Prim.dalf)
+      $(location :generate-stable-package) --module GHC.Tuple -o $(location daml-prim/GHC-Tuple.dalf)
+      $(location :generate-stable-package) --module DA.Types -o $(location daml-prim/DA-Types.dalf)
     """,
     tools = [":generate-stable-package"],
     visibility = ["//visibility:public"],
@@ -39,7 +43,9 @@ genrule(
 filegroup(
     name = "stable-packages",
     srcs = [
+        "daml-prim/DA-Types.dalf",
         "daml-prim/GHC-Prim.dalf",
+        "daml-prim/GHC-Tuple.dalf",
         "daml-prim/GHC-Types.dalf",
     ],
     visibility = ["//visibility:public"],

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DarReaderTest.scala
@@ -37,17 +37,23 @@ class DarReaderTest extends WordSpec with Matchers with Inside with BazelRunfile
               ((packageId3, archive3), LanguageMajorVersion.V1) ::
               ((packageId4, archive4), LanguageMajorVersion.V1) ::
               ((packageId5, archive5), LanguageMajorVersion.V1) ::
+              ((packageId6, archive6), LanguageMajorVersion.V1) ::
+              ((packageId7, archive7), LanguageMajorVersion.V1) ::
               Nil)) =>
         packageId1 shouldNot be('empty)
         packageId2 shouldNot be('empty)
         packageId3 shouldNot be('empty)
         packageId4 shouldNot be('empty)
         packageId5 shouldNot be('empty)
+        packageId6 shouldNot be('empty)
+        packageId7 shouldNot be('empty)
         archive1.getDamlLf1.getModulesCount should be > 0
         archive2.getDamlLf1.getModulesCount should be > 0
         archive3.getDamlLf1.getModulesCount should be > 0
         archive4.getDamlLf1.getModulesCount should be > 0
         archive5.getDamlLf1.getModulesCount should be > 0
+        archive6.getDamlLf1.getModulesCount should be > 0
+        archive7.getDamlLf1.getModulesCount should be > 0
 
         val archive1Modules = archive1.getDamlLf1.getModulesList.asScala
         val archive1InternedDotted = archive1.getDamlLf1.getInternedDottedNamesList.asScala
@@ -82,10 +88,8 @@ class DarReaderTest extends WordSpec with Matchers with Inside with BazelRunfile
           "GHC.Enum",
           "GHC.Show",
           "GHC.Num",
-          "DA.Types",
           "GHC.Classes",
           "Control.Exception.Base",
-          "GHC.Tuple",
           "GHC.Err",
           "GHC.Base",
           "LibraryModules"

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -129,7 +129,7 @@ tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \pid _te
     lid <- getLedgerIdentity
     pids <- listPackages lid
     liftIO $ do
-        assertEqual "#packages" 5 (length pids)
+        assertEqual "#packages" 7 (length pids)
         assertBool "The pid is listed" (pid `elem` pids)
 
 tGetPackage :: SandboxTest

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -35,7 +35,7 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.length == 5)
+    assert(interfaces.length == 7)
     assert(pkgPrefixes == Map.empty)
   }
 
@@ -48,8 +48,8 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.map(_.packageId).length == 5)
-    assert(pkgPrefixes.size == 5)
+    assert(interfaces.map(_.packageId).length == 7)
+    assert(pkgPrefixes.size == 7)
     assert(pkgPrefixes.values.forall(_ == "PREFIX"))
   }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -52,7 +52,7 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
         logEntry <- submitArchives("test-stable-submission", testStablePackages.all: _*).map(_._2)
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
-        logEntry.getPackageUploadEntry.getArchivesCount shouldEqual 5
+        logEntry.getPackageUploadEntry.getArchivesCount shouldEqual 7
       }
     }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -450,10 +450,12 @@ class JdbcLedgerDaoSpec
       } yield {
         firstUploadResult shouldBe Map(PersistenceResponse.Ok -> 1)
         secondUploadResult shouldBe Map(
-          PersistenceResponse.Ok -> 4,
+          PersistenceResponse.Ok -> 6,
           PersistenceResponse.Duplicate -> 1)
         loadedPackages.values.flatMap(_.sourceDescription.toList) should contain theSameElementsAs Seq(
           firstDescription,
+          secondDescription,
+          secondDescription,
           secondDescription,
           secondDescription,
           secondDescription,


### PR DESCRIPTION
This moves the remaining two modules DA.Types and GHC.Tuple to
separate LF packages with stable identifiers.

The only data types remaining are the ones for typeclasses which will
disappear once we move this to type synonyms.

CHANGELOG_BEGIN

- [DAML Compiler] The modules DA.Types and GHC.Tuple from daml-prim
have been moved to separate packages.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
