### PR TITLE
Fix typo in JavaDoc

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  * an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}:
  * <ol>
  *     <li>Create an instance of a {@link Builder} using {@link DamlLedgerClient#newBuilder(String, int)}
- *     <li>Specify and expected ledger identifier, {@link SslContext}, and/or access token, depending on your needs</li>
+ *     <li>Specify an expected ledger identifier, {@link SslContext}, and/or access token, depending on your needs</li>
  *     <li>Invoke {@link Builder#build()} to finalize and construct a {@link DamlLedgerClient}</li>
  *     <li>Call the method {@link DamlLedgerClient#connect()} to initialize the clients for that particular ledger</li>
  *     <li>Retrieve one of the clients by using a getter, e.g. {@link DamlLedgerClient#getActiveContractSetClient()}</li>


### PR DESCRIPTION
Addresses  the typo brought up by https://github.com/digital-asset/daml/pull/3788#discussion_r355468943

The other comment (https://github.com/digital-asset/daml/pull/3788#discussion_r355469578) is unfortunately not testable because:
- the constructor is deprecated
- the tests are written in Scala and we have fatal warnings enabled for the Scala compiler
- there is currently no way to have a whitelist for deprecated stuff

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
