### PR TITLE
Include package name in manifest file

### DIFF
--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -21,6 +21,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.UTF8 as BSUTF8
 import Data.Char
+import Data.Either.Extra
 import Data.List.Extra
 import Data.Maybe
 import qualified Data.Text as T
@@ -91,6 +92,7 @@ data DalfManifest = DalfManifest
     , dalfPaths :: [FilePath]
     -- ^ Includes the mainDalf.
     , sdkVersion :: String
+    , packageName :: Maybe String
     } deriving (Show)
 
 -- | The dalfs stored in the DAR.
@@ -106,7 +108,8 @@ readDalfManifest dar = do
     mainDalf <- getAttr "Main-Dalf" attrs
     dalfPaths <- splitOn ", " <$> getAttr "Dalfs" attrs
     sdkVersion <- getAttr "Sdk-Version" attrs
-    pure $ DalfManifest mainDalf dalfPaths sdkVersion
+    let mbName = eitherToMaybe (getAttr "Name" attrs)
+    pure $ DalfManifest mainDalf dalfPaths sdkVersion mbName
   where
     getAttr :: ByteString -> [(ByteString, ByteString)] -> Either String String
     getAttr attrName attrs =

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -344,6 +344,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies srcRoot fileD
         map (breakAt72Bytes . BSLUTF8.fromString)
             [ "Manifest-Version: 1.0"
             , "Created-By: damlc"
+            , "Name: " <> pkgNameVersion pName pVersion
             , "Sdk-Version: " <> unPackageSdkVersion pSdkVersion
             , "Main-Dalf: " <> toPosixFilePath location
             , "Dalfs: " <> intercalate ", " (map toPosixFilePath dalfs)

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -243,6 +243,7 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-reader",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/compiler/damlc/tests/src/DarReaderTest.hs
+++ b/compiler/damlc/tests/src/DarReaderTest.hs
@@ -21,12 +21,14 @@ unitTests = testGroup "testing dar reader for longer manifest lines"
                  [ ("Dalfs", "stdlib.dalf, prim.dalf")
                  , ("Main-Dalf", "testing.dalf")
                  , ("Sdk-Version", "0.13.30")
+                 , ("Name", "foobar-2.0")
                  ])
             (parseManifestFile $ BS.unlines
                  [ "Dalfs: stdlib.da"
                  , " lf, prim.dalf"
                  , "Main-Dalf: testing.dalf"
                  , "Sdk-Version: 0.13.30"
+                 , "Name: foobar-2.0"
                  ])
     , testCase "multiline manifest file test" $
         assertEqual "all content in the same line"


### PR DESCRIPTION
Currently, we generate the `depends` field in the ghc-pkg config file
based on the file name of the DARs in the `dependencies` field in
`daml.yaml`. This falls apart when you use the -o option to `daml
build` since `ghc-pkg` will complain about missing packages.

This PR adds the name to the manifest so that we can generate the
`depends` field based on that but I’ll leave that change for a
separate PR.

See https://github.com/digital-asset/daml/blob/master/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs#L289

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
