### PR TITLE
sandbox: Re-add the Docker images with a public base image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -602,6 +602,15 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+container_pull(
+    name = "openjdk_base",
+    registry = "docker.io",
+    repository = "openjdk",
+    tag = "8-alpine",
+)
+
 load("@io_bazel_rules_docker//java:image.bzl", java_image_repositories = "repositories")
 
 java_image_repositories()

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -158,7 +158,8 @@ genrule(
 
 container_image(
     name = "sandbox-image-base",
-    base = "@java_image_base//image",
+    base = "@openjdk_base//image",
+    cmd = None,
     directory = "/usr/bin",
     files = [
         "@com_github_grpc_ecosystem_grpc_health_probe_binary//file",

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -5,6 +5,8 @@ load("//rules_daml:daml.bzl", "daml_compile")
 load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library", "da_scala_test_suite")
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("//ledger/ledger-api-test-tool:conformance.bzl", "server_conformance_test")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 load("@os_info//:os_info.bzl", "is_windows")
 
 compileDependencies = [
@@ -153,6 +155,24 @@ genrule(
     """,
     visibility = ["//visibility:public"],
 )
+
+container_image(
+    name = "sandbox-image-base",
+    base = "@java_image_base//image",
+    directory = "/usr/bin",
+    files = [
+        "@com_github_grpc_ecosystem_grpc_health_probe_binary//file",
+    ],
+) if not is_windows else None
+
+java_image(
+    name = "sandbox-image",
+    base = ":sandbox-image-base",
+    main_class = "com.digitalasset.platform.sandbox.SandboxMain",
+    resources = ["src/main/resources/logback.xml"],
+    visibility = ["//visibility:public"],
+    runtime_deps = [":sandbox"],
+) if not is_windows else None
 
 alias(
     name = "Test-1.5.dar",


### PR DESCRIPTION
There were two issues with the images as originally created.

1. The default Java base image, `gcr.io/distroless/java`, requires Google authentication even though it's public. This requires installing and configuring `docker-credential-gcr`, which is way too much to ask especially given that most users will never want to use these rules.
2. @dajmaki had an issue regarding a missing `docker-credential-secretservice` binary:
    ```
    Image pull was unsuccessful: reading image "gcr.io/distroless/java@sha256:ae0eb3d54fb9172fe0f0c2158ef21501c090333c336ccaefa816bbe326c8716e": error getting credentials - err: exec: "docker-credential-secretservice": executable file not found in $PATH, out: ``
   ```

Part 2 was resolved by @dajmaki deleting his Docker configuration, which explicitly referenced the "secretservice" credentials mechanism.

This PR resolves the other part by using the `openjdk` base image, which is public and does not require any authentication.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
