### PR TITLE
Expose generic equality in compiler.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -208,6 +208,7 @@ data BuiltinExpr
 
   -- Polymorphic functions
   | BEError                      -- :: ∀a. Text -> a
+  | BEEqualGeneric               -- :: ∀t. t -> t -> Bool
   | BEEqual      !BuiltinType    -- :: t -> t -> Bool, where t is the builtin type
   | BELess       !BuiltinType    -- :: t -> t -> Bool, where t is the builtin type
   | BELessEq     !BuiltinType    -- :: t -> t -> Bool, where t is the builtin type

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -195,6 +195,7 @@ instance Pretty BuiltinExpr where
     BEUnit -> keyword_ "unit"
     BEBool b -> keyword_ $ case b of { False -> "false"; True -> "true" }
     BEError -> "ERROR"
+    BEEqualGeneric -> "EQUAL"
     BEEqual t     -> maybeParens (prec > precEApp) ("EQUAL"      <-> prettyBTyArg lvl t)
     BELess t      -> maybeParens (prec > precEApp) ("LESS"       <-> prettyBTyArg lvl t)
     BELessEq t    -> maybeParens (prec > precEApp) ("LESS_EQ"    <-> prettyBTyArg lvl t)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -308,9 +308,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionEQUAL_PARTY -> BEEqual BTParty
   LF1.BuiltinFunctionEQUAL_BOOL -> BEEqual BTBool
   LF1.BuiltinFunctionEQUAL_TYPE_REP -> BEEqual BTTypeRep
-  LF1.BuiltinFunctionEQUAL ->
-    -- FIXME https://github.com/digital-asset/daml/issues/3376
-    error "EQUAL is not supported"
+  LF1.BuiltinFunctionEQUAL -> BEEqualGeneric
 
   LF1.BuiltinFunctionLEQ_INT64 -> BELessEq BTInt64
   LF1.BuiltinFunctionLEQ_DECIMAL -> BELessEq BTDecimal

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -346,6 +346,7 @@ encodeBuiltinExpr = \case
         False -> P.PrimConCON_FALSE
         True -> P.PrimConCON_TRUE
 
+    BEEqualGeneric -> builtin P.BuiltinFunctionEQUAL
     BEEqual typ -> case typ of
       BTInt64 -> builtin P.BuiltinFunctionEQUAL_INT64
       BTDecimal -> builtin P.BuiltinFunctionEQUAL_DECIMAL

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -115,6 +115,7 @@ safetyStep = \case
       BEUnit              -> Safe 0
       BEBool _            -> Safe 0
       BEError             -> Safe 0
+      BEEqualGeneric      -> Safe 1 -- may crash if values are incomparable
       BEEqual _           -> Safe 2
       BELess _            -> Safe 2
       BELessEq _          -> Safe 2

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -156,6 +156,7 @@ typeOfBuiltin = \case
   BEUnit             -> pure TUnit
   BEBool _           -> pure TBool
   BEError            -> pure $ TForall (alpha, KStar) (TText :-> tAlpha)
+  BEEqualGeneric     -> pure $ TForall (alpha, KStar) (tAlpha :-> tAlpha :-> TBool)
   BEEqual     btype  -> pure $ tComparison btype
   BELess      btype  -> pure $ tComparison btype
   BELessEq    btype  -> pure $ tComparison btype

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -44,6 +44,8 @@ convertPrim _ "SGetParty" (t1@TText :-> TScenario TParty) =
     ETmLam (varV1, t1) $ EScenario $ SGetParty $ EVar varV1
 
 -- Comparison
+convertPrim v "BEEqual" (a1 :-> a2 :-> TBool) | a1 == a2, v `supports` featureGenMap =
+    EBuiltin BEEqualGeneric `ETyApp` a1
 convertPrim _ "BEEqual" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
     EBuiltin $ BEEqual a1
 convertPrim _ "BELess" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
@@ -56,8 +58,10 @@ convertPrim _ "BEGreater" (TBuiltin a1 :-> TBuiltin a2 :-> TBool) | a1 == a2 =
     EBuiltin $ BEGreater a1
 convertPrim _ "BEEqualList" ((a1 :-> a2 :-> TBool) :-> TList a3 :-> TList a4 :-> TBool) | a1 == a2, a2 == a3, a3 == a4 =
     EBuiltin BEEqualList `ETyApp` a1
-convertPrim _ "BEEqualContractId" (TContractId a1 :-> TContractId a2 :-> TBool) | a1 == a2 =
-    EBuiltin BEEqualContractId `ETyApp` a1
+convertPrim v "BEEqualContractId" (TContractId a1 :-> TContractId a2 :-> TBool) | a1 == a2 =
+    if v `supports` featureGenMap
+        then EBuiltin BEEqualGeneric `ETyApp` TContractId a1
+        else EBuiltin BEEqualContractId `ETyApp` a1
 
 -- Decimal arithmetic
 convertPrim _ "BEAddDecimal" (TDecimal :-> TDecimal :-> TDecimal) =
@@ -219,8 +223,10 @@ convertPrim _ "BECastNumeric" (TNumeric n1 :-> TNumeric n2) =
     EBuiltin BECastNumeric `ETyApp` n1 `ETyApp` n2
 convertPrim _ "BEShiftNumeric" (TNumeric n1 :-> TNumeric n2) =
     EBuiltin BEShiftNumeric `ETyApp` n1 `ETyApp` n2
-convertPrim _ "BEEqualNumeric" (TNumeric n1 :-> TNumeric n2 :-> TBool) | n1 == n2 =
-    ETyApp (EBuiltin BEEqualNumeric) n1
+convertPrim v "BEEqualNumeric" (TNumeric n1 :-> TNumeric n2 :-> TBool) | n1 == n2 =
+    if v `supports` featureGenMap
+        then ETyApp (EBuiltin BEEqualGeneric) (TNumeric n1)
+        else ETyApp (EBuiltin BEEqualNumeric) n1
 convertPrim _ "BELessNumeric" (TNumeric n1 :-> TNumeric n2 :-> TBool) | n1 == n2 =
     ETyApp (EBuiltin BELessNumeric) n1
 convertPrim _ "BELessEqNumeric" (TNumeric n1 :-> TNumeric n2 :-> TBool) | n1 == n2 =


### PR DESCRIPTION
Advances the state of #3766.

This PR exposes generic equality in the compiler as the `"BEEqual"` primitive in DAML. It eliminates the use of the following primitives when targeting LF 1.dev:

* EQUAL_INT64
* EQUAL_DECIMAL (already eliminated in LF 1.7)
* EQUAL_TEXT
* EQUAL_TIMESTAMP
* EQUAL_DATE
* EQUAL_PARTY
* EQUAL_BOOL
* EQUAL_TYPE_REP
* EQUAL_NUMERIC
* EQUAL_CONTRACT_ID

This means the only equality primitives we still need are `EQUAL_LIST` and the new generic one `EQUAL`.