### PR TITLE
DAML-LF: decommission equality function for atomic values

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1406,10 +1406,6 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(GREATER_DATE, BGreaterDate),
       BuiltinFunctionInfo(EQUAL, BEqual, minVersion = genMap),
       BuiltinFunctionInfo(EQUAL_LIST, BEqualList),
-      BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId),
-      // FIXME https://github.com/digital-asset/daml/issues/3752
-      // Constrain max version of the following 'EQUAL_' builtin once
-      // generic equality is handled by the compiler
       BuiltinFunctionInfo(EQUAL_INT64, BEqual, implicitParameters = List(TInt64)),
       BuiltinFunctionInfo(
         EQUAL_DECIMAL,
@@ -1417,17 +1413,43 @@ private[lf] object DecodeV1 {
         maxVersion = Some(numeric),
         implicitParameters = List(TNat.Decimal)
       ),
-      BuiltinFunctionInfo(EQUAL_NUMERIC, BEqualNumeric, minVersion = numeric),
-      BuiltinFunctionInfo(EQUAL_TEXT, BEqual, implicitParameters = List(TText)),
-      BuiltinFunctionInfo(EQUAL_TIMESTAMP, BEqual, implicitParameters = List(TTimestamp)),
-      BuiltinFunctionInfo(EQUAL_DATE, BEqual, implicitParameters = List(TDate)),
-      BuiltinFunctionInfo(EQUAL_PARTY, BEqual, implicitParameters = List(TParty)),
-      BuiltinFunctionInfo(EQUAL_BOOL, BEqual, implicitParameters = List(TBool)),
+      BuiltinFunctionInfo(
+        EQUAL_NUMERIC,
+        BEqualNumeric,
+        minVersion = numeric,
+        maxVersion = Some(genMap)),
+      BuiltinFunctionInfo(
+        EQUAL_TEXT,
+        BEqual,
+        maxVersion = Some(genMap),
+        implicitParameters = List(TText)),
+      BuiltinFunctionInfo(
+        EQUAL_TIMESTAMP,
+        BEqual,
+        maxVersion = Some(genMap),
+        implicitParameters = List(TTimestamp)),
+      BuiltinFunctionInfo(
+        EQUAL_DATE,
+        BEqual,
+        maxVersion = Some(genMap),
+        implicitParameters = List(TDate)),
+      BuiltinFunctionInfo(
+        EQUAL_PARTY,
+        BEqual,
+        maxVersion = Some(genMap),
+        implicitParameters = List(TParty)),
+      BuiltinFunctionInfo(
+        EQUAL_BOOL,
+        BEqual,
+        maxVersion = Some(genMap),
+        implicitParameters = List(TBool)),
       BuiltinFunctionInfo(
         EQUAL_TYPE_REP,
         BEqual,
         minVersion = typeRep,
+        maxVersion = Some(genMap),
         implicitParameters = List(TTypeRep)),
+      BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId, maxVersion = Some(genMap)),
       BuiltinFunctionInfo(TRACE, BTrace),
       BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId, minVersion = coerceContractId),
       BuiltinFunctionInfo(TEXT_TO_UPPER, BTextToUpper, minVersion = unstable),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -373,11 +373,14 @@ class DecodeV1Spec
 
     "translate Numeric builtins as is if version >= 1.7" in {
 
+      val v1_7 = LV.Minor.Stable("7")
+
       forEvery(postNumericMinVersions) { version =>
         val decoder = moduleDecoder(version)
 
         forEvery(numericBuiltinTestCases) { (proto, scala) =>
-          decoder.decodeExpr(toProtoExpr(proto), "test") shouldBe scala
+          if (proto != DamlLf1.BuiltinFunction.EQUAL_NUMERIC || version == v1_7)
+            decoder.decodeExpr(toProtoExpr(proto), "test") shouldBe scala
         }
       }
     }

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2711,6 +2711,8 @@ ContractId functions
   Returns ``'True'`` if the first contact id is equal to the second,
   ``'False'`` otherwise.
 
+  [*Available in versions < 1.dev*]
+
 * ``COERCE_CONTRACT_ID  : ∀ (α : ⋆) (β : ⋆) . 'ContractId' α → 'ContractId' β``
 
   Returns the given contract id unchanged at a different type.


### PR DESCRIPTION
Final step to fix #3766.

This PR decommission the following primitives when targeting LF 1.dev:

*   ``EQUAL_INT64``
*   ``EQUAL_DECIMA`` (already eliminated in LF 1.7)
*   ``EQUAL_TEXT``
*   ``EQUAL_TIMESTAMP``
*   ``EQUAL_DATE``
*   ``EQUAL_PARTY``
*   ``EQUAL_BOOL``
*   ``EQUAL_TYPE_REP``
*   ``EQUAL_NUMERIC``
*   ``EQUAL_CONTRACT_ID``

This means the only equality primitives we still allow are ``EQUAL_LIST`` and the new generic one ``EQUAL``

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
