### PR TITLE
restore 0.13.38 logging defaults for daml jars

### DIFF
--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -41,3 +41,5 @@ da_scala_binary(
     visibility = ["//visibility:public"],
     deps = [":script-runner-lib"],
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -187,3 +187,5 @@ da_scala_test_suite(
         ":extractor-scala-tests-lib",
     ] + testDependencies,
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -283,3 +283,5 @@ da_scala_test(
         "@maven//:io_reactivex_rxjava2_rxjava",
     ],
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -263,3 +263,5 @@ server_conformance_test(
         "--exclude=TimeIT",
     ],
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/navigator/backend/BUILD.bazel
+++ b/navigator/backend/BUILD.bazel
@@ -18,8 +18,8 @@ common_jvm_flags = [
     "-Xmx2G",
 ]
 
-# All frontend resource files.
-# These come in a manually created JAR file, this rule is just wrapping it in
+# All frontend resource files.
+# These come in a manually created JAR file, this rule is just wrapping it in
 # a java_import, so that it is a valid target for the 'resources' property of
 # scala_binary.
 java_import(
@@ -30,7 +30,7 @@ java_import(
     visibility = ["//visibility:public"],
 )
 
-# Version file, as a top level resources.
+# Version file, as a top level resources.
 java_library(
     name = "version-resource",
     resources = [
@@ -39,7 +39,7 @@ java_library(
     visibility = ["//visibility:public"],
 )
 
-# Static backend resources.
+# Static backend resources.
 java_library(
     name = "backend-resources",
     resources = glob(["src/main/resources/**/*"]),
@@ -148,7 +148,7 @@ da_scala_binary(
     ],
 )
 
-# Static test resources.
+# Static test resources.
 java_library(
     name = "test-resources",
     resources = glob(["src/test/resources/**/*"]),
@@ -168,3 +168,5 @@ da_scala_test_suite(
         ":version-resource",
     ] + testDependencies,
 )
+
+exports_files(["src/main/resources/logback.xml"])

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -37,15 +37,15 @@ commands:
 - name: sandbox
   path: daml-helper/daml-helper
   desc: "Launch the Sandbox"
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "sandbox"]
+  args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
 - name: navigator
   path: daml-helper/daml-helper
   desc: "Launch the Navigator"
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "navigator"]
+  args: ["run-jar", "--logback-config=daml-sdk/navigator-logback.xml", "daml-sdk/daml-sdk.jar", "navigator"]
 - name: extractor
   path: daml-helper/daml-helper
   desc: "Launch the Extractor"
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "extractor"]
+  args: ["run-jar", "--logback-config=daml-sdk/extractor-logback.xml", "daml-sdk/daml-sdk.jar", "extractor"]
 - name: ledger
   path: daml-helper/daml-helper
   desc: "Interact with a DAML ledger (experimental)"
@@ -64,12 +64,12 @@ commands:
 - name: codegen
   path: daml-helper/daml-helper
   desc: "Run the DAML codegen"
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "codegen"]
+  args: ["run-jar", "--logback-config=daml-sdk/codegen-logback.xml", "daml-sdk/daml-sdk.jar", "codegen"]
 - name: trigger
   path: daml-helper/daml-helper
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "trigger"]
+  args: ["run-jar", "--logback-config=daml-sdk/trigger-logback.xml", "daml-sdk/daml-sdk.jar", "trigger"]
   desc: "Run a DAML trigger (experimental)"
 - name: script
   path: daml-helper/daml-helper
-  args: ["run-jar", "daml-sdk/daml-sdk.jar", "script"]
+  args: ["run-jar", "--logback-config=daml-sdk/script-logback.xml", "daml-sdk/daml-sdk.jar", "script"]
   desc: "Run a DAML trigger (experimental)"

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -8,7 +8,13 @@ def sdk_tarball(name, version):
             ":sdk-config.yaml.tmpl",
             ":install.sh",
             ":install.bat",
+            "//ledger/sandbox:src/main/resources/logback.xml",
+            "//navigator/backend:src/main/resources/logback.xml",
+            "//extractor:src/main/resources/logback.xml",
             "//ledger-service/http-json:release/json-api-logback.xml",
+            "//language-support/java/codegen:src/main/resources/logback.xml",
+            "//triggers/runner:src/main/resources/logback.xml",
+            "//daml-script/runner:src/main/resources/logback.xml",
             "//:NOTICES",
             version,
             "//daml-assistant:daml-dist",
@@ -71,6 +77,12 @@ def sdk_tarball(name, version):
           mkdir -p $$OUT/daml-sdk
           cp $(location //daml-assistant/daml-sdk:sdk_deploy.jar) $$OUT/daml-sdk/daml-sdk.jar
           cp -L $(location //ledger-service/http-json:release/json-api-logback.xml) $$OUT/daml-sdk/
+          cp -L $(location //ledger/sandbox:src/main/resources/logback.xml) $$OUT/daml-sdk/sandbox-logback.xml
+          cp -L $(location //navigator/backend:src/main/resources/logback.xml) $$OUT/daml-sdk/navigator-logback.xml
+          cp -L $(location //extractor:src/main/resources/logback.xml) $$OUT/daml-sdk/extractor-logback.xml
+          cp -L $(location //language-support/java/codegen:src/main/resources/logback.xml) $$OUT/daml-sdk/codegen-logback.xml
+          cp -L $(location //triggers/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/trigger-logback.xml
+          cp -L $(location //daml-script/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/script-logback.xml
 
           tar zcf $@ --format=ustar $$OUT
         """.format(version = version),


### PR DESCRIPTION
CHANGELOG_BEGIN
- [Sandbox] Restore 0.13.38 logging behaviour.
- [Navigator] Restore 0.13.38 logging behaviour.
- [Extractor] Restore 0.13.38 logging behaviour.
- [Internals] As of 0.13.39, we merged a number of internal JAR files in
  the SDK tarball to reduce its size. These jars used to be standalone
  JARs you could invoke as e.g. ``java -jar sandbox.jar <args>``. As a
  result of merging the jars, they lost their individual ``logback.xml``
  configuration file. Although running the jars directly was (and is
  still) not supported, note that you can now achieve the same behaviour
  with e.g. ``java -Dlogback.configurationFile=sandbox-logback.xml -jar
  daml-sdk.jar sandbox <args>``.
CHANGELOG_END

This is meant to fix #3784. The solution I came up with ended up being a lot more Bazel-y and a lot less Java-y than I originally thought.

> *Edit* Removed Triggers and Script lines from changelog as they had actually not changed (i.e. their logback.xml is the same as the one in the jar, which is daml-assistant/daml-sdk/src/main/resources/logback.xml).