### PR TITLE
sandbox/reference-v2: Split `Config` into three.

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.platform.apiserver
+package com.daml.ledger.api.server.damlonx.reference.v2
 
 import java.io.File
 
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref.LedgerString
 import com.digitalasset.ledger.api.tls.TlsConfiguration
-import com.digitalasset.platform.apiserver.Config._
+import com.digitalasset.platform.indexer.IndexerStartupMode
 
 final case class Config(
     port: Int,
@@ -21,30 +21,23 @@ final case class Config(
     tlsConfig: Option[TlsConfiguration],
     participantId: ParticipantId,
     extraParticipants: Vector[(ParticipantId, Int, String)],
-    startupMode: StartupMode,
+    startupMode: IndexerStartupMode,
 )
 
 object Config {
-  sealed trait StartupMode
-
-  object StartupMode {
-    case object ValidateAndStart extends StartupMode
-    case object MigrateAndStart extends StartupMode
-    case object MigrateOnly extends StartupMode
-  }
-
   val DefaultMaxInboundMessageSize = 4194304
+
   def default: Config =
     new Config(
-      0,
-      None,
-      List.empty,
-      DefaultMaxInboundMessageSize,
-      TimeProvider.UTC,
-      "",
-      None,
-      LedgerString.assertFromString("standalone-participant"),
-      Vector.empty,
-      StartupMode.MigrateAndStart
+      port = 0,
+      portFile = None,
+      archiveFiles = List.empty,
+      maxInboundMessageSize = DefaultMaxInboundMessageSize,
+      timeProvider = TimeProvider.UTC,
+      jdbcUrl = "",
+      tlsConfig = None,
+      participantId = LedgerString.assertFromString("standalone-participant"),
+      extraParticipants = Vector.empty,
+      startupMode = IndexerStartupMode.MigrateAndStart,
     )
 }

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
@@ -22,7 +22,10 @@ final case class Config(
     participantId: ParticipantId,
     extraParticipants: Vector[(ParticipantId, Int, String)],
     startupMode: IndexerStartupMode,
-)
+) {
+  def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config =
+    copy(tlsConfig = Some(modify(tlsConfig.getOrElse(TlsConfiguration.Empty))))
+}
 
 object Config {
   val DefaultMaxInboundMessageSize = 4194304

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -29,9 +29,9 @@ object ReferenceServer extends App {
     Cli
       .parse(
         args,
-        "damlonx-reference-server",
-        "A fully compliant DAML Ledger API server backed by an in-memory store.",
-        allowExtraParticipants = true)
+        binaryName = "damlonx-reference-server",
+        description = "A fully compliant DAML Ledger API server backed by an in-memory store.",
+      )
       .getOrElse(sys.exit(1))
 
   implicit val system: ActorSystem = ActorSystem("indexed-kvutils")

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -13,9 +13,9 @@ import com.daml.ledger.participant.state.kvutils.InMemoryKVParticipantState
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.auth.AuthServiceWildcard
-import com.digitalasset.platform.apiserver.{Config, StandaloneApiServer}
+import com.digitalasset.platform.apiserver.{ApiServerConfig, StandaloneApiServer}
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
-import com.digitalasset.platform.indexer.StandaloneIndexerServer
+import com.digitalasset.platform.indexer.{IndexerConfig, StandaloneIndexerServer}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -79,14 +79,23 @@ object ReferenceServer extends App {
   def newIndexer(config: Config) =
     StandaloneIndexerServer(
       readService,
-      config,
+      IndexerConfig(config.participantId, config.jdbcUrl, config.startupMode),
       NamedLoggerFactory.forParticipant(config.participantId),
       SharedMetricRegistries.getOrCreate(s"indexer-${config.participantId}"),
     )
 
   def newApiServer(config: Config) =
     new StandaloneApiServer(
-      config,
+      ApiServerConfig(
+        config.participantId,
+        config.archiveFiles,
+        config.port,
+        config.jdbcUrl,
+        config.tlsConfig,
+        config.timeProvider,
+        config.maxInboundMessageSize,
+        config.portFile,
+      ),
       readService,
       writeService,
       authService,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
@@ -4,9 +4,9 @@ package com.daml.ledger.api.server.damlonx.reference.v2.cli
 
 import java.io.File
 
+import com.daml.ledger.api.server.damlonx.reference.v2.Config
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.ledger.api.tls.TlsConfiguration
-import com.digitalasset.platform.apiserver.Config
 import scopt.Read
 
 object Cli {

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
@@ -6,7 +6,6 @@ import java.io.File
 
 import com.daml.ledger.api.server.damlonx.reference.v2.Config
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.ledger.api.tls.TlsConfiguration
 import scopt.Read
 
 object Cli {
@@ -23,28 +22,7 @@ object Cli {
       case a => throw new RuntimeException(s"Expected a comma-separated triple, got '$a'")
     }
 
-  private val pemConfig = (path: String, config: Config) =>
-    config.copy(
-      tlsConfig = config.tlsConfig.fold(
-        Some(TlsConfiguration(enabled = true, None, Some(new File(path)), None)))(c =>
-        Some(c.copy(keyFile = Some(new File(path))))))
-
-  private val crtConfig = (path: String, config: Config) =>
-    config.copy(
-      tlsConfig = config.tlsConfig.fold(
-        Some(TlsConfiguration(enabled = true, Some(new File(path)), None, None)))(c =>
-        Some(c.copy(keyCertChainFile = Some(new File(path))))))
-
-  private val cacrtConfig = (path: String, config: Config) =>
-    config.copy(
-      tlsConfig = config.tlsConfig.fold(
-        Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>
-        Some(c.copy(trustCertCollectionFile = Some(new File(path))))))
-
-  private def cmdArgParser(
-      binaryName: String,
-      description: String,
-      allowExtraParticipants: Boolean) =
+  private def cmdArgParser(binaryName: String, description: String) =
     new scopt.OptionParser[Config](binaryName) {
       head(description)
       opt[Int]("port")
@@ -58,15 +36,17 @@ object Cli {
       opt[String]("pem")
         .optional()
         .text("TLS: The pem file to be used as the private key.")
-        .action(pemConfig)
+        .action((path, config) => config.withTlsConfig(c => c.copy(keyFile = Some(new File(path)))))
       opt[String]("crt")
         .optional()
         .text("TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set.")
-        .action(crtConfig)
+        .action((path, config) =>
+          config.withTlsConfig(c => c.copy(keyCertChainFile = Some(new File(path)))))
       opt[String]("cacrt")
         .optional()
         .text("TLS: The crt file to be used as the the trusted root CA.")
-        .action(cacrtConfig)
+        .action((path, config) =>
+          config.withTlsConfig(c => c.copy(trustCertCollectionFile = Some(new File(path)))))
       opt[Int]("maxInboundMessageSize")
         .action((x, c) => c.copy(maxInboundMessageSize = x))
         .text(
@@ -78,13 +58,11 @@ object Cli {
         .optional()
         .text("The participant id given to all components of a ledger api server")
         .action((p, c) => c.copy(participantId = p))
-      if (allowExtraParticipants) {
-        opt[(Ref.LedgerString, Int, String)]('P', "extra-participant")
-          .optional()
-          .unbounded()
-          .text("A list of triples in the form `<participant-id>,<port>,<index-jdbc-url>` to spin up multiple nodes backed by the same in-memory ledger")
-          .action((e, c) => c.copy(extraParticipants = c.extraParticipants :+ e))
-      }
+      opt[(Ref.LedgerString, Int, String)]('P', "extra-participant")
+        .optional()
+        .unbounded()
+        .text("A list of triples in the form `<participant-id>,<port>,<index-jdbc-url>` to spin up multiple nodes backed by the same in-memory ledger")
+        .action((e, c) => c.copy(extraParticipants = c.extraParticipants :+ e))
       arg[File]("<archive>...")
         .optional()
         .unbounded()
@@ -92,10 +70,6 @@ object Cli {
         .text("DAR files to load. Scenarios are ignored. The servers starts with an empty ledger by default.")
     }
 
-  def parse(
-      args: Array[String],
-      binaryName: String,
-      description: String,
-      allowExtraParticipants: Boolean = false): Option[Config] =
-    cmdArgParser(binaryName, description, allowExtraParticipants).parse(args, Config.default)
+  def parse(args: Array[String], binaryName: String, description: String): Option[Config] =
+    cmdArgParser(binaryName, description).parse(args, Config.default)
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -12,7 +12,8 @@ final case class TlsConfiguration(
     enabled: Boolean,
     keyCertChainFile: Option[File], // mutual auth is disabled if null
     keyFile: Option[File],
-    trustCertCollectionFile: Option[File]) { // System default if null
+    trustCertCollectionFile: Option[File] // System default if null
+) {
 
   def keyFileOrFail: File =
     keyFile.getOrElse(throw new IllegalStateException(
@@ -49,4 +50,13 @@ final case class TlsConfiguration(
           .build
       )
     else None
+}
+
+object TlsConfiguration {
+  val Empty = TlsConfiguration(
+    enabled = true,
+    keyCertChainFile = None,
+    keyFile = None,
+    trustCertCollectionFile = None,
+  )
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.apiserver
+
+import java.io.File
+
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.ledger.api.tls.TlsConfiguration
+
+case class ApiServerConfig(
+    participantId: ParticipantId,
+    archiveFiles: List[File],
+    port: Int,
+    jdbcUrl: String,
+    tlsConfig: Option[TlsConfiguration],
+    timeProvider: TimeProvider, // enables use of non-wall-clock time in tests
+    maxInboundMessageSize: Int,
+    portFile: Option[File],
+)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -32,7 +32,7 @@ import scala.util.control.NonFatal
 // Main entry point to start an index server that also hosts the ledger API.
 // See v2.ReferenceServer on how it is used.
 final class StandaloneApiServer(
-    config: Config,
+    config: ApiServerConfig,
     readService: ReadService,
     writeService: WriteService,
     authService: AuthService,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerConfig.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.indexer
+
+import com.daml.ledger.participant.state.v1.ParticipantId
+
+case class IndexerConfig(
+    participantId: ParticipantId,
+    jdbcUrl: String,
+    startupMode: IndexerStartupMode,
+)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerStartupMode.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerStartupMode.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.indexer
+
+sealed trait IndexerStartupMode
+
+object IndexerStartupMode {
+  case object ValidateAndStart extends IndexerStartupMode
+
+  case object MigrateAndStart extends IndexerStartupMode
+
+  case object MigrateOnly extends IndexerStartupMode
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -6,8 +6,6 @@ package com.digitalasset.platform.indexer
 import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.ReadService
-import com.digitalasset.platform.apiserver.Config
-import com.digitalasset.platform.apiserver.Config.StartupMode
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import com.digitalasset.platform.common.util.DirectExecutionContext.implicitEC
 
@@ -22,7 +20,7 @@ object StandaloneIndexerServer {
 
   def apply(
       readService: ReadService,
-      config: Config,
+      config: IndexerConfig,
       loggerFactory: NamedLoggerFactory,
       metrics: MetricRegistry,
   ): Future[AutoCloseable] = {
@@ -54,11 +52,11 @@ object StandaloneIndexerServer {
 
     try {
       config.startupMode match {
-        case StartupMode.MigrateOnly =>
+        case IndexerStartupMode.MigrateOnly =>
           promise.success(())
-        case StartupMode.MigrateAndStart =>
+        case IndexerStartupMode.MigrateAndStart =>
           startIndexer(indexerFactory.migrateSchema(config.jdbcUrl))
-        case StartupMode.ValidateAndStart =>
+        case IndexerStartupMode.ValidateAndStart =>
           startIndexer(indexerFactory.validateSchema(config.jdbcUrl))
       }
     } catch {


### PR DESCRIPTION
This split's the `Config` class in the Sandbox into three, more appropriate classes:

- Reference v2 CLI configuration (which is basically the same as the original)
- Standalone API server configuration
- Standalone indexer configuration

It's now the job of the Reference v2 server to deconstruct its config into the various parts for the API server and indexer.

This pull request also simplifies the CLI argument-parsing code in the Reference v2 server somewhat.

Furthers #2733. Once this is in it'll be easier to add a port to the indexer for health checks.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
