### PR TITLE
Remove type variable workaround.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -195,12 +195,10 @@ envLookupAlias x = MS.lookup x . envAliases
 
 -- | Bind a type var without shadowing its LF name.
 envBindTypeVar :: Var -> Env -> (TypeVarName, Env)
-envBindTypeVar x env = try 1 (TypeVarName (prefix <> suffix))
+envBindTypeVar x env = try 1 (TypeVarName prefix)
     where
         prefix = getOccText x
-        suffix = "_" <> T.pack (show (varUnique x))
-            -- NOTE: Workaround for #3777. Remove suffix once issue fixed.
-        nameFor i = TypeVarName (prefix <> T.pack (show i) <> suffix)
+        nameFor i = TypeVarName (prefix <> T.pack (show i))
 
         try :: Int -> TypeVarName -> (TypeVarName, Env)
         try !i name =


### PR DESCRIPTION
Remove the workaround introduced in #3790, now that the issues with fresh variables & substitutiton are fixed.