### PR TITLE
Check lookup by key nodes

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
@@ -47,11 +47,7 @@ trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
 
   /** Callback to query a contract by key, used for validating NodeLookupByKey nodes.
     * */
-  def lookupContractByKey(key: GlobalKey, forParty: Party): Option[AbsoluteContractId]
-
-  /** Callback to check whether a contract key exists, used for transaction validation.
-    * */
-  def keyExists(key: GlobalKey): Boolean
+  def lookupContractByKey(key: GlobalKey): Option[AbsoluteContractId]
 
   /** Called when a new contract is created */
   def addContract(c: ActiveContract, keyO: Option[GlobalKey]): Self

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerState.scala
@@ -45,7 +45,12 @@ trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
     * */
   def lookupContractLet(cid: AbsoluteContractId): Option[LetLookup]
 
-  /** Callback to query a contract key, used for transaction validation */
+  /** Callback to query a contract by key, used for validating NodeLookupByKey nodes.
+    * */
+  def lookupContractByKey(key: GlobalKey, forParty: Party): Option[AbsoluteContractId]
+
+  /** Callback to check whether a contract key exists, used for transaction validation.
+    * */
   def keyExists(key: GlobalKey): Boolean
 
   /** Called when a new contract is created */

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -26,13 +26,18 @@ case class InMemoryActiveLedgerState(
     parties: Map[Party, PartyDetails])
     extends ActiveLedgerState[InMemoryActiveLedgerState] {
 
-  def isVisibleFor(contractId: AbsoluteContractId, forParty: Party): Boolean =
+  def isVisibleForDivulgees(contractId: AbsoluteContractId, forParty: Party): Boolean =
     activeContracts
       .get(contractId)
       .exists(ac => ac.witnesses.contains(forParty) || ac.divulgences.contains(forParty))
 
+  def isVisibleForStakeholders(contractId: AbsoluteContractId, forParty: Party): Boolean =
+    activeContracts
+      .get(contractId)
+      .exists(ac => ac.signatories.contains(forParty) || ac.observers.contains(forParty))
+
   def lookupContractByKeyFor(key: GlobalKey, forParty: Party): Option[AbsoluteContractId] =
-    keys.get(key).filter(isVisibleFor(_, forParty))
+    keys.get(key).filter(isVisibleForStakeholders(_, forParty))
 
   override def lookupContractByKey(key: GlobalKey): Option[AbsoluteContractId] =
     keys.get(key)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -31,10 +31,11 @@ case class InMemoryActiveLedgerState(
       .get(contractId)
       .exists(ac => ac.witnesses.contains(forParty) || ac.divulgences.contains(forParty))
 
-  override def lookupContractByKey(key: GlobalKey, forParty: Party): Option[AbsoluteContractId] =
+  def lookupContractByKeyFor(key: GlobalKey, forParty: Party): Option[AbsoluteContractId] =
     keys.get(key).filter(isVisibleFor(_, forParty))
 
-  override def keyExists(key: GlobalKey): Boolean = keys.contains(key)
+  override def lookupContractByKey(key: GlobalKey): Option[AbsoluteContractId] =
+    keys.get(key)
 
   def lookupContract(cid: AbsoluteContractId): Option[Contract] =
     activeContracts.get(cid).orElse[Contract](divulgedContracts.get(cid))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ErrorCause.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ErrorCause.scala
@@ -27,6 +27,8 @@ object ErrorCause {
             s"Dependency contract ${cid.coid} has higher time ($time) than current let ($let)"
           case SequencingError.DuplicateKey(gk) =>
             s"Duplicate contract key ${gk.key} for template ${gk.templateId}"
+          case SequencingError.InvalidLookup(gk, cid, currentCid) =>
+            s"Lookup by key ${gk.key} uses contract $cid instead of the current $currentCid"
         }
         .mkString("Sequencing errors: [", ", ", "]")
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -254,6 +254,7 @@ object ScenarioLoader {
           time.toInstant,
           transactionId,
           workflowId,
+          Some(richTransaction.committer),
           tx,
           mappedExplicitDisclosure,
           mappedLocalImplicitDisclosure,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SequencingError.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/SequencingError.scala
@@ -47,4 +47,12 @@ object SequencingError {
   final case class DuplicateKey(gk: GlobalKey) extends SequencingError {
     override def isFinal: Boolean = true
   }
+
+  final case class InvalidLookup(
+      gk: GlobalKey,
+      cid: Option[AbsoluteContractId],
+      currentCid: Option[AbsoluteContractId]
+  ) extends SequencingError {
+    override def isFinal: Boolean = true
+  }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -105,12 +105,12 @@ class InMemoryLedger(
       contractId: AbsoluteContractId,
       forParty: Party): Future[Option[ActiveLedgerState.Contract]] =
     Future.successful(this.synchronized {
-      acs.activeContracts.get(contractId).filter(ac => acs.isVisibleFor(ac.id, forParty))
+      acs.activeContracts.get(contractId).filter(ac => acs.isVisibleForDivulgees(ac.id, forParty))
     })
 
   override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =
     Future.successful(this.synchronized {
-      acs.keys.get(key).filter(acs.isVisibleFor(_, forParty))
+      acs.keys.get(key).filter(acs.isVisibleForStakeholders(_, forParty))
     })
 
   override def publishHeartbeat(time: Instant): Future[Unit] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -105,17 +105,12 @@ class InMemoryLedger(
       contractId: AbsoluteContractId,
       forParty: Party): Future[Option[ActiveLedgerState.Contract]] =
     Future.successful(this.synchronized {
-      acs.activeContracts.get(contractId).filter(ac => isVisibleFor(ac.id, forParty))
+      acs.activeContracts.get(contractId).filter(ac => acs.isVisibleFor(ac.id, forParty))
     })
-
-  private def isVisibleFor(contractId: AbsoluteContractId, forParty: Party): Boolean =
-    acs.activeContracts
-      .get(contractId)
-      .exists(ac => ac.witnesses.contains(forParty) || ac.divulgences.contains(forParty))
 
   override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =
     Future.successful(this.synchronized {
-      acs.keys.get(key).filter(isVisibleFor(_, forParty))
+      acs.keys.get(key).filter(acs.isVisibleFor(_, forParty))
     })
 
   override def publishHeartbeat(time: Instant): Future[Unit] =
@@ -184,6 +179,7 @@ class InMemoryLedger(
         transactionMeta.ledgerEffectiveTime.toInstant,
         trId,
         transactionMeta.workflowId,
+        Some(submitterInfo.submitter),
         mappedTx,
         mappedDisclosure,
         mappedLocalDivulgence,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/JdbcLedgerDao.scala
@@ -795,13 +795,8 @@ private class JdbcLedgerDao(
         disclosure) =>
       final class AcsStoreAcc extends ActiveLedgerState[AcsStoreAcc] {
 
-        override def lookupContractByKey(
-            key: GlobalKey,
-            forParty: Party): Option[AbsoluteContractId] =
-          lookupKeySync(key, forParty)
-
-        override def keyExists(key: GlobalKey): Boolean =
-          selectContractKey(key).isDefined
+        override def lookupContractByKey(key: GlobalKey): Option[AbsoluteContractId] =
+          selectContractKey(key)
 
         override def lookupContractLet(cid: AbsoluteContractId): Option[LetLookup] =
           lookupContractLetSync(cid)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/JdbcLedgerDao.scala
@@ -471,13 +471,13 @@ private class JdbcLedgerDao(
   private val SQL_SELECT_CONTRACT_KEY_FOR_PARTY =
     SQL(
       """select ck.contract_id from contract_keys ck
-        |left join contract_witnesses cowi on ck.contract_id = cowi.contract_id and cowi.witness = {party}
-        |left join contract_divulgences codi on ck.contract_id = codi.contract_id and codi.party = {party}
+        |left join contract_signatories cosi on ck.contract_id = cosi.contract_id and cosi.signatory = {party}
+        |left join contract_observers coob on ck.contract_id = coob.contract_id and coob.observer = {party}
         |where
         |  ck.package_id={package_id} and
         |  ck.name={name} and
         |  ck.value_hash={value_hash} and
-        |  (cowi.witness is not null or codi.party is not null)
+        |  (cosi.signatory is not null or coob.observer is not null)
         |""".stripMargin)
 
   private val SQL_REMOVE_CONTRACT_KEY =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -343,15 +343,8 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
 
       final class AcsStoreAcc extends ActiveLedgerState[AcsStoreAcc] {
 
-        override def lookupContractByKey(
-            key: GlobalKey,
-            forParty: Party): Option[AbsoluteContractId] =
-          // Note: this implementation does not respect privacy rules, but this is how it worked
-          // when this migration was written.
+        override def lookupContractByKey(key: GlobalKey): Option[AbsoluteContractId] =
           selectContractKey(key)
-
-        override def keyExists(key: GlobalKey): Boolean =
-          selectContractKey(key).isDefined
 
         override def lookupContractLet(cid: AbsoluteContractId) =
           lookupActiveContractLetSync(cid)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -343,10 +343,18 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
 
       final class AcsStoreAcc extends ActiveLedgerState[AcsStoreAcc] {
 
+        override def lookupContractByKey(
+            key: GlobalKey,
+            forParty: Party): Option[AbsoluteContractId] =
+          // Note: this implementation does not respect privacy rules, but this is how it worked
+          // when this migration was written.
+          selectContractKey(key)
+
+        override def keyExists(key: GlobalKey): Boolean =
+          selectContractKey(key).isDefined
+
         override def lookupContractLet(cid: AbsoluteContractId) =
           lookupActiveContractLetSync(cid)
-
-        override def keyExists(key: GlobalKey): Boolean = selectContractKey(key).isDefined
 
         override def addContract(c: ActiveLedgerState.ActiveContract, keyO: Option[GlobalKey]) = {
           storeContract(offset, c)
@@ -400,6 +408,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
         ledgerEffectiveTime,
         transactionId,
         workflowId,
+        tx.submittingParty,
         transaction,
         mappedDisclosure,
         localDivulgence,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -50,12 +50,6 @@ import com.digitalasset.platform.sandbox.persistence.PostgresAroundAll
 import com.digitalasset.platform.sandbox.stores.ActiveLedgerState.ActiveContract
 import com.digitalasset.platform.sandbox.stores.ledger.sql.dao._
 import com.digitalasset.platform.sandbox.stores.ledger.sql.migration.FlywayMigrations
-import com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation.{
-  ContractSerializer,
-  KeyHasher,
-  TransactionSerializer,
-  ValueSerializer
-}
 import com.digitalasset.platform.sandbox.stores.ledger.sql.util.DbDispatcher
 import com.digitalasset.platform.sandbox.stores.ledger.{ConfigurationEntry, LedgerEntry}
 import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}


### PR DESCRIPTION
This PR does 3 things:
- It adds validation to `LookupByKey` transaction nodes, verifying that the lookup at command interpretation time returned the same result as the lookup at serialization time.
- It changes `lookupByKey` to only return contracts for which the submitter is a stakeholder. Previously, the submitter could also be a witness or divulgee.
- Changes tests to the new behavior.

Fixes #3543

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
