### PR TITLE
Sandbox / Reference v2: Close the Ledger API Server on failure.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.apiserver
 import java.io.IOException
 import java.net.{BindException, InetSocketAddress}
 import java.util.UUID
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
 
 import akka.stream.ActorMaterializer
 import com.codahale.metrics.MetricRegistry
@@ -14,6 +14,7 @@ import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSeque
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
 import io.grpc.ServerInterceptor
 import io.grpc.netty.NettyServerBuilder
+import io.netty.channel.EventLoopGroup
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.ssl.SslContext
@@ -24,16 +25,16 @@ import scala.util.control.NoStackTrace
 
 trait ApiServer extends AutoCloseable {
 
-  /** returns the api port the server is listening on */
+  /** the API port the server is listening on */
   def port: Int
 
-  /** returns when all services have been closed during the shutdown */
+  /** completes when all services have been closed during the shutdown */
   def servicesClosed(): Future[Unit]
 
 }
 
 object LedgerApiServer {
-  def create(
+  def start(
       createApiServices: (ActorMaterializer, ExecutionSequencerFactory) => Future[ApiServices],
       desiredPort: Int,
       maxInboundMessageSize: Int,
@@ -41,7 +42,10 @@ object LedgerApiServer {
       loggerFactory: NamedLoggerFactory,
       sslContext: Option[SslContext] = None,
       interceptors: List[ServerInterceptor] = List.empty,
-      metrics: MetricRegistry)(implicit mat: ActorMaterializer): Future[ApiServer] = {
+      metrics: MetricRegistry,
+  )(implicit mat: ActorMaterializer): Future[ApiServer] = {
+
+    val logger = loggerFactory.getLogger(this.getClass)
 
     val serverEsf = new AkkaExecutionSequencerPool(
       // NOTE(JM): Pick a unique pool name as we want to allow multiple ledger api server
@@ -53,47 +57,88 @@ object LedgerApiServer {
       actorCount = Runtime.getRuntime.availableProcessors() * 8
     )(mat.system)
 
+    val workerEventLoopGroup = createEventLoopGroup(
+      mat.system.name + "-nio-worker",
+      parallelism = Runtime.getRuntime.availableProcessors)
+    val bossEventLoopGroup = createEventLoopGroup(mat.system.name + "-nio-boss", parallelism = 1)
+
     createApiServices(mat, serverEsf).map { apiServices =>
+      val builder = address.fold(NettyServerBuilder.forPort(desiredPort))(address =>
+        NettyServerBuilder.forAddress(new InetSocketAddress(address, desiredPort)))
+      sslContext
+        .fold {
+          logger.info("Starting plainText server")
+        } { sslContext =>
+          logger.info("Starting TLS server")
+          val _ = builder.sslContext(sslContext)
+        }
+      builder.directExecutor()
+      builder.channelType(classOf[NioServerSocketChannel])
+      builder.bossEventLoopGroup(bossEventLoopGroup)
+      builder.workerEventLoopGroup(workerEventLoopGroup)
+      builder.permitKeepAliveTime(10, SECONDS)
+      builder.permitKeepAliveWithoutCalls(true)
+      builder.maxInboundMessageSize(maxInboundMessageSize)
+      interceptors.foreach(builder.intercept)
+      builder.intercept(new MetricsInterceptor(metrics))
+      apiServices.services.foreach(builder.addService)
+      val grpcServer = builder.build()
+
+      try {
+        grpcServer.start()
+      } catch {
+        case io: IOException if io.getCause != null && io.getCause.isInstanceOf[BindException] =>
+          throw new UnableToBind(desiredPort, io.getCause)
+      }
+
+      val host = address.getOrElse("localhost")
+      val actualPort = grpcServer.getPort
+      logger.info(s"listening on $host:$actualPort")
+
       new ApiServer {
-        private val impl = new LedgerApiServer(
-          apiServices,
-          desiredPort,
-          maxInboundMessageSize,
-          address,
-          loggerFactory,
-          sslContext,
-          interceptors,
-          metrics
-        )
+        private val servicesClosedP = Promise[Unit]()
 
-        /** returns the api port the server is listening on */
-        override def port: Int = impl.port
+        override def port: Int = actualPort
 
-        /** returns when all services have been closed during the shutdown */
-        override def servicesClosed(): Future[Unit] = impl.servicesClosed()
+        override def servicesClosed(): Future[Unit] = servicesClosedP.future
 
         override def close(): Unit = {
-          impl.close()
+          apiServices.close()
+          servicesClosedP.success(())
+
+          grpcServer.shutdown()
+
+          if (!grpcServer.awaitTermination(10, SECONDS)) {
+            logger.warn(
+              "Server did not terminate gracefully in one second. " +
+                "Clients probably did not disconnect. " +
+                "Proceeding with forced termination.")
+            val _ = grpcServer.shutdownNow()
+          }
+
+          // `shutdownGracefully` has a "quiet period" which specifies a time window in which
+          // _no requests_ must be witnessed before shutdown is _initiated_. Here we want to
+          // start immediately, so no quiet period -- by default it's 2 seconds.
+          // Moreover, there's also a "timeout" parameter
+          // which caps the time to wait for the quiet period to be fullfilled. Since we have
+          // no quiet period, this can also be 0.
+          // See <https://netty.io/4.1/api/io/netty/util/concurrent/EventExecutorGroup.html#shutdownGracefully-long-long-java.util.concurrent.TimeUnit->.
+          // The 10 seconds to wait is sort of arbitrary, it's long enough to be noticeable though.
+          Seq(
+            workerEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS),
+            bossEventLoopGroup.shutdownGracefully(0, 0, MILLISECONDS),
+          ).foreach(_.await(10, SECONDS))
+
           serverEsf.close()
         }
       }
     }(mat.executionContext)
   }
 
-}
-
-private class LedgerApiServer(
-    apiServices: ApiServices,
-    desiredPort: Int,
-    maxInboundMessageSize: Int,
-    address: Option[String],
-    loggerFactory: NamedLoggerFactory,
-    sslContext: Option[SslContext] = None,
-    interceptors: List[ServerInterceptor] = List.empty,
-    metrics: MetricRegistry)(implicit mat: ActorMaterializer)
-    extends ApiServer {
-
-  private val logger = loggerFactory.getLogger(this.getClass)
+  private def createEventLoopGroup(threadPoolName: String, parallelism: Int): EventLoopGroup =
+    new NioEventLoopGroup(
+      parallelism,
+      new DefaultThreadFactory(s"$threadPoolName-grpc-eventloop-${UUID.randomUUID()}", true))
 
   class UnableToBind(port: Int, cause: Throwable)
       extends RuntimeException(
@@ -101,87 +146,4 @@ private class LedgerApiServer(
           "User should terminate the process occupying the port, or choose a different one.",
         cause)
       with NoStackTrace
-
-  private val workerEventLoopGroup = createEventLoopGroup(mat.system.name + "-nio-worker")
-
-  private val bossEventLoopGroup = createEventLoopGroup(mat.system.name + "-nio-boss", 1)
-
-  private val (grpcServer, actualPort) = startServer()
-
-  override def port: Int = actualPort
-
-  private def startServer() = {
-    val builder = address.fold(NettyServerBuilder.forPort(desiredPort))(address =>
-      NettyServerBuilder.forAddress(new InetSocketAddress(address, desiredPort)))
-
-    sslContext
-      .fold {
-        logger.info("Starting plainText server")
-      } { sslContext =>
-        logger.info("Starting TLS server")
-        val _ = builder.sslContext(sslContext)
-      }
-
-    builder.directExecutor()
-    builder.channelType(classOf[NioServerSocketChannel])
-    builder.bossEventLoopGroup(bossEventLoopGroup)
-    builder.workerEventLoopGroup(workerEventLoopGroup)
-    builder.permitKeepAliveTime(10, TimeUnit.SECONDS)
-    builder.permitKeepAliveWithoutCalls(true)
-    builder.maxInboundMessageSize(maxInboundMessageSize)
-    interceptors.foreach(builder.intercept)
-    builder.intercept(new MetricsInterceptor(metrics))
-    val grpcServer = apiServices.services.foldLeft(builder)(_ addService _).build
-    try {
-      grpcServer.start()
-      logger.info(s"listening on ${address.getOrElse("localhost")}:${grpcServer.getPort}")
-      (grpcServer, grpcServer.getPort)
-    } catch {
-      case io: IOException if io.getCause != null && io.getCause.isInstanceOf[BindException] =>
-        throw new UnableToBind(desiredPort, io.getCause)
-    }
-  }
-
-  private def createEventLoopGroup(
-      threadPoolName: String,
-      parallelism: Int = Runtime.getRuntime.availableProcessors): NioEventLoopGroup = {
-    val threadFactory =
-      new DefaultThreadFactory(s"$threadPoolName-grpc-eventloop-${UUID.randomUUID}", true)
-    new NioEventLoopGroup(parallelism, threadFactory)
-  }
-
-  private val servicesClosedP = Promise[Unit]()
-
-  /** returns when all services have been closed during the shutdown */
-  override def servicesClosed(): Future[Unit] = servicesClosedP.future
-
-  override def close(): Unit = {
-    apiServices.close()
-    servicesClosedP.success(())
-    grpcServer.shutdown()
-
-    if (!grpcServer.awaitTermination(10L, TimeUnit.SECONDS)) {
-      logger.warn(
-        "Server did not terminate gracefully in one second. " +
-          "Clients probably did not disconnect. " +
-          "Proceeding with forced termination.")
-      grpcServer.shutdownNow()
-    }
-    // `shutdownGracefully` has a "quiet period" which specifies a time window in which
-    // _no requests_ must be witnessed before shutdown is _initiated_. Here we want to
-    // start immediately, so no quiet period -- by default it's 2 seconds.
-    // Moreover, there's also a "timeout" parameter
-    // which caps the time to wait for the quiet period to be fullfilled. Since we have
-    // no quiet period, this can also be 0.
-    // See <https://netty.io/4.1/api/io/netty/util/concurrent/EventExecutorGroup.html#shutdownGracefully-long-long-java.util.concurrent.TimeUnit->.
-    // The 10 seconds to wait is sort of arbitrary, it's long enough to be noticeable though.
-    val workerEventLoopGroupShutdown =
-      workerEventLoopGroup.shutdownGracefully(0L, 0L, TimeUnit.MILLISECONDS)
-    val bossEventLoopGroupShutdown =
-      bossEventLoopGroup.shutdownGracefully(0L, 0L, TimeUnit.MILLISECONDS)
-
-    val workerShutdownComplete = workerEventLoopGroupShutdown.await(10L, TimeUnit.SECONDS)
-    val bossShutdownComplete = bossEventLoopGroupShutdown.await(10L, TimeUnit.SECONDS)
-  }
-
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -22,7 +22,7 @@ import io.netty.util.concurrent.DefaultThreadFactory
 
 import scala.collection.mutable
 import scala.concurrent.{Future, Promise}
-import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.control.NoStackTrace
 
 trait ApiServer extends AutoCloseable {
 
@@ -112,11 +112,9 @@ object LedgerApiServer {
         grpcServer.start()
       } catch {
         case io: IOException if io.getCause != null && io.getCause.isInstanceOf[BindException] =>
-          stop()
           throw new UnableToBind(desiredPort, io.getCause)
-        case NonFatal(e) =>
-          stop()
-          throw e
+      } finally {
+        stop()
       }
       closeables.push(() => {
         grpcServer.shutdown()
@@ -140,7 +138,7 @@ object LedgerApiServer {
       })
 
       new ApiServer {
-        override def port: Int = actualPort
+        override val port: Int = actualPort
 
         override def servicesClosed(): Future[Unit] = servicesClosedP.future
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -103,7 +103,7 @@ final class StandaloneApiServer(
         "read" -> readService,
         "write" -> writeService,
       )
-      apiServer <- LedgerApiServer.create(
+      apiServer <- LedgerApiServer.start(
         (am: ActorMaterializer, esf: ExecutionSequencerFactory) =>
           ApiServices
             .create(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -249,7 +249,7 @@ class SandboxServer(actorSystemName: String, config: => SandboxConfig) extends A
     )
 
     val apiServer = Await.result(
-      LedgerApiServer.create(
+      LedgerApiServer.start(
         (am: ActorMaterializer, esf: ExecutionSequencerFactory) =>
           ApiServices
             .create(


### PR DESCRIPTION
If the Ledger API Server fails to start (for example, because the port is taken), it should clean up its resources as well as logging the exception. This will prevent it from living in a half-open state, which could be problematic.

This PR doesn't actually fix the problem yet; just cleans up _some_ of the mess. In Reference v2, the indexer is started first, so even with this cleanup, that stays running, which can be problematic.

Came across this when looking to factor out the gRPC server so that the Indexer can push out its health checks independently for #2733. I'd rather not start sharing the broken logic.

I'm looking into a more general solution for this that will properly fix the problem, but for now, I'd like to get this part reviewed.

The first two commits are pure refactoring; the third changes behavior.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
