### PR TITLE
daml2ts: Tie the knot between templates and their choices without hacks

### DIFF
--- a/language-support/ts/codegen/src/Main.hs
+++ b/language-support/ts/codegen/src/Main.hs
@@ -157,7 +157,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                             map ("  " <>) (onHead ("decoder: " <>) serDesc) ++
                             concat
                             [ ["  " <> x <> ": {"
-                              ,"    template: undefined as unknown as daml.Template<" <> conName <> ">,"
+                              ,"    template: () => " <> conName <> ","
                               ,"    choiceName: '" <> x <> "',"
                               ,"    decoder: " <> t <> ".decoder,"
                               ,"  },"
@@ -165,13 +165,11 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                             | (x, t) <- chcs
                             ] ++
                             ["};"]
-                        knots =
-                            [conName <> "." <> x <> ".template = " <> conName <> ";" | (x, _) <- chcs]
                         registrations =
                             ["daml.registerTemplate(" <> conName <> ");"]
                         refs = Set.unions (fieldRefs ++ argRefs)
                     in
-                    ((makeType typeDesc, dict ++ knots ++ registrations), refs)
+                    ((makeType typeDesc, dict ++ registrations), refs)
       where
         paramNames = map (unTypeVarName . fst) (dataParams def)
         typeParams

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -45,7 +45,7 @@ export interface Template<T extends {}> extends Serializable<T> {
  * `Choice` type class in DAML.
  */
 export interface Choice<T, C> extends Serializable<C> {
-  template: Template<T>;
+  template: () => Template<T>;
   choiceName: string;
 }
 

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -158,7 +158,7 @@ class Ledger {
    */
   async exercise<T, C>(choice: Choice<T, C>, contractId: ContractId<T>, argument: C): Promise<Event[]> {
     const payload = {
-      templateId: choice.template.templateId,
+      templateId: choice.template().templateId,
       contractId,
       choice: choice.choiceName,
       argument,
@@ -172,7 +172,7 @@ class Ledger {
    * contract key as a query.
    */
   async pseudoExerciseByKey<T, C>(choice: Choice<T, C>, key: Query<T>, argument: C): Promise<Event[]> {
-    const contract = await this.pseudoFetchByKey(choice.template, key);
+    const contract = await this.pseudoFetchByKey(choice.template(), key);
     return this.exercise(choice, contract.contractId, argument);
   }
 


### PR DESCRIPTION
In the code generated by `daml2ts`, every template companion object lists
all its choices and every choice has a pointer back to the companion object
of its template. Thus, there's a knot to tie.

So far, we initialized the choices as `undefined` and later mutated them to
point to the template companion object. This feels kind of hacky,
particularly since we end up with cyclic values.

This PR pushes the pointer from the choice back to the template companion
object behind a lambda. This makes the hack unnecessary and removes the
cyclic values.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3839)
<!-- Reviewable:end -->
