### PR TITLE
daml2ts: Move types for create/archive events into daml-json-types

### DIFF
--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Choice, Contract, ContractId, Party, Template, Query, TemplateId, Serializable } from '@digitalasset/daml-json-types';
+import { Choice, Contract, ContractId, Event, Template, Query } from '@digitalasset/daml-json-types';
 import * as jtv from '@mojotech/json-type-validation';
 import fetch from 'cross-fetch';
 
@@ -13,47 +13,6 @@ type LedgerResponse = {
 type LedgerError = {
   status: number;
   errors: string[];
-}
-
-export type CreatedEvent = {
-  created: Contract<object>;
-}
-
-export type ArchivedEvent = {
-  archived: {
-    templateId: TemplateId;
-    contractId: ContractId<object>;
-    witnessParties: Party[];
-  };
-}
-
-export type Event = CreatedEvent | ArchivedEvent;
-
-// FIXME(MH): The cast below is a gross hack relying on the fact that
-// `Contract` will only use the `decoder` field of its argument. We should
-// instead provide something like a proper `AnyContract` in `daml-json-types`.
-const AnyTemplate: Template<object> = {
-  decoder: () => jtv.object({}),
-} as Template<object>;
-
-const CreatedEvent: Serializable<CreatedEvent> = {
-  decoder: () => jtv.object({
-    created: Contract(AnyTemplate).decoder(),
-  }),
-};
-
-const ArchivedEvent: Serializable<ArchivedEvent> = {
-  decoder: () => jtv.object({
-    archived: jtv.object({
-      templateId: TemplateId.decoder(),
-      contractId: ContractId(AnyTemplate).decoder(),
-      witnessParties: jtv.array(Party.decoder()),
-    }),
-  }),
-};
-
-const Event: Serializable<Event> = {
-  decoder: () => jtv.oneOf<Event>(CreatedEvent.decoder(), ArchivedEvent.decoder()),
 }
 
 /**
@@ -192,4 +151,3 @@ class Ledger {
 }
 
 export default Ledger;
-


### PR DESCRIPTION
Currently, they are in `daml-ledger-fetch`, which doesn't make sense since
they are not bound to ledger clients implemented using fetch.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3855)
<!-- Reviewable:end -->
