### PR TITLE
Move optWriteIface to `compile`-specific options

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -66,12 +66,8 @@ data Options = Options
     -- ^ The directory in which stable DALF packages are located.
   , optMbPackageName :: Maybe String
     -- ^ compile in the context of the given package name and create interface files
-  , optWriteInterface :: Bool
-    -- ^ whether to write interface files or not during `damlc compile`. This is _only_
-    -- relevant for `compile` which at the moment is only used for building daml-stdlib
-    -- and daml-prim.
   , optIfaceDir :: Maybe FilePath
-    -- ^ alternative directory to write interface files to. Default is <current working dir>.daml/interfaces.
+    -- ^ directory to write interface files to. If set to `Nothing` we default to <current working dir>.daml/interfaces.
   , optHideAllPkgs :: Bool
     -- ^ hide all imported packages
   , optPackageImports :: [PackageImport]
@@ -202,7 +198,6 @@ defaultOptions mbVersion =
         , optPackageDbs = []
         , optStablePackages = Nothing
         , optMbPackageName = Nothing
-        , optWriteInterface = False
         , optIfaceDir = Nothing
         , optHideAllPkgs = False
         , optPackageImports = []

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -181,8 +181,7 @@ generateAndInstallIfaceFiles dalf src opts workDir dbPath projectPackageDatabase
     opts' <-
         mkOptions $
         opts
-            { optWriteInterface = False
-            , optIfaceDir = Nothing
+            { optIfaceDir = Nothing
             -- We write ifaces below using writeIfacesAndHie so we don’t need to enable these options.
             , optPackageDbs = projectPackageDatabase : optPackageDbs opts
             , optIsGenerated = True
@@ -292,8 +291,7 @@ generateAndInstallInstancesPkg thisSdkVer templInstSrc opts dbPath projectPackag
             opts' <-
                 mkOptions $
                 opts
-                    { optWriteInterface = False
-                    , optIfaceDir = Nothing
+                    { optIfaceDir = Nothing
                     , optPackageDbs = projectPackageDatabaseAbs : optPackageDbs opts
                     , optIsGenerated = True
                     , optDflagCheck = False

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -251,7 +251,6 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> optPackageDir
     <*> pure Nothing
     <*> parsePkgName
-    <*> optWriteIface
     <*> pure Nothing
     <*> optHideAllPackages
     <*> many optPackageImport
@@ -283,12 +282,6 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     optPackageDir = many $ strOption $ metavar "LOC-OF-PACKAGE-DB"
                       <> help "use package database in the given location"
                       <> long "package-db"
-
-    optWriteIface :: Parser Bool
-    optWriteIface =
-        switch $
-          help "Whether to write interface files during type checking, required for building a package such as daml-prim" <>
-          long "write-iface"
 
     optPackageImport :: Parser PackageImport
     optPackageImport =


### PR DESCRIPTION
Originally, this made sense as a flag in Options since we read it
during typechecking to write out interfaces on the fly. But now, we
write this is only used in execCompile so having this be a global
option that is ignored anywhere but in `compile` is rather confusing.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
