### PR TITLE
Bump timeout in CommandClientIT

### DIFF
--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -164,7 +164,7 @@ final class CommandClientIT
       client: CommandClient,
       checkpoint: LedgerOffset,
       expected: Set[String],
-      timeLimit: Span = 3.seconds): Future[(Set[String], Set[String])] =
+      timeLimit: Span = 6.seconds): Future[(Set[String], Set[String])] =
     readExpectedElements(client.completionSource(submittingPartyList, checkpoint).collect {
       case CompletionStreamElement.CompletionElement(c) => c.commandId
     }, expected, timeLimit)


### PR DESCRIPTION
This test suite was introduced in #3870 and seems to be extremely
flaky both locally (I get about 16/20 failures) and on CI.

The error is

  - should return completions of commands that are submitted after subscription *** FAILED *** (4 seconds, 945 milliseconds)
    Set() did not contain all elements of List("5104", "5100", "5105", "5109", "5103", "5106", "5107", "5102", "5108", "5101") (CommandClientIT.scala:330)

After bumping the timeout, I don’t get any failures locally.

Happy to choose another timeout, I have no clue what a sensible value
is here.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
