### PR TITLE
clean up kv metric names

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -253,7 +253,7 @@ object KeyValueCommitting {
   private object Metrics {
     //TODO: Replace with metrics registry object passed in constructor
     private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-    private val prefix = "kvutils.committing"
+    private val prefix = "kvutils.committer"
 
     // Timer (and count) of how fast submissions have been processed.
     val runTimer: metrics.Timer = registry.timer(s"$prefix.run-timer")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -251,6 +251,7 @@ object KeyValueCommitting {
   }
 
   private object Metrics {
+    //TODO: Replace with metrics registry object passed in constructor
     private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
     private val prefix = "kvutils.committing"
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -256,7 +256,7 @@ object KeyValueCommitting {
     private val prefix = "kvutils.committer"
 
     // Timer (and count) of how fast submissions have been processed.
-    val runTimer: metrics.Timer = registry.timer(s"$prefix.run-timer")
+    val runTimer: metrics.Timer = registry.timer(s"$prefix.run_timer")
 
     // Number of exceptions seen.
     val exceptions: metrics.Counter = registry.counter(s"$prefix.exceptions")
@@ -265,13 +265,13 @@ object KeyValueCommitting {
     val processing: metrics.Counter = registry.counter(s"$prefix.processing")
 
     val lastRecordTimeGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.record-time", lastRecordTimeGauge)
+    registry.register(s"$prefix.last.record_time", lastRecordTimeGauge)
 
     val lastEntryIdGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.entry-id", lastEntryIdGauge)
+    registry.register(s"$prefix.last.entry_id", lastEntryIdGauge)
 
     val lastParticipantIdGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.participant-id", lastParticipantIdGauge)
+    registry.register(s"$prefix.last.participant_id", lastParticipantIdGauge)
 
     val lastExceptionGauge = new VarGauge[String]("<none>")
     registry.register(s"$prefix.last.exception", lastExceptionGauge)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -50,7 +50,7 @@ private[kvutils] trait Committer[Submission, PartialResult] {
   val metricsRegistry: metrics.MetricRegistry =
     metrics.SharedMetricRegistries.getOrCreate("kvutils")
   def metricsName(metric: String): String =
-    metrics.MetricRegistry.name("kvutils.committing", committerName, metric)
+    metrics.MetricRegistry.name("kvutils.committer", committerName, metric)
   private val runTimer: Timer = metricsRegistry.timer(metricsName("run-timer"))
   private lazy val stepTimers: Map[StepInfo, Timer] =
     steps.map {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -39,17 +39,18 @@ private[kvutils] trait Committer[Submission, PartialResult] {
   type StepInfo = String
   type Step = (CommitContext, PartialResult) => StepResult[PartialResult]
   def steps: Iterable[(StepInfo, Step)]
+  lazy val committerName: String = this.getClass.getSimpleName.toLowerCase
 
   /** The initial internal state passed to first step. */
   def init(ctx: CommitContext, subm: Submission): PartialResult
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  /** Metrics for this committer. */
+  //TODO: Replace with metrics registry object passed in constructor
   val metricsRegistry: metrics.MetricRegistry =
     metrics.SharedMetricRegistries.getOrCreate("kvutils")
   def metricsName(metric: String): String =
-    metrics.MetricRegistry.name(this.getClass.getSimpleName, metric)
+    metrics.MetricRegistry.name("kvutils.committing", committerName, metric)
   private val runTimer: Timer = metricsRegistry.timer(metricsName("run-timer"))
   private lazy val stepTimers: Map[StepInfo, Timer] =
     steps.map {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -51,11 +51,11 @@ private[kvutils] trait Committer[Submission, PartialResult] {
     metrics.SharedMetricRegistries.getOrCreate("kvutils")
   def metricsName(metric: String): String =
     metrics.MetricRegistry.name("kvutils.committer", committerName, metric)
-  private val runTimer: Timer = metricsRegistry.timer(metricsName("run-timer"))
+  private val runTimer: Timer = metricsRegistry.timer(metricsName("run_timer"))
   private lazy val stepTimers: Map[StepInfo, Timer] =
     steps.map {
       case (info, _) =>
-        info -> metricsRegistry.timer(metricsName(s"step-timers.${info}"))
+        info -> metricsRegistry.timer(metricsName(s"step_timers.${info}"))
     }.toMap
 
   /** A committer can `run` a submission and produce a log entry and output states. */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -20,8 +20,8 @@ private[kvutils] case class ConfigCommitter(
 
   private object Metrics {
     // kvutils.ConfigCommitter.*
-    val accepts = metricsRegistry.counter("accepts")
-    val rejections = metricsRegistry.counter("rejections")
+    val accepts = metricsRegistry.counter(metricsName("accepts"))
+    val rejections = metricsRegistry.counter(metricsName("rejections"))
   }
 
   private def rejectionTraceLog(msg: String, submission: DamlConfigurationSubmission): Unit =
@@ -203,5 +203,7 @@ private[kvutils] case class ConfigCommitter(
     "deduplicateSubmission" -> deduplicateSubmission,
     "buildLogEntry" -> buildLogEntry
   )
+
+  override lazy val committerName = "config"
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -197,11 +197,11 @@ private[kvutils] case class ConfigCommitter(
     )
 
   override val steps: Iterable[(StepInfo, Step)] = Iterable(
-    "checkTTL" -> checkTtl,
-    "authorizeSubmission" -> authorizeSubmission,
-    "validateSubmission" -> validateSubmission,
-    "deduplicateSubmission" -> deduplicateSubmission,
-    "buildLogEntry" -> buildLogEntry
+    "check_ttl" -> checkTtl,
+    "authorize_submission" -> authorizeSubmission,
+    "validate_submission" -> validateSubmission,
+    "deduplicate_submission" -> deduplicateSubmission,
+    "build_log_entry" -> buildLogEntry
   )
 
   override lazy val committerName = "config"

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -20,12 +20,12 @@ private[kvutils] case class PackageCommitter(engine: Engine)
     extends Committer[DamlPackageUploadEntry, DamlPackageUploadEntry.Builder] {
   private object Metrics {
     // kvutils.PackageCommitter.*
-    val preloadTimer: Timer = metricsRegistry.timer(metricsName("preload-timer"))
-    val decodeTimer: Timer = metricsRegistry.timer(metricsName("decode-timer"))
+    val preloadTimer: Timer = metricsRegistry.timer(metricsName("preload_timer"))
+    val decodeTimer: Timer = metricsRegistry.timer(metricsName("decode_timer"))
     val accepts: Counter = metricsRegistry.counter(metricsName("accepts"))
     val rejections: Counter = metricsRegistry.counter(metricsName("rejections"))
     metricsRegistry.gauge(
-      metricsName("loaded-packages"),
+      metricsName("loaded_packages"),
       () =>
         new Gauge[Int] {
           override def getValue: Int = engine.compiledPackages().packageIds.size
@@ -154,15 +154,15 @@ private[kvutils] case class PackageCommitter(engine: Engine)
     uploadEntry.toBuilder
 
   override val steps: Iterable[(StepInfo, Step)] = Iterable(
-    "authorizeSubmission" -> authorizeSubmission,
-    "validateEntry" -> validateEntry,
-    "deduplicateSubmission" -> deduplicateSubmission,
-    "filterDuplicates" -> filterDuplicates,
-    "enqueuePreload" -> enqueuePreload,
-    "buildLogEntry" -> buildLogEntry
+    "authorize_submission" -> authorizeSubmission,
+    "validate_entry" -> validateEntry,
+    "deduplicate_submission" -> deduplicateSubmission,
+    "filter_duplicates" -> filterDuplicates,
+    "enqueue_preload" -> enqueuePreload,
+    "build_log_entry" -> buildLogEntry
   )
 
-  override lazy val committerName = "packageUpload"
+  override lazy val committerName = "package_upload"
 
   private def buildRejectionLogEntry(
       ctx: CommitContext,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -162,6 +162,8 @@ private[kvutils] case class PackageCommitter(engine: Engine)
     "buildLogEntry" -> buildLogEntry
   )
 
+  override lazy val committerName = "packageUpload"
+
   private def buildRejectionLogEntry(
       ctx: CommitContext,
       packageUploadEntry: DamlPackageUploadEntry.Builder,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -161,4 +161,6 @@ private[kvutils] case object PartyAllocationCommitter
     "buildLogEntry" -> buildLogEntry
   )
 
+  override lazy val committerName = "partyAllocation"
+
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -154,13 +154,13 @@ private[kvutils] case object PartyAllocationCommitter
     partyAllocationEntry.toBuilder
 
   override val steps: Iterable[(StepInfo, Step)] = Iterable(
-    "authorizeSubmission" -> authorizeSubmission,
-    "validateParty" -> validateParty,
-    "deduplicateSubmission" -> deduplicateSubmission,
-    "deduplicateParty" -> deduplicateParty,
-    "buildLogEntry" -> buildLogEntry
+    "authorize_submission" -> authorizeSubmission,
+    "validate_party" -> validateParty,
+    "deduplicate_submission" -> deduplicateSubmission,
+    "deduplicate_party" -> deduplicateParty,
+    "build_log_entry" -> buildLogEntry
   )
 
-  override lazy val committerName = "partyAllocation"
+  override lazy val committerName = "party_allocation"
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -411,6 +411,7 @@ private[kvutils] case class ProcessTransactionSubmission(
 
 object ProcessTransactionSubmission {
   private[committing] object Metrics {
+    //TODO: Replace with metrics registry object passed in constructor
     private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
     private val prefix = "kvutils.committing.transaction"
     val runTimer: Timer = registry.timer(s"$prefix.run-timer")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -414,8 +414,8 @@ object ProcessTransactionSubmission {
     //TODO: Replace with metrics registry object passed in constructor
     private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
     private val prefix = "kvutils.committer.transaction"
-    val runTimer: Timer = registry.timer(s"$prefix.run-timer")
-    val interpretTimer: Timer = registry.timer(s"$prefix.interpret-timer")
+    val runTimer: Timer = registry.timer(s"$prefix.run_timer")
+    val interpretTimer: Timer = registry.timer(s"$prefix.interpret_timer")
     val accepts: Counter = registry.counter(s"$prefix.accepts")
     val rejections: Map[Int, Counter] =
       DamlTransactionRejectionEntry.ReasonCase.values

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -413,7 +413,7 @@ object ProcessTransactionSubmission {
   private[committing] object Metrics {
     //TODO: Replace with metrics registry object passed in constructor
     private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-    private val prefix = "kvutils.committing.transaction"
+    private val prefix = "kvutils.committer.transaction"
     val runTimer: Timer = registry.timer(s"$prefix.run-timer")
     val interpretTimer: Timer = registry.timer(s"$prefix.interpret-timer")
     val accepts: Counter = registry.counter(s"$prefix.accepts")

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -166,7 +166,7 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
         reg.counter("kvutils.committer.config.accepts").getCount should be >= 1L
         reg.counter("kvutils.committer.config.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.config.run-timer").getCount should be >= 1L
+        reg.timer("kvutils.committer.config.run_timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -164,9 +164,9 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committing.config.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committing.config.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committing.config.run-timer").getCount should be >= 1L
+        reg.counter("kvutils.committer.config.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.config.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committer.config.run-timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -90,9 +90,9 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committing.packageUpload.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committing.packageUpload.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committing.packageUpload.run-timer").getCount should be >= 1L
+        reg.counter("kvutils.committer.packageUpload.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.packageUpload.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committer.packageUpload.run-timer").getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -90,9 +90,9 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.packageUpload.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committer.packageUpload.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.packageUpload.run-timer").getCount should be >= 1L
+        reg.counter("kvutils.committer.package_upload.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.package_upload.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committer.package_upload.run_timer").getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -85,9 +85,9 @@ class KVUtilsPartySpec extends WordSpec with Matchers {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.partyAllocation.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committer.partyAllocation.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.partyAllocation.run-timer").getCount should be >= 1L
+        reg.counter("kvutils.committer.party_allocation.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.party_allocation.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committer.party_allocation.run_timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -85,9 +85,9 @@ class KVUtilsPartySpec extends WordSpec with Matchers {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committing.partyAllocation.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committing.partyAllocation.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committing.partyAllocation.run-timer").getCount should be >= 1L
+        reg.counter("kvutils.committer.partyAllocation.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.partyAllocation.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committer.partyAllocation.run-timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils
 
+import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlPartyAllocationRejectionEntry
@@ -73,6 +74,20 @@ class KVUtilsPartySpec extends WordSpec with Matchers {
         logEntry1.getPartyAllocationRejectionEntry.getReasonCase shouldEqual
           DamlPartyAllocationRejectionEntry.ReasonCase.DUPLICATE_SUBMISSION
 
+      }
+    }
+
+    "metrics get updated" in KVTest.runTestWithSimplePackage() {
+      for {
+        //Submit party twice to force one acceptance and one rejection on duplicate
+        _ <- submitPartyAllocation("submission-1", "alice", p0)
+        _ <- submitPartyAllocation("submission-1", "bob", p0)
+      } yield {
+        // Check that we're updating the metrics (assuming this test at least has been run)
+        val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
+        reg.counter("kvutils.committing.partyAllocation.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committing.partyAllocation.rejections").getCount should be >= 1L
+        reg.timer("kvutils.committing.partyAllocation.run-timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -167,11 +167,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committing.transaction.accepts").getCount should be >= 1L
+        reg.counter("kvutils.committer.transaction.accepts").getCount should be >= 1L
         reg
-          .counter(s"kvutils.committing.transaction.rejections_${disputed.name}")
+          .counter(s"kvutils.committer.transaction.rejections_${disputed.name}")
           .getCount should be >= 1L
-        reg.timer("kvutils.committing.transaction.run-timer").getCount should be >= 1L
+        reg.timer("kvutils.committer.transaction.run-timer").getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -171,7 +171,7 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         reg
           .counter(s"kvutils.committer.transaction.rejections_${disputed.name}")
           .getCount should be >= 1L
-        reg.timer("kvutils.committer.transaction.run-timer").getCount should be >= 1L
+        reg.timer("kvutils.committer.transaction.run_timer").getCount should be >= 1L
       }
     }
 


### PR DESCRIPTION
Make all the kvutils committer metrics to follow the pattern of:
kvutils.committing.\<committerName\>.*

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
