### PR TITLE
Sandbox: Test RecoveringIndexer logs, and stop dumping them to STDERR.

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
@@ -13,19 +13,15 @@ import org.slf4j.Logger
   * The name can be constructed in a nested, left-to-right append manner.
   */
 trait NamedLoggerFactory {
-  val name: String
+  protected val name: String
 
-  def append(subName: String): NamedLoggerFactory
+  def getLogger(cls: Class[_]): Logger =
+    getLogger(nameOfClass(cls))
 
-  def forParticipant(id: String): NamedLoggerFactory =
-    append(s"participant/$id")
-
-  def getLogger(klass: Class[_]): Logger = {
-    val fullName = Array(klass.getName, name)
+  protected def nameOfClass(cls: Class[_]): String =
+    Array(cls.getName, name)
       .filterNot(_.isEmpty)
       .mkString(":")
-    getLogger(fullName)
-  }
 
   protected def getLogger(fullName: String): Logger
 }
@@ -35,7 +31,7 @@ object NamedLoggerFactory {
 
   def apply(cls: Class[_]): NamedLoggerFactory = apply(cls.getSimpleName)
 
-  def forParticipant(name: String): NamedLoggerFactory = root.forParticipant(name)
+  def forParticipant(id: String): NamedLoggerFactory = NamedLoggerFactory(s"participant/$id")
 
   def root: NamedLoggerFactory = NamedLoggerFactory("")
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
@@ -6,28 +6,20 @@ package com.digitalasset.platform.common.logging
 import org.slf4j.Logger
 
 /**
-  * NamedLoggerFactory augments a regular class-based slf4j logger with one annotated with a "name" where the name provides
-  * human readable context identifying a class instance, e.g. which participant in a set of participants has logged
-  * a particular message.
+  * NamedLoggerFactory augments a regular class-based slf4j logger with one annotated with a "name"
+  * where the name provides human readable context identifying a class instance, e.g. which
+  * participant in a set of participants has logged a particular message.
   *
   * The name can be constructed in a nested, left-to-right append manner.
   */
 trait NamedLoggerFactory {
-
-  /** Name for the logger. Can be empty. */
   val name: String
 
-  /** Augment the name with another sub-name. Useful when transitioning from one caller to one specific named callee */
   def append(subName: String): NamedLoggerFactory
 
   def forParticipant(id: String): NamedLoggerFactory =
     append(s"participant/$id")
 
-  /** get a loggers in factory methods
-    *
-    * Sometimes, the NamedLogging trait can not be used, e.g. in a factory method. In these
-    * cases, a logger can be created using this function.
-    */
   def getLogger(klass: Class[_]): Logger = {
     val fullName = Array(klass.getName, name)
       .filterNot(_.isEmpty)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/NamedLoggerFactory.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.platform.common.logging
 
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.Logger
 
 /**
   * NamedLoggerFactory augments a regular class-based slf4j logger with one annotated with a "name" where the name provides
@@ -20,9 +20,8 @@ trait NamedLoggerFactory {
   /** Augment the name with another sub-name. Useful when transitioning from one caller to one specific named callee */
   def append(subName: String): NamedLoggerFactory
 
-  def forParticipant(id: String): NamedLoggerFactory = append(s"participant/$id")
-
-  private[logging] def getLogger(fullName: String): Logger
+  def forParticipant(id: String): NamedLoggerFactory =
+    append(s"participant/$id")
 
   /** get a loggers in factory methods
     *
@@ -36,21 +35,15 @@ trait NamedLoggerFactory {
     getLogger(fullName)
   }
 
-}
-
-// Named Logger Factory implementation
-private[logging] final class SimpleNamedLoggerFactory(val name: String) extends NamedLoggerFactory {
-  override def append(subName: String): NamedLoggerFactory =
-    if (name.isEmpty) new SimpleNamedLoggerFactory(subName)
-    else new SimpleNamedLoggerFactory(s"$name/$subName")
-
-  override private[logging] def getLogger(fullName: String) = LoggerFactory.getLogger(fullName)
+  protected def getLogger(fullName: String): Logger
 }
 
 object NamedLoggerFactory {
   def apply(name: String): NamedLoggerFactory = new SimpleNamedLoggerFactory(name)
+
   def apply(cls: Class[_]): NamedLoggerFactory = apply(cls.getSimpleName)
 
   def forParticipant(name: String): NamedLoggerFactory = root.forParticipant(name)
+
   def root: NamedLoggerFactory = NamedLoggerFactory("")
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
@@ -5,7 +5,6 @@ package com.digitalasset.platform.common.logging
 
 import org.slf4j.{Logger, LoggerFactory}
 
-// Named Logger Factory implementation
 private[logging] final class SimpleNamedLoggerFactory(val name: String) extends NamedLoggerFactory {
   override def append(subName: String): NamedLoggerFactory =
     if (name.isEmpty) new SimpleNamedLoggerFactory(subName)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
@@ -6,10 +6,6 @@ package com.digitalasset.platform.common.logging
 import org.slf4j.{Logger, LoggerFactory}
 
 private[logging] final class SimpleNamedLoggerFactory(val name: String) extends NamedLoggerFactory {
-  override def append(subName: String): NamedLoggerFactory =
-    if (name.isEmpty) new SimpleNamedLoggerFactory(subName)
-    else new SimpleNamedLoggerFactory(s"$name/$subName")
-
   override protected def getLogger(fullName: String): Logger =
     LoggerFactory.getLogger(fullName)
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/logging/SimpleNamedLoggerFactory.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.common.logging
+
+import org.slf4j.{Logger, LoggerFactory}
+
+// Named Logger Factory implementation
+private[logging] final class SimpleNamedLoggerFactory(val name: String) extends NamedLoggerFactory {
+  override def append(subName: String): NamedLoggerFactory =
+    if (name.isEmpty) new SimpleNamedLoggerFactory(subName)
+    else new SimpleNamedLoggerFactory(s"$name/$subName")
+
+  override protected def getLogger(fullName: String): Logger =
+    LoggerFactory.getLogger(fullName)
+}

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/logging/TestNamedLoggerFactory.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/logging/TestNamedLoggerFactory.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import ch.qos.logback.{classic => logback}
+import com.digitalasset.platform.common.logging.NamedLoggerFactory
+import com.digitalasset.platform.sandbox.logging.TestNamedLoggerFactory._
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class TestNamedLoggerFactory(override val name: String) extends NamedLoggerFactory {
+
+  private val loggers = mutable.Map[String, (Logger, ListAppender[ILoggingEvent])]()
+  private val cleanupOperations = mutable.Buffer[() => Unit]()
+
+  override def append(subName: String): NamedLoggerFactory =
+    if (name.isEmpty)
+      new TestNamedLoggerFactory(subName)
+    else
+      new TestNamedLoggerFactory(s"$name/$subName")
+
+  override protected def getLogger(fullName: String): Logger =
+    loggers
+      .getOrElseUpdate(
+        fullName, {
+          val logger = LoggerFactory.getLogger(fullName).asInstanceOf[logback.Logger]
+          val additive = logger.isAdditive
+          logger.setAdditive(false)
+          val appender = new ListAppender[ILoggingEvent]
+          val normalAppenders = logger.iteratorForAppenders().asScala.toVector
+          normalAppenders.foreach(logger.detachAppender)
+          logger.addAppender(appender)
+          appender.start()
+          cleanupOperations += (() => {
+            logger.detachAppender(appender)
+            normalAppenders.foreach(logger.addAppender)
+            logger.setAdditive(additive)
+          })
+          (logger, appender)
+        }
+      )
+      ._1
+
+  def logs[C](klass: Class[C]): Seq[LogEvent] = {
+    val fullName = Array(klass.getName, name)
+      .filterNot(_.isEmpty)
+      .mkString(":")
+    logs(fullName)
+  }
+
+  def logs(fullName: String): Seq[LogEvent] =
+    loggers
+      .get(fullName)
+      .map(_._2.events)
+      .getOrElse(Seq.empty)
+      .map(event => event.getLevel -> event.getMessage)
+
+  def cleanup(): Unit = {
+    for (operation <- cleanupOperations)
+      operation()
+    cleanupOperations.clear()
+    loggers.clear()
+  }
+}
+
+object TestNamedLoggerFactory {
+
+  type LogEvent = (Level, String)
+
+  def apply(name: String): TestNamedLoggerFactory = new TestNamedLoggerFactory(name)
+
+  def apply(cls: Class[_]): TestNamedLoggerFactory = apply(cls.getSimpleName)
+
+  def forParticipant(name: String): TestNamedLoggerFactory =
+    root.forParticipant(name).asInstanceOf[TestNamedLoggerFactory]
+
+  def root: NamedLoggerFactory = TestNamedLoggerFactory("")
+
+  private class ListAppender[E] extends AppenderBase[E] {
+    private val eventsBuffer = mutable.Buffer[E]()
+
+    override def append(eventObject: E): Unit = {
+      eventsBuffer += eventObject
+    }
+
+    def events: Seq[E] =
+      eventsBuffer
+  }
+}

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/logging/TestNamedLoggerFactory.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/logging/TestNamedLoggerFactory.scala
@@ -19,12 +19,6 @@ class TestNamedLoggerFactory(override val name: String) extends NamedLoggerFacto
   private val loggers = mutable.Map[String, (Logger, ListAppender[ILoggingEvent])]()
   private val cleanupOperations = mutable.Buffer[() => Unit]()
 
-  override def append(subName: String): NamedLoggerFactory =
-    if (name.isEmpty)
-      new TestNamedLoggerFactory(subName)
-    else
-      new TestNamedLoggerFactory(s"$name/$subName")
-
   override protected def getLogger(fullName: String): Logger =
     loggers
       .getOrElseUpdate(
@@ -47,12 +41,8 @@ class TestNamedLoggerFactory(override val name: String) extends NamedLoggerFacto
       )
       ._1
 
-  def logs[C](klass: Class[C]): Seq[LogEvent] = {
-    val fullName = Array(klass.getName, name)
-      .filterNot(_.isEmpty)
-      .mkString(":")
-    logs(fullName)
-  }
+  def logs[C](cls: Class[C]): Seq[LogEvent] =
+    logs(nameOfClass(cls))
 
   def logs(fullName: String): Seq[LogEvent] =
     loggers
@@ -76,11 +66,6 @@ object TestNamedLoggerFactory {
   def apply(name: String): TestNamedLoggerFactory = new TestNamedLoggerFactory(name)
 
   def apply(cls: Class[_]): TestNamedLoggerFactory = apply(cls.getSimpleName)
-
-  def forParticipant(name: String): TestNamedLoggerFactory =
-    root.forParticipant(name).asInstanceOf[TestNamedLoggerFactory]
-
-  def root: NamedLoggerFactory = TestNamedLoggerFactory("")
 
   private class ListAppender[E] extends AppenderBase[E] {
     private val eventsBuffer = mutable.Buffer[E]()

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerSpec.scala
@@ -8,28 +8,12 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import akka.actor.ActorSystem
 import akka.pattern.after
 import com.digitalasset.platform.common.logging.NamedLoggerFactory
-import com.digitalasset.platform.common.util.{DirectExecutionContext => DEC}
+import com.digitalasset.platform.common.util.DirectExecutionContext
+import com.digitalasset.platform.indexer.TestIndexer._
 import org.scalatest.{AsyncWordSpec, Matchers}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future, Promise}
-
-case class SubscribeResult(
-    name: String,
-    subscribeDelay: FiniteDuration,
-    subscribeSucceeds: Boolean,
-    completeDelay: FiniteDuration,
-    completeSucceeds: Boolean)
-
-sealed abstract class IndexerEvent {
-  def name: String
-}
-final case class EventStreamFail(name: String) extends IndexerEvent
-final case class EventStreamComplete(name: String) extends IndexerEvent
-final case class EventStopCalled(name: String) extends IndexerEvent
-final case class EventSubscribeCalled(name: String) extends IndexerEvent
-final case class EventSubscribeSuccess(name: String) extends IndexerEvent
-final case class EventSubscribeFail(name: String) extends IndexerEvent
 
 class TestIndexer(results: Iterator[SubscribeResult]) {
   private[this] val actorSystem = ActorSystem("TestIndexer")
@@ -37,21 +21,22 @@ class TestIndexer(results: Iterator[SubscribeResult]) {
 
   val actions = new ConcurrentLinkedQueue[IndexerEvent]()
 
-  class TestIndexerFeedHandle(result: SubscribeResult) extends IndexFeedHandle {
+  class TestIndexerFeedHandle(result: SubscribeResult)(implicit executionContext: ExecutionContext)
+      extends IndexFeedHandle {
     private[this] val promise = Promise[akka.Done]()
 
-    if (result.completeSucceeds) {
+    if (result.status == SuccessfullyCompletes) {
       scheduler.scheduleOnce(result.completeDelay)({
         actions.add(EventStreamComplete(result.name))
         promise.trySuccess(akka.Done)
         ()
-      })(DEC)
+      })
     } else {
       scheduler.scheduleOnce(result.completeDelay)({
         actions.add(EventStreamFail(result.name))
         promise.tryFailure(new RuntimeException("Random simulated failure: subscribe"))
         ()
-      })(DEC)
+      })
     }
 
     override def stop(): Future[akka.Done] = {
@@ -65,29 +50,53 @@ class TestIndexer(results: Iterator[SubscribeResult]) {
     }
   }
 
-  def subscribe(): Future[IndexFeedHandle] = {
+  def subscribe()(implicit executionContext: ExecutionContext): Future[IndexFeedHandle] = {
     val result = results.next()
     actions.add(EventSubscribeCalled(result.name))
-    if (result.subscribeSucceeds) {
+    if (result.status != SubscriptionFails) {
       after(result.subscribeDelay, scheduler)({
         actions.add(EventSubscribeSuccess(result.name))
         Future.successful(new TestIndexerFeedHandle(result))
-      })(DEC)
+      })
     } else {
       after(result.subscribeDelay, scheduler)({
         actions.add(EventSubscribeFail(result.name))
         Future.failed(new RuntimeException("Random simulated failure: subscribe"))
-      })(DEC)
+      })
     }
   }
 }
 
-class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
+object TestIndexer {
+  case class SubscribeResult(
+      name: String,
+      status: SubscribeStatus,
+      subscribeDelay: FiniteDuration,
+      completeDelay: FiniteDuration,
+  )
 
-  private[this] implicit val ec: ExecutionContext = DEC
+  sealed abstract class IndexerEvent {
+    def name: String
+  }
+  final case class EventStreamFail(name: String) extends IndexerEvent
+  final case class EventStreamComplete(name: String) extends IndexerEvent
+  final case class EventStopCalled(name: String) extends IndexerEvent
+  final case class EventSubscribeCalled(name: String) extends IndexerEvent
+  final case class EventSubscribeSuccess(name: String) extends IndexerEvent
+  final case class EventSubscribeFail(name: String) extends IndexerEvent
+
+  sealed trait SubscribeStatus
+  case object StreamFails extends SubscribeStatus
+  case object SubscriptionFails extends SubscribeStatus
+  case object SuccessfullyCompletes extends SubscribeStatus
+}
+
+class RecoveringIndexerSpec extends AsyncWordSpec with Matchers {
+
+  private[this] implicit val executionContext: ExecutionContext = DirectExecutionContext
   private[this] val actorSystem = ActorSystem("RecoveringIndexerIT")
   private[this] val scheduler = actorSystem.scheduler
-  private[this] val loggerFactory = NamedLoggerFactory(RecoveringIndexerIT.super.getClass)
+  private[this] val loggerFactory = NamedLoggerFactory(getClass)
 
   "RecoveringIndexer" should {
 
@@ -96,7 +105,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
         new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second, loggerFactory)
       val testIndexer = new TestIndexer(
         List(
-          SubscribeResult("A", 10.millis, true, 10.millis, true)
+          SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.millis)
         ).iterator)
 
       val end = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -105,7 +114,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
           IndexerEvent](
           EventSubscribeCalled("A"),
           EventSubscribeSuccess("A"),
-          EventStreamComplete("A")
+          EventStreamComplete("A"),
         )
       }
     }
@@ -116,7 +125,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
       // Stream completes after 10sec, but stop() is called before
       val testIndexer = new TestIndexer(
         List(
-          SubscribeResult("A", 10.millis, true, 10000.millis, true) // Stream completes after a long delay
+          SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.seconds),
         ).iterator)
 
       val end = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -127,7 +136,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
           IndexerEvent](
           EventSubscribeCalled("A"),
           EventSubscribeSuccess("A"),
-          EventStopCalled("A")
+          EventStopCalled("A"),
         )
       }
     }
@@ -138,9 +147,9 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
         List(
-          SubscribeResult("A", 10.millis, false, 10.millis, true), // Subscribe fails
-          SubscribeResult("B", 10.millis, true, 10.millis, false), // Stream fails
-          SubscribeResult("C", 10.millis, true, 10.millis, true) // Stream completes
+          SubscribeResult("A", SubscriptionFails, 10.millis, 10.millis),
+          SubscribeResult("B", StreamFails, 10.millis, 10.millis),
+          SubscribeResult("C", SuccessfullyCompletes, 10.millis, 10.millis),
         ).iterator)
 
       val end = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -155,7 +164,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
           EventStreamFail("B"),
           EventSubscribeCalled("C"),
           EventSubscribeSuccess("C"),
-          EventStreamComplete("C")
+          EventStreamComplete("C"),
         )
       }
     }
@@ -166,8 +175,8 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
       // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.
       val testIndexer = new TestIndexer(
         List(
-          SubscribeResult("A", 0.millis, false, 0.millis, true), // Subscribe fails
-          SubscribeResult("B", 0.millis, true, 0.millis, true) // Stream completes
+          SubscribeResult("A", SubscriptionFails, 0.millis, 0.millis),
+          SubscribeResult("B", SuccessfullyCompletes, 0.millis, 0.millis),
         ).iterator)
 
       val t0 = System.nanoTime()
@@ -182,7 +191,7 @@ class RecoveringIndexerIT extends AsyncWordSpec with Matchers {
           EventSubscribeFail("A"),
           EventSubscribeCalled("B"),
           EventSubscribeSuccess("B"),
-          EventStreamComplete("B")
+          EventStreamComplete("B"),
         )
       }
     }


### PR DESCRIPTION
Printing logs during test execution is really annoying. This stubs the logger factory with a TestNamedLoggerFactory which captures them in a list instead, for testing purposes.

I have also fixed all the warnings in `RecoveringIndexerSpec`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
