### PR TITLE
Add 'R' to 'Choice<T,C,R>' defn

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -175,7 +175,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                             [ ["  " <> x <> ": {"
                               ,"    template: () => " <> conName <> ","
                               ,"    choiceName: '" <> x <> "',"
-                              ,"    argDecoder: " <> t <> ".decoder,"
+                              ,"    argumentDecoder: " <> t <> ".decoder,"
                               -- We'd write,
                               --   "   resultDecoder: " <> rtyp <> ".decoder"
                               -- here but, consider the following scenario:

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -3,12 +3,27 @@
 
 load("//rules_daml:daml.bzl", "daml_compile")
 
+# This rule builds a dar from the daml sources under the 'daml'
+# directory. It is referenced from the 'build-and-lint' test that
+# follows.
 daml_compile(
     name = "daml2ts-test",
     srcs = glob(["daml/**/*.daml"]),
     main_src = "daml/Main.daml",
 )
 
+# The 'build-and-lint' (test) target:
+#  - Causes 'daml2ts-test.dar' to be produced (from the sources under 'ts/daml');
+#  - Invokes 'daml2ts' on that dar to produce typescript bindings in' ts/generated/src/daml';
+#  - Invokes 'yarn install' in 'ts' to install dependencies;
+#  - Invokes 'yarn build' then 'yarn lint' on each of the 'daml-json-types', 'daml-ledger-fetch' and 'generated' packages;
+#  - Invokes 'yarn test' from the 'ts/generated' directory.
+# That last step causes 'ts/generated/src/tests/__tests__/test.ts' to be executed which:
+#  - Spins up a sandbox running the 'daml2ts-test.dar';
+#  - Spins up a http-json-api connected to the sandbox;
+#  - Evaluates assertions of http-json-api specified ledger operations involving contracts defined by the dar;
+#  - Gracefully tears down the processes it started when its work is done.
+# All in all, a pretty slick bit of work!
 sh_test(
     name = "build-and-lint",
     srcs = ["build-and-lint.sh"],

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -4,27 +4,16 @@
 
 set -euo pipefail
 
-# --- begin runfiles.bash initialization ---
-# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  if [[ -f "$0.runfiles_manifest" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    export RUNFILES_DIR="$0.runfiles"
-  fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+    set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+    source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+      source "$0.runfiles/$f" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+      { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
 JAVA=$(rlocation "$TEST_WORKSPACE/$1")
 YARN=$(rlocation "$TEST_WORKSPACE/$2")

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -34,15 +34,17 @@ export type TemplateId = {
  */
 export interface Template<T> extends Serializable<T> {
   templateId: TemplateId;
-  Archive: Choice<T, {}>;
+  Archive: Choice<T, {}, {}>;
 }
 
 /**
  * Interface for objects representing DAML choices. It is similar to the
  * `Choice` type class in DAML.
  */
-export interface Choice<T, C> extends Serializable<C> {
+export interface Choice<T, C, R> {
   template: () => Template<T>;
+  argDecoder: () => jtv.Decoder<C>;
+  resultDecoder: () => jtv.Decoder<R>;
   choiceName: string;
 }
 

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -43,7 +43,7 @@ export interface Template<T> extends Serializable<T> {
  */
 export interface Choice<T, C, R> {
   template: () => Template<T>;
-  argDecoder: () => jtv.Decoder<C>;
+  argumentDecoder: () => jtv.Decoder<C>;
   resultDecoder: () => jtv.Decoder<R>;
   choiceName: string;
 }

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -184,7 +184,7 @@ class Ledger {
   /**
    * Exercise a choice on a contract.
    */
-  async exercise<T, C>(choice: Choice<T, C>, contractId: ContractId<T>, argument: C): Promise<Event<unknown>[]> {
+  async exercise<T, C, R>(choice: Choice<T, C, R>, contractId: ContractId<T>, argument: C): Promise<[R , Event<unknown>[]]> {
     const payload = {
       templateId: choice.template().templateId,
       contractId,
@@ -192,14 +192,14 @@ class Ledger {
       argument,
     };
     const json = await this.submit('command/exercise', payload);
-    return jtv.Result.withException(jtv.array(decodeEventUnknown()).run(json));
+    return jtv.Result.withException(jtv.tuple([choice.resultDecoder(), jtv.array(decodeEventUnknown())]).run(json));
   }
 
   /**
    * Mimic DAML's `exerciseByKey`. The `key` must be a formulation of the
    * contract key as a query.
    */
-  async pseudoExerciseByKey<T, C>(choice: Choice<T, C>, key: Query<T>, argument: C): Promise<Event<unknown>[]> {
+  async pseudoExerciseByKey<T, C, R>(choice: Choice<T, C, R>, key: Query<T>, argument: C): Promise<[R, Event<unknown>[]]> {
     const contract = await this.pseudoFetchByKey(choice.template(), key);
     return this.exercise(choice, contract.contractId, argument);
   }

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -191,7 +191,6 @@ class Ledger {
       choice: choice.choiceName,
       argument,
     };
-
     const json = await this.submit('command/exercise', payload);
     console.log ("exercise json response" + JSON.stringify(json));
     // Decode the server response into a tuple.

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -194,7 +194,10 @@ class Ledger {
     const json = await this.submit('command/exercise', payload);
     console.log ("exercise json response" + JSON.stringify(json));
     // Decode the server response into a tuple.
-    const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<unknown>[]}> = jtv.object ({exerciseResult: choice.resultDecoder(), contracts: jtv.array(decodeEventUnknown())});
+    const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<unknown>[]}> = jtv.object({
+      exerciseResult: choice.resultDecoder(),
+      contracts: jtv.array(decodeEventUnknown()),
+    });
     const response: {exerciseResult: R; contracts: Event<unknown>[]} = jtv.Result.withException(responseDecoder.run(json));
     const result: [R, Event<unknown>[]] = [response.exerciseResult, response.contracts]; // Unpack record fields into a tuple.
 

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -192,7 +192,6 @@ class Ledger {
       argument,
     };
     const json = await this.submit('command/exercise', payload);
-    console.log ("exercise json response" + JSON.stringify(json));
     // Decode the server response into a tuple.
     const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<unknown>[]}> = jtv.object({
       exerciseResult: choice.resultDecoder(),

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -198,9 +198,8 @@ class Ledger {
       contracts: jtv.array(decodeEventUnknown()),
     });
     const {exerciseResult, contracts} = jtv.Result.withException(responseDecoder.run(json));
-    return [exerciseResult, contracts];
 
-    return result;
+    return [exerciseResult, contracts];
   }
 
   /**

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -191,8 +191,14 @@ class Ledger {
       choice: choice.choiceName,
       argument,
     };
+
     const json = await this.submit('command/exercise', payload);
-    return jtv.Result.withException(jtv.tuple([choice.resultDecoder(), jtv.array(decodeEventUnknown())]).run(json));
+    // Decode the server response into a tuple.
+    const responseDecoder: jtv.Decoder<{_1: R; _2: Event<unknown>[]}> = jtv.object ({_1: choice.resultDecoder(), _2: jtv.array(decodeEventUnknown())});
+    const response: {_1: R; _2: Event<unknown>[]} = jtv.Result.withException(responseDecoder.run(json));
+    const result: [R, Event<unknown>[]] = [response._1, response._2]; // Unpack record fields into a tuple.
+
+    return result;
   }
 
   /**

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -198,7 +198,7 @@ class Ledger {
       contracts: jtv.array(decodeEventUnknown()),
     });
     const {exerciseResult, contracts} = jtv.Result.withException(responseDecoder.run(json));
-    const result: [R, Event<unknown>[]] = [response.exerciseResult, response.contracts]; // Unpack record fields into a tuple.
+    return [exerciseResult, contracts];
 
     return result;
   }

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -197,7 +197,7 @@ class Ledger {
       exerciseResult: choice.resultDecoder(),
       contracts: jtv.array(decodeEventUnknown()),
     });
-    const response: {exerciseResult: R; contracts: Event<unknown>[]} = jtv.Result.withException(responseDecoder.run(json));
+    const {exerciseResult, contracts} = jtv.Result.withException(responseDecoder.run(json));
     const result: [R, Event<unknown>[]] = [response.exerciseResult, response.contracts]; // Unpack record fields into a tuple.
 
     return result;

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -193,10 +193,11 @@ class Ledger {
     };
 
     const json = await this.submit('command/exercise', payload);
+    console.log ("exercise json response" + JSON.stringify(json));
     // Decode the server response into a tuple.
-    const responseDecoder: jtv.Decoder<{_1: R; _2: Event<unknown>[]}> = jtv.object ({_1: choice.resultDecoder(), _2: jtv.array(decodeEventUnknown())});
-    const response: {_1: R; _2: Event<unknown>[]} = jtv.Result.withException(responseDecoder.run(json));
-    const result: [R, Event<unknown>[]] = [response._1, response._2]; // Unpack record fields into a tuple.
+    const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<unknown>[]}> = jtv.object ({exerciseResult: choice.resultDecoder(), contracts: jtv.array(decodeEventUnknown())});
+    const response: {exerciseResult: R; contracts: Event<unknown>[]} = jtv.Result.withException(responseDecoder.run(json));
+    const result: [R, Event<unknown>[]] = [response.exerciseResult, response.contracts]; // Unpack record fields into a tuple.
 
     return result;
   }

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -4,7 +4,6 @@
 import { ChildProcess, spawn } from 'child_process';
 import waitOn from 'wait-on';
 import { encode } from 'jwt-simple';
-import Ledger from '@digitalasset/daml-ledger-fetch'
 import Ledger, { CreateEvent, ArchiveEvent } from  '@digitalasset/daml-ledger-fetch'
 import * as Main from '../daml/daml-tests/Main';
 

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -87,7 +87,7 @@ test('create + fetch & exercise', async () => {
   const aliceOldContract: ArchiveEvent<Main.Person> = (es[0] as { archived: ArchiveEvent<Main.Person> }).archived;
   const aliceNewContract: CreateEvent<Main.Person>  = (es[1] as { created: CreateEvent<Main.Person> }).created;
   // The result of the exercise ('er') is her new record ID.
-  expect (er).not.toEqual(aliceContract.contractId);
+  expect(er).not.toEqual(aliceContract.contractId);
   expect (aliceOldContract.contractId).toEqual(aliceContract.contractId);
   expect (aliceNewContract.contractId).toEqual(er);
 

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -5,7 +5,7 @@ import { ChildProcess, spawn } from 'child_process';
 import waitOn from 'wait-on';
 import { encode } from 'jwt-simple';
 import Ledger from '@digitalasset/daml-ledger-fetch'
-import { CreateEvent, ArchiveEvent } from  '@digitalasset/daml-ledger-fetch'
+import Ledger, { CreateEvent, ArchiveEvent } from  '@digitalasset/daml-ledger-fetch'
 import * as Main from '../daml/daml-tests/Main';
 
 const LEDGER_ID = 'daml2ts-tests';


### PR DESCRIPTION
We add the type parameter `R` to `Choice<T, C, R>` and generate `argDecoder` and `resultDecoder` fields. The ledger functions `exercise` and `psudoExerciseByKey` functions have been updated to return exercise results.

