### PR TITLE
Limit ghci target on CI to damlc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ cat <<EOF > $GHCI_SCRIPT
 :main --help
 :quit
 EOF
-da-ghci --data yes //:repl -ghci-script $GHCI_SCRIPT -e '()'
+da-ghci --data yes //compiler/damlc:damlc -ghci-script $GHCI_SCRIPT -e '()'
 # Check that our IDE works on our codebase
 ./compiler/ghcide-daml.sh compiler/damlc/exe/Main.hs 2>&1 | tee ide-log
 grep -q "1 file worked, 0 files failed" ide-log


### PR DESCRIPTION
I’ve seen a bunch of builds on MacOS that seemed to hang forever
somewhere during loading the target (during the step where ghci is
loading modules so after Bazel). I don’t quite know what is going on
there but it seems to correlate with the change in
https://github.com/digital-asset/daml/pull/3829 that further extended
the repl target. Given that the GHCi step takes several minutes by
now, even if it is successful, I think it makes sense to limit this to
damlc given that we very rarely have issues that would result in damlc
loading but the repl target not loading (and very few people use the
latter anyway).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
