### PR TITLE
Avoid globbing for stable packages

### DIFF
--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -46,6 +46,7 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# If you change this you also need to update generateStablePackages in Development.IDE.Core.Rules.Daml
 filegroup(
     name = "stable-packages",
     srcs = [


### PR DESCRIPTION
I managed to break our Windows CI twice already due to this so while
it makes me sad, I think hardcoding those files is the more sensible
option for now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
