### PR TITLE
Expose address config option in StandloneApiServer

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
@@ -14,7 +14,7 @@ import com.digitalasset.platform.indexer.IndexerStartupMode
 
 final case class Config(
     port: Int,
-    address: Option[String], // address for ledger-api server to bind to
+    address: Option[String], // address for ledger-api server to bind to, defaulting to `localhost` for None
     portFile: Option[Path],
     archiveFiles: List[File],
     maxInboundMessageSize: Int,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
@@ -14,6 +14,7 @@ import com.digitalasset.platform.indexer.IndexerStartupMode
 
 final case class Config(
     port: Int,
+    address: Option[String], // address for ledger-api server to bind to
     portFile: Option[Path],
     archiveFiles: List[File],
     maxInboundMessageSize: Int,
@@ -34,6 +35,7 @@ object Config {
   def default: Config =
     new Config(
       port = 0,
+      address = None,
       portFile = None,
       archiveFiles = List.empty,
       maxInboundMessageSize = DefaultMaxInboundMessageSize,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -110,6 +110,7 @@ object ReferenceServer extends App {
         config.participantId,
         config.archiveFiles,
         config.port,
+        config.address,
         config.jdbcUrl,
         config.tlsConfig,
         config.timeProvider,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -14,7 +14,7 @@ case class ApiServerConfig(
     participantId: ParticipantId,
     archiveFiles: List[File],
     port: Int,
-    address: Option[String], // address for ledger-api server to bind to
+    address: Option[String], // address for ledger-api server to bind to, defaulting to `localhost` for None
     jdbcUrl: String,
     tlsConfig: Option[TlsConfiguration],
     timeProvider: TimeProvider, // enables use of non-wall-clock time in tests

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -14,6 +14,7 @@ case class ApiServerConfig(
     participantId: ParticipantId,
     archiveFiles: List[File],
     port: Int,
+    address: Option[String], // address for ledger-api server to bind to
     jdbcUrl: String,
     tlsConfig: Option[TlsConfiguration],
     timeProvider: TimeProvider, // enables use of non-wall-clock time in tests

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -136,11 +136,12 @@ class LedgerApiServer(
       workerEventLoopGroup: EventLoopGroup,
       apiServices: ApiServices,
   ) extends ResourceOwner[Server] {
-    override def acquire()(implicit executionContext: ExecutionContext): Resource[Server] =
+    override def acquire()(implicit executionContext: ExecutionContext): Resource[Server] = {
+      val host = address.map(InetAddress.getByName).getOrElse(InetAddress.getLoopbackAddress)
       Resource(
         Future {
-          val builder = address.fold(NettyServerBuilder.forPort(desiredPort))(address =>
-            NettyServerBuilder.forAddress(new InetSocketAddress(address, desiredPort)))
+          val builder =
+            NettyServerBuilder.forAddress(new InetSocketAddress(host, desiredPort))
           builder.sslContext(sslContext.orNull)
           builder.channelType(classOf[NioServerSocketChannel])
           builder.permitKeepAliveTime(10, SECONDS)
@@ -163,6 +164,7 @@ class LedgerApiServer(
         },
         server => Future(server.shutdown().awaitTermination())
       )
+    }
   }
 
   // This is necessary because we need to signal to the ResetService that we have shut down the

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.platform.apiserver
 
 import java.io.IOException
-import java.net.{BindException, InetSocketAddress}
+import java.net.{BindException, InetSocketAddress, InetAddress}
 import java.util.UUID
 import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -132,7 +132,7 @@ final class StandaloneApiServer(
             )(mat, esf),
         config.port,
         config.maxInboundMessageSize,
-        None,
+        config.address,
         loggerFactory,
         config.tlsConfig.flatMap(_.server),
         List(AuthorizationInterceptor(authService, ec)),


### PR DESCRIPTION
Before this PR, it was not possible to set the ledger-api-server
address and so it defaulted to localhost. Now, there is a configuration
variable address in the ApiServerConfig.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
