### PR TITLE
Fix WallClockTimeIT sandbox configuration

### DIFF
--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/time/WallClockTimeIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/time/WallClockTimeIT.scala
@@ -34,7 +34,7 @@ final class WallClockTimeIT
 
   override val timeLimit: Span = 15.seconds
 
-  override protected def config: SandboxConfig = SandboxConfig.default.copy(
+  override protected def config: SandboxConfig = super.config.copy(
     timeProviderType = TimeProviderType.WallClock,
   )
 


### PR DESCRIPTION
Using the default configuration as a base for this test meant binding on 6865 instead of using dynamic port binding, which could cause flaky errors if some other test is occupying the port

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
