### PR TITLE
daml test-script

### DIFF
--- a/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
+++ b/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.sdk
 import com.digitalasset.daml.lf.engine.trigger.{RunnerMain => Trigger}
 import com.digitalasset.daml.lf.engine.script.{RunnerMain => Script}
+import com.digitalasset.daml.lf.engine.script.{TestMain => TestScript}
 import com.digitalasset.codegen.{CodegenMain => Codegen}
 import com.digitalasset.extractor.{Main => Extractor}
 import com.digitalasset.http.{Main => JsonApi}
@@ -17,6 +18,7 @@ object SdkMain {
     command match {
       case "trigger" => Trigger.main(rest)
       case "script" => Script.main(rest)
+      case "test-script" => TestScript.main(rest)
       case "codegen" => Codegen.main(rest)
       case "extractor" => Extractor.main(rest)
       case "json-api" => JsonApi.main(rest)

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -27,6 +27,8 @@ da_scala_library(
         "//ledger-service/lf-value-json",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//ledger/participant-state",
+        "//ledger/sandbox",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_spray_spray_json_2_12",

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -42,4 +42,11 @@ da_scala_binary(
     deps = [":script-runner-lib"],
 )
 
+da_scala_binary(
+    name = "test-runner",
+    main_class = "com.digitalasset.daml.lf.engine.script.TestMain",
+    visibility = ["//visibility:public"],
+    deps = [":script-runner-lib"],
+)
+
 exports_files(["src/main/resources/logback.xml"])

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -59,8 +59,6 @@ object TestConfig {
         failure("Must specify both --ledger-host and --ledger-port")
       } else if (c.ledgerHost.isDefined && c.participantConfig.isDefined) {
         failure("Cannot specify both --ledger-host and --participant-config")
-      } else if (c.ledgerHost.isEmpty && c.participantConfig.isEmpty) {
-        failure("Must specify either --ledger-host or --participant-config")
       } else {
         success
       }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.script
+
+import java.io.File
+import java.time.Duration
+
+import com.digitalasset.platform.services.time.TimeProviderType
+
+case class TestConfig(
+    darPath: File,
+    ledgerHost: Option[String],
+    ledgerPort: Option[Int],
+    participantConfig: Option[File],
+    timeProviderType: TimeProviderType,
+    commandTtl: Duration,
+)
+
+object TestConfig {
+  private val parser = new scopt.OptionParser[TestConfig]("test-script") {
+    head("test-script")
+
+    opt[File]("dar")
+      .required()
+      .action((f, c) => c.copy(darPath = f))
+      .text("Path to the dar file containing the script")
+
+    opt[String]("ledger-host")
+      .optional()
+      .action((t, c) => c.copy(ledgerHost = Some(t)))
+      .text("Ledger hostname")
+
+    opt[Int]("ledger-port")
+      .optional()
+      .action((t, c) => c.copy(ledgerPort = Some(t)))
+      .text("Ledger port")
+
+    opt[File]("participant-config")
+      .optional()
+      .action((t, c) => c.copy(participantConfig = Some(t)))
+      .text("File containing the participant configuration in JSON format")
+
+    opt[Unit]('w', "wall-clock-time")
+      .action { (t, c) =>
+        c.copy(timeProviderType = TimeProviderType.WallClock)
+      }
+      .text("Use wall clock time (UTC). When not provided, static time is used.")
+
+    opt[Long]("ttl")
+      .action { (t, c) =>
+        c.copy(commandTtl = Duration.ofSeconds(t))
+      }
+      .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
+
+    checkConfig(c => {
+      // TODO: Start in-memory ledger automatically. See #3687.
+      if (c.ledgerHost.isDefined != c.ledgerPort.isDefined) {
+        failure("Must specify both --ledger-host and --ledger-port")
+      } else if (c.ledgerHost.isDefined && c.participantConfig.isDefined) {
+        failure("Cannot specify both --ledger-host and --participant-config")
+      } else if (c.ledgerHost.isEmpty && c.participantConfig.isEmpty) {
+        failure("Must specify either --ledger-host or --participant-config")
+      } else {
+        success
+      }
+    })
+  }
+  def parse(args: Array[String]): Option[TestConfig] =
+    parser.parse(
+      args,
+      TestConfig(
+        darPath = null,
+        ledgerHost = None,
+        ledgerPort = None,
+        participantConfig = None,
+        timeProviderType = TimeProviderType.Static,
+        commandTtl = Duration.ofSeconds(30L),
+      )
+    )
+}

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.engine.script

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -54,7 +54,6 @@ object TestConfig {
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
 
     checkConfig(c => {
-      // TODO: Start in-memory ledger automatically. See #3687.
       if (c.ledgerHost.isDefined != c.ledgerPort.isDefined) {
         failure("Must specify both --ledger-host and --ledger-port")
       } else if (c.ledgerHost.isDefined && c.participantConfig.isDefined) {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.script
+
+import akka.actor.ActorSystem
+import akka.stream._
+import java.time.Instant
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import scala.io.Source
+import scalaz.syntax.traverse._
+import spray.json._
+
+import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.daml.lf.archive.{Dar, DarReader}
+import com.digitalasset.daml.lf.archive.Decode
+import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
+import com.digitalasset.daml.lf.language.Ast.Package
+import com.digitalasset.daml_lf_dev.DamlLf
+import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
+import com.digitalasset.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
+import com.digitalasset.ledger.client.services.commands.CommandUpdater
+import com.digitalasset.platform.services.time.TimeProviderType
+
+object TestMain {
+
+  def main(args: Array[String]): Unit = {
+
+    TestConfig.parse(args) match {
+      case None => sys.exit(1)
+      case Some(config) => {
+        val encodedDar: Dar[(PackageId, DamlLf.ArchivePayload)] =
+          DarReader().readArchiveFromFile(config.darPath).get
+        val dar: Dar[(PackageId, Package)] = encodedDar.map {
+          case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
+        }
+
+        val applicationId = ApplicationId("Script Test")
+        val clientConfig = LedgerClientConfiguration(
+          applicationId = ApplicationId.unwrap(applicationId),
+          ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
+          commandClient = CommandClientConfiguration.default,
+          sslContext = None
+        )
+        val timeProvider: TimeProvider =
+          config.timeProviderType match {
+            case TimeProviderType.Static => TimeProvider.Constant(Instant.EPOCH)
+            case TimeProviderType.WallClock => TimeProvider.UTC
+            case _ =>
+              throw new RuntimeException(s"Unexpected TimeProviderType: $config.timeProviderType")
+          }
+        val commandUpdater = new CommandUpdater(
+          timeProviderO = Some(timeProvider),
+          ttl = config.commandTtl,
+          overrideTtl = true)
+
+        val system: ActorSystem = ActorSystem("ScriptTest")
+        implicit val sequencer: ExecutionSequencerFactory =
+          new AkkaExecutionSequencerPool("ScriptTestPool")(system)
+        implicit val ec: ExecutionContext = system.dispatcher
+        implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
+
+        val runner = new Runner(dar, applicationId, commandUpdater)
+        val participantParams = config.participantConfig match {
+          case Some(file) => {
+            val source = Source.fromFile(file)
+            val fileContent = try {
+              source.mkString
+            } finally {
+              source.close
+            }
+            val jsVal = fileContent.parseJson
+            import ParticipantsJsonProtocol._
+            jsVal.convertTo[Participants[ApiParameters]]
+          }
+          case None =>
+            Participants(
+              default_participant =
+                Some(ApiParameters(config.ledgerHost.get, config.ledgerPort.get)),
+              participants = Map.empty,
+              party_participants = Map.empty)
+        }
+        // XXX: Iterate over test scripts.
+        val flow: Future[Unit] = for {
+          clients <- Runner.connect(participantParams, clientConfig)
+          _ <- runner.run(clients, scriptId, None)
+        } yield ()
+
+        flow.onComplete(_ => system.terminate())
+        Await.result(flow, Duration.Inf)
+      }
+    }
+  }
+}

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -73,8 +73,8 @@ object TestMain {
         val system: ActorSystem = ActorSystem("ScriptTest")
         implicit val sequencer: ExecutionSequencerFactory =
           new AkkaExecutionSequencerPool("ScriptTestPool")(system)
+        implicit val materializer: Materializer = Materializer(system)
         implicit val ec: ExecutionContext = system.dispatcher
-        implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
 
         val runner = new Runner(dar, applicationId, commandUpdater)
         val (participantParams, participantCleanup) = config.participantConfig match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -24,7 +24,11 @@ import com.digitalasset.daml.lf.language.Ast.Package
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
-import com.digitalasset.ledger.client.configuration.{CommandClientConfiguration, LedgerClientConfiguration, LedgerIdRequirement}
+import com.digitalasset.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
 import com.digitalasset.ledger.client.services.commands.CommandUpdater
 import com.digitalasset.platform.sandbox.SandboxServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
@@ -97,7 +101,8 @@ object TestMain {
                 if (sandboxClosed.compareAndSet(false, true)) sandbox.close()
               }
 
-              try Runtime.getRuntime.addShutdownHook(new Thread(() => closeSandbox())) catch {
+              try Runtime.getRuntime.addShutdownHook(new Thread(() => closeSandbox()))
+              catch {
                 case NonFatal(t) =>
                   //logger.error("Shutting down Sandbox application because of initialization error", t)
                   closeSandbox()
@@ -106,10 +111,12 @@ object TestMain {
             } else {
               (ApiParameters(config.ledgerHost.get, config.ledgerPort.get), () => ())
             }
-            (Participants(
-              default_participant = Some(apiParameters),
-              participants = Map.empty,
-              party_participants = Map.empty), cleanup)
+            (
+              Participants(
+                default_participant = Some(apiParameters),
+                participants = Map.empty,
+                party_participants = Map.empty),
+              cleanup)
         }
 
         val flow: Future[Unit] = for {
@@ -117,15 +124,20 @@ object TestMain {
           _ <- clients.getParticipant(None) match {
             case Left(err) => throw new RuntimeException(err)
             case Right(client) =>
-              client.packageManagementClient.uploadDarFile(ByteString.readFrom(new FileInputStream(config.darPath)))
+              client.packageManagementClient.uploadDarFile(
+                ByteString.readFrom(new FileInputStream(config.darPath)))
           }
           _ <- Future.sequence {
             dar.main._2.modules.flatMap {
               case (moduleName, module) =>
                 module.definitions.collect {
-                  case (name, Ast.DValue(Ast.TApp(Ast.TTyCon(tycon), _), _, _, _)) if tycon == runner.scriptTyCon =>
+                  case (name, Ast.DValue(Ast.TApp(Ast.TTyCon(tycon), _), _, _, _))
+                      if tycon == runner.scriptTyCon =>
                     val testRun: Future[Unit] = for {
-                      _ <- runner.run(clients, Identifier(dar.main._1, QualifiedName(moduleName, name)), None)
+                      _ <- runner.run(
+                        clients,
+                        Identifier(dar.main._1, QualifiedName(moduleName, name)),
+                        None)
                     } yield ()
                     testRun.onComplete {
                       case Failure(exception) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The DAML Authors. All rights reserved.
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.lf.engine.script
@@ -105,7 +105,9 @@ object TestMain extends StrictLogging {
               try Runtime.getRuntime.addShutdownHook(new Thread(() => closeSandbox()))
               catch {
                 case NonFatal(t) =>
-                  logger.error("Shutting down Sandbox application because of initialization error", t)
+                  logger.error(
+                    "Shutting down Sandbox application because of initialization error",
+                    t)
                   closeSandbox()
               }
               (ApiParameters("localhost", sandbox.port), () => closeSandbox())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -7,6 +7,7 @@ import java.io.FileInputStream
 
 import akka.actor.ActorSystem
 import akka.stream._
+import com.typesafe.scalalogging.StrictLogging
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -38,7 +39,7 @@ import com.google.protobuf.ByteString
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-object TestMain {
+object TestMain extends StrictLogging {
 
   def main(args: Array[String]): Unit = {
 
@@ -104,7 +105,7 @@ object TestMain {
               try Runtime.getRuntime.addShutdownHook(new Thread(() => closeSandbox()))
               catch {
                 case NonFatal(t) =>
-                  //logger.error("Shutting down Sandbox application because of initialization error", t)
+                  logger.error("Shutting down Sandbox application because of initialization error", t)
                   closeSandbox()
               }
               (ApiParameters("localhost", sandbox.port), () => closeSandbox())

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -121,3 +121,18 @@ client_server_test(
     server_files = ["$(rootpath :script-test.dar)"],
     tags = ["exclusive"],
 )
+
+sh_test(
+    name = "test_daml_script_test_runner",
+    srcs = [":daml-script-test-runner.sh"],
+    args = [
+        "$(rootpath //daml-script/runner:test-runner)",
+        "$(rootpath :script-test.dar)",
+    ],
+    data = [
+        ":script-test.dar",
+        "//daml-script/runner:test-runner",
+    ],
+    tags = ["exclusive"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -137,6 +137,6 @@ sh_test(
         "//daml-script/runner:test-runner",
     ],
     tags = ["exclusive"],
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
-    toolchains = ["@rules_sh//sh/posix:make_variables"]
 )

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -128,6 +128,9 @@ sh_test(
     args = [
         "$(rootpath //daml-script/runner:test-runner)",
         "$(rootpath :script-test.dar)",
+        "$(POSIX_DIFF)",
+        "$(POSIX_GREP)",
+        "$(POSIX_SORT)",
     ],
     data = [
         ":script-test.dar",
@@ -135,4 +138,5 @@ sh_test(
     ],
     tags = ["exclusive"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
+    toolchains = ["@rules_sh//sh/posix:make_variables"]
 )

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euo pipefail
+
+$(rlocation $TEST_WORKSPACE/$1) --dar=$(rlocation $TEST_WORKSPACE/$2)

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2019 The DAML Authors. All rights reserved.
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Copy-pasted from the Bazel Bash runfiles library v2.

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -131,3 +131,11 @@ testCreateAndExercise = do
       <*> createAndExerciseCmd (C alice 42) GetCValue
       <*> exerciseCmd cid GetCValue
   pure r
+
+-- Used in daml test-script test-case.
+failingTest : Script ()
+failingTest = do
+  alice <- allocateParty "alice"
+  cid <- submit alice $ createCmd (C alice 42)
+  submit alice $ exerciseCmd cid ShouldFail
+  pure ()

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
@@ -7,6 +7,7 @@ import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.auth.client.LedgerCallCredentials
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc
+import com.digitalasset.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc
 import com.digitalasset.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc
 import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc
 import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc
@@ -16,6 +17,7 @@ import com.digitalasset.ledger.api.v1.package_service.PackageServiceGrpc
 import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc
 import com.digitalasset.ledger.client.configuration.LedgerClientConfiguration
 import com.digitalasset.ledger.client.services.acs.ActiveContractSetClient
+import com.digitalasset.ledger.client.services.admin.PackageManagementClient
 import com.digitalasset.ledger.client.services.admin.PartyManagementClient
 import com.digitalasset.ledger.client.services.commands.{CommandClient, SynchronousCommandClient}
 import com.digitalasset.ledger.client.services.identity.LedgerIdentityClient
@@ -52,6 +54,10 @@ final class LedgerClient private (
 
   val packageClient: PackageClient =
     new PackageClient(ledgerId, LedgerClient.stub(PackageServiceGrpc.stub(channel), config.token))
+
+  val packageManagementClient: PackageManagementClient =
+    new PackageManagementClient(
+      LedgerClient.stub(PackageManagementServiceGrpc.stub(channel), config.token))
 
   val partyManagementClient: PartyManagementClient =
     new PartyManagementClient(

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -72,4 +72,8 @@ commands:
 - name: script
   path: daml-helper/daml-helper
   args: ["run-jar", "--logback-config=daml-sdk/script-logback.xml", "daml-sdk/daml-sdk.jar", "script"]
-  desc: "Run a DAML trigger (experimental)"
+  desc: "Run a DAML script (experimental)"
+- name: test-script
+  path: daml-helper/daml-helper
+  args: ["run-jar", "--logback-config=daml-sdk/test-script-logback.xml", "daml-sdk/daml-sdk.jar", "test-script"]
+  desc: "Run a DAML script tests (experimental)"


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/3687

* Adds a new command `daml test-script` which takes a DAR and runs all definitions matching the type `Script a` in the main package as test-cases.
* The test-runner can use an existing ledger with the `--ledger-host,--ledger-port` flags or the `--participant-config` flag. If neither is specified it will start a sandbox in the background.
* Test output is very simplistic for now:
    Each succeeding test-case is reported as `<module-name>:<test-name> SUCCESS`
    Each failing test-case is reported as `<module-name>:<test-name> FAILURE (<exception>)`
    The relevant interpreter error is printed in the surrounding output. E.g.
    ```
    ScriptTest:testKey SUCCESS
    ScriptTest:testCreateAndExercise SUCCESS
    MultiTest:multiTest SUCCESS
    15:57:56.874 [ScriptTest-akka.actor.default-dispatcher-11] ERROR c.d.daml.lf.engine.script.Runner - Error: User abort: Submit failed with code 3: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:20], partial transaction: <empty transaction>.
    ScriptTest:test3 FAILURE (com.digitalasset.daml.lf.speedy.SError$DamlEUserError)
    ScriptTest:test4 SUCCESS
    ScriptTest:test1 SUCCESS
    Exception in thread "main" ScriptTest:test0 SUCCESS
    ScriptExample:test SUCCESS
    com.digitalasset.daml.lf.speedy.SError$DamlEUserError
            at com.digitalasset.daml.lf.speedy.SBuiltin$SBError$.execute(SBuiltin.scala:1292)
            at com.digitalasset.daml.lf.speedy.Speedy$CtrlValue.execute(Speedy.scala:333)
            at com.digitalasset.daml.lf.speedy.Speedy$Machine.step(Speedy.scala:115)
            at com.digitalasset.daml.lf.engine.script.Runner.stepToValue$1(Runner.scala:274)
            at com.digitalasset.daml.lf.engine.script.Runner.go$1(Runner.scala:307)
            at com.digitalasset.daml.lf.engine.script.Runner.$anonfun$run$10(Runner.scala:356)
            at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:303)
            at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:37)
            at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
            at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
            at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92)
            at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
            at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
            at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92)
            at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:47)
            at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:47)
            at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
            at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
            at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
            at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
    ```
    This could be improved in future by attaching the `machine.stackTrace()` to the error thrown in `Runner.stepToValue` and rendering that in the failure message.
* Adds a test-case in `//daml-script/test:test_daml_script_test_runner`
* Exposes `PackageManagementClient` in `LedgerClient` to upload DARs from `TestMain`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
