### PR TITLE
reenable scalafmt

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -37,7 +37,7 @@ import com.digitalasset.http.EndpointsCompanion._
 class Endpoints(
     ledgerId: lar.LedgerId,
     decodeJwt: EndpointsCompanion.ValidateJwt,
-    commandService: CommandService,
+     commandService: CommandService,
     contractsService: ContractsService,
     partiesService: PartiesService,
     encoder: DomainJsonEncoder,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -37,7 +37,7 @@ import com.digitalasset.http.EndpointsCompanion._
 class Endpoints(
     ledgerId: lar.LedgerId,
     decodeJwt: EndpointsCompanion.ValidateJwt,
-     commandService: CommandService,
+    commandService: CommandService,
     contractsService: ContractsService,
     partiesService: PartiesService,
     encoder: DomainJsonEncoder,

--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -5,4 +5,4 @@
 set -eu -o pipefail
 
 cd "${0%/*}"
-scalafmt --mode=diff "$@"
+scalafmt --mode=diff --diff-branch=origin/master "$@"

--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -5,4 +5,4 @@
 set -eu -o pipefail
 
 cd "${0%/*}"
-scalafmt --git true --config .scalafmt.conf "$@"
+scalafmt --mode=diff "$@"

--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -5,4 +5,4 @@
 set -eu -o pipefail
 
 cd "${0%/*}"
-scalafmt --mode=diff "$@"
+scalafmt --git true --config .scalafmt.conf "$@"


### PR DESCRIPTION
Scalafmt was disabled when there is no local `master` branch in the course of #3654; the meaning of the help text for `--diff` and `--mode=diff`, "format files listed in `git diff` against master", means "the local branch called master"; if the branch is absent, `scalafmt.sh` does nothing, even in `--test` mode.

This also disabled scalafmt in CI; see stage "Platform-agnostic lints and checks" in 
18dd9cd's build in this PR.

You can see locally by

1. removing any local `master` branch,
2. checking out 9ae56db3391878a5c80c1d2c293c8068c4dc557c, which has differences with master,
3. running `./scalafmt.sh` (no changes),
4. running `./scalafmt.sh --test` (no CI errors), and
5. running `scalafmt --config .scalafmt.conf ledger-service/http-json`, which makes changes.

This follows up #3654 and #3764 by setting the comparison basis to `origin/master`. The assumption that `origin` is equal to the `digital-asset/daml` repo is, I think, safe enough. If you don't like that, we can always add to scalafmt.sh

```sh
for r in `git remote`; do
    case "`git remote get-url $r`" in
        *digital-asset/daml*) break;;
        *):;;
    esac
    r=origin
done
```

Additionally, we may wish to disable `diff` mode entirely in CI, reserving it for local runs only. That might depend on upgrading scalafmt to properly handle some of the sbt files, though, which oughtn't hold up this PR.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
