### PR TITLE
bindings-rxjava: Attempt to fix the flakiness in BotTest.

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -210,7 +210,7 @@ final class BotTest extends FlatSpec with Matchers {
     Bot.wire(appId, ledgerClient, transactionFilter, bot, _ => counter)
 
     // when the bot is wired-up, no command should have been submitted to the server
-    ledgerClient.submitted.size shouldBe 0
+    ledgerClient.submitted should have size 0
     counter.get shouldBe 0
 
     // when the bot receives a transaction, a command should be submitted to the server
@@ -219,7 +219,7 @@ final class BotTest extends FlatSpec with Matchers {
 
     while (!finishedWork.get) Thread.sleep(1)
 
-    ledgerClient.submitted.size shouldBe 3
+    ledgerClient.submitted should have size 3
     counter.get shouldBe 3
 
     transactions.complete()
@@ -290,20 +290,20 @@ final class BotTest extends FlatSpec with Matchers {
 
     // when the bot is wired-up, no command should have been submitted to the server
     Thread.sleep(100)
-    ledgerClient.submitted.size shouldBe 0
+    ledgerClient.submitted should have size 0
 
     // when the bot receives a transaction, a command should be submitted to the server
     val createdEvent1 = create(party, templateId)
     transactions.emit(transaction(createdEvent1))
     Thread.sleep(100)
-    ledgerClient.submitted.size shouldBe 1
+    ledgerClient.submitted should have size 1
 
     val archivedEvent1 = archive(createdEvent1)
     val createEvent2 = create(party, templateId)
     val createEvent3 = create(party, templateId)
     transactions.emit(transaction(archivedEvent1, createEvent2, createEvent3))
     Thread.sleep(100)
-    ledgerClient.submitted.size shouldBe 3
+    ledgerClient.submitted should have size 3
 
     // we complete the first command with success and then check that the client hasn't submitted a new command
     commandCompletions.emit(
@@ -317,7 +317,7 @@ final class BotTest extends FlatSpec with Matchers {
             .build()).asJava
       ))
     Thread.sleep(100)
-    ledgerClient.submitted.size shouldBe 3
+    ledgerClient.submitted should have size 3
 
     // WARNING: THE FOLLOWING TEST IS NOT PASSING YET
     // // we complete the second command with failure and then check that the client has submitted a new command
@@ -333,7 +333,7 @@ final class BotTest extends FlatSpec with Matchers {
     //     ).asJava
     //   ))
     // Thread.sleep(100)
-    // ledgerClient.submitted.size shouldBe 4
+    // ledgerClient.submitted should have size 4
 
     transactions.complete()
     commandCompletions.complete()

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala
@@ -7,9 +7,10 @@ import java.time.Instant
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.{Collections, Optional}
+import java.util.{Collections, Optional, function}
 
 import com.daml.ledger.javaapi.data.{Unit => DAMLUnit, _}
+import com.daml.ledger.rxjava.components.BotTest._
 import com.daml.ledger.rxjava.components.LedgerViewFlowable.LedgerView
 import com.daml.ledger.rxjava.components.helpers.{CommandsAndPendingSet, CreatedContract}
 import com.daml.ledger.rxjava.components.tests.helpers.DummyLedgerClient
@@ -36,19 +37,13 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.util.Random
 import scala.util.control.NonFatal
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 final class BotTest extends FlatSpec with Matchers {
-
-  def ledgerServices: LedgerServices = new LedgerServices("bot-test")
-  val ec: ExecutionContext = ledgerServices.executionContext
-  val logger = LoggerFactory.getLogger(this.getClass)
-
-  val random = new Random()
-  val zeroTimestamp = Instant.EPOCH
+  private def ledgerServices: LedgerServices = new LedgerServices("bot-test")
 
   "Bot" should "create a flowable of WorkflowEvents from the ACS" in {
     val acs = new TestFlowable[GetActiveContractsResponse]("acs")
@@ -81,7 +76,6 @@ final class BotTest extends FlatSpec with Matchers {
   }
 
   it should "create a flowable of WorkflowEvents from the transactions" in {
-//    val acs = new TestFlowable[GetActiveContractsResponse]("acs")
     val transactions = new TestFlowable[Transaction]("transactions")
     val templateId = new Identifier("pid", "mname", "ename")
     val ledgerClient = new DummyLedgerClient(
@@ -100,13 +94,12 @@ final class BotTest extends FlatSpec with Matchers {
       "transactionId",
       "commandId",
       "workflowId",
-      zeroTimestamp,
+      ZeroTimestamp,
       List[Event](contract1).asJava,
       "1")
     val testSub = workflowEvents.test()
 
     transactions.emit(t1)
-//    acs.complete()
     transactions.complete()
 
     testSub
@@ -171,17 +164,16 @@ final class BotTest extends FlatSpec with Matchers {
     val finishedWork = new AtomicBoolean(false)
 
     val cid = "cid_1"
-    val bot =
-      new java.util.function.Function[LedgerView[AtomicInteger], Flowable[CommandsAndPendingSet]] {
-
+    val bot: function.Function[LedgerView[AtomicInteger], Flowable[CommandsAndPendingSet]] =
+      new function.Function[LedgerView[AtomicInteger], Flowable[CommandsAndPendingSet]] {
         private val logger = LoggerFactory.getLogger("TestBot")
 
         override def apply(fcs: LedgerView[AtomicInteger]): Flowable[CommandsAndPendingSet] = {
           logger.debug(s"apply(fcs: $fcs)")
           val contracts = fcs.getContracts(templateId)
           if (contracts.isEmpty) {
-            // this function gets called again after the contract has been set to pending, so we expect no free contract
-            // in the ledger view
+            // this function gets called again after the contract has been set to pending, so we
+            // expect no free contract in the ledger view
             Flowable.empty()
           } else {
             // after each failure, we expect to see the same initial contract again
@@ -198,8 +190,8 @@ final class BotTest extends FlatSpec with Matchers {
                 appId,
                 s"commandId_${counter.get()}",
                 party,
-                zeroTimestamp,
-                zeroTimestamp,
+                ZeroTimestamp,
+                ZeroTimestamp,
                 commandList
               )
               Flowable.fromArray(
@@ -223,7 +215,7 @@ final class BotTest extends FlatSpec with Matchers {
 
     // when the bot receives a transaction, a command should be submitted to the server
     val createdEvent1 = create(party, templateId, id = 1)
-    transactions.emit(transactionArray(createdEvent1))
+    transactions.emit(transaction(createdEvent1))
 
     while (!finishedWork.get) Thread.sleep(1)
 
@@ -256,8 +248,8 @@ final class BotTest extends FlatSpec with Matchers {
     // In this way we can see how many commands are submitted to the ledger-client and
     // verify the result
     val atomicCount = new AtomicInteger(0)
-    val bot =
-      new java.util.function.Function[LedgerView[CreatedContract], Flowable[CommandsAndPendingSet]] {
+    val bot: function.Function[LedgerView[CreatedContract], Flowable[CommandsAndPendingSet]] =
+      new function.Function[LedgerView[CreatedContract], Flowable[CommandsAndPendingSet]] {
 
         private val logger = LoggerFactory.getLogger("TestBot")
 
@@ -279,8 +271,8 @@ final class BotTest extends FlatSpec with Matchers {
                       appId,
                       s"commandId_${atomicCount.incrementAndGet()}",
                       party,
-                      zeroTimestamp,
-                      zeroTimestamp,
+                      ZeroTimestamp,
+                      ZeroTimestamp,
                       commandList
                     )
                   logger.debug(s"commands: $commands")
@@ -295,26 +287,26 @@ final class BotTest extends FlatSpec with Matchers {
     Bot.wireSimple(appId, ledgerClient, transactionFilter, bot)
 
     // when the bot is wired-up, no command should have been submitted to the server
-    Thread.sleep(100l)
+    Thread.sleep(100)
     ledgerClient.submitted.size shouldBe 0
 
     // when the bot receives a transaction, a command should be submitted to the server
     val createdEvent1 = create(party, templateId)
-    transactions.emit(transactionArray(createdEvent1))
-    Thread.sleep(100l)
+    transactions.emit(transaction(createdEvent1))
+    Thread.sleep(100)
     ledgerClient.submitted.size shouldBe 1
 
     val archivedEvent1 = archive(createdEvent1)
     val createEvent2 = create(party, templateId)
     val createEvent3 = create(party, templateId)
-    transactions.emit(transactionArray(archivedEvent1, createEvent2, createEvent3))
-    Thread.sleep(100l)
+    transactions.emit(transaction(archivedEvent1, createEvent2, createEvent3))
+    Thread.sleep(100)
     ledgerClient.submitted.size shouldBe 3
 
     // we complete the first command with success and then check that the client hasn't submitted a new command
     commandCompletions.emit(
       new CompletionStreamResponse(
-        Optional.of(new Checkpoint(zeroTimestamp, new LedgerOffset.Absolute(""))),
+        Optional.of(new Checkpoint(ZeroTimestamp, new LedgerOffset.Absolute(""))),
         List(
           scalaAPI.CompletionOuterClass.Completion
             .newBuilder()
@@ -322,15 +314,24 @@ final class BotTest extends FlatSpec with Matchers {
             .setStatus(Status.newBuilder().setCode(OK.value).build())
             .build()).asJava
       ))
-    Thread.sleep(100l)
+    Thread.sleep(100)
     ledgerClient.submitted.size shouldBe 3
 
     // WARNING: THE FOLLOWING TEST IS NOT PASSING YET
-//    // we complete the second command with failure and then check that the client has submitted a new command
-//    commandCompletionsEmitter.emit(new CompletionStreamResponse(new Checkpoint(zeroTimestamp, new LedgerOffset.Absolute("")),
-//      List(CompletionOuterClass.Completion.newBuilder().setCommandId("commandId_1").setStatus(Status.newBuilder().setCode(Code.INVALID_ARGUMENT.value())).build()).asJava))
-//    Thread.sleep(1l)
-//    ledgerClient.submitted.size shouldBe 4
+    // // we complete the second command with failure and then check that the client has submitted a new command
+    // commandCompletions.emit(
+    //   new CompletionStreamResponse(
+    //     Optional.of(new Checkpoint(ZeroTimestamp, new LedgerOffset.Absolute(""))),
+    //     List(
+    //       CompletionOuterClass.Completion
+    //         .newBuilder()
+    //         .setCommandId("commandId_1")
+    //         .setStatus(Status.newBuilder().setCode(INVALID_ARGUMENT.value))
+    //         .build(),
+    //     ).asJava
+    //   ))
+    // Thread.sleep(100)
+    // ledgerClient.submitted.size shouldBe 4
   }
 
   it should "query first the ACS and then the LedgerEnd sequentially so that there is not race condition and LedgerEnd >= ACS offset" in {
@@ -421,7 +422,7 @@ final class BotTest extends FlatSpec with Matchers {
       // test is passed, we wait a bit to avoid issues with gRPC and then close the client. If there is an exception,
       // we just ignore it as there are some problems with gRPC
       try {
-        Thread.sleep(100l)
+        Thread.sleep(100)
         client.close()
       } catch {
         case NonFatal(e) =>
@@ -430,8 +431,19 @@ final class BotTest extends FlatSpec with Matchers {
       }
     }
   }
+}
 
-  def create(party: String, templateId: Identifier, id: Int = random.nextInt()): CreatedEvent =
+object BotTest {
+  private val ZeroTimestamp = Instant.EPOCH
+
+  private val logger = LoggerFactory.getLogger(classOf[BotTest])
+  private val random = new Random()
+
+  private def create(
+      party: String,
+      templateId: Identifier,
+      id: Int = random.nextInt(),
+  ): CreatedEvent =
     new CreatedEvent(
       List(party).asJava,
       s"eid_$id",
@@ -444,78 +456,66 @@ final class BotTest extends FlatSpec with Matchers {
       Collections.emptySet()
     )
 
-  def archive(event: CreatedEvent): ArchivedEvent =
+  private def archive(event: CreatedEvent): ArchivedEvent =
     new ArchivedEvent(
       event.getWitnessParties,
       s"${event.getEventId}_archive",
       event.getTemplateId,
       event.getContractId)
 
-  def transaction(events: List[Event]): Transaction =
+  private def transaction(events: Event*): Transaction =
     new Transaction(
       "tid",
       s"cid_${random.nextInt()}",
       "wid",
-      zeroTimestamp,
-      events.asJava,
-      events.size.toString)
+      ZeroTimestamp,
+      events.toList.asJava,
+      events.toList.size.toString)
 
-  def transactionWithOffset(offset: String, events: List[Event]): Transaction =
-    new Transaction("tid", s"cid_${random.nextInt()}", "wid", zeroTimestamp, events.asJava, offset)
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private class TestFlowable[A](name: String) extends Flowable[A] {
+    private val logger = LoggerFactory.getLogger(s"${getClass.getSimpleName}($name)")
 
-  def transactionArray(events: Event*): Transaction = transaction(events.toList)
-}
+    private val buffer: mutable.Buffer[A] = mutable.Buffer.empty[A]
+    private var observerMay = Option.empty[Subscriber[_ >: A]]
 
-@SuppressWarnings(Array("org.wartremover.warts.Any"))
-class TestFlowable[A](name: String) extends Flowable[A] {
+    override def subscribeActual(observer: Subscriber[_ >: A]): Unit = {
+      observerMay match {
+        case Some(oldObserver) =>
+          throw new IllegalStateException(
+            s"${getClass.getSimpleName} supports only one subscriber. Currently subscribed $oldObserver, want to subscribe $observer")
+        case None =>
+          observerMay = Option(observer)
+          logger.debug(s"Subscribed observer $observer")
+          observer.onSubscribe(new Subscription {
+            override def request(n: Long): Unit = ()
 
-  private val buffer: mutable.Buffer[A] = mutable.Buffer.empty[A]
-  private var isComplete: Boolean = false
+            override def cancel(): Unit = ()
+          })
+          buffer.foreach(a => observer.onNext(a))
+          buffer.clear()
+      }
+    }
 
-  private val logger = LoggerFactory.getLogger(s"TestFlowable($name)")
+    def emit(a: A): Unit = {
+      observerMay match {
+        case None =>
+          logger.debug(s"no observer, buffering $a")
+          buffer.append(a)
+        case Some(observer) =>
+          logger.debug(s"emitting $a to subscribed $observer")
+          observer.onNext(a)
+      }
+    }
 
-  private var observerMay = Option.empty[Subscriber[_ >: A]]
-
-  override def subscribeActual(observer: Subscriber[_ >: A]): Unit = {
-    this.observerMay match {
-      case Some(oldObserver) =>
-        throw new RuntimeException(
-          this.getClass.getSimpleName + " supports only one subscriber. Currently" +
-            " subscribed " + oldObserver.toString + ", want to subscribe " + observer.toString)
-      case None =>
-        this.observerMay = Option(observer)
-        logger.debug("Subscribed observer " + observer.toString)
-        observer.onSubscribe(new Subscription {
-          override def request(n: Long): Unit = ()
-
-          override def cancel(): Unit = ()
-        })
-        buffer.foreach(a => observer.onNext(a))
-        buffer.clear()
-        if (this.isComplete) {
+    def complete(): Unit = {
+      observerMay match {
+        case None =>
+          logger.debug("no observer, buffering onComplete")
+        case Some(observer) =>
+          logger.debug(s"calling onComplete() on subscribed $observer")
           observer.onComplete()
-        }
-    }
-  }
-
-  def emit(a: A): Unit = {
-    this.observerMay match {
-      case None =>
-        logger.debug(s"no observer, buffering $a")
-        this.buffer.append(a)
-      case Some(observer) =>
-        logger.debug(s"emitting $a to subscribed $observer")
-        observer.onNext(a)
-    }
-  }
-
-  def complete(): Unit = {
-    this.observerMay match {
-      case None =>
-        logger.debug("no observer, buffering onComplete")
-      case Some(observer) =>
-        logger.debug(s"calling onComplete() on subscribed $observer")
-        observer.onComplete()
+      }
     }
   }
 }


### PR DESCRIPTION
[I saw this on CI](https://dev.azure.com/digitalasset/daml/_build/results?buildId=26972&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=2a9ec019-0f0c-5539-ddaa-bb626e8e6d44), but I can't reproduce this problem on my local machine. It feels like a timeout issue, so I've attempted to replace `Thread.sleep` with `Eventually` in the hope it'll be a bit more robust.

Most of this PR is cleanup and refactoring. Check the last commit for the actual fix.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
