### PR TITLE
Strip trailing newlines in access-token-file

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -804,7 +804,10 @@ getTokFromFile tokFileM = do
   case tokFileM of
     Nothing -> return Nothing
     Just tokFile -> do
-      tok <- readFileUTF8 tokFile
+      -- This postprocessing step which allows trailing newlines
+      -- matches the behavior of the Scala token reader in
+      -- com.digitalasset.auth.TokenHolder.
+      tok <- intercalate "\n" . lines <$> readFileUTF8 tokFile
       return (Just (Token tok))
 
 getHostAndPortDefaults :: LedgerFlags -> IO LedgerArgs

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -613,7 +613,8 @@ deployTest deployDir = testCase "daml deploy" $ do
                             , ".daml/dist/proj1-0.0.1.dar"
                             ]) { std_out = UseHandle devNull }
                 let tokenFile = deployDir </> "secretToken.jwt"
-                writeFileUTF8 tokenFile ("Bearer " <> makeSignedJwt sharedSecret)
+                -- The trailing newline is not required but we want to test that it is supported.
+                writeFileUTF8 tokenFile ("Bearer " <> makeSignedJwt sharedSecret <> "\n")
                 withCreateProcess sandboxProc  $ \_ _ _ ph ->
                     race_ (waitForProcess' sandboxProc ph) $ do
                         waitForConnectionOnPort (threadDelay 100000) port


### PR DESCRIPTION
As mentioned in the inline comment, this matches the behavior on the
Scala side and given that most people configure their editors to
always add trailing newlines, this is quite convenient (especially
given that the error message is horrible if you do include the
newline).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
