### PR TITLE
daml script-test choose free port

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -93,6 +93,7 @@ object TestMain extends StrictLogging {
           case None =>
             val (apiParameters, cleanup) = if (config.ledgerHost.isEmpty) {
               val sandboxConfig = SandboxConfig.default.copy(
+                port = 0, // Automatically choose a free port.
                 timeProviderType = config.timeProviderType
               )
               val sandbox = new SandboxServer(sandboxConfig)

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -136,7 +136,6 @@ sh_test(
         ":script-test.dar",
         "//daml-script/runner:test-runner",
     ],
-    tags = ["exclusive"],
     toolchains = ["@rules_sh//sh/posix:make_variables"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )


### PR DESCRIPTION
Automatically choose a free port in daml script runner. See https://github.com/digital-asset/daml/pull/3918#discussion_r362731097. The chosen port is exposed by the `SandboxServer` object and directly available to the test runner.
No longer requires the test to be marked exclusive.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
