### PR TITLE
daml-assistant: Install bash completion scripts on Linux and Mac.

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -56,10 +56,10 @@ main = displayErrors $ do
                     ]
                 exitFailure
 
-            versionChecks env
             sdkConfig <- readSdkConfig (fromJust envSdkPath)
             sdkCommands <- fromRightM throwIO (listSdkCommands sdkConfig)
             userCommand <- getCommand sdkCommands
+            versionChecks env
             handleCommand env userCommand
 
 -- | Perform version checks, i.e. warn user if project SDK version or assistant SDK

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -111,6 +111,7 @@ autoInstall env@Env{..} = do
                 , iActivate = ActivateInstall False
                 , iForce = ForceInstall False
                 , iSetPath = SetPath True
+                , iBashCompletions = BashCompletions Auto
                 }
             installEnv = InstallEnv
                 { options = options

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -83,7 +83,7 @@ versionParser = VersionOptions
 
 installParser :: Parser InstallOptions
 installParser = InstallOptions
-    <$> optional (RawInstallTarget <$> argument str (metavar "TARGET" <> help "The SDK version to install. Use 'latest' to download and install the latest stable SDK version available. Run 'daml install' to see the full set of options."))
+    <$> optional (RawInstallTarget <$> argument str (metavar "TARGET" <> completeWith ["latest"] <> help "The SDK version to install. Use 'latest' to download and install the latest stable SDK version available. Run 'daml install' to see the full set of options."))
     <*> (InstallAssistant <$> flagYesNoAuto' "install-assistant" "Install associated DAML assistant version. Can be set to \"yes\" (always installs), \"no\" (never installs), or \"auto\" (installs if newer). Default is \"auto\"." idm)
     <*> iflag ActivateInstall "activate" hidden "Activate installed version of daml"
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
@@ -99,5 +99,3 @@ uninstallParser =
 readSdkVersion :: ReadM SdkVersion
 readSdkVersion =
     eitherReader (mapLeft displayException . parseVersion . pack)
-
-

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -89,6 +89,7 @@ installParser = InstallOptions
     <*> iflag ForceInstall "force" (short 'f') "Overwrite existing installation"
     <*> iflag QuietInstall "quiet" (short 'q') "Don't display installation messages"
     <*> fmap SetPath (flagYesNoAuto "set-path" True "Adjust PATH automatically. This option only has an effect on Windows." idm)
+    <*> fmap BashCompletions (flagYesNoAuto' "bash-completions" "Install bash completions for DAML assistant. Default is yes for linux and mac, no for windows." idm)
     where
         iflag p name opts desc = fmap p (switch (long name <> help desc <> opts))
 

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -15,6 +15,7 @@ import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Util
 import qualified DA.Daml.Assistant.Install.Github as Github
 import DA.Daml.Assistant.Install.Path
+import DA.Daml.Assistant.Install.BashCompletion
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
 import DA.Daml.Project.Util
@@ -190,6 +191,7 @@ activateDaml env@InstallEnv{..} targetPath = do
             else createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
 
     updatePath options (\s -> unlessQuiet env (output s)) damlBinaryTargetDir
+    installBashCompletions options damlPath (\s -> unlessQuiet env (output s))
 
 data WalkCallbacks = WalkCallbacks
     { walkOnFile :: FilePath -> IO ()

--- a/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
@@ -1,0 +1,55 @@
+
+-- | Installation of bash completions. These are installed in
+-- /usr/local/etc/bash_completion.d (on Mac) or /etc/bash_completion.d (on Linux).
+-- These are not installed on Windows by default.
+module DA.Daml.Assistant.Install.BashCompletion
+    ( installBashCompletions
+    ) where
+
+import DA.Daml.Assistant.Types
+
+import qualified Data.ByteString.Lazy as BSL
+import Control.Monad.Extra (when, unlessM)
+import System.Directory (doesDirectoryExist, doesFileExist)
+import System.FilePath ((</>))
+import System.Info.Extra (isMac, isWindows)
+import System.Process.Typed (proc, readProcessStdout_)
+
+installBashCompletions :: InstallOptions -> DamlPath -> (String -> IO ()) -> IO ()
+installBashCompletions options damlPath output =
+    when (shouldInstallBashCompletions options) $
+        doInstallBashCompletions damlPath output
+
+shouldInstallBashCompletions :: InstallOptions -> Bool
+shouldInstallBashCompletions options =
+    case iBashCompletions options of
+        BashCompletions Yes -> True
+        BashCompletions No -> False
+        BashCompletions Auto -> not isWindows
+
+doInstallBashCompletions :: DamlPath -> (String -> IO ()) -> IO ()
+doInstallBashCompletions damlPath output = do
+    dirExists <- doesDirectoryExist bashCompletionDir
+    if dirExists
+        then do
+            unlessM (doesFileExist bashCompletionScript) $ do
+                completionScript <- getCompletionScript damlPath
+                BSL.writeFile bashCompletionScript completionScript
+                output ("Bash completions for DAML assistant installed in " <> bashCompletionDir)
+        else output ("Bash completions for DAML assistant not installed: " <> bashCompletionDir <> " does not exist")
+
+getCompletionScript :: DamlPath -> IO BSL.ByteString
+getCompletionScript damlPath = do
+    let assistant = assistantPath damlPath
+    readProcessStdout_ (proc assistant ["--bash-completion-script", assistant])
+
+assistantPath :: DamlPath -> FilePath
+assistantPath (DamlPath p) = p </> "bin" </> "daml"
+
+bashCompletionDir :: FilePath
+bashCompletionDir
+    | isMac = "/usr/local/etc/bash_completion.d"
+    | otherwise = "/etc/bash_completion.d"
+
+bashCompletionScript :: FilePath
+bashCompletionScript = bashCompletionDir </> "daml"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
@@ -75,9 +75,9 @@ addCompletionHook scriptPath = do
 -- | Check the daml path is default. We don't want to install completions
 -- for non-standard paths by default.
 isDefaultDamlPath :: DamlPath -> IO Bool
-isDefaultDamlPath damlPath = do
-    rawDamlPath <- getAppUserDataDirectory "daml"
-    pure $ damlPath == DamlPath rawDamlPath
+isDefaultDamlPath (DamlPath damlPath) = do
+    rawDamlPath <- tryIO (getAppUserDataDirectory "daml")
+    pure $ Right damlPath == rawDamlPath
 
 newtype HookPath = HookPath FilePath
 newtype Hook = Hook { unHook :: String } deriving Eq

--- a/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
@@ -1,3 +1,5 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 -- | Installation of bash completions. These are installed in
 -- /usr/local/etc/bash_completion.d (on Mac) or

--- a/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
@@ -1,11 +1,9 @@
 -- Copyright (c) 2020 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
--- | Installation of bash completions. These are installed in
--- /usr/local/etc/bash_completion.d (on Mac) or
--- /etc/bash_completion.d (elsewhere). These are not installed on
--- Windows by default, and won't be reinstalled unless the user
--- asks by passing @--bash-completions=yes@ explicitly.
+-- | Installation of bash completions. The completion script is
+-- installed in @~/.daml/bash_completion.sh@ and a hook is added
+-- in @~/.bash_completion@ to invoke it if available.
 module DA.Daml.Assistant.Install.BashCompletion
     ( installBashCompletions
     ) where
@@ -13,50 +11,90 @@ module DA.Daml.Assistant.Install.BashCompletion
 import DA.Daml.Assistant.Types
 
 import qualified Data.ByteString.Lazy as BSL
-import Control.Monad.Extra (andM, whenM)
-import System.Directory (doesDirectoryExist, doesFileExist)
+import Control.Exception.Safe (catchIO)
+import Control.Monad.Extra (unless, andM, whenM)
+import System.Directory (getHomeDirectory, doesFileExist)
 import System.FilePath ((</>))
-import System.Info.Extra (isMac, isWindows)
+import System.Info.Extra (isWindows)
 import System.Process.Typed (proc, readProcessStdout_)
+import System.IO.Extra (readFileUTF8, writeFileUTF8)
 
+-- | Install bash completion script if we should.
 installBashCompletions :: InstallOptions -> DamlPath -> (String -> IO ()) -> IO ()
 installBashCompletions options damlPath output =
-    whenM (shouldInstallBashCompletions options) $
+    whenM (shouldInstallBashCompletions options damlPath) $
         doInstallBashCompletions damlPath output
 
-shouldInstallBashCompletions :: InstallOptions -> IO Bool
-shouldInstallBashCompletions options =
+-- | Should we install bash completions? By default, yes, but only if the
+-- we're not on Windows and the completion script hasn't yet been generated.
+shouldInstallBashCompletions :: InstallOptions -> DamlPath -> IO Bool
+shouldInstallBashCompletions options damlPath =
     case iBashCompletions options of
         BashCompletions Yes -> pure True
         BashCompletions No -> pure False
         BashCompletions Auto -> andM
             [ pure (not isWindows)
-            , doesDirectoryExist bashCompletionDirPath
-            , not <$> doesFileExist bashCompletionScriptPath
+            , not <$> doesFileExist (completionScriptPath damlPath)
             ]
 
+-- | Generate the bash completion script, and add a hook.
 doInstallBashCompletions :: DamlPath -> (String -> IO ()) -> IO ()
 doInstallBashCompletions damlPath output = do
-    dirExists <- doesDirectoryExist bashCompletionDirPath
-    if dirExists
-        then do
-            completionScript <- getCompletionScript damlPath
-            BSL.writeFile bashCompletionScriptPath completionScript
-            output "Bash completions installed for DAML assistant."
-        else output ("Bash completions not installed for DAML assistant: " <> bashCompletionDirPath <> " does not exist")
+    let scriptPath = completionScriptPath damlPath
+    script <- getCompletionScript damlPath
+    BSL.writeFile scriptPath script
+    addCompletionHook scriptPath
+    output "Bash completions installed for DAML assistant."
 
+-- | Read the bash completion script from optparse-applicative's
+-- built-in @--bash-completion-script@ routine. Please read
+-- https://github.com/pcapriotti/optparse-applicative/wiki/Bash-Completion
+-- for more details. Note that the bash completion script doesn't
+-- in general contain any daml-assistant specific information, it's only
+-- specific to the path, so we don't need to regenerate it every version.
 getCompletionScript :: DamlPath -> IO BSL.ByteString
 getCompletionScript damlPath = do
     let assistant = assistantPath damlPath
     readProcessStdout_ (proc assistant ["--bash-completion-script", assistant])
 
+-- | Add a completion hook in ~/.bash_completion
+-- Does nothing if the hook is already there
+addCompletionHook :: FilePath -> IO ()
+addCompletionHook scriptPath = do
+    let newHook = makeHook scriptPath
+    hookPath <- getHookPath
+    hooks <- readHooks hookPath
+    unless (newHook `elem` hooks) $ do
+        writeHooks hookPath (hooks ++ [newHook])
+
+newtype HookPath = HookPath FilePath
+newtype Hook = Hook { unHook :: String } deriving Eq
+
+makeHook :: FilePath -> Hook
+makeHook scriptPath = Hook $ concat
+    [ "[ -f "
+    , show scriptPath
+    , " ] && source "
+    , show scriptPath
+    ]
+
+getHookPath :: IO HookPath
+getHookPath = do
+    home <- getHomeDirectory
+    pure (HookPath $ home </> ".bash_completion")
+
+readHooks :: HookPath -> IO [Hook]
+readHooks (HookPath p) = catchIO
+    (map Hook . lines <$> readFileUTF8 p)
+    (const $ pure [])
+
+writeHooks :: HookPath -> [Hook] -> IO ()
+writeHooks (HookPath p) = writeFileUTF8 p . unlines . map unHook
+
+----
+
 assistantPath :: DamlPath -> FilePath
 assistantPath (DamlPath p) = p </> "bin" </> "daml"
 
-bashCompletionDirPath :: FilePath
-bashCompletionDirPath
-    | isMac = "/usr/local/etc/bash_completion.d"
-    | otherwise = "/etc/bash_completion.d"
-
-bashCompletionScriptPath :: FilePath
-bashCompletionScriptPath = bashCompletionDirPath </> "daml"
+completionScriptPath :: DamlPath -> FilePath
+completionScriptPath (DamlPath p) = p </> "bash_completions.sh"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/BashCompletion.hs
@@ -3,7 +3,7 @@
 -- /usr/local/etc/bash_completion.d (on Mac) or
 -- /etc/bash_completion.d (elsewhere). These are not installed on
 -- Windows by default, and won't be reinstalled unless the user
--- asks by passing @--bash-completions=yes@ specifically.
+-- asks by passing @--bash-completions=yes@ explicitly.
 module DA.Daml.Assistant.Install.BashCompletion
     ( installBashCompletions
     ) where
@@ -29,19 +29,19 @@ shouldInstallBashCompletions options =
         BashCompletions No -> pure False
         BashCompletions Auto -> andM
             [ pure (not isWindows)
-            , doesDirectoryExist bashCompletionDir
-            , not <$> doesFileExist bashCompletionScript
+            , doesDirectoryExist bashCompletionDirPath
+            , not <$> doesFileExist bashCompletionScriptPath
             ]
 
 doInstallBashCompletions :: DamlPath -> (String -> IO ()) -> IO ()
 doInstallBashCompletions damlPath output = do
-    dirExists <- doesDirectoryExist bashCompletionDir
+    dirExists <- doesDirectoryExist bashCompletionDirPath
     if dirExists
         then do
             completionScript <- getCompletionScript damlPath
-            BSL.writeFile bashCompletionScript completionScript
+            BSL.writeFile bashCompletionScriptPath completionScript
             output "Bash completions installed for DAML assistant."
-        else output ("Bash completions not installed for DAML assistant: " <> bashCompletionDir <> " does not exist")
+        else output ("Bash completions not installed for DAML assistant: " <> bashCompletionDirPath <> " does not exist")
 
 getCompletionScript :: DamlPath -> IO BSL.ByteString
 getCompletionScript damlPath = do
@@ -51,10 +51,10 @@ getCompletionScript damlPath = do
 assistantPath :: DamlPath -> FilePath
 assistantPath (DamlPath p) = p </> "bin" </> "daml"
 
-bashCompletionDir :: FilePath
-bashCompletionDir
+bashCompletionDirPath :: FilePath
+bashCompletionDirPath
     | isMac = "/usr/local/etc/bash_completion.d"
     | otherwise = "/etc/bash_completion.d"
 
-bashCompletionScript :: FilePath
-bashCompletionScript = bashCompletionDir </> "daml"
+bashCompletionScriptPath :: FilePath
+bashCompletionScriptPath = bashCompletionDirPath </> "daml"

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -88,6 +88,7 @@ data InstallOptions = InstallOptions
     , iForce :: ForceInstall -- ^ force reinstall if already installed
     , iQuiet :: QuietInstall -- ^ don't print messages
     , iSetPath :: SetPath -- ^ set the user's PATH (on Windows)
+    , iBashCompletions :: BashCompletions -- ^ install bash completions for the daml assistant
     } deriving (Eq, Show)
 
 -- | An install URL is a fully qualified HTTP[S] URL to an SDK release tarball. For example:
@@ -102,5 +103,4 @@ newtype QuietInstall = QuietInstall { unQuietInstall :: Bool } deriving (Eq, Sho
 newtype ActivateInstall = ActivateInstall { unActivateInstall :: Bool } deriving (Eq, Show)
 newtype SetPath = SetPath Bool deriving (Eq, Show)
 newtype InstallAssistant = InstallAssistant { unwrapInstallAssistant :: YesNoAuto } deriving (Eq, Show)
-
-
+newtype BashCompletions = BashCompletions { unwrapBashCompletions :: YesNoAuto } deriving (Eq, Show)

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -378,6 +378,7 @@ testInstall = Tasty.testGroup "DA.Daml.Assistant.Install"
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     , iSetPath = SetPath False
+                    , iBashCompletions = BashCompletions No
                     }
 
             setCurrentDirectory base
@@ -411,6 +412,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                           , iQuiet = QuietInstall True
                           , iForce = ForceInstall False
                           , iSetPath = SetPath False
+                          , iBashCompletions = BashCompletions No
                           }
 
                   setCurrentDirectory base
@@ -439,6 +441,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     , iSetPath = SetPath False
+                    , iBashCompletions = BashCompletions No
                     }
 
             setCurrentDirectory base
@@ -467,6 +470,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     , iSetPath = SetPath False
+                    , iBashCompletions = BashCompletions No
                     }
 
             setCurrentDirectory base

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -191,5 +191,3 @@ The ``daml`` assistant comes with support for ``bash`` completions. These will b
 
 You can override whether bash completions are installed for ``daml`` by
 passing ``--bash-completions=yes`` or ``--bash-completions=no`` to ``daml install``.
-
-In the future, ``zsh`` and ``fish`` terminal completions may be implemented.

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -184,3 +184,12 @@ Rarely, you might need to install an SDK release from a downloaded SDK release t
 
   daml install path-to-tarball.tar.gz
 
+Terminal Command Completion
+***************************
+
+The ``daml`` assistant comes with support for ``bash`` completions. These will be installed automatically on Linux and Mac when you install or upgrade the DAML assistant. If you use the ``bash`` shell, and your ``bash`` supports completions, you can use the TAB key to complete many ``daml`` commands, such as ``daml install`` and ``daml version``.
+
+You can override whether bash completions are installed for ``daml`` by
+passing ``--bash-completions=yes`` or ``--bash-completions=no`` to ``daml install``.
+
+In the future, ``zsh`` and ``fish`` terminal completions may be implemented.

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -29,7 +29,7 @@ determineAuto b = \case
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    option reader (long flagName <> value Auto <> help helpText <> mods)
+    option reader (long flagName <> value Auto <> help helpText <> completeWith ["yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes
             "no" -> Right No
@@ -43,4 +43,3 @@ flagYesNoAuto flagName defaultValue helpText mods =
     determineAuto defaultValue <$> flagYesNoAuto' flagName (helpText <> commonHelp) mods
     where
         commonHelp = " Can be set to \"yes\", \"no\" or \"auto\" to select the default (" <> show defaultValue <> ")"
-


### PR DESCRIPTION
This PR implements bash completion for the daml assistant. Most of this was already available out of the box via optparse-applicative's `--bash-completion-script` command, so this PR is mostly just concerned with installing that script in a standard location, if possible.

The command-line completion knows all the commands, and knows all the options for built-in commands (like `daml version` and `daml install`), but it cannot give any information for commands that are distributed with the SDK (like `daml damlc` or `daml sandbox`) because it doesn't know anything about their arguments. But at least the completion still tells you which commands are available.

Fixes #3875 for bash at least.
