### PR TITLE
ECDA512 algorithm support

### DIFF
--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -118,7 +118,7 @@ where
 The ``public`` claim is implicitly held by anyone bearing a valid JWT (even without being an admin or being able to act or read on behalf of any party).
 
 Generating JSON Web Tokens (JWT)
-=====================
+================================
 
 To generate tokens for testing purposes, use the `jtw.io <https://jwt.io/>`__ web site.
 

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -74,6 +74,11 @@ use one of the following command line options:
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certicates (binary files) are supported.
 
+- ``--auth-jwt-ec-crt=<filename>``.
+  The sandbox will expect all tokens to be signed with ECDSA512 with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certicates (binary files) are supported.
+
 - ``--auth-jwt-rs256-jwks=<url>``.
   The sandbox will expect all tokens to be signed with RSA256 with the public key loaded from the given `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
 
@@ -112,10 +117,14 @@ where
 
 The ``public`` claim is implicitly held by anyone bearing a valid JWT (even without being an admin or being able to act or read on behalf of any party).
 
-Generating tokens
-=================
+Generating JWT tokens
+=====================
 
 To generate tokens for testing purposes, use the `jtw.io <https://jwt.io/>`__ web site.
+
+
+Generating RSA keys
+===================
 
 To generate RSA keys for testing purposes, use the following command
 
@@ -127,6 +136,21 @@ which generates the following files:
 
 - ``sandbox.key``: the private key in PEM/DER/PKCS#1 format
 - ``sandbox.crt``: a self-signed certificate containing the public key, in PEM/DER/X.509 Certificate format
+
+Generating EC keys
+==================
+
+To generate EC (elliptic curve) keys for testing purposes, use the following command
+
+.. code-block:: none
+
+  openssl req -x509 -nodes -days 3650 -newkey ec:<(openssl ecparam -name prime256v1) -keyout ecdsa.key -out ecdsa.crt
+
+which generates the following files:
+
+- ``ecdsa.key``: the private key in PEM/DER/PKCS#1 format
+- ``ecdsa.crt``: a self-signed certificate containing the public key, in PEM/DER/X.509 Certificate format
+
 
 Command-line reference
 **********************

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -117,7 +117,7 @@ where
 
 The ``public`` claim is implicitly held by anyone bearing a valid JWT (even without being an admin or being able to act or read on behalf of any party).
 
-Generating JWT tokens
+Generating JSON Web Tokens (JWT)
 =====================
 
 To generate tokens for testing purposes, use the `jtw.io <https://jwt.io/>`__ web site.

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtSigner.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtSigner.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.jwt
 
 import java.nio.charset.Charset
-import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.{ECPrivateKey, RSAPrivateKey}
 
 import com.auth0.jwt.algorithms.Algorithm
 import scalaz.syntax.traverse._
@@ -43,6 +43,24 @@ object JwtSigner {
 
         signature <- \/.fromTryCatchNonFatal(algorithm.sign(base64Jwt.header, base64Jwt.payload))
           .leftMap(e => Error(Symbol("RSA256.sign"), e.getMessage))
+
+        base64Signature <- base64Encode(signature)
+
+      } yield
+        domain.Jwt(
+          s"${str(base64Jwt.header): String}.${str(base64Jwt.payload)}.${str(base64Signature): String}")
+  }
+
+  object ECDA512 {
+    def sign(jwt: domain.DecodedJwt[String], privateKey: ECPrivateKey): Error \/ domain.Jwt =
+      for {
+        base64Jwt <- base64Encode(jwt)
+
+        algorithm <- \/.fromTryCatchNonFatal(Algorithm.ECDSA512(null, privateKey))
+          .leftMap(e => Error(Symbol("ECDA512.sign"), e.getMessage))
+
+        signature <- \/.fromTryCatchNonFatal(algorithm.sign(base64Jwt.header, base64Jwt.payload))
+          .leftMap(e => Error(Symbol("ECDA512.sign"), e.getMessage))
 
         base64Signature <- base64Encode(signature)
 

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
@@ -4,11 +4,11 @@
 package com.digitalasset.jwt
 
 import java.io.File
-import java.security.interfaces.RSAPublicKey
+import java.security.interfaces.{ECPublicKey, RSAPublicKey}
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
-import com.auth0.jwt.interfaces.RSAKeyProvider
+import com.auth0.jwt.interfaces.{ECDSAKeyProvider, RSAKeyProvider}
 import com.digitalasset.jwt.JwtVerifier.Error
 import com.typesafe.scalalogging.StrictLogging
 import scalaz.{Show, \/}
@@ -58,6 +58,22 @@ object HMAC256Verifier extends StrictLogging {
       val verifier = JWT.require(algorithm).build()
       new JwtVerifier(verifier)
     }.leftMap(e => Error('HMAC256, e.getMessage))
+}
+
+// ECDA512 validator factory
+object ECDA512Verifier extends StrictLogging {
+  def apply(keyProvider: ECDSAKeyProvider): Error \/ JwtVerifier =
+    \/.fromTryCatchNonFatal{
+      val algorithm = Algorithm.ECDSA384(keyProvider)
+      val verifier = JWT.require(algorithm).build()
+      new JwtVerifier(verifier)
+    }.leftMap(e => Error('ECDA512, e.getMessage))
+  def apply(publicKey: ECPublicKey): Error \/ JwtVerifier =
+    \/.fromTryCatchNonFatal{
+      val algorithm = Algorithm.ECDSA384(publicKey, null)
+      val verifier = JWT.require(algorithm).build()
+      new JwtVerifier(verifier)
+    }.leftMap(e => Error('ECDA512, e.getMessage))
 }
 
 // RSA256 validator factory

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/JwtVerifier.scala
@@ -64,13 +64,13 @@ object HMAC256Verifier extends StrictLogging {
 object ECDA512Verifier extends StrictLogging {
   def apply(keyProvider: ECDSAKeyProvider): Error \/ JwtVerifier =
     \/.fromTryCatchNonFatal{
-      val algorithm = Algorithm.ECDSA384(keyProvider)
+      val algorithm = Algorithm.ECDSA512(keyProvider)
       val verifier = JWT.require(algorithm).build()
       new JwtVerifier(verifier)
     }.leftMap(e => Error('ECDA512, e.getMessage))
   def apply(publicKey: ECPublicKey): Error \/ JwtVerifier =
     \/.fromTryCatchNonFatal{
-      val algorithm = Algorithm.ECDSA384(publicKey, null)
+      val algorithm = Algorithm.ECDSA512(publicKey, null)
       val verifier = JWT.require(algorithm).build()
       new JwtVerifier(verifier)
     }.leftMap(e => Error('ECDA512, e.getMessage))

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
@@ -43,9 +43,9 @@ object KeyUtils {
   }
 
   /**
-   * Reads an EC public key from a X509 encoded file.
-   * These usually have the .crt file extension.
-   */
+    * Reads an EC public key from a X509 encoded file.
+    * These usually have the .crt file extension.
+    */
   def readECPublicKeyFromCrt(file: File): Try[ECPublicKey] = {
     bracket(Try(new FileInputStream(file)))(is => Try(is.close())).flatMap { istream =>
       Try(

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/KeyUtils.scala
@@ -7,7 +7,7 @@ import java.io.{File, FileInputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.cert.CertificateFactory
-import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.security.interfaces.{ECPublicKey, RSAPrivateKey, RSAPublicKey}
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.KeyFactory
 
@@ -39,6 +39,21 @@ object KeyUtils {
           .generateCertificate(istream)
           .getPublicKey
           .asInstanceOf[RSAPublicKey])
+    }
+  }
+
+  /**
+   * Reads an EC public key from a X509 encoded file.
+   * These usually have the .crt file extension.
+   */
+  def readECPublicKeyFromCrt(file: File): Try[ECPublicKey] = {
+    bracket(Try(new FileInputStream(file)))(is => Try(is.close())).flatMap { istream =>
+      Try(
+        CertificateFactory
+          .getInstance("X.509")
+          .generateCertificate(istream)
+          .getPublicKey
+          .asInstanceOf[ECPublicKey])
     }
   }
 

--- a/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/SignatureSpec.scala
+++ b/ledger-service/jwt/src/test/scala/com/digitalasset/jwt/SignatureSpec.scala
@@ -133,7 +133,6 @@ class SignatureSpec extends WordSpec with Matchers {
             .sign(jwt, privateKey)
             .leftMap(e => fail(e.shows))
 
-
           verifier <- ECDA512Verifier(publicKey)
             .leftMap(e => fail(e.shows))
           verifiedJwt <- verifier

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 
 import ch.qos.logback.classic.Level
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.jwt.{HMAC256Verifier, JwksVerifier, RSA256Verifier}
+import com.digitalasset.jwt.{ECDA512Verifier, HMAC256Verifier, JwksVerifier, RSA256Verifier}
 import com.digitalasset.ledger.api.auth.AuthServiceJWT
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.tls.TlsConfiguration
@@ -167,6 +167,12 @@ object Cli {
       .validate(v => Either.cond(v.length > 0, (), "Certificate file path must be a non-empty string"))
       .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given X509 certificate file (.crt)")
       .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(RSA256Verifier.fromCrtFile(path).valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
+
+    opt[String]("auth-jwt-ec-crt")
+      .optional()
+      .validate(v => Either.cond(v.length > 0, (), "Certificate file path must be a non-empty string"))
+      .text("Enables JWT-based authorization, where the JWT is signed by ECDA512 with a public key loaded from the given X509 certificate file (.crt)")
+      .action( (path, config) => config.copy(authService = Some(AuthServiceJWT(ECDA512Verifier.fromCrtFile(path).valueOr(err => sys.error(s"Failed to create ECDA512 verifier: $err"))))))
 
     opt[String]("auth-jwt-rs256-jwks")
       .optional()


### PR DESCRIPTION
Several DAML-on-x implementations (mostly notably daml-on-sawtooth) uses elliptic curve (EC) as the algorithm of choice for private keys and for the JWT tokens that are verified.

To avoid code duplication in these implementations, this PR provides elliptic curve ECDA512 algorithm support within AuthServiceJWT

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.