### PR TITLE
Type checking DAML-LF type synonyms

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -239,6 +239,7 @@ da_haskell_repl(
     visibility = ["//visibility:public"],
     deps = [
         ":damlc",
+        "//compiler/daml-lf-ast:tests",
         "//compiler/damlc/stable-packages:generate-stable-package",
         "//compiler/damlc/tests:generate-simple-dalf",
         "//daml-assistant:daml",

--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -37,6 +37,7 @@ da_haskell_test(
     hackage_deps = [
         "base",
         "containers",
+        "extra",
         "tasty",
         "tasty-hunit",
     ],
@@ -45,6 +46,7 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         ":daml-lf-ast",
+        "//compiler/daml-lf-tools",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -171,9 +171,9 @@ data Type
   -- | Reference to a type variable.
   = TVar        !TypeVarName
   -- | Reference to a type constructor.
-  | TSyn        !(Qualified TypeSynName)
-  -- | Application of a type function to a type.
   | TCon        !(Qualified TypeConName)
+  -- | Application of a type synonym to its arguments.
+  | TSynApp     !(Qualified TypeSynName) ![Type]
   -- | Application of a type function to a type.
   | TApp        !Type !Type
   -- | Builtin type.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -172,7 +172,7 @@ data Type
   = TVar        !TypeVarName
   -- | Reference to a type constructor.
   | TCon        !(Qualified TypeConName)
-  -- | Application of a type synonym to its arguments.
+  -- | Fully-applied type synonym.
   | TSynApp     !(Qualified TypeSynName) ![Type]
   -- | Application of a type function to a type.
   | TApp        !Type !Type

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -97,8 +97,8 @@ builtinType :: Traversal' Type BuiltinType
 builtinType f =
     \case
         TVar n -> pure $ TVar n
-        TSyn tySyn -> pure $ TSyn tySyn
         TCon tyCon -> pure $ TCon tyCon
+        TSynApp syn args -> TSynApp syn <$> traverse (builtinType f) args
         TApp s t -> TApp <$> builtinType f s <*> builtinType f t
         TBuiltin x -> TBuiltin <$> f x
         TForall b body -> TForall b <$> builtinType f body

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -158,8 +158,9 @@ prettyStruct lvl sept fields =
 instance Pretty Type where
   pPrintPrec lvl prec = \case
     TVar v -> pretty v
-    TSyn s -> pretty s
     TCon c -> pretty c
+    TSynApp s args ->
+      pretty s <-> hsep [pPrintPrec lvl (succ precTApp) arg | arg <- args ]
     TApp (TApp (TBuiltin BTArrow) tx) ty ->
       maybeParens (prec > precTFun)
         (pPrintPrec lvl (succ precTFun) tx <-> prettyFunArrow <-> pPrintPrec lvl precTFun ty)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -26,8 +26,8 @@ freeVars e = go Set.empty e Set.empty
         TVar v
             | v `Set.member` boundVars -> acc
             | otherwise -> Set.insert v acc
-        TSyn _ -> acc
         TCon _ -> acc
+        TSynApp _ args -> foldl' (\acc t -> go boundVars t acc) acc args
         TApp s1 s2 -> go boundVars s1 $ go boundVars s2 acc
         TBuiltin _ -> acc
         TForall (v, _k) s -> go (Set.insert v boundVars) s acc
@@ -96,8 +96,8 @@ substitute subst = go (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.emp
       TVar v
         | Just t <- Map.lookup v subst0 -> t
         | otherwise                     -> TVar v
-      TSyn s -> TSyn s
       TCon c -> TCon c
+      TSynApp s args -> TSynApp s (map go0 args)
       TApp t1 t2 -> TApp (go0 t1) (go0 t2)
       TBuiltin b -> TBuiltin b
       TForall (v0, k) t

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -13,6 +13,7 @@ module DA.Daml.LF.Ast.World(
     ExternalPackage(..),
     LookupError,
     lookupTemplate,
+    lookupTypeSyn,
     lookupDataType,
     lookupChoice,
     lookupValue,
@@ -84,6 +85,7 @@ extendWorldSelf = over (worldSelf . _packageModules) . NM.insert
 data LookupError
   = LEPackage !PackageId
   | LEModule !PackageRef !ModuleName
+  | LETypeSyn !(Qualified TypeSynName)
   | LEDataType !(Qualified TypeConName)
   | LEValue !(Qualified ExprValName)
   | LETemplate !(Qualified TypeConName)
@@ -115,6 +117,9 @@ lookupDefinition selDefs mkError ref world = do
     Nothing -> Left (mkError ref)
     Just def -> pure def
 
+lookupTypeSyn :: Qualified TypeSynName -> World -> Either LookupError DefTypeSyn
+lookupTypeSyn = lookupDefinition moduleSynonyms LETypeSyn
+
 lookupDataType :: Qualified TypeConName -> World -> Either LookupError DefDataType
 lookupDataType = lookupDefinition moduleDataTypes LEDataType
 
@@ -136,6 +141,7 @@ instance Pretty LookupError where
     LEPackage pkgId -> "unknown package:" <-> pretty pkgId
     LEModule PRSelf modName -> "unknown module:" <-> pretty modName
     LEModule (PRImport pkgId) modName -> "unknown module:" <-> pretty pkgId <> ":" <> pretty modName
+    LETypeSyn synRef -> "unknown type synonym:" <-> pretty synRef
     LEDataType datRef -> "unknown data type:" <-> pretty datRef
     LEValue valRef-> "unknown value:" <-> pretty valRef
     LETemplate tplRef -> "unknown template:" <-> pretty tplRef

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -141,8 +141,7 @@ typeSynTests =
     , (makeSynDef myBad [(f,KStar `KArrow` KStar)] (TVar f), "kind mismatch")
     , (makeSynDef myBad [(x,KStar)] (TApp (TVar x) TInt64), "expected higher kinded type")
     , (makeSynDef myBad [(x,KStar),(x,KStar)] (TVar x), "duplicate type parameter: x")
-    , (makeSynDef myBad [] (TSynApp (q missing) []), "")
-    -- TODO This example should be rejected
+    , (makeSynDef myBad [] (TSynApp (q missing) []), "unknown type synonym: M:Missing")
     ]
 
   x,y,f :: TypeVarName

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -7,7 +7,7 @@ module DA.Daml.LF.Ast.Tests
 
 import Control.Monad (unless)
 import Data.Foldable
-import Data.List (isInfixOf,intercalate)
+import Data.List (isInfixOf)
 import Data.List.Extra (trim)
 import qualified Data.Map.Strict as Map
 import qualified Data.NameMap as NM
@@ -95,8 +95,8 @@ typeSynTests =
     , (TSynApp (q myIdentity) [TSynApp (q myInt) []], TInt64)
     , (TSynApp (q myIdentity) [TSynApp (q myIdentity) [TParty]], TParty)
     , (TSynApp (q myPairXY) [TDate,TParty], mkPair TDate TParty)
-    , (TSynApp (q myHigh) [TBuiltin BTList], (TList TInt64))
-    , (TSynApp (q myHigh2) [TBuiltin BTArrow,TParty], (TParty :-> TParty))
+    , (TSynApp (q myHigh) [TBuiltin BTList], TList TInt64)
+    , (TSynApp (q myHigh2) [TBuiltin BTArrow,TParty], TParty :-> TParty)
     ]
 
   sadExamples :: [(Type,Type,String)]
@@ -114,11 +114,11 @@ typeSynTests =
     , (TSynApp (q myPairXY) [TDate], TParty, "wrong arity in type synonym application")
     , (TSynApp (q myPairXY) [TDate], TParty, "expected: 2, found: 1")
     , (TSynApp (q myPairXX) [TDate,TParty], TParty, "wrong arity in type synonym application")
-    , (TSynApp (q myIdentity) [TBuiltin BTList], (TList TInt64),"kind mismatch")
-    , (TSynApp (q myHigh) [TBuiltin BTList], (TList TParty), "type mismatch")
-    , (TSynApp (q myHigh) [TBuiltin BTArrow], (TList TInt64),"kind mismatch")
-    , (TSynApp (q myHigh) [TInt64], (TList TInt64),"kind mismatch")
-    , (TSynApp (q myHigh2) [TBuiltin BTList,TParty], (TParty :-> TParty), "kind mismatch")
+    , (TSynApp (q myIdentity) [TBuiltin BTList], TList TInt64,"kind mismatch")
+    , (TSynApp (q myHigh) [TBuiltin BTList], TList TParty, "type mismatch")
+    , (TSynApp (q myHigh) [TBuiltin BTArrow], TList TInt64,"kind mismatch")
+    , (TSynApp (q myHigh) [TInt64], TList TInt64,"kind mismatch")
+    , (TSynApp (q myHigh2) [TBuiltin BTList,TParty], TParty :-> TParty, "kind mismatch")
     ]
 
   goodDefs :: [DefTypeSyn]
@@ -196,7 +196,7 @@ typeSynTests =
       Left s -> assertStringContains s (Fragment frag)
       Right () -> assertFailure "expected type error, but got none"
     where
-      looseNewlines = intercalate " " . map trim . lines
+      looseNewlines = unwords . map trim . lines
 
   makeModuleToTestTypeSyns :: Type -> Type -> Module
   makeModuleToTestTypeSyns ty1 ty2 = do

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -141,6 +141,8 @@ typeSynTests =
     , (makeSynDef myBad [(f,KStar `KArrow` KStar)] (TVar f), "kind mismatch")
     , (makeSynDef myBad [(x,KStar)] (TApp (TVar x) TInt64), "expected higher kinded type")
     , (makeSynDef myBad [(x,KStar),(x,KStar)] (TVar x), "duplicate type parameter: x")
+    , (makeSynDef myBad [] (TSynApp (q missing) []), "")
+    -- TODO This example should be rejected
     ]
 
   x,y,f :: TypeVarName

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -5,8 +5,12 @@ module DA.Daml.LF.Ast.Tests
     ( main
     ) where
 
+import Control.Monad (unless)
 import Data.Foldable
+import Data.List (isInfixOf,intercalate)
+import Data.List.Extra (trim)
 import qualified Data.Map.Strict as Map
+import qualified Data.NameMap as NM
 import Text.Read
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -14,11 +18,17 @@ import Test.Tasty.HUnit
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.Numeric
 import DA.Daml.LF.Ast.Type
+import DA.Daml.LF.Ast.Util
+import DA.Daml.LF.Ast.Version
+import DA.Daml.LF.Ast.World (initWorld)
+import DA.Daml.LF.TypeChecker (checkModule)
+import DA.Pretty (renderPretty)
 
 main :: IO ()
 main = defaultMain $ testGroup "DA.Daml.LF.Ast"
     [ numericTests
     , substitutionTests
+    , typeSynTests
     ]
 
 numericExamples :: [(String, Numeric)]
@@ -59,3 +69,166 @@ substitutionTests = testGroup "substitution"
     beta11 = TypeVarName "beta11"
     vBeta1 = TVar beta1
     vBeta11 = TVar beta11
+
+
+typeSynTests :: TestTree
+typeSynTests =
+  testGroup "type synonyms"
+  [ testGroup "happy" (map mkHappyTestcase happyExamples)
+  , testGroup "sad" (map mkSadTestcase sadExamples)
+  , testGroup "bad" (map mkBadTestcase badDefs)
+  ] where
+
+  happyExamples :: [(Type,Type)]
+  happyExamples =
+    [ (TInt64, TInt64)
+    , (TParty, TParty)
+    , (TSynApp (q myInt) [], TInt64)
+    , (TSynApp (q myMyInt) [], TInt64)
+    , (TSynApp (q myMyInt) [], TSynApp (q myMyInt) [])
+    , (TSynApp (q myPairIP) [], mkPair TInt64 TParty)
+    , (TSynApp (q myPairIP) [], mkPair (TSynApp (q myMyInt) []) TParty)
+    , (TSynApp (q myIdentity) [TDate], TDate)
+    , (TSynApp (q myPairXX) [TDate], mkPair TDate TDate)
+    , (TSynApp (q myPairXI) [TDate], mkPair TDate TInt64)
+    , (TSynApp (q myPairXI) [TInt64], TSynApp (q myPairXX) [TInt64])
+    , (TSynApp (q myIdentity) [TSynApp (q myInt) []], TInt64)
+    , (TSynApp (q myIdentity) [TSynApp (q myIdentity) [TParty]], TParty)
+    , (TSynApp (q myPairXY) [TDate,TParty], mkPair TDate TParty)
+    , (TSynApp (q myHigh) [TBuiltin BTList], (TList TInt64))
+    , (TSynApp (q myHigh2) [TBuiltin BTArrow,TParty], (TParty :-> TParty))
+    ]
+
+  sadExamples :: [(Type,Type,String)]
+  sadExamples =
+    [ (TInt64, TParty, "type mismatch")
+    , (TParty, TInt64, "type mismatch")
+    , (TParty `TApp` TInt64, TParty, "expected higher kinded type")
+    , (TParty, TParty `TApp` TInt64, "expected higher kinded type")
+    , (TSynApp (q missing) [], TInt64, "unknown type synonym: M:Missing")
+    , (TSynApp (q myInt) [], TParty, "type mismatch")
+    , (TSynApp (q myPairIP) [], mkPair TParty TInt64, "type mismatch")
+    , (TSynApp (q myIdentity) [], TParty, "wrong arity in type synonym application")
+    , (TSynApp (q myIdentity) [TDate], TParty, "type mismatch")
+    , (TSynApp (q myPairXI) [TDate], TSynApp (q myPairXX) [TDate], "type mismatch")
+    , (TSynApp (q myPairXY) [TDate], TParty, "wrong arity in type synonym application")
+    , (TSynApp (q myPairXY) [TDate], TParty, "expected: 2, found: 1")
+    , (TSynApp (q myPairXX) [TDate,TParty], TParty, "wrong arity in type synonym application")
+    , (TSynApp (q myIdentity) [TBuiltin BTList], (TList TInt64),"kind mismatch")
+    , (TSynApp (q myHigh) [TBuiltin BTList], (TList TParty), "type mismatch")
+    , (TSynApp (q myHigh) [TBuiltin BTArrow], (TList TInt64),"kind mismatch")
+    , (TSynApp (q myHigh) [TInt64], (TList TInt64),"kind mismatch")
+    , (TSynApp (q myHigh2) [TBuiltin BTList,TParty], (TParty :-> TParty), "kind mismatch")
+    ]
+
+  goodDefs :: [DefTypeSyn]
+  goodDefs =
+    [ makeSynDef myInt [] TInt64
+    , makeSynDef myMyInt [] (TSynApp (q myInt) [])
+    , makeSynDef myPairIP [] (mkPair TInt64 TParty)
+    , makeSynDef myIdentity [(x,KStar)] (TVar x)
+    , makeSynDef myPairXX [(x,KStar)] (mkPair (TVar x) (TVar x))
+    , makeSynDef myPairXI [(x,KStar)] (mkPair (TVar x) TInt64)
+    , makeSynDef myPairXY [(x,KStar),(y,KStar)] (mkPair (TVar x) (TVar y))
+    , makeSynDef myHigh [(f,KStar `KArrow` KStar)] (TApp (TVar f) TInt64)
+    , makeSynDef myHigh2 [(f,KStar `KArrow` KStar `KArrow` KStar),(x,KStar)] (TVar f `TApp` TVar x `TApp` TVar x)
+    ]
+
+  badDefs :: [(DefTypeSyn,String)]
+  badDefs =
+    [ (makeSynDef myBad [] (TVar x), "unknown type variable: x")
+    , (makeSynDef myBad [] (TBuiltin BTArrow), "kind mismatch")
+    , (makeSynDef myBad [(f,KStar `KArrow` KStar)] (TVar f), "kind mismatch")
+    , (makeSynDef myBad [(x,KStar)] (TApp (TVar x) TInt64), "expected higher kinded type")
+    , (makeSynDef myBad [(x,KStar),(x,KStar)] (TVar x), "duplicate type parameter: x")
+    ]
+
+  x,y,f :: TypeVarName
+  x = TypeVarName "x"
+  y = TypeVarName "y"
+  f = TypeVarName "f"
+
+  moduleName :: ModuleName
+  moduleName = ModuleName ["M"]
+
+  q :: a -> Qualified a
+  q = Qualified PRSelf moduleName
+
+  missing = TypeSynName ["Missing"]
+  myInt = TypeSynName ["MyInt"]
+  myMyInt = TypeSynName ["MyMyInt"]
+  myPairIP = TypeSynName ["MyPairIP"]
+  myIdentity = TypeSynName ["MyIdentity"]
+  myPairXX = TypeSynName ["MyPairXX"]
+  myPairXI = TypeSynName ["MyPairXI"]
+  myPairXY = TypeSynName ["MyPairXY"]
+  myHigh = TypeSynName ["MyHigh"]
+  myHigh2 = TypeSynName ["MyHigh2"]
+  myBad = TypeSynName ["MyBad"]
+
+  mkPair ty1 ty2 = TStruct [(FieldName "fst",ty1),(FieldName "snd",ty2)]
+
+  makeSynDef :: TypeSynName -> [(TypeVarName,Kind)] -> Type -> DefTypeSyn
+  makeSynDef synName synParams synType = do
+    DefTypeSyn { synLocation = Nothing, synName, synParams, synType}
+
+  mkHappyTestcase :: (Type,Type) -> TestTree
+  mkHappyTestcase (ty1,ty2) = do
+    let name = renderPretty ty1 <> " == " <> renderPretty ty2
+    let mod = makeModuleToTestTypeSyns ty1 ty2
+    testCase name $ case typeCheck mod of
+      Left s -> assertFailure $ "unexpected type error: " <> s
+      Right () -> return ()
+
+  mkSadTestcase :: (Type,Type,String) -> TestTree
+  mkSadTestcase (ty1,ty2,frag) = do
+    let name = renderPretty ty1 <> " =/= " <> renderPretty ty2
+    let mod = makeModuleToTestTypeSyns ty1 ty2
+    testCase name $ case typeCheck mod of
+      Left s -> assertStringContains s (Fragment frag)
+      Right () -> assertFailure "expected type error, but got none"
+
+  mkBadTestcase :: (DefTypeSyn,String) -> TestTree
+  mkBadTestcase (def,frag) = do
+    let name = looseNewlines $ renderPretty def
+    let mod = makeModule [def] []
+    testCase name $ case typeCheck mod of
+      Left s -> assertStringContains s (Fragment frag)
+      Right () -> assertFailure "expected type error, but got none"
+    where
+      looseNewlines = intercalate " " . map trim . lines
+
+  makeModuleToTestTypeSyns :: Type -> Type -> Module
+  makeModuleToTestTypeSyns ty1 ty2 = do
+    let definition = DefValue
+          { dvalLocation = Nothing
+          , dvalBinder = (ExprValName "MyFun", ty1 :-> TUnit)
+          , dvalNoPartyLiterals = HasNoPartyLiterals True
+          , dvalIsTest = IsTest False
+          , dvalBody = ETmLam (ExprVarName "ignored", ty2) EUnit
+          }
+    makeModule goodDefs [definition]
+
+  makeModule :: [DefTypeSyn] -> [DefValue] -> Module
+  makeModule synDefs valDefs = do
+    Module
+      { moduleName
+      , moduleSource = Nothing
+      , moduleFeatureFlags = FeatureFlags {forbidPartyLiterals = True}
+      , moduleSynonyms = NM.fromList synDefs
+      , moduleDataTypes = NM.fromList []
+      , moduleValues = NM.fromList valDefs
+      , moduleTemplates = NM.empty
+      }
+
+typeCheck :: Module -> Either String ()
+typeCheck mod = do
+  let version = V1 (PointStable 7)
+  either (Left . renderPretty) Right $ checkModule (initWorld [] version) version mod
+
+assertStringContains :: String -> Fragment -> IO ()
+assertStringContains text (Fragment frag) =
+  unless (frag `isInfixOf` text) (assertFailure msg)
+  where msg = "expected frag: " ++ frag ++ "\n contained in: " ++ text
+
+newtype Fragment = Fragment String

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -729,7 +729,7 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
   LF1.TypeSumCon (LF1.Type_Con mbCon args) ->
     decodeWithArgs args $ TCon <$> mayDecode "type_ConTycon" mbCon decodeTypeConName
   LF1.TypeSumSyn (LF1.Type_Syn mbSyn args) ->
-    decodeWithArgs args $ TSyn <$> mayDecode "type_SynTysyn" mbSyn decodeTypeSynName
+    TSynApp <$> mayDecode "type_SynTysyn" mbSyn decodeTypeSynName <*> traverse decodeType (V.toList args)
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Right prim)) args) -> do
     decodeWithArgs args $ TBuiltin <$> decodePrim prim
   LF1.TypeSumPrim (LF1.Type_Prim (Proto.Enumerated (Left idx)) _args) ->

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -294,14 +294,14 @@ encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
         type_VarVar <- encodeName unTypeVarName var
         type_VarArgs <- encodeList encodeType' args
         pure $ P.TypeSumVar P.Type_Var{..}
-    (TSyn syn, args) -> do
-        type_SynTysyn <- encodeQualTypeSynName syn
-        type_SynArgs <- encodeList encodeType' args
-        pure $ P.TypeSumSyn P.Type_Syn{..}
     (TCon con, args) -> do
         type_ConTycon <- encodeQualTypeConName con
         type_ConArgs <- encodeList encodeType' args
         pure $ P.TypeSumCon P.Type_Con{..}
+    (TSynApp syn args, []) -> do
+        type_SynTysyn <- encodeQualTypeSynName syn
+        type_SynArgs <- encodeList encodeType' args
+        pure $ P.TypeSumSyn P.Type_Syn{..}
     (TBuiltin bltn, args) -> do
         let type_PrimPrim = encodeBuiltinType bltn
         type_PrimArgs <- encodeList encodeType' args
@@ -324,6 +324,7 @@ encodeType' typ = fmap (P.Type . Just) $ case typ ^. _TApps of
     -- NOTE(MH): The following case requires impredicative polymorphism,
     -- which we don't support.
     (TForall{}, _:_) -> error "Application of TForall"
+    (TSynApp{}, _:_) -> error "Application of TSynApp"
 
 encodeType :: Type -> Encode (Just P.Type)
 encodeType t = Just <$> encodeType' t

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -591,7 +591,7 @@ checkExpr' expr typ = do
   exprTypeX <- expandTypeSynonyms exprType
   typX <- expandTypeSynonyms typ
   unless (alphaEquiv exprTypeX typX) $
-    throwWithContext ETypeMismatch{foundType = exprType, expectedType = typ, expr = Just expr}
+    throwWithContext ETypeMismatch{foundType = exprTypeX, expectedType = typX, expr = Just expr}
   pure exprType
 
 checkExpr :: MonadGamma m => Expr -> Type -> m ()

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -67,7 +67,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
       TVar v
         | v `HS.member` vars -> noConditions
         | otherwise -> Left (URFreeVar v)
-      TSyn _ -> Left URTypeSyn
+      TSynApp{} -> Left URTypeSyn
       TCon tcon
         | Just (modName, _) <- mbModNameTpls
         , Right tconName <- matching (_PRSelfModule modName) tcon ->

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -468,7 +468,7 @@ convType env =
     \case
         LF.TVar tyVarName ->
             HsTyVar noExt NotPromoted $ mkRdrName $ LF.unTypeVarName tyVarName
-        LF.TSyn tySyn -> error $ "TODO: DataDependencies, convType, type synonym: " <> show tySyn
+        LF.TSynApp tySyn _ -> error $ "TODO: DataDependencies, convType, type synonym application: " <> show tySyn
         LF.TCon LF.Qualified {..}
           | qualModule == LF.ModuleName ["DA", "Types"]
           , [name] <- LF.unTypeConName qualObject

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -261,8 +261,8 @@ genType curModName = go
                     ( con' <> "<" <> T.intercalate ", " ts' <> ">"
                     , ser <> "(" <> T.intercalate ", " sers <> ")"
                     )
-        TSyn _ -> error "TODO: genType, type synonym"
         TCon _ -> error "IMPOSSIBLE: lonely type constructor"
+        TSynApp{} -> error "TODO: genType, type synonym"
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -262,7 +262,7 @@ genType curModName = go
                     , ser <> "(" <> T.intercalate ", " sers <> ")"
                     )
         TCon _ -> error "IMPOSSIBLE: lonely type constructor"
-        TSynApp{} -> error "TODO: genType, type synonym"
+        TSynApp{} -> error "IMPOSSIBLE: type synonym not serializable"
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"


### PR DESCRIPTION
Extend DAML-LF type-checking to deal with type synonyms.
- checker code here: `compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs`
- driven by tests here: `compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs`

- we changed the AST to ensure type-synonyms are fully applied

TODO: (in a following PR)
- check/disallow cyclic type-synonyms



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
