### PR TITLE
check for changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 - [ ] Include appropriate tests
 - [ ] Set a descriptive title and thorough description
 - [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
-- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
+- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
 - [ ] Normal production system change, include purpose of change in description
 
 NOTE: CI is not automatically run on non-members pull-requests for security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ For Git commit messages, our principle is that `git log --pretty=oneline` should
 - Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
 - If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
 - If your PR includes user-facing changes, the squashed commit for the PR must include in its body a section between the ``CHANGELOG_BEGIN`` and ``CHANGELOG_END`` tags that includes relevant changelog entries, where each entry starts with the component to which it belongs in square brackets. Use RST to format links as this text will be added to the changelog upon release.
+- If your PR does not include user-facing changes, you still need to include a changelog section, but it can be empty, i.e. it is valid for the `CHANGELOG_END` to be right after the `CHANGELOG_BEGIN` line.
 
 The following is an example of a well-formed commit, including the description (first line) and a body that includes changelog additions:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ pr:
 
 jobs:
   - job: check_standard_change_label
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
     steps:
@@ -36,11 +37,11 @@ jobs:
           if has_changed_infra_folder; then
               fail_if_missing_std_change_label
           fi
-        condition: eq(variables['Build.Reason'], 'PullRequest')
         env:
           PR: $(System.PullRequest.PullRequestNumber)
 
   - job: check_changelog_entry
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,14 @@ jobs:
         condition: eq(variables['Build.Reason'], 'PullRequest')
         env:
           PR: $(System.PullRequest.PullRequestNumber)
+
+  - job: check_changelog_entry
+    pool:
+      name: 'linux-pool'
+    steps:
+      - checkout: self
+      - bash: ci/check-changelog.sh
+
   - job: Linux
     timeoutInMinutes: 360
     pool:

--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+contains_changelog () {
+    local awk_script="
+        BEGIN { flag = 0 }
+
+        toupper(\$0) ~ /CHANGELOG_BEGIN/ && flag == 0 { flag = 1 }
+
+        toupper(\$0) ~ /CHANGELOG_END/ && flag == 1 { flag = 2 }
+
+        END { print flag }
+    "
+    [[ 2 == $(git show -s --format=%B $1 | awk "$awk_script") ]]
+}
+
+for sha in $(git rev-list origin/master..); do
+    if contains_changelog $sha; then
+        echo "Commit $sha contains a changelog entry."
+        exit 0
+    fi
+done
+echo "
+No changelog entry found; please add one. If your PR does not need a
+changelog entry, please add an explicit, empty one, i.e. add
+
+CHANGELOG_BEGIN
+CHANGELOG_END
+
+to your commit message.
+"
+exit 1

--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 contains_changelog () {


### PR DESCRIPTION
This PR adds an automated check that a PR has at least an empty CHANGELOG entry. The reasoning is that by forcing people to explicitly mark their PR as not having a changelog, it makes them think about whether it needs one, and hopefully reduces the likelihood that a PR needs one but doesn't have it.