### PR TITLE
Allow omitting submitter info in kvutils transaction log entries

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -25,10 +25,10 @@ import com.google.protobuf.{ByteString, Empty}
 
 import scala.util.Try
 
-/** Internal utilities for converting between protobuf messages and our scala
+/** Utilities for converting between protobuf messages and our scala
   * data structures.
   */
-private[kvutils] object Conversions {
+object Conversions {
 
   val configurationStateKey: DamlStateKey =
     DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -28,7 +28,7 @@ import scala.util.Try
 /** Utilities for converting between protobuf messages and our scala
   * data structures.
   */
-object Conversions {
+private[state] object Conversions {
 
   val configurationStateKey: DamlStateKey =
     DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -221,7 +221,8 @@ object KeyValueConsumption {
       BaseEncoding.base16.encode(entryId.toByteArray)
     )
     Update.TransactionAccepted(
-      optSubmitterInfo = Some(parseSubmitterInfo(txEntry.getSubmitterInfo)),
+      optSubmitterInfo =
+        if (txEntry.hasSubmitterInfo) Some(parseSubmitterInfo(txEntry.getSubmitterInfo)) else None,
       transactionMeta = TransactionMeta(
         ledgerEffectiveTime = parseTimestamp(txEntry.getLedgerEffectiveTime),
         workflowId = Some(txEntry.getWorkflowId)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -124,6 +124,9 @@ object KVTest {
           KeyValueCommitting.submissionOutputs(entryId, submission)
       )
 
+      // Verify that we can always process the log entry
+      val _ = KeyValueConsumption.logEntryToUpdate(entryId, logEntry)
+
       entryId -> logEntry
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -222,7 +222,6 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         val txAccepted = updates.head.asInstanceOf[Update.TransactionAccepted]
         txAccepted.optSubmitterInfo should be(None)
       }
-
     }
   }
 }


### PR DESCRIPTION
This fixes a blocker with extending kvutils with privacy, where the submitter info is not always included in the log entry seen by the participant.

Additionally this makes the kvutils `Conversions` public as it contains important utilities required for extending kvutils.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags, if appropriate
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
