### PR TITLE
Better handling of recursive return types

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -125,7 +125,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
         DataEnum enumCons ->
           let
             typeDesc =
-                [ "export enum " <> conName <> "{"] ++
+                [ "export enum " <> conName <> " {"] ++
                 [ "  " <> cons <> " = " <> "\'" <> cons <> "\'" <> ","
                 | VariantConName cons <- enumCons] ++
                 [ "}"
@@ -133,9 +133,9 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                 ]
 
             serDesc =
-                ["  () => jtv.oneOf("] ++
-                ["    jtv.constant(" <> conName <> "." <> cons <> ")," | VariantConName cons <- enumCons] ++
-                ["  )"]
+                ["() => jtv.oneOf("] ++
+                ["  jtv.constant(" <> conName <> "." <> cons <> ")," | VariantConName cons <- enumCons] ++
+                [");"]
           in
           ((typeDesc, makeNameSpace serDesc), Set.empty)
         DataRecord fields ->
@@ -145,7 +145,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                 typeDesc =
                     ["{"] ++
                     ["  " <> x <> ": " <> t <> ";" | (x, t) <- zip fieldNames fieldTypesTs] ++
-                    ["};"]
+                    ["}"]
                 serDesc =
                     ["() => jtv.object({"] ++
                     ["  " <> x <> ": " <> ser <> ".decoder()," | (x, ser) <- zip fieldNames fieldSers] ++
@@ -155,7 +155,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                 Nothing -> ((makeType typeDesc, makeSer serDesc), Set.unions fieldRefs)
                 Just tpl ->
                     let (chcs, argRefs) = unzip
-                            [((unChoiceName (chcName chc), t, r, rtyp), argRefs)
+                            [((unChoiceName (chcName chc), rLf, t, r, rtyp), argRefs)
                             | chc <- NM.toList (tplChoices tpl)
                             , let tLf = snd (chcArgBinder chc)
                             , let rLf = chcReturnType chc
@@ -165,7 +165,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                             ]
                         dict =
                             ["export const " <> conName <> ": daml.Template<" <> conName <> "> & {"] ++
-                            ["  " <> x <> ": daml.Choice<" <> conName <> ", " <> t <> ", " <> r <> " >;" | (x, t, r, _) <- chcs] ++
+                            ["  " <> x <> ": daml.Choice<" <> conName <> ", " <> t <> ", " <> r <> " >;" | (x, _, t, r, _) <- chcs] ++
                             ["} = {"
                             ] ++
                             ["  templateId: templateId('" <> conName <> "'),"
@@ -176,19 +176,12 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                               ,"    template: () => " <> conName <> ","
                               ,"    choiceName: '" <> x <> "',"
                               ,"    argumentDecoder: " <> t <> ".decoder,"
-                              -- We'd write,
-                              --   "   resultDecoder: " <> rtyp <> ".decoder"
-                              -- here but, consider the following scenario:
-                              --   export const Person: daml.Template<Person>...
-                              --    = {  ...
-                              --         Birthday: { resultDecoder: daml.ContractId(Person).decoder, ... }
-                              --         ...
-                              --      }
-                              -- This gives rise to "error TS2454: Variable 'Person' is used before being assigned."
-                              ,"    resultDecoder: () => " <> rtyp <> ".decoder()," -- Eta-conversion provides an escape hatch.
+                              ,"    resultDecoder: " <> if not $ occurs (dataTypeCon def) rLf
+                                                        then rtyp <> ".decoder,"
+                                                        else "() => " <> rtyp <> ".decoder(), /* Thunk (since recursive in '" <> conName <> "'). */"
                               ,"  },"
                               ]
-                            | (x, t, _r, rtyp) <- chcs
+                            | (x, rLf, t, _r, rtyp) <- chcs
                             ] ++
                             ["};"]
                         registrations =
@@ -212,10 +205,9 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
             ["});"]
         makeNameSpace serDesc =
             [ "// eslint-disable-next-line @typescript-eslint/no-namespace"
-            , "export namespace " <> conName <> "{"
-            , "  export const decoder ="
+            , "export namespace " <> conName <> " {"
             ] ++
-            serDesc ++
+            map ("  " <>) (onHead ("export const decoder = " <>) serDesc) ++
             ["}"]
 
 genType :: ModuleName -> Type -> (T.Text, T.Text)
@@ -291,3 +283,16 @@ onHead :: (a -> a) -> [a] -> [a]
 onHead f = \case
     [] -> []
     x:xs -> f x:xs
+
+-- Does 'tc' appear in 'typ'?
+occurs :: TypeConName -> Type -> Bool
+occurs tc typ =
+  case typ of
+    TCon (Qualified _ _ c) -> tc == c
+    TApp u v -> occursChk [u, v]
+    TForall _ u -> occursChk [u]
+    TStruct flds -> occursChk (map snd flds)
+    _ -> False
+  where
+   occursChk :: [Type] -> Bool
+   occursChk ts = foldl (\r u -> r || occurs tc u) False ts


### PR DESCRIPTION
Generating correct code for decoders in presence of recursive data structures is a little tricky to get right. This PR adds a utility (`occurs`) to help and applies it to choice return types. 

CHANGELOG_BEGIN
CHANGELOG_END
