### PR TITLE
`/contracts/lookup` to return `result: null` when contract is not found

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -152,7 +152,7 @@ class Endpoints(
         ): ET[Option[domain.ActiveContract[LfValue]]]
 
         jsVal <- either(
-          ac.cata(x => lfAcToJsValue(x).leftMap(e => ServerError(e.shows)), \/-(JsObject()))
+          ac.cata(x => lfAcToJsValue(x).leftMap(e => ServerError(e.shows)), \/-(JsNull))
         ): ET[JsValue]
 
       } yield jsVal


### PR DESCRIPTION
When contract is not found, `/contracts/lookup` endpoint returns
 `{"status":200,"result":null}` instead of `{"status":200,"result":{}}`.
 This is consistent with how DAML-LF JSON Encoding spec treats Optional.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
