### PR TITLE
Remove Optional definition in LF conversion

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -382,6 +382,7 @@ convertTypeDef env o@(ATyCon t) = withRange (convNameLoc t) $ if
     | NameIn DA_Internal_LF n <- t
     , n `elementOfUniqSet` internalTypes
     -> pure []
+    | NameIn DA_Internal_Prelude "Optional" <- t -> pure []
     -- Consumption marker types used to transfer information from template desugaring to LF conversion.
     | NameIn DA_Internal_Desugar n <- t
     , n `elementOfUniqSet` consumingTypes
@@ -778,7 +779,7 @@ convertBind env (name, x)
 -- during conversion to DAML-LF together with their constructors since we
 -- deliberately remove 'GHC.Types.Opaque' as well.
 internalTypes :: UniqSet FastString
-internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap", "Map", "Any", "TypeRep"]
+internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap", "Map", "Any", "TypeRep", "Optional"]
 
 consumingTypes :: UniqSet FastString
 consumingTypes = mkUniqSet ["PreConsuming", "PostConsuming", "NonConsuming"]


### PR DESCRIPTION
All references to Optional are already mapped to the builtin Optional
type in LF but we forgot to filter out the type definition.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
