### PR TITLE
Add regression test for unstable serializable types

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -345,6 +345,30 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "unstable-types",
+    srcs = ["src/unstable-types.sh"],
+    args = [
+        "$(location @jq_dev_env//:jq)",
+        "$(location :src/query-lf-interned.jq)",
+        "$(location //compiler/damlc/pkg-db)",
+        "$(location //compiler/damlc)",
+        "$(POSIX_DIFF)",
+    ],
+    data = [
+        ":src/query-lf-interned.jq",
+        "//compiler/damlc",
+        "//compiler/damlc/pkg-db",
+        "@jq_dev_env//:jq",
+    ],
+    toolchains = [
+        "@rules_sh//sh/posix:make_variables",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # Generate a simple DALF for plain DALF import testing
 
 genrule(

--- a/compiler/damlc/tests/src/unstable-types.sh
+++ b/compiler/damlc/tests/src/unstable-types.sh
@@ -22,7 +22,7 @@ DIFF=$5
 
 get_serializable_types() {
 
-    $DAMLC inspect $1 --json | $JQ 'import "./compiler/damlc/tests/src/query-lf-interned" as lf; .Sum.daml_lf_1 as $pkg | $pkg.modules | .[] | (.name | lf::get_dotted_name($pkg) | join(".")) as $modname | .data_types | .[] | select(.serializable) | .name | lf::get_dotted_name($pkg) | $modname + ":" + join(".")'
+    $DAMLC inspect $1 --json | $JQ -L $(dirname $JQ_LF_LIB) 'import "query-lf-interned" as lf; .Sum.daml_lf_1 as $pkg | $pkg.modules | .[] | (.name | lf::get_dotted_name($pkg) | join(".")) as $modname | .data_types | .[] | select(.serializable) | .name | lf::get_dotted_name($pkg) | $modname + ":" + join(".")'
 }
 
 EXPECTED_STDLIB_TYPES=(

--- a/compiler/damlc/tests/src/unstable-types.sh
+++ b/compiler/damlc/tests/src/unstable-types.sh
@@ -54,7 +54,7 @@ for LF_VERSION in $PKG_DB/*; do
     if [ $(basename $LF_VERSION) != "1.6" ]; then
         stdlib=$LF_VERSION/daml-stdlib-*.dalf
         prim=$LF_VERSION/daml-prim.dalf
-        $DIFF -u <(get_serializable_types $stdlib) <(cat <<EOF
+        $DIFF -b -u <(get_serializable_types $stdlib) <(cat <<EOF
 "DA.Upgrade:MetaEquiv"
 "DA.Random:Minstd"
 "DA.Next.Set:Set"
@@ -73,7 +73,7 @@ for LF_VERSION in $PKG_DB/*; do
 "DA.Internal.Prelude:Optional"
 EOF
 )
-        $DIFF -u <(get_serializable_types $prim) <(cat <<EOF
+        $DIFF -b -u <(get_serializable_types $prim) <(cat <<EOF
 EOF
 )
     fi

--- a/compiler/damlc/tests/src/unstable-types.sh
+++ b/compiler/damlc/tests/src/unstable-types.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euo pipefail
+
+JQ="$(rlocation "$TEST_WORKSPACE/$1")"
+JQ_LF_LIB="$(rlocation "$TEST_WORKSPACE/$2")"
+PKG_DB="$(rlocation "$TEST_WORKSPACE/$3")"
+DAMLC="$(rlocation "$TEST_WORKSPACE/$4")"
+DIFF=$5
+
+get_serializable_types() {
+
+    $DAMLC inspect $1 --json | $JQ 'import "./compiler/damlc/tests/src/query-lf-interned" as lf; .Sum.daml_lf_1 as $pkg | $pkg.modules | .[] | (.name | lf::get_dotted_name($pkg) | join(".")) as $modname | .data_types | .[] | select(.serializable) | .name | lf::get_dotted_name($pkg) | $modname + ":" + join(".")'
+}
+
+EXPECTED_STDLIB_TYPES=(
+    "DA.Upgrade:MetaEquiv"
+    "DA.Random:Minstd"
+    "DA.Next.Set:Set"
+    "DA.Next.Map:Map"
+    "DA.Generics:MetaSel0"
+    "DA.Generics:MetaData0"
+    "DA.Generics:DecidedStrictness"
+    "DA.Generics:SourceStrictness"
+    "DA.Generics:SourceUnpackedness"
+    "DA.Generics:Associativity"
+    "DA.Generics:Infix0"
+    "DA.Generics:Fixity"
+    "DA.Generics:K1"
+    "DA.Generics:Par1"
+    "DA.Generics:U1"
+    "DA.Internal.Prelude:Optional"
+)
+
+EXPECTED_PRIM_TYPES=()
+
+echo ${EXPECTED_STDLIB_TYPES[@]}
+
+for LF_VERSION in $PKG_DB/*; do
+    # Skip 1.6 since we don’t really care about it and it removes the need to handle LF versions without
+    # interning.
+    if [ $(basename $LF_VERSION) != "1.6" ]; then
+        stdlib=$LF_VERSION/daml-stdlib-*.dalf
+        prim=$LF_VERSION/daml-prim.dalf
+        $DIFF -u <(get_serializable_types $stdlib) <(cat <<EOF
+"DA.Upgrade:MetaEquiv"
+"DA.Random:Minstd"
+"DA.Next.Set:Set"
+"DA.Next.Map:Map"
+"DA.Generics:MetaSel0"
+"DA.Generics:MetaData0"
+"DA.Generics:DecidedStrictness"
+"DA.Generics:SourceStrictness"
+"DA.Generics:SourceUnpackedness"
+"DA.Generics:Associativity"
+"DA.Generics:Infix0"
+"DA.Generics:Fixity"
+"DA.Generics:K1"
+"DA.Generics:Par1"
+"DA.Generics:U1"
+"DA.Internal.Prelude:Optional"
+EOF
+)
+        $DIFF -u <(get_serializable_types $prim) <(cat <<EOF
+EOF
+)
+    fi
+done

--- a/compiler/damlc/tests/src/unstable-types.sh
+++ b/compiler/damlc/tests/src/unstable-types.sh
@@ -25,29 +25,6 @@ get_serializable_types() {
     $DAMLC inspect $1 --json | $JQ -L $(dirname $JQ_LF_LIB) 'import "query-lf-interned" as lf; .Sum.daml_lf_1 as $pkg | $pkg.modules | .[] | (.name | lf::get_dotted_name($pkg) | join(".")) as $modname | .data_types | .[] | select(.serializable) | .name | lf::get_dotted_name($pkg) | $modname + ":" + join(".")'
 }
 
-EXPECTED_STDLIB_TYPES=(
-    "DA.Upgrade:MetaEquiv"
-    "DA.Random:Minstd"
-    "DA.Next.Set:Set"
-    "DA.Next.Map:Map"
-    "DA.Generics:MetaSel0"
-    "DA.Generics:MetaData0"
-    "DA.Generics:DecidedStrictness"
-    "DA.Generics:SourceStrictness"
-    "DA.Generics:SourceUnpackedness"
-    "DA.Generics:Associativity"
-    "DA.Generics:Infix0"
-    "DA.Generics:Fixity"
-    "DA.Generics:K1"
-    "DA.Generics:Par1"
-    "DA.Generics:U1"
-    "DA.Internal.Prelude:Optional"
-)
-
-EXPECTED_PRIM_TYPES=()
-
-echo ${EXPECTED_STDLIB_TYPES[@]}
-
 for LF_VERSION in $PKG_DB/*; do
     # Skip 1.6 since we don’t really care about it and it removes the need to handle LF versions without
     # interning.
@@ -70,7 +47,6 @@ for LF_VERSION in $PKG_DB/*; do
 "DA.Generics:K1"
 "DA.Generics:Par1"
 "DA.Generics:U1"
-"DA.Internal.Prelude:Optional"
 EOF
 )
         $DIFF -b -u <(get_serializable_types $prim) <(cat <<EOF


### PR DESCRIPTION
This test verifies that we only have the serializable types in
daml-prim and daml-stdlib that we expect and don’t introduce new ones
by accident.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
