### PR TITLE
daml2ts: Use master version of damlc in watch-damlc.sh

### DIFF
--- a/language-support/ts/codegen/tests/daml/.gitignore
+++ b/language-support/ts/codegen/tests/daml/.gitignore
@@ -1,2 +1,1 @@
 .daml
-daml.yaml

--- a/language-support/ts/codegen/tests/daml/daml.yaml
+++ b/language-support/ts/codegen/tests/daml/daml.yaml
@@ -1,0 +1,12 @@
+sdk-version: 0.0.0
+name: daml
+version: 1.0.0
+source: Main.daml
+parties:
+- Alice
+- Bob
+exposed-modules:
+- Main
+dependencies:
+- daml-prim
+- daml-stdlib

--- a/language-support/ts/codegen/tests/watch-damlc.sh
+++ b/language-support/ts/codegen/tests/watch-damlc.sh
@@ -8,6 +8,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DAML=$DIR/daml
 
 pushd $DAML
-daml init
-daml build
-fswatch -0 --exclude ".*" --include "\\.daml$" $DAML | xargs -0 -I {} daml build
+bazel run //:damlc -- build --project-root $DAML
+fswatch -0 --exclude ".*" --include "\\.daml$" $DAML | xargs -0 -I {} bazel run //:damlc -- build --project-root $DAML


### PR DESCRIPTION
So far, we've used the version of damlc installed with the SDK on the
devs machine. This lead to hard to debug version mismatches. This PR
changes `watch-damlc.sh` to use `bazel run //:damlc` instead.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3979)
<!-- Reviewable:end -->
