### PR TITLE
Log DAML trace messages

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -47,6 +47,7 @@ da_scala_test_suite(
         "@maven//:org_scalacheck_scalacheck_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -18,6 +18,7 @@ import java.util.ArrayList
 
 import com.digitalasset.daml.lf.CompiledPackages
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import org.slf4j.LoggerFactory
 
 object Speedy {
 
@@ -229,6 +230,7 @@ object Speedy {
   }
 
   object Machine {
+    private val damlTraceLog = LoggerFactory.getLogger("daml.tracelog")
     private def initial(checkSubmitterInMaintainers: Boolean, compiledPackages: CompiledPackages) =
       Machine(
         ctrl = null,
@@ -238,7 +240,7 @@ object Speedy {
         ptx = PartialTransaction.initial,
         committers = Set.empty,
         commitLocation = None,
-        traceLog = TraceLog(100),
+        traceLog = TraceLog(damlTraceLog, 100),
         compiledPackages = compiledPackages,
         checkSubmitterInMaintainers = checkSubmitterInMaintainers,
         validating = false,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
@@ -4,14 +4,18 @@
 package com.digitalasset.daml.lf.speedy
 
 import com.digitalasset.daml.lf.data.Ref.Location
+import org.slf4j.Logger
 
-final case class TraceLog(capacity: Int) {
+final case class TraceLog(logger: Logger, capacity: Int) {
 
   private val buffer = Array.ofDim[(String, Option[Location])](capacity)
   private var pos: Int = 0
   private var size: Int = 0
 
   def add(message: String, optLocation: Option[Location]): Unit = {
+    if (logger.isDebugEnabled) {
+      logger.debug(s"${Pretty.prettyLoc(optLocation).renderWideStream.mkString}: $message")
+    }
     buffer(pos) = (message, optLocation)
     pos = (pos + 1) % capacity
     if (size < capacity)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -15,6 +15,7 @@ import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
+import org.slf4j.LoggerFactory
 
 import scala.language.implicitConversions
 
@@ -153,12 +154,13 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
   }
 
   "tracelog" should {
+    val logger = LoggerFactory.getLogger("test-daml-trace-logger")
     "empty size" in {
-      val log = TraceLog(10)
+      val log = TraceLog(logger, 10)
       log.iterator.hasNext shouldBe false
     }
     "half full" in {
-      val log = TraceLog(2)
+      val log = TraceLog(logger, 2)
       log.add("test", None)
       val iter = log.iterator
       iter.hasNext shouldBe true
@@ -166,7 +168,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       iter.hasNext shouldBe false
     }
     "overflow" in {
-      val log = TraceLog(2)
+      val log = TraceLog(logger, 2)
       log.add("test1", None)
       log.add("test2", None)
       log.add("test3", None) // should replace "test1"

--- a/daml-script/runner/src/main/resources/logback.xml
+++ b/daml-script/runner/src/main/resources/logback.xml
@@ -2,12 +2,13 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="io.netty" level="WARN" />
     <logger name="io.grpc.netty" level="WARN" />
+    <logger name="daml.tracelog" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -24,7 +24,7 @@ import com.digitalasset.daml.lf.iface
 import com.digitalasset.daml.lf.iface.EnvironmentInterface
 import com.digitalasset.daml.lf.iface.reader.InterfaceReader
 import com.digitalasset.daml.lf.language.Ast._
-import com.digitalasset.daml.lf.speedy.{Compiler, Pretty, Speedy, SValue, TraceLog}
+import com.digitalasset.daml.lf.speedy.{Compiler, Pretty, Speedy, SValue}
 import com.digitalasset.daml.lf.speedy.SExpr._
 import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.speedy.SValue._
@@ -281,16 +281,6 @@ class Runner(
             throw new RuntimeException(s"Unexpected speedy result $res")
           }
         }
-      }
-      // TODO Share this logic with the trigger runner
-      var traceEmpty = true
-      machine.traceLog.iterator.foreach {
-        case (msg, optLoc) =>
-          traceEmpty = false
-          println(s"TRACE ${Pretty.prettyLoc(optLoc).render(80)}: $msg")
-      }
-      if (!traceEmpty) {
-        machine = machine.copy(traceLog = TraceLog(machine.traceLog.capacity))
       }
     }
 

--- a/triggers/runner/src/main/resources/logback.xml
+++ b/triggers/runner/src/main/resources/logback.xml
@@ -2,12 +2,13 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="io.netty" level="WARN" />
     <logger name="io.grpc.netty" level="WARN" />
+    <logger name="daml.tracelog" level="DEBUG" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Fixes #28.

CHANGELOG_BEGIN
[Sandbox] DAML trace logs (trace, traceRaw, traceId) are now logged via the regular logging system (slf4j+logback) at interpretation time via the logger `daml.tracelog` at DEBUG level.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
