### PR TITLE
daml2ts: Support lookupByKey

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -168,12 +168,19 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
                             , let (rtyp, rser) = genType curModName rLf
                             , let argRefs = Set.setOf typeModuleRef tLf
                             ]
+                        (keyTypeTs, keySer) = case tplKey tpl of
+                            Nothing -> ("undefined", "() => jtv.constant(undefined)")
+                            Just key ->
+                                let (keyTypeTs, keySer) = genType curModName (tplKeyType key)
+                                in
+                                (keyTypeTs, "() => " <> keySer <> ".decoder()")
                         dict =
-                            ["export const " <> conName <> ": daml.Template<" <> conName <> "> & {"] ++
+                            ["export const " <> conName <> ": daml.Template<" <> conName <> ", " <> keyTypeTs <> "> & {"] ++
                             ["  " <> x <> ": daml.Choice<" <> conName <> ", " <> t <> ", " <> rtyp <> " >;" | (x, t, rtyp, _) <- chcs] ++
                             ["} = {"
                             ] ++
                             ["  templateId: templateId('" <> conName <> "'),"
+                            ,"  keyDecoder: " <> keySer <> ","
                             ] ++
                             map ("  " <>) (onHead ("decoder: " <>) serDesc) ++
                             concat

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -38,6 +38,9 @@ template Person with
   where
     signatory party
 
+    key (party, age): (Party, Int)
+    maintainer key._1
+
     choice Birthday: ContractId Person
       controller party
       do

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -32,8 +32,9 @@ export type TemplateId = {
  * Interface for objects representing DAML templates. It is similar to the
  * `Template` type class in DAML.
  */
-export interface Template<T extends object> extends Serializable<T> {
+export interface Template<T extends object, K = unknown> extends Serializable<T> {
   templateId: TemplateId;
+  keyDecoder: () => jtv.Decoder<K>;
   Archive: Choice<T, {}, {}>;
 }
 

--- a/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-ledger-fetch/src/index.ts
@@ -145,7 +145,7 @@ class Ledger {
     return this.query(template, {} as Query<T>);
   }
 
-  async lookupByKey<T extends object, K>(template: Template<T, K>, key: K): Promise<CreateEvent<T, K> | null> {
+  async lookupByKey<T extends object, K>(template: Template<T, K>, key: K extends undefined ? never : K): Promise<CreateEvent<T, K> | null> {
     const payload = {
       templateId: template.templateId,
       key,

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -72,12 +72,20 @@ test('create + fetch & exercise', async () => {
     party: ALICE_PARTY,
     age: '5',
   };
+  const aliceKey = {_1: alice.party, _2: alice.age};
   const aliceContract = await ledger.create(Main.Person, alice);
   expect(aliceContract.payload).toEqual(alice);
+  expect(aliceContract.key).toEqual(aliceKey);
 
   const personContracts = await ledger.fetchAll(Main.Person);
   expect(personContracts).toHaveLength(1);
   expect(personContracts[0]).toEqual(aliceContract);
+
+  const aliceContractByKey = await ledger.lookupByKey(Main.Person, aliceKey);
+  expect(aliceContractByKey).toEqual(aliceContract);
+
+  const bobByKey = await ledger.lookupByKey(Main.Person, {_1: 'Bob', _2: '4'});
+  expect(bobByKey).toBeNull();
 
   // Alice has a birthday.
   const [er, es] = await ledger.exercise(Main.Person.Birthday, aliceContract.contractId, {});
@@ -114,6 +122,7 @@ test('create + fetch & exercise', async () => {
   };
   const allTypesContract = await ledger.create(Main.AllTypes, allTypes);
   expect(allTypesContract.payload).toEqual(allTypes);
+  expect(allTypesContract.key).toBeUndefined();
 
   const allTypesContracts = await ledger.fetchAll(Main.AllTypes);
   expect(allTypesContracts).toHaveLength(1);


### PR DESCRIPTION
We'll add `fetchByKey` and `exerciseByKey` in a separate PR. We'll remove
the `pseudo*` methods in another PR after that one.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3987)
<!-- Reviewable:end -->
