### PR TITLE
daml2ts: Lift type annotation for variant decoders to jtv.oneOf

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -125,7 +125,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
           let
             (typs, sers) = unzip $ map genBranch bs
             typeDesc = [""] ++ typs
-            serDesc  = ["() => jtv.oneOf("] ++ sers ++ [")"]
+            serDesc  = ["() => jtv.oneOf<" <> conName <> typeParams <> ">("] ++ sers ++ [")"]
           in
           ((makeType typeDesc, makeSer serDesc), Set.unions $ map (Set.setOf typeModuleRef . snd) bs)
         DataEnum enumCons ->
@@ -224,7 +224,7 @@ genDefDataType curModName tpls def = case unTypeConName (dataTypeCon def) of
         genBranch (VariantConName cons, t) =
           let (typ, ser) = genType curModName t in
           ( "  |  { tag: '" <> cons <> "'; value: " <> typ <> " }"
-          , "  jtv.object<" <> conName <> typeParams <> ">({tag: jtv.constant('" <> cons <> "'), value: jtv.lazy(() => " <> ser <> ".decoder())}),"
+          , "  jtv.object({tag: jtv.constant('" <> cons <> "'), value: jtv.lazy(() => " <> ser <> ".decoder())}),"
           )
 
 


### PR DESCRIPTION
Currently, the generated decoder for, say, `Either` looks like
```ts
() => jtv.oneOf(
  jtv.object<Either<a, b>>(...),
  jtv.object<Either<a, b>>(...),
)
```
After this PR, the generated code will look like
```ts
() => jtv.oneOf<Either<a, b>>(
  jtv.object(...),
  jtv.object(...),
)
```
That saves us a few type annotations but nothing major.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/3994)
<!-- Reviewable:end -->
