### PR TITLE
add more information to collect_build_data output

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -415,11 +415,12 @@ jobs:
           # tracking those for now. "Not set" in Azure world means set to the
           # expression Azure would otherwise substitute, i.e. the literal value
           # of the string in the `env:` block below.
-          if [[ "$GOOGLE_APPLICATION_CREDENTIALS_CONTENT" != '$(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)' ]]; then
+          if [[ "${GOOGLE_APPLICATION_CREDENTIALS_CONTENT:1:${#GOOGLE_APPLICATION_CREDENTIALS_CONTENT}-1}" != '(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)' ]]; then
               echo "$GOOGLE_APPLICATION_CREDENTIALS_CONTENT" > $GCS_KEY
               gcloud auth activate-service-account --key-file=$GCS_KEY
               BOTO_CONFIG=/dev/null gsutil cp $REPORT_GZ gs://daml-data/builds/$(Build.BuildId)_$(date -u +%Y%m%d_%H%M%SZ).json.gz
           else
+              echo "Could not save build data: no credentials. Data was:"
               cat $REPORT
           fi
 
@@ -439,6 +440,16 @@ jobs:
               || "$(Windows_signing.status)" == "Failed"
               || "$(release.status)" == "Canceled"
               || "$(release.status)" == "Failed" ]]; then
+              echo "Status check failed. Failing build so re-run button appears."
+              echo "Collected statuses were:"
+              echo "  Linux: $(Linux.status)"
+              echo "  macOS: $(macOS.status)"
+              echo "  Windows: $(Windows.status)"
+              echo "  perf: $(perf.status)"
+              echo "  check_standard_change_label: $(std_change.status)"
+              echo "  Windows_signing: $(Windows_signing.status)"
+              echo "  release: $(release.status)"
+              echo "  write_ledger_dump: $(dump.status)"
               exit 1
           fi
         env:


### PR DESCRIPTION
The `collect_build_data` step has been failing on master. Based on its current output, it looks like:
1. It doesn't have GCP credentials, and
2. The status checks for other jobs erroneously fails.

Regarding 1, I currently have no clue what may be happening. Regarding 2, Azure did change the enum strings used for job statuses a few weeks ago, so maybe that happened again. I don't think we'll be able to know until this runs on master.