### PR TITLE
Send session ping telemetry messages

### DIFF
--- a/compiler/damlc/daml-ide/BUILD.bazel
+++ b/compiler/damlc/daml-ide/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_library(
     hackage_deps = [
         "aeson",
         "async",
+        "clock",
         "base",
         "containers",
         "data-default",
@@ -28,6 +29,7 @@ da_haskell_library(
         "tagged",
         "text",
         "uri-encode",
+        "unordered-containers",
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer.hs
@@ -27,7 +27,9 @@ import Development.IDE.Core.Rules
 import Development.IDE.Core.Rules.Daml
 import Development.IDE.Core.Service.Daml
 
+import DA.Daml.SessionTelemetry
 import DA.Daml.LanguageServer.Visualize
+import qualified DA.Service.Logger as Lgr
 import qualified Network.URI                               as URI
 
 import Language.Haskell.LSP.Messages
@@ -101,10 +103,11 @@ withUriDaml _ _ = return ()
 ------------------------------------------------------------------------
 
 runLanguageServer
-    :: (IO LSP.LspId -> (FromServerMessage -> IO ()) -> VFSHandle -> ClientCapabilities -> IO IdeState)
+    :: Lgr.Handle IO
+    -> (IO LSP.LspId -> (FromServerMessage -> IO ()) -> VFSHandle -> ClientCapabilities -> IO IdeState)
     -> IO ()
-runLanguageServer getIdeState = do
-    let handlers = setHandlersKeepAlive <> setHandlersVirtualResource <> setHandlersCodeLens <> setIgnoreOptionalHandlers <> setCommandHandler
+runLanguageServer lgr getIdeState = withSessionPings lgr $ \setSessionHandlers -> do
+    let handlers = setHandlersKeepAlive <> setHandlersVirtualResource <> setHandlersCodeLens <> setIgnoreOptionalHandlers <> setCommandHandler <> setSessionHandlers
     LS.runLanguageServer options handlers getIdeState
 
 

--- a/compiler/damlc/daml-ide/src/DA/Daml/SessionTelemetry.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/SessionTelemetry.hs
@@ -1,0 +1,63 @@
+module DA.Daml.SessionTelemetry
+    ( withSessionPings
+    ) where
+
+import Control.Concurrent.Async
+import Control.Concurrent.Extra
+import Control.Monad
+import qualified Data.HashMap.Strict as HM
+import Data.Int
+import qualified Data.Text as T
+import Development.IDE.LSP.Server
+import qualified Language.Haskell.LSP.Core as LSP
+import System.Clock
+import System.Time.Extra
+
+import qualified DA.Service.Logger as Lgr
+
+data SessionState = SessionState
+  { lastActive :: !(Var TimeSpec)
+  -- ^ Monotonic timespec to check if users were active within the last session.
+  , gcpLogger :: Lgr.Handle IO
+  -- ^ The logger we use to send session pings.
+  }
+
+initSessionState :: Lgr.Handle IO -> IO SessionState
+initSessionState gcpLogger = do
+    lastActive <- newVar =<< getTime Monotonic
+    pure SessionState{..}
+
+setSessionHandlers :: SessionState -> PartialHandlers
+setSessionHandlers SessionState{..} = PartialHandlers  $ \WithMessage{..} handlers -> pure handlers
+    { LSP.didOpenTextDocumentNotificationHandler = withNotification (LSP.didOpenTextDocumentNotificationHandler handlers) $
+        \_ _ _ -> touch
+    , LSP.didCloseTextDocumentNotificationHandler = withNotification (LSP.didCloseTextDocumentNotificationHandler handlers) $
+        \_ _ _ -> touch
+    , LSP.didChangeTextDocumentNotificationHandler = withNotification (LSP.didChangeTextDocumentNotificationHandler handlers) $
+        \_ _ _ -> touch
+    }
+    where
+        touch = writeVar lastActive =<< getTime Monotonic
+
+withSessionPings :: Lgr.Handle IO -> (PartialHandlers -> IO a) -> IO a
+withSessionPings lgr f = do
+    sessionState <- initSessionState lgr
+    withAsync (pingThread sessionState) $ const (f $ setSessionHandlers sessionState)
+  where pingThread SessionState{..} = forever $ do
+            currentTime <- getTime Monotonic
+            lastActive <- readVar lastActive
+            when (currentTime - lastActive <= TimeSpec (activeMinutesInterval * 60) 0) $ do
+              Lgr.logDebug gcpLogger "Sending session ping"
+              -- We were active in the last 5 minutes so send a ping.
+              sendSessionPing gcpLogger
+            -- sleep for 5 minutes and then check again
+            sleep (fromIntegral activeMinutesInterval * 60)
+
+-- | We consider a user to be active if they’ve done an action in the last 5 minutes.
+activeMinutesInterval :: Int64
+activeMinutesInterval = 5
+
+sendSessionPing :: Lgr.Handle IO -> IO ()
+sendSessionPing lgr = Lgr.logJson lgr Lgr.Telemetry $ HM.fromList @T.Text @T.Text
+  [ ("type", "session_ping")
+  ]

--- a/compiler/damlc/daml-ide/src/DA/Daml/SessionTelemetry.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/SessionTelemetry.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Daml.SessionTelemetry
     ( withSessionPings
     ) where
@@ -61,3 +64,4 @@ sendSessionPing :: Lgr.Handle IO -> IO ()
 sendSessionPing lgr = Lgr.logJson lgr Lgr.Telemetry $ HM.fromList @T.Text @T.Text
   [ ("type", "session_ping")
   ]
+

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -398,7 +398,7 @@ execIde telemetry (Debug debug) enableScenarioService ghcOpts mbProfileDir (from
               withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do
                   sdkVersion <- getSdkVersion `catchIO` const (pure "Unknown (not started via the assistant)")
                   Logger.logInfo loggerH (T.pack $ "SDK version: " <> sdkVersion)
-                  runLanguageServer $ \getLspId sendMsg vfs caps ->
+                  runLanguageServer loggerH $ \getLspId sendMsg vfs caps ->
                       getDamlIdeState opts mbScenarioService loggerH getLspId sendMsg vfs (clientSupportsProgress caps)
 
 


### PR DESCRIPTION
This PR adds telemetry information that is sent regularly (every 5
minutes) while users are active (they’ve opened, closed or changed a
file). This allows us to track how long user sessions are.

This PR does not include any additional information in the session
ping but we plan to add more in the future.

The ping messages can be found in big query by filtering for
`jsonPayload.type = "session_ping"`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
