### PR TITLE
fix logic bug in docs release cron

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -239,7 +239,7 @@ fetch_gh_versions = do
     resp <- http_get "https://api.github.com/repos/digital-asset/daml/releases"
     let releases = filter (not . prerelease) resp
     let versions = Set.fromList $ map (to_v . name) releases
-    let latest = List.maximumOn (to_v . name) resp
+    let latest = List.maximumOn (to_v . name) releases
     return (versions, latest)
 
 main :: IO ()


### PR DESCRIPTION
The latest changes to the docs cron have introduced a bug whereby the "latest" version is determined including prereleases.