### PR TITLE
Fix Sandbox CLI help text for the -a option

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -54,7 +54,7 @@ object Cli {
 
     opt[String]('a', "address")
       .action((x, c) => c.copy(address = Some(x)))
-      .text("Sandbox service host. Defaults to binding on all addresses.")
+      .text("Sandbox service host. Defaults to binding on localhost.")
 
     // TODO remove in next major release.
     opt[Unit]("dalf")


### PR DESCRIPTION
CHANGELOG_BEGIN
[Sandbox] Fix the Sandbox command line help text to reflect the recent
  change that the default address is ``localhost`` (``127.0.0.1`` or
  ``::1``)
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
