### PR TITLE
fix collect-build-data status

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -433,23 +433,9 @@ jobs:
               || "$(macOS.status)" != "Succeeded"
               || "$(Windows.status)" != "Succeeded"
               || "$(perf.status)" != "Succeeded"
-              || "$(std_change.status)" != "Succeeded"
               || "$(dump.status)" == "Canceled"
-              || "$(dump.status)" == "Failed"
               || "$(Windows_signing.status)" == "Canceled"
-              || "$(Windows_signing.status)" == "Failed"
-              || "$(release.status)" == "Canceled"
-              || "$(release.status)" == "Failed" ]]; then
-              echo "Status check failed. Failing build so re-run button appears."
-              echo "Collected statuses were:"
-              echo "  Linux: $(Linux.status)"
-              echo "  macOS: $(macOS.status)"
-              echo "  Windows: $(Windows.status)"
-              echo "  perf: $(perf.status)"
-              echo "  check_standard_change_label: $(std_change.status)"
-              echo "  Windows_signing: $(Windows_signing.status)"
-              echo "  release: $(release.status)"
-              echo "  write_ledger_dump: $(dump.status)"
+              || "$(release.status)" == "Canceled" ]]; then
               exit 1
           fi
         env:


### PR DESCRIPTION
The main goal of this job is to fail when other, required jobs are canceled. The reason for this is that the communication between Azure and GitHub does not always work very well, particularly around canceled jobs, so that when a job gets canceled GitHub does not always know about it, and furthermore GitHub does not provide a "re-run" button for canceled jobs.

Thus, this one provides a failed job that does display a "re-run" button, which re-runs all the failed/canceled jobs in the current build.

Therefore, this only needs to detect canceled jobs, not failed ones (because those will have their own "re-run" button).

Additionally, we recently changed the standard-change label check to not run on master (as it really only makes sense on PRs), resulting in a Skipped status instead of Succeeded, which made this job fail.