### PR TITLE
Fix trigger time tests

### DIFF
--- a/triggers/tests/daml/Time.daml
+++ b/triggers/tests/daml/Time.daml
@@ -11,14 +11,14 @@ test = Trigger
   { initialState = \party _ _ ->
       ((False, []), [Commands (CommandId "a") [createCmd (T party)]])
   , update = \time msg (done, ts) ->
-      let
-        cmds = case (done, msg) of
-          (False, MTransaction (Transaction _ _ [CreatedEvent (fromCreated @T -> Some (_, _, t))])) ->
-            [Commands (CommandId "b") [createCmd t]]
-          _ -> []
-        newState = (True, time :: ts)
-      in
-      (newState, cmds)
+  case msg of
+    MTransaction (Transaction _ _ events) ->
+      let cmds = case (done, events) of
+            (False, [CreatedEvent (fromCreated @T -> Some (_, _, t))]) -> [Commands (CommandId "b") [createCmd t]]
+            _ -> []
+          newState = (True, time :: ts)
+      in (newState, cmds)
+    _ -> ((done, ts), [])
   , registeredTemplates = AllInDar
   }
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
@@ -945,8 +945,9 @@ case class TimeTests(dar: Dar[(PackageId, Package)], runner: TestRunner) {
                     case TimeProviderType.Static =>
                       TestRunner.assertEqual(timeA, timeB, "static times")
                     case _ =>
-                      if (timeA <= timeB) {
-                        Left(s"Second create should have happened after first")
+                      // Given the limited resolution it can happen that timeA == timeB
+                      if (!(timeA >= timeB)) {
+                        Left(s"Second create at $timeA should have happened after first $timeB")
                       } else {
                         Right(())
                       }
@@ -977,8 +978,8 @@ case class TimeTests(dar: Dar[(PackageId, Package)], runner: TestRunner) {
     test(
       "Time",
       "test",
-      // 2 creates
-      NumMessages(2)
+      // 2 creates and 2 completions
+      NumMessages(4)
     )
   }
 }


### PR DESCRIPTION
These have failed quite a few times on Windows and occasionally also
on MacOS.

This test, first fixes a small issue where the tests were actually
using the times from completions instead of only the timings from
creations. (that technically shouldn’t be an issue but it’s at least
confusing since the error claims to test creations).

In addition to that, this PR changes the condition to allow for the
times to be equal since especially on Windows we don’t seem to have a
very high resolution and the tests are remarkably quick so sometimes
the times can be identical.

I’ve slightly rephrased the condition since I got confused by the fact
that we test for the negated condition.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
