### PR TITLE
Implement DAML trigger heartbeat

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -105,6 +105,7 @@ To create a trigger you need to define a value of type ``Trigger s`` where ``s``
       , updateState : ACS -> Message -> s -> s
       , rule : Party -> ACS -> Time -> Map CommandId [Command] -> s -> TriggerA ()
       , registeredTemplates : RegisteredTemplates
+      , heartbeat : Optional RelTime
       }
 
 The ``initialize`` function is called on startup and allows you to
@@ -124,12 +125,16 @@ The type ``TriggerA`` allows you to emit commands that are then sent
 to the ledger. Like ``Scenario`` or ``Update``, you can use ``do``
 notation with ``TriggerA``.
 
-Finally, we can specify the templates that our trigger will operate
+We can specify the templates that our trigger will operate
 on. In our case, we will simply specify ``AllInDar`` which means that
 the trigger will receive events for all template types defined in the
 DAR. It is also possible to specify an explicit list of templates,
 e.g., ``RegisteredTemplates [registeredTemplate @Original, registeredTemplate @Subscriber, registeredTemplate @Copy]``.
 This is mainly useful for performance reasons if your DAR contains many templates that are not relevant for your trigger.
+
+Finally, you can specify an optional heartbeat interval at which the trigger
+will be sent a ``MHeartbeat`` message. This is useful if you want to ensure
+that the trigger is executed at a certain rate to issue timed commands.
 
 For our DAML trigger, the definition looks as follows:
 

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -55,6 +55,7 @@ copyTrigger = Trigger
   , updateState = \_acs _message () -> ()
   , rule = copyRule
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 -- TRIGGER_END
 

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -27,6 +27,7 @@ module Daml.Trigger
  , CompletionStatus(..)
  , RegisteredTemplates(..)
  , registeredTemplate
+ , RelTime(..)
  ) where
 
 import DA.Action
@@ -75,6 +76,8 @@ data Trigger s = Trigger
   -- `emitCommands` to change the ACS.
   , registeredTemplates : RegisteredTemplates
   -- ^ The templates the trigger will receive events for.
+  , heartbeat : Optional RelTime
+  -- ^ Send a heartbeat message at the given interval.
   }
 
 -- | TriggerA is the type used in the `rule` of a DAML trigger.
@@ -157,6 +160,7 @@ runTrigger userTrigger = LowLevel.Trigger
   { initialState = initialState
   , update = update
   , registeredTemplates = userTrigger.registeredTemplates
+  , heartbeat = userTrigger.heartbeat
   }
   where
     initialState party time (ActiveContracts createdEvents) =

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -30,9 +30,11 @@ module Daml.Trigger.LowLevel
   , fromExerciseByKey
   , RegisteredTemplates(..)
   , registeredTemplate
+  , RelTime(..)
   ) where
 
 import DA.Next.Map (MapKey(..))
+import DA.Time (RelTime(..))
 
 -- | This type represents the contract id of an unknown template.
 -- You can use `fromAnyContractId` to check which template it corresponds to.
@@ -117,6 +119,7 @@ fromArchived Archived {eventId, contractId}
 data Message
   = MTransaction Transaction
   | MCompletion Completion
+  | MHeartbeat
 
 -- | A completion message.
 -- Note that you will only get completions for commands emitted from the trigger.
@@ -140,6 +143,7 @@ data Trigger s = Trigger
   { initialState : Party -> Time -> ActiveContracts -> (s, [Commands])
   , update : Time -> Message -> s -> (s, [Commands])
   , registeredTemplates : RegisteredTemplates
+  , heartbeat : Optional RelTime
   }
 
 -- | A template that the trigger will receive events for.

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -17,13 +17,22 @@ import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.SValue
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, RelativeContractId}
-import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand, ExerciseByKeyCommand, ExerciseCommand}
+import com.digitalasset.ledger.api.v1.commands.{
+  Command,
+  CreateCommand,
+  ExerciseByKeyCommand,
+  ExerciseCommand
+}
 import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.ledger.api.v1.value
 import com.digitalasset.ledger.api.validation.ValueValidator
-import com.digitalasset.platform.participant.util.LfEngineToApi.{lfValueToApiRecord, lfValueToApiValue, toApiIdentifier}
+import com.digitalasset.platform.participant.util.LfEngineToApi.{
+  lfValueToApiRecord,
+  lfValueToApiValue,
+  toApiIdentifier
+}
 
 import scala.concurrent.duration.{FiniteDuration, MICROSECONDS}
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -5,10 +5,10 @@ package com.digitalasset.daml.lf.engine.trigger
 
 import com.digitalasset.daml.lf.engine.{ResultDone, ValueTranslator}
 import java.util
+
 import scala.collection.JavaConverters._
 import scalaz.std.either._
 import scalaz.syntax.traverse._
-
 import com.digitalasset.daml.lf.CompiledPackages
 import com.digitalasset.daml.lf.archive.Dar
 import com.digitalasset.daml.lf.data.FrontStack
@@ -17,29 +17,23 @@ import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.SValue
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, RelativeContractId}
-
-import com.digitalasset.ledger.api.v1.commands.{
-  Command,
-  CreateCommand,
-  ExerciseCommand,
-  ExerciseByKeyCommand
-}
+import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand, ExerciseByKeyCommand, ExerciseCommand}
 import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.transaction.Transaction
 import com.digitalasset.ledger.api.v1.value
 import com.digitalasset.ledger.api.validation.ValueValidator
-import com.digitalasset.platform.participant.util.LfEngineToApi.{
-  toApiIdentifier,
-  lfValueToApiRecord,
-  lfValueToApiValue
-}
+import com.digitalasset.platform.participant.util.LfEngineToApi.{lfValueToApiRecord, lfValueToApiValue, toApiIdentifier}
+
+import scala.concurrent.duration.{FiniteDuration, MICROSECONDS}
 
 // Convert from a Ledger API transaction to an SValue corresponding to a Message from the Daml.Trigger module
 case class Converter(
     fromTransaction: Transaction => Either[String, SValue],
     fromCompletion: Completion => Either[String, SValue],
+    fromHeartbeat: SValue,
     fromACS: Seq[CreatedEvent] => Either[String, SValue],
+    toFiniteDuration: SValue => Either[String, FiniteDuration],
     toCommands: SValue => Either[String, (String, Seq[Command])],
     toRegisteredTemplates: SValue => Either[String, Seq[Identifier]],
 )
@@ -304,6 +298,29 @@ object Converter {
       ))
   }
 
+  private def fromHeartbeat(ids: TriggerIds): SValue = {
+    val messageTy = ids.getId("Message")
+    SVariant(
+      messageTy,
+      Name.assertFromString("MHeartbeat"),
+      SUnit
+    )
+  }
+
+  private def toFiniteDuration(ids: TriggerIds, value: SValue): Either[String, FiniteDuration] = {
+    value match {
+      case SRecord(_, _, values) if values.size() == 1 =>
+        values.get(0) match {
+          case SInt64(microseconds) =>
+            Right(FiniteDuration(microseconds, MICROSECONDS))
+          case _ =>
+            Left(s"Expected RelTime but got $value.")
+        }
+      case _ =>
+        Left(s"Expected RelTime but got $value.")
+    }
+  }
+
   private def toText(v: SValue): Either[String, String] = {
     v match {
       case SText(t) => Right(t)
@@ -528,7 +545,9 @@ object Converter {
     Converter(
       fromTransaction(valueTranslator, triggerIds, _),
       fromCompletion(triggerIds, _),
+      fromHeartbeat(triggerIds),
       fromACS(valueTranslator, triggerIds, _),
+      toFiniteDuration(triggerIds, _),
       toCommands(triggerIds, _),
       toRegisteredTemplates(_),
     )

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -8,12 +8,16 @@ import akka.stream._
 import akka.stream.scaladsl._
 import com.google.rpc.status.Status
 import com.typesafe.scalalogging.StrictLogging
+
 import io.grpc.StatusRuntimeException
 import java.time.Instant
 import java.util.UUID
-import scalaz.syntax.tag._
-import scala.concurrent.{ExecutionContext, Future}
 
+import scalaz.syntax.tag._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.PureCompiledPackages
 import com.digitalasset.daml.lf.archive.Dar
@@ -23,22 +27,18 @@ import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.speedy.Compiler
 import com.digitalasset.daml.lf.speedy.Pretty
-import com.digitalasset.daml.lf.speedy.{SExpr, Speedy, SValue}
+import com.digitalasset.daml.lf.speedy.{SExpr, SValue, Speedy}
 import com.digitalasset.daml.lf.speedy.SExpr._
 import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.speedy.SValue._
-import com.digitalasset.ledger.api.refinements.ApiTypes.{ApplicationId}
+import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
 import com.digitalasset.ledger.api.v1.commands.Commands
 import com.digitalasset.ledger.api.v1.completion.Completion
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.event._
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.Transaction
-import com.digitalasset.ledger.api.v1.transaction_filter.{
-  Filters,
-  InclusiveFilters,
-  TransactionFilter
-}
+import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.services.commands.CompletionStreamElement._
 import com.digitalasset.platform.participant.util.LfEngineToApi.toApiIdentifier
@@ -47,6 +47,7 @@ import com.digitalasset.platform.services.time.TimeProviderType
 sealed trait TriggerMsg
 final case class CompletionMsg(c: Completion) extends TriggerMsg
 final case class TransactionMsg(t: Transaction) extends TriggerMsg
+final case class HeartbeatMsg() extends TriggerMsg
 
 class Runner(
     client: LedgerClient,
@@ -162,6 +163,23 @@ class Runner(
     }
   }
 
+  def getTriggerHeartbeat(triggerId: Identifier): Option[FiniteDuration] = {
+    val (triggerExpr, triggerTy) = getTrigger(triggerId)
+    val heartbeat = compiler.compile(
+      ERecProj(triggerTy, Name.assertFromString("heartbeat"), triggerExpr)
+    )
+    var machine = Speedy.Machine.fromSExpr(heartbeat, false, compiledPackages)
+    stepToValue(machine)
+    machine.toSValue match {
+      case SOptional(None) => None
+      case SOptional(Some(relTime)) => converter.toFiniteDuration(relTime) match {
+        case Left(err) => throw new ConverterException(err)
+        case Right(duration) => Some(duration)
+      }
+      case value => throw new ConverterException(s"Expected Optional but got $value.")
+    }
+  }
+
   def getTriggerFilter(triggerId: Identifier): TransactionFilter = {
     val (triggerExpr, triggerTy) = getTrigger(triggerId)
     val registeredTemplates = compiler.compile(
@@ -198,6 +216,7 @@ class Runner(
   def msgSource(
       client: LedgerClient,
       offset: LedgerOffset,
+      heartbeat: Option[FiniteDuration],
       party: String,
       filter: TransactionFilter)(implicit materializer: Materializer)
     : (Source[TriggerMsg, NotUsed], (String, StatusRuntimeException) => Unit) = {
@@ -218,13 +237,17 @@ class Runner(
         })
         .merge(completionQueueSource)
         .map[TriggerMsg](CompletionMsg)
+    val source = heartbeat match {
+      case Some(interval) => transactionSource.merge(completionSource).merge(Source.tick[TriggerMsg](interval, interval, HeartbeatMsg()))
+      case None => transactionSource.merge(completionSource)
+    }
     def postSubmitFailure(commandId: String, s: StatusRuntimeException) = {
       val _ = completionQueue.offer(
         Completion(
           commandId,
           Some(Status(s.getStatus().getCode().value(), s.getStatus().getDescription()))))
     }
-    (transactionSource.merge(completionSource), postSubmitFailure)
+    (source, postSubmitFailure)
   }
 
   def getTriggerSink(
@@ -281,6 +304,7 @@ class Runner(
             // This happens for invalid UUIDs which we might get for transactions not emitted by the trigger.
             case e: IllegalArgumentException => List(TransactionMsg(t.copy(commandId = "")))
           }
+        case x@HeartbeatMsg() => List(x)
       })
       .toMat(Sink.fold[SExpr, TriggerMsg](SEValue(evaluatedInitialState))((state, message) => {
         val messageVal = message match {
@@ -300,6 +324,7 @@ class Runner(
               case Right(x) => x
             }
           }
+          case HeartbeatMsg() => converter.fromHeartbeat
         }
         val clientTime: Timestamp =
           Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
@@ -327,12 +352,13 @@ class Runner(
   def runWithACS(
       triggerId: Identifier,
       timeProviderType: TimeProviderType,
+      heartbeat: Option[FiniteDuration],
       acs: Seq[CreatedEvent],
       offset: LedgerOffset,
       filter: TransactionFilter,
       msgFlow: Flow[TriggerMsg, TriggerMsg, NotUsed] = Flow[TriggerMsg],
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Future[SExpr] = {
-    val (source, postFailure) = msgSource(client, offset, party, filter)
+    val (source, postFailure) = msgSource(client, offset, heartbeat, party, filter)
     def submit(req: SubmitRequest) = {
       val f = client.commandClient
         .withTimeProvider(Some(Runner.getTimeProvider(timeProviderType)))
@@ -373,9 +399,10 @@ object Runner extends StrictLogging {
       dar
     )
     val filter = runner.getTriggerFilter(triggerId)
+    val heartbeat = runner.getTriggerHeartbeat(triggerId)
     for {
       (acs, offset) <- runner.queryACS(client, filter)
-      finalState <- runner.runWithACS(triggerId, timeProviderType, acs, offset, filter)
+      finalState <- runner.runWithACS(triggerId, timeProviderType, heartbeat, acs, offset, filter)
     } yield finalState
   }
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -38,7 +38,11 @@ import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
 import com.digitalasset.ledger.api.v1.event._
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.transaction.Transaction
-import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
+import com.digitalasset.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  TransactionFilter
+}
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.services.commands.CompletionStreamElement._
 import com.digitalasset.platform.participant.util.LfEngineToApi.toApiIdentifier
@@ -172,10 +176,11 @@ class Runner(
     stepToValue(machine)
     machine.toSValue match {
       case SOptional(None) => None
-      case SOptional(Some(relTime)) => converter.toFiniteDuration(relTime) match {
-        case Left(err) => throw new ConverterException(err)
-        case Right(duration) => Some(duration)
-      }
+      case SOptional(Some(relTime)) =>
+        converter.toFiniteDuration(relTime) match {
+          case Left(err) => throw new ConverterException(err)
+          case Right(duration) => Some(duration)
+        }
       case value => throw new ConverterException(s"Expected Optional but got $value.")
     }
   }
@@ -238,7 +243,10 @@ class Runner(
         .merge(completionQueueSource)
         .map[TriggerMsg](CompletionMsg)
     val source = heartbeat match {
-      case Some(interval) => transactionSource.merge(completionSource).merge(Source.tick[TriggerMsg](interval, interval, HeartbeatMsg()))
+      case Some(interval) =>
+        transactionSource
+          .merge(completionSource)
+          .merge(Source.tick[TriggerMsg](interval, interval, HeartbeatMsg()))
       case None => transactionSource.merge(completionSource)
     }
     def postSubmitFailure(commandId: String, s: StatusRuntimeException) = {
@@ -304,7 +312,7 @@ class Runner(
             // This happens for invalid UUIDs which we might get for transactions not emitted by the trigger.
             case e: IllegalArgumentException => List(TransactionMsg(t.copy(commandId = "")))
           }
-        case x@HeartbeatMsg() => List(x)
+        case x @ HeartbeatMsg() => List(x)
       })
       .toMat(Sink.fold[SExpr, TriggerMsg](SEValue(evaluatedInitialState))((state, message) => {
         val messageVal = message match {

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -31,6 +31,7 @@ genrule(
       cp -L $(location :daml/PendingSet.daml) $$TMP_DIR/daml
       cp -L $(location :daml/TemplateIdFilter.daml) $$TMP_DIR/daml
       cp -L $(location :daml/Time.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/Heartbeat.daml) $$TMP_DIR/daml
       cp -L $(location //docs:source/triggers/template-root/src/CopyTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -36,6 +36,7 @@ test = Trigger
   { initialState = \party _time acs -> (initState party acs, [])
   , update = \_time -> update
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
   where
     update : Message -> TriggerState -> (TriggerState, [Commands])
@@ -62,6 +63,7 @@ test = Trigger
           ArchivedEvent (fromArchived @Asset -> Some (_, assetId)) ->
             (cmds, filter (/= assetId) acs)
           _ -> (cmds, acs)
+    update MHeartbeat state = (state, [])
 
 template Asset
   with

--- a/triggers/tests/daml/CommandId.daml
+++ b/triggers/tests/daml/CommandId.daml
@@ -17,6 +17,7 @@ test = Trigger
         (cmdId :: cmdIds, [])
       _ -> (s, [])
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 
 template T

--- a/triggers/tests/daml/ExerciseByKey.daml
+++ b/triggers/tests/daml/ExerciseByKey.daml
@@ -17,6 +17,7 @@ exerciseByKeyTrigger = Trigger
       _ -> allowedFail
   , rule = retryRule
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 
 -- Create one T template and then call a choice by key to create T_.

--- a/triggers/tests/daml/Heartbeat.daml
+++ b/triggers/tests/daml/Heartbeat.daml
@@ -1,0 +1,25 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module Heartbeat where
+
+import DA.Time
+import Daml.Trigger.LowLevel
+
+test : Trigger Int
+test = Trigger
+  { initialState = \party _ _ -> (0, [])
+  , update = \_ msg count ->
+      case msg of
+        MHeartbeat -> (count + 1, [])
+        _ -> (count, [])
+  , registeredTemplates = AllInDar
+  , heartbeat = Some (convertMicrosecondsToRelTime 1)
+  }
+
+template T
+  with
+    p : Party
+  where
+    signatory p

--- a/triggers/tests/daml/Numeric.daml
+++ b/triggers/tests/daml/Numeric.daml
@@ -16,6 +16,7 @@ test = Trigger
         (True, [Commands (CommandId "mycreate2") [createCmd (t { v = t.v + 1.0 })]])
       _ -> (s, [])
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 
 template T

--- a/triggers/tests/daml/PendingSet.daml
+++ b/triggers/tests/daml/PendingSet.daml
@@ -40,6 +40,7 @@ booTrigger = Trigger with
   updateState = \acs _ s -> s
   rule = booRule
   registeredTemplates = AllInDar
+  heartbeat = None
 
 booRule : Party -> ACS -> Time -> Map CommandId [Command] -> () -> TriggerA ()
 booRule party acs _time _commandsInFlight _userState = do

--- a/triggers/tests/daml/Retry.daml
+++ b/triggers/tests/daml/Retry.daml
@@ -17,6 +17,7 @@ retryTrigger = Trigger
       _ -> allowedFail
   , rule = retryRule
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 
 -- We first create a T template, then we try to exercise C 3 times until allowedRetries is 0

--- a/triggers/tests/daml/TemplateIdFilter.daml
+++ b/triggers/tests/daml/TemplateIdFilter.daml
@@ -21,6 +21,7 @@ test registered = Trigger
         ([_], []) | null doneOnes -> dedupCreate DoneOne with p = party
         ([], [_]) | null doneTwos -> dedupCreate DoneTwo with p = party
         _ -> pure ()
+  , heartbeat = None
   }
 
 testOne = test $ RegisteredTemplates [registeredTemplate @One, registeredTemplate @DoneOne]

--- a/triggers/tests/daml/Time.daml
+++ b/triggers/tests/daml/Time.daml
@@ -20,6 +20,7 @@ test = Trigger
       in
       (newState, cmds)
   , registeredTemplates = AllInDar
+  , heartbeat = None
   }
 
 template T

--- a/triggers/tests/list-triggers.sh
+++ b/triggers/tests/list-triggers.sh
@@ -33,6 +33,7 @@ EXPECTED="\
   PendingSet:booTrigger
   CopyTrigger:copyTrigger
   ExerciseByKey:exerciseByKeyTrigger
+  Heartbeat:test
   Numeric:test
   Retry:retryTrigger
   ACS:test

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
@@ -17,7 +17,11 @@ import scala.util.{Failure, Success}
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
-import com.digitalasset.ledger.client.configuration.{CommandClientConfiguration, LedgerClientConfiguration, LedgerIdRequirement}
+import com.digitalasset.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.api.util.TimestampConversion.fromInstant
 import com.digitalasset.ledger.api.v1.command_submission_service._
@@ -993,14 +997,14 @@ case class HeartbeatTests(dar: Dar[(PackageId, Package)], runner: TestRunner) {
       }
     }
     def assertFinalACS(
-                        acs: Map[Identifier, Seq[(String, Lf.ValueRecord[Lf.AbsoluteContractId])]],
-                        commandsR: Unit) = {
+        acs: Map[Identifier, Seq[(String, Lf.ValueRecord[Lf.AbsoluteContractId])]],
+        commandsR: Unit) = {
       Right(())
     }
     def cmds(client: LedgerClient, party: String) = { implicit ec: ExecutionContext =>
-    { implicit mat: Materializer =>
-      Future {}
-    }
+      { implicit mat: Materializer =>
+        Future {}
+      }
     }
     runner.genericTest(name, dar, triggerId, cmds, numMessages, assertFinalState, assertFinalACS)
   }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala
@@ -136,11 +136,13 @@ class TestRunner(val config: Config) extends StrictLogging {
       client <- clientF
       runner = new Runner(client, applicationId, party, dar)
       filter = runner.getTriggerFilter(triggerId)
+      heartbeat = runner.getTriggerHeartbeat(triggerId)
       (acs, offset) <- runner.queryACS(client, filter)
       _ = acsPromise.success(())
       finalState <- runner.runWithACS(
         triggerId,
         config.timeProviderType,
+        heartbeat,
         acs,
         offset,
         filter,


### PR DESCRIPTION
Closes #3993 

- Adds a field `heartbeat : Optional RelTime` to the `Trigger` record allowing the user to configure a heartbeat interval.
- If specified, the trigger will receive an `MHeartbeat` message at the configured interval.
- Adds corresponding documentation.
- Adds a test-case with heartbeat enabled.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
