### PR TITLE
`/contracts/search` should return HTTP 200 and report unresolved Template IDs in the `warnings` element

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -221,6 +221,36 @@ Each contract formatted according to :doc:`lf-value-specification`.
         "status": 200
     }
 
+Nonempty Response with Unknown Template IDs Warning
+---------------------------------------------------
+
+.. code-block:: json
+
+    {
+        "warnings": {
+            "unknownTemplateIds": ["UnknownModule:UnknownEntity"]
+        },
+        "result": [
+            {
+                "observers": [],
+                "agreementText": "",
+                "payload": {
+                    "observers": [],
+                    "issuer": "Alice",
+                    "amount": "999.99",
+                    "currency": "USD",
+                    "owner": "Alice"
+                },
+                "signatories": [
+                    "Alice"
+                ],
+                "contractId": "#52:0",
+                "templateId": "b10d22d6c2f2fae41b353315cf893ed66996ecb0abe4424ea6a81576918f658a:Iou:Iou"
+            }
+        ],
+        "status": 200
+    }
+
 POST ``/command/create``
 ========================
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -100,22 +100,18 @@ class CommandService(
   private def createCommand(
       input: CreateCommand[lav1.value.Record]): Error \/ lav1.commands.Command.Command.Create = {
     resolveTemplateId(input.templateId)
-      .bimap(
-        e => Error('createCommand, e.shows),
-        x => Commands.create(refApiIdentifier(x), input.argument))
+      .toRightDisjunction(
+        Error('createCommand, ErrorMessages.cannotResolveTemplateId(input.templateId)))
+      .map(tpId => Commands.create(refApiIdentifier(tpId), input.argument))
   }
 
   private def exerciseCommand(
       input: ExerciseCommand[lav1.value.Value]): Error \/ lav1.commands.Command.Command.Exercise =
-    for {
-      templateId <- resolveTemplateId(input.templateId)
-        .leftMap(e => Error('exerciseCommand, e.shows))
-    } yield
-      Commands.exercise(
-        refApiIdentifier(templateId),
-        input.contractId,
-        input.choice,
-        input.argument)
+    resolveTemplateId(input.templateId)
+      .toRightDisjunction(
+        Error('exerciseCommand, ErrorMessages.cannotResolveTemplateId(input.templateId)))
+      .map(tpId =>
+        Commands.exercise(refApiIdentifier(tpId), input.contractId, input.choice, input.argument))
 
   private def submitAndWaitRequest(
       jwtPayload: JwtPayload,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -14,12 +14,12 @@ import com.digitalasset.http.json.JsonProtocol.LfValueCodec
 import com.digitalasset.http.query.ValuePredicate
 import com.digitalasset.http.query.ValuePredicate.LfV
 import com.digitalasset.http.util.ApiValueToLfValueConverter
-import com.digitalasset.util.ExceptionOps._
 import com.digitalasset.http.util.FutureUtil.toFuture
 import com.digitalasset.http.util.IdentifierConverters.apiIdentifier
 import com.digitalasset.jwt.domain.Jwt
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => api}
+import com.digitalasset.util.ExceptionOps._
 import com.typesafe.scalalogging.StrictLogging
 import scalaz.syntax.show._
 import scalaz.syntax.std.option._
@@ -122,35 +122,37 @@ class ContractsService(
 
   def retrieveAll(
       jwt: Jwt,
-      jwtPayload: JwtPayload): Source[Error \/ domain.ActiveContract[LfValue], NotUsed] =
+      jwtPayload: JwtPayload): SearchResult[Error \/ domain.ActiveContract[LfValue]] =
     retrieveAll(jwt, jwtPayload.party)
 
   def retrieveAll(
       jwt: Jwt,
-      party: domain.Party): Source[Error \/ domain.ActiveContract[LfValue], NotUsed] =
-    Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, party, x, Map.empty))
+      party: domain.Party): SearchResult[Error \/ domain.ActiveContract[LfValue]] =
+    SearchResult(
+      Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, party, x, Map.empty)),
+      Set.empty)
 
-  def search(jwt: Jwt, jwtPayload: JwtPayload, request: GetActiveContractsRequest)
-    : Source[Error \/ domain.ActiveContract[JsValue], NotUsed] =
+  def search(
+      jwt: Jwt,
+      jwtPayload: JwtPayload,
+      request: GetActiveContractsRequest): SearchResult[Error \/ domain.ActiveContract[JsValue]] =
     search(jwt, jwtPayload.party, request.templateIds, request.query)
 
   def search(
       jwt: Jwt,
       party: domain.Party,
       templateIds: Set[domain.TemplateId.OptionalPkg],
-      queryParams: Map[String, JsValue])
-    : Source[Error \/ domain.ActiveContract[JsValue], NotUsed] = {
+      queryParams: Map[String, JsValue]): SearchResult[Error \/ domain.ActiveContract[JsValue]] = {
 
-    resolveRequiredTemplateIds(templateIds) match {
-      case -\/(e) =>
-        Source.single(-\/(Error('search, e.shows)))
-      case \/-(resolvedTemplateIds) =>
-        daoAndFetch.cata(
-          x => searchDb(x._1, x._2)(jwt, party, resolvedTemplateIds.toSet, queryParams),
-          searchInMemory(jwt, party, resolvedTemplateIds.toSet, queryParams)
-            .map(_.flatMap(lfAcToJsAc))
-        )
-    }
+    val (resolvedTemplateIds, unresolvedTemplateIds) = resolveTemplateIds(templateIds)
+
+    val source = daoAndFetch.cata(
+      x => searchDb(x._1, x._2)(jwt, party, resolvedTemplateIds, queryParams),
+      searchInMemory(jwt, party, resolvedTemplateIds, queryParams)
+        .map(_.flatMap(lfAcToJsAc))
+    )
+
+    SearchResult(source, unresolvedTemplateIds)
   }
 
   // we store create arguments as JASON in DB, that is why it is `domain.ActiveContract[JsValue]` in the result
@@ -304,17 +306,18 @@ class ContractsService(
     \/.fromTryCatchNonFatal(LfValueCodec.apiValueToJsValue(a)).leftMap(e =>
       Error('lfValueToJsValue, e.description))
 
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  private def resolveRequiredTemplateIds(
-      xs: Set[domain.TemplateId.OptionalPkg]): Error \/ List[domain.TemplateId.RequiredPkg] = {
-    import scalaz.std.list._
-    xs.toList.traverse(resolveRequiredTemplateId)
-  }
+  private def resolveTemplateIds(xs: Set[domain.TemplateId.OptionalPkg])
+    : (Set[domain.TemplateId.RequiredPkg], Set[domain.TemplateId.OptionalPkg]) = {
 
-  private def resolveRequiredTemplateId(
-      x: domain.TemplateId.OptionalPkg): Error \/ domain.TemplateId.RequiredPkg =
-    resolveTemplateId(x).toRightDisjunction(
-      Error('resolveRequiredTemplateId, ErrorMessages.cannotResolveTemplateId(x)))
+    val z = (Set.empty[domain.TemplateId.RequiredPkg], Set.empty[domain.TemplateId.OptionalPkg])
+
+    xs.toList.foldLeft(z) { (b, a) =>
+      resolveTemplateId(a) match {
+        case Some(x) => (b._1 + x, b._2)
+        case None => (b._1, b._2 + a)
+      }
+    }
+  }
 }
 
 object ContractsService {
@@ -329,4 +332,9 @@ object ContractsService {
       s"ContractService Error, ${e.id: Symbol}: ${e.message: String}"
     }
   }
+
+  final case class SearchResult[A](
+      source: Source[A, NotUsed],
+      unresolvedTemplateIds: Set[domain.TemplateId.OptionalPkg]
+  )
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -27,7 +27,7 @@ import scalaz.syntax.traverse._
 import scalaz.{-\/, Show, \/, \/-}
 import spray.json.JsValue
 
-import scala.collection.{SeqLike, breakOut}
+import scala.collection.breakOut
 import scala.concurrent.{ExecutionContext, Future}
 
 // TODO(Leo) split it into ContractsServiceInMemory and ContractsServiceDb
@@ -309,6 +309,9 @@ class ContractsService(
 
   private def resolveTemplateIds(xs: Set[domain.TemplateId.OptionalPkg])
     : (Set[domain.TemplateId.RequiredPkg], Set[domain.TemplateId.OptionalPkg]) = {
+
+    import util.Collections.SeqOps
+
     xs.toSeq.partitionMap { x =>
       resolveTemplateId(x) toLeftDisjunction x
     }(breakOut, breakOut)
@@ -332,22 +335,4 @@ object ContractsService {
       source: Source[A, NotUsed],
       unresolvedTemplateIds: Set[domain.TemplateId.OptionalPkg]
   )
-
-  private implicit final class `Seq WSS extras`[A, Self](private val self: SeqLike[A, Self])
-      extends AnyVal {
-
-    import collection.generic.CanBuildFrom
-
-    @SuppressWarnings(Array("org.wartremover.warts.Any"))
-    def partitionMap[E, B, Es, That](f: A => E \/ B)(
-        implicit es: CanBuildFrom[Self, E, Es],
-        that: CanBuildFrom[Self, B, That]): (Es, That) = {
-      val esb = es(self.repr)
-      val thatb = that(self.repr)
-      self foreach { a =>
-        f(a) fold (esb.+=, thatb.+=)
-      }
-      (esb.result, thatb.result)
-    }
-  }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http
+
+object ErrorMessages {
+  def cannotResolveTemplateId[A](t: domain.TemplateId[A]): String =
+    s"Cannot resolve template ID, given: ${t.toString}"
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -110,7 +110,6 @@ object HttpService extends StrictLogging {
       )
 
       contractsService = new ContractsService(
-        packageService.resolveTemplateIds,
         packageService.resolveTemplateId,
         packageService.allTemplateIds,
         LedgerClientJwt.getActiveContracts(client),

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonDecoder.scala
@@ -3,10 +3,12 @@
 
 package com.digitalasset.http.json
 
+import com.digitalasset.http.ErrorMessages.cannotResolveTemplateId
 import com.digitalasset.http.domain.HasTemplateId
 import com.digitalasset.http.{PackageService, domain}
 import com.digitalasset.ledger.api.{v1 => lav1}
 import scalaz.syntax.show._
+import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
 import scalaz.{Traverse, \/, \/-}
 import spray.json.{JsObject, JsValue, JsonReader}
@@ -80,8 +82,8 @@ class DomainJsonDecoder(
     val H: HasTemplateId[F] = implicitly
     val templateId: domain.TemplateId.OptionalPkg = H.templateId(fa)
     for {
-      tId <- resolveTemplateId(templateId)
-        .leftMap(e => JsonError("DomainJsonDecoder_lookupLfType " + e.shows))
+      tId <- resolveTemplateId(templateId).toRightDisjunction(
+        JsonError(s"DomainJsonDecoder_lookupLfType: ${cannotResolveTemplateId(templateId)}"))
       lfType <- H
         .lfType(fa, tId, resolveTemplateRecordType, resolveRecordType, resolveKey)
         .leftMap(e => JsonError("DomainJsonDecoder_lookupLfType " + e.shows))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -5,6 +5,7 @@ package com.digitalasset.http.json
 
 import java.time.Instant
 
+import akka.http.scaladsl.model.StatusCode
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml.lf.value.json.ApiCodecCompressed
@@ -219,4 +220,23 @@ object JsonProtocol extends DefaultJsonProtocol {
 
   implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
     jsonFormat2(domain.ExerciseResponse[JsValue])
+
+  implicit val StatusCodeFormat: RootJsonFormat[StatusCode] =
+    new RootJsonFormat[StatusCode] {
+      override def read(json: JsValue): StatusCode = json match {
+        case JsNumber(x) => StatusCode.int2StatusCode(x.toIntExact)
+        case _ => deserializationError(s"Expected JsNumber, got: $json")
+      }
+
+      override def write(obj: StatusCode): JsValue = JsNumber(obj.intValue)
+    }
+
+  implicit val OkResponseFormat: RootJsonFormat[domain.OkResponse[JsValue, JsValue]] = jsonFormat3(
+    domain.OkResponse[JsValue, JsValue])
+
+  implicit val ErrorResponseFormat: RootJsonFormat[domain.ErrorResponse[JsValue]] = jsonFormat2(
+    domain.ErrorResponse[JsValue])
+
+  implicit val UnknownTemplateIdsFormat: RootJsonFormat[domain.UnknownTemplateIds] = jsonFormat1(
+    domain.UnknownTemplateIds)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -237,6 +237,20 @@ object JsonProtocol extends DefaultJsonProtocol {
   implicit val ErrorResponseFormat: RootJsonFormat[domain.ErrorResponse[JsValue]] = jsonFormat2(
     domain.ErrorResponse[JsValue])
 
+  implicit val ServiceWarningFormat: RootJsonFormat[domain.ServiceWarning] =
+    new RootJsonFormat[domain.ServiceWarning] {
+      override def read(json: JsValue): domain.ServiceWarning = json match {
+        case JsObject(fields) if fields.contains("unknownTemplateIds") =>
+          UnknownTemplateIdsFormat.read(json)
+        case _ =>
+          deserializationError(s"Expected JsObject(unknownTemplateIds -> JsArray(...)), got: $json")
+      }
+
+      override def write(obj: domain.ServiceWarning): JsValue = obj match {
+        case x: domain.UnknownTemplateIds => UnknownTemplateIdsFormat.write(x)
+      }
+    }
+
   implicit val UnknownTemplateIdsFormat: RootJsonFormat[domain.UnknownTemplateIds] = jsonFormat1(
     domain.UnknownTemplateIds)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http.util
+
+import scalaz.\/
+
+import scala.collection.SeqLike
+
+object Collections {
+
+  implicit final class SeqOps[A, Self](private val self: SeqLike[A, Self]) extends AnyVal {
+
+    import collection.generic.CanBuildFrom
+
+    @SuppressWarnings(Array("org.wartremover.warts.Any"))
+    def partitionMap[E, B, Es, That](f: A => E \/ B)(
+        implicit es: CanBuildFrom[Self, E, Es],
+        that: CanBuildFrom[Self, B, That]): (Es, That) = {
+      val esb = es(self.repr)
+      val thatb = that(self.repr)
+      self foreach { a =>
+        f(a) fold (esb.+=, thatb.+=)
+      }
+      (esb.result, thatb.result)
+    }
+  }
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -276,10 +276,10 @@ abstract class AbstractHttpServiceIntegrationTest
         case (status, output) =>
           status shouldBe StatusCodes.BadRequest
           assertStatus(output, StatusCodes.BadRequest)
-          val unknownTemplateId: domain.TemplateId.NoPkg =
-            domain.TemplateId((), command.templateId.moduleName, command.templateId.entityName)
+          val unknownTemplateId: domain.TemplateId.OptionalPkg =
+            domain.TemplateId(None, command.templateId.moduleName, command.templateId.entityName)
           expectedOneErrorMessage(output) should include(
-            s"Cannot resolve template ID, given: ${unknownTemplateId: domain.TemplateId.NoPkg}")
+            s"Cannot resolve template ID, given: ${unknownTemplateId: domain.TemplateId.OptionalPkg}")
       }: Future[Assertion]
   }
 


### PR DESCRIPTION
Closes: #3771

- Refactoring `PackageService.resolveTemplateId`, now it is:
  `type ResolveTemplateId =  TemplateId.OptionalPkg => Option[TemplateId.RequiredPkg]`
  used to be:
  `type ResolveTemplateId =  TemplateId.OptionalPkg => Error \/ TemplateId.RequiredPkg`
- Changing `/contracts/search` endpoint to treat and report unresolved template IDs as warnings

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
