### PR TITLE
Test parameteric sum of product

### DIFF
--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -29,6 +29,7 @@ template AllTypes with
     enumList: [Color]
     variant: Expr Int
     sumProd : Quux
+    parametericSumProd : Expr2 Int
   where
     signatory party
 
@@ -65,6 +66,12 @@ data Expr a =
     Lit a
   | Var Text
   | Add (Expr a, Expr a)
+  deriving (Show, Eq)
+
+data Expr2 a =
+    Lit2 a
+  | Var2 Text
+  | Add2 {lhs : Expr2 a, rhs: Expr2 a}
   deriving (Show, Eq)
 
 data Color = Red | Blue | Yellow deriving (Eq, Show)

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -149,7 +149,8 @@ test('create + fetch & exercise', async () => {
     enum: Main.Color.Red,
     enumList: [Main.Color.Red, Main.Color.Blue, Main.Color.Yellow],
     variant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
-    sumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}}
+    sumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}},
+    parametericSumProd: {tag: 'Add2', value: {lhs:{tag: 'Lit2', value: '1'}, rhs:{tag: 'Lit2', value: '2'}}},
   };
   const allTypesContract = await ledger.create(Main.AllTypes, allTypes);
   expect(allTypesContract.payload).toEqual(allTypes);


### PR DESCRIPTION
Add a test for a parametric sum-of-product. It is this test that exhibited the failure of our first attempt to remove the `_NS` on namespaces.

```
CHANGELOG_BEGIN
CHANGELOG_END
```
