### PR TITLE
Engine: untie RelativeContractId from NodeId

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -293,10 +293,10 @@ case class Conversions(homePackageId: Ref.PackageId) {
           .setContractId(coid)
           .setTemplateId(convertIdentifier(templateId))
           .build
-      case V.RelativeContractId(txnid) =>
+      case V.RelativeContractId(index) =>
         ContractRef.newBuilder
           .setRelative(true)
-          .setContractId(txnid.index.toString)
+          .setContractId(index.toString)
           .setTemplateId(convertIdentifier(templateId))
           .build
     }
@@ -304,7 +304,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
   def convertContractId(coid: V.ContractId): String =
     coid match {
       case V.AbsoluteContractId(coid) => coid
-      case V.RelativeContractId(txnid) => txnid.index.toString
+      case V.RelativeContractId(index) => index.toString
     }
 
   def convertScenarioStep(
@@ -626,8 +626,8 @@ case class Conversions(homePackageId: Ref.PackageId) {
         coid match {
           case V.AbsoluteContractId(acoid) =>
             builder.setContractId(acoid)
-          case V.RelativeContractId(txnid) =>
-            builder.setContractId(txnid.index.toString)
+          case V.RelativeContractId(index) =>
+            builder.setContractId(index.toString)
         }
       case V.ValueList(values) =>
         builder.setList(

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
@@ -18,6 +18,8 @@ object Relation {
   type Relation[A, B] = Map[A, Set[B]]
 
   object Relation {
+    def empty[A, B]: Relation[A, B] = Map.empty
+
     def union[A, B](r1: Relation[A, B], r2: Relation[A, B]): Relation[A, B] = {
       r2.foldLeft(r1) {
         case (acc, (a, bs)) =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -33,7 +33,7 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
     cid match {
       case r: RelativeContractId =>
         // It is safe to concatenate numbers and "-" to form a valid ContractId
-        AbsoluteContractId(Ref.ContractIdString.assertFromString(s"$txCounter-${r.txnid.index}"))
+        AbsoluteContractId(Ref.ContractIdString.assertFromString(s"$txCounter-${r.index}"))
       case a: AbsoluteContractId => a
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -552,12 +552,11 @@ object Ledger {
   ) extends FailedAuthorization
 
   /** State to use during enriching a transaction with disclosure information. */
-  final case class EnrichState(
-      nodes: Map[ScenarioNodeId, Node],
-      disclosures: Relation[Transaction.NodeId, Party],
-      localDivulgences: Relation[Transaction.NodeId, Party],
-      globalDivulgences: Relation[AbsoluteContractId, Party],
-      failedAuthorizations: Map[Transaction.NodeId, FailedAuthorization]
+  private final case class EnrichState(
+      disclosures: Relation[Transaction.NodeId, Party] = Relation.empty,
+      localDivulgences: Relation[Transaction.NodeId, Party] = Relation.empty,
+      globalDivulgences: Relation[AbsoluteContractId, Party] = Relation.empty,
+      failedAuthorizations: Map[Transaction.NodeId, FailedAuthorization] = Map.empty,
   ) {
     def discloseTo(witnesses: Set[Party], i: Transaction.NodeId): EnrichState =
       copy(
@@ -786,11 +785,6 @@ object Ledger {
     }
   }
 
-  object EnrichState {
-    def empty =
-      EnrichState(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty)
-  }
-
   sealed trait Authorization {
     def fold[A](ifDontAuthorize: A)(ifAuthorize: Set[Party] => A): A =
       this match {
@@ -927,7 +921,7 @@ object Ledger {
     }
 
     val finalState =
-      tr.roots.foldLeft(EnrichState.empty) { (s, nodeId) =>
+      tr.roots.foldLeft(EnrichState()) { (s, nodeId) =>
         enrichNode(s, initialParentExerciseWitnesses, authorization, nodeId)
       }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/SEquatableValuesSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/SEquatableValuesSpec.scala
@@ -9,7 +9,7 @@ import com.digitalasset.daml.lf.data.{FrontStack, InsertOrdMap, Numeric, Ref, Ti
 import com.digitalasset.daml.lf.language.{Ast, Util => AstUtil}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.speedy.{SBuiltin, SExpr, SValue}
-import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, NodeId, RelativeContractId}
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, RelativeContractId}
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
 import org.scalatest.{Matchers, WordSpec}
 import scalaz._
@@ -66,7 +66,7 @@ class SEquatableValuesSpec extends WordSpec with Matchers with TableDrivenProper
     List("a", "b")
       .map(x => SContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString(x))))
   private val relativeContractId =
-    List(0, 1).map(x => SContractId(RelativeContractId(NodeId.unsafeFromIndex(x))))
+    List(0, 1).map(x => SContractId(RelativeContractId.unsafeFromIndex(x)))
   private val contractIds = absoluteContractId ++ relativeContractId
 
   private val enums = List(EnumCon1, EnumCon2).map(SEnum(EnumTypeCon, _))

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -30,7 +30,7 @@ object ValueGenerators {
   val defaultCidDecode: ValueCoder.DecodeCid[Tx.TContractId] = ValueCoder.DecodeCid(
     { i: String =>
       if (i.startsWith("RCOID")) {
-        Right(RelativeContractId(Tx.NodeId.unsafeFromIndex(i.split(":::")(1).toInt)))
+        Right(RelativeContractId.unsafeFromIndex(i.split(":::")(1).toInt))
       } else if (i.startsWith("ACOID")) {
         Right(AbsoluteContractId(toContractId(i.split(":::")(1))))
       } else {
@@ -41,7 +41,7 @@ object ValueGenerators {
         parseInt(i)
           .bimap(
             e => ValueCoder.DecodeError(e.getMessage),
-            n => RelativeContractId(NodeId unsafeFromIndex n))
+            n => RelativeContractId.unsafeFromIndex(n))
           .toEither
       else Right(AbsoluteContractId(toContractId(i)))
     }
@@ -55,10 +55,10 @@ object ValueGenerators {
   val defaultCidEncode: ValueCoder.EncodeCid[Tx.TContractId] = ValueCoder.EncodeCid(
     {
       case AbsoluteContractId(coid) => s"ACOID:::${coid: String}"
-      case RelativeContractId(i) => s"RCOID:::${i.index: Int}"
+      case RelativeContractId(i) => s"RCOID:::${i: Int}"
     }, {
       case AbsoluteContractId(coid) => (coid, false)
-      case RelativeContractId(i) => ((i.index: Int).toString, true)
+      case RelativeContractId(i) => ((i: Int).toString, true)
     }
   )
 
@@ -205,7 +205,7 @@ object ValueGenerators {
 
   def coidGen: Gen[ContractId] = {
     val genRel: Gen[ContractId] =
-      Arbitrary.arbInt.arbitrary.map(i => RelativeContractId(Transaction.NodeId.unsafeFromIndex(i)))
+      Arbitrary.arbInt.arbitrary.map(i => RelativeContractId.unsafeFromIndex(i))
     val genAbs: Gen[ContractId] =
       Gen.zip(Gen.alphaChar, Gen.alphaStr) map {
         case (h, t) => AbsoluteContractId(toContractId(h +: t))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -44,10 +44,10 @@ private[state] object Conversions {
       BaseEncoding.base16.encode(txId.getEntryId.toByteArray)
     coid match {
       case a @ AbsoluteContractId(_) => a
-      case RelativeContractId(txnid) =>
+      case RelativeContractId(index) =>
         // NOTE(JM): Must be in sync with [[absoluteContractIdToLogEntryId]] and
         // [[absoluteContractIdToStateKey]].
-        AbsoluteContractId(ContractIdString.assertFromString(s"$hexTxId:${txnid.index}"))
+        AbsoluteContractId(ContractIdString.assertFromString(s"$hexTxId:$index"))
     }
   }
 
@@ -89,7 +89,7 @@ private[state] object Conversions {
   def encodeRelativeContractId(entryId: DamlLogEntryId, rcoid: RelativeContractId): DamlContractId =
     DamlContractId.newBuilder
       .setEntryId(entryId)
-      .setNodeId(rcoid.txnid.index.toLong)
+      .setNodeId(rcoid.index.toLong)
       .build
 
   def decodeContractId(coid: DamlContractId): AbsoluteContractId = {
@@ -287,7 +287,7 @@ private[state] object Conversions {
   // FIXME(JM): Should we have a well-defined schema for this?
   private val cidEncoder: ValueCoder.EncodeCid[ContractId] = {
     val asStruct: ContractId => (String, Boolean) = {
-      case RelativeContractId(nid) => (s"~${nid.index}", true)
+      case RelativeContractId(index) => (s"~$index", true)
       case AbsoluteContractId(coid) => (s"$coid", false)
     }
 
@@ -300,7 +300,7 @@ private[state] object Conversions {
           case None =>
             Left(DecodeError(s"Invalid relative contract id: $x"))
           case Some(i) =>
-            Right(RelativeContractId(NodeId.unsafeFromIndex(i)))
+            Right(RelativeContractId.unsafeFromIndex(i))
         }
       } else {
         ContractIdString

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -77,7 +77,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
     "yield two projection roots for single root transaction with two parties" in {
       val nid = NodeId.unsafeFromIndex(1)
       val root = makeCreateNode(
-        RelativeContractId(nid),
+        RelativeContractId.unsafeFromIndex(2),
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice"), Party.assertFromString("Bob")))
       val tx =
@@ -95,27 +95,31 @@ class ProjectionsSpec extends WordSpec with Matchers {
       val nid3 = NodeId.unsafeFromIndex(3)
       val nid4 = NodeId.unsafeFromIndex(4)
 
+      val rcoid1 = RelativeContractId.unsafeFromIndex(1001)
+      val rcoid2 = RelativeContractId.unsafeFromIndex(1002)
+      val rcoid3 = RelativeContractId.unsafeFromIndex(1003)
+
       // Alice creates an "offer contract" to Bob as part of her workflow.
       // Alice sees both the exercise and the create, and Bob only
       // sees the offer.
       val create = makeCreateNode(
-        RelativeContractId(nid2),
+        rcoid1,
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Bob")))
       val exe = makeExeNode(
-        RelativeContractId(nid1),
+        rcoid1,
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice")),
         ImmArray(nid2)
       )
       val bobCreate = makeCreateNode(
-        RelativeContractId(nid3),
+        rcoid2,
         Set(Party.assertFromString("Bob")),
         Set(Party.assertFromString("Bob")))
 
       val charlieCreate = makeCreateNode(
-        RelativeContractId(nid4),
+        rcoid3,
         Set(Party.assertFromString("Charlie")),
         Set(Party.assertFromString("Charlie")))
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/EventIdFormatter.scala
@@ -6,6 +6,7 @@ package com.digitalasset.platform.sandbox
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, TransactionIdString}
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.types.Ledger
+import com.digitalasset.daml.lf.value.Value.RelativeContractId
 import com.digitalasset.daml.lf.value.{Value => Lf}
 
 import scala.util.{Failure, Success, Try}
@@ -19,18 +20,25 @@ object EventIdFormatter {
   def makeAbsCoid(transactionId: TransactionIdString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
     coid match {
       case a @ Lf.AbsoluteContractId(_) => a
-      case Lf.RelativeContractId(txnid) =>
-        Lf.AbsoluteContractId(fromTransactionId(transactionId, txnid))
+      case rcoid: Lf.RelativeContractId =>
+        Lf.AbsoluteContractId(fromTransactionId(transactionId, rcoid))
     }
 
   // this method defines the EventId format used by the sandbox
   def fromTransactionId(transactionId: TransactionIdString, nid: Transaction.NodeId): LedgerString =
     fromTransactionId(transactionId, nid.name)
 
+  // this method defines the EventId format used by the sandbox
+  def fromTransactionId(
+      transactionId: TransactionIdString,
+      rcoid: RelativeContractId
+  ): LedgerString =
+    fromTransactionId(transactionId, rcoid.name)
+
   /** When loading a scenario we get already absolute nids from the ledger -- still prefix them with the transaction
     * id, just to be safe.
     */
-  def fromTransactionId(
+  private def fromTransactionId(
       transactionId: TransactionIdString,
       nid: Ledger.ScenarioNodeId,
   ): LedgerString =


### PR DESCRIPTION
In this PR we untie RelativeContractId from NodeId.
This will simply upcoming  redesign of RelativeContractId .

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
