### PR TITLE
Allow submitMustFail in scenarios when initializing sandbox

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -281,8 +281,7 @@ object ScenarioLoader {
             throw new RuntimeException(s"Error when augmenting acs at step $stepId: $err")
         }
       case _: L.AssertMustFail =>
-        throw new RuntimeException(
-          s"Scenario $scenarioRef contains a must fail -- you cannot use it to initialize the sandbox.")
+        (acs, time, mbOldTxId)
       case L.PassTime(dtMicros) =>
         (acs, time.addMicros(dtMicros), mbOldTxId)
     }

--- a/ledger/test-common/src/main/daml/Test.daml
+++ b/ledger/test-common/src/main/daml/Test.daml
@@ -411,6 +411,8 @@ testScenario = do
   pass (seconds 10)
   submit party (create DummyContractFactory with operator = party)
   pass (seconds 10)
+  other <- getParty "other"
+  submitMustFail party (create Dummy with operator = other)
   return ()
 
 template Delegated


### PR DESCRIPTION
Our users seem to stumble over this problem over and over again. Since there's
no technical reason to ban `submitMustFail` during sandbix initialization, we
can also allow for it.

CHANGELOG_BEGIN

- [Sandbox] Allow ``submitMustFail`` in scenarios used for sandbox initialization.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4036)
<!-- Reviewable:end -->
