### PR TITLE
daml2ts : sum-of-product rewrite

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -152,8 +152,14 @@ genDefDataType curPkgId conName mod tpls def =
 
               serDesc  = ["() => jtv.oneOf<" <> conName <> typeParams <> ">("] ++ sers ++ ["),"] ++ assocTypSers
 
+              header = ": daml.Serializable<" <> conName <> "> & {" <> (T.intercalate ";" (map (\name -> name <> ": daml.Serializable<" <> conName <> "." <> name <> ">") assocDataNames)) <> "} ="
+
+              makeSer' serDesc =
+                ["export const " <> conName <> header <> " ({"] ++
+                map ("  " <>) (onHead ("decoder: " <>) serDesc) ++
+                ["})"]
             in
-              ((makeType typeDesc, onLast (<> "; ") (makeSer serDesc)), Set.unions $ map (Set.setOf typeModuleRef . snd) bs)
+              ((makeType typeDesc, onLast (<> "; ") (makeSer' serDesc)), Set.unions $ map (Set.setOf typeModuleRef . snd) bs)
           else
             let
               (typs, sers) = unzip $ map genBranch bs

--- a/language-support/ts/codegen/tests/ts/generated/tsconfig.json
+++ b/language-support/ts/codegen/tests/ts/generated/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/language-support/ts/codegen/tests/ts/generated/tsconfig.json
+++ b/language-support/ts/codegen/tests/ts/generated/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "strict": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Rewrites the serialization code for variants in such a way that `_NS` namespace obfuscations is eliminated.