### PR TITLE
Allow invoking generate-src on the main dalf of a dar

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -627,7 +627,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
 
     targetFilePath = fromMaybe defaultDarFile mbOutFile
 
--- | Given a path to a .dalf or a .dar either return either the bytes of the .dalf file
+-- | Given a path to a .dalf or a .dar return the bytes of either the .dalf file
 -- or the the main dalf from the .dar
 -- In addition to the bytes, we also return the basename of the dalf file.
 getDalfBytes :: FilePath -> IO (B.ByteString, FilePath)

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -627,19 +627,25 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
 
     targetFilePath = fromMaybe defaultDarFile mbOutFile
 
+-- | Given a path to a .dalf or a .dar either return either the bytes of the .dalf file
+-- or the the main dalf from the .dar
+-- In addition to the bytes, we also return the basename of the dalf file.
+getDalfBytes :: FilePath -> IO (B.ByteString, FilePath)
+getDalfBytes fp
+  | "dar" `isExtensionOf` fp = do
+        dar <- B.readFile fp
+        let archive = ZipArchive.toArchive $ BSL.fromStrict dar
+        manifest <- either fail pure $ readDalfManifest archive
+        dalfs <- either fail pure $ readDalfs archive
+        pure (BSL.toStrict $ mainDalf dalfs, takeBaseName $ mainDalfPath manifest)
+  | otherwise = (, takeBaseName fp) <$> B.readFile fp
+
 execInspect :: FilePath -> FilePath -> Bool -> DA.Pretty.PrettyLevel -> Command
 execInspect inFile outFile jsonOutput lvl =
   Command Inspect Nothing effect
   where
     effect = do
-      bytes <-
-          if "dar" `isExtensionOf` inFile
-              then do
-                  dar <- B.readFile inFile
-                  dalfs <- either fail pure $ readDalfs $ ZipArchive.toArchive $ BSL.fromStrict dar
-                  pure $! BSL.toStrict $ mainDalf dalfs
-              else B.readFile inFile
-
+      (bytes, _) <- getDalfBytes inFile
       if jsonOutput
       then do
         payloadBytes <- PLF.archivePayload <$> errorOnLeft "Cannot decode archive" (PS.fromByteString bytes)
@@ -792,11 +798,11 @@ execMergeDars darFp1 darFp2 mbOutFp =
 
 -- | Generate daml source files from a dalf package.
 execGenerateSrc :: Options -> FilePath -> Maybe FilePath -> Command
-execGenerateSrc opts dalfFp mbOutDir = Command GenerateSrc Nothing effect
+execGenerateSrc opts dalfOrDar mbOutDir = Command GenerateSrc Nothing effect
   where
-    unitId = stringToUnitId $ takeBaseName dalfFp
     effect = do
-        bytes <- B.readFile dalfFp
+        (bytes, dalfPath) <- getDalfBytes dalfOrDar
+        let unitId = stringToUnitId dalfPath
         (pkgId, pkg) <- decode bytes
         opts <- mkOptions opts
         logger <- getLogger opts "generate-src"


### PR DESCRIPTION
Given that daml build outputs a .dar file this is much more convenient
for testing against actual build outputs of damlc rather than
handcrafted .dalf files.

The behavior matches the one of `damlc inspect` in that it detects
whether it works on a .dar or a .dalf based on the file ending.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
