### PR TITLE
Fix bug that can cause the transaction stream to not terminate.

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
@@ -27,10 +27,7 @@ trait Dispatcher[Index] extends AutoCloseable {
   def startingAt[T](
       startInclusive: Index,
       subSource: SubSource[Index, T],
-      endExclusive: Option[Index]): Source[(Index, T), NotUsed]
-
-  /** Returns a source of all values starting at the given index, in the form (successor index, value) */
-  def startingAt[T](start: Index, subSource: SubSource[Index, T]): Source[(Index, T), NotUsed]
+      endExclusive: Option[Index] = None): Source[(Index, T), NotUsed]
 }
 
 object Dispatcher {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -265,7 +265,8 @@ abstract class LedgerBackedIndexService(
           .map(converter.toAbsolute(_).map(Some(_)))
           .getOrElse(Source.single(None))
           .flatMapConcat { endOpt =>
-            lazy val stream = ledger.ledgerEntries(Some(absBegin.toLong))
+            lazy val stream =
+              ledger.ledgerEntries(Some(absBegin.toLong), endOpt.map(_.value.toLong))
 
             val finalStream = endOpt match {
               case None => stream
@@ -278,16 +279,21 @@ abstract class LedgerBackedIndexService(
                   ErrorFactories.invalidArgument(s"End offset $end is before Begin offset $begin."))
 
               case Some(LedgerOffset.Absolute(end)) =>
+                val endL = end.toLong
                 stream
                   .takeWhile(
                     {
                       case (offset, _) =>
                         //note that we can have gaps in the increasing offsets!
-                        (offset + 1) < end.toLong //api offsets are +1 compared to backend offsets
+                        (offset + 1) < endL //api offsets are +1 compared to backend offsets
                     },
                     inclusive = true // we need this to be inclusive otherwise the stream will be hanging until a new element from upstream arrives
                   )
-                  .filter(_._1 < end.toLong)
+                  // after the following step, we will add +1 to the offset before we expose it on the ledger api.
+                  // when the interval is [5, 7[, then we should only emit ledger entries with _backend_ offsets 5 and 6,
+                  // which then get changed to 6 and 7 respectively. the application can then take the offset of the last received
+                  // transaction and use it as a begin offset for another transaction service request.
+                  .filter(_._1 < endL)
             }
             // we MUST do the offset comparison BEFORE collecting only the accepted transactions,
             // because currentLedgerEnd refers to the offset of the mixed set of LedgerEntries (e.g. completions, transactions, ...).
@@ -343,7 +349,7 @@ abstract class LedgerBackedIndexService(
     converter.toAbsolute(begin).flatMapConcat {
       case LedgerOffset.Absolute(absBegin) =>
         ledger
-          .ledgerEntries(Some(absBegin.toLong))
+          .ledgerEntries(Some(absBegin.toLong), endExclusive = None)
           .map {
             case (offset, entry) =>
               (offset + 1, entry) //doing the same as above with transactions. The ledger api has to return a non-inclusive offset

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -75,7 +75,9 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
 
   def ledgerId: LedgerId
 
-  def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed]
+  def ledgerEntries(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long]): Source[(Long, LedgerEntry), NotUsed]
 
   def ledgerEnd: Long
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -43,8 +43,10 @@ private class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegis
 
   override def currentHealth(): HealthStatus = ledger.currentHealth()
 
-  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
-    ledger.ledgerEntries(offset)
+  override def ledgerEntries(
+      offset: Option[Long],
+      endOpt: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
+    ledger.ledgerEntries(offset, endOpt)
 
   override def ledgerEnd: Long = ledger.ledgerEnd
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -81,9 +81,11 @@ class InMemoryLedger(
 
   override def currentHealth(): HealthStatus = Healthy
 
-  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
+  override def ledgerEntries(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
     entries
-      .getSource(offset)
+      .getSource(beginInclusive, endExclusive)
       .collect { case (offset, InMemoryLedgerEntry(entry)) => offset -> entry }
 
   // mutable state
@@ -288,7 +290,7 @@ class InMemoryLedger(
     })
 
   override def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed] = {
-    entries.getSource(Some(beginOffset)).collect {
+    entries.getSource(Some(beginOffset), None).collect {
       case (offset, InMemoryPartyEntry(partyEntry)) => (offset, partyEntry)
     }
   }
@@ -303,7 +305,7 @@ class InMemoryLedger(
     packageStoreRef.get.getLfPackage(packageId)
 
   override def packageEntries(beginOffset: Long): Source[(Long, PackageLedgerEntry), NotUsed] =
-    entries.getSource(Some(beginOffset)).collect {
+    entries.getSource(Some(beginOffset), None).collect {
       case (offset, InMemoryPackageEntry(entry)) => (offset, entry)
     }
 
@@ -380,7 +382,7 @@ class InMemoryLedger(
   override def configurationEntries(
       startInclusive: Option[Long]): Source[(Long, ConfigurationEntry), NotUsed] =
     entries
-      .getSource(startInclusive)
+      .getSource(startInclusive, None)
       .collect { case (offset, InMemoryConfigEntry(entry)) => offset -> entry }
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
@@ -45,13 +45,16 @@ private[ledger] class LedgerEntries[T](identify: T => String) {
 
   private val dispatcher = Dispatcher[Long]("inmemory-ledger", ledgerBeginning, ledgerEnd)
 
-  def getSource(offset: Option[Long]): Source[(Long, T), NotUsed] =
+  def getSource(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long]): Source[(Long, T), NotUsed] =
     dispatcher.startingAt(
-      offset.getOrElse(ledgerBeginning),
+      beginInclusive.getOrElse(ledgerBeginning),
       RangeSource(
         (inclusiveStart, exclusiveEnd) =>
           Source[(Long, T)](state.get().items.range(inclusiveStart, exclusiveEnd)),
-      )
+      ),
+      endExclusive
     )
 
   def publish(item: T): Long = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/BaseLedger.scala
@@ -43,8 +43,15 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
   override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =
     ledgerDao.lookupKey(key, forParty)
 
-  override def ledgerEntries(offset: Option[Long]): Source[(Long, LedgerEntry), NotUsed] =
-    dispatcher.startingAt(offset.getOrElse(0), RangeSource(ledgerDao.getLedgerEntries(_, _)))
+  override def ledgerEntries(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long]): Source[(Long, LedgerEntry), NotUsed] = {
+    dispatcher.startingAt(
+      beginInclusive.getOrElse(0),
+      RangeSource(ledgerDao.getLedgerEntries(_, _)),
+      endExclusive
+    )
+  }
 
   override def ledgerEnd: Long = dispatcher.getHead()
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -179,7 +179,7 @@ class ImplicitPartyAdditionIT
         )
         // Wait until both transactions have been processed
         _ <- ledger
-          .ledgerEntries(None)
+          .ledgerEntries(None, None)
           .take(2)
           .runWith(Sink.seq)
         parties <- ledger.parties

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -97,7 +97,7 @@ class TransactionMRTComplianceIT
         .publishTransaction(submitterInfo, transactionMeta, dummyTransaction)
         .map(_ shouldBe SubmissionResult.Acknowledged)
       ledger
-        .ledgerEntries(None)
+        .ledgerEntries(None, None)
         .runWith(Sink.head)
         .map(_._2)
         .map {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntriesSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntriesSpec.scala
@@ -46,7 +46,7 @@ class LedgerEntriesSpec
           .take(NO_OF_MESSAGES.toLong)
           .toMat(Sink.seq)(Keep.right)
 
-      val blocksF = ledger.getSource(None).runWith(sink)
+      val blocksF = ledger.getSource(None, None).runWith(sink)
 
       blocksF.map { blocks =>
         val readTransactions = blocks.collect { case (_, transaction) => transaction }
@@ -72,7 +72,7 @@ class LedgerEntriesSpec
       def subscribe() = {
         val subscribeRate = NO_OF_MESSAGES / (Random.nextInt(100) + 1)
         ledger
-          .getSource(None)
+          .getSource(None, None)
           .runWith(
             Flow[(Long, Either[Error, Transaction])]
               .throttle(subscribeRate, 100.milliseconds, subscribeRate, ThrottleMode.shaping)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.stores.ledger.sql
+import java.time.{Duration => JDuration}
+
+import akka.stream.scaladsl.Sink
+import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.api.testing.utils.{
+  SuiteResourceManagementAroundAll,
+  MockMessages => M
+}
+import com.digitalasset.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc
+import com.digitalasset.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc
+import com.digitalasset.ledger.api.v1.command_submission_service.{
+  CommandSubmissionServiceGrpc,
+  SubmitRequest
+}
+import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand}
+import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
+import com.digitalasset.ledger.api.v1.transaction_service.TransactionServiceGrpc
+import com.digitalasset.ledger.api.v1.value.{Record, RecordField, Value}
+import com.digitalasset.ledger.client.configuration.CommandClientConfiguration
+import com.digitalasset.ledger.client.services.admin.PartyManagementClient
+import com.digitalasset.ledger.client.services.commands.CommandClient
+import com.digitalasset.ledger.client.services.transactions.TransactionClient
+import com.digitalasset.platform.sandbox.config.SandboxConfig
+import com.digitalasset.platform.sandbox.services.{SandboxFixture, TestCommands}
+import com.digitalasset.platform.services.time.TimeProviderType
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Span}
+import org.scalatest.{AsyncWordSpec, Matchers}
+import scalaz.syntax.tag._
+
+class TransactionStreamTerminationIT
+    extends AsyncWordSpec
+    with Matchers
+    with ScalaFutures
+    with TestCommands
+    with SandboxFixture
+    with SuiteResourceManagementAroundAll {
+
+  override implicit def patienceConfig: PatienceConfig =
+    PatienceConfig(scaled(Span(15000, Millis)), scaled(Span(150, Millis)))
+
+  override protected def config: SandboxConfig = super.config.copy(
+    jdbcUrl = Some("jdbc:h2:mem:static_time;db_close_delay=-1"),
+    timeProviderType = TimeProviderType.Static
+  )
+  def commandClientConfig =
+    CommandClientConfiguration(
+      config.commandConfig.maxCommandsInFlight,
+      config.commandConfig.maxParallelSubmissions,
+      true,
+      JDuration.ofMillis(2000)
+    )
+  private val applicationId = "transaction-stream-termination-test"
+
+  private def newTransactionClient(ledgerId: domain.LedgerId) =
+    new TransactionClient(ledgerId, TransactionServiceGrpc.stub(channel))
+
+  private def newPartyManagement(ledgerId: domain.LedgerId) =
+    new PartyManagementClient(PartyManagementServiceGrpc.stub(channel))
+
+  private def newCommandSubmissionClient(ledgerId: domain.LedgerId) =
+    new CommandClient(
+      CommandSubmissionServiceGrpc.stub(channel),
+      CommandCompletionServiceGrpc.stub(channel),
+      ledgerId,
+      applicationId,
+      commandClientConfig,
+      None
+    )
+
+  "TransactionService" when {
+    "streaming transactions until ledger end with no corresponding ledger entries" should {
+      "terminate properly" in {
+
+        val actualLedgerId = ledgerId()
+        val begin =
+          LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))
+        val end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))
+        val submitRequest: SubmitRequest =
+          M.submitRequest.update(
+            _.commands.ledgerId := actualLedgerId.unwrap,
+            _.commands.applicationId := applicationId,
+            _.commands.commands := List(
+              Command(Command.Command.Create(CreateCommand(
+                Some(templateIds.dummy),
+                Some(Record(
+                  Some(templateIds.dummy),
+                  Seq(RecordField(
+                    "operator",
+                    Option(Value(Value.Sum.Party(M.submitAndWaitRequest.commands.get.party)))))))
+              ))))
+          )
+
+        val commandClient = newCommandSubmissionClient(actualLedgerId)
+        val txClient = newTransactionClient(actualLedgerId)
+        val partyManagementClient = newPartyManagement(actualLedgerId)
+
+        def getLedgerEnd = txClient.getLedgerEnd().map(_.getOffset.value.absolute.get.toLong)
+        for {
+          endAtStartOfTest <- getLedgerEnd
+          // first we create a transaction
+          _ <- commandClient.trackSingleCommand(submitRequest)
+          endAfterSubmission <- getLedgerEnd
+          // next we allocate a party. this causes the ledger end to move without a corresponding ledger entry
+          _ <- partyManagementClient.allocateParty(None, None)
+          endAfterParty <- getLedgerEnd
+          // without the fix, this call will cause the test to run into a timeout
+          transactions <- txClient
+            .getTransactions(begin, Some(end), M.transactionFilter)
+            .runWith(Sink.seq)
+        } yield {
+          endAtStartOfTest should be < endAfterSubmission
+          endAfterSubmission should be < endAfterParty
+          transactions should have size 1
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #3984.

CHANGELOG_BEGIN
[Sandbox] Fix bug that can cause the transaction stream to not terminate.
  See `issue #3984 <https://github.com/digital-asset/daml/issues/3984>`__.
CHANGELOG_END

The bug is that the ledger end gets updated without writing any ledger entries,
for example when uploading packages or in case of duplicate commands.

The termination of the stream (i.e. the comparison of offsets) only happened
on actual ledger entries. If there are none, then the stream just waits for the next
entry to be written. In case of a ledger with static time (i.e. no heartbeats/checkpoints) and no other transaction being accepted or rejected, this can lead to a transaction stream over the Ledger API to not terminate.

This change moves the stream termination/completion to BEFORE potential entries
are loaded. The stream knows that after a certain offset has been reached, that it can
be terminated/completed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
