### PR TITLE
fix Bash syntax in Docker cron

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -58,6 +58,8 @@ jobs:
           set -euo pipefail
 
           eval "$(dev-env/bin/dade-assist)"
+          HEAD=$(git rev-parse HEAD)
+          while ! nix-build -A tools.sed -A tools.jq -A tools.curl nix; do :; done
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
           RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
           DIR=$(pwd)
@@ -67,17 +69,17 @@ jobs:
           # We do not update docker images for older releases so only docker images for SDK releases
           # >= 0.13.43 are built this way.
           for version in $(echo $RELEASES | sed -e 's/ /\n/g'); do
-            git checkout "$version"
-            while ! nix-build -A tools -A cached nix; do; done
             LAST_UPDATE=$(echo $VERSIONS | jq -r '.results[] | select(.name == "'${version#v}'") | .last_updated')
             if [[ -n "$LAST_UPDATE" ]]; then
               echo "${version#v} already exists, skipping."
             else
               echo "Building version ${version#v}..."
+              git checkout "$version"
               cd ci/docker/daml-sdk
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
               docker push digitalasset/daml-sdk:${version#v}
               cd "$DIR"
+              git checkout $HEAD
               echo "Done."
             fi
           done


### PR DESCRIPTION
This PR:
- moves the nix install line outside the loop, because we just want a working environment to run this script, we do not need to reproduce an exact replica of the build environment for each version (nothing gets built here, he just run the install script from within the Docker image).
- changes the nix install line to only install the binaries we need, rather than all of the dev-env.
- corrects the syntax of the empty while loop; Bash apparently doesn't support empty while loops (it worked on my `zsh` and I forgot to check for Bash), but does support `:` as a built-in no-op program that always succeeds.