### PR TITLE
Basic numeric type support : first cut

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -343,7 +343,6 @@ genType curModName = go
         TCon _ -> error "IMPOSSIBLE: lonely type constructor"
         TSynApp{} -> error "IMPOSSIBLE: type synonym not serializable"
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
-          -- The above case also handles 'TNumeric a' where 'a' is not a type level nat.
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"
         TStruct{} -> error "IMPOSSIBLE: structural record not serializable"

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -303,7 +303,10 @@ genType curModName = go
         TBool -> ("boolean", "daml.Bool")
         TInt64 -> dup "daml.Int"
         TDecimal -> dup "daml.Decimal"
-        TNumeric _ -> dup "daml.Numeric"  -- TODO(MH): Figure out what to do with the scale.
+        TNumeric (TNat n) -> (
+            "daml.Numeric"
+          , "daml.Numeric(" <> T.pack (show (fromTypeLevelNat n :: Integer)) <> ")"
+          )
         TText -> ("string", "daml.Text")
         TTimestamp -> dup "daml.Time"
         TParty -> dup "daml.Party"
@@ -340,6 +343,7 @@ genType curModName = go
         TCon _ -> error "IMPOSSIBLE: lonely type constructor"
         TSynApp{} -> error "IMPOSSIBLE: type synonym not serializable"
         t@TApp{} -> error $ "IMPOSSIBLE: type application not serializable - " <> DA.Pretty.renderPretty t
+          -- The above case also handles 'TNumeric a' where 'a' is not a type level nat.
         TBuiltin t -> error $ "IMPOSSIBLE: partially applied primitive type not serializable - " <> DA.Pretty.renderPretty t
         TForall{} -> error "IMPOSSIBLE: universally quantified type not serializable"
         TStruct{} -> error "IMPOSSIBLE: structural record not serializable"

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -30,6 +30,9 @@ template AllTypes with
     variant: Expr Int
     sumProd : Quux
     parametericSumProd : Expr2 Int
+    n0 : Numeric 0
+    n5 : Numeric 5
+    n10 : Decimal
   where
     signatory party
 

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -113,6 +113,26 @@ export const Decimal: Serializable<Decimal> = {
 }
 
 /**
+ * The counterpart of DAML's `Numeric` type. We represent `Numeric`s as string
+ * in order to avoid a loss of precision. The string must match the regular
+ * expression `-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?`.
+ */
+export type Numeric = string;
+
+/**
+ * Companion function of the `Numeric` type.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Numeric = function (_: number): Serializable<Numeric> {
+  // To-do : Write a smarter decoder to replace 'jtv.string' that
+  // performs validation on string inputs taking the scale parameter
+  // into account.
+  return ({
+    decoder: jtv.string,
+  });
+}
+
+/**
  * The counterpart of DAML's `Text` type.
  */
 export type Text = string;

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -99,37 +99,24 @@ export const Int: Serializable<Int> = {
 }
 
 /**
- * The counterpart of DAML's `Decimal` type. We represent `Decimal`s as string
- * in order to avoid a loss of precision. The string must match the regular
- * expression `-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?`.
- */
-export type Decimal = string;
-
-/**
- * Companion object of the `Decimal` type.
- */
-export const Decimal: Serializable<Decimal> = {
-  decoder: jtv.string,
-}
-
-/**
  * The counterpart of DAML's `Numeric` type. We represent `Numeric`s as string
  * in order to avoid a loss of precision. The string must match the regular
  * expression `-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?`.
  */
 export type Numeric = string;
+export type Decimal = Numeric;
 
 /**
  * Companion function of the `Numeric` type.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Numeric = function (_: number): Serializable<Numeric> {
-  // To-do : Write a smarter decoder to replace 'jtv.string' that
-  // performs validation on string inputs taking the scale parameter
-  // into account.
-  return ({
+export const Numeric = (_: number): Serializable<Numeric> =>
+  ({
     decoder: jtv.string,
-  });
+  })
+
+export const Decimal: Serializable<Decimal> = {
+  decoder: Numeric(10).decoder,
 }
 
 /**

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -151,6 +151,9 @@ test('create + fetch & exercise', async () => {
     variant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
     sumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}},
     parametericSumProd: {tag: 'Add2', value: {lhs:{tag: 'Lit2', value: '1'}, rhs:{tag: 'Lit2', value: '2'}}},
+    n0:  '3.0',          // Numeric 0
+    n5:  '3.14159',      // Numeric 5
+    n10: '3.1415926536', // Numeric 10
   };
   const allTypesContract = await ledger.create(Main.AllTypes, allTypes);
   expect(allTypesContract.payload).toEqual(allTypes);


### PR DESCRIPTION
Adds minimal support to `daml2ts` for DAML `Numeric n` values. Next step, write a smarter decoder for them than `jtv.string`.

changelog_begin
changelog_end

