### PR TITLE
document that null Optional-in-record shortcut *not* used in JSON output

### DIFF
--- a/docs/source/json-api/lf-value-specification.rst
+++ b/docs/source/json-api/lf-value-specification.rst
@@ -375,8 +375,8 @@ you get when you have eliminated all type variables.
 Output
 ======
 
-Encoded as described above, always applying the shortcut for None record
-fields.
+Encoded as described above, never applying the shortcut for None record
+fields; e.g. ``{ foo: None }`` will always encode as ``{ foo: null }``.
 
 Variant
 *******


### PR DESCRIPTION
The output format has never used the shortcut, and the current behavior is desirable as mentioned by @hurryabit , so just document correctly.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
