### PR TITLE
Engine: Add node and contract Discriminator

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -295,7 +295,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
           .setContractId(coid)
           .setTemplateId(convertIdentifier(templateId))
           .build
-      case V.RelativeContractId(txnid) =>
+      case V.RelativeContractId(txnid, _) =>
         ContractRef.newBuilder
           .setRelative(true)
           .setContractId(txnid.index.toString)
@@ -306,7 +306,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
   def convertContractId(coid: V.ContractId): String =
     coid match {
       case V.AbsoluteContractId(coid) => coid
-      case V.RelativeContractId(txnid) => txnid.index.toString
+      case V.RelativeContractId(txnid, _) => txnid.index.toString
     }
 
   def convertScenarioStep(
@@ -375,8 +375,8 @@ case class Conversions(homePackageId: Ref.PackageId) {
         ptx.context.children.toImmArray.toSeq.sortBy(_.index).map(convertTxNodeId).asJava)
 
     ptx.context match {
-      case Tx.ContextRoot(_) =>
-      case Tx.ContextExercises(ctx, _) =>
+      case Tx.PartialTransaction.ContextRoot(_, _) =>
+      case Tx.PartialTransaction.ContextExercise(ctx, _) =>
         val ecBuilder = ExerciseContext.newBuilder
           .setTargetId(mkContractRef(ctx.targetId, ctx.templateId))
           .setChoiceId(ctx.choiceId)
@@ -628,7 +628,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
         coid match {
           case V.AbsoluteContractId(acoid) =>
             builder.setContractId(acoid)
-          case V.RelativeContractId(txnid) =>
+          case V.RelativeContractId(txnid, _) =>
             builder.setContractId(txnid.index.toString)
         }
       case V.ValueList(values) =>

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -13,6 +13,9 @@ import scala.collection.mutable
 final class BackStack[+A] private (fq: BQ[A], len: Int) {
 
   /** O(1) */
+  def length: Int = len
+
+  /** O(1) */
   def :+[B >: A](x: B): BackStack[B] = new BackStack(BQSnoc(fq, x), len + 1)
 
   /** O(1) */

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.engine
+package com.digitalasset.daml.lf
+package engine
 
 import java.util
 import java.io.File
@@ -37,6 +38,8 @@ import scala.language.implicitConversions
 class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunfiles {
 
   import EngineTest._
+
+  private def hash(s: String) = Some(crypto.Hash.hashPrivateKey(s))
 
   private val party = Party.assertFromString("Party")
   private val alice = Party.assertFromString("Alice")
@@ -438,7 +441,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       .consume(lookupContract, lookupPackage, lookupKey)
     res shouldBe 'right
     val interpretResult = engine
-      .submit(Commands(party, ImmArray(command), let, "test"))
+      .submit(Commands(party, ImmArray(command), let, "test"), hash("minimal create command"))
       .consume(lookupContract, lookupPackage, lookupKey)
 
     "be translated" in {
@@ -450,7 +453,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
       val reinterpretResult =
         engine
-          .reinterpret(Set(party), txRoots, let)
+          .reinterpret(tx.transactionSeed, Set(party), txRoots, let)
           .consume(lookupContract, lookupPackage, lookupKey)
       (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -476,6 +479,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "exercise command" should {
+    val seed = hash("exercise command")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:Simple")
     val hello = Identifier(basicTestsPkgId, "BasicTests:Hello")
     val let = Time.Timestamp.now()
@@ -495,13 +499,15 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               checkSubmitterInMaintainers = true,
               submitters = Set(party),
               commands = r,
-              time = let)
+              time = let,
+              transactionSeed = seed
+            )
             .consume(lookupContract, lookupPackage, lookupKey))
     val Right(tx) = interpretResult
 
     "be translated" in {
       val submitResult = engine
-        .submit(Commands(party, ImmArray(command), let, "test"))
+        .submit(Commands(party, ImmArray(command), let, "test"), seed)
         .consume(lookupContract, lookupPackage, lookupKey)
       interpretResult shouldBe 'right
       (interpretResult |@| submitResult)(_ isReplayedBy _) shouldBe Right(true)
@@ -511,7 +517,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
       val reinterpretResult =
         engine
-          .reinterpret(Set(party), txRoots, let)
+          .reinterpret(tx.transactionSeed, Set(party), txRoots, let)
           .consume(lookupContract, lookupPackage, lookupKey)
       (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -541,6 +547,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "exercise-by-key command with missing key" should {
+    val seed = hash("exercise-by-key command with missing key")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:WithKey")
     val let = Time.Timestamp.now()
     val command = ExerciseByKeyCommand(
@@ -557,13 +564,14 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     "fail at submission" in {
       val submitResult = engine
-        .submit(Commands(alice, ImmArray(command), let, "test"))
+        .submit(Commands(alice, ImmArray(command), let, "test"), seed)
         .consume(lookupContractWithKey, lookupPackage, lookupKey)
       submitResult.left.value.msg should startWith("dependency error: couldn't find key")
     }
   }
 
   "exercise-by-key command with existing key" should {
+    val seed = hash("exercise-by-key command with existing key")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:WithKey")
     val let = Time.Timestamp.now()
     val command = ExerciseByKeyCommand(
@@ -586,13 +594,15 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               checkSubmitterInMaintainers = true,
               submitters = Set(alice),
               commands = r,
-              time = let)
+              time = let,
+              transactionSeed = seed
+            )
             .consume(lookupContractWithKey, lookupPackage, lookupKey))
     val tx = result.right.value
 
     "be translated" in {
       val submitResult = engine
-        .submit(Commands(alice, ImmArray(command), let, "test"))
+        .submit(Commands(alice, ImmArray(command), let, "test"), seed)
         .consume(lookupContractWithKey, lookupPackage, lookupKey)
       (result |@| submitResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -601,7 +611,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
       val reinterpretResult =
         engine
-          .reinterpret(Set(alice), txRoots, let)
+          .reinterpret(tx.transactionSeed, Set(alice), txRoots, let)
           .consume(lookupContractWithKey, lookupPackage, lookupKey)
       (result |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -631,6 +641,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "create-and-exercise command" should {
+    val seed = hash("create-and-exercise command")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:Simple")
     val hello = Identifier(basicTestsPkgId, "BasicTests:Hello")
     val let = Time.Timestamp.now()
@@ -655,7 +666,9 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               checkSubmitterInMaintainers = true,
               submitters = Set(party),
               commands = r,
-              time = let)
+              time = let,
+              transactionSeed = seed
+            )
             .consume(lookupContract, lookupPackage, lookupKey))
     val Right(tx) = interpretResult
 
@@ -671,7 +684,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
       val reinterpretResult =
         engine
-          .reinterpret(Set(party), txRoots, let)
+          .reinterpret(tx.transactionSeed, Set(party), txRoots, let)
           .consume(lookupContract, lookupPackage, lookupKey)
       (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -851,6 +864,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "exercise callable command" should {
+    val seed = hash("exercise callable command")
     val originalCoid = "1"
     val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
     val let = Time.Timestamp.now()
@@ -873,13 +887,15 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               checkSubmitterInMaintainers = true,
               submitters = Set(bob),
               commands = r,
-              time = let)
+              time = let,
+              transactionSeed = seed
+            )
             .consume(lookupContractForPayout, lookupPackage, lookupKey))
     interpretResult shouldBe 'right
 
     "be translated" in {
       val submitResult = engine
-        .submit(Commands(bob, ImmArray(command), let, "test"))
+        .submit(Commands(bob, ImmArray(command), let, "test"), seed)
         .consume(lookupContractForPayout, lookupPackage, lookupKey)
       submitResult shouldBe 'right
 
@@ -894,7 +910,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
       val reinterpretResult =
         engine
-          .reinterpret(Set(bob), txRoots, let)
+          .reinterpret(tx.transactionSeed, Set(bob), txRoots, let)
           .consume(lookupContractForPayout, lookupPackage, lookupKey)
       (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
@@ -904,8 +920,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       // Bob sees both the archive and the create
       val bobView = Blinding.divulgedTransaction(blindingInfo.localDisclosure, bob, tx)
       bobView.nodes.size shouldBe 2
-
-      bobView.nodes(Tx.NodeId.unsafeFromIndex(0)) match {
+      findNodeByIdx(bobView.nodes, 0).getOrElse(fail("node not found")) match {
         case NodeExercises(
             coid,
             _,
@@ -923,12 +938,12 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
           coid shouldBe AbsoluteContractId(originalCoid)
           consuming shouldBe true
           actingParties shouldBe Set(bob)
-          children shouldBe ImmArray(Tx.NodeId.unsafeFromIndex(1))
+          children.map(_.index) shouldBe ImmArray(1)
           choice shouldBe "Transfer"
         case _ => fail("exercise expected first for Bob")
       }
 
-      bobView.nodes(Tx.NodeId.unsafeFromIndex(1)) match {
+      findNodeByIdx(bobView.nodes, 1).getOrElse(fail("node not found")) match {
         case NodeCreate(_, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
@@ -939,7 +954,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val claraView = Blinding.divulgedTransaction(blindingInfo.localDisclosure, clara, tx)
 
       claraView.nodes.size shouldBe 1
-      claraView.nodes(Tx.NodeId.unsafeFromIndex(1)) match {
+      findNodeByIdx(claraView.nodes, 1).getOrElse(fail("node not found")) match {
         case NodeCreate(_, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
@@ -949,12 +964,17 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     "events generated correctly" in {
       val Right(tx) = interpretResult
+      val Seq(_, noid1) = tx.nodes.keys.toSeq.sortBy(_.index)
       val Right(blindingInfo) =
         Blinding.checkAuthorizationAndBlind(tx, Set(bob))
       val events = Event.collectEvents(tx, blindingInfo.disclosure)
       val partyEvents = events.filter(_.witnesses contains bob)
       partyEvents.roots.length shouldBe 1
       val bobExercise = partyEvents.events(partyEvents.roots(0))
+      val discriminator =
+        crypto.Hash.assertFromString(
+          "9f047ad81fb2aa354ca89f95e1efa9c2141ba4a2224f4e42c96d3d278017cf1e")
+      val cid = RelativeContractId(noid1, Some(discriminator))
       bobExercise shouldBe
         ExerciseEvent(
           contractId = AbsoluteContractId(originalCoid),
@@ -966,17 +986,16 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               ImmArray((Some[Name]("newReceiver"), ValueParty(clara))))),
           actingParties = Set(bob),
           isConsuming = true,
-          children = ImmArray(Tx.NodeId.unsafeFromIndex(1)),
+          children = ImmArray(noid1),
           stakeholders = Set(bob, alice),
           witnesses = Set(bob, alice),
-          exerciseResult = Some(
-            assertAsVersionedValue(
-              ValueContractId(RelativeContractId(Tx.NodeId.unsafeFromIndex(1)))))
+          exerciseResult = Some(assertAsVersionedValue(ValueContractId(cid)))
         )
-      val bobVisibleCreate = partyEvents.events(Tx.NodeId.unsafeFromIndex(1))
+
+      val bobVisibleCreate = partyEvents.events(noid1)
       bobVisibleCreate shouldBe
         CreateEvent(
-          RelativeContractId(Tx.NodeId.unsafeFromIndex(1)),
+          cid,
           Identifier(basicTestsPkgId, "BasicTests:CallablePayout"),
           None,
           assertAsVersionedValue(
@@ -999,6 +1018,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     // Basic test: an exercise (on a "Fetcher" contract) with a single consequence, a fetch of the "Fetched" contract
     // Test a couple of scenarios, with different combination of signatories/observers/actors on the parent action
 
+    val seed = hash("dynamic fetch actors")
     val fetchedStrCid = "1"
     val fetchedCid = AbsoluteContractId(fetchedStrCid)
     val fetchedStrTid = "BasicTests:Fetched"
@@ -1077,7 +1097,9 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
               checkSubmitterInMaintainers = true,
               submitters = Set(exerciseActor),
               commands = r,
-              time = let)
+              time = let,
+              transactionSeed = seed
+            )
             .consume(lookupContract, lookupPackage, lookupKey))
 
     }
@@ -1103,9 +1125,9 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         }
       fetchNodes.foreach {
         case (nid, n) =>
-          val fetchTx = GenTx(HashMap(nid -> n), ImmArray(nid), None)
+          val fetchTx = GenTx(HashMap(nid -> n), ImmArray(nid), None, seed)
           val Right(reinterpreted) = engine
-            .reinterpret(n.requiredAuthorizers, Seq(n), let)
+            .reinterpret(nid.discriminator, n.requiredAuthorizers, Seq(n), let)
             .consume(lookupContract, lookupPackage, lookupKey)
           (fetchTx isReplayedBy reinterpreted) shouldBe true
       }
@@ -1113,6 +1135,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "reinterpreting fetch nodes" should {
+
+    val seed = hash("reinterpreting fetch nodes")
 
     val fetchedCid = AbsoluteContractId("1")
     val fetchedStrTid = "BasicTests:Fetched"
@@ -1155,7 +1179,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val let = Time.Timestamp.now()
 
       val reinterpreted = engine
-        .reinterpret(Set.empty, Seq(fetchNode), let)
+        .reinterpret(seed, Set.empty, Seq(fetchNode), let)
         .consume(lookupContract, lookupPackage, lookupKey)
 
       reinterpreted shouldBe 'right
@@ -1181,6 +1205,9 @@ object EngineTest {
     as.foreach(a.add)
     a
   }
+
+  private def findNodeByIdx[Cid, Val](nodes: Map[NodeId, GenNode[NodeId, Cid, Val]], idx: Int) =
+    nodes.collectFirst { case (nodeId, node) if nodeId.index == idx => node }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private implicit def resultEq: Equality[Either[Error, SValue]] = {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.engine
+package com.digitalasset.daml.lf
+package engine
 
 import java.io.File
 
@@ -23,6 +24,9 @@ import scala.language.implicitConversions
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
+
+  def hash(s: String, i: Int) =
+    Some(crypto.Hash.hashPrivateKey(s + ":" + i.toString))
 
   private def loadPackage(
       resource: String): (PackageId, Ast.Package, Map[PackageId, Ast.Package]) = {
@@ -80,14 +84,23 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     val rangeOfIntsTemplateId = Identifier(largeTx._1, qn("LargeTransaction:RangeOfInts"))
     val createCmd = rangeOfIntsCreateCmd(rangeOfIntsTemplateId, 0, 1, txSize)
     val createCmdTx: Transaction =
-      submitCommand(pcs, engine)(party, createCmd, "create RangeOfInts")
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = createCmd,
+        cmdReference = "create RangeOfInts",
+        seed = hash("testLargeTransactionOneContract:create", txSize))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListContainerExerciseCmd(rangeOfIntsTemplateId, contractId)
     val (exerciseCmdTx, quanity) = measureWithResult(
-      submitCommand(pcs, engine)(party, exerciseCmd, "exercise RangeOfInts.ToListContainer"))
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = exerciseCmd,
+        cmdReference = "exercise RangeOfInts.ToListContainer",
+        seed = hash("testLargeTransactionOneContract:exercise", txSize),
+      ))
 
     assertOneContractWithManyInts(exerciseCmdTx, List.range(0L, txSize.toLong))
     quanity
@@ -98,14 +111,23 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     val rangeOfIntsTemplateId = Identifier(largeTx._1, qn("LargeTransaction:RangeOfInts"))
     val createCmd = rangeOfIntsCreateCmd(rangeOfIntsTemplateId, 0, 1, num)
     val createCmdTx: Transaction =
-      submitCommand(pcs, engine)(party, createCmd, "create RangeOfInts")
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = createCmd,
+        cmdReference = "create RangeOfInts",
+        seed = hash("testLargeTransactionManySmallContracts:create", num))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListOfIntContainers(rangeOfIntsTemplateId, contractId)
     val (exerciseCmdTx, quanity) = measureWithResult(
-      submitCommand(pcs, engine)(party, exerciseCmd, "exercise RangeOfInts.ToListContainer"))
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = exerciseCmd,
+        cmdReference = "exercise RangeOfInts.ToListContainer",
+        seed = hash("testLargeTransactionManySmallContracts:exercise", num)
+      ))
 
     assertManyContractsOneIntPerContract(exerciseCmdTx, num)
     quanity
@@ -116,14 +138,22 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     val listUtilTemplateId = Identifier(largeTx._1, qn("LargeTransaction:ListUtil"))
     val createCmd = listUtilCreateCmd(listUtilTemplateId)
     val createCmdTx: Transaction =
-      submitCommand(pcs, engine)(party, createCmd, "create ListUtil")
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = createCmd,
+        cmdReference = "create ListUtil",
+        seed = hash("testLargeChoiceArgument:create", size))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = sizeExerciseCmd(listUtilTemplateId, contractId)(size)
     val (exerciseCmdTx, quantity) = measureWithResult(
-      submitCommand(pcs, engine)(party, exerciseCmd, "exercise ListUtil.Size"))
+      submitCommand(pcs, engine)(
+        submitter = party,
+        cmd = exerciseCmd,
+        cmdReference = "exercise ListUtil.Size",
+        seed = hash("testLargeTransactionManySmallContracts:exercise", size)))
 
     assertSizeExerciseTransaction(exerciseCmdTx, size.toLong)
     quantity
@@ -162,11 +192,14 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     } shouldBe expectedNumberOfContracts
   }
 
-  private def submitCommand(
-      pcs: PrivateLedgerData,
-      engine: Engine)(submitter: Party, cmd: Command, cmdReference: String): Tx.Transaction = {
+  private def submitCommand(pcs: PrivateLedgerData, engine: Engine)(
+      submitter: Party,
+      cmd: Command,
+      cmdReference: String,
+      seed: Option[crypto.Hash]
+  ): Tx.Transaction = {
     engine
-      .submit(Commands(submitter, ImmArray(cmd), Time.Timestamp.now(), cmdReference))
+      .submit(Commands(submitter, ImmArray(cmd), Time.Timestamp.now(), cmdReference), seed)
       .consume(pcs.get, lookupPackage, { _ =>
         sys.error("TODO keys for LargeTransactionTest")
       }) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -63,7 +63,8 @@ object Pretty {
               // exercised.
               case None =>
                 (line + text("Recursive exercise of ") + prettyTypeConName(tid)).nested(4)
-              case Some(nid) => (line + prettyTransactionNode(nid)).nested(4)
+              case Some(node) =>
+                (line + prettyTransactionNode(node)).nested(4)
             })
 
       case DamlEWronglyTypedContract(coid, expected, actual) =>
@@ -325,7 +326,7 @@ object Pretty {
   def prettyContractId(coid: ContractId): Doc =
     coid match {
       case AbsoluteContractId(acoid) => char('#') + text(acoid)
-      case RelativeContractId(rcoid) => char('#') + str(rcoid)
+      case RelativeContractId(rcoid, _) => char('#') + str(rcoid)
     }
 
   def prettyActiveContracts(c: L.LedgerData): Doc = {
@@ -401,7 +402,7 @@ object Pretty {
           text(constructor)
       case ValueText(t) => char('"') + text(t) + char('"')
       case ValueContractId(AbsoluteContractId(acoid)) => char('#') + text(acoid)
-      case ValueContractId(RelativeContractId(rcoid)) =>
+      case ValueContractId(RelativeContractId(rcoid, _)) =>
         char('~') + text(rcoid.toString)
       case ValueUnit => text("<unit>")
       case ValueBool(b) => str(b)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -25,7 +25,7 @@ object Ledger {
     def apply(acoid: AbsoluteContractId): ScenarioNodeId = acoid.coid
 
     def apply(commitPrefix: LedgerString, txnid: Transaction.NodeId): ScenarioNodeId =
-      apply(txNodeIdToAbsoluteContractId(commitPrefix, txnid))
+      apply(txNodeIdToAbsoluteContractId(commitPrefix, txnid.index))
   }
 
   /** This is the function that we use to turn relative contract ids (which are made of
@@ -35,16 +35,16 @@ object Ledger {
   @inline
   def txNodeIdToAbsoluteContractId(
       commitPrefix: LedgerString,
-      txnid: Transaction.NodeId
+      txnidx: Int
   ): AbsoluteContractId =
-    AbsoluteContractId(ContractIdString.concat(commitPrefix, txnid.name))
+    AbsoluteContractId(ContractIdString.concat(commitPrefix, LedgerString.fromInt(txnidx)))
 
   @inline
   def relativeToAbsoluteContractId(
       commitPrefix: LedgerString,
-      i: RelativeContractId
+      cid: RelativeContractId
   ): AbsoluteContractId =
-    txNodeIdToAbsoluteContractId(commitPrefix, i.txnid)
+    txNodeIdToAbsoluteContractId(commitPrefix, cid.txnid.index)
 
   @inline
   def contractIdToAbsoluteContractId(
@@ -567,10 +567,10 @@ object Ledger {
 
     def divulgeCoidTo(witnesses: Set[Party], coid: ContractId): EnrichState = {
       def divulgeRelativeCoidTo(ws: Set[Party], rcoid: RelativeContractId): EnrichState = {
-        val i = rcoid.txnid
+        val nid = rcoid.txnid
         copy(
           localDivulgences = localDivulgences
-            .updated(i, ws union localDivulgences.getOrElse(i, Set.empty)))
+            .updated(nid, ws union localDivulgences.getOrElse(nid, Set.empty)))
       }
 
       coid match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/SEquatableValuesSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/SEquatableValuesSpec.scala
@@ -66,7 +66,7 @@ class SEquatableValuesSpec extends WordSpec with Matchers with TableDrivenProper
     List("a", "b")
       .map(x => SContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString(x))))
   private val relativeContractId =
-    List(0, 1).map(x => SContractId(RelativeContractId(NodeId.unsafeFromIndex(x))))
+    List(0, 1).map(x => SContractId(RelativeContractId(NodeId(x))))
   private val contractIds = absoluteContractId ++ relativeContractId
 
   private val enums = List(EnumCon1, EnumCon2).map(SEnum(EnumTypeCon, _))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -11,15 +11,19 @@ import java.util
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Utf8}
 import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.value.Value
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
-class Hash private (private val bytes: Array[Byte]) {
+import scala.util.control.NonFatal
+
+final class Hash private (private val bytes: Array[Byte]) {
 
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexa: Ref.LedgerString =
-    Ref.LedgerString.assertFromString(bytes.map("%02x" format _).mkString)
+  def toLedgerString: Ref.LedgerString =
+    Hash.toLedgerString(this)
 
-  override def toString: String = s"Hash($toHexa)"
+  override def toString: String = s"Hash($toLedgerString)"
 
   override def equals(other: Any): Boolean =
     other match {
@@ -41,15 +45,35 @@ class Hash private (private val bytes: Array[Byte]) {
 
 object Hash {
 
-  private[crypto] abstract class Builder {
+  private val version = 0.toByte
+  private val underlyingHashLength = 32
 
-    def add(a: Array[Byte]): this.type
+  implicit val HashOrdering: Ordering[Hash] =
+    ((hash1, hash2) => implicitly[Ordering[Iterable[Byte]]].compare(hash1.bytes, hash2.bytes))
 
-    def add(a: ByteBuffer): this.type
+  private[crypto] sealed abstract class Builder {
 
-    def add(a: Byte): this.type
+    protected def update(a: Array[Byte]): Unit
 
-    def build: Hash
+    protected def doFinal(buf: Array[Byte], offset: Int): Unit
+
+    final def build: Hash = {
+      val a = Array.ofDim[Byte](underlyingHashLength)
+      doFinal(a, 0)
+      new Hash(a)
+    }
+
+    final def add(a: Array[Byte]): this.type = {
+      update(a)
+      this
+    }
+
+    private val byteBuff = Array.ofDim[Byte](1)
+
+    final def add(a: Byte): this.type = {
+      byteBuff(0) = a
+      add(byteBuff)
+    }
 
     final def add(a: Hash): this.type = add(a.bytes)
 
@@ -60,34 +84,37 @@ object Hash {
 
     private val intBuffer = ByteBuffer.allocate(java.lang.Integer.BYTES)
 
-    def add(a: Int): this.type = {
+    final def add(a: Int): this.type = {
       intBuffer.rewind()
       add(intBuffer.putInt(a).array())
     }
 
     private val longBuffer = ByteBuffer.allocate(java.lang.Long.BYTES)
 
-    def add(a: Long): this.type = {
+    final def add(a: Long): this.type = {
       longBuffer.rewind()
       add(longBuffer.putLong(a).array())
     }
 
-    def iterateOver[T, U](a: ImmArray[T])(f: (this.type, T) => this.type): this.type =
+    final def iterateOver[T, U](a: ImmArray[T])(f: (this.type, T) => this.type): this.type =
       a.foldLeft[this.type](add(a.length))(f)
 
-    def addDottedName(name: Ref.DottedName): this.type =
+    final def iterateOver[T](a: Iterator[T], size: Int)(f: (this.type, T) => this.type): this.type =
+      a.foldLeft[this.type](add(size))(f)
+
+    final def addDottedName(name: Ref.DottedName): this.type =
       iterateOver(name.segments)(_ add _)
 
-    def addQualifiedName(name: Ref.QualifiedName): this.type =
+    final def addQualifiedName(name: Ref.QualifiedName): this.type =
       addDottedName(name.module).addDottedName(name.name)
 
-    def addIdentifier(id: Ref.Identifier): this.type =
+    final def addIdentifier(id: Ref.Identifier): this.type =
       add(id.packageId).addQualifiedName(id.qualifiedName)
 
     // In order to avoid hash collision, this should be used together
     // with an other data representing uniquely the type of `value`.
     // See for instance hash : Node.GlobalKey => SHA256Hash
-    def addTypedValue(value: Value[Value.AbsoluteContractId]): this.type =
+    final def addTypedValue(value: Value[Value.AbsoluteContractId]): this.type =
       value match {
         case Value.ValueUnit =>
           add(0.toByte)
@@ -138,6 +165,7 @@ object Hash {
   private[crypto] object Purpose {
     val Testing = Purpose(1)
     val ContractKey = Purpose(2)
+    val PrivateKey = Purpose(3)
   }
 
   // package private for testing purpose.
@@ -146,34 +174,91 @@ object Hash {
 
     private val md = MessageDigest.getInstance("SHA-256")
 
-    override def add(a: Array[Byte]): this.type = {
+    override protected def update(a: Array[Byte]): Unit =
       md.update(a)
-      this
-    }
 
-    override def add(a: ByteBuffer): this.type = {
-      md.update(a)
-      this
-    }
+    override protected def doFinal(buf: Array[Byte], offset: Int): Unit =
+      assert(md.digest(buf, offset, underlyingHashLength) == underlyingHashLength)
 
-    override def add(a: Byte): this.type = {
-      md.update(a)
-      this
-    }
+    md.update(version)
+    md.update(purpose.id)
 
-    add(purpose.id)
-
-    override def build: Hash = new Hash(md.digest)
   }
+
+  private val hMacAlgorithm = "HmacSHA256"
+
+  private[crypto] def hMacBuilder(key: Hash): Builder = new Builder {
+
+    private val mac: Mac = Mac.getInstance(hMacAlgorithm)
+
+    mac.init(new SecretKeySpec(key.bytes, hMacAlgorithm))
+
+    override protected def update(a: Array[Byte]): Unit =
+      mac.update(a)
+
+    override protected def doFinal(buf: Array[Byte], offset: Int): Unit =
+      mac.doFinal(buf, offset)
+
+  }
+
+  def toLedgerString(hash: Hash): Ref.LedgerString =
+    Ref.LedgerString.assertFromString(hash.bytes.map("%02x" format _).mkString)
+
+  def fromString(s: String): Either[String, Hash] = {
+    def error = s"Cannot parse hash $s"
+    try {
+      val bytes = s.sliding(2, 2).map(Integer.parseInt(_, 16).toByte).toArray
+      Either.cond(
+        bytes.length == underlyingHashLength,
+        new Hash(bytes),
+        error
+      )
+    } catch {
+      case NonFatal(_) => Left(error)
+    }
+  }
+
+  def assertFromString(s: String): Hash =
+    data.assertRight(fromString(s))
+
+  def hashPrivateKey(s: String): Hash =
+    builder(Purpose.PrivateKey).add(s).build
 
   // This function assumes that key is well typed, i.e. :
   // 1 - `key.identifier` is the identifier for a template with a key of type τ
   // 2 - `key.key` is a value of type τ
-  def apply(key: Node.GlobalKey): Hash =
-    Hash
-      .builder(Hash.Purpose.ContractKey)
+  def hashContractKey(key: Node.GlobalKey): Hash =
+    builder(Hash.Purpose.ContractKey)
       .addIdentifier(key.templateId)
       .addTypedValue(key.key.value)
+      .build
+
+  def deriveTransactionSeed(
+      nonce: Hash,
+      participantId: Ref.LedgerString,
+      applicationId: Ref.LedgerString,
+      commandId: Ref.LedgerString,
+      submitter: Ref.Party,
+  ): Hash =
+    hMacBuilder(nonce)
+      .add(participantId)
+      .add(applicationId)
+      .add(commandId)
+      .add(submitter)
+      .build
+
+  def deriveNodeDiscriminator(
+      parentDiscriminator: Hash,
+      childIdx: Int
+  ): Hash =
+    hMacBuilder(parentDiscriminator).add(childIdx).build
+
+  def deriveContractDiscriminator(
+      nodeDiscriminator: Hash,
+      parties: Set[Ref.Party]
+  ) =
+    hMacBuilder(nodeDiscriminator)
+      .iterateOver(parties.toSeq.sorted[String].iterator, parties.size)(_ add _)
       .build
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -87,10 +87,10 @@ class HashSpec extends WordSpec with Matchers {
   "KeyHasher" should {
 
     "be stable" in {
-      val hash = "a0a47f146a6ba1aca8865d9cc3741b766595a7810c25132fd87d92e433fa37bc"
+      val hash = "ea24627f5b014af67dbedb13d950e60be7f96a1a5bd9fb1a3b9a85b7fa9db4bc"
       val value = complexRecordT.inj(complexRecordV)
       val name = defRef("module", "name")
-      Hash(GlobalKey(name, value)).toHexa shouldBe hash
+      Hash.hashContractKey(GlobalKey(name, value)).toLedgerString shouldBe hash
     }
 
     "be deterministic and thread safe" in {
@@ -99,7 +99,7 @@ class HashSpec extends WordSpec with Matchers {
       val hashes = Vector
         .fill(1000)(GlobalKey(defRef("module", "name"), complexRecordT.inj(complexRecordV)))
         .par
-        .map(Hash(_))
+        .map(Hash.hashContractKey)
 
       hashes.toSet.size shouldBe 1
     }
@@ -108,8 +108,8 @@ class HashSpec extends WordSpec with Matchers {
       // Same value but different template ID should produce a different hash
       val value = VA.text.inj("A")
 
-      val hash1 = Hash(GlobalKey(defRef("AA", "A"), value))
-      val hash2 = Hash(GlobalKey(defRef("A", "AA"), value))
+      val hash1 = Hash.hashContractKey(GlobalKey(defRef("AA", "A"), value))
+      val hash2 = Hash.hashContractKey(GlobalKey(defRef("A", "AA"), value))
 
       hash1 should !==(hash2)
     }
@@ -122,8 +122,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -137,8 +137,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -151,8 +151,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -165,8 +165,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -178,8 +178,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -192,8 +192,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -206,8 +206,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -218,8 +218,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -230,8 +230,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -242,8 +242,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -254,8 +254,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -266,8 +266,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -278,8 +278,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -292,8 +292,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash(GlobalKey(tid, value1))
-      val hash2 = Hash(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
+      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
 
       hash1 should !==(hash2)
     }
@@ -420,119 +420,119 @@ class HashSpec extends WordSpec with Matchers {
 
       val expectedOut =
         """ValueUnit
-          | 47dc540c94ceb704a23875c11273e16bb0b8a87aed84de911f2133568115f254
+          | faee935763044f124d7526755a5058a33f9402a595994d59eddd4be8546ff201
           |ValueBool(true)
-          | 9dcf97a184f32623d11a73124ceb99a5709b083721e878a16d78f596718ba7b2
+          | fbb59ed10e9cd4ff45a12c5bb92cbd80df984ba1fe60f26a30febf218e2f0f5e
           |ValueBool(false)
-          | 47dc540c94ceb704a23875c11273e16bb0b8a87aed84de911f2133568115f254
+          | faee935763044f124d7526755a5058a33f9402a595994d59eddd4be8546ff201
           |ValueInt64(-1)
-          | 1272f520cf7ca5cf117a0b5a3116518371bf20fb7fac043ac1be568b8c55b96c
+          | 8c6461aec2028ecd3880ad2243b6e0fdb4033ab46ce1702f5289819fb45f8a93
           |ValueInt64(0)
-          | a536aa3cede6ea3c1f3e0357c3c60e0f216a8c89b853df13b29daa8f85065dfb
+          | 13c6a7b85fcb0443c1d31dafe22561aac714fbaa99d3b9a56474d8dda0c9aee0
           |ValueInt64(1)
-          | f52f3a746c2545658e1c6add32e5410365553ebaaa0433f5f8bd90c6f85fd6e2
+          | 36dd3485b6affcd5d59600c58aca5c1cdc2c01bb0a2956bfaa690d157bc9b2be
           |ValueNumeric(-10000.0000000000)
-          | 06688bdccaa8613e22b96e399b601884a4c7476b97647a1adcb173ab2c94ed4c
+          | 19d45e6d088423c70208cf7f87cc10429e66ef343c4c608ba69f675562d4be1e
           |ValueNumeric(0E-10)
-          | a90d4563c6a0ae0417ab3110f1ba68592833465954774201b0a69e8c457dc6ad
+          | ea87c0c1539dfbbd804c58717ecf30f5b50b946638a39fdaf6712253b952ab40
           |ValueNumeric(10000.0000000000)
-          | f704cf5962e1f9e6568d0c9bc08f9caa2b7524ac901f311911c8cb70d8a01608
+          | 1e4b9819cb11e44c0a5a826b7b81e756f3dfaf3061d9f9baa345c1a6c2d7c284
           |ValueNumeric(-10000)
-          | af020447b2978bcc3114cf0d8c832f028c75ab7713a3985d44715e37c668807e
+          | 02dfadf86a4fbb948e165e20350e472d087072695feb613f9c9562eccda56be8
           |ValueNumeric(0)
-          | a90d4563c6a0ae0417ab3110f1ba68592833465954774201b0a69e8c457dc6ad
+          | ea87c0c1539dfbbd804c58717ecf30f5b50b946638a39fdaf6712253b952ab40
           |ValueNumeric(10000)
-          | 28b2998d102b9dbc2f39cbb1781f930e80f29fa585a3920c920028f92d1e6a6c
+          | 5a97286594af94c406d9354d35bf515a12e9d46b61f6dd6d4679e85395fde5f6
           |ValueDate(1970-01-01)
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueDate(1969-07-21)
-          | aeb4c265245cd7aa582d4e9953e108b182516f279a60919795130842fab5912d
+          | f6538d4cb9a7663f9aeac6cd8b1cb5ddba62337ca3ca2b21b29297d85ec53ae5
           |ValueDate(2019-12-16)
-          | 247de9bec9f7a30173b946038ba22b7ea4f1d9c03aa2eb278c9f1c8de110e084
+          | 4a5ce4f9f37be5e93ccd1360f5e3d0b93ac4445be1532bfdbe2e0805dc0fc133
           |ValueTimestamp(1970-01-01T00:00:00Z)
-          | a536aa3cede6ea3c1f3e0357c3c60e0f216a8c89b853df13b29daa8f85065dfb
+          | 13c6a7b85fcb0443c1d31dafe22561aac714fbaa99d3b9a56474d8dda0c9aee0
           |ValueTimestamp(1969-07-21T02:56:15Z)
-          | fcaf4b00d1f94c7126299dd9fe753ec03ca5823669a79e5cef0b706bedc98d74
+          | c4f34225847a9d0d7a788df5c9f5aa3ac6e98ae7ad68d29b650411d6c95aaddb
           |ValueTimestamp(2019-12-16T11:17:54.940779Z)
-          | 79e7e25c280740fbe3ba3a9c083f5cecc5dae5ad6f4dd77858113867d504b78e
+          | 18f13afe32a31b84d8f0e24eba45e710a0dbef47282c81b0be4a361f8aacbb01
           |ValueText()
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueText(someText)
-          | 71209c3a5e05a8bb796881eaec6a498d96995ea4d212b9bf6dec8f4ab069f0ed
+          | 657c0cf2531d5219dc34b4e03f94278f78efc7c90cc0f03b48049bf66572d070
           |ValueText(a¶‱😂)
-          | a9eb3431bd82a173e23fc0897642b30ffffb35b2d9bb0d47119a124031137d02
+          | 88ee87e8038f8aa94057d5809adee8d12f9cb6657338171942695fad51fb8df1
           |ValueParty(alice)
-          | 151a185ae945526e7ba8dd89864b4f157eef8cec96ca7f00524186723e54d348
+          | 274830656c6f7de1daf729d11c57c40ef271a101a831d89e45f034ce7bd71d9d
           |ValueParty(bob)
-          | 1bc9e1ce9982ee796fac0e2542aff3f6863ecf5e64b459054b2e8928bb432c67
+          | dc1f0fc026d3200a1781f0989dd1801022e028e8afe5d953a033e6d35e8ea50b
           |ValueContractId(AbsoluteContractId(07e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5))
-          | afa1aa91da7ea6dbd74a719c98d169addf4106ce0916430656f8a2bba73ea280
+          | 399c8d4fb942204c9384a8bda062676d75a3a52080c798f98560b2914af61ad8
           |ValueContractId(AbsoluteContractId(59b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b))
-          | d0a26432252903db999a354a5ed6b2fbd5010e53637afcf804cdb4e4c37fc315
+          | f05d36c187b003a1c1ca669579bdcf0cfce85ce634029cc533d23d24fd8382a1
           |ValueOptional(None)
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueOptional(Some(ValueBool(false)))
-          | a90d4563c6a0ae0417ab3110f1ba68592833465954774201b0a69e8c457dc6ad
+          | ea87c0c1539dfbbd804c58717ecf30f5b50b946638a39fdaf6712253b952ab40
           |ValueOptional(Some(ValueBool(true)))
-          | 71ca9703af0fda42b802aa93ef5ff20cc9d02353e1b2d514acae2ec02f2c7278
+          | 5b5ca90960b8594498cc778421a40ff2aed14d788d06ede5d4a41207933d3e13
           |ValueOptional(Some(ValueOptional(None)))
-          | c1a55026080627649a9e5f2226e3ce91f2c1b7959d429a312a0c96339108b6c9
+          | 86c779d69df35dd466459fa498249d58d0cff42d4a65f112842d0a81d93c3774
           |ValueOptional(Some(ValueOptional(Some(ValueBool(false)))))
-          | 649cc24b99273730cbfc3ad5726781e62593837e78a3d6b0b615f320c488abd6
+          | d9ef2f4d617d921548e1e01da5af2b7ff67e7ed24a0cbd2e29fd30f4cce6ac4e
           |ValueList(FrontStack())
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueList(FrontStack(ValueBool(false)))
-          | a90d4563c6a0ae0417ab3110f1ba68592833465954774201b0a69e8c457dc6ad
+          | ea87c0c1539dfbbd804c58717ecf30f5b50b946638a39fdaf6712253b952ab40
           |ValueList(FrontStack(ValueBool(true)))
-          | 71ca9703af0fda42b802aa93ef5ff20cc9d02353e1b2d514acae2ec02f2c7278
+          | 5b5ca90960b8594498cc778421a40ff2aed14d788d06ede5d4a41207933d3e13
           |ValueList(FrontStack(ValueBool(false),ValueBool(false)))
-          | 1d3e4d40ae7f934c7b67fb747ae99f9af5bfc867f52966e7c3cf6b7975dd237a
+          | 8f5dff2ff3f971b847284fb225522005587449fad2746879a0280bbd036f1abc
           |ValueList(FrontStack(ValueBool(false),ValueBool(true)))
-          | f9ce3cd0946bd8a778fa90b81a439f80a999e263fac5877fe7316170298ae139
+          | 4f6de867c24682cee05db95d48e1ea47cf5f8b6e74fe07582d3cd8cecaea84b7
           |ValueList(FrontStack(ValueBool(true),ValueBool(false)))
-          | b238496934cc67758abae39e09934168f2da4f4db828cf25dfce22e276e58b9b
+          | 768c5b90ed7ae5b727381e331fac83d7defd397d040f46ba067c80ec2af3eb33
           |ValueTextMap(SortedLookupList())
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueTextMap(SortedLookupList((a,ValueBool(false))))
-          | e8dc56307e050c735828adff3914e46cc2ca3e6508e15f0e3a9f7f56998aa3e8
+          | 4c4384399821a8ed7526d8b29dc6f76ad87014ade285386e7d05d71e61d86c7c
           |ValueTextMap(SortedLookupList((a,ValueBool(false))))
-          | e8dc56307e050c735828adff3914e46cc2ca3e6508e15f0e3a9f7f56998aa3e8
+          | 4c4384399821a8ed7526d8b29dc6f76ad87014ade285386e7d05d71e61d86c7c
           |ValueTextMap(SortedLookupList((b,ValueBool(false))))
-          | d1385328e6b074f7bef63c877357b09ab11de0035747c344fe60ed0f733caf8f
+          | b0c45256eea6bf29c0390e82ce89efe2974db7af5dad8f14d25dad6a92cf3faf
           |ValueTextMap(SortedLookupList((a,ValueBool(false)),(b,ValueBool(false))))
-          | 11f7643a5d2c1abdd28cb912a32f94cc9b145e9ea0932a423b0afd5d6da36dbb
+          | 132fba96cd6130c57d63f8eb2b9a245deaa8a618c4cb9793af32f1190624e6bd
           |ValueTextMap(SortedLookupList((a,ValueBool(true)),(b,ValueBool(false))))
-          | b3cfd3d5a67480d1a0819d0ef66a9826c7a91b8d0125cbc82e0dca1b4b68a42e
+          | 954d9283d02236a4f1cd6d1cdf8f8c8a0ced4fc18f14a8380574c4d09485ec60
           |ValueTextMap(SortedLookupList((a,ValueBool(false)),(b,ValueBool(true))))
-          | b91b20a3daf58619e432c77b6dbca0c24d105092dfc4e420c72ede6e1cef5c23
+          | da9ab333c3de358c2e5aead8a9ced5cbe5dda7fc454ade82180596120c5abdc6
           |ValueTextMap(SortedLookupList((a,ValueBool(false)),(c,ValueBool(false))))
-          | 8df4200e13434cab9917c19c2d0b764e2259fdeaaf29e9817989af83eb22e583
+          | 5ac45cbc29a66cd2f10dad87daf37dbb5fa905f5647586fc5f2eafca5d349bac
           |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Red)
-          | e913123a57c91b08dde781877cba20bcedd7e67dbb4bfb9e1b2fad2ac9201f89
+          | 048b20422b487b8eeba059a219589ad477e5f11eb769c7fea658b63f1bb1d405
           |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Green)
-          | 6db1b39e291c0f9af7290149adc84cb0d04fff38c40056bb8bf1caa08664315d
+          | ff89416f14a9369d7ef3f9a23057878320aa7b777c7233a79f2b0cab812a3e7a
           |ValueEnum(Some(Identifier(pkgId,Mod:ColorBis)),Green)
-          | 6db1b39e291c0f9af7290149adc84cb0d04fff38c40056bb8bf1caa08664315d
+          | ff89416f14a9369d7ef3f9a23057878320aa7b777c7233a79f2b0cab812a3e7a
           |ValueRecord(Some(Identifier(pkgId,Mod:Unit)),ImmArray())
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueRecord(Some(Identifier(pkgId,Mod:UnitBis)),ImmArray())
-          | 957b88b12730e646e0f33d3618b77dfa579e8231e3c59c7104be7165611c8027
+          | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
-          | 1d3e4d40ae7f934c7b67fb747ae99f9af5bfc867f52966e7c3cf6b7975dd237a
+          | 8f5dff2ff3f971b847284fb225522005587449fad2746879a0280bbd036f1abc
           |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(true)),(Some(_2),ValueBool(false))))
-          | b238496934cc67758abae39e09934168f2da4f4db828cf25dfce22e276e58b9b
+          | 768c5b90ed7ae5b727381e331fac83d7defd397d040f46ba067c80ec2af3eb33
           |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(true))))
-          | f9ce3cd0946bd8a778fa90b81a439f80a999e263fac5877fe7316170298ae139
+          | 4f6de867c24682cee05db95d48e1ea47cf5f8b6e74fe07582d3cd8cecaea84b7
           |ValueRecord(Some(Identifier(pkgId,Mod:TupleBis)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
-          | 1d3e4d40ae7f934c7b67fb747ae99f9af5bfc867f52966e7c3cf6b7975dd237a
+          | 8f5dff2ff3f971b847284fb225522005587449fad2746879a0280bbd036f1abc
           |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(false))
-          | f94f4b19d80fd21a583399cc5d788421e624e4e433f813c236851417489d8c5a
+          | 41edeaec86ac919e3c184057b021753781bd2ac1d60b8d4329375f60df953097
           |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(true))
-          | a80f8894f18978ee0d7e7c20b9b6adac521fb2274304fb2dfba9b9c8e2927ac7
+          | 31d69356947365e8a3dd9706774182e86774af1aa6550055efc56a22bb594745
           |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Right,ValueBool(false))
-          | fbda4dff63596daae1be44be3eec19d25547a883a62ca4c1cca713208966983f
+          | bd89c47c2379a69e8e0d46ff634c533449e8e7e532e84def4e2b2e168bc786e7
           |ValueVariant(Some(Identifier(pkgId,Mod:EitherBis)),Left,ValueBool(false))
-          | f94f4b19d80fd21a583399cc5d788421e624e4e433f813c236851417489d8c5a
+          | 41edeaec86ac919e3c184057b021753781bd2ac1d60b8d4329375f60df953097
           |""".stripMargin
 
       val sep = System.getProperty("line.separator")
@@ -542,14 +542,19 @@ class HashSpec extends WordSpec with Matchers {
             .builder(Hash.Purpose.Testing)
             .addTypedValue(value)
             .build
-            .toByteArray
-            .map("%02x" format _)
-            .mkString
+            .toLedgerString
           s"${value.toString}$sep $hash"
         }
         .mkString("", sep, sep)
       actualOutput shouldBe expectedOut
 
+    }
+  }
+
+  "Hash.fromString" should {
+    "convert properly string" in {
+      val s = "01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086"
+      Hash.assertFromString(s).toLedgerString shouldBe s
     }
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.daml.lf.transaction
+package com.digitalasset.daml.lf
+package transaction
 
 import com.digitalasset.daml.lf.EitherAssertions
 import com.digitalasset.daml.lf.data.ImmArray
@@ -47,7 +48,7 @@ class TransactionCoderSpec
     "do NodeCreate" in {
       forAll(malformedCreateNodeGen, valueVersionGen()) {
         (node: NodeCreate[Tx.TContractId, Tx.Value[Tx.TContractId]], valVer: ValueVersion) =>
-          Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             defaultNidDecode,
             defaultCidDecode,
             defaultValDecode,
@@ -58,7 +59,7 @@ class TransactionCoderSpec
                 defaultCidEncode,
                 defaultValEncode,
                 defaultTransactionVersion,
-                Tx.NodeId.unsafeFromIndex(0),
+                Tx.NodeId(0),
                 node)
               .toOption
               .get
@@ -69,7 +70,7 @@ class TransactionCoderSpec
     "do NodeFetch" in {
       forAll(fetchNodeGen, valueVersionGen()) {
         (node: NodeFetch[ContractId], valVer: ValueVersion) =>
-          Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             defaultNidDecode,
             defaultCidDecode,
             defaultValDecode,
@@ -80,7 +81,7 @@ class TransactionCoderSpec
                 defaultCidEncode,
                 defaultValEncode,
                 defaultTransactionVersion,
-                Tx.NodeId.unsafeFromIndex(0),
+                Tx.NodeId(0),
                 node)
               .toOption
               .get
@@ -91,7 +92,7 @@ class TransactionCoderSpec
     "do NodeExercises" in {
       forAll(danglingRefExerciseNodeGen) {
         node: NodeExercises[Tx.NodeId, Tx.TContractId, Tx.Value[Tx.TContractId]] =>
-          Right((Tx.NodeId.unsafeFromIndex(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             defaultNidDecode,
             defaultCidDecode,
             defaultValDecode,
@@ -102,7 +103,7 @@ class TransactionCoderSpec
                 defaultCidEncode,
                 defaultValEncode,
                 defaultTransactionVersion,
-                Tx.NodeId.unsafeFromIndex(0),
+                Tx.NodeId(0),
                 node)
               .toOption
               .get

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -44,7 +44,7 @@ private[state] object Conversions {
       BaseEncoding.base16.encode(txId.getEntryId.toByteArray)
     coid match {
       case a @ AbsoluteContractId(_) => a
-      case RelativeContractId(txnid) =>
+      case RelativeContractId(txnid, _) =>
         // NOTE(JM): Must be in sync with [[absoluteContractIdToLogEntryId]] and
         // [[absoluteContractIdToStateKey]].
         AbsoluteContractId(ContractIdString.assertFromString(s"$hexTxId:${txnid.index}"))
@@ -291,7 +291,7 @@ private[state] object Conversions {
   // FIXME(JM): Should we have a well-defined schema for this?
   private val cidEncoder: ValueCoder.EncodeCid[ContractId] = {
     val asStruct: ContractId => (String, Boolean) = {
-      case RelativeContractId(nid) => (s"~${nid.index}", true)
+      case RelativeContractId(nid, _) => (s"~${nid.index}", true)
       case AbsoluteContractId(coid) => (s"$coid", false)
     }
 
@@ -304,7 +304,7 @@ private[state] object Conversions {
           case None =>
             Left(DecodeError(s"Invalid relative contract id: $x"))
           case Some(i) =>
-            Right(RelativeContractId(NodeId.unsafeFromIndex(i)))
+            Right(RelativeContractId(NodeId(i)))
         }
       } else {
         ContractIdString
@@ -347,7 +347,7 @@ private[state] object Conversions {
   }
 
   private val nidDecoder: String => Either[ValueCoder.DecodeError, NodeId] =
-    nid => Right(NodeId.unsafeFromIndex(nid.toInt))
+    nid => Right(NodeId(nid.toInt))
   private val nidEncoder: TransactionCoder.EncodeNid[NodeId] =
     nid => nid.index.toString
   private val valEncoder: TransactionCoder.EncodeVal[Transaction.Value[ContractId]] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -228,7 +228,7 @@ private[kvutils] case class ProcessTransactionSubmission(
           val cs = DamlContractState.newBuilder
           cs.setActiveAt(buildTimestamp(txLet))
           val localDisclosure =
-            blindingInfo.localDisclosure(NodeId.unsafeFromIndex(key.getContractId.getNodeId.toInt))
+            blindingInfo.localDisclosure(NodeId(key.getContractId.getNodeId.toInt))
           cs.addAllLocallyDisclosedTo((localDisclosure: Iterable[String]).asJava)
           val absCoInst =
             createNode.coinst.mapValue(_.mapContractId(Conversions.toAbsCoid(entryId, _)))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -75,7 +75,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
     }
 
     "yield two projection roots for single root transaction with two parties" in {
-      val nid = NodeId.unsafeFromIndex(1)
+      val nid = NodeId(1)
       val root = makeCreateNode(
         RelativeContractId(nid),
         Set(Party.assertFromString("Alice")),
@@ -90,10 +90,10 @@ class ProjectionsSpec extends WordSpec with Matchers {
     }
 
     "yield proper projection roots in complex transaction" in {
-      val nid1 = NodeId.unsafeFromIndex(1)
-      val nid2 = NodeId.unsafeFromIndex(2)
-      val nid3 = NodeId.unsafeFromIndex(3)
-      val nid4 = NodeId.unsafeFromIndex(4)
+      val nid1 = NodeId(1)
+      val nid2 = NodeId(2)
+      val nid3 = NodeId(3)
+      val nid4 = NodeId(4)
 
       // Alice creates an "offer contract" to Bob as part of her workflow.
       // Alice sees both the exercise and the create, and Bob only

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/EventIdFormatter.scala
@@ -19,7 +19,7 @@ object EventIdFormatter {
   def makeAbsCoid(transactionId: TransactionIdString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
     coid match {
       case a @ Lf.AbsoluteContractId(_) => a
-      case Lf.RelativeContractId(txnid) =>
+      case Lf.RelativeContractId(txnid, _) =>
         Lf.AbsoluteContractId(fromTransactionId(transactionId, txnid))
     }
 
@@ -47,8 +47,7 @@ object EventIdFormatter {
                 .fromString(transIdString)
                 .fold(err => Failure(new IllegalArgumentException(err)), Success(_))
               _ <- Try(transId)
-            } yield
-              TransactionIdWithIndex(transId, Transaction.NodeId.unsafeFromIndex(ix))).toOption
+            } yield TransactionIdWithIndex(transId, Transaction.NodeId(ix))).toOption
           case _ => None
         }
       case _ => None

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/EventIdFormatterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/EventIdFormatterSpec.scala
@@ -13,7 +13,7 @@ class EventIdFormatterSpec extends WordSpec with Matchers with ScalaFutures {
 
   "EventIdFormatter" should {
     val transactionId: Ref.TransactionIdString = Ref.TransactionIdString.fromInt(42)
-    val index: Transaction.NodeId = Transaction.NodeId.unsafeFromIndex(42)
+    val index: Transaction.NodeId = Transaction.NodeId(42)
     val referenceEventID = s"#$transactionId:${index.index}"
 
     "format an EventId from a TransactionId and an index" in {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -101,7 +101,7 @@ class ImplicitPartyAdditionIT
       submitter: String,
       commandId: String,
       node: GenNode[NodeId, TContractId, Value[TContractId]]): Future[SubmissionResult] = {
-    val event1: NodeId = NodeId.unsafeFromIndex(0)
+    val event1: NodeId = NodeId(0)
 
     val transaction = GenTransaction[NodeId, TContractId, Value[TContractId]](
       HashMap(event1 -> node),

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -189,7 +189,8 @@ class Runner(
     val (triggerExpr, triggerTy) = getTrigger(triggerId)
     val registeredTemplates = compiler.compile(
       ERecProj(triggerTy, Name.assertFromString("registeredTemplates"), triggerExpr))
-    var machine = Speedy.Machine.fromSExpr(registeredTemplates, false, compiledPackages)
+    var machine =
+      Speedy.Machine.fromSExpr(registeredTemplates, false, compiledPackages)
     stepToValue(machine)
     val templateIds = machine.toSValue match {
       case SVariant(_, "AllInDar", _) => {


### PR DESCRIPTION
This PR advances the state of #3830 

In this PR:
 - We untie NodeId and relative contractId 
 - We calculate the cryptographic discriminator in the nodeId and  relative contractId. 

In the current state the discriminator is dropped when nodeId relative contractId are transalated to EventId and absolute contract id.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
