### PR TITLE
navigator: navigator broke after the rules_nodejs upgrade

### DIFF
--- a/navigator/frontend/webpack.config.js
+++ b/navigator/frontend/webpack.config.js
@@ -52,14 +52,8 @@ const APP_NAME = 'Navigator';
  */
 module.exports = (env) => {
   const paths_case_check = env && env.paths_case_check  || 'true';
-  // const in_dir           = env && env.bazel_in_dir  || __dirname;
-  // const out_dir          = env && env.bazel_out_dir || path.join(__dirname, 'dist');
-  // TODO (drsk) there seems to be a bug in the code producing the `env.bazel_in_dir,
-  // env.bazel_out_dir` that just concats directory components. We should switch back to rely on
-  // bazel_in_dir/bazel_out_dir once it's fixed.
-  // The issue is reported and tracked here: https://github.com/bazelbuild/rules_nodejs/issues/1554
-  const in_dir           = __dirname;
-  const out_dir          = path.join(__dirname, 'dist');
+  const in_dir           = env && env.bazel_in_dir  || __dirname;
+  const out_dir          = env && env.bazel_out_dir || path.join(__dirname, 'dist');
   const build_version    = env && env.bazel_version_file ? fs.readFileSync(env.bazel_version_file, 'utf8').trim() : 'HEAD';
   const build_commit     = env && env.bazel_commit_file  ? fs.readFileSync(env.bazel_commit_file, 'utf8').trim()  : 'HEAD';
   const isProduction     = env ? (!!env.prod || !!env.production) : false;


### PR DESCRIPTION
Interestingly the build works without the changes introduced in the
uprade, hence not necessary.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
