### PR TITLE
damldocs: Fix handling of constraint tuples.

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -726,6 +726,8 @@ typeToContext dc ty =
     let ctx = typeToConstraints dc ty
     in guard (notNull ctx) >> Just (TypeTuple ctx)
 
+-- | Is this type a constraint? Constraints are either typeclass constraints,
+-- constraint tuples, or whatever else GHC decides is a constraint.
 isConstraintType :: TyCoRep.Type -> Bool
 isConstraintType = tcIsConstraintKind . Type.typeKind
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -41,8 +41,6 @@ import           "ghc-lib-parser" CoreSyn
 import           "ghc-lib-parser" Id
 import           "ghc-lib-parser" Name
 import           "ghc-lib-parser" RdrName
-import qualified "ghc-lib-parser" Outputable                      as Out
-import qualified "ghc-lib-parser" DynFlags                        as DF
 import           "ghc-lib-parser" Bag (bagToList)
 
 import Control.Monad
@@ -428,7 +426,7 @@ getTypeDocs ctx@DocCtx{..} (DeclData (L _ (TyClD _ decl)) doc)
 
     fieldDoc :: (DDoc.Type, LConDeclField GhcPs) -> Maybe FieldDoc
     fieldDoc (fd_type, L _ ConDeclField{..}) = do
-        let fd_name = Fieldname . T.concat . map (toText . unLoc) $ cd_fld_names
+        let fd_name = Fieldname . T.concat . map (packFieldOcc . unLoc) $ cd_fld_names
             fd_anchor = Just $ functionAnchor dc_modname fd_name
             fd_descr = fmap (docToText . unLoc) cd_fld_doc
         Just FieldDoc{..}
@@ -549,7 +547,9 @@ isTemplate ClsInstDecl{..}
   , HsAppTy _ (L _ t1) t2 <- ty
   , HsTyVar _ _ (L _ tmplClass) <- t1
   , Just (L _ tmplName) <- hsTyGetAppHead_maybe t2
-  , toText tmplClass == "DA.Internal.Desugar.HasCreate"
+  , Qual classModule classOcc <- tmplClass
+  , moduleNameString classModule == "DA.Internal.Desugar"
+  , occNameString classOcc == "HasCreate"
   = Just (Typename . packRdrName $ tmplName)
 
   | otherwise = Nothing
@@ -567,7 +567,9 @@ isChoice ClsInstDecl{..}
   , HsTyVar _ _ (L _ choiceClass) <- choice
   , Just (L _ choiceName) <- hsTyGetAppHead_maybe cName
   , Just (L _ tmplName) <- hsTyGetAppHead_maybe cTmpl
-  , toText choiceClass == "DA.Internal.Desugar.HasExercise"
+  , Qual classModule classOcc <- choiceClass
+  , moduleNameString classModule == "DA.Internal.Desugar"
+  , occNameString classOcc == "HasExercise"
   = Just (Typename . packRdrName $ tmplName, Typename . packRdrName $ choiceName)
 
   | otherwise = Nothing
@@ -642,6 +644,15 @@ packOccName = T.pack . occNameString
 -- | Turn a RdrName into Text by taking the unqualified name it represents.
 packRdrName :: RdrName -> T.Text
 packRdrName = packOccName . rdrNameOcc
+
+-- | Turn a FieldOcc into Text by taking the unqualified name it represents.
+packFieldOcc :: FieldOcc p -> T.Text
+packFieldOcc = packRdrName . unLoc . rdrNameFieldOcc
+
+-- | Turn a TyLit into a text.
+packTyLit :: TyLit -> T.Text
+packTyLit (NumTyLit x) = T.pack (show x)
+packTyLit (StrTyLit x) = T.pack (show x)
 
 -- | Turn a GHC Module into a Modulename. (Unlike the above functions,
 -- we only ever want this to be a Modulename, so no reason to return
@@ -786,17 +797,9 @@ typeToType ctx = \case
             b' -> TypeFun [typeToType ctx a, b']
 
     CastTy a _ -> typeToType ctx a
-    LitTy x -> TypeLit (toText x)
+    LitTy lit -> TypeLit (packTyLit lit)
     CoercionTy _ -> unexpected "coercion" -- TODO?
 
   where
     -- | Unhandled case.
     unexpected x = error $ "typeToType: found an unexpected " <> x
-
-
----- HACK ZONE --------------------------------------------------------
-
--- Generic ppr for various things we need as text.
--- FIXME Replace by specialised functions for the particular things.
-toText :: Out.Outputable a => a -> T.Text
-toText = T.pack . Out.showSDocOneLine DF.unsafeGlobalDynFlags . Out.ppr

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -1,0 +1,41 @@
+# <a name="module-constrainttuples-44760"></a>Module ConstraintTuples
+
+## Data Types
+
+<a name="type-constrainttuples-eq2-31733"></a>**type** [Eq2](#type-constrainttuples-eq2-31733) a b
+
+> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b)
+
+<a name="type-constrainttuples-eq3-75180"></a>**type** [Eq3](#type-constrainttuples-eq3-75180) a b c
+
+> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c)
+
+<a name="type-constrainttuples-eq4-2935"></a>**type** [Eq4](#type-constrainttuples-eq4-2935) a b c d
+
+> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) d)
+
+## Functions
+
+<a name="function-constrainttuples-eq2-12289"></a>[eq2](#function-constrainttuples-eq2-12289)
+
+> : [Eq2](#type-constrainttuples-eq2-31733) a b -\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+
+<a name="function-constrainttuples-eq2tick-62955"></a>[eq2'](#function-constrainttuples-eq2tick-62955)
+
+> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+
+<a name="function-constrainttuples-eq3-55736"></a>[eq3](#function-constrainttuples-eq3-55736)
+
+> : [Eq3](#type-constrainttuples-eq3-75180) a b c -\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+
+<a name="function-constrainttuples-eq3tick-75648"></a>[eq3'](#function-constrainttuples-eq3tick-75648)
+
+> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+
+<a name="function-constrainttuples-eq4-56779"></a>[eq4](#function-constrainttuples-eq4-56779)
+
+> : [Eq4](#type-constrainttuples-eq4-2935) a b c d -\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+
+<a name="function-constrainttuples-eq4tick-50089"></a>[eq4'](#function-constrainttuples-eq4tick-50089)
+
+> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -18,7 +18,7 @@
 
 <a name="function-constrainttuples-eq2-12289"></a>[eq2](#function-constrainttuples-eq2-12289)
 
-> : [Eq2](#type-constrainttuples-eq2-31733) a b -\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq2](#type-constrainttuples-eq2-31733) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq2tick-62955"></a>[eq2'](#function-constrainttuples-eq2tick-62955)
 
@@ -26,7 +26,7 @@
 
 <a name="function-constrainttuples-eq3-55736"></a>[eq3](#function-constrainttuples-eq3-55736)
 
-> : [Eq3](#type-constrainttuples-eq3-75180) a b c -\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq3](#type-constrainttuples-eq3-75180) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq3tick-75648"></a>[eq3'](#function-constrainttuples-eq3tick-75648)
 
@@ -34,7 +34,7 @@
 
 <a name="function-constrainttuples-eq4-56779"></a>[eq4](#function-constrainttuples-eq4-56779)
 
-> : [Eq4](#type-constrainttuples-eq4-2935) a b c d -\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq4](#type-constrainttuples-eq4-2935) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq4tick-50089"></a>[eq4'](#function-constrainttuples-eq4tick-50089)
 

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -27,7 +27,7 @@ Functions
 .. _function-constrainttuples-eq2-12289:
 
 `eq2 <function-constrainttuples-eq2-12289_>`_
-  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \-\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq2tick-62955:
 
@@ -37,7 +37,7 @@ Functions
 .. _function-constrainttuples-eq3-55736:
 
 `eq3 <function-constrainttuples-eq3-55736_>`_
-  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \-\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq3tick-75648:
 
@@ -47,7 +47,7 @@ Functions
 .. _function-constrainttuples-eq4-56779:
 
 `eq4 <function-constrainttuples-eq4-56779_>`_
-  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \-\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq4tick-50089:
 

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -1,0 +1,55 @@
+.. _module-constrainttuples-44760:
+
+Module ConstraintTuples
+-----------------------
+
+Data Types
+^^^^^^^^^^
+
+.. _type-constrainttuples-eq2-31733:
+
+**type** `Eq2 <type-constrainttuples-eq2-31733_>`_ a b
+  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b)
+
+.. _type-constrainttuples-eq3-75180:
+
+**type** `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c
+  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c)
+
+.. _type-constrainttuples-eq4-2935:
+
+**type** `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d
+  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ d)
+
+Functions
+^^^^^^^^^
+
+.. _function-constrainttuples-eq2-12289:
+
+`eq2 <function-constrainttuples-eq2-12289_>`_
+  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \-\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+
+.. _function-constrainttuples-eq2tick-62955:
+
+`eq2' <function-constrainttuples-eq2tick-62955_>`_
+  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+
+.. _function-constrainttuples-eq3-55736:
+
+`eq3 <function-constrainttuples-eq3-55736_>`_
+  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \-\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+
+.. _function-constrainttuples-eq3tick-75648:
+
+`eq3' <function-constrainttuples-eq3tick-75648_>`_
+  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+
+.. _function-constrainttuples-eq4-56779:
+
+`eq4 <function-constrainttuples-eq4-56779_>`_
+  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \-\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+
+.. _function-constrainttuples-eq4tick-50089:
+
+`eq4' <function-constrainttuples-eq4tick-50089_>`_
+  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_


### PR DESCRIPTION
The check in damldocs for whether a type in a type signature is part of the context did not take constraint tuples into account. With this PR, we rely a little bit more on GHC's API to decide whether a type is a constraint or not.