### PR TITLE
docs cron: generate correct checksums

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -191,7 +191,9 @@ build_docs_folder path versions latest = do
             shell_ "bazel build //docs:docs"
             shell_ $ "mkdir -p  " <> path </> version
             shell_ $ "tar xzf bazel-bin/docs/html.tar.gz --strip-components=1 -C" <> path </> version
-            checksums <- shell $ "cd " <> path </> version <> "; find . -type f -exec sha256sum {} \\;"
+            -- when syncing with s3 later on we exclude .doctrees and
+            -- .buildinfo, so we need to do the same here
+            checksums <- shell $ "cd " <> path </> version <> "; find . -type f | grep -v '\\.doctrees' | grep -v '\\.buildinfo' | xargs sha256sum"
             writeFile (path </> version </> "checksum") checksums
         create_versions_json versions path = do
             -- Not going through Aeson because it represents JSON objects as


### PR DESCRIPTION
Looking through the logs of the docs cron for release 0.13.44 ([1](https://dev.azure.com/digitalasset/daml/_build/results?buildId=28679&view=logs&j=7e620c85-24a8-5ffa-8b1f-642bc9b1fc36&t=62c738a8-f3d0-5b21-b2dc-a7e81adb62c0), [2](https://dev.azure.com/digitalasset/daml/_build/results?buildId=28681&view=logs&j=7e620c85-24a8-5ffa-8b1f-642bc9b1fc36&t=62c738a8-f3d0-5b21-b2dc-a7e81adb62c0)), I have discovered a few minor issues. This is the first in a series of corresponding fixes.

--

The checksum we currently generate include files that are not subsequently uploaded to s3, and therefore the checksum check always fails. This patch updates the checksum generation code to have the same exclusions as the s3 upload one.