### PR TITLE
Include runtime_deps in POM file generation

### DIFF
--- a/bazel_tools/pom_file.bzl
+++ b/bazel_tools/pom_file.bzl
@@ -52,6 +52,7 @@ def has_scala_version_suffix(kind, version, tags):
 def _collect_maven_info_impl(_target, ctx):
     tags = getattr(ctx.rule.attr, "tags", [])
     deps = getattr(ctx.rule.attr, "deps", [])
+    runtime_deps = getattr(ctx.rule.attr, "runtime_deps", [])
     exports = getattr(ctx.rule.attr, "exports", [])
     jars = getattr(ctx.rule.attr, "jars", [])
 
@@ -107,7 +108,7 @@ def _collect_maven_info_impl(_target, ctx):
         if tag == "fat_jar":
             fat_jar = True
 
-    deps = depset([], transitive = [depset([d]) for d in _maven_coordinates(deps + exports + jars)])
+    deps = depset([], transitive = [depset([d]) for d in _maven_coordinates(deps + runtime_deps + exports + jars)])
     filtered_deps = [
         d
         for d in deps.to_list()
@@ -130,6 +131,7 @@ _collect_maven_info = aspect(
         "deps",
         "exports",
         "jars",
+        "runtime_deps",
     ],
     doc = """
     Collects the Maven information for targets and their dependencies.


### PR DESCRIPTION
Include `runtime_deps` in the generated POM files.

The pruning of Scala dependencies with the unused dependency checker moved some dependencies from `deps` to `runtime_deps`. The `pom_file` rule, however, only kept track of `deps` such that the generated pom files were no longer listing some dependencies, e.g. sandbox not listing `org.postgresql`.

This PR changes the `pom_file` rule to capture `runtime_deps` as well. This currently does not use [Maven dependency scopes](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope) to distinguish between build time and runtime dependencies.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
