### PR TITLE
Make data-dependencies work with packages produced by damlc

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -149,6 +149,7 @@ da_haskell_library(
         "tasty",
         "temporary",
         "text",
+        "transformers",
         "utf8-string",
         "vector",
         "xml",

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -51,7 +51,7 @@ instance Show PackageImport where
         showString "pkgImportExposeImplicit = " .
         shows pkgImportExposeImplicit .
         showCommaSpace .
-        showString "pkgImportModRenamings" .
+        showString "pkgImportModRenamings = " .
         shows (map (bimap GHC.moduleNameString GHC.moduleNameString) pkgImportModRenamings) .
         showString "}"
      where appPrec = 10

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -226,6 +226,7 @@ da_haskell_test(
     data = [
         "//compiler/damlc",
         "//compiler/damlc/tests:generate-simple-dalf",
+        "//daml-lf/repl",
     ],
     hackage_deps = [
         "base",


### PR DESCRIPTION
This PR fixes a whole bunch of bugs when using data-dependencies on a
package produced by damlc rather than the handcrafted simple-dalf.

The end result is that we are able to build a package with
`--target=1.6` and use it as a data-dependency from a package with
`-target=1.7`. While the test that I’ve added for this is not
cross-SDK it is arguably even trickier since we cannot rely on the
unit id of daml-stdlib changing the version in the unit id so this should be a nice improvement :tada: 

The changes all fall into one of the following two categories:

- Special handling for daml-prim and daml-stdlib to avoid collisions
  with the one from the current SDK.
- Special treatment of stable packages to avoid generating new code
  for those.
- Remove a couple of filters for daml-prim since we do need to include
  daml-prim from a data-dependency if it is a different version.

This is definitely not perfect and there are a bunch of rather hacky
parts in here but it seems like a good intermediate step (and it has a
test :))

changelog_begin
changelog_end

foobar

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
