### PR TITLE
damldocs: Add a --drop-orphan-instances flag

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -263,6 +263,7 @@ genrule(
             --input-format=json \
             --format=Hoogle \
             --exclude-instances=HasField \
+            --drop-orphan-instances \
             --template=$(location :daml-base-hoogle-template) \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
     """,
@@ -285,6 +286,7 @@ genrule(
             --input-format=json \
             --format=Rst \
             --exclude-instances=HasField \
+            --drop-orphan-instances \
             --template=$(location :daml-base-rst-template) \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
     """,

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -8,61 +8,17 @@ module DA.Daml.Doc.Transform
   ) where
 
 import DA.Daml.Doc.Types
-import DA.Daml.Doc.Annotate
+import DA.Daml.Doc.Transform.Options
+import DA.Daml.Doc.Transform.Annotations
+import DA.Daml.Doc.Transform.Instances
+import DA.Daml.Doc.Transform.DropEmpty
 
 import Data.Maybe
-import Data.List.Extra
-import System.FilePath (pathSeparator) -- because FilePattern uses it
-import System.FilePattern
-import qualified Data.Text as T
-import qualified Data.Map as Map
-import qualified Data.Set as Set
-
-data TransformOptions = TransformOptions
-    { to_includeModules :: Maybe [String]
-    , to_excludeModules :: Maybe [String]
-    , to_excludeInstances :: Set.Set String
-    , to_dataOnly :: Bool -- ^ do not generate docs for functions and classes
-    , to_ignoreAnnotations :: Bool -- ^ ignore MOVE and HIDE annotations
-    , to_omitEmpty :: Bool -- ^ omit all items that do not have documentation
-    }
-
-defaultTransformOptions :: TransformOptions
-defaultTransformOptions = TransformOptions
-    { to_includeModules = Nothing
-    , to_excludeModules = Nothing
-    , to_excludeInstances = Set.empty
-    , to_dataOnly = False
-    , to_ignoreAnnotations = False
-    , to_omitEmpty = False
-    }
-
-keepModule :: TransformOptions -> ModuleDoc -> Bool
-keepModule TransformOptions{..} m = includeModuleFilter && excludeModuleFilter
-  where
-    includeModuleFilter :: Bool
-    includeModuleFilter = maybe True moduleMatchesAny to_includeModules
-
-    excludeModuleFilter :: Bool
-    excludeModuleFilter = maybe True (not . moduleMatchesAny) to_excludeModules
-
-    moduleMatchesAny :: [String] -> Bool
-    moduleMatchesAny ps = any (?== name) (map withSlashes ps)
-
-    withSlashes :: String -> String
-    withSlashes = replace "." [pathSeparator]
-
-    name :: String
-    name = withSlashes . T.unpack . unModulename . md_name $ m
-
-keepInstance :: TransformOptions -> InstanceDoc -> Bool
-keepInstance TransformOptions{..} InstanceDoc{..} =
-    let nameM = T.unpack . unTypename <$> getTypeAppName id_type
-    in maybe True (`Set.notMember` to_excludeInstances) nameM
 
 applyTransform :: TransformOptions -> [ModuleDoc] -> [ModuleDoc]
 applyTransform opts@TransformOptions{..}
-    = distributeInstanceDocs opts
+    = (if to_dropOrphanInstances then map pruneOrphanInstances else id)
+    . distributeInstanceDocs opts
     . (if to_omitEmpty then mapMaybe dropEmptyDocs else id)
     . (if to_ignoreAnnotations then id else applyAnnotations)
     . (if to_dataOnly then map pruneNonData else id)
@@ -77,127 +33,9 @@ applyTransform opts@TransformOptions{..}
                       , md_instances = []
                       , md_adts = map noInstances $ md_adts m
                       }
+
     noInstances :: ADTDoc -> ADTDoc
     noInstances d = d{ ad_instances = Nothing }
 
--- emptiness of documentation, recursing into items
-dropEmptyDocs :: ModuleDoc -> Maybe ModuleDoc
-dropEmptyDocs m
-  | isEmpty m = Nothing
-  | otherwise = Just m
-
--- Helper class for emptiness test
-class IsEmpty a
-  where isEmpty :: a -> Bool
-
-instance IsEmpty ModuleDoc
-  where isEmpty ModuleDoc{..} =
-          all isEmpty md_templates
-          && all isEmpty md_adts
-          && all isEmpty md_functions
-          && all isEmpty md_classes
-          -- If the module description is the only documentation item, the
-          -- doc.s aren't very useful.
-          && (isNothing md_descr
-               || null md_adts && null md_templates
-                  && null md_functions && null md_classes)
-
-instance IsEmpty TemplateDoc
-  where isEmpty TemplateDoc{..} =
-          isNothing td_descr
-          && all isEmpty td_payload
-          && all isEmpty td_choices
-
-instance IsEmpty ChoiceDoc
-  where isEmpty ChoiceDoc{..} =
-          isNothing cd_descr
-          && all isEmpty cd_fields
-
-instance IsEmpty ClassDoc
-  where isEmpty ClassDoc{..} =
-          isNothing cl_descr && all isEmpty cl_methods
-
-instance IsEmpty ClassMethodDoc where
-    isEmpty ClassMethodDoc{..} = isNothing cm_descr
-
-instance IsEmpty ADTDoc
-  where isEmpty ADTDoc{..} =
-          isNothing ad_descr && all isEmpty ad_constrs
-        isEmpty TypeSynDoc{..} =
-          isNothing ad_descr
-
-instance IsEmpty ADTConstr
-  where isEmpty PrefixC{..} =
-          isNothing ac_descr
-        isEmpty RecordC{..} =
-          isNothing ac_descr && all isEmpty ac_fields
-
-instance IsEmpty FieldDoc
-  where isEmpty FieldDoc{..} = isNothing fd_descr
-
-instance IsEmpty FunctionDoc
-  where isEmpty FunctionDoc{..} = isNothing fct_descr
-
-type InstanceMap = Map.Map Anchor (Set.Set InstanceDoc)
-
--- | Add relevant instances to every type and class.
-distributeInstanceDocs :: TransformOptions -> [ModuleDoc] -> [ModuleDoc]
-distributeInstanceDocs opts docs =
-    let instanceMap = getInstanceMap docs
-    in map (addInstances instanceMap) docs
-
-  where
-
-    getInstanceMap :: [ModuleDoc] -> InstanceMap
-    getInstanceMap docs =
-        Map.unionsWith Set.union (map getModuleInstanceMap docs)
-
-    getModuleInstanceMap :: ModuleDoc -> InstanceMap
-    getModuleInstanceMap ModuleDoc{..}
-        = Map.unionsWith Set.union
-        . map getInstanceInstanceMap
-        . filter (keepInstance opts)
-        $ md_instances
-
-    getInstanceInstanceMap :: InstanceDoc -> InstanceMap
-    getInstanceInstanceMap inst = Map.fromList
-        [ (anchor, Set.singleton inst)
-        | anchor <- Set.toList . getTypeAnchors $ id_type inst ]
-
-    -- | Get the set of internal references i.e. anchors in the type expression.
-    getTypeAnchors :: Type -> Set.Set Anchor
-    getTypeAnchors = \case
-        TypeApp (Just (Reference Nothing anchor)) _ args -> Set.unions
-            $ Set.singleton anchor
-            : map getTypeAnchors args
-        TypeApp _ _ args -> Set.unions $ map getTypeAnchors args
-        TypeFun parts -> Set.unions $ map getTypeAnchors parts
-        TypeTuple parts -> Set.unions $ map getTypeAnchors parts
-        TypeList p -> getTypeAnchors p
-        TypeLit _ -> Set.empty
-
-    addInstances :: InstanceMap -> ModuleDoc -> ModuleDoc
-    addInstances imap ModuleDoc{..} = ModuleDoc
-        { md_name = md_name
-        , md_anchor = md_anchor
-        , md_descr = md_descr
-        , md_functions = md_functions
-        , md_templates = md_templates
-        , md_classes = map (addClassInstances imap) md_classes
-        , md_adts = map (addTypeInstances imap) md_adts
-        , md_instances = md_instances
-        }
-
-    addClassInstances :: InstanceMap -> ClassDoc -> ClassDoc
-    addClassInstances imap cl = cl
-        { cl_instances = Set.toList <$> do
-            anchor <- cl_anchor cl
-            Map.lookup anchor imap
-        }
-
-    addTypeInstances :: InstanceMap -> ADTDoc -> ADTDoc
-    addTypeInstances imap ad = ad
-        { ad_instances = Set.toList <$> do
-            anchor <- ad_anchor ad
-            Map.lookup anchor imap
-        }
+    pruneOrphanInstances :: ModuleDoc -> ModuleDoc
+    pruneOrphanInstances m = m { md_instances = [] }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform.hs
@@ -17,8 +17,7 @@ import Data.Maybe
 
 applyTransform :: TransformOptions -> [ModuleDoc] -> [ModuleDoc]
 applyTransform opts@TransformOptions{..}
-    = (if to_dropOrphanInstances then map pruneOrphanInstances else id)
-    . distributeInstanceDocs opts
+    = distributeInstanceDocs opts
     . (if to_omitEmpty then mapMaybe dropEmptyDocs else id)
     . (if to_ignoreAnnotations then id else applyAnnotations)
     . (if to_dataOnly then map pruneNonData else id)
@@ -36,6 +35,3 @@ applyTransform opts@TransformOptions{..}
 
     noInstances :: ADTDoc -> ADTDoc
     noInstances d = d{ ad_instances = Nothing }
-
-    pruneOrphanInstances :: ModuleDoc -> ModuleDoc
-    pruneOrphanInstances m = m { md_instances = [] }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Annotations.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Annotations.hs
@@ -1,18 +1,22 @@
 -- Copyright (c) 2020 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+module DA.Daml.Doc.Transform.Annotations
+    ( applyAnnotations
+    ) where
 
-module DA.Daml.Doc.Annotate(applyAnnotations) where
+import DA.Daml.Doc.Types
 
-import           DA.Daml.Doc.Types
 import qualified Data.Text as T
-import           Data.List.Extra
+import Data.List.Extra
+import Control.Applicative ((<|>))
 
-
--- | Apply the annotation HIDE to hide either modules or declarations
+-- | Apply HIDE and MOVE annotations.
 applyAnnotations :: [ModuleDoc] -> [ModuleDoc]
 applyAnnotations = applyMove . applyHide
 
+-- | Apply the MOVE annotation, which moves all the docs from one
+-- module to another.
 applyMove :: [ModuleDoc] -> [ModuleDoc]
 applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
     where
@@ -23,7 +27,7 @@ applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
         g m1 m2 = ModuleDoc
             { md_anchor = md_anchor m1
             , md_name = md_name m1
-            , md_descr = md_descr m1
+            , md_descr = md_descr m1 <|> md_descr m2
             , md_adts = md_adts m1 ++ md_adts m2
             , md_functions = md_functions m1 ++ md_functions m2
             , md_templates = md_templates m2 ++ md_templates m2
@@ -35,6 +39,9 @@ applyMove = map (foldr1 g) . groupSortOn (modulePriorityKey . md_name) . map f
         modulePriorityKey :: Modulename -> (Int,Modulename)
         modulePriorityKey m = (if m == "Prelude" then 0 else 1, m)
 
+-- | Apply the HIDE annotation, which removes the current subtree from
+-- the docs. This can be applied to an entire module, or to a specific
+-- type, a constructor, a field, a class, a method, or a function.
 applyHide :: [ModuleDoc] -> [ModuleDoc]
 applyHide = concatMap onModule
     where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/DropEmpty.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/DropEmpty.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Daml.Doc.Transform.DropEmpty
     ( dropEmptyDocs
     ) where
@@ -66,3 +69,4 @@ isFieldEmpty FieldDoc{..} =
 isFunctionEmpty :: FunctionDoc -> Bool
 isFunctionEmpty FunctionDoc{..} =
     isNothing fct_descr
+

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/DropEmpty.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/DropEmpty.hs
@@ -1,0 +1,68 @@
+module DA.Daml.Doc.Transform.DropEmpty
+    ( dropEmptyDocs
+    ) where
+
+import DA.Daml.Doc.Types
+import Data.Maybe
+
+-- | Drop modules that are devoid of any documentation.
+dropEmptyDocs :: ModuleDoc -> Maybe ModuleDoc
+dropEmptyDocs m
+  | isModuleEmpty m = Nothing
+  | otherwise = Just m
+
+isModuleEmpty :: ModuleDoc -> Bool
+isModuleEmpty ModuleDoc{..} =
+    all isTemplateEmpty md_templates
+    && all isADTEmpty md_adts
+    && all isFunctionEmpty md_functions
+    && all isClassEmpty md_classes
+    -- If the module description is the only documentation item, the
+    -- docs aren't very useful.
+    && (isNothing md_descr
+        || null md_adts && null md_templates
+        && null md_functions && null md_classes)
+
+isTemplateEmpty :: TemplateDoc -> Bool
+isTemplateEmpty TemplateDoc{..} =
+    isNothing td_descr
+    && all isFieldEmpty td_payload
+    && all isChoiceEmpty td_choices
+
+isChoiceEmpty :: ChoiceDoc -> Bool
+isChoiceEmpty ChoiceDoc{..} =
+    isNothing cd_descr
+    && all isFieldEmpty cd_fields
+
+isClassEmpty :: ClassDoc -> Bool
+isClassEmpty ClassDoc{..} =
+    isNothing cl_descr
+    && all isClassMethodEmpty cl_methods
+
+isClassMethodEmpty :: ClassMethodDoc -> Bool
+isClassMethodEmpty ClassMethodDoc{..} =
+    isNothing cm_descr
+
+isADTEmpty :: ADTDoc -> Bool
+isADTEmpty = \case
+    ADTDoc{..} ->
+        isNothing ad_descr
+        && all isADTConstrEmpty ad_constrs
+    TypeSynDoc{..} ->
+        isNothing ad_descr
+
+isADTConstrEmpty :: ADTConstr -> Bool
+isADTConstrEmpty = \case
+    PrefixC{..} ->
+        isNothing ac_descr
+    RecordC{..} ->
+        isNothing ac_descr
+        && all isFieldEmpty ac_fields
+
+isFieldEmpty :: FieldDoc -> Bool
+isFieldEmpty FieldDoc{..} =
+    isNothing fd_descr
+
+isFunctionEmpty :: FunctionDoc -> Bool
+isFunctionEmpty FunctionDoc{..} =
+    isNothing fct_descr

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
@@ -18,9 +18,7 @@ distributeInstanceDocs :: TransformOptions -> [ModuleDoc] -> [ModuleDoc]
 distributeInstanceDocs opts docs =
     let instanceMap = getInstanceMap docs
     in map (addInstances instanceMap) docs
-
   where
-
     getInstanceMap :: [ModuleDoc] -> InstanceMap
     getInstanceMap docs =
         Map.unionsWith Set.union (map getModuleInstanceMap docs)
@@ -58,7 +56,10 @@ distributeInstanceDocs opts docs =
         , md_templates = md_templates
         , md_classes = map (addClassInstances imap) md_classes
         , md_adts = map (addTypeInstances imap) md_adts
-        , md_instances = md_instances
+        , md_instances =
+            if to_dropOrphanInstances opts
+                then filter (not . id_isOrphan) md_instances
+                else md_instances
         }
 
     addClassInstances :: InstanceMap -> ClassDoc -> ClassDoc

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
@@ -1,0 +1,76 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.Doc.Transform.Instances
+    ( distributeInstanceDocs
+    ) where
+
+import DA.Daml.Doc.Types
+import DA.Daml.Doc.Transform.Options
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+type InstanceMap = Map.Map Anchor (Set.Set InstanceDoc)
+
+-- | Add relevant instances to every type and class.
+distributeInstanceDocs :: TransformOptions -> [ModuleDoc] -> [ModuleDoc]
+distributeInstanceDocs opts docs =
+    let instanceMap = getInstanceMap docs
+    in map (addInstances instanceMap) docs
+
+  where
+
+    getInstanceMap :: [ModuleDoc] -> InstanceMap
+    getInstanceMap docs =
+        Map.unionsWith Set.union (map getModuleInstanceMap docs)
+
+    getModuleInstanceMap :: ModuleDoc -> InstanceMap
+    getModuleInstanceMap ModuleDoc{..}
+        = Map.unionsWith Set.union
+        . map getInstanceInstanceMap
+        . filter (keepInstance opts)
+        $ md_instances
+
+    getInstanceInstanceMap :: InstanceDoc -> InstanceMap
+    getInstanceInstanceMap inst = Map.fromList
+        [ (anchor, Set.singleton inst)
+        | anchor <- Set.toList . getTypeAnchors $ id_type inst ]
+
+    -- | Get the set of internal references i.e. anchors in the type expression.
+    getTypeAnchors :: Type -> Set.Set Anchor
+    getTypeAnchors = \case
+        TypeApp (Just (Reference Nothing anchor)) _ args -> Set.unions
+            $ Set.singleton anchor
+            : map getTypeAnchors args
+        TypeApp _ _ args -> Set.unions $ map getTypeAnchors args
+        TypeFun parts -> Set.unions $ map getTypeAnchors parts
+        TypeTuple parts -> Set.unions $ map getTypeAnchors parts
+        TypeList p -> getTypeAnchors p
+        TypeLit _ -> Set.empty
+
+    addInstances :: InstanceMap -> ModuleDoc -> ModuleDoc
+    addInstances imap ModuleDoc{..} = ModuleDoc
+        { md_name = md_name
+        , md_anchor = md_anchor
+        , md_descr = md_descr
+        , md_functions = md_functions
+        , md_templates = md_templates
+        , md_classes = map (addClassInstances imap) md_classes
+        , md_adts = map (addTypeInstances imap) md_adts
+        , md_instances = md_instances
+        }
+
+    addClassInstances :: InstanceMap -> ClassDoc -> ClassDoc
+    addClassInstances imap cl = cl
+        { cl_instances = Set.toList <$> do
+            anchor <- cl_anchor cl
+            Map.lookup anchor imap
+        }
+
+    addTypeInstances :: InstanceMap -> ADTDoc -> ADTDoc
+    addTypeInstances imap ad = ad
+        { ad_instances = Set.toList <$> do
+            anchor <- ad_anchor ad
+            Map.lookup anchor imap
+        }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Options.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Options.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module DA.Daml.Doc.Transform.Options
     ( TransformOptions (..)
     , defaultTransformOptions
@@ -57,3 +60,4 @@ keepInstance :: TransformOptions -> InstanceDoc -> Bool
 keepInstance TransformOptions{..} InstanceDoc{..} =
     let nameM = T.unpack . unTypename <$> getTypeAppName id_type
     in maybe True (`Set.notMember` to_excludeInstances) nameM
+

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Options.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Options.hs
@@ -1,0 +1,59 @@
+module DA.Daml.Doc.Transform.Options
+    ( TransformOptions (..)
+    , defaultTransformOptions
+    , keepModule
+    , keepInstance
+    ) where
+
+import DA.Daml.Doc.Types
+
+import Data.List.Extra (replace)
+import System.FilePath (pathSeparator) -- because FilePattern uses it
+import System.FilePattern ((?==))
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+
+data TransformOptions = TransformOptions
+    { to_includeModules :: Maybe [String]
+    , to_excludeModules :: Maybe [String]
+    , to_excludeInstances :: Set.Set String
+    , to_dropOrphanInstances :: Bool -- ^ remove orphan instance docs
+    , to_dataOnly :: Bool -- ^ do not generate docs for functions and classes
+    , to_ignoreAnnotations :: Bool -- ^ ignore MOVE and HIDE annotations
+    , to_omitEmpty :: Bool -- ^ omit all items that do not have documentation
+    }
+
+defaultTransformOptions :: TransformOptions
+defaultTransformOptions = TransformOptions
+    { to_includeModules = Nothing
+    , to_excludeModules = Nothing
+    , to_excludeInstances = Set.empty
+    , to_dropOrphanInstances = False
+    , to_dataOnly = False
+    , to_ignoreAnnotations = False
+    , to_omitEmpty = False
+    }
+
+keepModule :: TransformOptions -> ModuleDoc -> Bool
+keepModule TransformOptions{..} m = includeModuleFilter && excludeModuleFilter
+  where
+    includeModuleFilter :: Bool
+    includeModuleFilter = maybe True moduleMatchesAny to_includeModules
+
+    excludeModuleFilter :: Bool
+    excludeModuleFilter = maybe True (not . moduleMatchesAny) to_excludeModules
+
+    moduleMatchesAny :: [String] -> Bool
+    moduleMatchesAny ps = any (?== name) (map withSlashes ps)
+
+    withSlashes :: String -> String
+    withSlashes = replace "." [pathSeparator]
+
+    name :: String
+    name = withSlashes . T.unpack . unModulename . md_name $ m
+
+keepInstance :: TransformOptions -> InstanceDoc -> Bool
+keepInstance TransformOptions{..} InstanceDoc{..} =
+    let nameM = T.unpack . unTypename <$> getTypeAppName id_type
+    in maybe True (`Set.notMember` to_excludeInstances) nameM

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -39,6 +39,7 @@ documentation numProcessors = Damldoc
     <*> optInclude
     <*> optExclude
     <*> optExcludeInstances
+    <*> optDropOrphanInstances
     <*> optCombine
     <*> optExtractOptions
     <*> argMainFiles
@@ -138,6 +139,11 @@ documentation numProcessors = Damldoc
                 "Example: `HasField'. Default: none.")
         <> value []
 
+    optDropOrphanInstances :: Parser Bool
+    optDropOrphanInstances = switch $
+        long "drop-orphan-instances"
+        <> help "Drop orphan instance docs."
+
     optCombine :: Parser Bool
     optCombine = switch $
         long "combine"
@@ -191,6 +197,7 @@ data CmdArgs = Damldoc
     , cIncludeMods :: [String]
     , cExcludeMods :: [String]
     , cExcludeInstances :: Set.Set String
+    , cDropOrphanInstances :: Bool
     , cCombine :: Bool
     , cExtractOptions :: ExtractOptions
     , cMainFiles :: [FilePath]
@@ -219,6 +226,7 @@ exec Damldoc{..} = do
         { to_includeModules = if null cIncludeMods then Nothing else Just cIncludeMods
         , to_excludeModules = if null cExcludeMods then Nothing else Just cExcludeMods
         , to_excludeInstances = cExcludeInstances
+        , to_dropOrphanInstances = cDropOrphanInstances
         , to_dataOnly = cDataOnly
         , to_ignoreAnnotations = cNoAnnot
         , to_omitEmpty = cOmitEmpty


### PR DESCRIPTION
Because of the way the DAML standard library docs are recombined across packages, and make frequent use of MOVE, the stdlib ends up with a lot of "orphan instance docs" that aren't really orphan instances. Well ... they really are orphan instances, but they shouldn't be considered orphan instances as far as the standard library docs are concerned, because users don't need to worry about how these are implemented. Pruning these is expensive and complicated, but a simple approach that gets us 99.9% of the way there is to just drop all orphan instance docs from the stdlib docs.

This PR refactors `DA.Daml.Doc.Transform` into separate modules, adds a `--drop-orphan-instances` flag, and uses this flag to improve the stdlib docs.

```
CHANGELOG_BEGIN

- [DAML SDK] Added a ``--drop-orphan-instances`` flag in ``daml damlc
docs``.

CHANGELOG_END
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
