### PR TITLE
support type synonyms in scala

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -160,6 +160,7 @@ instance Pretty Type where
     TVar v -> pretty v
     TCon c -> pretty c
     TSynApp s args ->
+      maybeParens (prec > precTApp) $
       pretty s <-> hsep [pPrintPrec lvl (succ precTApp) arg | arg <- args ]
     TApp (TApp (TBuiltin BTArrow) tx) ty ->
       maybeParens (prec > precTFun)

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -104,17 +104,11 @@ main = do
             , tplChoices = NM.fromList ([chc,chc2] <> [arc | withArchiveChoice])
             , tplKey = Nothing
             }
-    let syn = DefTypeSyn
-            { synLocation = Nothing
-            , synName = TypeSynName ["MySyn1"]
-            , synParams = []
-            , synType = TUnit
-            }
     let mod = Module
             { moduleName = ModuleName ["Module"]
             , moduleSource = Nothing
             , moduleFeatureFlags = FeatureFlags{forbidPartyLiterals = True}
-            , moduleSynonyms = NM.fromList [syn]
+            , moduleSynonyms = NM.fromList []
             , moduleDataTypes = NM.fromList ([tplRec, chcArg, chcArg2] <> [emptyRec | withArchiveChoice])
             , moduleValues = NM.empty
             , moduleTemplates = NM.fromList [tpl]

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -174,6 +174,10 @@ object Ref {
   type TypeConName = Identifier
   val TypeConName = Identifier
 
+  /** Reference to a type synonym. */
+  type TypeSynName = Identifier
+  val TypeSynName = Identifier
+
   /**
     * Used to reference to leger objects like contractIds, ledgerIds,
     * transactionId, ... We use the same type for those ids, because we

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -74,6 +74,10 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
             }
           case value @ DValue(_, _, _, _) =>
             builder.addValues(name -> value)
+
+          case DTypeSyn(params @ _, typ @ _) =>
+            throw new RuntimeException("TODO #3616, EncodeV1, DTypeSyn")
+
         }
         builder
       }
@@ -205,6 +209,9 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
           case _ => typ0 -> ImmArray.empty
         }
       val builder = PLF.Type.newBuilder()
+      // Be warned: Both the use of the unapply pattern TForalls and the pattern
+      //    case TBuiltin(BTArrow) if versionIsOlderThan(LV.Features.arrowType) =>
+      // cause scala's exhaustivty checking to be disabled in the following match.
       typ match {
         case TVar(varName) =>
           val b = PLF.Type.Var.newBuilder()
@@ -242,6 +249,8 @@ private[digitalasset] class EncodeV1(val minor: LV.Minor) {
         case TStruct(fields) =>
           expect(args.isEmpty)
           builder.setStruct(PLF.Type.Struct.newBuilder().accumulateLeft(fields)(_ addFields _))
+        case TSynApp(_, _) =>
+          throw new RuntimeException("TODO #3616,encodeTypeBuilder")
       }
     }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/PackageLookup.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/PackageLookup.scala
@@ -15,9 +15,12 @@ object PackageLookup {
     for {
       defn <- lookupDefinition(pkg, identifier)
       dataTyp <- defn match {
+        case dataType: DDataType => Right(dataType)
         case _: DValue =>
           Left(Error(s"Got value definition instead of datatype when looking up $identifier"))
-        case dataType: DDataType => Right(dataType)
+        case _: DTypeSyn =>
+          Left(
+            Error(s"Got type synonym definition instead of datatype when looking up $identifier"))
       }
     } yield dataTyp
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueTranslator.scala
@@ -65,6 +65,9 @@ private[engine] class ValueTranslator(compiledPackages: CompiledPackages) {
           case struct: TStruct =>
             fail(
               s"Unexpected struct when replacing parameters in command translation -- all types should be serializable, and structs are not: $struct")
+          case syn: TSynApp =>
+            fail(
+              s"Unexpected type synonym application when replacing parameters in command translation -- all types should be serializable, and synonyms are not: $syn")
         }
 
       go(typ0)

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -62,6 +62,7 @@ object LanguageVersion {
     val anyType = v1_7
     val typeRep = v1_7
     val genMap = v1_dev
+    val typeSynonyms = v1_dev
 
     /** Unstable, experimental features. This should stay in 1.dev forever.
       * Features implemented with this flag should be moved to a separate

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -52,6 +52,7 @@ private[digitalasset] class AstRewriter(
     if (typeRule.isDefinedAt(x)) typeRule(x)
     else
       x match {
+        case TSynApp(_, _) => throw new RuntimeException("TODO #3616,AstRewriter,TSynApp")
         case TVar(_) | TNat(_) | TBuiltin(_) => x
         case TTyCon(typeCon) =>
           TTyCon(apply(typeCon))
@@ -205,6 +206,9 @@ private[digitalasset] class AstRewriter(
         x
       case DValue(typ, noPartyLiterals, body, isTest) =>
         DValue(apply(typ), noPartyLiterals, apply(body), isTest)
+
+      case DTypeSyn(params @ _, typ @ _) =>
+        throw new RuntimeException("TODO #3616,AstRewriter,DTypeSyn")
     }
 
   def apply(x: Template): Template =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -42,7 +42,7 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
     }
 
   private lazy val definition: Parser[Def] =
-    recDefinition | variantDefinition | enumDefinition | valDefinition | templateDefinition
+    synDefinition | recDefinition | variantDefinition | enumDefinition | valDefinition | templateDefinition
 
   private def tags(allowed: Set[String]): Parser[Set[String]] =
     rep(`@` ~> id) ^^ { tags =>
@@ -55,6 +55,13 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
 
   private lazy val binder: Parser[(Name, Type)] =
     id ~ `:` ~ typ ^^ { case id ~ _ ~ typ => id -> typ }
+
+  private lazy val synDefinition: Parser[DataDef] =
+    Id("synonym") ~>! dottedName ~ rep(typeBinder) ~
+      (`=` ~> typ) ^^ {
+      case id ~ params ~ typ =>
+        DataDef(id, DTypeSyn(ImmArray(params), typ))
+    }
 
   private lazy val recDefinition: Parser[DataDef] =
     Id("record") ~>! tags(dataDefTags) ~ dottedName ~ rep(typeBinder) ~

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -59,11 +59,15 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
   private lazy val tStruct: Parser[Type] =
     `<` ~>! rep1sep(fieldType, `,`) <~ `>` ^^ (fs => TStruct(ImmArray(fs)))
 
+  private lazy val tTypeSynApp: Parser[Type] =
+    `|` ~> fullIdentifier ~ rep(typ0) <~ `|` ^^ { case id ~ tys => TSynApp(id, ImmArray(tys)) }
+
   lazy val typ0: Parser[Type] =
     `(` ~> typ <~ `)` |
       tNat |
       tForall |
       tStruct |
+      tTypeSynApp |
       (id ^? builtinTypes) ^^ TBuiltin |
       fullIdentifier ^^ TTyCon.apply |
       id ^^ TVar.apply

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -272,6 +272,7 @@ object Repl {
 
   def prettyDefinitionType(defn: Definition, pkgId: PackageId, modId: ModuleName): String =
     defn match {
+      case DTypeSyn(_, _) => "<type synonym>" // FIXME: pp this
       case DDataType(_, _, _) => "<data type>" // FIXME(JM): pp this
       case DValue(typ, _, _, _) => prettyType(typ, pkgId, modId)
     }
@@ -295,6 +296,12 @@ object Repl {
       if (needParens) s"($s)" else s
 
     def prettyType(t0: Type, prec: Int = precTForall): String = t0 match {
+      case TSynApp(syn, args) =>
+        maybeParens(
+          prec > precTApp,
+          prettyQualified(pkgId, modId, syn)
+            + " " + args.map(t => prettyType(t, precTApp + 1)).toSeq.mkString(" ")
+        )
       case TVar(n) => n
       case TNat(n) => n.toString
       case TTyCon(con) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
@@ -68,6 +68,10 @@ private[validation] object Collision {
         // ignore values
         // List(NValDef(module, defName, vDef))
         List.empty
+
+      case _: Ast.DTypeSyn =>
+        List.empty // TODO #3616: check type synonyms
+
     }
 
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
@@ -25,6 +25,8 @@ private[validation] object Recursion {
     val modRefsInType: Set[ModuleName] = {
 
       def modRefsInType(acc: Set[ModuleName], typ0: Type): Set[ModuleName] = typ0 match {
+        case TSynApp(typeSynName, _) if typeSynName.packageId == pkgId =>
+          ((acc + typeSynName.qualifiedName.module) /: TypeTraversable(typ0))(modRefsInType)
         case TTyCon(typeConName) if typeConName.packageId == pkgId =>
           acc + typeConName.qualifiedName.module
         case otherwise =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -58,6 +58,7 @@ private[validation] object Serializability {
         if (!vars(name)) unserializable(URFreeVar(name))
       case TNat(_) =>
         unserializable(URNat)
+      case TSynApp(syn, _) => unserializable(URTypeSyn(syn))
       case TTyCon(tycon) =>
         lookupDefinition(ctx, tycon) match {
           case DDataType(true, _, _) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -15,6 +15,7 @@ private[validation] object TypeSubst {
 
   private def go(fv0: Set[TypeVarName], subst0: Map[TypeVarName, Type], typ0: Type): Type =
     typ0 match {
+      case TSynApp(syn, args) => TSynApp(syn, args.map(go(fv0, subst0, _)))
       case TVar(name) => subst0.getOrElse(name, typ0)
       case TTyCon(_) | TBuiltin(_) | TNat(_) => typ0
       case TApp(t1, t2) => TApp(go(fv0, subst0, t1), go(fv0, subst0, t2))

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -16,6 +16,9 @@ final case class LEPackage(packageId: PackageId) extends LookupError {
 final case class LEModule(packageId: PackageId, moduleRef: ModuleName) extends LookupError {
   def pretty: String = s"unknown module: $moduleRef"
 }
+final case class LETypeSyn(syn: TypeSynName) extends LookupError {
+  def pretty: String = s"unknown type synonym: ${syn.qualifiedName}"
+}
 final case class LEDataType(conName: TypeConName) extends LookupError {
   def pretty: String = s"unknown data type: ${conName.qualifiedName}"
 }
@@ -135,6 +138,9 @@ case object URContractId extends UnserializabilityReason {
 final case class URDataType(conName: TypeConName) extends UnserializabilityReason {
   def pretty: String = s"unserializable data type ${conName.qualifiedName}"
 }
+final case class URTypeSyn(synName: TypeSynName) extends UnserializabilityReason {
+  def pretty: String = s"type synonym ${synName.qualifiedName}"
+}
 final case class URHigherKinded(varName: TypeVarName, kind: Kind) extends UnserializabilityReason {
   def pretty: String = s"higher-kinded type variable $varName : ${kind.pretty}"
 }
@@ -168,6 +174,15 @@ final case class EUnknownExprVar(context: Context, varName: ExprVarName) extends
 final case class EUnknownDefinition(context: Context, lookupError: LookupError)
     extends ValidationError {
   protected def prettyInternal: String = lookupError.pretty
+}
+final case class ETypeSynAppWrongArity(
+    context: Context,
+    expectedArity: Int,
+    syn: TypeSynName,
+    args: ImmArray[Type])
+    extends ValidationError {
+  protected def prettyInternal: String =
+    s"wrong arity in type synonym application: ${syn.qualifiedName} ${args.toSeq.map(_.pretty).mkString(" ")}"
 }
 final case class ETypeConAppWrongArity(context: Context, expectedArity: Int, conApp: TypeConApp)
     extends ValidationError {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/World.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/World.scala
@@ -19,6 +19,14 @@ private[validation] class World(packages: PartialFunction[PackageId, Ast.Package
     lookupModule(ctx, name.packageId, name.qualifiedName.module).definitions
       .getOrElse(name.qualifiedName.name, throw EUnknownDefinition(ctx, LEDataType(name)))
 
+  def lookupTypeSyn(ctx: => Context, name: TypeSynName): Ast.DTypeSyn =
+    lookupDefinition(ctx, name) match {
+      case typeSyn: Ast.DTypeSyn =>
+        typeSyn
+      case _ =>
+        throw EUnknownDefinition(ctx, LETypeSyn(name))
+    }
+
   def lookupDataType(ctx: => Context, name: TypeConName): Ast.DDataType =
     lookupDefinition(ctx, name) match {
       case dataType: Ast.DDataType =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -118,6 +118,7 @@ private[validation] object ExprTraversable {
 
   private[traversable] def foreach[U](x: Definition, f: Expr => U): Unit =
     x match {
+      case DTypeSyn(params @ _, typ @ _) =>
       case DDataType(serializable @ _, params @ _, DataRecord(fields @ _, template)) =>
         template.foreach(foreach(_, f))
       case DDataType(serializable @ _, params @ _, DataVariant(variants @ _)) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -15,6 +15,8 @@ private[validation] object TypeTraversable {
 
   private[validation] def foreach[U](typ: Type, f: Type => U): Unit =
     typ match {
+      case TSynApp(_, args) =>
+        args.iterator.foreach(f)
       case TVar(_) | TTyCon(_) | TBuiltin(_) | TNat(_) =>
       case TApp(tyfun, arg) =>
         f(tyfun)
@@ -146,6 +148,9 @@ private[validation] object TypeTraversable {
 
   private[validation] def foreach[U](defn: Definition, f: Type => U): Unit =
     defn match {
+      case DTypeSyn(params @ _, typ) =>
+        f(typ)
+        ()
       case DDataType(serializable @ _, params @ _, DataRecord(fields, template)) =>
         fields.values.foreach(f)
         template.foreach(foreach(_, f))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -233,6 +233,8 @@ class Runner(
       .get(scriptId.packageId)
       .flatMap(_.lookupIdentifier(scriptId.qualifiedName).toOption) match {
       case Some(DValue(ty, _, _, _)) => ty
+      case Some(d @ DTypeSyn(_, _)) =>
+        throw new RuntimeException(s"Expected DAML script but got synonym $d")
       case Some(d @ DDataType(_, _, _)) =>
         throw new RuntimeException(s"Expected DAML script but got datatype $d")
       case None => throw new RuntimeException(s"Could not find DAML script $scriptId")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import com.digitalasset.daml.lf.CompiledPackages
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.Ast
-import com.digitalasset.daml.lf.language.Ast.{DDataType, DValue, Definition}
+import com.digitalasset.daml.lf.language.Ast.{DTypeSyn, DDataType, DValue, Definition}
 import com.digitalasset.daml.lf.speedy.{ScenarioRunner, Speedy}
 import com.digitalasset.daml.lf.types.{Ledger => L}
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
@@ -149,6 +149,9 @@ object ScenarioLoader {
   private def getScenarioExpr(scenarioRef: Ref.DefinitionRef, scenarioDef: Definition): Ast.Expr = {
     scenarioDef match {
       case DValue(_, _, body, _) => body
+      case _: DTypeSyn =>
+        throw new RuntimeException(
+          s"Requested scenario $scenarioRef is a type synonym, not a definition")
       case _: DDataType =>
         throw new RuntimeException(
           s"Requested scenario $scenarioRef is a data type, not a definition")


### PR DESCRIPTION
Support DAML-LF type synonyms in scala code base.
- AST
- decode
- type check
- extended DAML-LF parser, to allow:
- testing of synonym expansion during type checking

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
