### PR TITLE
Make DAR generation deterministic

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -476,6 +476,7 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
             "range-set-list",
             "recursion-schemes",
             "regex-tdfa",
+            "resourcet",
             "retry",
             "rope-utf16-splay",
             "safe",

--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -23,6 +23,7 @@ da_haskell_library(
         "haskell-lsp",
         "lens",
         "mtl",
+        "resourcet",
         "safe",
         "safe-exceptions",
         "shake",


### PR DESCRIPTION
This fixes the ZIP modification times in all DARs to a specific
value (1980-01-01) whereas they used the current time before. This
both gives us the nice property that not only our DALF builds but also
DAR builds should be deterministic (and there is a test for this). I
have a suspicion that this could help significantly with build times
and avoid rerunning half of the Scala tests on a change to damlc that
should not change the DALFs.

changelog_begin

- [DAML Compiler] The modification times in a DAR are now fixed to a
  given value which makes the output of ``daml build`` deterministic
  in single-threaded mode (which is the default).

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
