### PR TITLE
Support nested optionals

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -319,11 +319,10 @@ genType curModName = go
             let (t', ser) = go t
             in
             (t' <> "[]", "daml.List(" <> ser <> ")")
-        TOptional (TOptional _) -> error "TODO(MH): nested optionals"
         TOptional t ->
             let (t', ser) = go t
             in
-            ("(" <> t' <> " | null)", "daml.Optional(" <> ser <> ")")
+            ("daml.Optional<" <> t' <> ">", "daml.Optional(" <> ser <> ")")
         TTextMap t  ->
             let (t', ser) = go t
             in

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -17,6 +17,10 @@ template AllTypes with
     party: Party
     contractId: ContractId Person
     optional: Optional Int
+    optional2: Optional Int
+    optionalOptionalInt: Optional (Optional Int)
+    optionalOptionalInt2: Optional (Optional Int)
+    optionalOptionalInt3: Optional (Optional Int)
     list: [Bool]
     textMap: TextMap Int
     monoRecord: Person
@@ -28,8 +32,11 @@ template AllTypes with
     enum: Color
     enumList: [Color]
     variant: Expr Int
+    optionalVariant: Expr Int
     sumProd : Quux
+    optionalSumProd : Optional Quux
     parametericSumProd : Expr2 Int
+    optionalOptionalParametericSumProd : Optional (Optional (Expr2 Int))
     n0 : Numeric 0
     n5 : Numeric 5
     n10 : Decimal

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -207,49 +207,31 @@ export const ContractId = <T>(_t: Serializable<T>): Serializable<ContractId<T>> 
 });
 
 /**
- * The counterpart of DAML's `Optional T` type. Nested optionals are not yet
- * supported.
- */
-export type Optional<T> = T | null;
-
-// --
-
-/**
  * The counterpart of DAML's `Optional T` type.
  */
-export type Optional_<T> =
+export type Optional<T> =
   | null
-  | Optional_.Inner<T>
-
-namespace Optional_ {
+  | Optional.Inner<T>
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Optional {
   export type Inner<T> = null extends T ? ([] | [Exclude<T, null>]) : T;
 }
 
 /**
  * Companion function of the `Optional` type.
  */
-export const Optional_ = <T>(t: Serializable<T>): Serializable<Optional_<T>> => ({
-  decoder : () => jtv.oneOf<Optional_<T>>(jtv.constant(null), Optional_.Inner(t)),
+export const Optional = <T>(t: Serializable<T>): Serializable<Optional<T>> => ({
+  decoder : () => jtv.oneOf<Optional<T>>(jtv.constant(null), Optional.Inner(t)),
   isOptional: true,
 });
-Optional_.Inner = <T>(t: Serializable<T>): jtv.Decoder<Optional_.Inner<T>> =>
+Optional.Inner = <T>(t: Serializable<T>): jtv.Decoder<Optional.Inner<T>> =>
   ! t.isOptional
-  ? t.decoder() as jtv.Decoder<Optional_.Inner<T>>
+  ? t.decoder() as jtv.Decoder<Optional.Inner<T>>
   : jtv.oneOf(
       jtv.constant([]) as jtv.Decoder<[] | [Exclude<T, null>]>,
       jtv.tuple([t.decoder()]) as jtv.Decoder<[] | [Exclude<T, null>]>
-  ) as jtv.Decoder<Optional_.Inner<T>>
+  ) as jtv.Decoder<Optional.Inner<T>>
 ;
-
-// --
-
-/**
- * Companion function of the `Optional` type.
- */
-export const Optional = <T>(t: Serializable<T>): Serializable<Optional<T>> => ({
-  decoder: () => jtv.oneOf(jtv.constant(null), t.decoder()),
-  isOptional: true,
-});
 
 /**
  * The counterpart of DAML's `TextMap T` type. We represent `TextMap`s as

--- a/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/daml-json-types/src/index.ts
@@ -212,12 +212,43 @@ export const ContractId = <T>(_t: Serializable<T>): Serializable<ContractId<T>> 
  */
 export type Optional<T> = T | null;
 
+// --
+
 /**
- * Companion object of the `Optional` type.
+ * The counterpart of DAML's `Optional T` type.
+ */
+export type Optional_<T> =
+  | null
+  | Optional_.Inner<T>
+
+namespace Optional_ {
+  export type Inner<T> = null extends T ? ([] | [Exclude<T, null>]) : T;
+}
+
+/**
+ * Companion function of the `Optional` type.
+ */
+export const Optional_ = <T>(t: Serializable<T>): Serializable<Optional_<T>> => ({
+  decoder : () => jtv.oneOf<Optional_<T>>(jtv.constant(null), Optional_.Inner(t)),
+  isOptional: true,
+});
+Optional_.Inner = <T>(t: Serializable<T>): jtv.Decoder<Optional_.Inner<T>> =>
+  ! t.isOptional
+  ? t.decoder() as jtv.Decoder<Optional_.Inner<T>>
+  : jtv.oneOf(
+      jtv.constant([]) as jtv.Decoder<[] | [Exclude<T, null>]>,
+      jtv.tuple([t.decoder()]) as jtv.Decoder<[] | [Exclude<T, null>]>
+  ) as jtv.Decoder<Optional_.Inner<T>>
+;
+
+// --
+
+/**
+ * Companion function of the `Optional` type.
  */
 export const Optional = <T>(t: Serializable<T>): Serializable<Optional<T>> => ({
   decoder: () => jtv.oneOf(jtv.constant(null), t.decoder()),
-  isOptional: false,
+  isOptional: true,
 });
 
 /**

--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -137,7 +137,11 @@ test('create + fetch & exercise', async () => {
     time: '2019-12-31T12:34:56.789Z',
     party: ALICE_PARTY,
     contractId: alice5Contract.contractId,
-    optional: '5',
+    optional: '5', // Some 5
+    optional2: null,  // None
+    optionalOptionalInt: ['5'], // Some (Some 5)
+    optionalOptionalInt2: [], // Some (None)
+    optionalOptionalInt3: null, // None
     list: [true, false],
     textMap: {'alice': '2', 'bob & carl': '3'},
     monoRecord: alice5,
@@ -149,8 +153,11 @@ test('create + fetch & exercise', async () => {
     enum: Main.Color.Red,
     enumList: [Main.Color.Red, Main.Color.Blue, Main.Color.Yellow],
     variant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
+    optionalVariant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
     sumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}},
+    optionalSumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}},
     parametericSumProd: {tag: 'Add2', value: {lhs:{tag: 'Lit2', value: '1'}, rhs:{tag: 'Lit2', value: '2'}}},
+    optionalOptionalParametericSumProd: [{tag: 'Add2', value: {lhs:{tag: 'Lit2', value: '1'}, rhs:{tag: 'Lit2', value: '2'}}}],
     n0:  '3.0',          // Numeric 0
     n5:  '3.14159',      // Numeric 5
     n10: '3.1415926536', // Numeric 10


### PR DESCRIPTION
This PR extends `Optional<T>` so as to support nested optionals.