### PR TITLE
daml2ts: Isolate tests better

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -214,7 +214,7 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 buildifier_excluded_patterns = [
     "./3rdparty/haskell/c2hs-package.bzl",
     "./3rdparty/haskell/network-package.bzl",
-    "./node_modules/*",
+    "**/node_modules/*",
 ]
 
 # Run this to check if BUILD files are well-formatted.

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -45,7 +45,11 @@ sh_test(
         ":daml2ts-test.dar",
     ] + glob(
         ["ts/**"],
-        exclude = ["ts/**/node_modules/**"],
+        exclude = [
+            "ts/**/node_modules/**",
+            "ts/**/lib/**",
+            "ts/generated/src/daml/**",
+        ],
     ),
     deps = [
         "@bazel_tools//tools/bash/runfiles",


### PR DESCRIPTION
Currently, the `sh_test` for `daml2ts` copies too many files into the
temporary directory where the test is run. This can cause issues with
stale files from development experiments being copied into the test.

This PR addresses the issue by exluding some directories which only
contain generated files.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4111)
<!-- Reviewable:end -->
