### PR TITLE
docs cron: follow github pagination links

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -386,6 +386,7 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
             "blaze-html",
             "bytestring",
             "Cabal",
+            "case-insensitive",
             "cereal",
             "clock",
             "cmark-gfm",

--- a/ci/cron/BUILD.bazel
+++ b/ci/cron/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_binary(
     hackage_deps = [
         "aeson",
         "base",
+        "case-insensitive",
         "containers",
         "directory",
         "extra",
@@ -17,6 +18,7 @@ da_haskell_binary(
         "http-client-tls",
         "http-types",
         "process",
+        "regex-tdfa",
         "split",
         "text",
         "unordered-containers",


### PR DESCRIPTION
The GitHub API is paginated (30 items by default). This creates two problems:

1. At the moment, older versions silently drop from the docs website, without us having made any explicit decision about it.
2. When we prepare a new version, it gets created as a pre-release version. Our script filters that out, but that happens on our end so we end up with 29 published versions and the list is different form the existing one. If the prerelease then gets dropped, the oldest version comes back.

It is possible that we will sometime decide we do not want to keep old documentation around forever, but that should be an explicit decision. This patch changes the logic to fetch the list of versions from GitHub so that we always get all the published versions (barring race conditions inherent to that kind of paginated API).