### PR TITLE
Standardize metrics naming to snake_case

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsInterceptor.scala
@@ -6,24 +6,85 @@ package com.digitalasset.platform.apiserver
 import com.codahale.metrics.MetricRegistry
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
 
+import scala.collection.concurrent.TrieMap
+
+object MetricsInterceptor {
+
+  private[this] val capitalization = "[A-Z]+".r
+  private[this] val startWordCapitalization = "^[A-Z]+".r
+  private[this] val endWordAcronym = "[A-Z]{2,}$".r
+
+  private[this] val snakifyWholeWord = (s: String) => if (s.forall(_.isUpper)) s.toLowerCase else s
+
+  private[this] val snakify = (s: String) =>
+    capitalization.findAllMatchIn(s).foldRight(s) { (m, r) =>
+      val s = m.toString
+      if (s.length == 1) r.patch(m.start, s"_${s.toLowerCase}", 1)
+      else r.patch(m.start, s"_${s.init.toLowerCase}_${s.last.toLower}", s.length)
+  }
+
+  private[this] val snakifyStart = (s: String) =>
+    startWordCapitalization.findFirstIn(s).fold(s) { m =>
+      s.patch(
+        0,
+        if (m.length == 1) m.toLowerCase else m.init.toLowerCase,
+        math.max(m.length - 1, 1))
+  }
+
+  private[this] val snakifyEnd = (s: String) =>
+    endWordAcronym.findFirstIn(s).fold(s) { m =>
+      s.patch(s.length - m.length, s"_${m.toLowerCase}", m.length)
+  }
+
+  // Turns a camelCased string into a snake_cased one
+  private[apiserver] val camelCaseToSnakeCase: String => String =
+    snakifyWholeWord andThen snakifyStart andThen snakifyEnd andThen snakify
+
+  // assert(fullServiceName("org.example.SomeService/someMethod") == "daml.lapi.some_service.some_method")
+  private[apiserver] def nameFor(fullMethodName: String): String = {
+    val serviceAndMethodName = fullMethodName.split('/')
+    assert(
+      serviceAndMethodName.length == 2,
+      s"Expected service and method names separated by '/', got '$fullMethodName'")
+    val serviceName = camelCaseToSnakeCase(serviceAndMethodName(0).split('.').last)
+    val methodName = camelCaseToSnakeCase(serviceAndMethodName(1))
+    s"daml.lapi.$serviceName.$methodName"
+  }
+
+}
+
 /**
   * An interceptor that counts all incoming calls by method.
-  * The metrics generated will be of the following schema:
-  * <pre>LedgerApi.&lt;service-name&gt;.&lt;method-name&gt;</pre>
-  * <br/>
-  * For example:
-  * <pre>LedgerApi.com.digitalasset.ledger.api.v1.TransactionService.GetTransactionTrees</pre>
+  *
+  * Given a fully qualified method name 'q' in the form "org.example.SomeService/someMethod" where
+  * - "org.example.SomeService" is the fully qualified service name and
+  * - "SomeService" is the simplified service name 's'
+  * - "someMethod" is the method 'm'
+  * the names assigned to metrics measured for the service identified by
+  * 'q' is prepended by the concatenation of
+  * - the literal string "daml"
+  * - the literal string "lapi"
+  * - 's' converted to snake_case
+  * - 'm' converted to snake_case
+  * joined together with the character '.'
+  *
+  * e.g. "org.example.SomeService/someMethod" becomes "daml.lapi.some_service.some_method"
   */
-class MetricsInterceptor(metrics: MetricRegistry) extends ServerInterceptor {
+final class MetricsInterceptor(metrics: MetricRegistry) extends ServerInterceptor {
+
+  // Cache the result of calling MetricsInterceptor.nameFor, which practically has a
+  // limited co-domain and whose cost we don't want to pay every time an endpoint is hit
+  private val fullServiceToMetricNameCache = TrieMap.empty[String, String]
+
   override def interceptCall[ReqT, RespT](
       call: ServerCall[ReqT, RespT],
       headers: Metadata,
       next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
-    // The service name and method name are separated by a '/'.
-    // Converting it to a '.' makes it easier for downstream tools to
-    // put the metrics into a hierarchy.
-    val serviceName = call.getMethodDescriptor.getFullMethodName.replace('/', '.')
-    metrics.meter(s"LedgerApi.$serviceName").mark()
+    val fullMethodName = call.getMethodDescriptor.getFullMethodName
+    val metricName = fullServiceToMetricNameCache.getOrElseUpdate(
+      fullMethodName,
+      MetricsInterceptor.nameFor(fullMethodName))
+    metrics.meter(metricName).mark()
     next.startCall(call, headers)
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -94,10 +94,10 @@ class ApiSubmissionService private (
 
   private object Metrics {
     val failedInterpretationsMeter =
-      metrics.meter("CommandSubmission.failedCommandInterpretations")
+      metrics.meter("daml.lapi.command_submission_service.failed_command_interpretations")
 
     val submittedTransactionsTimer =
-      metrics.timer("CommandSubmission.submittedTransactions")
+      metrics.timer("daml.lapi.command_submission_service.submitted_transactions")
   }
 
   override def submit(request: SubmitRequest): Future[Unit] = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -146,13 +146,15 @@ class JdbcIndexer private[indexer] (
   private var lastReceivedOffset: LedgerString = _
 
   object Metrics {
-    val stateUpdateProcessingTimer: Timer =
-      metrics.timer("JdbcIndexer.processedStateUpdates")
+
+    val processedStateUpdatesName = "daml.indexer.processed_state_updates"
+    val lastReceivedRecordTimeName = "daml.indexer.last_received_record_time"
+    val lastReceivedOffsetName = "daml.indexer.last_received_offset"
+    val currentRecordTimeLagName = "daml.indexer.current_record_time_lag"
+
+    val stateUpdateProcessingTimer: Timer = metrics.timer(processedStateUpdatesName)
 
     private[JdbcIndexer] def setup(): Unit = {
-      val lastReceivedRecordTimeName = "JdbcIndexer.lastReceivedRecordTime"
-      val lastReceivedOffsetName = "JdbcIndexer.lastReceivedOffset"
-      val currentRecordTimeLagName = "JdbcIndexer.currentRecordTimeLag"
 
       metrics.remove(lastReceivedRecordTimeName)
       metrics.remove(lastReceivedOffsetName)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -29,14 +29,14 @@ private class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegis
     extends ReadOnlyLedger {
 
   private object Metrics {
-    val lookupContract = metrics.timer("Ledger.lookupContract")
-    val lookupKey = metrics.timer("Ledger.lookupKey")
-    val lookupTransaction = metrics.timer("Ledger.lookupTransaction")
-    val lookupLedgerConfiguration = metrics.timer("Ledger.lookupLedgerConfiguration ")
-    val parties = metrics.timer("Ledger.parties")
-    val listLfPackages = metrics.timer("Ledger.listLfPackages")
-    val getLfArchive = metrics.timer("Ledger.getLfArchive")
-    val getLfPackage = metrics.timer("Ledger.getLfPackage")
+    val lookupContract = metrics.timer("daml.index.lookup_contract")
+    val lookupKey = metrics.timer("daml.index.lookup_key")
+    val lookupTransaction = metrics.timer("daml.index.lookup_transaction")
+    val lookupLedgerConfiguration = metrics.timer("daml.index.lookup_ledger_configuration ")
+    val parties = metrics.timer("daml.index.parties")
+    val listLfPackages = metrics.timer("daml.index.list_lf_packages")
+    val getLfArchive = metrics.timer("daml.index.get_lf_archive")
+    val getLfPackage = metrics.timer("daml.index.get_lf_package")
   }
 
   override def ledgerId: LedgerId = ledger.ledgerId
@@ -105,11 +105,11 @@ private class MeteredLedger(ledger: Ledger, metrics: MetricRegistry)
     with Ledger {
 
   private object Metrics {
-    val publishHeartbeat = metrics.timer("Ledger.publishHeartbeat")
-    val publishTransaction = metrics.timer("Ledger.publishTransaction")
-    val publishPartyAllocation = metrics.timer("Ledger.publishPartyAllocation")
-    val uploadPackages = metrics.timer("Ledger.uploadPackages")
-    val publishConfiguration = metrics.timer("Ledger.publishConfiguration ")
+    val publishHeartbeat = metrics.timer("daml.index.publish_heartbeat")
+    val publishTransaction = metrics.timer("daml.index.publish_transaction")
+    val publishPartyAllocation = metrics.timer("daml.index.publish_party_allocation")
+    val uploadPackages = metrics.timer("daml.index.upload_packages")
+    val publishConfiguration = metrics.timer("daml.index.publish_configuration")
   }
 
   override def publishHeartbeat(time: Instant): Future[Unit] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/HikariJdbcConnectionProvider.scala
@@ -114,7 +114,7 @@ object HikariJdbcConnectionProvider {
       // these connections should never time out as we have the same number of threads as connections
       dataSource <- HikariConnection.owner(
         jdbcUrl,
-        "Short-Lived-Connections",
+        "daml.index.db.connection",
         maxConnections,
         maxConnections,
         250.millis,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/dao/MeteredLedgerDao.scala
@@ -33,17 +33,18 @@ private class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegi
     extends LedgerReadDao {
 
   private object Metrics {
-    val lookupLedgerId: Timer = metrics.timer("LedgerDao.lookupLedgerId")
-    val lookupLedgerEnd: Timer = metrics.timer("LedgerDao.lookupLedgerEnd")
-    val lookupExternalLedgerEnd: Timer = metrics.timer("LedgerDao.lookupExternalLedgerEnd")
-    val lookupLedgerEntry: Timer = metrics.timer("LedgerDao.lookupLedgerEntry")
-    val lookupTransaction: Timer = metrics.timer("LedgerDao.lookupTransaction")
-    val lookupLedgerConfiguration: Timer = metrics.timer("LedgerDao.lookupLedgerConfiguration")
-    val lookupKey: Timer = metrics.timer("LedgerDao.lookupKey")
-    val lookupActiveContract: Timer = metrics.timer("LedgerDao.lookupActiveContract")
-    val getParties: Timer = metrics.timer("LedgerDao.getParties")
-    val listLfPackages: Timer = metrics.timer("LedgerDao.listLfPackages")
-    val getLfArchive: Timer = metrics.timer("LedgerDao.getLfArchive")
+    val lookupLedgerId: Timer = metrics.timer("daml.index.db.lookup_ledger_id")
+    val lookupLedgerEnd: Timer = metrics.timer("daml.index.db.lookup_ledger_end")
+    val lookupExternalLedgerEnd: Timer = metrics.timer("daml.index.db.lookup_external_ledger_end")
+    val lookupLedgerEntry: Timer = metrics.timer("daml.index.db.lookup_ledger_entry")
+    val lookupTransaction: Timer = metrics.timer("daml.index.db.lookup_transaction")
+    val lookupLedgerConfiguration: Timer =
+      metrics.timer("daml.index.db.lookup_ledger_configuration")
+    val lookupKey: Timer = metrics.timer("daml.index.db.lookup_key")
+    val lookupActiveContract: Timer = metrics.timer("daml.index.db.lookup_active_contract")
+    val getParties: Timer = metrics.timer("daml.index.db.get_parties")
+    val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
+    val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
   }
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
@@ -121,11 +122,11 @@ private class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: MetricRegistry)
     with LedgerDao {
 
   private object Metrics {
-    val storePartyEntry: Timer = metrics.timer("LedgerDao.storePartyEntry")
-    val storeInitialState: Timer = metrics.timer("LedgerDao.storeInitialState")
-    val storePackageEntry: Timer = metrics.timer("LedgerDao.storePackageEntry")
-    val storeLedgerEntry: Timer = metrics.timer("LedgerDao.storeLedgerEntry")
-    val storeConfigurationEntry: Timer = metrics.timer("LedgerDao.storeConfigurationEntry")
+    val storePartyEntry: Timer = metrics.timer("daml.index.db.store_party_entry")
+    val storeInitialState: Timer = metrics.timer("daml.index.db.store_initial_state")
+    val storePackageEntry: Timer = metrics.timer("daml.index.db.store_package_entry")
+    val storeLedgerEntry: Timer = metrics.timer("daml.index.db.store_ledger_entry")
+    val storeConfigurationEntry: Timer = metrics.timer("daml.index.db.store_configuration_entry")
   }
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrations.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/FlywayMigrations.scala
@@ -25,7 +25,7 @@ class FlywayMigrations(jdbcUrl: String, loggerFactory: NamedLoggerFactory) {
   private def newDataSource()(
       implicit executionContext: ExecutionContext
   ): Resource[HikariDataSource] =
-    HikariConnection.owner(jdbcUrl, "Flyway-Pool", 2, 2, 250.millis, None).acquire()
+    HikariConnection.owner(jdbcUrl, "daml.index.db.migration", 2, 2, 250.millis, None).acquire()
 
   def validate(): Unit = {
     val dataSourceResource = newDataSource()(DirectExecutionContext)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/util/DbDispatcher.scala
@@ -27,8 +27,8 @@ final class DbDispatcher(
   private val sqlExecution = ExecutionContext.fromExecutorService(sqlExecutor)
 
   object Metrics {
-    val waitAllTimer: Timer = metrics.timer("sql_all_wait")
-    val execAllTimer: Timer = metrics.timer("sql_all_exec")
+    val waitAllTimer: Timer = metrics.timer("daml.index.db.all.wait")
+    val execAllTimer: Timer = metrics.timer("daml.index.db.all.exec")
   }
 
   override def currentHealth(): HealthStatus = connectionProvider.currentHealth()
@@ -41,8 +41,8 @@ final class DbDispatcher(
   def executeSql[T](description: String, extraLog: Option[String] = None)(
       sql: Connection => T
   ): Future[T] = {
-    val waitTimer = metrics.timer(s"sql_${description}_wait")
-    val execTimer = metrics.timer(s"sql_${description}_exec")
+    val waitTimer = metrics.timer(s"daml.index.db.$description.wait")
+    val execTimer = metrics.timer(s"daml.index.db.$description.exec")
     val startWait = System.nanoTime()
     Future {
       val waitNanos = System.nanoTime() - startWait

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/MetricsInterceptorSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/MetricsInterceptorSpec.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.apiserver
+
+import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc
+import com.digitalasset.ledger.api.v1.command_service.CommandServiceGrpc
+import com.digitalasset.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
+import org.scalatest.{FlatSpec, Matchers}
+
+final class MetricsInterceptorSpec extends FlatSpec with Matchers {
+
+  behavior of "MetricsInterceptor.camelCaseToSnakeCase"
+
+  import MetricsInterceptor.camelCaseToSnakeCase
+
+  it should "leave an empty string unchanged" in {
+    camelCaseToSnakeCase("") shouldBe ""
+  }
+
+  it should "leave a snake_cased string unchanged" in {
+    camelCaseToSnakeCase("snake_cased") shouldBe "snake_cased"
+  }
+
+  it should "remove the capitalization of the first letter" in {
+    camelCaseToSnakeCase("Camel") shouldBe "camel"
+  }
+
+  it should "turn a single capital letter into a an underscore followed by a lower case letter" in {
+    camelCaseToSnakeCase("CamelCase") shouldBe "camel_case"
+    camelCaseToSnakeCase("camelCase") shouldBe "camel_case"
+  }
+
+  it should "keep acronyms together and change their capitalization as a single unit" in {
+    camelCaseToSnakeCase("DAML") shouldBe "daml"
+    camelCaseToSnakeCase("DAMLFactory") shouldBe "daml_factory"
+    camelCaseToSnakeCase("AbstractDAML") shouldBe "abstract_daml"
+    camelCaseToSnakeCase("AbstractDAMLFactory") shouldBe "abstract_daml_factory"
+    camelCaseToSnakeCase("AbstractDAMLProxyJVMFactory") shouldBe "abstract_daml_proxy_jvm_factory"
+  }
+
+  it should "treat single letter words intelligently" in {
+    camelCaseToSnakeCase("ATeam") shouldBe "a_team"
+    camelCaseToSnakeCase("TeamA") shouldBe "team_a"
+    camelCaseToSnakeCase("BustAMove") shouldBe "bust_a_move"
+
+    // the following is mostly to document a reasonable short-coming:
+    // a single letter word followed by an acronym will be detected as a single acronym
+    camelCaseToSnakeCase("AJVMHeap") shouldBe "ajvm_heap"
+  }
+
+  behavior of "MetricsInterceptor.nameFor"
+
+  import MetricsInterceptor.nameFor
+
+  it should "produce the expected name for a selection of services" in {
+    nameFor(CommandServiceGrpc.METHOD_SUBMIT_AND_WAIT.getFullMethodName) shouldBe "daml.lapi.command_service.submit_and_wait"
+    nameFor(CommandSubmissionServiceGrpc.METHOD_SUBMIT.getFullMethodName) shouldBe "daml.lapi.command_submission_service.submit"
+    nameFor(ActiveContractsServiceGrpc.METHOD_GET_ACTIVE_CONTRACTS.getFullMethodName) shouldBe "daml.lapi.active_contracts_service.get_active_contracts"
+  }
+
+}


### PR DESCRIPTION
CHANGELOG_BEGIN
[Sandbox] Metrics are now namespaced by "daml" and their names have been
standardize to snake_case
CHANGELOG_END

Please note that HikariJDBC records its own metrics but this is outside
of our reach, so connection-pool-related metrics will keep being called
with camelCase names.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
