### PR TITLE
Remove the key field from pkg.conf files

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -315,7 +315,6 @@ mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = do
         unlines $
             [ "name: " ++ pName
             , "id: " ++ pkgNameVersion pName pVersion
-            , "key: " ++ pkgNameVersion pName pVersion
             ]
             ++ ["version: " ++ v | Just v <- [pVersion] ]
             ++

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -119,9 +119,10 @@ setPackageDbs paths dflags =
 setPackageImports :: Bool -> [(UnitId, ModRenaming)] -> DynFlags -> DynFlags
 setPackageImports hideAllPkgs pkgImports dflags = dflags {
     packageFlags = packageFlags dflags ++
-        [ExposePackage ("-package-id " <> unitIdString pkgName) (UnitIdArg pkgName) renaming
-        -- The first string is only used in error messages so it doesn’t really matter
-        -- but we use UnitIdArg which corresponds to GHC’s -package-id flag.
+        [ExposePackage ("--package " <> unitIdString pkgName) (UnitIdArg pkgName) renaming
+        -- The first string is only used in error messages so it doesn’t really matter.
+        -- Our --package flag corresponds to GHC’s -package-id but it makes more sense
+        -- to mention the flag name used in DAML in error messages.
         | (pkgName, renaming) <- pkgImports
         ]
     , generalFlags = if hideAllPkgs

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -119,8 +119,9 @@ setPackageDbs paths dflags =
 setPackageImports :: Bool -> [(UnitId, ModRenaming)] -> DynFlags -> DynFlags
 setPackageImports hideAllPkgs pkgImports dflags = dflags {
     packageFlags = packageFlags dflags ++
-        [ExposePackage ("-package " <> unitIdString pkgName) (UnitIdArg pkgName) renaming
-        -- The first string is only used in error messages.
+        [ExposePackage ("-package-id " <> unitIdString pkgName) (UnitIdArg pkgName) renaming
+        -- The first string is only used in error messages so it doesn’t really matter
+        -- but we use UnitIdArg which corresponds to GHC’s -package-id flag.
         | (pkgName, renaming) <- pkgImports
         ]
     , generalFlags = if hideAllPkgs

--- a/compiler/damlc/pkg-db/util.bzl
+++ b/compiler/damlc/pkg-db/util.bzl
@@ -32,8 +32,7 @@ PACKAGE_CONF_TEMPLATE = """
 name: {name}
 version: __SDK_VERSION__
 id: __ID__
-key: __ID__
-copyright: 2015-2018 Digital Asset Holdings
+copyright: 2020 Digital Asset Holdings
 maintainer: Digital Asset
 exposed: True
 exposed-modules: {modules}


### PR DESCRIPTION
We never use this and it only a legacy field that is deprecated in
favor of id in GHC.

There is also a minor change in the docs around ExposePackage which
should at most affect error messages.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
