### PR TITLE
engine: node are ordered in transactions

### DIFF
--- a/daml-lf/spec/transaction.rst
+++ b/daml-lf/spec/transaction.rst
@@ -456,7 +456,8 @@ definition referred to by ``template_id``.
 ``children`` is constrained as described under `field node_id`_.  Every
 node referred to as one of ``children`` is another update to the ledger
 taken as part of this transaction and as a consequence of exercising
-this choice.
+this choice. Nodes in ``children`` appear in the order they were
+created during interpretation.
 
 Every element of ``actors``, ``stakeholders``, ``signatories``, and
 ``controllers`` is a party identifier.

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
@@ -13,15 +13,10 @@ import com.digitalasset.ledger.api.v1.transaction.TreeEvent.Kind.{
   Exercised => TreeExercised
 }
 import scalaz.Tag
-import scalaz.syntax.tag._
 
 object EventOps {
 
-  private val eventIndexFromIdRegex = """.*[-:](\d+)$""".r
-
   implicit class EventOps(val event: Event) extends AnyVal {
-
-    def eventIndex: Int = event.event.eventIndex
 
     def eventId: EventId = event.event.eventId
 
@@ -36,8 +31,6 @@ object EventOps {
   }
 
   implicit class EventEventOps(val event: Event.Event) extends AnyVal {
-
-    def eventIndex: Int = getEventIndex(event.event.eventId.unwrap)
 
     def eventId: EventId = event match {
       case Archived(value) => EventId(Ref.LedgerString.assertFromString(value.eventId))
@@ -74,17 +67,6 @@ object EventOps {
       case Empty => Empty
     }
 
-  }
-
-  def getEventIndex(eventId: String): Int = {
-    eventIndexFromIdRegex
-      .findFirstMatchIn(eventId)
-      .fold {
-        throw new IllegalArgumentException(
-          s"Event ID $eventId does not match regex $eventIndexFromIdRegex")
-      } {
-        _.group(1).toInt
-      }
   }
 
   implicit class TreeEventKindOps(kind: TreeEvent.Kind) {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransientContractRemover.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransientContractRemover.scala
@@ -31,16 +31,6 @@ object TransientContractRemover {
     resultBuilder.collect { case Some(v) if v.witnessParties.nonEmpty => v }(breakOut)
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  private def failOnUnsortedInput(
-      nodes: List[CreateOrArchiveEvent],
-      prevEventIndex: Int,
-      processedEventIndex: Int): Nothing = {
-    throw new IllegalArgumentException(
-      s"This method requires all eventIds in its input to be in order. " +
-        s"This was not true for received events ${nodes.map(_.eventId)}: $prevEventIndex appeared before $processedEventIndex")
-  }
-
   /**
     * Update resultBuilder given the next event.
     * This will insert a new element and possibly update a previous one.

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransientContractRemover.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransientContractRemover.scala
@@ -5,8 +5,6 @@ package com.digitalasset.platform.server.services.transaction
 
 import com.digitalasset.ledger.api.domain.ContractId
 import com.digitalasset.ledger.api.domain.Event.{ArchivedEvent, CreateOrArchiveEvent, CreatedEvent}
-import com.digitalasset.platform.api.v1.event.EventOps._
-import scalaz.syntax.tag._
 
 import scala.collection.{breakOut, mutable}
 
@@ -15,6 +13,7 @@ object TransientContractRemover {
   /**
     * Cancels out witnesses on creates and archives that are about the same contract.
     * If no witnesses remain on either, the node is removed.
+    *
     * @param nodes Must be sorted by event index.
     * @throws IllegalArgumentException if the argument is not sorted properly.
     */
@@ -23,18 +22,11 @@ object TransientContractRemover {
     val resultBuilder = new Array[Option[CreateOrArchiveEvent]](nodes.size)
     val creationByContractId = new mutable.HashMap[ContractId, (Int, CreatedEvent)]()
 
-    nodes.iterator.zipWithIndex
-      .foldLeft(-1) {
-        case (prevEventIndex, (event, indexInList)) =>
-          // Each call adds a new (possibly null) element to resultBuilder, and may update items previously added
-          updateResultBuilder(resultBuilder, creationByContractId, event, indexInList)
-
-          // This defensive code has substantial overhead, because we extract the integer event index of every element
-          // from the eventId String. If we received the nodes with integer IDs, it would make this faster.
-          val processedEventIndex = getEventIndex(event.eventId.unwrap)
-          if (processedEventIndex > prevEventIndex) processedEventIndex
-          else failOnUnsortedInput(nodes, prevEventIndex, processedEventIndex)
-      }
+    nodes.zipWithIndex.foreach {
+      case (event, indexInList) =>
+        // Each call adds a new (possibly null) element to resultBuilder, and may update items previously added
+        updateResultBuilder(resultBuilder, creationByContractId, event, indexInList)
+    }
 
     resultBuilder.collect { case Some(v) if v.witnessParties.nonEmpty => v }(breakOut)
   }
@@ -57,14 +49,14 @@ object TransientContractRemover {
       resultBuilder: Array[Option[CreateOrArchiveEvent]],
       creationByContractId: mutable.HashMap[ContractId, (Int, CreatedEvent)],
       event: CreateOrArchiveEvent,
-      indexInList: Int): Unit = {
+      indexInList: Int
+  ): Unit =
     event match {
       case createdEvent @ CreatedEvent(_, contractId, _, _, witnessParties, _, _, _, _) =>
         if (witnessParties.nonEmpty) {
           resultBuilder.update(indexInList, Some(event))
           val _ = creationByContractId.put(contractId, indexInList -> createdEvent)
         }
-
       case archivedEvent @ ArchivedEvent(_, contractId, _, witnessParties) =>
         if (witnessParties.nonEmpty) {
           creationByContractId
@@ -84,5 +76,5 @@ object TransientContractRemover {
             }
         }
     }
-  }
+
 }


### PR DESCRIPTION
In this PR we removed unnecessary sorted of nodes and made explicit the node are ordered when appearing  in transaction roots or exercises children.  

This PR advance #3830

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
