### PR TITLE
Remove pseudo* functions from daml-ledger-fetch

### DIFF
--- a/language-support/ts/daml-ledger-fetch/index.ts
+++ b/language-support/ts/daml-ledger-fetch/index.ts
@@ -139,6 +139,9 @@ class Ledger {
     return this.query(template, {} as Query<T>);
   }
 
+  /**
+   * Fetch a contract by its key.
+   */
   async lookupByKey<T extends object, K>(template: Template<T, K>, key: K extends undefined ? never : K): Promise<CreateEvent<T, K> | null> {
     const payload = {
       templateId: template.templateId,
@@ -146,30 +149,6 @@ class Ledger {
     };
     const json = await this.submit('contracts/lookup', payload);
     return jtv.Result.withException(jtv.oneOf(jtv.constant(null), decodeCreateEvent(template)).run(json));
-  }
-
-  /**
-   * Mimic DAML's `lookupByKey`. The `key` must be a formulation of the
-   * contract key as a query.
-   */
-  async pseudoLookupByKey<T extends object, K>(template: Template<T, K>, key: Query<T>): Promise<CreateEvent<T, K> | undefined> {
-    const contracts = await this.query(template, key);
-    if (contracts.length > 1) {
-      throw Error("pseudoLookupByKey: query returned multiple contracts");
-    }
-    return contracts[0];
-  }
-
-  /**
-   * Mimic DAML's `fetchByKey`. The `key` must be a formulation of the
-   * contract key as a query.
-   */
-  async pseudoFetchByKey<T extends object, K>(template: Template<T, K>, key: Query<T>): Promise<CreateEvent<T, K>> {
-    const contract = await this.pseudoLookupByKey(template, key);
-    if (contract === undefined) {
-      throw Error("pseudoFetchByKey: query returned no contract");
-    }
-    return contract;
   }
 
   /**
@@ -225,26 +204,17 @@ class Ledger {
   }
 
   /**
-   * Mimic DAML's `exerciseByKey`. The `key` must be a formulation of the
-   * contract key as a query.
-   */
-  async pseudoExerciseByKey<T extends object, C, R>(choice: Choice<T, C, R>, key: Query<T>, argument: C): Promise<[R, Event<object>[]]> {
-    const contract = await this.pseudoFetchByKey(choice.template(), key);
-    return this.exercise(choice, contract.contractId, argument);
-  }
-
-  /**
-   * Archive a contract given by its contract id.
+   * Archive a contract.
    */
   async archive<T extends object>(template: Template<T>, contractId: ContractId<T>): Promise<unknown> {
     return this.exercise(template.Archive, contractId, {});
   }
 
   /**
-   * Archive a contract given by its contract id.
+   * Archive a contract identified by its key.
    */
-  async pseudoArchiveByKey<T extends object>(template: Template<T>, key: Query<T>): Promise<unknown> {
-    return this.pseudoExerciseByKey(template.Archive, key, {});
+  async archiveByKey<T extends object>(template: Template<T>, key: Query<T>): Promise<unknown> {
+    return this.exerciseByKey(template.Archive, key, {});
   }
 }
 


### PR DESCRIPTION
Since the JSON API supports `fetchByKey` and `exerciseByKey` now, we don't need the `pseudo*` versions of these functions anymore.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4130)
<!-- Reviewable:end -->
