### PR TITLE
Document consumability qualifiers in the reference docs

### DIFF
--- a/docs/source/daml/code-snippets/Reference.daml
+++ b/docs/source/daml/code-snippets/Reference.daml
@@ -79,13 +79,21 @@ template NameOfTemplate
         do
           return () -- replace () with the actual return type
 -- start choice-first preconsuming snippet
-    preconsuming choice ExampleChoice3
+    preconsuming choice ExampleChoice5
           : () -- replace () with the actual return type
 -- end choice-first preconsuming snippet
+        with -- params
+        controller exampleParty
+          do
+            return ()
 -- start choice-first postconsuming snippet
-    postconsuming choice ExampleChoice3
+    postconsuming choice ExampleChoice6
           : () -- replace () with the actual return type
 -- end choice-first postconsuming snippet
+        with -- params
+        controller exampleParty
+          do
+            return ()
 -- start choice-first nonconsuming snippet
     nonconsuming choice ExampleChoice3
           : () -- replace () with the actual return type
@@ -109,13 +117,17 @@ template NameOfTemplate
         do
           return () -- replace () with the actual return type
 -- start controller-first preconsuming snippet
-      preconsuming ExampleChoice4
+      preconsuming ExampleChoice7
           : () -- replace () with the actual return type
 -- end controller-first preconsuming snippet
+        do
+          return () -- replace () with the actual return type
 -- start controller-first postconsuming snippet
-      postconsuming ExampleChoice4
+      postconsuming ExampleChoice8
           : () -- replace () with the actual return type
 -- end controller-first postconsuming snippet
+        do
+          return () -- replace () with the actual return type
 -- start controller-first nonconsuming snippet
       nonconsuming ExampleChoice4
           : () -- replace () with the actual return type

--- a/docs/source/daml/code-snippets/Reference.daml
+++ b/docs/source/daml/code-snippets/Reference.daml
@@ -78,6 +78,14 @@ template NameOfTemplate
 -- end choice-first controller snippet
         do
           return () -- replace () with the actual return type
+-- start choice-first preconsuming snippet
+    preconsuming choice ExampleChoice3
+          : () -- replace () with the actual return type
+-- end choice-first preconsuming snippet
+-- start choice-first postconsuming snippet
+    postconsuming choice ExampleChoice3
+          : () -- replace () with the actual return type
+-- end choice-first postconsuming snippet
 -- start choice-first nonconsuming snippet
     nonconsuming choice ExampleChoice3
           : () -- replace () with the actual return type
@@ -100,6 +108,14 @@ template NameOfTemplate
 -- end controller-first params snippet
         do
           return () -- replace () with the actual return type
+-- start controller-first preconsuming snippet
+      preconsuming ExampleChoice4
+          : () -- replace () with the actual return type
+-- end controller-first preconsuming snippet
+-- start controller-first postconsuming snippet
+      postconsuming ExampleChoice4
+          : () -- replace () with the actual return type
+-- end controller-first postconsuming snippet
 -- start controller-first nonconsuming snippet
       nonconsuming ExampleChoice4
           : () -- replace () with the actual return type

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -79,7 +79,7 @@ Consumability
 
 If no qualifier is present, choices are *consuming*: the contract is archived before the evaluation of the choice body.
 
-Note that the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised. This behavior differs from the one made of *preconsuming* and *postconsuming* choices.
+Note that the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised. This behavior differs from that of *preconsuming* and *postconsuming* choices.
 
 Preconsuming choices
 ********************

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -138,10 +138,9 @@ Non-consuming choices
 - ``nonconsuming`` keyword. Optional.
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
 - Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+- Useful in the many situations when you want to be able to exercise a choice more than once.
 
-  By default, choices are *preconsuming*: when a choice on a contract is exercised, that contract instance is *archived*. Archived means that it's permanently marked as being inactive, and no more choices can be exercised on it, though it still exists on the ledger.
-
-- Both *preconsuming* and *postconsuming* behaviors are useful in the many situations when you want to be able to exercise a choice more than once.
+  By default, choices are *consuming*: when a choice on a contract is exercised, that contract instance is *archived*. Archived means that it's permanently marked as being inactive, and no more choices can be exercised on it, though it still exists on the ledger.
 
 .. _daml-ref-return-type:
 

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -77,9 +77,9 @@ Controllers
 Consumability
 =============
 
-If no qualifier is present, choices are *consuming*. This means that, just like in *preconsuming* choices, the contract is archived before the evaluation of the choice body.
+If no qualifier is present, choices are *consuming*: the contract is archived before the evaluation of the choice body.
 
-Unlike *preconsuming* choices, though, the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+Note that the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised. This behavior differs from the one made of *preconsuming* and *postconsuming* choices.
 
 Preconsuming choices
 ********************
@@ -97,8 +97,9 @@ Preconsuming choices
    :caption: Option 2 for specifying choices: controller first
 
 - ``preconsuming`` keyword. Optional.
-- Makes a choice preconsuming: the contract is archived before the body of the exercise is executed.
-- Contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+- Makes a choice pre-consuming: the contract is archived before the body of the exercise is executed.
+- The archival behavior is analogous to the *consuming* default behavior.
+- Unlike what happens the in *consuming* default behavior, though, contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
 
 Postconsuming choices
 *********************
@@ -116,9 +117,9 @@ Postconsuming choices
    :caption: Option 2 for specifying choices: controller first
 
 - ``postconsuming`` keyword. Optional.
-- Makes a choice postconsuming: the contract is archived after the body of the exercise is executed.
+- Makes a choice post-consuming: the contract is archived after the body of the exercise is executed.
 - The contract can still be used in the body of the exercise.
-- Contracts created in the choice body are known only to the signatories and controllers of these contracts and are divulged to the observers of the contract on which the choice was exercised.
+- Contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
 
 Non-consuming choices
 *********************
@@ -139,8 +140,6 @@ Non-consuming choices
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
 - Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
 - Useful in the many situations when you want to be able to exercise a choice more than once.
-
-  By default, choices are *consuming*: when a choice on a contract is exercised, that contract instance is *archived*. Archived means that it's permanently marked as being inactive, and no more choices can be exercised on it, though it still exists on the ledger.
 
 .. _daml-ref-return-type:
 

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -77,7 +77,9 @@ Controllers
 Consumability
 =============
 
-If no qualifier is present, choices are *preconsuming*. This behavior is also usually referred to simply as *consuming*.
+If no qualifier is present, choices are *consuming*. This means that, just like in *preconsuming* choices, the contract is archived before the evaluation of the choice body.
+
+Unlike *preconsuming* choices, though, the contracts created in the choice body are disclosed to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
 
 Preconsuming choices
 ********************

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -72,10 +72,55 @@ Controllers
 
   The conjunction of **all** the parties are required to authorize when this choice is exercised.
 
-.. _daml-ref-anytime:
+.. _daml-ref-consumability:
+
+Consumability
+=============
+
+If no qualifier is present, choices are *preconsuming*. This behavior is also usually referred to simply as *consuming*.
+
+Preconsuming choices
+*****************
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first preconsuming snippet
+   :end-before: -- end choice-first preconsuming snippet
+   :caption: Option 1 for specifying choices: choice name first
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start controller-first preconsuming snippet
+   :end-before: -- end controller-first preconsuming snippet
+   :caption: Option 2 for specifying choices: controller first
+
+- ``preconsuming`` keyword. Optional.
+- Makes a choice preconsuming: the contract is archived before the body of the exercise is executed.
+- Default behavior, equivalent to not specifying a consumability qualifier.
+- Contracts created in the choice body are known to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+
+Postconsuming choices
+*********************
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start choice-first postconsuming snippet
+   :end-before: -- end choice-first postconsuming snippet
+   :caption: Option 1 for specifying choices: choice name first
+
+.. literalinclude:: ../code-snippets/Reference.daml
+   :language: daml
+   :start-after: -- start controller-first postconsuming snippet
+   :end-before: -- end controller-first postconsuming snippet
+   :caption: Option 2 for specifying choices: controller first
+
+- ``postconsuming`` keyword. Optional.
+- Makes a choice postconsuming: the contract is archived after the body of the exercise is executed.
+- The contract can still be used in the body of the exercise.
+- Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
 
 Non-consuming choices
-=====================
+*********************
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml
@@ -91,9 +136,11 @@ Non-consuming choices
 
 - ``nonconsuming`` keyword. Optional.
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
+- Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
 
-  By default, choices are *consuming*: when a choice on a contract is exercised, that contract instance is *archived*. Archived means that it's permanently marked as being inactive, and no more choices can be exercised on it, though it still exists on the ledger.
-- This is useful in the many situations when you want to be able to exercise a choice more than once.
+  By default, choices are *preconsuming*: when a choice on a contract is exercised, that contract instance is *archived*. Archived means that it's permanently marked as being inactive, and no more choices can be exercised on it, though it still exists on the ledger.
+
+- Both *preconsuming* and *postconsuming* behaviors are useful in the many situations when you want to be able to exercise a choice more than once.
 
 .. _daml-ref-return-type:
 

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -77,9 +77,7 @@ Controllers
 Contract consumption
 ====================
 
-If no qualifier is present, choices are *consuming*: the contract is archived before the evaluation of the choice body.
-
-Note that the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised. This behavior differs from that of *preconsuming* and *postconsuming* choices.
+If no qualifier is present, choices are *consuming*: the contract is archived before the evaluation of the choice body and both the controllers and all contract stakeholders see all consequences of the action.
 
 Preconsuming choices
 ********************
@@ -99,7 +97,7 @@ Preconsuming choices
 - ``preconsuming`` keyword. Optional.
 - Makes a choice pre-consuming: the contract is archived before the body of the exercise is executed.
 - The archival behavior is analogous to the *consuming* default behavior.
-- Unlike what happens the in *consuming* default behavior, though, contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
+- Unlike what happens the in *consuming* behavior, though, only the controllers and signatories of the contract see all consequences of the action. If the choice archives the contract, other stakeholders merely see an archive action.
 - Can be thought as a non-consuming choice that implicitly archives the contract before anything else happens
 
 Postconsuming choices
@@ -120,7 +118,7 @@ Postconsuming choices
 - ``postconsuming`` keyword. Optional.
 - Makes a choice post-consuming: the contract is archived after the body of the exercise is executed.
 - The contract can still be used in the body of the exercise.
-- Contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
+- Only the controllers and signatories of the contract see all consequences of the action. If the choice archives the contract, other stakeholders merely see an archive action.
 - Can be thought as a non-consuming choice that implicitly archives the contract after the choice has been exercised
 
 Non-consuming choices
@@ -140,7 +138,7 @@ Non-consuming choices
 
 - ``nonconsuming`` keyword. Optional.
 - Makes a choice non-consuming: that is, exercising the choice does not archive the contract.
-- Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+- Only the controllers and signatories of the contract see all consequences of the action. If the choice archives the contract, other stakeholders merely see an archive action.
 - Useful in the many situations when you want to be able to exercise a choice more than once.
 
 .. _daml-ref-return-type:

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -100,6 +100,7 @@ Preconsuming choices
 - Makes a choice pre-consuming: the contract is archived before the body of the exercise is executed.
 - The archival behavior is analogous to the *consuming* default behavior.
 - Unlike what happens the in *consuming* default behavior, though, contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
+- Can be thought as a non-consuming choice that implicitly archives the contract before anything else happens
 
 Postconsuming choices
 *********************
@@ -120,6 +121,7 @@ Postconsuming choices
 - Makes a choice post-consuming: the contract is archived after the body of the exercise is executed.
 - The contract can still be used in the body of the exercise.
 - Contracts created in the choice body are divulged only to their respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
+- Can be thought as a non-consuming choice that implicitly archives the contract after the choice has been exercised
 
 Non-consuming choices
 *********************

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -118,7 +118,7 @@ Postconsuming choices
 - ``postconsuming`` keyword. Optional.
 - Makes a choice postconsuming: the contract is archived after the body of the exercise is executed.
 - The contract can still be used in the body of the exercise.
-- Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+- Contracts created in the choice body are known only to the signatories and controllers of these contracts and are divulged to the observers of the contract on which the choice was exercised.
 
 Non-consuming choices
 *********************

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -98,7 +98,6 @@ Preconsuming choices
 
 - ``preconsuming`` keyword. Optional.
 - Makes a choice preconsuming: the contract is archived before the body of the exercise is executed.
-- Default behavior, equivalent to not specifying a consumability qualifier.
 - Contracts created in the choice body are known to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
 
 Postconsuming choices

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -80,7 +80,7 @@ Consumability
 If no qualifier is present, choices are *preconsuming*. This behavior is also usually referred to simply as *consuming*.
 
 Preconsuming choices
-*****************
+********************
 
 .. literalinclude:: ../code-snippets/Reference.daml
    :language: daml

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -79,7 +79,7 @@ Consumability
 
 If no qualifier is present, choices are *consuming*. This means that, just like in *preconsuming* choices, the contract is archived before the evaluation of the choice body.
 
-Unlike *preconsuming* choices, though, the contracts created in the choice body are disclosed to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+Unlike *preconsuming* choices, though, the contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
 
 Preconsuming choices
 ********************
@@ -98,7 +98,7 @@ Preconsuming choices
 
 - ``preconsuming`` keyword. Optional.
 - Makes a choice preconsuming: the contract is archived before the body of the exercise is executed.
-- Contracts created in the choice body are known to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+- Contracts created in the choice body are divulged to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
 
 Postconsuming choices
 *********************

--- a/docs/source/daml/reference/choices.rst
+++ b/docs/source/daml/reference/choices.rst
@@ -74,8 +74,8 @@ Controllers
 
 .. _daml-ref-consumability:
 
-Consumability
-=============
+Contract consumption
+====================
 
 If no qualifier is present, choices are *consuming*: the contract is archived before the evaluation of the choice body.
 

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -97,19 +97,19 @@ Here's the structure of a choice inside a template. There are two ways of specif
     - ``preconsuming`` keyword
 
         Exercising this choice archives the contract before the body is executed.
-        Contracts created in the choice body are known to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
 
     - ``postconsuming`` keyword
 
         Exercising this choice archives the contract after the body is executed. The contract can be used in the body of the exercise.
-        Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
 
     - ``nonconsuming`` keyword
 
         Exercising this choice will not archive the contract.
-        Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
 
-    If no qualifier is present the choice is *preconsuming*.
+    If no qualifier is present the choice is *consuming*. The archival behavior is the same as with ``preconsuming`` (the contract is archived immediately and it's not available in the choice body) but contracts created in the choice body are divulged to the respective signatories and controllers as well as to the observers of the contract on which the choice was exercised.
 
 :ref:`a name <daml-ref-choice-name>`
     Must begin with a capital letter. Must be unique - choices in different templates can't have the same name.

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -90,26 +90,9 @@ Here's the structure of a choice inside a template. There are two ways of specif
 
     Who can exercise the choice.
 
-:ref:`consumability <daml-ref-consumability>`
-
-    At most one of the following:
-
-    - ``preconsuming`` keyword
-
-        Exercising this choice archives the contract before the body is executed.
-        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
-
-    - ``postconsuming`` keyword
-
-        Exercising this choice archives the contract after the body is executed. The contract can be used in the body of the exercise.
-        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
-
-    - ``nonconsuming`` keyword
-
-        Exercising this choice will not archive the contract.
-        Contracts created in the choice body are divulged exclusively to the respective signatories and controllers and not to the observers of the contract on which the choice was exercised.
-
-    If no qualifier is present the choice is *consuming*. The archival behavior is the same as with ``preconsuming`` (the contract is archived immediately and it's not available in the choice body) but contracts created in the choice body are divulged to the respective signatories and controllers as well as to the observers of the contract on which the choice was exercised.
+:ref:`consumption annotation <daml-ref-consumability>`
+    Optionally one of ``preconsuming``, ``postconsuming``, ``nonconsuming``, which changes the behavior of the choice with respect to privacy and if and when the contract is archived.
+    See :ref:`contract consumption in choices <daml-ref-consumability>` for more details.
 
 :ref:`a name <daml-ref-choice-name>`
     Must begin with a capital letter. Must be unique - choices in different templates can't have the same name.

--- a/docs/source/daml/reference/structure.rst
+++ b/docs/source/daml/reference/structure.rst
@@ -90,10 +90,26 @@ Here's the structure of a choice inside a template. There are two ways of specif
 
     Who can exercise the choice.
 
-:ref:`consumability <daml-ref-anytime>`
-    ``nonconsuming`` keyword
+:ref:`consumability <daml-ref-consumability>`
 
-    By default, contracts are archived when a choice on them is exercised, which means that choices can no longer be exercised on them. If you include ``nonconsuming``, this choice can be exercised over and over.
+    At most one of the following:
+
+    - ``preconsuming`` keyword
+
+        Exercising this choice archives the contract before the body is executed.
+        Contracts created in the choice body are known to the signatories and controllers of the contracts as well as to the observers of the contract on which the choice was exercised.
+
+    - ``postconsuming`` keyword
+
+        Exercising this choice archives the contract after the body is executed. The contract can be used in the body of the exercise.
+        Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+
+    - ``nonconsuming`` keyword
+
+        Exercising this choice will not archive the contract.
+        Contracts created in the choice body are known only to the signatories and controllers of the contracts and not made known to the observers of the contract on which the choice was exercised.
+
+    If no qualifier is present the choice is *preconsuming*.
 
 :ref:`a name <daml-ref-choice-name>`
     Must begin with a capital letter. Must be unique - choices in different templates can't have the same name.


### PR DESCRIPTION
Also documents their privacy implications.

CHANGELOG_BEGIN
[Documentation] Documented consumability qualifiers in the DAML reference docs, along with their privacy implications
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
