### PR TITLE
Avoid intermediate nodejs_dev_env

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -640,6 +640,11 @@ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install
 
 node_repositories(
     package_json = ["//:package.json"],
+    # Using `dev_env_tool` introduces an additional layer of symlink
+    # indirection. Bazel doesn't track dependencies through symbolic links.
+    # Occasionally, this can cause build failures on CI if a build is not
+    # invalidated despite a change of an original source. To avoid such issues
+    # we use the `nixpkgs_package` directly.
     vendored_node = "@nodejs_dev_env" if is_windows else "@node_nix",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -377,7 +377,7 @@ nixpkgs_package(
 #node & npm
 nixpkgs_package(
     name = "node_nix",
-    attribute_path = "nodejs",
+    attribute_path = "nodejsNested",
     fail_not_supported = False,
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,6 +382,7 @@ nixpkgs_package(
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,
+    build_file_content = 'exports_files(glob(["node_nix/**"]))',
 )
 
 #sass
@@ -613,6 +614,8 @@ load("@io_bazel_rules_docker//java:image.bzl", java_image_repositories = "reposi
 
 java_image_repositories()
 
+# TODO (aherrmann) This wrapper is only used on Windows.
+#   Replace by an appropriate Windows only `dadew_tool` call.
 dev_env_tool(
     name = "nodejs_dev_env",
     nix_include = [
@@ -637,7 +640,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install
 
 node_repositories(
     package_json = ["//:package.json"],
-    vendored_node = "@nodejs_dev_env",
+    vendored_node = "@nodejs_dev_env" if is_windows else "@node_nix",
 )
 
 yarn_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -384,14 +384,6 @@ nixpkgs_package(
     repositories = dev_env_nix_repos,
 )
 
-nixpkgs_package(
-    name = "npm_nix",
-    attribute_path = "nodejs",
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
-)
-
 #sass
 nixpkgs_package(
     name = "sass_nix",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -378,11 +378,11 @@ nixpkgs_package(
 nixpkgs_package(
     name = "node_nix",
     attribute_path = "nodejsNested",
+    build_file_content = 'exports_files(glob(["node_nix/**"]))',
     fail_not_supported = False,
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,
-    build_file_content = 'exports_files(glob(["node_nix/**"]))',
 )
 
 #sass

--- a/deps.bzl
+++ b/deps.bzl
@@ -183,6 +183,7 @@ def daml_deps():
             urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.1.0/rules_nodejs-1.1.0.tar.gz"],
             sha256 = "c97bf38546c220fa250ff2cc052c1a9eac977c662c1fc23eda797b0ce8e70a43",
             patches = [
+                # Work around for https://github.com/bazelbuild/rules_nodejs/issues/1565
                 "@com_github_digital_asset_daml//bazel_tools:rules_nodejs_npm_cli_path.patch",
             ],
             patch_args = ["-p1"],

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -19,7 +19,6 @@ let shared = rec {
     jdk8
     jq
     netcat-gnu
-    nodejs
     patchelf
     postgresql_9_6
     protobuf3_8
@@ -46,6 +45,10 @@ let shared = rec {
   mvn = pkgs.writeScriptBin "mvn" ''
     exec ${pkgs.maven}/bin/mvn ''${MVN_SETTINGS:+-s "$MVN_SETTINGS"} "$@"
   '';
+
+  # rules_nodejs expects nodejs in a subdirectory of a repository rule.
+  # We use a linkFarm to fulfill this requirement.
+  nodejs = pkgs.linkFarm "nodejs" [ { name = "node_nix"; path = pkgs.nodejs; }];
 
   sass = pkgs.sass;
 

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -19,6 +19,7 @@ let shared = rec {
     jdk8
     jq
     netcat-gnu
+    nodejs
     patchelf
     postgresql_9_6
     protobuf3_8
@@ -48,7 +49,7 @@ let shared = rec {
 
   # rules_nodejs expects nodejs in a subdirectory of a repository rule.
   # We use a linkFarm to fulfill this requirement.
-  nodejs = pkgs.linkFarm "nodejs" [ { name = "node_nix"; path = pkgs.nodejs; }];
+  nodejsNested = pkgs.linkFarm "nodejs" [ { name = "node_nix"; path = pkgs.nodejs; }];
 
   sass = pkgs.sass;
 


### PR DESCRIPTION
rules_nodejs requires a vendored node to contain the node distribution
in a subdirectory of the provided external repository. With the default
node Nix package this is not the case. The nodejs_dev_env workspace used
an intermediate repository rule to fulfill these requirements.
This caused flakiness on CI.

This change fulfills this requirement on the Nix side, so that Bazel can
consume the provided Nix derivation directly.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
