### PR TITLE
Use GHC’s syntax for the --package flag

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -310,10 +310,10 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
             _ -> Nothing
       where parse = do
                 pkg_arg <- tok GHC.parseUnitId
-                ( do _ <- tok $ R.string "with"
+                do _ <- tok $ R.string "with"
                      fmap (PackageImport pkg_arg True) parseRns
-                 R.<++ fmap (PackageImport pkg_arg False) parseRns
-                 R.<++ return (PackageImport pkg_arg True []))
+                  R.<++ fmap (PackageImport pkg_arg False) parseRns
+                  R.<++ return (PackageImport pkg_arg True [])
             parseRns :: R.ReadP [(GHC.ModuleName, GHC.ModuleName)]
             parseRns = do
                 _ <- tok $ R.char '('
@@ -321,9 +321,9 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
                 _ <- tok $ R.char ')'
                 return rns
             parseItem = do
-                orig <- tok $ GHC.parseModuleName
+                orig <- tok GHC.parseModuleName
                 (do _ <- tok $ R.string "as"
-                    new <- tok $ GHC.parseModuleName
+                    new <- tok GHC.parseModuleName
                     return (orig, new)
                   R.+++
                  return (orig, orig))

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -322,11 +322,10 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
                 return rns
             parseItem = do
                 orig <- tok GHC.parseModuleName
-                (do _ <- tok $ R.string "as"
-                    new <- tok GHC.parseModuleName
-                    return (orig, new)
-                  R.+++
-                 return (orig, orig))
+                do _ <- tok $ R.string "as"
+                   new <- tok GHC.parseModuleName
+                   return (orig, new)
+                 R.+++ return (orig, orig)
             tok :: R.ReadP a -> R.ReadP a
             tok m = m >>= \x -> R.skipSpaces >> return x
 

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -311,9 +311,9 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
       where parse = do
                 pkg_arg <- tok GHC.parseUnitId
                 do _ <- tok $ R.string "with"
-                     fmap (PackageImport pkg_arg True) parseRns
-                  R.<++ fmap (PackageImport pkg_arg False) parseRns
-                  R.<++ return (PackageImport pkg_arg True [])
+                   fmap (PackageImport pkg_arg True) parseRns
+                 R.<++ fmap (PackageImport pkg_arg False) parseRns
+                 R.<++ return (PackageImport pkg_arg True [])
             parseRns :: R.ReadP [(GHC.ModuleName, GHC.ModuleName)]
             parseRns = do
                 _ <- tok $ R.char '('

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -5,8 +5,7 @@ module DA.Cli.Options
   ( module DA.Cli.Options
   ) where
 
-import Data.Bifunctor
-import           Data.List.Extra     (trim, splitOn)
+import Data.List.Extra     (trim, splitOn)
 import Options.Applicative.Extended
 import Safe (lastMay)
 import Data.List
@@ -17,7 +16,7 @@ import qualified DA.Daml.LF.Ast.Version as LF
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
 import qualified Module as GHC
-import Text.Read
+import qualified Text.ParserCombinators.ReadP as R
 
 
 -- | Pretty-printing documents with syntax-highlighting annotations.
@@ -291,13 +290,45 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
       long "package" <>
       internal
 
-    readPackageImport = maybeReader $ \s -> do
-        (unitId, exposeImplicit, modRenamings) <- readMaybe s
-        pure PackageImport
-          { pkgImportUnitId = GHC.stringToUnitId unitId
-          , pkgImportExposeImplicit = exposeImplicit
-          , pkgImportModRenamings = map (bimap GHC.mkModuleName GHC.mkModuleName) modRenamings
-          }
+    -- This is a slightly adapted version of GHC’s @parsePackageFlag@ from DynFlags
+    -- which is sadly not exported.
+    -- We use ReadP to stick as close to GHC’s implementation as possible.
+    -- The only difference is that we fix it to parsing -package-id flags and
+    -- therefore unit ids whereas GHC’s implementation is generic.
+    --
+    -- Here are a couple of examples for the syntax:
+    --
+    --  * @--package foo@ is @PackageImport "foo" True []@
+    --  * @--package foo ()@ is @PackageImport "foo" False []@
+    --  * @--package foo (A)@ is @PackageImport "foo" False [("A", "A")]@
+    --  * @--package foo (A as B)@ is @PackageImport "foo" False [("A", "B")]@
+    --  * @--package foo with (A as B)@ is @PackageImport "foo" True [("A", "B")]@
+    readPackageImport :: ReadM PackageImport
+    readPackageImport = maybeReader $ \str ->
+        case filter ((=="").snd) (R.readP_to_S parse str) of
+            [(r, "")] -> Just r
+            _ -> Nothing
+      where parse = do
+                pkg_arg <- tok GHC.parseUnitId
+                ( do _ <- tok $ R.string "with"
+                     fmap (PackageImport pkg_arg True) parseRns
+                 R.<++ fmap (PackageImport pkg_arg False) parseRns
+                 R.<++ return (PackageImport pkg_arg True []))
+            parseRns :: R.ReadP [(GHC.ModuleName, GHC.ModuleName)]
+            parseRns = do
+                _ <- tok $ R.char '('
+                rns <- tok $ R.sepBy parseItem (tok $ R.char ',')
+                _ <- tok $ R.char ')'
+                return rns
+            parseItem = do
+                orig <- tok $ GHC.parseModuleName
+                (do _ <- tok $ R.string "as"
+                    new <- tok $ GHC.parseModuleName
+                    return (orig, new)
+                  R.+++
+                 return (orig, orig))
+            tok :: R.ReadP a -> R.ReadP a
+            tok m = m >>= \x -> R.skipSpaces >> return x
 
     optHideAllPackages :: Parser Bool
     optHideAllPackages =

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -91,8 +91,7 @@ tests damlc repl davlDar = testGroup "Packaging"
             , "  - daml-prim"
             , "  - daml-stdlib"
             , "  - " <> aDar
-            , "build-options:"
-            , "- '--package=(\"a-1.0\", True, [(\"A\", \"C\")])'"
+            , "build-options: ['--package', 'a-1.0 with (A as C)']"
             ]
             -- the last option checks that module aliases work and modules imported without aliases
             -- are still exposed.
@@ -570,9 +569,9 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
           withCurrentDirectory projb $ callProcessSilent damlc
             [ "build", "--target=" <> LF.renderVersion targetLfVer, "-o", projb </> "projb.dar"
             , "--hide-all-packages"
-            , "--package", "(\"daml-prim\", True, [])"
-            , "--package", "(\"" <> damlStdlib <> "\", True, [])"
-            , "--package", "(\"proja-0.0.1\", True, [])"
+            , "--package", "daml-prim"
+            , "--package", damlStdlib
+            , "--package", "proja-0.0.1"
             ]
           callProcessSilent repl ["validate", projb </> "projb.dar"]
           projbPkgIds <- darPackageIds (projb </> "projb.dar")
@@ -632,11 +631,11 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
           withCurrentDirectory tmpDir $ callProcessSilent damlc
             [ "build", "-o", tmpDir </> "foobar.dar"
             , "--hide-all-packages"
-            , "--package", "(\"daml-prim\", True, [])"
-            , "--package", "(\"" <> damlStdlib <> "\", True, [])"
+            , "--package", "daml-prim"
+            , "--package", damlStdlib
             -- We need to use the old stdlib for the Archive type
-            , "--package", "(\"daml-stdlib-cc6d52aa624250119006cd19d51c60006762bd93ca5a6d288320a703024b33da\", False, [(\"DA.Internal.Template\", \"OldStdlib.DA.Internal.Template\")])"
-            , "--package", "(\"davl-0.0.3\", True, [])"
+            , "--package", "daml-stdlib-cc6d52aa624250119006cd19d51c60006762bd93ca5a6d288320a703024b33da (DA.Internal.Template as OldStdlib.DA.Internal.Template)"
+            , "--package", "davl-0.0.3"
             ]
           step "Validating DAR"
           callProcessSilent repl ["validate", tmpDir </> "foobar.dar"]
@@ -667,9 +666,10 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
             , "gen/Foo.daml"
             , "-o"
             , "FooGen.dalf"
-            , "--package=(" <> show damlStdlib <>
-              ", False, [(\"DA.Internal.LF\", \"CurrentSdk.DA.Internal.LF\"), (\"DA.Internal.Prelude\", \"Sdk.DA.Internal.Prelude\"), (\"DA.Internal.Template\", \"CurrentSdk.DA.Internal.Template\")])"
-            , "--package=(\"daml-prim\", False, [(\"DA.Types\", \"CurrentSdk.DA.Types\"), (\"GHC.Types\", \"CurrentSdk.GHC.Types\")])"
+            , "--package"
+            , damlStdlib <> " (DA.Internal.LF as CurrentSdk.DA.Internal.LF, DA.Internal.Prelude as CurrentSdk.DA.Internal.Prelude, DA.Internal.Template as CurrentSdk.DA.Internal.Template)"
+            , "--package"
+            , "daml-prim (DA.Types as CurrentSdk.DA.Types, GHC.Types as CurrentSdk.GHC.Types)"
             ]
         assertBool "FooGen.dalf was not created" =<< doesFileExist "FooGen.dalf"
     ] <>
@@ -688,7 +688,7 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
           , "dependencies: [daml-prim, daml-stdlib]"
           , "data-dependencies: [simple-dalf-0.0.0.dalf]"
           , "build-options:"
-          , "- '--package=(\"daml-stdlib-" <> sdkVersion <> "\", True, [])'"
+          , "- '--package=" <> damlStdlib <> "'"
           ]
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "daml 1.2"


### PR DESCRIPTION
The previous syntax was just based on the Read instance of a 3-tuple
which was pretty much unusable. This changes it to GHC’s much nicer
syntax.

I deliberately did not add a changelog entry for this, since this
flag isn’t something that we have documented at all and it is
currently only useful in combination with data-dependencies.

fixes #4126

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
