### PR TITLE
Engine: Simplify ordering of nodes in transaction

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -109,7 +109,7 @@ object Blinding {
     * transaction has Nid references that are not present in its nodes. Use `isWellFormed`
     * if you are getting the transaction from a third party.
     */
-  def divulgedTransaction[Nid: Ordering, Cid, Val](
+  def divulgedTransaction[Nid, Cid, Val](
       divulgences: Relation[Nid, Party],
       party: Party,
       tx: GenTransaction[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] = {
@@ -117,7 +117,7 @@ object Blinding {
     // Note that this relies on the local divulgence to be well-formed:
     // if an exercise node is divulged to A but some of its descendants
     // aren't the resulting transaction will not be well formed.
-    val filteredNodes = tx.nodes.filterKeys(partyDivulgences.contains)
+    val filteredNodes = tx.nodes.filter { case (k, _) => partyDivulgences.contains(k) }
 
     @tailrec
     def go(filteredRoots: BackStack[Nid], remainingRoots: FrontStack[Nid]): ImmArray[Nid] = {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.{EitherValues, Matchers, WordSpec}
 import scalaz.std.either._
 import scalaz.syntax.apply._
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
 
 @SuppressWarnings(
@@ -1054,7 +1054,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     def txFetchActors[Nid, Cid, Val](tx: GenTx[Nid, Cid, Val]): Set[Party] =
-      tx.fold(GenTx.AnyOrder, Set[Party]()) {
+      tx.fold(Set[Party]()) {
         case (actors, (_, n)) => actors union actFetchActors(n)
       }
 
@@ -1097,13 +1097,13 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "be retained when reinterpreting single fetch nodes" in {
       val Right(tx) = runExample(fetcher1StrCid, clara)
       val fetchNodes =
-        tx.fold(GenTx.TopDown, Seq[(NodeId, GenNode.WithTxValue[NodeId, ContractId])]()) {
+        tx.fold(Seq[(NodeId, GenNode.WithTxValue[NodeId, ContractId])]()) {
           case (ns, (nid, n @ NodeFetch(_, _, _, _, _, _))) => ns :+ ((nid, n))
           case (ns, _) => ns
         }
       fetchNodes.foreach {
         case (nid, n) =>
-          val fetchTx = GenTx(TreeMap(nid -> n), ImmArray(nid), None)
+          val fetchTx = GenTx(HashMap(nid -> n), ImmArray(nid), None)
           val Right(reinterpreted) = engine
             .reinterpret(n.requiredAuthorizers, Seq(n), let)
             .consume(lookupContract, lookupPackage, lookupKey)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.daml.lf.types
 
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.{ImmArray, Time}
 import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.Transaction
@@ -119,7 +118,7 @@ object Ledger {
       committer: Party,
       effectiveAt: Time.Timestamp,
       roots: ImmArray[ScenarioNodeId],
-      nodes: immutable.SortedMap[ScenarioNodeId, Node],
+      nodes: immutable.HashMap[ScenarioNodeId, Node],
       explicitDisclosure: Relation[ScenarioNodeId, Party],
       localImplicitDisclosure: Relation[ScenarioNodeId, Party],
       globalImplicitDisclosure: Relation[AbsoluteContractId, Party],
@@ -132,7 +131,7 @@ object Ledger {
       // The transaction root nodes.
       roots: ImmArray[Transaction.NodeId],
       // All nodes of this transaction.
-      nodes: immutable.SortedMap[Transaction.NodeId, Transaction.Node],
+      nodes: immutable.HashMap[Transaction.NodeId, Transaction.Node],
       // A relation between a node id and the parties to which this node gets explicitly disclosed.
       explicitDisclosure: Relation[Transaction.NodeId, Party],
       // A relation between a node id and the parties to which this node get implictly disclosed

--- a/daml-lf/spec/transaction.rst
+++ b/daml-lf/spec/transaction.rst
@@ -191,6 +191,8 @@ versions.
 
 ``roots`` is constrained as described under `field node_id`_.
 
+The node of the tree appears in pre-order traversal in ``nodes``
+
 message ContractInstance
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -17,7 +17,8 @@ import com.digitalasset.daml.lf.transaction._
 import com.digitalasset.daml.lf.value.Value._
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
-import scala.collection.immutable.TreeMap
+
+import scala.collection.immutable.HashMap
 import scalaz.syntax.apply._
 import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz.std.string.parseInt
@@ -391,7 +392,7 @@ object ValueGenerators {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(NodeId.unsafeFromIndex))
-    } yield GenTransaction(TreeMap(nodes: _*), ImmArray(roots), None)
+    } yield GenTransaction(HashMap(nodes: _*), ImmArray(roots), None)
   }
 
   @deprecated("use malformedGenTransaction instead", since = "100.11.17")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -339,11 +339,6 @@ object Value {
     def unsafeFromIndex(i: Int) = new NodeId(i)
   }
 
-  implicit object NodeIdOrdering extends Ordering[NodeId] {
-    override def compare(x: NodeId, y: NodeId): Int =
-      x.index.compare(y.index)
-  }
-
   /*** Keys cannot contain contract ids */
   type Key = Value[Nothing]
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Inside, Matchers, WordSpec}
 
 import scala.collection.breakOut
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class TransactionCoderSpec
@@ -254,7 +254,7 @@ class TransactionCoderSpec
         (nid.toString, node)
       })
       val tx = GenTransaction(
-        nodes = TreeMap(nodes.toSeq: _*),
+        nodes = HashMap(nodes.toSeq: _*),
         roots = nodes.map(_._1),
         optUsedPackages = None
       )
@@ -308,12 +308,12 @@ class TransactionCoderSpec
         ne copy (key = ne.key.map(_.copy(maintainers = Set.empty)))
       case _ => gn
     }
-  def transactionWithout[Nid: Ordering, Cid, Val](
+  def transactionWithout[Nid, Cid, Val](
       t: GenTransaction[Nid, Cid, Val],
       f: GenNode[Nid, Cid, Val] => GenNode[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] =
     t copy (nodes = t.nodes.transform((_, gn) => f(gn))(breakOut))
 
-  def minimalistTx[Nid: Ordering, Cid, Val](
+  def minimalistTx[Nid, Cid, Val](
       txvMin: TransactionVersion,
       tx: GenTransaction[Nid, Cid, Val]): GenTransaction[Nid, Cid, Val] = {
     def condApply(before: TransactionVersion, f: GenNode[Nid, Cid, Val] => GenNode[Nid, Cid, Val])

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -20,7 +20,7 @@ import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
 
 class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropertyChecks {
@@ -28,23 +28,23 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
   "isWellFormed" - {
     "detects dangling references in roots" in {
-      val tx = StringTransaction(TreeMap.empty, ImmArray("1"))
+      val tx = StringTransaction(HashMap.empty, ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", DanglingNodeId))
     }
 
     "detects dangling references in children" in {
-      val tx = StringTransaction(TreeMap("1" -> dummyExerciseNode(ImmArray("2"))), ImmArray("1"))
+      val tx = StringTransaction(HashMap("1" -> dummyExerciseNode(ImmArray("2"))), ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("2", DanglingNodeId))
     }
 
     "detects cycles" in {
-      val tx = StringTransaction(TreeMap("1" -> dummyExerciseNode(ImmArray("1"))), ImmArray("1"))
+      val tx = StringTransaction(HashMap("1" -> dummyExerciseNode(ImmArray("1"))), ImmArray("1"))
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", AliasedNode))
     }
 
     "detects aliasing from roots and exercise" in {
       val tx = StringTransaction(
-        TreeMap(
+        HashMap(
           "0" -> dummyExerciseNode(ImmArray("1")),
           "1" -> dummyExerciseNode(ImmArray("2")),
           "2" -> dummyCreateNode),
@@ -53,7 +53,7 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
     }
 
     "detects orphans" in {
-      val tx = StringTransaction(TreeMap("1" -> dummyCreateNode), ImmArray.empty)
+      val tx = StringTransaction(HashMap("1" -> dummyCreateNode), ImmArray.empty)
       tx.isWellFormed shouldBe Set(NotWellFormedError("1", OrphanedNode))
     }
   }
@@ -115,7 +115,7 @@ object TransactionSpec {
   private[this] type Value[+Cid] = V[Cid]
   type StringTransaction = GenTransaction[String, String, Value[String]]
   def StringTransaction(
-      nodes: TreeMap[String, GenNode[String, String, Value[String]]],
+      nodes: HashMap[String, GenNode[String, String, Value[String]]],
       roots: ImmArray[String]): StringTransaction = GenTransaction(nodes, roots, None)
 
   def dummyExerciseNode(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -11,7 +11,7 @@ import value.ValueVersions.asVersionedValue
 import TransactionVersions.assignVersion
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 
 class TransactionVersionSpec extends WordSpec with Matchers {
   import TransactionVersionSpec._
@@ -52,12 +52,12 @@ object TransactionVersionSpec {
   import TransactionSpec.{dummyCreateNode, dummyExerciseNode, StringTransaction}
   private[this] val singleId = "a"
   private val dummyCreateTransaction =
-    StringTransaction(TreeMap((singleId, dummyCreateNode)), ImmArray(singleId))
+    StringTransaction(HashMap(singleId -> dummyCreateNode), ImmArray(singleId))
   private val dummyExerciseWithResultTransaction =
-    StringTransaction(TreeMap((singleId, dummyExerciseNode(ImmArray.empty))), ImmArray(singleId))
+    StringTransaction(HashMap(singleId -> dummyExerciseNode(ImmArray.empty)), ImmArray(singleId))
   private val dummyExerciseTransaction =
     StringTransaction(
-      TreeMap((singleId, dummyExerciseNode(ImmArray.empty, false))),
+      HashMap(singleId -> dummyExerciseNode(ImmArray.empty, false)),
       ImmArray(singleId))
 
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/services/transaction/TransactionFiltration.scala
@@ -51,20 +51,18 @@ object TransactionFiltration {
       val inheritedWitnessesByNode =
         mutable.Map.empty[Nid, immutable.Set[Party]].withDefaultValue(Set.empty)
 
-      transaction.foreach(
-        GenTransaction.TopDown, { (nodeId, node) =>
-          templateId(node).foreach { tpl =>
-            val requestingParties = partiesByTemplate(tpl)
-            val inheritedWitnesses = inheritedWitnessesByNode(nodeId)
-            val explicitWitnesses = explicitWitnessesForNode(node)
-            val allWitnesses = inheritedWitnesses union explicitWitnesses
-            val requestingWitnesses = requestingParties intersect allWitnesses
+      transaction.foreach { (nodeId, node) =>
+        templateId(node).foreach { tpl =>
+          val requestingParties = partiesByTemplate(tpl)
+          val inheritedWitnesses = inheritedWitnessesByNode(nodeId)
+          val explicitWitnesses = explicitWitnessesForNode(node)
+          val allWitnesses = inheritedWitnesses union explicitWitnesses
+          val requestingWitnesses = requestingParties intersect allWitnesses
 
-            filteredPartiesByNode += ((nodeId, requestingWitnesses))
-            inheritedWitnessesByNode ++= children(node).map(_ -> allWitnesses)
-          }
+          filteredPartiesByNode += ((nodeId, requestingWitnesses))
+          inheritedWitnessesByNode ++= children(node).map(_ -> allWitnesses)
         }
-      )
+      }
 
       // We currently allow composite commands without any actual commands and
       // emit empty flat transactions. To be consistent with that behavior,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.v1.SubmittedTransaction
 import com.digitalasset.daml.lf.data.InsertOrdSet
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.transaction.Node._
-import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
+import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.value.Value.{
   AbsoluteContractId,
   ContractId,
@@ -75,7 +75,7 @@ private[kvutils] object InputsAndEffects {
       InsertOrdSet.fromSeq(parties.toList.sorted.map(partyStateKey))
     }
 
-    tx.fold(GenTransaction.TopDown, packageInputs: Set[DamlStateKey]) {
+    tx.fold(packageInputs: Set[DamlStateKey]) {
         case (inputs, (nodeId, node)) =>
           node match {
             case fetch: NodeFetch[ContractId] =>
@@ -103,7 +103,7 @@ private[kvutils] object InputsAndEffects {
   def computeEffects(entryId: DamlLogEntryId, tx: SubmittedTransaction): Effects = {
     // TODO(JM): Skip transient contracts in createdContracts/updateContractKeys. E.g. rewrite this to
     // fold bottom up (with reversed roots!) and skip creates of archived contracts.
-    tx.fold(GenTransaction.TopDown, Effects.empty) {
+    tx.fold(Effects.empty) {
       case (effects, (nodeId, node)) =>
         node match {
           case fetch: NodeFetch[ContractId] =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -15,7 +15,7 @@ import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.engine.{Blinding, Engine}
 import com.digitalasset.daml.lf.transaction.Node.{GlobalKey, NodeCreate, NodeExercises}
-import com.digitalasset.daml.lf.transaction.{BlindingInfo, GenTransaction}
+import com.digitalasset.daml.lf.transaction.BlindingInfo
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId, NodeId, VersionedValue}
 import org.slf4j.LoggerFactory
 
@@ -179,7 +179,7 @@ private[kvutils] case class ProcessTransactionSubmission(
       }.toSet
 
       allUnique = relTx
-        .fold(GenTransaction.TopDown, (true, startingKeys)) {
+        .fold((true, startingKeys)) {
           case (
               (allUnique, existingKeys),
               (_nodeId, exe: NodeExercises[_, _, VersionedValue[ContractId]]))

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -23,7 +23,7 @@ import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import org.scalatest.Assertions._
 import org.scalatest.{Assertion, AsyncWordSpec, BeforeAndAfterEach}
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.HashMap
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
@@ -514,7 +514,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
 object ParticipantStateIntegrationSpecBase {
   private val DefaultIdleTimeout = FiniteDuration(5, TimeUnit.SECONDS)
   private val emptyTransaction: SubmittedTransaction =
-    GenTransaction(SortedMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
+    GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 
   private val participantId: ParticipantId =
     Ref.LedgerString.assertFromString("in-memory-participant")

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -19,7 +19,7 @@ import com.digitalasset.daml.lf.value.Value.{
 import com.digitalasset.daml.lf.value.ValueVersions
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 
 class ProjectionsSpec extends WordSpec with Matchers {
 
@@ -70,7 +70,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
   "computePerPartyProjectionRoots" should {
 
     "yield no roots with empty transaction" in {
-      val emptyTransaction: Transaction = GenTransaction(TreeMap.empty, ImmArray.empty, None)
+      val emptyTransaction: Transaction = GenTransaction(HashMap.empty, ImmArray.empty, None)
       project(emptyTransaction) shouldBe List.empty
     }
 
@@ -81,7 +81,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice"), Party.assertFromString("Bob")))
       val tx =
-        GenTransaction(nodes = TreeMap(nid -> root), roots = ImmArray(nid), optUsedPackages = None)
+        GenTransaction(nodes = HashMap(nid -> root), roots = ImmArray(nid), optUsedPackages = None)
 
       project(tx) shouldBe List(
         ProjectionRoots(Party.assertFromString("Alice"), BackStack(nid)),
@@ -121,7 +121,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
 
       val tx =
         GenTransaction(
-          nodes = TreeMap(nid1 -> exe, nid2 -> create, nid3 -> bobCreate, nid4 -> charlieCreate),
+          nodes = HashMap(nid1 -> exe, nid2 -> create, nid3 -> bobCreate, nid4 -> charlieCreate),
           roots = ImmArray(nid1, nid3, nid4),
           optUsedPackages = None)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -19,7 +19,7 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, WordSpec}
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
 
 class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
@@ -81,7 +81,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
   private val aParty = Ref.Party.assertFromString("aParty")
 
   private val anEmptyTransaction: SubmittedTransaction =
-    GenTransaction(SortedMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
+    GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 
   private val aSubmissionId: SubmissionId =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -14,7 +14,6 @@ import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.Update._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.Ref.LedgerString
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId}
 import com.digitalasset.daml_lf_dev.DamlLf

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ActiveLedgerStateManager.scala
@@ -94,7 +94,7 @@ class ActiveLedgerStateManager[ALS](initialState: => ALS)(
     //   archived in this transaction.
     val st =
       transaction
-        .fold[AddTransactionState](GenTransaction.TopDown, AddTransactionState(initialState)) {
+        .fold[AddTransactionState](AddTransactionState(initialState)) {
           case (ats @ AddTransactionState(None, _, _, _), _) => ats
           case (ats @ AddTransactionState(Some(acc), errs, parties, archivedIds), (nodeId, node)) =>
             // If some node requires a contract, check that we have that contract, and check that that contract is not

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -19,7 +19,6 @@ import com.digitalasset.daml.lf.types.Ledger.ScenarioTransactionId
 import com.digitalasset.platform.sandbox.stores.ledger.LedgerEntry.Transaction
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.transaction.VersionTimeline
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 
 import scala.collection.breakOut
 import scala.collection.mutable.ArrayBuffer

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionConversion.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionConversion.scala
@@ -7,7 +7,6 @@ import com.digitalasset.daml.lf.engine
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
 import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.domain.eventIdOrdering
 import com.digitalasset.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import com.digitalasset.platform.common.{PlatformTypes => P}
 import com.digitalasset.platform.participant.util.EventFilter

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -11,7 +11,6 @@ import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.api.util.TimeProvider
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.Ref.{PackageId, Party, TransactionIdString}
 import com.digitalasset.daml.lf.data.{ImmArray, Time}
 import com.digitalasset.daml.lf.engine.Blinding

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -14,7 +14,6 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.api.util.TimeProvider
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.engine.Blinding

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V4_1__Collect_Parties.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/migration/postgres/V4_1__Collect_Parties.scala
@@ -102,7 +102,7 @@ class V4_1__Collect_Parties extends BaseJavaMigration {
 
   private def getParties(transaction: Transaction): Set[Ref.Party] = {
     transaction
-      .fold[Set[Ref.Party]](GenTransaction.TopDown, Set.empty) {
+      .fold[Set[Ref.Party]](Set.empty) {
         case (parties, (_, node)) =>
           node match {
             case nf: NodeFetch[AbsoluteContractId] =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/TransactionSerializer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/serialisation/TransactionSerializer.scala
@@ -4,7 +4,6 @@ package com.digitalasset.platform.sandbox.stores.ledger.sql.serialisation
 
 import com.digitalasset.daml.lf.archive.{Decode, Reader}
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.transaction._
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, VersionedValue}
 import com.digitalasset.daml.lf.value.ValueCoder.{DecodeError, EncodeError}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -37,7 +37,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
@@ -104,7 +104,7 @@ class ImplicitPartyAdditionIT
     val event1: NodeId = NodeId.unsafeFromIndex(0)
 
     val transaction = GenTransaction[NodeId, TContractId, Value[TContractId]](
-      TreeMap(event1 -> node),
+      HashMap(event1 -> node),
       ImmArray(event1),
       None
     )

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -29,7 +29,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.implicitConversions
@@ -83,7 +83,7 @@ class TransactionMRTComplianceIT
   "A Ledger" should {
     "reject transactions with a record time after the MRT" in allFixtures { ledger =>
       val dummyTransaction =
-        GenTransaction[NodeId, TContractId, Value[TContractId]](TreeMap.empty, ImmArray.empty, None)
+        GenTransaction[NodeId, TContractId, Value[TContractId]](HashMap.empty, ImmArray.empty, None)
 
       val submitterInfo = SubmitterInfo(
         Ref.Party.assertFromString("submitter"),

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/JdbcLedgerDaoSpec.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.{Configuration, Offset, TimeModel}
 import com.digitalasset.daml.bazeltools.BazelRunfiles
 import com.digitalasset.daml.lf.archive.DarReader
-import com.digitalasset.daml.lf.data.Ref.LedgerString.ordering
 import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.GenTransaction
@@ -54,7 +53,7 @@ import com.digitalasset.platform.sandbox.stores.ledger.{ConfigurationEntry, Ledg
 import com.digitalasset.resources.Resource
 import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}
 
-import scala.collection.immutable.TreeMap
+import scala.collection.immutable.HashMap
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.implicitConversions
@@ -173,7 +172,7 @@ class JdbcLedgerDaoSpec
         let,
         let,
         GenTransaction(
-          TreeMap(
+          HashMap(
             event1 -> NodeCreate(
               absCid,
               someContractInstance,
@@ -478,7 +477,7 @@ class JdbcLedgerDaoSpec
         let,
         let,
         GenTransaction(
-          TreeMap(
+          HashMap(
             event1 -> NodeCreate(
               absCid,
               someContractInstance,
@@ -525,7 +524,7 @@ class JdbcLedgerDaoSpec
         // normally the record time is some time after the ledger effective time
         let.plusMillis(42),
         GenTransaction(
-          TreeMap(
+          HashMap(
             event1 -> NodeCreate(
               absCid,
               someContractInstance,
@@ -579,7 +578,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeCreate(
                 absCid,
                 someContractInstance,
@@ -607,7 +606,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeExercises(
                 targetCid,
                 someTemplateId,
@@ -782,7 +781,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeCreate(
                 AbsoluteContractId(s"contractId$id"),
                 someContractInstance,
@@ -816,7 +815,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeExercises(
                 targetCoid = AbsoluteContractId(s"contractId$cid"),
                 templateId = someTemplateId,
@@ -858,7 +857,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeLookupByKey(
                 someTemplateId,
                 None,
@@ -889,7 +888,7 @@ class JdbcLedgerDaoSpec
           let,
           let,
           GenTransaction(
-            TreeMap(
+            HashMap(
               (s"event$id": EventId) -> NodeFetch(
                 coid = AbsoluteContractId(s"contractId$cid"),
                 templateId = someTemplateId,


### PR DESCRIPTION
In this PR, we replace the ordering of nodeIds in `GenTransaction` by the natural order of node in transaction (i.e. the order in which they have been created with exercise node ordered before their children). This order is yielded by the `foreach`/`fold` iterators from `GenTransaction`

We drop also unused traversals. 

This adavances #3830  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
