### PR TITLE
docs cron: use GitHub-Flavoured Markdown

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -277,7 +277,11 @@ instance JSON.ToJSON SubmitBlog where
 tell_hubspot :: GitHubVersion -> IO ()
 tell_hubspot latest = do
     putStrLn $ "Publishing "<> name latest <> " to Hubspot..."
-    desc <- http_post "https://api.github.com/markdown/raw" [("Content-Type", "text/plain")] (LBS.fromString $ notes latest)
+    desc <- http_post "https://api.github.com/markdown"
+                      [("Content-Type", "application/json")]
+                      (JSON.encode $ JSON.object [("text", JSON.String $ Text.pack $ notes latest),
+                                                  ("mode", "gfm"),
+                                                  ("context", "digital-asset/daml")])
     -- DEBUG
     putStrLn $ "About to read date " <> (show $ published_at latest) <> " to epoch ms"
     date <- (read <$> (<> "000")) . init <$> (shell $ "date -d " <> published_at latest <> " +%s")


### PR DESCRIPTION
This patch changes the call to the GitHub API that translates the release notes from markdown to HTML to use gfm instead of plain markdown. gfm is a superset of markdown that adds the following:

- GitHub usernames (`@`-mentions) are turned into links to the user's profile page.
- Issues and PR numbers (`#1234`) are turned into links to the corresponding issue or PR.
- Existing git shas are turned into links to the corresponding commit.

An example of this feature missing is the release notes for [v0.13.42](https://blog.daml.com/release-notes/0.13.42-1), where intended links such as

> - Rename argument in active contract to payload. See #3826.

are not rendered.