### PR TITLE
Fix enums in data-dependencies

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -62,7 +62,7 @@ damlPreprocessor mbPkgName x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = checkModuleName x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x
-        , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName $ enumTypePreprocessor x
+        , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName $ enumTypePreprocessor "GHC.Types" x
         }
     where
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
@@ -73,7 +73,7 @@ generatedPreprocessor x =
     IdePreprocessedSource
       { preprocWarnings = []
       , preprocErrors = []
-      , preprocSource = enumTypePreprocessor x
+      , preprocSource = enumTypePreprocessor "CurrentSdk.GHC.Types" x
       }
 
 -- | No preprocessing.

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/EnumType.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/EnumType.hs
@@ -8,6 +8,7 @@ module DA.Daml.Preprocessor.EnumType
 
 import "ghc-lib" GHC
 import "ghc-lib-parser" BasicTypes
+import "ghc-lib-parser" FastString
 import "ghc-lib-parser" RdrName
 import "ghc-lib-parser" OccName
 
@@ -16,22 +17,25 @@ import "ghc-lib-parser" OccName
 -- picked up during LF conversion and turned into an enum definition. This is
 -- distinguishible from @data A = B {}@ at the core level. @DamlEnum@ is a
 -- 0-parameter typeclass defined in GHC.Types and re-exported in Prelude.
-enumTypePreprocessor :: ParsedSource -> ParsedSource
-enumTypePreprocessor (L l src) = L l src
-    { hsmodDecls =  map fixEnumTypeDecl (hsmodDecls src) }
+--
+-- This rule is parametrized by the module containing damlEnumMod since this is different for
+-- data-dependencies where we want CurrentSdk.GHC.Types
+enumTypePreprocessor :: FastString -> ParsedSource -> ParsedSource
+enumTypePreprocessor damlEnumMod (L l src) = L l src
+    { hsmodDecls =  map (fixEnumTypeDecl damlEnumMod) (hsmodDecls src) }
 
-fixEnumTypeDecl :: LHsDecl GhcPs -> LHsDecl GhcPs
-fixEnumTypeDecl (L l decl)
+fixEnumTypeDecl :: FastString -> LHsDecl GhcPs -> LHsDecl GhcPs
+fixEnumTypeDecl damlEnumMod (L l decl)
     | TyClD xtcd tcd <- decl
     , DataDecl { tcdLName = lname, tcdTyVars = tyvars, tcdDataDefn = dd } <- tcd
     , HsQTvs _ [] <- tyvars -- enums cannot have type vars
     , HsDataDefn {dd_ctxt = (L lctx []), dd_cons = [con]} <- dd
     , PrefixCon [] <- con_args (unLoc con) -- no arguments to constructor
-    = L l (TyClD xtcd tcd { tcdDataDefn = dd { dd_ctxt = L lctx (makeEnumCtx lname) } })
+    = L l (TyClD xtcd tcd { tcdDataDefn = dd { dd_ctxt = L lctx (makeEnumCtx damlEnumMod lname) } })
 
-fixEnumTypeDecl ldecl = ldecl
+fixEnumTypeDecl _ ldecl = ldecl
 
-makeEnumCtx :: Located RdrName -> [LHsType GhcPs]
-makeEnumCtx (L loc _) =
-    [L loc (HsTyVar noExt NotPromoted (L loc (mkUnqual tcName "DamlEnum")))]
+makeEnumCtx :: FastString -> Located RdrName -> [LHsType GhcPs]
+makeEnumCtx damlEnumMod (L loc _) =
+    [L loc (HsTyVar noExt NotPromoted (L loc (mkQual tcName (damlEnumMod, "DamlEnum"))))]
         -- TODO: qualify with Prelude.

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -536,6 +536,7 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               -- This ensures that we have a reference to daml-stdlib and therefore daml-prim.
               , "x : [Text]"
               , "x = lines \"abc\\ndef\""
+              , "data X = X" -- This should generate a DAML-LF enum
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -556,6 +557,8 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               , "module B where"
               , "import A"
               , "data B = B A"
+              , "f : X"
+              , "f = X"
               ]
           writeFileUTF8 (projb </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion


### PR DESCRIPTION
To differentiate between "data X = X" which is translated to a DAML-LF
enum and "data X = X {}" which is translated to a DAML-LF record, we
add a datatype context with GHC.Types.DamlEnum. For
`data-dependencies` this needs to point to Currentsdk.GHC.Types.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
