### PR TITLE
Handle unserializable scenario result types

### DIFF
--- a/compiler/damlc/tests/daml-test-files/UnserializableScenario.daml
+++ b/compiler/damlc/tests/daml-test-files/UnserializableScenario.daml
@@ -1,0 +1,16 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module UnserializableScenario where
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+
+run : Scenario TemplateTypeRep
+run = scenario do
+  pure $ templateTypeRep @T

--- a/compiler/damlc/tests/daml-test-files/UnserializableScenario.daml
+++ b/compiler/damlc/tests/daml-test-files/UnserializableScenario.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- @SINCE-LF 1.7
 daml 1.2
 module UnserializableScenario where
 


### PR DESCRIPTION
Previously, the conversions made some attempt at guarding against this
by matching on SPap and PClosure. While it would be possible to extend
this to match on STypeRep, this doesn’t actually fix the issue since
this can be nested, e.g., you can have a record with a field that is
an SPAP.

This PR changes this to simply catch any errors thrown from
`toValue`. While this feels a bit ugly, I think it’s a reasonable fix
for now.

changelog_begin

- [DAML Studio] Scenarios with unserializable result types no longer
  crash the scenario service.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
