### PR TITLE
Disable eslint_test on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -46,6 +46,8 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+bazel clean --expunge
+
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/language-support/ts/daml-json-types/BUILD.bazel
+++ b/language-support/ts/daml-json-types/BUILD.bazel
@@ -44,7 +44,7 @@ eslint_test(
         ["**/*.ts"],
         exclude = ["**/*.test.ts"],
     ),
-)
+) if not is_windows else None
 
 pkg_npm(
     name = "npm_package",

--- a/language-support/ts/daml-ledger-fetch/BUILD.bazel
+++ b/language-support/ts/daml-ledger-fetch/BUILD.bazel
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
@@ -37,7 +38,7 @@ genrule(
 eslint_test(
     name = "lint",
     srcs = glob(["**/*.ts"]),
-)
+) if not is_windows else None
 
 pkg_npm(
     name = "npm_package",


### PR DESCRIPTION
This is currently breaking CI completely so for now let’s disable it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
