### PR TITLE
ledger-api-test-tool-on-canton: Upgrade to Canton v0.7.0 and cl…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -836,7 +836,7 @@ java_import(
     jars = glob(["lib/**"]),
 )
 """,
-    sha256 = "2ac6fb16cc020dad77a014cc8bf7b828150ed1efa7255b156f6da2e89af20284",
-    strip_prefix = "canton-0.6.0",
-    urls = ["https://www.canton.io/releases/canton-0.6.0.tar.gz"],
+    sha256 = "3a2e05d3321ea0350249b69ff58594b3150c8df29b04f854ae67ac59bb9c9e80",
+    strip_prefix = "canton-0.7.0",
+    urls = ["https://www.canton.io/releases/canton-0.7.0.tar.gz"],
 )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -31,7 +31,7 @@ source "\$${RUNFILES_DIR:-/dev/null}/\$$f" 2>/dev/null || \
   source "\$$(grep -sm1 "^\$$f " "\$$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find \$$f"; exit 1; }; f=; set -e
 
-PATH="\$$(rlocation coreutils_nix/bin):\$$(rlocation jq_nix/bin):\$$(rlocation grpcurl_nix/bin):\$$(rlocation jq_dev_env/bin):\$$(rlocation netcat_dev_env/bin):\$$PATH"
+PATH="\$$(rlocation coreutils_nix/bin):\$$(rlocation curl_nix/bin):\$$(rlocation grpcurl_nix/bin):\$$(rlocation jq_dev_env/bin):\$$PATH"
 export PATH
 
 EOF
@@ -55,9 +55,9 @@ conformance_test(
         ":canton",
         ":canton.conf",
         "@coreutils_nix//:bin/base64",
+        "@curl_nix//:bin/curl",
         "@grpcurl_nix//:bin/grpcurl",
         "@jq_dev_env//:jq",
-        "@netcat_dev_env//:nc",
     ],
     ports = [
         5011,

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -25,7 +25,7 @@ PARTICIPANTS=(
 
 TIMEOUT=60
 
-function wait_until {
+function wait_until() {
   local start
 
   start="$(date +%s)"
@@ -35,7 +35,7 @@ function wait_until {
       return 1
     fi
 
-    if "$@" >& /dev/null; then
+    if "$@" >&/dev/null; then
       return 0
     fi
 
@@ -81,7 +81,7 @@ if ! kill -0 "$pid" 2>/dev/null; then
   exit 1
 fi
 
-function stop {
+function stop() {
   local status
   status=$?
   kill "$pid" || :
@@ -95,9 +95,9 @@ wait_until curl -fsS "http://${PARTICIPANT_1_HOST}:${PARTICIPANT_1_MONITORING_PO
 
 for participant in "${PARTICIPANTS[@]}"; do
   for dar in "${dars[@]}"; do
-    base64 "$dar" \
-      | jq -R --slurp '{"darFile": .}' \
-      | grpcurl \
+    base64 "$dar" |
+      jq -R --slurp '{"darFile": .}' |
+      grpcurl \
         -plaintext \
         -d @ \
         "$participant" \

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -84,7 +84,7 @@ fi
 function stop() {
   local status
   status=$?
-  kill "$pid" || :
+  kill -INT "$pid" || :
   rm -f "$port_file" || :
   exit "$status"
 }

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -69,10 +69,8 @@ if [[ -z "$port_file" ]]; then
 fi
 
 # Redirect the Canton logs to a file for now, because they're really, really noisy.
-log_file="$(mktemp -t 'canton.XXXXX.log')"
 echo >&2 'Starting Canton...'
-echo >&2 "(Logs will be written to \"${log_file}\".)"
-"${command[@]}" >&"$log_file" &
+"${command[@]}" &
 pid="$!"
 
 sleep 1

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -13,39 +13,29 @@ CANTON_COMMAND=(
   "--bootstrap=$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/bootstrap.canton)"
 )
 
-PARTICIPANT_1_LEDGER_API_HOST=localhost
+PARTICIPANT_1_HOST=localhost
 PARTICIPANT_1_LEDGER_API_PORT=5011
-PARTICIPANT_2_LEDGER_API_HOST=localhost
+PARTICIPANT_1_MONITORING_PORT=7000
+PARTICIPANT_2_HOST=localhost
 PARTICIPANT_2_LEDGER_API_PORT=5021
 PARTICIPANTS=(
-  "${PARTICIPANT_1_LEDGER_API_HOST}:${PARTICIPANT_1_LEDGER_API_PORT}"
-  "${PARTICIPANT_2_LEDGER_API_HOST}:${PARTICIPANT_2_LEDGER_API_PORT}"
+  "${PARTICIPANT_1_HOST}:${PARTICIPANT_1_LEDGER_API_PORT}"
+  "${PARTICIPANT_2_HOST}:${PARTICIPANT_2_LEDGER_API_PORT}"
 )
 
-TIMEOUT=30
+TIMEOUT=60
 
-function wait_for_ports {
-  local start success host port
+function wait_until {
+  local start
 
   start="$(date +%s)"
   while true; do
-    if [[ "$(( "$(date +%s)" - start ))" -gt "$TIMEOUT" ]]; then
+    if [[ "$(("$(date +%s)" - start))" -gt "$TIMEOUT" ]]; then
       echo >&2 "Timed out after ${TIMEOUT} seconds."
       return 1
     fi
 
-    success=true
-    for (( i=1; i < $#; i++ )); do
-      host="${!i}"
-      i=$(( i + 1 ))
-      port="${!i}"
-      if ! nc -w 1 -z "$host" "$port"; then
-        success=false
-        break
-      fi
-    done
-
-    if "$success"; then
+    if "$@" >& /dev/null; then
       return 0
     fi
 
@@ -56,7 +46,7 @@ function wait_for_ports {
 command=("${CANTON_COMMAND[@]}")
 dars=()
 port_file=''
-while (( $# )); do
+while (($#)); do
   # extract the port file
   if [[ "$1" == '--port-file' ]]; then
     port_file="$2"
@@ -82,11 +72,11 @@ fi
 log_file="$(mktemp -t 'canton.XXXXX.log')"
 echo >&2 'Starting Canton...'
 echo >&2 "(Logs will be written to \"${log_file}\".)"
-"${command[@]}" >& "$log_file" &
+"${command[@]}" >&"$log_file" &
 pid="$!"
 
 sleep 1
-if ! kill -0 "$pid" 2> /dev/null; then
+if ! kill -0 "$pid" 2>/dev/null; then
   echo >&2 'Failed to start Canton.'
   exit 1
 fi
@@ -101,9 +91,7 @@ function stop {
 
 trap stop EXIT INT TERM
 
-wait_for_ports \
-  "$PARTICIPANT_1_LEDGER_API_HOST" "$PARTICIPANT_1_LEDGER_API_PORT" \
-  "$PARTICIPANT_2_LEDGER_API_HOST" "$PARTICIPANT_2_LEDGER_API_PORT"
+wait_until curl -fsS "http://${PARTICIPANT_1_HOST}:${PARTICIPANT_1_MONITORING_PORT}/health"
 
 for participant in "${PARTICIPANTS[@]}"; do
   for dar in "${dars[@]}"; do
@@ -114,12 +102,12 @@ for participant in "${PARTICIPANTS[@]}"; do
         -d @ \
         "$participant" \
         com.digitalasset.ledger.api.v1.admin.PackageManagementService.UploadDarFile \
-      > /dev/null
+        >/dev/null
   done
 done
 
 # This should write two ports, but the runner doesn't support that.
-echo "$PARTICIPANT_1_LEDGER_API_PORT" > "$port_file"
+echo "$PARTICIPANT_1_LEDGER_API_PORT" >"$port_file"
 
 echo >&2 'Canton is up and running.'
 

--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -19,13 +19,8 @@ canton {
         type = memory
       }
 
-      ledger-api {
-        port = 5011
-      }
-
-      admin-api {
-        port = 5012
-      }
+      ledger-api.port = 5011
+      admin-api.port = 5012
 
       party-change-notification {
         type = via-domain
@@ -37,17 +32,22 @@ canton {
         type = memory
       }
 
-      ledger-api {
-        port = 5021
-      }
-
-      admin-api {
-        port = 5022
-      }
+      ledger-api.port = 5021
+      admin-api.port = 5022
 
       party-change-notification {
         type = via-domain
       }
+    }
+  }
+
+  monitoring.health {
+    server.port = 7000
+
+    check {
+      type = ping
+      participant = participant_1
+      interval = 5s
     }
   }
 }


### PR DESCRIPTION
1. Upgrade Canton to v0.7.0.
2. Use `curl` to hit the health endpoint instead of using `nc` to check if the ledger API port is open. Netty prints a warning when kicking it with `nc -z` from Nix's netcat-gnu. Not other netcats though… don't know why. This happens with the Ledger API Server too.
3. Stop Canton with SIGINT, rather than SIGTERM. When stopping it with SIGTERM, it prints a load of warnings to the logs, which doesn't happen on SIGINT.
4. Pipe Canton logs to STDOUT now that they're pretty clean. This should make debugging any transient failures in CI much easier.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
