### PR TITLE
Add parties to logging context of active contracts service

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiActiveContractsService.scala
@@ -16,8 +16,10 @@ import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService
 import com.digitalasset.ledger.api.v1.active_contracts_service._
 import com.digitalasset.ledger.api.v1.event.CreatedEvent
+import com.digitalasset.ledger.api.v1.transaction_filter.TransactionFilter
 import com.digitalasset.ledger.api.validation.TransactionFilterValidator
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
+import com.digitalasset.logging.LoggingContext._
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.participant.util.LfEngineToApi
 import com.digitalasset.platform.server.api.validation.ActiveContractsServiceValidation
@@ -38,56 +40,59 @@ final class ApiActiveContractsService private (
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
-  @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
-  override protected def getActiveContractsSource(
-      request: GetActiveContractsRequest): Source[GetActiveContractsResponse, NotUsed] = {
-    logger.trace("Serving an Active Contracts request...")
+  private def partiesIn(filter: Option[TransactionFilter]): Array[String] =
+    filter.fold(Array.empty[String])(_.filtersByParty.keysIterator.toArray)
 
-    TransactionFilterValidator
-      .validate(request.getFilter, "filter")
-      .fold(
-        Source.failed, { filter =>
-          Source
-            .future(backend.getActiveContractSetSnapshot(filter))
-            .flatMapConcat {
-              case ActiveContractSetSnapshot(offset, acsStream) =>
-                acsStream
-                  .map {
-                    case (wfId, create) =>
-                      GetActiveContractsResponse(
-                        workflowId = wfId.map(_.unwrap).getOrElse(""),
-                        activeContracts = List(
-                          CreatedEvent(
-                            create.eventId.unwrap,
-                            create.contractId.coid,
-                            Some(LfEngineToApi.toApiIdentifier(create.templateId)),
-                            create.contractKey.map(
-                              ck =>
+  override protected def getActiveContractsSource(
+      request: GetActiveContractsRequest): Source[GetActiveContractsResponse, NotUsed] =
+    withEnrichedLoggingContext("parties" -> partiesIn(request.filter)) { implicit logCtx =>
+      logger.trace("Serving an Active Contracts request...")
+
+      TransactionFilterValidator
+        .validate(request.getFilter, "filter")
+        .fold(
+          Source.failed, { filter =>
+            Source
+              .future(backend.getActiveContractSetSnapshot(filter))
+              .flatMapConcat {
+                case ActiveContractSetSnapshot(offset, acsStream) =>
+                  acsStream
+                    .map {
+                      case (wfId, create) =>
+                        GetActiveContractsResponse(
+                          workflowId = wfId.map(_.unwrap).getOrElse(""),
+                          activeContracts = List(
+                            CreatedEvent(
+                              create.eventId.unwrap,
+                              create.contractId.coid,
+                              Some(LfEngineToApi.toApiIdentifier(create.templateId)),
+                              create.contractKey.map(
+                                ck =>
+                                  LfEngineToApi.assertOrRuntimeEx(
+                                    "converting stored contract",
+                                    LfEngineToApi
+                                      .lfVersionedValueToApiValue(verbose = request.verbose, ck))),
+                              Some(
                                 LfEngineToApi.assertOrRuntimeEx(
                                   "converting stored contract",
                                   LfEngineToApi
-                                    .lfVersionedValueToApiValue(verbose = request.verbose, ck))),
-                            Some(
-                              LfEngineToApi.assertOrRuntimeEx(
-                                "converting stored contract",
-                                LfEngineToApi
-                                  .lfValueToApiRecord(
-                                    verbose = request.verbose,
-                                    create.argument.value))),
-                            create.stakeholders.toSeq,
-                            signatories = create.signatories.map(_.toString)(collection.breakOut),
-                            observers = create.observers.map(_.toString)(collection.breakOut),
-                            agreementText = Some(create.agreementText)
+                                    .lfValueToApiRecord(
+                                      verbose = request.verbose,
+                                      create.argument.value))),
+                              create.stakeholders.toSeq,
+                              signatories = create.signatories.map(_.toString)(collection.breakOut),
+                              observers = create.observers.map(_.toString)(collection.breakOut),
+                              agreementText = Some(create.agreementText)
+                            )
                           )
                         )
-                      )
-                  }
-                  .concat(Source.single(GetActiveContractsResponse(offset = offset.value)))
-            }
-        }
-      )
-      .via(logger.logErrorsOnStream)
-  }
+                    }
+                    .concat(Source.single(GetActiveContractsResponse(offset = offset.value)))
+              }
+          }
+        )
+        .via(logger.logErrorsOnStream)
+    }
 
   override def bindService(): ServerServiceDefinition =
     ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -26,7 +26,7 @@ import com.digitalasset.daml.lf.transaction.{BlindingInfo, Transaction}
 import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.digitalasset.ledger.api.messages.command.submission.SubmitRequest
-import com.digitalasset.logging.LoggingContext.withEnrichedLoggingContext
+import com.digitalasset.logging.LoggingContext._
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.sandbox.metrics.timedFuture

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -3,24 +3,42 @@
 
 package com.digitalasset.logging
 
-import net.logstash.logback.argument.StructuredArgument
+import net.logstash.logback.argument.{StructuredArgument, StructuredArguments}
 import net.logstash.logback.marker.MapEntriesAppendingMarker
 import org.slf4j.Marker
 
+import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 object LoggingContext {
 
+  @implicitNotFound(
+    "import com.digitalasset.logging.LoggingContext._ and use exclusively native types, strings and arrays as values in the logging context")
+  sealed abstract class AllowedValue[V] {
+    final def asString(v: V): String = StructuredArguments.toString(v)
+  }
+  implicit val allowedDouble: AllowedValue[Double] = new AllowedValue[Double] {}
+  implicit val allowedFloat: AllowedValue[Float] = new AllowedValue[Float] {}
+  implicit val allowedLong: AllowedValue[Long] = new AllowedValue[Long] {}
+  implicit val allowedInt: AllowedValue[Int] = new AllowedValue[Int] {}
+  implicit val allowedShort: AllowedValue[Short] = new AllowedValue[Short] {}
+  implicit val allowedByte: AllowedValue[Byte] = new AllowedValue[Byte] {}
+  implicit val allowedChar: AllowedValue[Char] = new AllowedValue[Char] {}
+  implicit val allowedBoolean: AllowedValue[Boolean] = new AllowedValue[Boolean] {}
+  implicit def allowedString[S <: String]: AllowedValue[S] = new AllowedValue[S] {}
+  implicit def allowedArray[A: AllowedValue]: AllowedValue[Array[A]] = new AllowedValue[Array[A]] {}
+
   def newLoggingContext[A](f: LoggingContext => A): A =
     f(new LoggingContext(Map.empty))
 
-  def newLoggingContext[A](kv: (String, String), kvs: (String, String)*)(
-      f: LoggingContext => A): A =
-    f(new LoggingContext((kv +: kvs).toMap))
+  def newLoggingContext[A, V: AllowedValue](kv: (String, V))(f: LoggingContext => A): A =
+    newLoggingContext { implicit logCtx =>
+      withEnrichedLoggingContext(kv)(f)
+    }
 
-  def withEnrichedLoggingContext[A](kv: (String, String), kvs: (String, String)*)(
-      f: LoggingContext => A)(implicit logCtx: LoggingContext): A =
-    f((logCtx + kv) ++ kvs)
+  def withEnrichedLoggingContext[A, V](kv: (String, V))(
+      f: LoggingContext => A)(implicit logCtx: LoggingContext, value: AllowedValue[V]): A =
+    f(logCtx + (kv._1 -> value.asString(kv._2)))
 
 }
 
@@ -33,7 +51,6 @@ final class LoggingContext private (ctxMap: Map[String, String]) {
       ifNot: Marker with StructuredArgument => Unit): Unit =
     if (ctxMap.isEmpty) doThis else ifNot(forLogging)
 
-  private def +(kv: (String, String)): LoggingContext = new LoggingContext(ctxMap + kv)
-  private def ++(kvs: Seq[(String, String)]): LoggingContext = new LoggingContext(ctxMap ++ kvs)
+  private def +[V](kv: (String, String)): LoggingContext = new LoggingContext(ctxMap + kv)
 
 }


### PR DESCRIPTION
Contributes to #3699

Allows more than just strings as values in the logging context.

Allowed values are restricted by a set of implicits to ensure only types that can be serialized in a meaningful manner (native types, strings and arrays) can be passed.

This can also be achieved with overloading. I decided to go for implicits because I found it to be less verbose in implementation but I'm more than happy to go the other way.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
