### PR TITLE
Fix yarn target in VSCode ext cron job

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -110,8 +110,8 @@ jobs:
             git checkout $GITHUB
             cd compiler/daml-extension
             # This produces out/src/extension.js
-            bazel run @nodejs//:bin/yarn
-            bazel run @nodejs//:bin/yarn compile
+            bazel run @nodejs//:yarn
+            bazel run @nodejs//:yarn compile
             bazel run --run_under="cd $PWD && " @daml_extension_deps//vsce/bin:vsce -- publish ${GITHUB#v} -p $MARKETPLACE_TOKEN
           else
             if [[ "${GITHUB#v}" == "$MARKET" ]]; then


### PR DESCRIPTION
This has changed in 0a26591849857a3c603fa22c55470a56e7d0b230 which
broke the build. We only build the latest release so changing this
should be safe and not break older releases.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
