### PR TITLE
More DAML LF type synonym validation tests

### DIFF
--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Implicits.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Implicits.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf.testing
 package parser
 
 import com.digitalasset.daml.lf.data.{Numeric, Ref}
-import com.digitalasset.daml.lf.language.Ast.{Expr, Kind, Package, Type}
+import com.digitalasset.daml.lf.language.Ast.{Expr, Kind, Module, Package, Type}
 
 object Implicits {
 
@@ -25,6 +25,9 @@ object Implicits {
 
     def p[P](args: Any*)(implicit parserParameters: ParserParameters[P]): Package =
       interpolate(new ModParser[P](parserParameters).pkg)(args)
+
+    def m[P](args: Any*)(implicit parserParameters: ParserParameters[P]): Module =
+      interpolate(new ModParser[P](parserParameters).mod)(args)
 
     @SuppressWarnings(Array("org.wartremover.warts.Any"))
     def n(args: Any*): Ref.Name =

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -265,7 +265,11 @@ private[validation] object Typing {
         }
       case (dfnName, dfn: DValue) =>
         Env(mod.languageVersion, world, ContextDefValue(pkgId, mod.name, dfnName)).checkDValue(dfn)
-      case (_, _: DTypeSyn) => // TODO #3616: check type synonyms
+      case (dfnName, DTypeSyn(params, replacementTyp)) =>
+        val env =
+          Env(mod.languageVersion, world, ContextTemplate(pkgId, mod.name, dfnName), params.toMap)
+        checkUniq[TypeVarName](params.keys, EDuplicateTypeParam(env.ctx, _))
+        env.checkType(replacementTyp, KStar)
     }
 
   case class Env(

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -850,7 +850,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
     val testCases = Table(
       "module"
         -> "reject",
-      //Goood
+      //Good
       m"""module Mod { synonym S = Int64 ; }""" -> false,
       m"""module Mod { synonym S a = a ; }""" -> false,
       m"""module Mod { synonym S a b = a ; }""" -> false,

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -815,10 +815,34 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
         T"(( (forall (a:*) . a) → Unit ))",
       E"(( λ (e : forall (a:*) . |Mod:SynIdentity a|) → () )) " ->
         T"(( (forall (a:*) . a) → Unit ))",
+      E"(( λ (e : |Mod:SynHigh List|) → () )) " ->
+        T"(( List Int64 → Unit ))",
+      E"(( λ (e : |Mod:SynHigh2 GenMap Party|) → () )) " ->
+        T"(( (GenMap Party Party) → Unit ))",
     )
 
     forEvery(testCases) { (exp: Expr, expectedType: Type) =>
       env.typeOf(exp) shouldBe expectedType
+    }
+  }
+
+  "reject ill formed type synonym application" in {
+    val testCases = Table(
+      "badly formed type synonym application",
+      E"(( λ (e : |Mod:MissingSyn|) → () )) ",
+      E"(( λ (e : |Mod:SynInt Text|) → () )) ",
+      E"(( λ (e : |Mod:SynIdentity|) → () )) ",
+      E"(( λ (e : |Mod:SynIdentity Text Text|) → () )) ",
+      E"(( λ (e : |Mod:SynPair Text|) → () )) ",
+      E"(( λ (e : |Mod:SynPair Text Text Text|) → () )) ",
+      E"(( λ (e : |Mod:SynIdentity List|) → () )) ",
+      E"(( λ (e : |Mod:SynHigh Text|) → () )) ",
+      E"(( λ (e : |Mod:SynHigh GenMap|) → () )) ",
+      E"(( λ (e : |Mod:SynHigh2 List Party|) → () )) ",
+    )
+
+    forEvery(testCases) { exp =>
+      a[ValidationError] should be thrownBy env.typeOf(exp)
     }
   }
 
@@ -838,6 +862,8 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
          synonym SynSelfFunc (a: *) = a -> a ;
          synonym SynFunc (a: *) (b: *) = a -> b ;
          synonym SynPair (a: *) (b: *) = <one: a, two: b>;
+         synonym SynHigh (f: * -> *) = f Int64 ;
+         synonym SynHigh2 (f: * -> * -> *) (a: *) = f a a ;
 
          record T = {person: Party, name: Text };
          template (this : T) =  {


### PR DESCRIPTION
More DAML LF type synonym validation tests
- negative tests for badly formed synonym applications
- check synonym definitions & test (positive/negative)

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
