### PR TITLE
Use template Key in template generic params list

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -216,10 +216,7 @@ genDefDataType curPkgId conName mod tpls def =
                             ]
                         (keyTypeTs, keySer) = case tplKey tpl of
                             Nothing -> ("undefined", "() => jtv.constant(undefined)")
-                            Just key ->
-                                let (keyTypeTs, keySer) = genType (moduleName mod) (tplKeyType key)
-                                in
-                                (keyTypeTs, "() => " <> keySer <> ".decoder()")
+                            Just key -> (conName <.> "Key", "() => " <> snd (genType (moduleName mod) (tplKeyType key)) <> ".decoder()")
                         dict =
                             ["export const " <> conName <> ": daml.Template<" <> conName <> ", " <> keyTypeTs <> "> & {"] ++
                             ["  " <> x <> ": daml.Choice<" <> conName <> ", " <> t <> ", " <> rtyp <> ", " <> keyTypeTs <> ">;" | (x, t, rtyp, _) <- chcs] ++
@@ -250,10 +247,10 @@ genDefDataType curPkgId conName mod tpls def =
                             ] ++
                             ["};"]
                         associatedTypes =
-                          maybe [] (const $
+                          maybe [] (\key ->
                               [ "// eslint-disable-next-line @typescript-eslint/no-namespace"
                               , "export namespace " <> conName <> " {"] ++
-                              ["  export type Key = " <> keyTypeTs <> ""] ++
+                              ["  export type Key = " <> fst (genType (moduleName mod) (tplKeyType key)) <> ""] ++
                               ["}"]) (tplKey tpl)
                         registrations =
                             ["daml.registerTemplate(" <> conName <> ");"]


### PR DESCRIPTION
Improves https://github.com/digital-asset/daml/pull/4172. The associated key type now appears in the definition of the template itself e.g.
```typescript
export const Person: daml.Template<Person, Person.Key> & {
  Archive: daml.Choice<Person, Archive, {}, Person.Key>;
  Birthday: daml.Choice<Person, Birthday, daml.ContractId<Person>, Person.Key>;
} = { /* ...  */ }
```