### PR TITLE
Rename `argument` field to `payload` in the `command/create` request

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -296,7 +296,7 @@ HTTP Request
 
     {
       "templateId": "Iou:Iou",
-      "argument": {
+      "payload": {
         "issuer": "Alice",
         "owner": "Alice",
         "currency": "USD",
@@ -312,7 +312,7 @@ Where:
   + ``"<package ID>:<module>:<entity>"`` or
   + ``"<module>:<entity>"`` if contract template can be uniquely identified by it's module and entity name.
 
-- ``argument`` field contains contract fields as defined in the DAML template and formatted according to :doc:`lf-value-specification`.
+- ``payload`` field contains contract fields as defined in the DAML template and formatted according to :doc:`lf-value-specification`.
 
 .. _create-response:
 
@@ -360,7 +360,7 @@ When creating a new contract, client may specify an optional ``meta`` field:
 
     {
       "templateId": "Iou:Iou",
-      "argument": {
+      "payload": {
         "observers": [],
         "issuer": "Alice",
         "amount": "999.99",

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -154,12 +154,12 @@ class Ledger {
   /**
    * Create a contract for a given template.
    */
-  async create<T extends object, K>(template: Template<T, K>, argument: T): Promise<CreateEvent<T, K>> {
-    const payload = {
+  async create<T extends object, K>(template: Template<T, K>, contractPayload: T): Promise<CreateEvent<T, K>> {
+    const command = {
       templateId: template.templateId,
-      argument,
+      payload: contractPayload,
     };
-    const json = await this.submit('command/create', payload);
+    const json = await this.submit('command/create', command);
     return jtv.Result.withException(decodeCreateEvent(template).run(json));
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -108,7 +108,7 @@ class CommandService(
     resolveTemplateId(input.templateId)
       .toRightDisjunction(
         Error('createCommand, ErrorMessages.cannotResolveTemplateId(input.templateId)))
-      .map(tpId => Commands.create(refApiIdentifier(tpId), input.argument))
+      .map(tpId => Commands.create(refApiIdentifier(tpId), input.payload))
   }
 
   private def exerciseCommand(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -83,7 +83,7 @@ object domain {
 
   final case class CreateCommand[+LfV](
       templateId: TemplateId.OptionalPkg,
-      argument: LfV,
+      payload: LfV,
       meta: Option[CommandMeta])
 
   final case class ExerciseCommand[+LfV, +Ref](
@@ -375,7 +375,7 @@ object domain {
     implicit val traverseInstance: Traverse[CreateCommand] = new Traverse[CreateCommand] {
       override def traverseImpl[G[_]: Applicative, A, B](fa: CreateCommand[A])(
           f: A => G[B]): G[CreateCommand[B]] =
-        f(fa.argument).map(a => fa.copy(argument = a))
+        f(fa.payload).map(a => fa.copy(payload = a))
     }
 
     implicit val hasTemplateId: HasTemplateId[CreateCommand] = new HasTemplateId[CreateCommand] {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
@@ -17,12 +17,12 @@ import scalaz.syntax.show._
 object Commands extends StrictLogging {
   def create(
       templateId: lar.TemplateId,
-      arguments: lav1.value.Record): lav1.commands.Command.Command.Create = {
+      payload: lav1.value.Record): lav1.commands.Command.Command.Create = {
 
     lav1.commands.Command.Command.Create(
       lav1.commands.CreateCommand(
         templateId = Some(lar.TemplateId.unwrap(templateId)),
-        createArguments = Some(arguments)))
+        createArguments = Some(payload)))
   }
 
   def exercise(

--- a/ledger-service/http-json/src/test/resources/it/iouCreateCommand.json
+++ b/ledger-service/http-json/src/test/resources/it/iouCreateCommand.json
@@ -1,6 +1,6 @@
 {
   "templateId": "Iou:Iou",
-  "argument": {
+  "payload": {
     "observers": [],
     "issuer": "Alice",
     "amount": "999.99",

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -443,7 +443,7 @@ abstract class AbstractHttpServiceIntegrationTest
       create: domain.CreateCommand[v.Record],
       exercise: domain.ExerciseCommand[v.Value, _]): Assertion = {
 
-    val expectedContractFields: Seq[v.RecordField] = create.argument.fields
+    val expectedContractFields: Seq[v.RecordField] = create.payload.fields
     val expectedNewOwner: v.Value = exercise.argument.sum.record
       .flatMap(_.fields.headOption)
       .flatMap(_.value)
@@ -471,9 +471,9 @@ abstract class AbstractHttpServiceIntegrationTest
 
     inside(SprayJson.decode[domain.ActiveContract[JsValue]](jsVal)) {
       case \/-(activeContract) =>
-        val expectedArgument: JsValue =
-          encoder.encodeUnderlyingRecord(command).map(_.argument).getOrElse(fail)
-        (activeContract.payload: JsValue) shouldBe expectedArgument
+        val expectedPayload: JsValue =
+          encoder.encodeUnderlyingRecord(command).map(_.payload).getOrElse(fail)
+        (activeContract.payload: JsValue) shouldBe expectedPayload
     }
   }
 
@@ -634,7 +634,7 @@ abstract class AbstractHttpServiceIntegrationTest
     (uri, _, _) =>
       val createCommand = jsObject("""{
         "templateId": "Account:KeyedByVariantAndRecord",
-        "argument": {
+        "payload": {
           "name": "ABC DEF",
           "party": "Alice",
           "age": 123,


### PR DESCRIPTION
Rename ``argument`` field to ``payload`` in the ``command/create`` request.

Closes: #4189

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
