### PR TITLE
Ignore missing maven deps on macos

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -27,6 +27,13 @@ step "set up temporary location"
 release_dir="$(mktemp -d)"
 step "temporary release directory is ${release_dir}"
 
+EXTRA_ARGS=""
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    EXTRA_ARGS="--ignore-missing-deps"
+fi
+
+
 if [[ "${BUILD_SOURCEBRANCHNAME:-}" == "master" ]]; then
     # set up bintray credentials
     mkdir -p ~/.jfrog
@@ -34,9 +41,9 @@ if [[ "${BUILD_SOURCEBRANCHNAME:-}" == "master" ]]; then
     unset JFROG_CONFIG_CONTENT
 
     step "run release script (with --upload)"
-    ./bazel-bin/release/release --artifacts release/artifacts.yaml --upload --log-level debug --release-dir "${release_dir}"
+    ./bazel-bin/release/release --artifacts release/artifacts.yaml --upload --log-level debug --release-dir "${release_dir}" $EXTRA_ARGS
 else
     step "run release script (dry run)"
-    ./bazel-bin/release/release --artifacts release/artifacts.yaml --log-level debug --release-dir "${release_dir}"
+    ./bazel-bin/release/release --artifacts release/artifacts.yaml --log-level debug --release-dir "${release_dir}" $EXTRA_ARGS
     step "release artifacts got stored in ${release_dir}"
 fi

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -26,6 +26,7 @@ data Options = Options
   , optsLogLevel :: LogLevel
   , optsAllArtifacts :: AllArtifacts
   , optsLocallyInstallJars :: Bool
+  , optsIgnoreMissingDeps :: IgnoreMissingDeps
   } deriving (Eq, Show)
 
 optsParser :: Parser Options
@@ -38,6 +39,8 @@ optsParser = Options
   <*> option readLogLevel (long "log-level" <> metavar "debug|info|warn|error (default: info)" <> help "Specify log level during release run" <> value LevelInfo )
   <*> (AllArtifacts <$> switch (long "all-artifacts" <> help "Produce all artifacts including platform-independent artifacts on MacOS"))
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")
+  <*> (IgnoreMissingDeps <$> switch (long "ignore-missing-deps" <> help "Do not check for missing Maven dependencies"))
+
   where
     readLogLevel :: ReadM LogLevel
     readLogLevel = do

--- a/release/src/Types.hs
+++ b/release/src/Types.hs
@@ -11,6 +11,7 @@ module Types (
     BintrayPackage(..),
     GitRev,
     GroupId,
+    IgnoreMissingDeps(..),
     MavenAllowUnsecureTls(..),
     MavenCoords(..),
     MavenUpload(..),
@@ -87,6 +88,12 @@ newtype MavenUpload = MavenUpload { getMavenUpload :: Bool }
 -- | If this is True, we produce all artifacts even platform independent artifacts on MacOS.
 -- This is useful for testing purposes.
 newtype AllArtifacts = AllArtifacts Bool
+    deriving (Eq, Show)
+
+-- | If True, we do not check for missing deps.
+-- This is significantly faster and deps checking is platform independent
+-- so we only run it on Linux which is usually faster than the MacOS build.
+newtype IgnoreMissingDeps = IgnoreMissingDeps { getIgnoreMissingDeps :: Bool }
     deriving (Eq, Show)
 
 -- execution


### PR DESCRIPTION
Currently, pretty much all of our builds are bottlenecked on
MacOS (mainly because the builders are slower and have worse
caching). The release step adds > 3min to each build which is a bit
annoying. It turns out that removing the calls to `bazel query` which
are used to check for missing Maven dependencies speeds this up by >
5x. Given that the check is platform independent anyway, we can just
disable it on MacOS.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
