### PR TITLE
daml-ledger.ts: Simplify types of *ByKey operations

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -142,7 +142,10 @@ class Ledger {
   /**
    * Fetch a contract by its key.
    */
-  async lookupByKey<T extends object, K>(template: Template<T, K>, key: K extends undefined ? never : K): Promise<CreateEvent<T, K> | null> {
+  async lookupByKey<T extends object, K>(template: Template<T, K>, key: K): Promise<CreateEvent<T, K> | null> {
+    if (key === undefined) {
+      throw Error(`Cannot lookup by key on template ${template.templateId} because it does not define a key.`);
+    }
     const payload = {
       templateId: template.templateId,
       key,
@@ -186,7 +189,10 @@ class Ledger {
   /**
    * Exercise a choice on a contract identified by its contract key.
    */
-  async exerciseByKey<T extends object, C, R, K>(choice: Choice<T, C, R, K>, key: K extends undefined ? never : K, argument: C): Promise<[R, Event<object>[]]> {
+  async exerciseByKey<T extends object, C, R, K>(choice: Choice<T, C, R, K>, key: K, argument: C): Promise<[R, Event<object>[]]> {
+    if (key === undefined) {
+      throw Error(`Cannot exercise by key on template ${choice.template().templateId} because it does not define a key.`);
+    }
     const payload = {
       templateId: choice.template().templateId,
       key,

--- a/language-support/ts/daml-ledger/tsconfig.json
+++ b/language-support/ts/daml-ledger/tsconfig.json
@@ -15,5 +15,8 @@
     "declaration": true,
     "sourceMap": true
     },
-  "include": ["**/*.ts"]
+  "include": [
+    "**/*.ts",
+    "lib/**/*"
+  ]
 }

--- a/language-support/ts/daml-types/tsconfig.json
+++ b/language-support/ts/daml-types/tsconfig.json
@@ -16,5 +16,8 @@
     "sourceMap": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": [
+    "**/*.test.ts",
+    "lib/**/*"
+  ]
 }


### PR DESCRIPTION
The current type signature adds complexity which is unjustified in my
opinion. Who would expect meaningful results when specifying a template
by key `undefined`?

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4202)
<!-- Reviewable:end -->
