### PR TITLE
Fix missing module refs issue

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -206,13 +206,14 @@ genDefDataType curPkgId conName mod tpls def =
                 Nothing -> ((makeType typeDesc, makeSer serDesc), Set.unions fieldRefs)
                 Just tpl ->
                     let (chcs, argRefs) = unzip
-                            [((unChoiceName (chcName chc), t, rtyp, rser), argRefs)
+                            [((unChoiceName (chcName chc), t, rtyp, rser), Set.union argRefs retRefs)
                             | chc <- NM.toList (tplChoices tpl)
                             , let tLf = snd (chcArgBinder chc)
                             , let rLf = chcReturnType chc
                             , let (t, _) = genType (moduleName mod) tLf
                             , let (rtyp, rser) = genType (moduleName mod) rLf
                             , let argRefs = Set.setOf typeModuleRef tLf
+                            , let retRefs = Set.setOf typeModuleRef rLf
                             ]
                         (keyTypeTs, keySer) = case tplKey tpl of
                             Nothing -> ("undefined", "() => jtv.constant(undefined)")

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -6,6 +6,7 @@ module Main where
 import DA.TextMap
 import Lib.Mod
 
+import T
 
 template AllTypes with
     unit: ()
@@ -90,3 +91,16 @@ data Quux =
     Corge { x: Int, y: Text }
   | Grault { z: Bool }
   deriving (Show, Eq)
+
+-- This template is interesting in that the 'T' it mentions is
+-- external to this module and only mentioned as a choice return
+-- type. Thus, for the resulting Main.ts to compile, we are testing
+-- that we have correctly generated import directives for this case.
+template U with
+    party: Party
+  where
+    signatory party
+    controller party can
+      C: ContractId T with
+        do
+          create T with party

--- a/language-support/ts/codegen/tests/daml/T.daml
+++ b/language-support/ts/codegen/tests/daml/T.daml
@@ -1,0 +1,9 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+daml 1.2
+-- See 'template U' in Main.daml for why this is here.
+module T where
+template T with
+    party: Party
+  where
+    signatory party


### PR DESCRIPTION
Fixes an issue whereby if a choice return type comes from an external module, a reference to that module was not being respected in the generated TypeScript.