### PR TITLE
Introduce NodeInfo.informeesOfNode

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -410,7 +410,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
   def convertTxNodeId(nodeId: Tx.NodeId): NodeId =
     NodeId.newBuilder.setId(nodeId.index.toString).build
 
-  def convertNode(nodeId: Ledger.ScenarioNodeId, nodeInfo: Ledger.NodeInfo): Node = {
+  def convertNode(nodeId: Ledger.ScenarioNodeId, nodeInfo: Ledger.LedgerNodeInfo): Node = {
     val builder = Node.newBuilder
     builder
       .setNodeId(convertNodeId(nodeId))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -291,7 +291,7 @@ object Ledger {
     *                       this is the immediate parent, which must be an
     *                       'NodeExercises' node.
     */
-  final case class NodeInfo(
+  final case class LedgerNodeInfo(
       node: Node,
       transaction: ScenarioTransactionId,
       effectiveAt: Time.Timestamp,
@@ -307,13 +307,13 @@ object Ledger {
       case ParticipantView(party) => observingSince contains party
     }
 
-    def addObservers(witnesses: Map[Party, ScenarioTransactionId]): NodeInfo = {
+    def addObservers(witnesses: Map[Party, ScenarioTransactionId]): LedgerNodeInfo = {
       // NOTE(JM): We combine with bias towards entries in `observingSince`.
       copy(observingSince = witnesses ++ observingSince)
     }
   }
 
-  type NodeInfos = Map[ScenarioNodeId, NodeInfo]
+  type LedgerNodeInfos = Map[ScenarioNodeId, LedgerNodeInfo]
 
   /*
    * Result from lookupGlobalContract. We provide detailed information why a lookup
@@ -576,11 +576,18 @@ object Ledger {
       globalDivulgences: Relation[AbsoluteContractId, Party],
       failedAuthorizations: Map[Transaction.NodeId, FailedAuthorization],
   ) {
-    def discloseTo(witnesses: Set[Party], i: Transaction.NodeId): EnrichState =
-      copy(
-        disclosures = disclosures
-          .updated(i, witnesses union disclosures.getOrElse(i, Set.empty)),
-      )
+    def discloseNode(
+        parentWitnesses: Set[Party],
+        nid: Transaction.NodeId,
+        node: Transaction.Node,
+    ): (Set[Party], EnrichState) = {
+      val witnesses = parentWitnesses union node.informeesOfNode
+      witnesses ->
+        copy(
+          disclosures = disclosures
+            .updated(nid, witnesses union disclosures.getOrElse(nid, Set.empty)),
+        )
+    }
 
     def divulgeContracts(witnesses: Set[Party], coids: Set[ContractId]): EnrichState =
       coids.foldLeft(this) {
@@ -856,8 +863,13 @@ object Ledger {
       tr: Transaction.Transaction,
   ): EnrichedTransaction = {
 
-    // Before we traversed through an exercise node the exercise witnesses are empty.
-    val initialParentExerciseWitnesses = Set[Party]()
+    // Before we traversed through an exercise node the exercise witnesses
+    // contain only the initial authorizers.
+    val initialParentExerciseWitnesses: Set[Party] =
+      authorization match {
+        case DontAuthorize => Set.empty
+        case Authorize(authorizers) => authorizers
+      }
 
     def enrichNode(
         state: EnrichState,
@@ -876,9 +888,7 @@ object Ledger {
           // divulge              : Nothing
           // well-authorized by A : signatories subsetOf A && non-empty signatories
           // ------------------------------------------------------------------
-
-          val witnesses = create.stakeholders.union(parentExerciseWitnesses)
-          val state1 = state
+          state
             .authorizeCreate(
               nodeId,
               create,
@@ -886,8 +896,8 @@ object Ledger {
               authorization = authorization,
               mbMaintainers = create.key.map(_.maintainers),
             )
-            .discloseTo(witnesses, nodeId)
-          state1
+            .discloseNode(parentExerciseWitnesses, nodeId, create)
+            ._2
 
         case fetch: NodeFetch[ContractId] =>
           // ------------------------------------------------------------------
@@ -895,15 +905,16 @@ object Ledger {
           // divulge              : referenced contract to witnesses of parent exercise node
           // well-authorized by A : A `intersect` stakeholders(fetched contract id) = non-empty
           // ------------------------------------------------------------------
-          val state1 = state
+          state
             .divulgeCoidTo(parentExerciseWitnesses -- fetch.stakeholders, fetch.coid)
-            .discloseTo(parentExerciseWitnesses, nodeId)
-          state1.authorizeFetch(
-            nodeId,
-            fetch,
-            stakeholders = fetch.stakeholders,
-            authorization = authorization,
-          )
+            .discloseNode(parentExerciseWitnesses, nodeId, fetch)
+            ._2
+            .authorizeFetch(
+              nodeId,
+              fetch,
+              stakeholders = fetch.stakeholders,
+              authorization = authorization,
+            )
 
         case ex: NodeExercises.WithTxValue[Transaction.NodeId, ContractId] =>
           // ------------------------------------------------------------------
@@ -930,14 +941,7 @@ object Ledger {
             )
 
           // Then enrich and authorize the children.
-          val witnesses =
-            if (ex.consuming)
-              ex.stakeholders.union(parentExerciseWitnesses)
-            else
-              ex.actingParties
-                .union(ex.signatories)
-                .union(parentExerciseWitnesses)
-          val state1 = state0.discloseTo(witnesses, nodeId)
+          val (witnesses, state1) = state0.discloseNode(parentExerciseWitnesses, nodeId, ex)
           val state2 =
             state1.divulgeCoidTo(parentExerciseWitnesses -- ex.stakeholders, ex.targetCoid)
           ex.children.foldLeft(state2) { (s, childNodeId) =>
@@ -959,7 +963,8 @@ object Ledger {
           // ------------------------------------------------------------------
           state
             .authorizeLookupByKey(nodeId, nlbk, authorization)
-            .discloseTo(parentExerciseWitnesses, nodeId)
+            .discloseNode(parentExerciseWitnesses, nodeId, nlbk)
+            ._2
 
       }
     }
@@ -1099,16 +1104,20 @@ object Ledger {
     */
   final case class LedgerData(
       activeContracts: Set[AbsoluteContractId],
-      nodeInfos: NodeInfos,
+      nodeInfos: LedgerNodeInfos,
       activeKeys: Map[GlobalKey, AbsoluteContractId],
       coidToNodeId: Map[AbsoluteContractId, ScenarioNodeId],
   ) {
-    def nodeInfoByCoid(coid: AbsoluteContractId): NodeInfo = nodeInfos(coidToNodeId(coid))
+    def nodeInfoByCoid(coid: AbsoluteContractId): LedgerNodeInfo = nodeInfos(coidToNodeId(coid))
 
-    def updateNodeInfo(coid: AbsoluteContractId)(f: (NodeInfo) => NodeInfo): LedgerData =
-      coidToNodeId.get(coid).map(updateNodeInfo(_)(f)).getOrElse(this)
+    def updateLedgerNodeInfo(
+        coid: AbsoluteContractId,
+    )(f: (LedgerNodeInfo) => LedgerNodeInfo): LedgerData =
+      coidToNodeId.get(coid).map(updateLedgerNodeInfo(_)(f)).getOrElse(this)
 
-    def updateNodeInfo(nodeId: ScenarioNodeId)(f: (NodeInfo) => NodeInfo): LedgerData =
+    def updateLedgerNodeInfo(
+        nodeId: ScenarioNodeId,
+    )(f: (LedgerNodeInfo) => LedgerNodeInfo): LedgerData =
       copy(
         nodeInfos = nodeInfos
           .get(nodeId)
@@ -1158,7 +1167,7 @@ object Ledger {
                 case None =>
                   crash(s"processTransaction: non-existent node '$nodeId'.")
                 case Some(node) =>
-                  val newNodeInfo = NodeInfo(
+                  val newLedgerNodeInfo = LedgerNodeInfo(
                     node = node,
                     transaction = trId,
                     effectiveAt = richTr.effectiveAt,
@@ -1167,7 +1176,8 @@ object Ledger {
                     consumedBy = None,
                     parent = mbParentId,
                   )
-                  val newCache = cache0.copy(nodeInfos = cache0.nodeInfos + (nodeId -> newNodeInfo))
+                  val newCache =
+                    cache0.copy(nodeInfos = cache0.nodeInfos + (nodeId -> newLedgerNodeInfo))
                   val idsToProcess = (mbParentId -> restOfNodeIds) :: restENPs
 
                   node match {
@@ -1192,14 +1202,14 @@ object Ledger {
 
                     case NodeFetch(referencedCoid, templateId @ _, optLoc @ _, _, _, _) =>
                       val newCacheP =
-                        newCache.updateNodeInfo(referencedCoid)(info =>
+                        newCache.updateLedgerNodeInfo(referencedCoid)(info =>
                           info.copy(referencedBy = info.referencedBy + nodeId))
 
                       processNodes(Right(newCacheP), idsToProcess)
 
                     case ex: NodeExercises.WithTxValue[ScenarioNodeId, AbsoluteContractId] =>
                       val newCache0 =
-                        newCache.updateNodeInfo(ex.targetCoid)(
+                        newCache.updateLedgerNodeInfo(ex.targetCoid)(
                           info =>
                             info.copy(
                               referencedBy = info.referencedBy + nodeId,
@@ -1236,7 +1246,7 @@ object Ledger {
                           processNodes(Right(newCache), idsToProcess)
                         case Some(referencedCoid) =>
                           val newCacheP =
-                            newCache.updateNodeInfo(referencedCoid)(info =>
+                            newCache.updateLedgerNodeInfo(referencedCoid)(info =>
                               info.copy(referencedBy = info.referencedBy + nodeId))
 
                           processNodes(Right(newCacheP), idsToProcess)
@@ -1263,7 +1273,7 @@ object Ledger {
         )
         .foldLeft(cacheAfterProcess) {
           case (cacheP, (nodeId, witnesses)) =>
-            cacheP.updateNodeInfo(nodeId)(_.addObservers(witnesses.map(_ -> trId).toMap))
+            cacheP.updateLedgerNodeInfo(nodeId)(_.addObservers(witnesses.map(_ -> trId).toMap))
         }
     }
   }

--- a/daml-lf/tests/scenario/daml-1.dev/contract-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.dev/contract-keys/EXPECTED.ledger
@@ -16,22 +16,26 @@ mustFailAt 'Bob' [Test:90]
 
 TX #4 1970-01-01T00:00:00Z [Test:93]
 #4:0
+│   known to (since): Alice (#4)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" } value-version: 1
 found #0:0
 
 TX #5 1970-01-01T00:00:00Z [Test:97]
 #5:0
+│   known to (since): Alice (#5)
 └─> ensure active #0:0
 
 TX #6 1970-01-01T00:00:00Z [Test:101]
 #6:0
+│   known to (since): Alice (#6)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "blah" } value-version: 1
 not found
 
 TX #7 1970-01-01T00:00:00Z [Test:105]
 #7:0
+│   known to (since): Bob (#7)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Bob', _2 = "some-key" } value-version: 1
 not found
@@ -45,6 +49,7 @@ TX #8 1970-01-01T00:00:00Z [Test:109]
 
 TX #9 1970-01-01T00:00:00Z [Test:112]
 #9:0
+│   known to (since): Alice (#9)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" } value-version: 1
 not found
@@ -66,6 +71,7 @@ TX #11 1970-01-01T00:00:00Z [Test:123]
     
 
 #11:1
+│   known to (since): Alice (#11)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key-2" } value-version: 1
 not found
@@ -79,6 +85,7 @@ TX #12 1970-01-01T00:00:00Z [Test:129]
 key { _1 = 'Alice', _2 = "same-submit-key" } value-version: 1
 
 #12:1
+│   known to (since): Alice (#12)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "same-submit-key" } value-version: 1
 found #12:0
@@ -125,6 +132,7 @@ key { _1 = 'Alice', _2 = "non-consuming-choice" } value-version: 1
     
 
 #16:2
+│   known to (since): Alice (#16)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "non-consuming-choice" } value-version: 1
 found #16:0

--- a/daml-lf/tests/scenario/test.sh
+++ b/daml-lf/tests/scenario/test.sh
@@ -45,4 +45,4 @@ $DAMLC package --debug $TESTMAIN 'main' -o $TESTDAR
 
 $REPL test Test:run $TESTDAR | sed '1d' | sed -E "$REGEX_HIDE_HASHES" > ${TESTDIR}/ACTUAL.ledger
 
-$DIFF --strip-trailing-cr ${TESTDIR}/ACTUAL.ledger ${TESTDIR}/EXPECTED.ledger
+$DIFF -u --strip-trailing-cr ${TESTDIR}/ACTUAL.ledger ${TESTDIR}/EXPECTED.ledger

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/NodeInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/NodeInfo.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.transaction
+
+import com.digitalasset.daml.lf.data.Ref.Party
+
+/** Trait for extracting information from an abstract node.
+  * Used for sharing the implementation of common computations
+  * over nodes and transactions.
+  *
+  * External codebases use these utilities on transaction and
+  * node implementations that are not the one defined by [[Node]]
+  * and hence the need for the indirection.
+  */
+trait NodeInfo {
+
+  /** Compute the informees of a node based on the ledger model definition.
+    *
+    * Refer to https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#projections
+    */
+  def informeesOfNode: Set[Party]
+
+  /** Required authorizers (see ledger model); UNSAFE TO USE on fetch nodes of transaction with versions < 5
+    *
+    * The ledger model defines the fetch node actingParties as the nodes' required authorizers.
+    * However, the our transaction data structure did not include the actingParties in versions < 5.
+    * The usage of this method must thus be restricted to:
+    * 1. settings where no fetch nodes appear (for example, the `validate` method of DAMLe, which uses it on root
+    *    nodes, which are guaranteed never to contain a fetch node)
+    * 2. DAML ledger implementations that do not store or process any transactions with version < 5
+    *
+    */
+  def requiredAuthorizers: Set[Party]
+}
+
+object NodeInfo {
+
+  trait Create extends NodeInfo {
+    def signatories: Set[Party]
+    def stakeholders: Set[Party]
+
+    final def requiredAuthorizers: Set[Party] = signatories
+    final def informeesOfNode: Set[Party] = stakeholders
+  }
+
+  trait Fetch extends NodeInfo {
+    def signatories: Set[Party]
+    def stakeholders: Set[Party]
+    def actingParties: Option[Set[Party]]
+
+    final def requiredAuthorizers: Set[Party] = actingParties.get
+    final def informeesOfNode: Set[Party] = signatories | actingParties.get
+  }
+
+  trait Exercise extends NodeInfo {
+
+    def consuming: Boolean
+    def signatories: Set[Party]
+    def stakeholders: Set[Party]
+    def actingParties: Set[Party]
+
+    final def requiredAuthorizers(): Set[Party] = actingParties
+
+    final def informeesOfNode: Set[Party] =
+      if (consuming)
+        stakeholders | actingParties
+      else
+        signatories | actingParties
+  }
+
+  trait LookupByKey extends NodeInfo {
+    def keyMaintainers: Set[Party]
+    def hasResult: Boolean
+
+    final def requiredAuthorizers(): Set[Party] = keyMaintainers
+    final def informeesOfNode: Set[Party] =
+      // TODO(JM): In the successful case the informees should be the
+      // signatories of the fetch contract. The signatories should be
+      // added to the LookupByKey node, or a successful lookup should
+      // become a Fetch.
+      keyMaintainers
+  }
+
+}

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -570,7 +570,7 @@ object TransactionCoder {
     } yield GenTransaction(ns, rs, None)
   }
 
-  private def toPartySet(strList: ProtocolStringList): Either[DecodeError, Set[Party]] = {
+  def toPartySet(strList: ProtocolStringList): Either[DecodeError, Set[Party]] = {
     val parties = strList
       .asByteStringList()
       .asScala
@@ -584,5 +584,76 @@ object TransactionCoder {
 
   private def toIdentifier(s: String): Either[DecodeError, Name] =
     Name.fromString(s).left.map(DecodeError)
+
+  /** Node information for a serialized transaction node. Used to compute
+    * informees when deserialization is too costly.
+    * This method is not supported for transaction version <5 (as NodeInfo does not support it).
+    * We're not using e.g. "implicit class" in order to keep the decoding errors explicit.
+    * NOTE(JM): Currently used only externally, but kept here to keep in sync
+    * with the implementation.
+    */
+  def protoNodeInfo(
+      txVersion: TransactionVersion,
+      protoNode: TransactionOuterClass.Node): Either[DecodeError, NodeInfo] =
+    if (txVersion precedes TransactionVersions.minFetchActors) {
+      Left(DecodeError(s"NodeInfo not supported for transaction version $txVersion"))
+    } else {
+      protoNode.getNodeTypeCase match {
+        case NodeTypeCase.CREATE =>
+          val protoCreate = protoNode.getCreate
+          for {
+            signatories_ <- toPartySet(protoCreate.getSignatoriesList)
+            stakeholders_ <- toPartySet(protoCreate.getStakeholdersList)
+          } yield {
+            new NodeInfo.Create {
+              def signatories = signatories_
+              def stakeholders = stakeholders_
+            }
+          }
+        case NodeTypeCase.FETCH =>
+          val protoFetch = protoNode.getFetch
+          for {
+            actingParties_ <- toPartySet(protoFetch.getActorsList)
+            stakeholders_ <- toPartySet(protoFetch.getStakeholdersList)
+            signatories_ <- toPartySet(protoFetch.getSignatoriesList)
+          } yield {
+            new NodeInfo.Fetch {
+              def signatories = signatories_
+              def stakeholders = stakeholders_
+              def actingParties = Some(actingParties_)
+            }
+          }
+
+        case NodeTypeCase.EXERCISE =>
+          val protoExe = protoNode.getExercise
+          for {
+            actingParties_ <- toPartySet(protoExe.getActorsList)
+            signatories_ <- toPartySet(protoExe.getSignatoriesList)
+            stakeholders_ <- toPartySet(protoExe.getStakeholdersList)
+          } yield {
+            new NodeInfo.Exercise {
+              def signatories = signatories_
+              def stakeholders = stakeholders_
+              def actingParties = actingParties_
+              def consuming = protoExe.getConsuming
+            }
+          }
+
+        case NodeTypeCase.LOOKUP_BY_KEY =>
+          val protoLookupByKey = protoNode.getLookupByKey
+          for {
+            maintainers <- toPartySet(protoLookupByKey.getKeyWithMaintainers.getMaintainersList)
+          } yield {
+            new NodeInfo.LookupByKey {
+              def hasResult =
+                protoLookupByKey.getContractId.nonEmpty ||
+                  protoLookupByKey.hasContractIdStruct
+              def keyMaintainers = maintainers
+            }
+          }
+
+        case NodeTypeCase.NODETYPE_NOT_SET => Left(DecodeError("Unset Node type"))
+      }
+    }
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -49,34 +49,35 @@ class TransactionCoderSpec
     "do NodeCreate" in {
       forAll(malformedCreateNodeGen, valueVersionGen()) {
         (node: NodeCreate[Tx.TContractId, Tx.Value[Tx.TContractId]], valVer: ValueVersion) =>
+          val encodedNode = TransactionCoder
+            .encodeNode(
+              defaultNidEncode,
+              defaultCidEncode,
+              defaultValEncode,
+              defaultTransactionVersion,
+              Tx.NodeId(0),
+              node,
+            )
+            .toOption
+            .get
           Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             defaultNidDecode,
             defaultCidDecode,
             defaultValDecode,
             defaultTransactionVersion,
+            encodedNode)
+
+          Right(node.informeesOfNode) shouldEqual
             TransactionCoder
-              .encodeNode(
-                defaultNidEncode,
-                defaultCidEncode,
-                defaultValEncode,
-                defaultTransactionVersion,
-                Tx.NodeId(0),
-                node,
-              )
-              .toOption
-              .get,
-          )
+              .protoNodeInfo(defaultTransactionVersion, encodedNode)
+              .map(_.informeesOfNode)
       }
     }
 
     "do NodeFetch" in {
       forAll(fetchNodeGen, valueVersionGen()) {
         (node: NodeFetch[ContractId], valVer: ValueVersion) =>
-          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
-            defaultNidDecode,
-            defaultCidDecode,
-            defaultValDecode,
-            defaultTransactionVersion,
+          val encodedNode =
             TransactionCoder
               .encodeNode(
                 defaultNidEncode,
@@ -87,19 +88,24 @@ class TransactionCoderSpec
                 node,
               )
               .toOption
-              .get,
-          )
+              .get
+          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
+            defaultNidDecode,
+            defaultCidDecode,
+            defaultValDecode,
+            defaultTransactionVersion,
+            encodedNode)
+          Right(node.informeesOfNode) shouldEqual
+            TransactionCoder
+              .protoNodeInfo(defaultTransactionVersion, encodedNode)
+              .map(_.informeesOfNode)
       }
     }
 
     "do NodeExercises" in {
       forAll(danglingRefExerciseNodeGen) {
         node: NodeExercises[Tx.NodeId, Tx.TContractId, Tx.Value[Tx.TContractId]] =>
-          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
-            defaultNidDecode,
-            defaultCidDecode,
-            defaultValDecode,
-            defaultTransactionVersion,
+          val encodedNode =
             TransactionCoder
               .encodeNode(
                 defaultNidEncode,
@@ -110,8 +116,18 @@ class TransactionCoderSpec
                 node,
               )
               .toOption
-              .get,
-          )
+              .get
+          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
+            defaultNidDecode,
+            defaultCidDecode,
+            defaultValDecode,
+            defaultTransactionVersion,
+            encodedNode)
+
+          Right(node.informeesOfNode) shouldEqual
+            TransactionCoder
+              .protoNodeInfo(defaultTransactionVersion, encodedNode)
+              .map(_.informeesOfNode)
       }
     }
 


### PR DESCRIPTION
Currently the code to compute the informees of a transaction node is
duplicated to several places. This adds a generic function to compute
this that works for different representations of transaction nodes
and allows reusing one common function for computing the informees
and from it, the transaction witnesses.

While writing this I noticed that the scenario ledger did not consider
the submitter an initial witness and hence we had e.g. fetch nodes
without any witnesses. This code fixes this and includes the fixes
to the tests. The main impact of this bug was missing "known to" line
in scenario results for top-level fetch nodes, which are only creatable
with scenarios.

The informees of a LookupByKey are still subtly wrong: the signatories
of the fetched contract should be informed, but we only inform the key
maintainers. Fix to that will be in another PR as it requires bigger changes
to transaction.

CHANGELOG_BEGIN
- [DAML SDK] Fix computation of witnesses of top-level fetch nodes in scenario results ("known to").
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
