### PR TITLE
Avoid including daml-stdlib and daml-prim twice

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -828,10 +828,8 @@ execGenerateSrc opts dalfOrDar mbOutDir = Command GenerateSrc Nothing effect
                 [ (LF.dalfPackageId dalfPkg, unitId)
                 | (unitId, dalfPkg) <- allDalfPkgs ]
 
-            stablePkgIds :: MS.Map LF.PackageId (UnitId, LF.ModuleName)
-            stablePkgIds = MS.fromList
-                [ (LF.dalfPackageId dalfPkg, k)
-                | (k, dalfPkg) <- MS.toList stableDalfPkgMap ]
+            stablePkgIds :: Set.Set LF.PackageId
+            stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stableDalfPkgMap
 
             genSrcs = generateSrcPkgFromLf pkgMap (getUnitId unitId unitIdMap) stablePkgIds (Just "CurrentSdk") pkg
 
@@ -870,7 +868,7 @@ execGenerateGenSrc darFp mbQual outDir = Command GenerateGenerics Nothing effect
             decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
         let getUid = getUnitId unitId pkgMap
         -- TODO Passing MS.empty is not right but this command is only used for debugging so for now this is fine.
-        let genSrcs = generateGenInstancesPkgFromLf getUid MS.empty Nothing mainPkgId mainLfPkg (fromMaybe "" mbQual)
+        let genSrcs = generateGenInstancesPkgFromLf getUid Set.empty Nothing mainPkgId mainLfPkg (fromMaybe "" mbQual)
         forM_ genSrcs $ \(path, src) -> do
             let fp = fromMaybe "" outDir </> fromNormalizedFilePath path
             createDirectoryIfMissing True $ takeDirectory fp

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -25,6 +25,8 @@ import Data.Graph
 import Data.List.Extra
 import qualified Data.Map.Strict as MS
 import Data.Maybe
+import Data.Set (Set)
+import qualified Data.Set as Set
 import qualified Data.Text.Extended as T
 import Development.IDE.Core.Service (runAction)
 import Development.IDE.Core.Shake
@@ -79,6 +81,7 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
 
     deps <- expandSdkPackages (filter (`notElem` basePackages) deps)
     depsExtracted <- mapM extractDar deps
+
     let uniqSdkVersions = nubSort $ unPackageSdkVersion thisSdkVer : map edSdkVersions depsExtracted
     let depsSdkVersions = map edSdkVersions depsExtracted
     unless (all (== unPackageSdkVersion thisSdkVer) depsSdkVersions) $
@@ -86,7 +89,28 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
            "Package dependencies from different SDK versions: " ++
            intercalate ", " uniqSdkVersions
 
-    -- deal with data imports first
+    -- Register deps at the very beginning. This allows data-dependencies to
+    -- depend on dependencies which is necessary so that we can reconstruct typeclass
+    -- instances for a typeclass defined in a library.
+    -- It does mean that we can’t have a dependency from a dependency on a
+    -- data-dependency but that seems acceptable.
+    -- See https://github.com/digital-asset/daml/issues/4218 for more details.
+    -- TODO Enforce this with useful error messages
+    forM_ depsExtracted $
+        \ExtractedDar{..} -> installDar dbPath edConfFiles edDalfs edSrcs
+
+    loggerH <- getLogger opts "generate package maps"
+    -- mkOptions is necessary to pick up the proper packagedb paths.
+    stablePkgsOpts <- mkOptions opts
+    (stablePkgs, dependencies) <- withDamlIdeState stablePkgsOpts loggerH diagnosticsLogger $ \ide -> runAction ide $
+        (,) <$> useNoFile_ GenerateStablePackages <*> useNoFile_ GeneratePackageMap
+    let stablePkgIds :: Set LF.PackageId
+        stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stablePkgs
+    -- This includes both SDK dependencies like daml-prim and daml-stdlib but also DARs specified
+    -- in the dependencies field.
+    let dependencyPkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems dependencies
+
+    -- Now handle data imports.
     let (fpDars, fpDalfs) = partition ((== ".dar") . takeExtension) dataDeps
     dars <- mapM extractDar fpDars
     -- These are the dalfs that are in a DAR that has been passed in via data-dependencies.
@@ -117,21 +141,20 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
         -- one of them), we instead include the package hash in the unit id.
         --
         -- In principle, we can run into the same issue if you combine "dependencies"
-        -- (which have precompiled interface files with uncontrollable unit ids) and
-        -- "data-dependencies" but given that our long-term goal is to kill "dependencies"
-        -- completely, we ignore that for now.
+        -- (which have precompiled interface files) and
+        -- "data-dependencies". However, there you can get away with changing the
+        -- package name and version to change the unit id which is not possible for
+        -- daml-prim.
+        --
+        -- If the version of daml-prim/daml-stdlib in a data-dependency is the same
+        -- as the one we are currently compiling against, we don’t need to apply this
+        -- hack.
         let parsedUnitId = parseUnitId name pkgId
         let unitId = stringToUnitId $ case splitUnitId parsedUnitId of
-              ("daml-prim", Nothing) -> "daml-prim-" <> T.unpack (LF.unPackageId pkgId)
-              ("daml-stdlib", _) -> "daml-stdlib-" <> T.unpack (LF.unPackageId pkgId)
+              ("daml-prim", Nothing) | pkgId `Set.notMember` dependencyPkgIds -> "daml-prim-" <> T.unpack (LF.unPackageId pkgId)
+              ("daml-stdlib", _) | pkgId `Set.notMember` dependencyPkgIds -> "daml-stdlib-" <> T.unpack (LF.unPackageId pkgId)
               _ -> parsedUnitId
         pure (pkgId, package, dalf, unitId)
-
-    loggerH <- getLogger opts "generate stable packages"
-    stablePkgsOpts <- mkOptions opts
-    stablePkgs <- withDamlIdeState stablePkgsOpts loggerH diagnosticsLogger $ \ide -> do
-        runAction ide $ useNoFile_ GenerateStablePackages
-    let stablePkgIds = MS.fromList $ map (\(k, pkg) -> (LF.dalfPackageId pkg, k)) $ MS.toList stablePkgs
 
     let (depGraph, vertexToNode) = buildLfPackageGraph pkgs stablePkgIds
     -- Iterate over the dependency graph in topological order.
@@ -142,7 +165,7 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
       let (pkgNode, pkgId) = vertexToNode vertex in
       -- stable packages are mapped to the current version of daml-prim/daml-stdlib
       -- so we don’t need to generate interface files for them.
-      unless (pkgId `MS.member` stablePkgIds) $ do
+      unless (pkgId `Set.member` stablePkgIds || pkgId `Set.member` dependencyPkgIds) $ do
         let unitIdStr = unitIdString $ unitId pkgNode
         let _instancesUnitIdStr = "instances-" <> unitIdStr
         let pkgIdStr = T.unpack $ LF.unPackageId pkgId
@@ -151,7 +174,7 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
                 [ unitIdString (unitId depPkgNode) <.> "dalf"
                 | (depPkgNode, depPkgId) <- map vertexToNode $ reachable depGraph vertex
                 , pkgId /= depPkgId
-                , not (depPkgId `MS.member` stablePkgIds)
+                , not (depPkgId `Set.member` stablePkgIds)
                 ]
         let workDir = dbPath </> unitIdStr <> "-" <> pkgIdStr
         createDirectoryIfMissing True workDir
@@ -170,10 +193,6 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
             pkgName
             mbPkgVersion
             deps
-
-    -- finally install the dependecies
-    forM_ depsExtracted $
-        \ExtractedDar{..} -> installDar dbPath edConfFiles edDalfs edSrcs
 
 -- generate interface files and install them in the package database
 generateAndInstallIfaceFiles ::
@@ -476,7 +495,7 @@ lfVersionString = DA.Pretty.renderPretty
 -- | The graph will have an edge from package A to package B if A depends on B.
 buildLfPackageGraph
     :: [(LF.PackageId, LF.Package, BS.ByteString, UnitId)]
-    -> MS.Map LF.PackageId (UnitId, LF.ModuleName)
+    -> Set LF.PackageId
     -> ( Graph
        , Vertex -> (PackageNode, LF.PackageId)
        )


### PR DESCRIPTION
This fixes #4114 and cleans up the situation around
`data-dependencies` and `dependencies` as described in #4218.

There is still more work to be done here mostly around ironing out all
the edge cases and producing useful error messages instead of
silentely doing the wrong thing but I’ll leave that to a separate PR.

To test this, I’ve fixed the packaging tests to no longer deduplicate
package ids (which means they would return the wrong number if
daml-prim ends up in there twice) and I addded a test where we have 3
projects:

- `lib`
- `a` which depends on `lib`
- `b` which depends on `lib` via `dependencies` and 'a' via
  `data-dependencies`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
