### PR TITLE
Preserve class method names during LF conversion.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -795,7 +795,7 @@ convertExpr env0 e = do
     go env (ConstraintTupleProjection index arity) args
         | (LExpr x : args') <- drop arity args -- drop the type arguments
         = fmap (, args') $ do
-            let fieldName = mkIndexedField index
+            let fieldName = mkSuperClassField index
             x' <- convertExpr env x
             pure $ EStructProj fieldName x'
 
@@ -1489,7 +1489,7 @@ convertType env = go env
             go env (expandTypeSynonyms o)
         | isConstraintTupleTyCon t = do
             fieldTys <- mapM (go env) ts
-            let fieldNames = map mkIndexedField [1..]
+            let fieldNames = map mkSuperClassField [1..]
             pure $ TStruct (zip fieldNames fieldTys)
          | tyConFlavour t == ClassFlavour && envLfVersion env `supports` featureTypeSynonyms = do
            tySyn <- convertQualifiedTySyn env t
@@ -1574,11 +1574,12 @@ defValue loc binder@(name, lftype) body =
 ---------------------------------------------------------------------
 -- UNPACK CONSTRUCTORS
 
--- NOTE(MH):
+-- NOTE:
 --
--- * Dictionary types contain multiple unnamed fields in general. Thus, it is
---   necessary to give them synthetic names. This is not a problem at all
---   since they don't show up in user interfaces.
+-- * Dictionary types are converted into LF structs with one field
+--   "s_1", "s_2", "s_3" ... per superclass, and one field
+--   "m_foo", "m_bar", .... per method. This also applies to
+--   constraint tuples, which only have superclasses.
 --
 -- * We treat all newtypes like records. First of all, not doing
 --   this would considerably complicate converting coercions. Second, it makes
@@ -1592,7 +1593,13 @@ ctorLabels con =
   where
   thetas = dataConTheta con
   conFields
-    | flv `elem` [ClassFlavour, TupleFlavour Boxed] || isTupleDataCon con
+    | flv == ClassFlavour
+    , tycon <- dataConTyCon con
+    , Just tycls <- tyConClass_maybe tycon
+    = map mkSuperClassField [1 .. length (classSCTheta tycls)]
+    ++ map (mkClassMethodField . getOccText) (classMethods tycls)
+
+    | flv `elem` [TupleFlavour Boxed] || isTupleDataCon con
       -- NOTE(MH): The line below is a workaround for ghc issue
       -- https://github.com/ghc/ghc/blob/ae4f1033cfe131fca9416e2993bda081e1f8c152/compiler/types/TyCon.hs#L2030
       -- If we omit this workaround, `GHC.Tuple.Unit` gets translated into a

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1599,7 +1599,7 @@ ctorLabels con =
     = map mkSuperClassField [1 .. length (classSCTheta tycls)]
     ++ map (mkClassMethodField . getOccText) (classMethods tycls)
 
-    | flv `elem` [TupleFlavour Boxed] || isTupleDataCon con
+    | flv == TupleFlavour Boxed || isTupleDataCon con
       -- NOTE(MH): The line below is a workaround for ghc issue
       -- https://github.com/ghc/ghc/blob/ae4f1033cfe131fca9416e2993bda081e1f8c152/compiler/types/TyCon.hs#L2030
       -- If we omit this workaround, `GHC.Tuple.Unit` gets translated into a

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
@@ -43,6 +43,12 @@ mkField = FieldName
 mkIndexedField :: Int -> FieldName
 mkIndexedField i = mkField ("_" <> T.pack (show i))
 
+mkSuperClassField :: Int -> FieldName
+mkSuperClassField i = mkField ("s_" <> T.pack (show i))
+
+mkClassMethodField :: T.Text -> FieldName
+mkClassMethodField t = mkField ("m_" <> t)
+
 mkVariantCon :: T.Text -> VariantConName
 mkVariantCon = VariantConName
 

--- a/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
+++ b/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
@@ -4,7 +4,7 @@
 -- Ensure that class method names are preserved during the translation
 -- to DAML-LF.
 --
--- @SINCE-LF 1.dev
+-- @SINCE-LF 1.7
 -- @QUERY-LF (.interned_strings | map(select(. == "m_baz")) == ["m_baz"])
 -- @QUERY-LF (.interned_strings | map(select(. == "m_bar")) == ["m_bar"])
 -- @QUERY-LF (.interned_strings | map(select(. == "m_foo1")) == ["m_foo1"])

--- a/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
+++ b/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
@@ -1,0 +1,26 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Ensure that class method names are preserved during the translation
+-- to DAML-LF.
+--
+-- @SINCE-LF 1.dev
+-- @QUERY-LF (.interned_strings | map(select(. == "m_baz")) == ["m_baz"])
+-- @QUERY-LF (.interned_strings | map(select(. == "m_bar")) == ["m_bar"])
+-- @QUERY-LF (.interned_strings | map(select(. == "m_foo1")) == ["m_foo1"])
+-- @QUERY-LF (.interned_strings | map(select(. == "m_foo2")) == ["m_foo2"])
+daml 1.2
+module ClassMethodNames where
+
+-- class with many methods
+class Foo t where
+    foo1 : t -> Int
+    foo2 : t -> Int
+
+-- class with super
+class Foo t => Bar t where
+    bar : t -> Int
+
+-- newtype-style class
+class Baz t where
+    baz : t -> Int

--- a/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
+++ b/compiler/damlc/tests/daml-test-files/ClassMethodNames.daml
@@ -9,6 +9,7 @@
 -- @QUERY-LF (.interned_strings | map(select(. == "m_bar")) == ["m_bar"])
 -- @QUERY-LF (.interned_strings | map(select(. == "m_foo1")) == ["m_foo1"])
 -- @QUERY-LF (.interned_strings | map(select(. == "m_foo2")) == ["m_foo2"])
+-- @QUERY-LF (.interned_strings | map(select(. == "s_1")) == ["s_1"])
 daml 1.2
 module ClassMethodNames where
 


### PR DESCRIPTION
This PR changes the LF conversion to pick names for dictionary
fields that will be easier to reconstruct as typeclasses
later.

For superclasses this uses "s_1", "s_2", "s_3" and so on,
and for methods this uses "m_foo", "m_bar", "m_baz" and
so on. (Is this enough C++?)

In the future we might want to distinguish between methods
that are mandatory and methods that are optional ... but
I think this should be good enough for now.

This change applies to constraint tuples as well, and I couldn't
think of a good reason to special case constraint tuples, but
we could revisit that later.

This PR also adds a test.

Fixes #4216

changelog_begin
changelog_end
