### PR TITLE
Test triggers in scenarios

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -179,6 +179,9 @@ instance CanAbort Update where
 instance CanAbort Scenario where
     abort = fail
 
+instance CanAbort (Either Text) where
+    abort = fail
+
 -- | The `Scenario` type is for simulating ledger interactions.
 -- The type `Scenario a` describes a set of actions taken by various parties during
 -- the simulated scenario, before returning a value of type `a`.

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -30,7 +30,7 @@ module Daml.Trigger
  , RelTime(..)
  , toACS
  , testRule
- , unpackCommands
+ , flattenCommands
  , assertCreateCmd
  , assertExerciseCmd
  , assertExerciseByKeyCmd
@@ -309,8 +309,8 @@ testRule trigger party acsBuilder commandsInFlight s = do
   let (_, commands) = runRule trigger.rule time state
   pure commands
 
-unpackCommands : [Commands] -> [Command]
-unpackCommands = concatMap commands
+flattenCommands : [Commands] -> [Command]
+flattenCommands = concatMap commands
 
 expectCommand
   : [Command]

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -298,7 +298,7 @@ testRule
   -> ACSBuilder  -- ^ List these contracts in the 'ACS'.
   -> Map CommandId [Command]  -- ^ The commands in flight.
   -> s  -- ^ The trigger state.
-  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule.
+  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule. The 'CommandId's will start from @"0"@.
 testRule trigger party acsBuilder commandsInFlight s = do
   time <- getTime
   acs <- buildACS party acsBuilder
@@ -307,7 +307,7 @@ testRule trigger party acsBuilder commandsInFlight s = do
         , party = party
         , userState = s
         , commandsInFlight = commandsInFlight
-        , nextCommandId = 0 -- XXX: succ (maxIdIn commandsInFlight)
+        , nextCommandId = 0
         }
   let (_, commands) = runRule trigger.rule time state
   pure commands

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -32,6 +32,8 @@ module Daml.Trigger
  , testRule
  , unpackCommands
  , assertCreateCmd
+ , assertExerciseCmd
+ , assertExerciseByKeyCmd
  ) where
 
 import DA.Action
@@ -326,7 +328,7 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
         Some (Right ()) -> Right ()
 
 assertCreateCmd
-  : (Eq t, Show t, Template t)
+  : Template t
   => [Command]
   -> (t -> Either Text ())
   -> Scenario ()
@@ -335,6 +337,29 @@ assertCreateCmd commands assertion =
     Right () -> pure ()
     Left msgs ->
       abort $ "Failure, found no matching create command." <> collectMessages msgs
+
+assertExerciseCmd
+  : (Template t, Choice t c r)
+  => [Command]
+  -> ((ContractId t, c) -> Either Text ())
+  -> Scenario ()
+assertExerciseCmd commands assertion =
+  case expectCommand commands fromExercise assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching exercise command." <> collectMessages msgs
+
+assertExerciseByKeyCmd
+  : forall t c r k
+  . (TemplateKey t k, Choice t c r)
+  => [Command]
+  -> ((k, c) -> Either Text ())
+  -> Scenario ()
+assertExerciseByKeyCmd commands assertion =
+  case expectCommand commands (fromExerciseByKey @t) assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching exercise command." <> collectMessages msgs
 
 collectMessages : [Text] -> Text
 collectMessages [] = ""

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -332,7 +332,7 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
         Some (Left msg) -> Left (msg :: msgs)
         Some (Right ()) -> Right ()
 
--- | Check that at least one command fulfills the given assertions.
+-- | Check that at least one command is a create command whose payload fulfills the given assertions.
 assertCreateCmd
   : (Template t, CanAbort m)
   => [Command]  -- ^ Check these commands.
@@ -344,7 +344,7 @@ assertCreateCmd commands assertion =
     Left msgs ->
       abort $ "Failure, found no matching create command." <> collectMessages msgs
 
--- | Check that at least one command fulfills the given assertions.
+-- | Check that at least one command is an exercise command whose contract id and choice argument fulfill the given assertions.
 assertExerciseCmd
   : (Template t, Choice t c r, CanAbort m)
   => [Command]  -- ^ Check these commands.
@@ -356,7 +356,7 @@ assertExerciseCmd commands assertion =
     Left msgs ->
       abort $ "Failure, found no matching exercise command." <> collectMessages msgs
 
--- | Check that at least one command fulfills the given assertions.
+-- | Check that at least one command is an exercise by key command whose key and choice argument fulfill the given assertions.
 assertExerciseByKeyCmd
   : forall t c r k m
   . (TemplateKey t k, Choice t c r, CanAbort m)

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -28,6 +28,7 @@ module Daml.Trigger
  , RegisteredTemplates(..)
  , registeredTemplate
  , RelTime(..)
+ , ACSBuilder
  , toACS
  , testRule
  , flattenCommands

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -359,7 +359,7 @@ assertExerciseByKeyCmd commands assertion =
   case expectCommand commands (fromExerciseByKey @t) assertion of
     Right () -> pure ()
     Left msgs ->
-      abort $ "Failure, found no matching exercise command." <> collectMessages msgs
+      abort $ "Failure, found no matching exerciseByKey command." <> collectMessages msgs
 
 collectMessages : [Text] -> Text
 collectMessages [] = ""

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -29,13 +29,17 @@ module Daml.Trigger
  , registeredTemplate
  , RelTime(..)
  , testRule
+ , unpackCommands
+ , assertCreateCmd
  ) where
 
 import DA.Action
 import DA.Action.State
+import qualified DA.List as List
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
 import DA.Optional
+import qualified DA.Text as Text
 
 import Daml.Trigger.LowLevel hiding (Trigger)
 import qualified Daml.Trigger.LowLevel as LowLevel
@@ -284,3 +288,56 @@ testRule trigger party activeContracts commandsInFlight s = do
         }
   let (_, commands) = runRule trigger.rule time state
   pure commands
+
+unpackCommands : [Commands] -> [Command]
+unpackCommands = concatMap commands
+
+expectCommand
+  : [Command]
+  -> (Command -> Optional a)
+  -> (a -> Either Text ())
+  -> Either [Text] ()
+expectCommand commands fromCommand assertion = foldl step (Left []) commands
+  where
+    step : Either [Text] () -> Command -> Either [Text] ()
+    step (Right ()) _ = Right ()
+    step (Left msgs) command =
+      case assertion <$> fromCommand command of
+        None -> Left msgs
+        Some (Left msg) -> Left (msg :: msgs)
+        Some (Right ()) -> Right ()
+
+assertCreateCmd
+  : (Eq t, Show t, Template t)
+  => [Command]
+  -> (t -> Either Text ())
+  -> Scenario ()
+assertCreateCmd commands assertion =
+  case expectCommand commands fromCreate assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching create command." <> collectMessages msgs
+
+collectMessages : [Text] -> Text
+collectMessages [] = ""
+collectMessages msgs = "\n" <> Text.unlines (map (bullet . nest) msgs)
+  where
+    bullet txt = "  * " <> txt
+    nest = Text.intercalate "\n" . List.intersperse "    " . Text.lines
+--assertCreateCmd commands tpl = go commands []
+--  where
+--    go : [Command] -> [Text] -> Scenario ()
+--    go [] insteads = abort $
+--      "Failure, expected create of "
+--        <> show tpl
+--        <> " but found "
+--        <> insteadMsg insteads
+--    go (command :: commands) insteads
+--      | Some createTpl <- fromCreate command
+--      = unless (createTpl == tpl) $
+--          go commands (show createTpl :: insteads)
+--      | otherwise
+--      = go commands insteads
+--    insteadMsg : [Text] -> Text
+--    insteadMsg [] = "none"
+--    insteadMsg insteads = Text.intercalate ", " insteads

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -28,6 +28,7 @@ module Daml.Trigger
  , RegisteredTemplates(..)
  , registeredTemplate
  , RelTime(..)
+ , testRule
  ) where
 
 import DA.Action
@@ -260,3 +261,26 @@ data TriggerState s = TriggerState
   , commandsInFlight : Map CommandId [Command]
   , nextCommandId : Int
   }
+
+testRule
+  : Trigger s
+  -> Party
+  -> [(AnyContractId, AnyTemplate)]
+  -> Map CommandId [Command]
+  -> s
+  -> Scenario [Commands]
+testRule trigger party activeContracts commandsInFlight s = do
+  time <- getTime
+  let acs = ACS
+        { activeContracts = activeContracts
+        , pendingContracts = Map.empty
+        }
+  let state = TriggerState
+        { acs = acs
+        , party = party
+        , userState = s
+        , commandsInFlight = commandsInFlight
+        , nextCommandId = 0 -- XXX: succ (maxIdIn commandsInFlight)
+        }
+  let (_, commands) = runRule trigger.rule time state
+  pure commands

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -333,10 +333,10 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
 
 -- | Check that at least one command fulfills the given assertions.
 assertCreateCmd
-  : Template t
+  : (Template t, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> (t -> Either Text ())  -- ^ Perform these assertions.
-  -> Scenario ()
+  -> m ()
 assertCreateCmd commands assertion =
   case expectCommand commands fromCreate assertion of
     Right () -> pure ()
@@ -345,10 +345,10 @@ assertCreateCmd commands assertion =
 
 -- | Check that at least one command fulfills the given assertions.
 assertExerciseCmd
-  : (Template t, Choice t c r)
+  : (Template t, Choice t c r, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
-  -> Scenario ()
+  -> m ()
 assertExerciseCmd commands assertion =
   case expectCommand commands fromExercise assertion of
     Right () -> pure ()
@@ -357,11 +357,11 @@ assertExerciseCmd commands assertion =
 
 -- | Check that at least one command fulfills the given assertions.
 assertExerciseByKeyCmd
-  : forall t c r k
-  . (TemplateKey t k, Choice t c r)
+  : forall t c r k m
+  . (TemplateKey t k, Choice t c r, CanAbort m)
   => [Command]  -- ^ Check these commands.
   -> ((k, c) -> Either Text ())  -- ^ Perform these assertions.
-  -> Scenario ()
+  -> m ()
 assertExerciseByKeyCmd commands assertion =
   case expectCommand commands (fromExerciseByKey @t) assertion of
     Right () -> pure ()

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -28,6 +28,7 @@ module Daml.Trigger
  , RegisteredTemplates(..)
  , registeredTemplate
  , RelTime(..)
+ , toACS
  , testRule
  , unpackCommands
  , assertCreateCmd
@@ -266,19 +267,36 @@ data TriggerState s = TriggerState
   , nextCommandId : Int
   }
 
+newtype ACSBuilder = ACSBuilder [Update (AnyContractId, AnyTemplate)]
+
+instance Semigroup ACSBuilder where
+  ACSBuilder l <> ACSBuilder r = ACSBuilder (l <> r)
+
+instance Monoid ACSBuilder where
+  mempty = ACSBuilder mempty
+
+buildACS : Party -> ACSBuilder -> Scenario ACS
+buildACS party (ACSBuilder fetches) = do
+  activeContracts <- submit party $ sequence fetches
+  pure ACS
+    { activeContracts = activeContracts
+    , pendingContracts = Map.empty
+    }
+
+toACS : Template t => ContractId t -> ACSBuilder
+toACS cid = ACSBuilder
+  [fetch cid >>= \tpl -> pure (toAnyContractId cid, toAnyTemplate tpl)]
+
 testRule
   : Trigger s
   -> Party
-  -> [(AnyContractId, AnyTemplate)]
+  -> ACSBuilder
   -> Map CommandId [Command]
   -> s
   -> Scenario [Commands]
-testRule trigger party activeContracts commandsInFlight s = do
+testRule trigger party acsBuilder commandsInFlight s = do
   time <- getTime
-  let acs = ACS
-        { activeContracts = activeContracts
-        , pendingContracts = Map.empty
-        }
+  acs <- buildACS party acsBuilder
   let state = TriggerState
         { acs = acs
         , party = party
@@ -324,20 +342,3 @@ collectMessages msgs = "\n" <> Text.unlines (map (bullet . nest) msgs)
   where
     bullet txt = "  * " <> txt
     nest = Text.intercalate "\n" . List.intersperse "    " . Text.lines
---assertCreateCmd commands tpl = go commands []
---  where
---    go : [Command] -> [Text] -> Scenario ()
---    go [] insteads = abort $
---      "Failure, expected create of "
---        <> show tpl
---        <> " but found "
---        <> insteadMsg insteads
---    go (command :: commands) insteads
---      | Some createTpl <- fromCreate command
---      = unless (createTpl == tpl) $
---          go commands (show createTpl :: insteads)
---      | otherwise
---      = go commands insteads
---    insteadMsg : [Text] -> Text
---    insteadMsg [] = "none"
---    insteadMsg insteads = Text.intercalate ", " insteads

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -269,6 +269,7 @@ data TriggerState s = TriggerState
   , nextCommandId : Int
   }
 
+-- | Used to construct an 'ACS' for 'testRule'.
 newtype ACSBuilder = ACSBuilder [Update (AnyContractId, AnyTemplate)]
 
 instance Semigroup ACSBuilder where
@@ -285,17 +286,19 @@ buildACS party (ACSBuilder fetches) = do
     , pendingContracts = Map.empty
     }
 
+-- | Include the given contract in the 'ACS'.
 toACS : Template t => ContractId t -> ACSBuilder
 toACS cid = ACSBuilder
   [fetch cid >>= \tpl -> pure (toAnyContractId cid, toAnyTemplate tpl)]
 
+-- | Execute a trigger's rule once in a scenario.
 testRule
-  : Trigger s
-  -> Party
-  -> ACSBuilder
-  -> Map CommandId [Command]
-  -> s
-  -> Scenario [Commands]
+  : Trigger s  -- ^ Test this trigger's 'Trigger.rule'.
+  -> Party  -- ^ Execute the rule as this 'Party'.
+  -> ACSBuilder  -- ^ List these contracts in the 'ACS'.
+  -> Map CommandId [Command]  -- ^ The commands in flight.
+  -> s  -- ^ The trigger state.
+  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule.
 testRule trigger party acsBuilder commandsInFlight s = do
   time <- getTime
   acs <- buildACS party acsBuilder
@@ -309,6 +312,7 @@ testRule trigger party acsBuilder commandsInFlight s = do
   let (_, commands) = runRule trigger.rule time state
   pure commands
 
+-- | Drop 'CommandId's and extract all 'Command's.
 flattenCommands : [Commands] -> [Command]
 flattenCommands = concatMap commands
 
@@ -327,10 +331,11 @@ expectCommand commands fromCommand assertion = foldl step (Left []) commands
         Some (Left msg) -> Left (msg :: msgs)
         Some (Right ()) -> Right ()
 
+-- | Check that at least one command fulfills the given assertions.
 assertCreateCmd
   : Template t
-  => [Command]
-  -> (t -> Either Text ())
+  => [Command]  -- ^ Check these commands.
+  -> (t -> Either Text ())  -- ^ Perform these assertions.
   -> Scenario ()
 assertCreateCmd commands assertion =
   case expectCommand commands fromCreate assertion of
@@ -338,10 +343,11 @@ assertCreateCmd commands assertion =
     Left msgs ->
       abort $ "Failure, found no matching create command." <> collectMessages msgs
 
+-- | Check that at least one command fulfills the given assertions.
 assertExerciseCmd
   : (Template t, Choice t c r)
-  => [Command]
-  -> ((ContractId t, c) -> Either Text ())
+  => [Command]  -- ^ Check these commands.
+  -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
   -> Scenario ()
 assertExerciseCmd commands assertion =
   case expectCommand commands fromExercise assertion of
@@ -349,11 +355,12 @@ assertExerciseCmd commands assertion =
     Left msgs ->
       abort $ "Failure, found no matching exercise command." <> collectMessages msgs
 
+-- | Check that at least one command fulfills the given assertions.
 assertExerciseByKeyCmd
   : forall t c r k
   . (TemplateKey t k, Choice t c r)
-  => [Command]
-  -> ((k, c) -> Either Text ())
+  => [Command]  -- ^ Check these commands.
+  -> ((k, c) -> Either Text ())  -- ^ Perform these assertions.
   -> Scenario ()
 assertExerciseByKeyCmd commands assertion =
   case expectCommand commands (fromExerciseByKey @t) assertion of

--- a/triggers/tests/scenarios/BUILD.bazel
+++ b/triggers/tests/scenarios/BUILD.bazel
@@ -16,4 +16,5 @@ sh_test(
         "//compiler/damlc",
         "//triggers/daml:daml-trigger.dar",
     ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/triggers/tests/scenarios/BUILD.bazel
+++ b/triggers/tests/scenarios/BUILD.bazel
@@ -4,16 +4,16 @@
 sh_test(
     name = "test-rule",
     srcs = ["test-scenarios.sh"],
-    data = [
-        "//:VERSION",
-        "//compiler/damlc",
-        "//triggers/daml:daml-trigger.dar",
-        "Rule.daml",
-    ],
     args = [
         "$(rootpath //:VERSION)",
         "$(rootpath //compiler/damlc)",
         "$(rootpath //triggers/daml:daml-trigger.dar)",
         "$(rootpath Rule.daml)",
+    ],
+    data = [
+        "Rule.daml",
+        "//:VERSION",
+        "//compiler/damlc",
+        "//triggers/daml:daml-trigger.dar",
     ],
 )

--- a/triggers/tests/scenarios/BUILD.bazel
+++ b/triggers/tests/scenarios/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sh_test(
+    name = "test-rule",
+    srcs = ["test-scenarios.sh"],
+    data = [
+        "//:VERSION",
+        "//compiler/damlc",
+        "//triggers/daml:daml-trigger.dar",
+        "Rule.daml",
+    ],
+    args = [
+        "$(rootpath //:VERSION)",
+        "$(rootpath //compiler/damlc)",
+        "$(rootpath //triggers/daml:daml-trigger.dar)",
+        "$(rootpath Rule.daml)",
+    ],
+)

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+daml 1.2
+module Rule where
+
+--import Daml.Trigger
+import DA.Assert
+
+test = scenario do
+  assertEq 0 0

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -48,7 +48,7 @@ test = scenario do
   let activeContracts = toACS tId
       commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1
-  let flatCommands = unpackCommands commands
+  let flatCommands = flattenCommands commands
   assertCreateCmd flatCommands $ \T { party, count } -> do
     assertEq party alice
     assertEq count 1

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -46,7 +46,7 @@ test = scenario do
   alice <- getParty "Alice"
   tId <- submit alice do create T with party = alice, count = 1
   let activeContracts = toACS tId
-      commandsInFlight = Map.empty
+  let commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1
   let flatCommands = flattenCommands commands
   assertCreateCmd flatCommands $ \T { party, count } -> do

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -4,8 +4,33 @@
 daml 1.2
 module Rule where
 
---import Daml.Trigger
+import DA.Action
 import DA.Assert
+import qualified DA.Next.Map as Map
+import Daml.Trigger
+
+template T
+  with
+    party : Party
+  where
+    signatory party
+
+trigger : Trigger Int
+trigger = Trigger with
+  initialize = const 0
+  updateState = \acs _msg count -> length (getContracts @T acs)
+  rule = \party _acs _time _commandsInFlight count -> do
+    when (count == 1) do
+      dedupCreate T with party
+  registeredTemplates = RegisteredTemplates [registeredTemplate @T]
+  heartbeat = None
 
 test = scenario do
-  assertEq 0 0
+  alice <- getParty "Alice"
+  tId <- submit alice do create T with party = alice
+  tVal <- submit alice do fetch tId
+  let activeContracts = [(toAnyContractId tId, toAnyTemplate tVal)]
+      commandsInFlight = Map.empty
+  commands <- testRule trigger alice activeContracts commandsInFlight 1
+  assertEq 1 (length commands)
+  pure ()

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -15,15 +15,30 @@ template T
     count : Int
   where
     signatory party
+    key (party, count) : (Party, Int)
+    maintainer key._1
+
+    nonconsuming choice Poke : ()
+      with
+        n : Int
+      controller party
+        do
+          pure ()
 
 trigger : Trigger Int
 trigger = Trigger with
   initialize = const 0
   updateState = \acs _msg count -> length (getContracts @T acs)
-  rule = \party _acs _time _commandsInFlight count -> do
+  rule = \party acs _time _commandsInFlight count -> do
     when (count == 1) do
+      -- Create two additional T.
       dedupCreate T with party, count
       dedupCreate T with party, count = succ count
+      -- Exercise a choice
+      let [(tId, _)] = getContracts @T acs
+      dedupExercise tId Poke with n = 0
+      -- Exercise a choice by key
+      dedupExerciseByKey @T (party, 0) Poke with n = 1
   registeredTemplates = RegisteredTemplates [registeredTemplate @T]
   heartbeat = None
 
@@ -33,7 +48,14 @@ test = scenario do
   let activeContracts = toACS tId
       commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1
-  assertCreateCmd (unpackCommands commands) $ \T { party, count } -> do
+  let flatCommands = unpackCommands commands
+  assertCreateCmd flatCommands $ \T { party, count } -> do
     assertEq party alice
     assertEq count 1
+  assertExerciseCmd flatCommands $ \(cid, choiceArg) -> do
+    assertEq cid tId
+    assertEq choiceArg (Poke 0)
+  assertExerciseByKeyCmd @T flatCommands $ \(k, choiceArg) -> do
+    assertEq k (alice, 0)
+    assertEq choiceArg (Poke 1)
   pure ()

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -30,8 +30,7 @@ trigger = Trigger with
 test = scenario do
   alice <- getParty "Alice"
   tId <- submit alice do create T with party = alice, count = 1
-  tVal <- submit alice do fetch tId
-  let activeContracts = [(toAnyContractId tId, toAnyTemplate tVal)]
+  let activeContracts = toACS tId
       commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1
   assertCreateCmd (unpackCommands commands) $ \T { party, count } -> do

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -12,6 +12,7 @@ import Daml.Trigger
 template T
   with
     party : Party
+    count : Int
   where
     signatory party
 
@@ -21,16 +22,19 @@ trigger = Trigger with
   updateState = \acs _msg count -> length (getContracts @T acs)
   rule = \party _acs _time _commandsInFlight count -> do
     when (count == 1) do
-      dedupCreate T with party
+      dedupCreate T with party, count
+      dedupCreate T with party, count = succ count
   registeredTemplates = RegisteredTemplates [registeredTemplate @T]
   heartbeat = None
 
 test = scenario do
   alice <- getParty "Alice"
-  tId <- submit alice do create T with party = alice
+  tId <- submit alice do create T with party = alice, count = 1
   tVal <- submit alice do fetch tId
   let activeContracts = [(toAnyContractId tId, toAnyTemplate tVal)]
       commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1
-  assertEq 1 (length commands)
+  assertCreateCmd (unpackCommands commands) $ \T { party, count } -> do
+    assertEq party alice
+    assertEq count 1
   pure ()

--- a/triggers/tests/scenarios/daml.yaml
+++ b/triggers/tests/scenarios/daml.yaml
@@ -1,0 +1,8 @@
+sdk-version: 0.13.44
+name: trigger-scenarios
+source: .
+version: 0.0.1
+dependencies:
+  - daml-stdlib
+  - daml-prim
+  - daml-trigger.dar

--- a/triggers/tests/scenarios/test-scenarios.sh
+++ b/triggers/tests/scenarios/test-scenarios.sh
@@ -1,13 +1,23 @@
 # Copyright (c) 2020 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
 set -eou pipefail
 
-# Source files are not found by rlocation.
-SDK_VERSION=$1
-DAMLC=$2
-DAML_TRIGGERS_DAR=$3
-DAML_SOURCE=$4
+# Avoid leading `./` which confuses `rlocation`.
+SDK_VERSION=$(rlocation $TEST_WORKSPACE/${1#./})
+DAMLC=$(rlocation $TEST_WORKSPACE/$2)
+DAML_TRIGGERS_DAR=$(rlocation $TEST_WORKSPACE/$3)
+DAML_SOURCE=$(rlocation $TEST_WORKSPACE/$4)
 
 TMP_DIR=$(mktemp -d)
 mkdir -p $TMP_DIR/daml

--- a/triggers/tests/scenarios/test-scenarios.sh
+++ b/triggers/tests/scenarios/test-scenarios.sh
@@ -24,4 +24,7 @@ EOF
 cp -L $DAML_TRIGGERS_DAR $TMP_DIR/
 cp -L $DAML_SOURCE $TMP_DIR/daml/
 
+# We need to run build to create the package database.
+# See https://github.com/digital-asset/daml/issues/3436
+$DAMLC build --project-root=$TMP_DIR
 $DAMLC test --project-root=$TMP_DIR

--- a/triggers/tests/scenarios/test-scenarios.sh
+++ b/triggers/tests/scenarios/test-scenarios.sh
@@ -14,6 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 set -eou pipefail
 
 # Avoid leading `./` which confuses `rlocation`.
+# See https://github.com/bazelbuild/bazel/issues/10670
 SDK_VERSION=$(rlocation $TEST_WORKSPACE/${1#./})
 DAMLC=$(rlocation $TEST_WORKSPACE/$2)
 DAML_TRIGGERS_DAR=$(rlocation $TEST_WORKSPACE/$3)

--- a/triggers/tests/scenarios/test-scenarios.sh
+++ b/triggers/tests/scenarios/test-scenarios.sh
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+# Source files are not found by rlocation.
+SDK_VERSION=$1
+DAMLC=$2
+DAML_TRIGGERS_DAR=$3
+DAML_SOURCE=$4
+
+TMP_DIR=$(mktemp -d)
+mkdir -p $TMP_DIR/daml
+cat <<EOF > $TMP_DIR/daml.yaml
+sdk-version: $(cat $SDK_VERSION)
+name: trigger-scenarios
+source: daml
+version: 0.0.1
+dependencies:
+  - daml-stdlib
+  - daml-prim
+  - daml-trigger.dar
+EOF
+cp -L $DAML_TRIGGERS_DAR $TMP_DIR/
+cp -L $DAML_SOURCE $TMP_DIR/daml/
+
+$DAMLC test --project-root=$TMP_DIR


### PR DESCRIPTION
This allows testing a trigger's `rule` in a `scenario` by providing the `testRule` function. It takes the `Party`, the ACS, the commands in flight, and the trigger state as parameters and returns the `[Commands]` issued by the trigger.

The user provides the ACS using the `ACSBuilder` type. This way it is sufficient for the user to provide `ContractId t`s and the fetching of the contract value and the conversion to `AnyContractId`/`AnyTemplate` is handled automatically.

The user can perform assertions on the emitted commands using `assertCreateCmd`, `assertExerciseCmd`, and `assertExerciseByKeyCmd`. These take a list of emitted `Command`s and the assertions as `a -> Either Text ()`. If none of the commands fulfills the assertions, then the scenario will fail.

To facilitate the above, this PR adds an `instance CanAbort (Either Text)`. `Either` already had the instances `Action`, and `ActionFail` before.

This PR adds a simple test case for `testRule` and the assertion functions.



### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
