### PR TITLE
Add daml2ts to the SDK release tarball

### DIFF
--- a/language-support/ts/codegen/BUILD.bazel
+++ b/language-support/ts/codegen/BUILD.bazel
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary")
+load("//bazel_tools/packaging:packaging.bzl", "package_app")
 
 da_haskell_binary(
     name = "daml2ts",
@@ -27,4 +28,10 @@ da_haskell_binary(
         "//compiler/daml-lf-reader",
         "//libs-haskell/da-hs-base",
     ],
+)
+
+package_app(
+    name = "daml2ts-dist",
+    binary = ":daml2ts",
+    visibility = ["//visibility:public"],
 )

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -21,6 +21,7 @@ def sdk_tarball(name, version):
             "//compiler/damlc:damlc-dist",
             "//compiler/daml-extension:vsix",
             "//daml-assistant/daml-helper:daml-helper-dist",
+            "//language-support/ts/codegen:daml2ts-dist",
             "//templates:templates-tarball.tar.gz",
             "//triggers/daml:daml-trigger.dar",
             "//daml-script/daml:daml-script.dar",
@@ -67,6 +68,9 @@ def sdk_tarball(name, version):
 
           mkdir -p $$OUT/daml-helper
           tar xf $(location //daml-assistant/daml-helper:daml-helper-dist) --strip-components=1 -C $$OUT/daml-helper
+
+          mkdir -p $$OUT/daml2ts
+          tar xf $(location //language-support/ts/codegen:daml2ts-dist) --strip-components=1 -C $$OUT/daml2ts
 
           mkdir -p $$OUT/studio
           cp $(location //compiler/daml-extension:vsix) $$OUT/studio/daml-bundled.vsix


### PR DESCRIPTION
This PR adds the Haskell binary daml2ts to the SDK release tarball. That's all it does. More work coming.