### PR TITLE
Engine: drop useless EContractId Ast node

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -17,7 +17,6 @@ import com.digitalasset.daml.lf.validation.{
   Validation,
   ValidationError
 }
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
@@ -445,9 +444,6 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
 
       case EVariantCon(tapp, variant, arg) =>
         SBVariantCon(tapp.tycon, variant)(translate(arg))
-
-      case EContractId(coid, _) =>
-        SEValue(SContractId(AbsoluteContractId(coid)))
 
       case let: ELet =>
         val (bindings, body) = collectLets(let)

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -124,20 +124,6 @@ object Ast {
   /** Scenario expression */
   final case class EScenario(scenario: Scenario) extends Expr
 
-  /** Contract ids. Note that:
-    *
-    * * The only reason why we have these here is that we want to translate Ledger API commands
-    *   to update expressions. Serialized DAML-LF programs never have these.
-    * * Since we only care about Ledger API commands we only allow absolute contract ids, here
-    *   represented as strings.
-    *
-    * Why not just parametrize the whole of Expr with ContractId, like we do to other structures?
-    * It is too annoying to do so, what pushed me over the edge is that ImmArray[T] is invariant
-    * in T, and thus it's not the case that `ImmArray[Expr[Nothing]] <: ImmArray[Expr[String]]`. We
-    * Might want to revisit this in the future.
-    */
-  final case class EContractId(coId: ContractIdString, tmplId: TypeConName) extends Expr
-
   /** Location annotations */
   final case class ELocation(loc: Location, expr: Expr) extends Expr
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -73,7 +73,7 @@ private[digitalasset] class AstRewriter(
       exprRule(x)
     else
       x match {
-        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EContractId(_, _) | ETypeRep(_) =>
+        case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | ETypeRep(_) =>
           x
         case EVal(ref) =>
           EVal(apply(ref))

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -35,7 +35,6 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eToAny |
       eFromAny |
       eToTextTypeConName |
-      contractId |
       fullIdentifier ^^ EVal |
       (id ^? builtinFunctions) ^^ EBuiltin |
       (id ^? builtinFunctions) ^^ EBuiltin |
@@ -62,11 +61,6 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     Id("True") ^^^ PCTrue |
       Id("False") ^^^ PCFalse |
       `(` ~ `)` ^^^ PCUnit
-
-  private lazy val contractId =
-    accept("ContractId", { case ContractId(cid) => cid }) ~ (`@` ~> fullIdentifier) ^^ {
-      case cid ~ t => EContractId(Ref.ContractIdString.assertFromString(cid), t)
-    }
 
   private lazy val eAppAgr: Parser[EAppAgr] =
     argTyp ^^ EAppTypArg |

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -287,8 +287,6 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
           ESome(TVar(n"a"), EVar(n"e")),
         "let x:Int64 = 2 in x" ->
           ELet(Binding(Some(x.value), t"Int64", e"2"), e"x"),
-        "#id @Mod:T" ->
-          EContractId(ContractIdString.assertFromString("#id"), T.tycon),
         "case e of () -> ()" ->
           ECase(e"e", ImmArray(CaseAlt(CPPrimCon(PCUnit), e"()"))),
         "case e of True -> False" ->

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -889,8 +889,6 @@ private[validation] object Typing {
         typeOfUpdate(update)
       case EScenario(scenario) =>
         typeOfScenario(scenario)
-      case EContractId(coId @ _, tmplId) =>
-        TContractId(TTyCon(tmplId))
       case ELocation(_, expr) =>
         typeOf(expr)
       case ENone(typ) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/ExprTraversable.scala
@@ -12,8 +12,8 @@ private[validation] object ExprTraversable {
 
   private[traversable] def foreach[U](x: Expr, f: Expr => U): Unit = {
     x match {
-      case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EContractId(_, _) |
-          EEnumCon(_, _) | ETypeRep(_) =>
+      case EVar(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EVal(_) | EEnumCon(_, _) | ETypeRep(
+            _) =>
       case ELocation(_, expr) =>
         f(expr)
       case ERecCon(tycon @ _, fields) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -31,8 +31,6 @@ private[validation] object TypeTraversable {
 
   private[validation] def foreach[U](expr0: Expr, f: Type => U): Unit = {
     expr0 match {
-      case EContractId(_, typeConName) =>
-        f(TTyCon(typeConName))
       case ERecCon(tycon, fields @ _) =>
         f(toType(tycon))
         fields.values.foreach(foreach(_, f))


### PR DESCRIPTION
In this PR we drop the useless EContractId Ast node

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
