### PR TITLE
sandbox: On initialization error, actually print the error and stop.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
@@ -26,12 +26,19 @@ object SandboxMain extends App {
       if (closed.compareAndSet(false, true)) server.close()
     }
 
+    server.failure.foreach { exception =>
+      logger.error(
+        s"Shutting down Sandbox application due to an initialization error:\n${exception.getMessage}")
+      sys.exit(1)
+    }
+
     try {
       Runtime.getRuntime.addShutdownHook(new Thread(() => closeServer()))
     } catch {
-      case NonFatal(t) =>
-        logger.error("Shutting down Sandbox application because of initialization error", t)
+      case NonFatal(exception) =>
+        logger.error("Shutting down Sandbox application due to an initialization error.", exception)
         closeServer()
+        sys.exit(1)
     }
   }
 


### PR DESCRIPTION
Three problems here:

1. On failure, the Sandbox didn't close down the metrics reporting thread, meaning the application would hang.
2. If there's a failure:
  a. we didn't print it, and
  b. we didn't exit with the correct status code.

These are now handled.

### Changelog

- **[Sandbox]** On initialization error, report the error correctly and exit with a status code of 1. Previously, the program would hang indefinitely. (This regression was introduced in v0.13.41.)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
