### PR TITLE
dam2ts: Make template id accessible at the type level

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -218,12 +218,13 @@ genDefDataType curPkgId conName mod tpls def =
                         (keyTypeTs, keySer) = case tplKey tpl of
                             Nothing -> ("undefined", "() => jtv.constant(undefined)")
                             Just key -> (conName <.> "Key", "() => " <> snd (genType (moduleName mod) (tplKeyType key)) <> ".decoder()")
+                        templateId =unPackageId curPkgId <> ":" <> T.intercalate "." (unModuleName (moduleName mod)) <> ":" <> conName 
                         dict =
-                            ["export const " <> conName <> ": daml.Template<" <> conName <> ", " <> keyTypeTs <> "> & {"] ++
+                            ["export const " <> conName <> ": daml.Template<" <> conName <> ", " <> keyTypeTs <> ", '" <> templateId <> "'> & {"] ++
                             ["  " <> x <> ": daml.Choice<" <> conName <> ", " <> t <> ", " <> rtyp <> ", " <> keyTypeTs <> ">;" | (x, t, rtyp, _) <- chcs] ++
                             ["} = {"
                             ] ++
-                            ["  templateId: '" <> unPackageId curPkgId <> ":" <> T.intercalate "." (unModuleName (moduleName mod)) <> ":" <> conName <> "',"
+                            ["  templateId: '" <> templateId <> "',"
                             ,"  keyDecoder: " <> keySer <> ","
                             ] ++
                             map ("  " <>) (onLast (<> ",") (onHead ("decoder: " <>) serDesc)) ++

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -4,8 +4,8 @@ import { Choice, ContractId, List, Party, Template, Text, lookupTemplate } from 
 import * as jtv from '@mojotech/json-type-validation';
 import fetch from 'cross-fetch';
 
-export type CreateEvent<T extends object, K = unknown> = {
-  templateId: string;
+export type CreateEvent<T extends object, K = unknown, I extends string = string> = {
+  templateId: I;
   contractId: ContractId<T>;
   signatories: List<Party>;
   observers: List<Party>;
@@ -14,17 +14,17 @@ export type CreateEvent<T extends object, K = unknown> = {
   payload: T;
 }
 
-export type ArchiveEvent<T extends object> = {
-  templateId: string;
+export type ArchiveEvent<T extends object, I extends string = string> = {
+  templateId: I;
   contractId: ContractId<T>;
 }
 
-export type Event<T extends object, K = unknown> =
-  | { created: CreateEvent<T, K> }
-  | { archived: ArchiveEvent<T> }
+export type Event<T extends object, K = unknown, I extends string = string> =
+  | { created: CreateEvent<T, K, I> }
+  | { archived: ArchiveEvent<T, I> }
 
-const decodeCreateEvent = <T extends object, K>(template: Template<T, K>): jtv.Decoder<CreateEvent<T, K>> => jtv.object({
-  templateId: jtv.string(),
+const decodeCreateEvent = <T extends object, K, I extends string>(template: Template<T, K, I>): jtv.Decoder<CreateEvent<T, K, I>> => jtv.object({
+  templateId: jtv.constant(template.templateId),
   contractId: ContractId(template).decoder(),
   signatories: List(Party).decoder(),
   observers: List(Party).decoder(),
@@ -126,7 +126,7 @@ class Ledger {
    * https://github.com/digital-asset/daml/blob/master/docs/source/json-api/search-query-language.rst
    * for a description of the query language.
    */
-  async query<T extends object, K>(template: Template<T, K>, query: Query<T>): Promise<CreateEvent<T, K>[]> {
+  async query<T extends object, K, I extends string>(template: Template<T, K, I>, query: Query<T>): Promise<CreateEvent<T, K, I>[]> {
     const payload = {templateIds: [template.templateId], query};
     const json = await this.submit('contracts/search', payload);
     return jtv.Result.withException(jtv.array(decodeCreateEvent(template)).run(json));
@@ -135,14 +135,14 @@ class Ledger {
   /**
    * Retrieve all contracts for a given template.
    */
-  async fetchAll<T extends object, K>(template: Template<T, K>): Promise<CreateEvent<T, K>[]> {
+  async fetchAll<T extends object, K, I extends string>(template: Template<T, K, I>): Promise<CreateEvent<T, K, I>[]> {
     return this.query(template, {} as Query<T>);
   }
 
   /**
    * Fetch a contract by its key.
    */
-  async lookupByKey<T extends object, K>(template: Template<T, K>, key: K): Promise<CreateEvent<T, K> | null> {
+  async lookupByKey<T extends object, K, I extends string>(template: Template<T, K, I>, key: K): Promise<CreateEvent<T, K, I> | null> {
     if (key === undefined) {
       throw Error(`Cannot lookup by key on template ${template.templateId} because it does not define a key.`);
     }
@@ -157,7 +157,7 @@ class Ledger {
   /**
    * Create a contract for a given template.
    */
-  async create<T extends object, K>(template: Template<T, K>, payload: T): Promise<CreateEvent<T, K>> {
+  async create<T extends object, K, I extends string>(template: Template<T, K, I>, payload: T): Promise<CreateEvent<T, K, I>> {
     const command = {
       templateId: template.templateId,
       payload,

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -23,8 +23,8 @@ export const STATIC_IMPLEMENTS_SERIALIZABLE_CHECK = <T>(_: Serializable<T>) => {
  * Interface for objects representing DAML templates. It is similar to the
  * `Template` type class in DAML.
  */
-export interface Template<T extends object, K = unknown> extends Serializable<T> {
-  templateId: string;
+export interface Template<T extends object, K = unknown, I extends string = string> extends Serializable<T> {
+  templateId: I;
   keyDecoder: () => jtv.Decoder<K>;
   Archive: Choice<T, {}, {}>;
 }


### PR DESCRIPTION
We add a third type parameter `I` to the `Template` interface and use it as
the type of the `templateId` field. We add this parameter to `CreateEvent`,
`ArchiveEvent` and `Event` as well. The reason behind this is to allow for
patterns like
```ts
function handleFooOrBar(event: CreateEvent<Foo, Foo.Key, typeof Foo.templateId>
                             | CreateEvent<Bar, Bar.Key, typeof Bar.templateId>) {
    switch (event.templateId) {
        case Foo.templateId: ...
        case Bar.templateId: ...
    }
}
```
and get exhaustiveness checking. This will become particularly handy when
handling upgrades, where `Foo` and `Bar` would be the old and new version
of a template, resp.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4248)
<!-- Reviewable:end -->
