### PR TITLE
Integrate daml2ts into the assistant

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -6,6 +6,7 @@ module DA.Daml.Helper.Run
     , runNew
     , runMigrate
     , runJar
+    , runDaml2ts
     , runListTemplates
     , runStart
 
@@ -309,6 +310,12 @@ runJar :: FilePath -> Maybe FilePath -> [String] -> IO ()
 runJar jarPath mbLogbackPath remainingArgs = do
     mbLogbackArg <- traverse getLogbackArg mbLogbackPath
     withJar jarPath (toList mbLogbackArg) remainingArgs (const $ pure ())
+
+runDaml2ts :: [String] -> IO ()
+runDaml2ts remainingArgs = do
+  daml2ts <- fmap (</> "daml2ts" </> "daml2ts") getSdkPath
+  withProcessWait_ (proc daml2ts remainingArgs) (const $ pure ()) `catchIO`
+    (\e -> hPutStrLn stderr "Failed to invoke daml2ts." *> throwIO e)
 
 getLogbackArg :: FilePath -> IO String
 getLogbackArg relPath = do

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -50,6 +50,10 @@ commands:
   path: daml-helper/daml-helper
   desc: "Interact with a DAML ledger (experimental)"
   args: ["ledger"]
+- name: codegen
+  path: daml-helper/daml-helper
+  desc: "Run a language bindings code generation tool"
+  args: ["codegen"]
 - name: deploy
   path: daml-helper/daml-helper
   desc: "Deploy DAML project to a ledger (experimental)"
@@ -61,10 +65,6 @@ commands:
   path: daml-helper/daml-helper
   desc: "Launch the HTTP JSON API (experimental)"
   args: ["run-jar", "--logback-config=daml-sdk/json-api-logback.xml", "daml-sdk/daml-sdk.jar", "json-api"]
-- name: codegen
-  path: daml-helper/daml-helper
-  desc: "Run the DAML codegen"
-  args: ["run-jar", "--logback-config=daml-sdk/codegen-logback.xml", "daml-sdk/daml-sdk.jar", "codegen"]
 - name: trigger
   path: daml-helper/daml-helper
   args: ["run-jar", "--logback-config=daml-sdk/trigger-logback.xml", "daml-sdk/daml-sdk.jar", "trigger"]


### PR DESCRIPTION
Generate TypeScript bindings to DAML with `daml codegen ts DAR -o OUTDIR`.