### PR TITLE
ledger-on-sql: Don't allow unnamed in-memory databases.

### DIFF
--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -56,7 +56,7 @@ supported_databases = [
             "@maven//:org_xerial_sqlite_jdbc",
         ],
         "conformance_test_server_args": [
-            "--jdbc-url=jdbc:sqlite::memory:",
+            "--jdbc-url=jdbc:sqlite:file:daml-on-sql-conformance-test?mode=memory&cache=shared",
         ],
     },
     {
@@ -164,6 +164,7 @@ da_scala_test_suite(
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils:kvutils-tests-lib",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -50,7 +50,4 @@ object Queries {
       BatchSql(query, params.head, params.drop(1).toArray: _*).execute()
     ()
   }
-
-  class InvalidDatabaseException(jdbcUrl: String)
-      extends RuntimeException(s"Unknown database: $jdbcUrl")
 }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -20,7 +20,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
     extends ParticipantStateIntegrationSpecBase(implementationName) {
   protected final implicit val ec: ExecutionContext = ExecutionContext.global
 
-  protected def jdbcUrl: String
+  protected def newJdbcUrl(): String
 
   override final val startIndex: Long = SqlLedgerReaderWriter.StartIndex
 
@@ -30,7 +30,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
   ): ResourceOwner[ParticipantState] =
     newLoggingContext { implicit logCtx =>
       SqlLedgerReaderWriter
-        .owner(ledgerId, participantId, jdbcUrl)
+        .owner(ledgerId, participantId, newJdbcUrl())
         .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
     }
 

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -27,14 +27,12 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
   override final def participantStateFactory(
       participantId: ParticipantId,
       ledgerId: LedgerString,
-  ): ResourceOwner[ParticipantState] = {
-    val currentJdbcUrl = jdbcUrl
+  ): ResourceOwner[ParticipantState] =
     newLoggingContext { implicit logCtx =>
       SqlLedgerReaderWriter
-        .owner(ledgerId, participantId, currentJdbcUrl)
+        .owner(ledgerId, participantId, jdbcUrl)
         .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
     }
-  }
 
   override final def currentRecordTime(): Timestamp =
     Timestamp.assertFromInstant(Clock.systemUTC().instant())

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.sql
+
+import com.daml.ledger.on.sql.Database.InvalidDatabaseException
+import com.digitalasset.logging.LoggingContext.newLoggingContext
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+class DatabaseSpec extends AsyncWordSpec with Matchers {
+  "Database" should {
+    "not accept unnamed H2 database URLs" in {
+      newLoggingContext { implicit logCtx =>
+        an[InvalidDatabaseException] should be thrownBy
+          Database.owner("jdbc:h2:mem:")
+      }
+    }
+
+    "not accept unnamed SQLite database URLs" in {
+      newLoggingContext { implicit logCtx =>
+        an[InvalidDatabaseException] should be thrownBy
+          Database.owner("jdbc:sqlite::memory:")
+      }
+    }
+  }
+}

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/H2FileSqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/H2FileSqlLedgerReaderWriterIntegrationSpec.scala
@@ -8,6 +8,6 @@ import java.nio.file.Files
 class H2FileSqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using H2 with a file") {
 
-  override def jdbcUrl: String =
+  override protected def newJdbcUrl(): String =
     s"jdbc:h2:file:${Files.createTempDirectory(getClass.getSimpleName)}/test"
 }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/H2MemorySqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/H2MemorySqlLedgerReaderWriterIntegrationSpec.scala
@@ -8,6 +8,6 @@ import scala.util.Random
 class H2MemorySqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using H2 in memory") {
 
-  override protected def jdbcUrl: String =
+  override protected def newJdbcUrl(): String =
     s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase()}_${Random.nextInt()}"
 }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
@@ -9,5 +9,6 @@ class PostgresqlSqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using PostgreSQL")
     with PostgresAroundAll {
 
-  override protected def jdbcUrl: String = createNewDatabase().jdbcUrl
+  override protected def newJdbcUrl(): String =
+    createNewDatabase().jdbcUrl
 }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteFileSqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteFileSqlLedgerReaderWriterIntegrationSpec.scala
@@ -8,6 +8,6 @@ import java.nio.file.Files
 class SqliteFileSqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using SQLite with a file") {
 
-  override def jdbcUrl: String =
+  override protected def newJdbcUrl(): String =
     s"jdbc:sqlite:${Files.createTempDirectory(getClass.getSimpleName)}/test.sqlite"
 }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteMemorySqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteMemorySqlLedgerReaderWriterIntegrationSpec.scala
@@ -3,8 +3,11 @@
 
 package com.daml.ledger.on.sql
 
+import scala.util.Random
+
 class SqliteMemorySqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using SQLite in memory") {
 
-  override protected val jdbcUrl = s"jdbc:sqlite::memory:"
+  override protected val jdbcUrl =
+    s"jdbc:sqlite:file:${getClass.getSimpleName.toLowerCase()}_${Random.nextInt()}?mode=memory&cache=shared"
 }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteMemorySqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/SqliteMemorySqlLedgerReaderWriterIntegrationSpec.scala
@@ -8,6 +8,6 @@ import scala.util.Random
 class SqliteMemorySqlLedgerReaderWriterIntegrationSpec
     extends SqlLedgerReaderWriterIntegrationSpecBase("SQL implementation using SQLite in memory") {
 
-  override protected val jdbcUrl =
+  override protected def newJdbcUrl() =
     s"jdbc:sqlite:file:${getClass.getSimpleName.toLowerCase()}_${Random.nextInt()}?mode=memory&cache=shared"
 }


### PR DESCRIPTION
It seems that changing the connection pool size at runtime causes weird issues, predominantly that sometimes all connections are dropped and therefore the in-memory database is lost after migration. Obviously, it then stops working.

This works around this problem by simply not allowing unnamed in-memory databases, guaranteeing that we can share the database between the various connection pools.

This will probably be necessary anyway when attempting to share the database between the ledger and the index.

I think this will fix the flaky builds we're seeing in CI. Interestingly, it doesn't manifest on my machine; I think there's a race condition exacerbated by slowness in CI.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
