### PR TITLE
language: add daml-react package to ts libraries

### DIFF
--- a/language-support/ts/daml-react/.gitignore
+++ b/language-support/ts/daml-react/.gitignore
@@ -1,0 +1,5 @@
+index.d.ts
+index.js
+index.js.map
+lib/
+yarn.lock

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -1,0 +1,73 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@os_info//:os_info.bzl", "is_windows")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("//language-support/ts:eslint.bzl", "eslint_test")
+load("//language-support/ts:jest.bzl", "jest_test")
+load("@sdk_version//:sdk_version.bzl", "sdk_version")
+
+ts_library(
+    name = "daml-react",
+    srcs = glob([
+        "**/*.ts",
+        "**/*.tsx",
+    ]),
+    data = [
+        ":LICENSE",
+        ":package.json",
+    ],
+    module_name = "@daml/react",
+    node_modules = "@language_support_ts_deps//:node_modules",
+    tsconfig = ":tsconfig.json",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//language-support/ts/daml-ledger",
+        "//language-support/ts/daml-types",
+        "@language_support_ts_deps//:node_modules",
+    ],
+) if not is_windows else None
+
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = """
+      cp $(location //:LICENSE) $@
+    """,
+)
+
+eslint_test(
+    name = "lint",
+    srcs = glob([
+        "**/*.ts",
+        "**/*.tsx",
+    ]),
+)
+
+pkg_npm(
+    name = "npm_package",
+    srcs = [
+        ":package.json",
+        ":tsconfig.json",
+    ],
+    substitutions = {"0.0.0-SDKVERSION": sdk_version},
+    visibility = ["//visibility:public"],
+    deps = [
+        "daml-react",
+        ":license",
+    ],
+) if not is_windows else None
+
+# This doesn't work currently because imports of local packages aren't resolved correctly.
+# jest_test(
+# name = "test",
+# srcs = glob(["**/*.ts", "**/*.tsx"]),
+# jest_config = ":jest.config.js",
+# deps = [
+# "//language-support/ts/daml-types",
+# "//language-support/ts/daml-ledger",
+# ],
+# )

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
     ],
 ) if not is_windows else None
 
+# We can't reference any files outside of the directory, hence this rule.
 genrule(
     name = "license",
     srcs = ["//:LICENSE"],

--- a/language-support/ts/daml-react/DamlLedger.tsx
+++ b/language-support/ts/daml-react/DamlLedger.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useReducer, useMemo } from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DamlLedgerContext } from './context';
 import Credentials from './credentials';
 import * as LedgerStore from './ledgerStore';

--- a/language-support/ts/daml-react/DamlLedger.tsx
+++ b/language-support/ts/daml-react/DamlLedger.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useReducer, useMemo } from 'react';
+import { DamlLedgerContext } from './context';
+import Credentials from './credentials';
+import * as LedgerStore from './ledgerStore';
+import Ledger from '@daml/ledger';
+import { reducer } from './reducer';
+
+type Props = {
+  credentials: Credentials;
+}
+
+const DamlLedger: React.FC<Props> = (props) => {
+  const [store, dispatch] = useReducer(reducer, LedgerStore.empty());
+  const state = useMemo(() => ({
+    store,
+    dispatch,
+    party: props.credentials.party,
+    ledger: new Ledger(props.credentials.token),
+  }), [props.credentials, store, dispatch])
+  return (
+    <DamlLedgerContext.Provider value={state}>
+      {props.children}
+    </DamlLedgerContext.Provider>
+  );
+}
+
+export default DamlLedger;

--- a/language-support/ts/daml-react/context.ts
+++ b/language-support/ts/daml-react/context.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//Copyright (c) 2020 The DAML Authors. All rights reserved.
+//SPDX-License-Identifier: Apache-2.0
+
+import Ledger from '@daml/ledger';
+import * as LedgerStore from './ledgerStore';
+import React from "react";
+import { Action } from "./reducer";
+import { Party } from '@daml/types';
+
+export type DamlLedgerState = {
+  store: LedgerStore.Store;
+  dispatch: React.Dispatch<Action>;
+  party: Party;
+  ledger: Ledger;
+}
+
+export const DamlLedgerContext = React.createContext(null as DamlLedgerState | null);
+

--- a/language-support/ts/daml-react/credentials.ts
+++ b/language-support/ts/daml-react/credentials.ts
@@ -3,20 +3,19 @@
 
 import { decode } from 'jwt-simple';
 
-const LEDGER_ID: string = 'DAVL';
-
 export type Credentials = {
   party: string;
   token: string;
+  ledgerId: string;
 }
 
 /**
  * Check that the party in the token matches the party of the credentials and
- * that the ledger ID in the token matches `LEDGER_ID`.
+ * that the ledger ID in the token matches the given ledger id.
  */
-export const preCheckCredentials = ({party, token}: Credentials): string | null => {
+export const preCheckCredentials = ({party, token, ledgerId}: Credentials): string | null => {
   const decoded = decode(token, '', true);
-  if (!decoded.ledgerId || decoded.ledgerId !== LEDGER_ID) {
+  if (!decoded.ledgerId || decoded.ledgerId !== ledgerId) {
     return 'The password is not valid for DAVL.';
   }
   if (!decoded.party || decoded.party !== party) {

--- a/language-support/ts/daml-react/credentials.ts
+++ b/language-support/ts/daml-react/credentials.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { decode } from 'jwt-simple';
+
+const LEDGER_ID: string = 'DAVL';
+
+export type Credentials = {
+  party: string;
+  token: string;
+}
+
+/**
+ * Check that the party in the token matches the party of the credentials and
+ * that the ledger ID in the token matches `LEDGER_ID`.
+ */
+export const preCheckCredentials = ({party, token}: Credentials): string | null => {
+  const decoded = decode(token, '', true);
+  if (!decoded.ledgerId || decoded.ledgerId !== LEDGER_ID) {
+    return 'The password is not valid for DAVL.';
+  }
+  if (!decoded.party || decoded.party !== party) {
+    return 'The password is not valid for this user.';
+  }
+  return null;
+}
+
+export default Credentials;

--- a/language-support/ts/daml-react/credentials.ts
+++ b/language-support/ts/daml-react/credentials.ts
@@ -16,7 +16,7 @@ export type Credentials = {
 export const preCheckCredentials = ({party, token, ledgerId}: Credentials): string | null => {
   const decoded = decode(token, '', true);
   if (!decoded.ledgerId || decoded.ledgerId !== ledgerId) {
-    return 'The password is not valid for DAVL.';
+    return 'The password is not valid for the given ledger id.';
   }
   if (!decoded.party || decoded.party !== party) {
     return 'The password is not valid for this user.';

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Template, Choice, ContractId } from "@daml/types";
+import { Query, CreateEvent } from '@daml/ledger';
+import { useEffect, useMemo, useState, useContext } from "react";
+import * as LedgerStore from './ledgerStore';
+import * as TemplateStore from './templateStore';
+import { setQueryLoading, setQueryResult, setFetchByKeyLoading, setFetchByKeyResult, addEvents } from "./reducer";
+import { DamlLedgerState, DamlLedgerContext } from './context';
+
+export const useDamlState = (): DamlLedgerState => {
+  const state = useContext(DamlLedgerContext);
+  if (!state) {
+    throw Error("Trying to use DamlLedgerContext before initializing.")
+  }
+  return state;
+}
+
+export const useParty = () => {
+  const state = useDamlState();
+  return state.party;
+}
+
+const loadQuery = async <T extends object>(state: DamlLedgerState, template: Template<T>, query: Query<T>) => {
+  state.dispatch(setQueryLoading(template, query));
+  const contracts = await state.ledger.query(template, query);
+  state.dispatch(setQueryResult(template, query, contracts));
+}
+
+const emptyQueryFactory = <T extends object>(): Query<T> => ({} as Query<T>);
+
+export type QueryResult<T extends object, K> = {
+  contracts: CreateEvent<T, K>[];
+  loading: boolean;
+}
+
+/// React Hook for a query against the `/contracts/search` endpoint of the JSON API.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = emptyQueryFactory, queryDeps?: readonly any[]): QueryResult<T, K> => {
+  const state = useDamlState();
+  const query = useMemo(queryFactory, queryDeps);
+  const contracts = LedgerStore.getQueryResult(state.store, template, query);
+  useEffect(() => {
+    if (contracts === undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      loadQuery(state, template, query);
+    }
+  }, [state, template, query, contracts]);
+  return contracts ?? TemplateStore.emptyQueryResult();
+}
+
+const loadFetchByKey = async <T extends object, K>(state: DamlLedgerState, template: Template<T, K>, key: K) => {
+  state.dispatch(setFetchByKeyLoading(template, key));
+  let contract;
+  if (key === undefined) {
+    console.error(`Calling useFetchByKey on template without a contract key: ${template}`);
+    contract = null;
+  } else {
+    contract = await state.ledger.lookupByKey(template, key as K extends undefined ? never : K);
+  }
+  state.dispatch(setFetchByKeyResult(template, key, contract));
+}
+
+export type FetchResult<T extends object, K> = {
+  contract: CreateEvent<T, K> | null;
+  loading: boolean;
+}
+
+/// React Hook for a lookup by key against the `/contracts/lookup` endpoint of the JSON API.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useFetchByKey = <T extends object, K>(template: Template<T, K>, keyFactory: () => K, keyDeps?: readonly any[]): FetchResult<T, K> => {
+  const state = useDamlState();
+  const key = useMemo(keyFactory, keyDeps);
+  const contract = LedgerStore.getFetchByKeyResult(state.store, template, key);
+  useEffect(() => {
+    if (contract === undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      loadFetchByKey(state, template, key);
+    }
+  }, [state, template, key, contract]);
+  return contract ?? TemplateStore.emptyFetchResult();
+}
+
+const reloadTemplate = async <T extends object, K>(state: DamlLedgerState, template: Template<T, K>) => {
+  const templateStore = state.store.templateStores.get(template) as TemplateStore.Store<T, K> | undefined;
+  if (templateStore) {
+    const queries: Query<T>[] = Array.from(templateStore.queryResults.keys());
+    const keys: K[] = Array.from(templateStore.fetchByKeyResults.keys());
+    await Promise.all([
+      Promise.all(queries.map(async (query) => await loadQuery(state, template, query))),
+      Promise.all(keys.map(async (key) => await loadFetchByKey(state, template, key))),
+    ]);
+  }
+}
+
+/// React Hook that returns a function to exercise a choice and a boolean
+/// indicator whether the exercise is currently running.
+export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): [(cid: ContractId<T>, argument: C) => Promise<R>, boolean] => {
+  const [loading, setLoading] = useState(false);
+  const state = useDamlState();
+
+  const exercise = async (cid: ContractId<T>, argument: C) => {
+    setLoading(true);
+    const [result, events] = await state.ledger.exercise(choice, cid, argument);
+    state.dispatch(addEvents(events));
+    setLoading(false);
+    return result;
+  }
+  return [exercise, loading];
+}
+
+/// React Hook that returns a function to exercise a choice and a boolean
+/// indicator whether the exercise is currently running.
+export const usePseudoExerciseByKey = <T extends object, C, R>(choice: Choice<T, C, R>): [(key: Query<T>, argument: C) => Promise<R>, boolean] => {
+  const [loading, setLoading] = useState(false);
+  const state = useDamlState();
+
+  const exercise = async (key: Query<T>, argument: C) => {
+    setLoading(true);
+    const [result, events] = await state.ledger.exerciseByKey(choice, key, argument);
+    state.dispatch(addEvents(events));
+    setLoading(false);
+    return result;
+  }
+  return [exercise, loading];
+}
+
+/// React Hook to reload all queries currently present in the store.
+export const useReload = (): () => Promise<void> => {
+  const state = useDamlState();
+  return async () => {
+    const templates = Array.from(state.store.templateStores.keys());
+    await Promise.all(templates.map((template) => reloadTemplate(state, template)));
+  }
+}

--- a/language-support/ts/daml-react/index.ts
+++ b/language-support/ts/daml-react/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import DamlLedger from './DamlLedger';
+
+export default DamlLedger;
+
+export * from './hooks';

--- a/language-support/ts/daml-react/jest.config.js
+++ b/language-support/ts/daml-react/jest.config.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = {
+  testEnvironment: "node",
+  testMatch: [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  }
+}
+

--- a/language-support/ts/daml-react/ledgerStore.test.tsx
+++ b/language-support/ts/daml-react/ledgerStore.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {ContractId, registerTemplate} from '@daml/types'
+import {Event} from '@daml/ledger'
+import * as jtv from '@mojotech/json-type-validation'
+import * as LedgerStore from './ledgerStore'
+
+// mock data
+const templateId = "A.B.C"
+const template = {  templateId: templateId
+                  , Archive: {  template: () => template
+                              , choiceName: 'Archive'
+                              , argumentDecoder: jtv.anyJson
+                              , resultDecoder: jtv.anyJson
+                              }
+                  , keyDecoder: jtv.string
+                  , decoder: jtv.anyJson
+                  }
+
+const query = {value: {value1 : '123'}}
+const payload = {value: {value1 : '123', value2: 1}}
+const key = "key"
+
+type T={
+  value: {value1: string; value2: number};
+}
+
+const createdEvent = (cid: ContractId<T>, argument: T = payload): Event<T> => {
+  return(
+    {created: { templateId: templateId
+              , contractId: cid
+              , signatories: []
+              , observers: []
+              , agreementText: ''
+              , key: key
+              , payload: argument
+              }
+    }
+  )
+}
+
+const archivedEvent = (cid: ContractId<T>): Event<T> => {
+  return(
+    {archived: { templateId: templateId
+               , contractId: cid
+               }
+    }
+  )
+}
+
+const emptyLedgerStore = () => LedgerStore.setQueryResult(LedgerStore.empty(), template, query, []);
+
+describe('daml-react-hooks', () => {
+  registerTemplate(template)
+
+  it("no events result in unchanged state", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, []);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(0);
+  });
+
+  it("adding one event", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, [createdEvent('0#0')]);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(1);
+  });
+
+  it("adding three events", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, [createdEvent('0#0'), createdEvent('0#1'), createdEvent('0#2')]);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(3);
+  });
+
+  it("adding two events and archiving one", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, [createdEvent('0#0'), createdEvent('0#1'), archivedEvent('0#0')]);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(1);
+  });
+
+  it("archiving a non-existant contract", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, [createdEvent('0#0'), archivedEvent('0#2')]);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(1);
+  });
+
+  it("adding an event that doesn't match the query", () => {
+    let store = emptyLedgerStore();
+    store = LedgerStore.addEvents(store, [createdEvent('0#0', {value : {value1: 'something else', value2: 1}})]);
+    expect(store.templateStores.get(template)?.queryResults.get(query)?.contracts).toHaveLength(0);
+  });
+});

--- a/language-support/ts/daml-react/ledgerStore.ts
+++ b/language-support/ts/daml-react/ledgerStore.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as immutable from 'immutable';
+import { Template, lookupTemplate } from '@daml/types';
+import { CreateEvent, Query, Event } from '@daml/ledger';
+import * as TemplateStore from './templateStore';
+
+export type Store = {
+  templateStores: immutable.Map<Template<object, unknown>, TemplateStore.Store<object, unknown>>;
+}
+
+export const empty = (): Store => ({
+  templateStores: immutable.Map(),
+});
+
+export const setTemplateLoading = <T extends object>(store: Store, template: Template<T>) => ({
+  ...store,
+  templateStores: store.templateStores.update(template, TemplateStore.setAllLoading)
+});
+
+export const getQueryResult = <T extends object, K>(store: Store, template: Template<T, K>, query: Query<T>): TemplateStore.QueryResult<T, K> | undefined => {
+  const templateStore = store.templateStores.get(template) as TemplateStore.Store<T, K> | undefined;
+  return templateStore?.queryResults.get(query);
+}
+
+export const setQueryLoading = <T extends object>(store: Store, template: Template<T>, query: Query<T>): Store => ({
+  ...store,
+  templateStores: store.templateStores.update(template, (templateStore = TemplateStore.empty()) =>
+    TemplateStore.setQueryLoading(templateStore, query))
+});
+
+export const setQueryResult = <T extends object>(store: Store, template: Template<T>, query: Query<T>, contracts: CreateEvent<T>[]): Store => ({
+  ...store,
+  templateStores: store.templateStores.update(template, (templateStore = TemplateStore.empty()) =>
+    TemplateStore.setQueryResult(templateStore, query, contracts))
+});
+
+export const getFetchByKeyResult = <T extends object, K>(store: Store, template: Template<T, K>, key: K): TemplateStore.FetchResult<T, K> | undefined => {
+  const templateStore = store.templateStores.get(template) as TemplateStore.Store<T, K> | undefined;
+  return templateStore?.fetchByKeyResults.get(key);
+}
+
+export const setFetchByKeyLoading = <T extends object, K>(store: Store, template: Template<T, K>, key: K): Store => ({
+  ...store,
+  templateStores: store.templateStores.update(template, (templateStore = TemplateStore.empty()) =>
+    TemplateStore.setFetchByKeyLoading(templateStore, key))
+});
+
+export const setFetchByKeyResult = <T extends object, K>(store: Store, template: Template<T>, key: K, contract: CreateEvent<T, K> | null): Store => ({
+  ...store,
+  templateStores: store.templateStores.update(template, (templateStore = TemplateStore.empty()) =>
+    TemplateStore.setFetchByKeyResult(templateStore, key, contract))
+});
+
+export const addEvents = (store: Store, events: Event<object>[]): Store => {
+  const eventsByTemplateId = immutable.List(events).groupBy((event) =>
+    'created' in event ? event.created.templateId : event.archived.templateId);
+  let templateStores = store.templateStores;
+  eventsByTemplateId.forEach((events, templateId) => {
+    const template = lookupTemplate(templateId);
+    if (templateStores.has(template)) {
+      templateStores = templateStores.update(template, (templateStore) =>
+        TemplateStore.addEvents(templateStore, events.valueSeq().toArray()));
+    }
+  });
+  return {templateStores};
+}

--- a/language-support/ts/daml-react/package.json
+++ b/language-support/ts/daml-react/package.json
@@ -1,0 +1,54 @@
+{
+  "private": false,
+  "name": "@daml/react",
+  "version": "0.0.0-SDKVERSION",
+  "description": "React framework to interact with a DAML ledger",
+  "homepage": "https://daml.com",
+  "keywords": ["daml", "react", "client", "API"],
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@daml/types": "0.0.0-SDKVERSION",
+    "@daml/ledger": "0.0.0-SDKVERSION",
+    "immutable": "^4.0.0-rc.12",
+    "jwt-simple": "^0.5.6",
+    "react": "^16.12.0",
+    "@types/react": "^16.9.16"
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
+    "test": "jest",
+    "lint": "eslint --ext .ts ./ --max-warnings 0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/eslint-recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "plugins": [
+      "@typescript-eslint"
+    ],
+    "rules": {
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-inferrable-types": "off"
+    }
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.16.0",
+    "@typescript-eslint/parser": "^2.16.0",
+    "eslint": "^6.8.0",
+    "typescript": "3.7.4",
+    "@types/jest": "^24.0.23",
+    "jest": "^24.9.0",
+    "ts-jest": "^24.2.0"
+  }
+}

--- a/language-support/ts/daml-react/reducer.ts
+++ b/language-support/ts/daml-react/reducer.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Template } from "@daml/types";
+import { CreateEvent, Query, Event } from '@daml/ledger';
+import * as LedgerStore from './ledgerStore';
+
+enum ActionType {
+  SetQueryLoading,
+  SetQueryResult,
+  SetFetchByKeyLoading,
+  SetFetchByKeyResult,
+  AddEvents,
+}
+
+type SetQueryLoadingAction<T extends object> = {
+  type: typeof ActionType.SetQueryLoading;
+  template: Template<T>;
+  query: Query<T>;
+}
+
+type SetQueryResultAction<T extends object> = {
+  type: typeof ActionType.SetQueryResult;
+  template: Template<T>;
+  query: Query<T>;
+  contracts: CreateEvent<T>[];
+}
+
+type SetFetchByKeyLoadingAction<T extends object, K> = {
+  type: typeof ActionType.SetFetchByKeyLoading;
+  template: Template<T, K>;
+  key: K;
+}
+
+type SetFetchByKeyResultAction<T extends object, K> = {
+  type: typeof ActionType.SetFetchByKeyResult;
+  template: Template<T, K>;
+  key: K;
+  contract: CreateEvent<T, K> | null;
+}
+
+type AddEventsAction = {
+  type: typeof ActionType.AddEvents;
+  events: Event<object>[];
+}
+
+export type Action =
+  | SetQueryLoadingAction<object>
+  | SetQueryResultAction<object>
+  | SetFetchByKeyLoadingAction<object, unknown>
+  | SetFetchByKeyResultAction<object, unknown>
+  | AddEventsAction
+
+export const setQueryLoading = <T extends object>(template: Template<T>, query: Query<T>): SetQueryLoadingAction<T> => ({
+  type: ActionType.SetQueryLoading,
+  template,
+  query,
+});
+
+export const setQueryResult = <T extends object>(template: Template<T>, query: Query<T>, contracts: CreateEvent<T>[]): SetQueryResultAction<T> => ({
+  type: ActionType.SetQueryResult,
+  template,
+  query,
+  contracts,
+});
+
+export const setFetchByKeyLoading = <T extends object, K>(template: Template<T, K>, key: K): SetFetchByKeyLoadingAction<T, K> => ({
+  type: ActionType.SetFetchByKeyLoading,
+  template,
+  key,
+});
+
+export const setFetchByKeyResult = <T extends object, K>(template: Template<T, K>, key: K, contract: CreateEvent<T, K> | null): SetFetchByKeyResultAction<T, K> => ({
+  type: ActionType.SetFetchByKeyResult,
+  template,
+  key,
+  contract,
+});
+
+export const addEvents= (events: Event<object>[]): AddEventsAction => ({
+  type: ActionType.AddEvents,
+  events,
+});
+
+export const reducer = (ledgerStore: LedgerStore.Store, action: Action): LedgerStore.Store => {
+  switch (action.type) {
+    case ActionType.SetQueryLoading: {
+      return LedgerStore.setQueryLoading(ledgerStore, action.template, action.query);
+    }
+    case ActionType.SetQueryResult: {
+      return LedgerStore.setQueryResult(ledgerStore, action.template, action.query, action.contracts);
+    }
+    case ActionType.SetFetchByKeyLoading: {
+      return LedgerStore.setFetchByKeyLoading(ledgerStore, action.template, action.key);
+    }
+    case ActionType.SetFetchByKeyResult: {
+      return LedgerStore.setFetchByKeyResult(ledgerStore, action.template, action.key, action.contract);
+    }
+    case ActionType.AddEvents: {
+      return LedgerStore.addEvents(ledgerStore, action.events);
+    }
+  }
+}

--- a/language-support/ts/daml-react/templateStore.ts
+++ b/language-support/ts/daml-react/templateStore.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as immutable from 'immutable';
+import { Event, Query, CreateEvent} from '@daml/ledger';
+import { ContractId } from '@daml/types'
+
+export type QueryResult<T extends object, K> = {
+  contracts: CreateEvent<T, K>[];
+  loading: boolean;
+}
+
+export type FetchResult<T extends object, K> = {
+  contract: CreateEvent<T, K> | null;
+  loading: boolean;
+}
+
+export type Store<T extends object, K> = {
+  queryResults: immutable.Map<Query<T>, QueryResult<T, K>>;
+  fetchByKeyResults: immutable.Map<K, FetchResult<T, K>>;
+}
+
+export const emptyQueryResult = <T extends object, K>(): QueryResult<T, K> => ({
+  contracts: [],
+  loading: false,
+});
+
+export const emptyFetchResult = <T extends object, K>(): FetchResult<T, K> => ({
+  contract: null,
+  loading: false,
+});
+
+export const empty = <T extends object, K>(): Store<T, K> => ({
+  queryResults: immutable.Map(),
+  fetchByKeyResults: immutable.Map(),
+});
+
+export const setAllLoading = <T extends object, K>(store: Store<T, K>): Store<T, K> => ({
+  queryResults: store.queryResults.map((res) => ({...res, loading: true})),
+  fetchByKeyResults: store.fetchByKeyResults.map((res) => ({...res, laoding: true})),
+});
+
+export const setQueryLoading = <T extends object, K>(store: Store<T, K>, query: Query<T>): Store<T, K> => ({
+  ...store,
+  queryResults: store.queryResults.update(query, (res = emptyQueryResult()) => ({...res, loading: true})),
+});
+
+export const setQueryResult = <T extends object, K>(store: Store<T, K>, query: Query<T>, contracts: CreateEvent<T, K>[]): Store<T, K> => ({
+  ...store,
+  queryResults: store.queryResults.set(query, {contracts, loading: false})
+});
+
+export const payloadMatchesQuery = <T>(payload: T, query: Query<T>): boolean => {
+  if (typeof payload === 'object' && typeof query === 'object') {
+    const keys = Object.keys(query) as (keyof T & keyof Query<T>)[]
+    return keys.reduce<boolean>(
+      // TODO(MH): We should consider some form of crashing/logging when the
+      // `key` below is not a key of `payload`.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (acc, key) => acc && key in payload && payloadMatchesQuery(payload[key], query[key] as any),
+      true,
+    );
+  } else {
+    return typeof payload === typeof query && payload === query
+  }
+}
+
+
+// TODO(MH): We need to update the key lookups as well.
+export const addEvents = <T extends object, K>(store: Store<T, K>, events: Event<T, K>[]): Store<T, K> => {
+  const archived: Set<ContractId<T>> = new Set();
+  const created: CreateEvent<T, K>[] = [];
+  for (const event of events) {
+    if ('created' in event) {
+      created.push(event.created);
+    } else {
+      archived.add(event.archived.contractId);
+    }
+  }
+  const queryResults = store.queryResults.map((queryResult, query) => {
+    const contracts = queryResult.contracts
+      .concat(created.filter((event) => payloadMatchesQuery(event.payload, query)))
+      .filter((contract) => !archived.has(contract.contractId));
+    return {...queryResult, contracts};
+  });
+  return {...store, queryResults};
+}
+
+export const setFetchByKeyLoading = <T extends object, K>(store: Store<T, K>, key: K): Store<T, K> => ({
+  ...store,
+  fetchByKeyResults: store.fetchByKeyResults.update(key, (res = emptyFetchResult()) => ({...res, loading: true})),
+});
+
+export const setFetchByKeyResult = <T extends object, K>(store: Store<T, K>, key: K, contract: CreateEvent<T, K> | null) => ({
+  ...store,
+  fetchByKeyResults: store.fetchByKeyResults.set(key, {contract, loading: false}),
+});

--- a/language-support/ts/daml-react/tsconfig.json
+++ b/language-support/ts/daml-react/tsconfig.json
@@ -15,6 +15,5 @@
     "module": "CommonJS",
     "declaration": true,
     "sourceMap": true
-    },
-  "files": ["index.ts"]
+    }
 }

--- a/language-support/ts/daml-react/tsconfig.json
+++ b/language-support/ts/daml-react/tsconfig.json
@@ -15,5 +15,5 @@
     "module": "CommonJS",
     "declaration": true,
     "sourceMap": true
-    }
+  }
 }

--- a/language-support/ts/daml-react/tsconfig.json
+++ b/language-support/ts/daml-react/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "es2015"
+     ],
+    "jsx": "react",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "outDir": "lib/",
+    "module": "CommonJS",
+    "declaration": true,
+    "sourceMap": true
+    },
+  "files": ["index.ts"]
+}

--- a/language-support/ts/package.json
+++ b/language-support/ts/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "workspaces": [
     "daml-types",
-    "daml-ledger"
+    "daml-ledger",
+    "daml-react"
   ]
 }

--- a/language-support/ts/packages/package.json
+++ b/language-support/ts/packages/package.json
@@ -2,7 +2,11 @@
   "dependencies": {
     "@mojotech/json-type-validation": "^3.1.0",
     "cross-fetch": "^3.0.4",
-    "typescript": "3.7.4"
+    "typescript": "3.7.4",
+    "immutable": "^4.0.0-rc.12",
+    "jwt-simple": "^0.5.6",
+    "react": "^16.12.0",
+    "@types/react": "^16.9.16"
   },
   "devDependencies": {
     "@bazel/bazel": "1.1.0",

--- a/language-support/ts/packages/yarn.lock
+++ b/language-support/ts/packages/yarn.lock
@@ -468,6 +468,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.16":
+  version "16.9.19"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
+  integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -533,6 +546,11 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 acorn-globals@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
@@ -588,6 +606,11 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.8.1"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -617,6 +640,19 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+are-we-there-yet@~1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -878,6 +914,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chownr@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -919,6 +960,11 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -956,6 +1002,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
 convert-source-map@^1.4.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -968,7 +1019,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -1004,6 +1055,11 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
+  integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1027,6 +1083,13 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -1043,6 +1106,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1082,6 +1150,16 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -1482,6 +1560,13 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1504,6 +1589,20 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -1598,6 +1697,11 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -1662,17 +1766,29 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ignore-walk@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+  dependencies:
+    minimatch "^3.0.4"
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
 
 import-fresh@^3.0.0:
   version "3.2.1"
@@ -1703,10 +1819,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@^7.0.0:
   version "7.0.3"
@@ -1824,6 +1945,13 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+  dependencies:
+    number-is-nan "^1.0.0"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -1899,7 +2027,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2422,6 +2550,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jwt-simple@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/jwt-simple/-/jwt-simple-0.5.6.tgz#3357adec55b26547114157be66748995b75b333a"
+  integrity sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2512,7 +2645,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2609,6 +2742,21 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -2617,7 +2765,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.x, mkdirp@^0.5.1:
+mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -2666,6 +2814,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+needle@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
+  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -2697,6 +2854,30 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
+node-pre-gyp@*:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
+
+nopt@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
+
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -2714,12 +2895,48 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-bundled@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
+npm-packlist@^1.1.6:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
+  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+    npm-normalize-package-bin "^1.0.1"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npmlog@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nwsapi@^2.0.7:
   version "2.2.0"
@@ -2730,6 +2947,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -2808,10 +3030,23 @@ optionator@^0.8.1, optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-os-tmpdir@~1.0.2:
+os-homedir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+osenv@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
 
 p-each-series@^1.0.0:
   version "1.0.0"
@@ -2955,6 +3190,11 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -2967,6 +3207,15 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 protobufjs@6.8.8:
   version "6.8.8"
@@ -3015,10 +3264,29 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-react-is@^16.8.4:
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -3036,6 +3304,19 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+readable-stream@^2.0.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -3156,10 +3437,17 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
+resolve@1.x, resolve@^1.3.2:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
   integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -3183,7 +3471,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -3214,7 +3502,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3251,7 +3539,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3266,7 +3554,7 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -3473,6 +3761,23 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -3506,6 +3811,20 @@ string.prototype.trimright@^2.1.1:
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3543,6 +3862,11 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -3571,6 +3895,19 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -3761,6 +4098,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
 util.promisify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
@@ -3864,6 +4206,13 @@ which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
+wide-align@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  dependencies:
+    string-width "^1.0.2 || 2"
+
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -3915,6 +4264,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^3.0.0, yallist@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@10.x:
   version "10.1.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "colors": "1.4.0",
     "http-proxy": "^1.17.0",
     "node-cache": "^4.2.0",
-    "typescript": "3.1.6",
+    "typescript": "3.7.4",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -94,6 +94,7 @@ main = do
       let npmPackages =
             [ "//language-support/ts/daml-types"
             , "//language-support/ts/daml-ledger"
+            , "//language-support/ts/daml-react"
             ]
       -- make sure the npm packages can be build.
       $logDebug "Building language-support typescript packages"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,10 +4014,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@~3.4.8:
   version "3.4.9"


### PR DESCRIPTION
This adds the library formerly known as `daml-react-hooks` into the
monorepo. We renamed it to `@daml/react`.

The tests sadly don't work with bazel right now because the local
imports aren't resolved correctly. Local testing with `yarn run test`
works as usual. We're working on the bazel test rules in the meantime.
 
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
