### PR TITLE
Daml.Trigger.Assert for trigger testing API

### DIFF
--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -13,6 +13,8 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml/Daml/Trigger
       cp -L $(location Daml/Trigger.daml) $$TMP_DIR/daml/Daml
+      cp -L $(location Daml/Trigger/Assert.daml) $$TMP_DIR/daml/Daml/Trigger
+      cp -L $(location Daml/Trigger/Internal.daml) $$TMP_DIR/daml/Daml/Trigger
       cp -L $(location Daml/Trigger/LowLevel.daml) $$TMP_DIR/daml/Daml/Trigger
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: $$(cat $(location //:VERSION))

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -21,6 +21,10 @@ sdk-version: $$(cat $(location //:VERSION))
 name: daml-trigger
 source: daml
 version: $$(cat $(location //:VERSION))
+exposed-modules:
+  - Daml.Trigger
+  - Daml.Trigger.Assert
+  - Daml.Trigger.LowLevel
 dependencies:
   - daml-stdlib
   - daml-prim

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -48,6 +48,7 @@ genrule(
             --format=Rst \
             --template=$(location :daml-trigger-rst-template.rst) \
             $(location Daml/Trigger.daml) \
+            $(location Daml/Trigger/Assert.daml) \
             $(location Daml/Trigger/LowLevel.daml)
     """,
     tools = ["//compiler/damlc"],

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -28,36 +28,19 @@ module Daml.Trigger
  , RegisteredTemplates(..)
  , registeredTemplate
  , RelTime(..)
- , ACSBuilder
- , toACS
- , testRule
- , flattenCommands
- , assertCreateCmd
- , assertExerciseCmd
- , assertExerciseByKeyCmd
  ) where
 
 import DA.Action
 import DA.Action.State
-import qualified DA.List as List
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
 import DA.Optional
-import qualified DA.Text as Text
 
+import Daml.Trigger.Internal
 import Daml.Trigger.LowLevel hiding (Trigger)
 import qualified Daml.Trigger.LowLevel as LowLevel
 
 -- public API
-
--- | Active contract set, you can use `getContracts` to access the templates of
--- a given type.
-
--- This will change to a Map once we have proper maps in DAML-LF
-data ACS = ACS
-  { activeContracts : [(AnyContractId, AnyTemplate)]
-  , pendingContracts : Map CommandId [AnyContractId]
-  }
 
 {-# DEPRECATED getTemplates "getTemplates is deprecated in favor of getContracts" #-}
 getTemplates : forall a. Template a => ACS -> [(ContractId a, a)]
@@ -88,12 +71,6 @@ data Trigger s = Trigger
   , heartbeat : Optional RelTime
   -- ^ Send a heartbeat message at the given interval.
   }
-
--- | TriggerA is the type used in the `rule` of a DAML trigger.
--- Its main feature is that you can call `emitCommands` to
--- send commands to the ledger.
-newtype TriggerA a = TriggerA (State TriggerAState a)
-  deriving (Functor, Applicative, Action)
 
 -- | Send a transaction consisting of the given commands to the ledger.
 -- The second argument can be used to mark a list of contract ids as pending.
@@ -204,174 +181,3 @@ runTrigger userTrigger = LowLevel.Trigger
           let userState = userTrigger.updateState state.acs MHeartbeat state.userState
               state' = state { userState }
           in runRule userTrigger.rule time state'
-
--- Internal API
-
-addCommands : Map CommandId [Command] -> Commands -> Map CommandId [Command]
-addCommands m (Commands cid cmds) = Map.insert cid cmds m
-
-insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
-insertTpl cid tpl acs = acs { activeContracts = (cid, tpl) :: acs.activeContracts }
-
-deleteTpl : AnyContractId -> ACS -> ACS
-deleteTpl cid acs = acs { activeContracts = filter (\(cid', _) -> cid /= cid') acs.activeContracts }
-
-lookupTpl : Template a => AnyContractId -> ACS -> Optional a
-lookupTpl cid acs = do
-  (_, tpl) <- find ((cid ==) . fst) $ acs.activeContracts
-  fromAnyTemplate tpl
-
-applyEvent : Event -> ACS -> ACS
-applyEvent ev acs = case ev of
-  CreatedEvent (Created _ cid tpl) -> insertTpl cid tpl acs
-  ArchivedEvent (Archived _ cid) -> deleteTpl cid acs
-
-applyTransaction : Transaction -> ACS -> ACS
-applyTransaction (Transaction _ _ evs) acs = foldl (flip applyEvent) acs evs
-
-runRule
-  : (Party -> ACS -> Time -> Map CommandId [Command] -> s -> TriggerA ())
-  -> Time
-  -> TriggerState s
-  -> (TriggerState s, [Commands])
-runRule rule time state =
-  let (_, aState) =
-        runTriggerA
-          (rule state.party state.acs time state.commandsInFlight state.userState)
-          (TriggerAState state.commandsInFlight [] state.acs.pendingContracts state.nextCommandId)
-      commandsInFlight = foldl addCommands state.commandsInFlight aState.emittedCommands
-      acs = state.acs { pendingContracts = aState.pendingContracts }
-  in (state { nextCommandId = aState.nextCommandId, commandsInFlight, acs }, aState.emittedCommands)
-
-runTriggerA : TriggerA a -> TriggerAState -> (a, TriggerAState)
-runTriggerA (TriggerA f) s =
-  let (a, s') = runState f s
-  in (a, s' { emittedCommands = reverse s'.emittedCommands })
-
-data TriggerAState = TriggerAState
-  { commandsInFlight : Map CommandId [Command]
-  -- This is not modified during a run (new commands end up in emittedCommands)
-  -- but for simplicity we keep it in TriggerAState instead of layering a
-  -- Reader on top of it.
-  -- This will be used for dedupCreateCmd/dedupExerciseCmd helpers.
-  , emittedCommands : [Commands]
-  -- ^ Emitted commands in reverse because I can’t be bothered to implement a dlist.
-  , pendingContracts : Map CommandId [AnyContractId]
-  -- ^ Map from command ids to the contract ids marked pending by that command.
-  , nextCommandId : Int
-  -- ^ Command id used for the next submit
-  }
-
-data TriggerState s = TriggerState
-  { acs : ACS
-  , party : Party
-  , userState : s
-  , commandsInFlight : Map CommandId [Command]
-  , nextCommandId : Int
-  }
-
--- | Used to construct an 'ACS' for 'testRule'.
-newtype ACSBuilder = ACSBuilder [Update (AnyContractId, AnyTemplate)]
-
-instance Semigroup ACSBuilder where
-  ACSBuilder l <> ACSBuilder r = ACSBuilder (l <> r)
-
-instance Monoid ACSBuilder where
-  mempty = ACSBuilder mempty
-
-buildACS : Party -> ACSBuilder -> Scenario ACS
-buildACS party (ACSBuilder fetches) = do
-  activeContracts <- submit party $ sequence fetches
-  pure ACS
-    { activeContracts = activeContracts
-    , pendingContracts = Map.empty
-    }
-
--- | Include the given contract in the 'ACS'.
-toACS : Template t => ContractId t -> ACSBuilder
-toACS cid = ACSBuilder
-  [fetch cid >>= \tpl -> pure (toAnyContractId cid, toAnyTemplate tpl)]
-
--- | Execute a trigger's rule once in a scenario.
-testRule
-  : Trigger s  -- ^ Test this trigger's 'Trigger.rule'.
-  -> Party  -- ^ Execute the rule as this 'Party'.
-  -> ACSBuilder  -- ^ List these contracts in the 'ACS'.
-  -> Map CommandId [Command]  -- ^ The commands in flight.
-  -> s  -- ^ The trigger state.
-  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule. The 'CommandId's will start from @"0"@.
-testRule trigger party acsBuilder commandsInFlight s = do
-  time <- getTime
-  acs <- buildACS party acsBuilder
-  let state = TriggerState
-        { acs = acs
-        , party = party
-        , userState = s
-        , commandsInFlight = commandsInFlight
-        , nextCommandId = 0
-        }
-  let (_, commands) = runRule trigger.rule time state
-  pure commands
-
--- | Drop 'CommandId's and extract all 'Command's.
-flattenCommands : [Commands] -> [Command]
-flattenCommands = concatMap commands
-
-expectCommand
-  : [Command]
-  -> (Command -> Optional a)
-  -> (a -> Either Text ())
-  -> Either [Text] ()
-expectCommand commands fromCommand assertion = foldl step (Left []) commands
-  where
-    step : Either [Text] () -> Command -> Either [Text] ()
-    step (Right ()) _ = Right ()
-    step (Left msgs) command =
-      case assertion <$> fromCommand command of
-        None -> Left msgs
-        Some (Left msg) -> Left (msg :: msgs)
-        Some (Right ()) -> Right ()
-
--- | Check that at least one command is a create command whose payload fulfills the given assertions.
-assertCreateCmd
-  : (Template t, CanAbort m)
-  => [Command]  -- ^ Check these commands.
-  -> (t -> Either Text ())  -- ^ Perform these assertions.
-  -> m ()
-assertCreateCmd commands assertion =
-  case expectCommand commands fromCreate assertion of
-    Right () -> pure ()
-    Left msgs ->
-      abort $ "Failure, found no matching create command." <> collectMessages msgs
-
--- | Check that at least one command is an exercise command whose contract id and choice argument fulfill the given assertions.
-assertExerciseCmd
-  : (Template t, Choice t c r, CanAbort m)
-  => [Command]  -- ^ Check these commands.
-  -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
-  -> m ()
-assertExerciseCmd commands assertion =
-  case expectCommand commands fromExercise assertion of
-    Right () -> pure ()
-    Left msgs ->
-      abort $ "Failure, found no matching exercise command." <> collectMessages msgs
-
--- | Check that at least one command is an exercise by key command whose key and choice argument fulfill the given assertions.
-assertExerciseByKeyCmd
-  : forall t c r k m
-  . (TemplateKey t k, Choice t c r, CanAbort m)
-  => [Command]  -- ^ Check these commands.
-  -> ((k, c) -> Either Text ())  -- ^ Perform these assertions.
-  -> m ()
-assertExerciseByKeyCmd commands assertion =
-  case expectCommand commands (fromExerciseByKey @t) assertion of
-    Right () -> pure ()
-    Left msgs ->
-      abort $ "Failure, found no matching exerciseByKey command." <> collectMessages msgs
-
-collectMessages : [Text] -> Text
-collectMessages [] = ""
-collectMessages msgs = "\n" <> Text.unlines (map (bullet . nest) msgs)
-  where
-    bullet txt = "  * " <> txt
-    nest = Text.intercalate "\n" . List.intersperse "    " . Text.lines

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -1,0 +1,128 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE AllowAmbiguousTypes #-}
+daml 1.2
+module Daml.Trigger.Assert
+ ( ACSBuilder
+ , toACS
+ , testRule
+ , flattenCommands
+ , assertCreateCmd
+ , assertExerciseCmd
+ , assertExerciseByKeyCmd
+ ) where
+
+import qualified DA.List as List
+import DA.Next.Map (Map)
+import qualified DA.Next.Map as Map
+import qualified DA.Text as Text
+
+import Daml.Trigger
+import Daml.Trigger.Internal
+import Daml.Trigger.LowLevel hiding (Trigger)
+
+-- | Used to construct an 'ACS' for 'testRule'.
+newtype ACSBuilder = ACSBuilder [Update (AnyContractId, AnyTemplate)]
+
+instance Semigroup ACSBuilder where
+  ACSBuilder l <> ACSBuilder r = ACSBuilder (l <> r)
+
+instance Monoid ACSBuilder where
+  mempty = ACSBuilder mempty
+
+buildACS : Party -> ACSBuilder -> Scenario ACS
+buildACS party (ACSBuilder fetches) = do
+  activeContracts <- submit party $ sequence fetches
+  pure ACS
+    { activeContracts = activeContracts
+    , pendingContracts = Map.empty
+    }
+
+-- | Include the given contract in the 'ACS'.
+toACS : Template t => ContractId t -> ACSBuilder
+toACS cid = ACSBuilder
+  [fetch cid >>= \tpl -> pure (toAnyContractId cid, toAnyTemplate tpl)]
+
+-- | Execute a trigger's rule once in a scenario.
+testRule
+  : Trigger s  -- ^ Test this trigger's 'Trigger.rule'.
+  -> Party  -- ^ Execute the rule as this 'Party'.
+  -> ACSBuilder  -- ^ List these contracts in the 'ACS'.
+  -> Map CommandId [Command]  -- ^ The commands in flight.
+  -> s  -- ^ The trigger state.
+  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule. The 'CommandId's will start from @"0"@.
+testRule trigger party acsBuilder commandsInFlight s = do
+  time <- getTime
+  acs <- buildACS party acsBuilder
+  let state = TriggerState
+        { acs = acs
+        , party = party
+        , userState = s
+        , commandsInFlight = commandsInFlight
+        , nextCommandId = 0
+        }
+  let (_, commands) = runRule trigger.rule time state
+  pure commands
+
+-- | Drop 'CommandId's and extract all 'Command's.
+flattenCommands : [Commands] -> [Command]
+flattenCommands = concatMap commands
+
+expectCommand
+  : [Command]
+  -> (Command -> Optional a)
+  -> (a -> Either Text ())
+  -> Either [Text] ()
+expectCommand commands fromCommand assertion = foldl step (Left []) commands
+  where
+    step : Either [Text] () -> Command -> Either [Text] ()
+    step (Right ()) _ = Right ()
+    step (Left msgs) command =
+      case assertion <$> fromCommand command of
+        None -> Left msgs
+        Some (Left msg) -> Left (msg :: msgs)
+        Some (Right ()) -> Right ()
+
+-- | Check that at least one command is a create command whose payload fulfills the given assertions.
+assertCreateCmd
+  : (Template t, CanAbort m)
+  => [Command]  -- ^ Check these commands.
+  -> (t -> Either Text ())  -- ^ Perform these assertions.
+  -> m ()
+assertCreateCmd commands assertion =
+  case expectCommand commands fromCreate assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching create command." <> collectMessages msgs
+
+-- | Check that at least one command is an exercise command whose contract id and choice argument fulfill the given assertions.
+assertExerciseCmd
+  : (Template t, Choice t c r, CanAbort m)
+  => [Command]  -- ^ Check these commands.
+  -> ((ContractId t, c) -> Either Text ())  -- ^ Perform these assertions.
+  -> m ()
+assertExerciseCmd commands assertion =
+  case expectCommand commands fromExercise assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching exercise command." <> collectMessages msgs
+
+-- | Check that at least one command is an exercise by key command whose key and choice argument fulfill the given assertions.
+assertExerciseByKeyCmd
+  : forall t c r k m
+  . (TemplateKey t k, Choice t c r, CanAbort m)
+  => [Command]  -- ^ Check these commands.
+  -> ((k, c) -> Either Text ())  -- ^ Perform these assertions.
+  -> m ()
+assertExerciseByKeyCmd commands assertion =
+  case expectCommand commands (fromExerciseByKey @t) assertion of
+    Right () -> pure ()
+    Left msgs ->
+      abort $ "Failure, found no matching exerciseByKey command." <> collectMessages msgs
+
+collectMessages : [Text] -> Text
+collectMessages [] = ""
+collectMessages msgs = "\n" <> Text.unlines (map (bullet . nest) msgs)
+  where
+    bullet txt = "  * " <> txt
+    nest = Text.intercalate "\n" . List.intersperse "    " . Text.lines

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -1,0 +1,106 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE AllowAmbiguousTypes #-}
+daml 1.2
+module Daml.Trigger.Internal
+  ( ACS (..)
+  , TriggerA (..)
+  , addCommands
+  , insertTpl
+  , deleteTpl
+  , lookupTpl
+  , applyEvent
+  , applyTransaction
+  , runRule
+  , runTriggerA
+  , TriggerAState (..)
+  , TriggerState (..)
+  ) where
+
+import DA.Action.State
+import DA.Next.Map (Map)
+import qualified DA.Next.Map as Map
+
+import Daml.Trigger.LowLevel hiding (Trigger)
+
+-- public API
+
+-- | Active contract set, you can use `getContracts` to access the templates of
+-- a given type.
+
+-- This will change to a Map once we have proper maps in DAML-LF
+data ACS = ACS
+  { activeContracts : [(AnyContractId, AnyTemplate)]
+  , pendingContracts : Map CommandId [AnyContractId]
+  }
+
+-- | TriggerA is the type used in the `rule` of a DAML trigger.
+-- Its main feature is that you can call `emitCommands` to
+-- send commands to the ledger.
+newtype TriggerA a = TriggerA (State TriggerAState a)
+  deriving (Functor, Applicative, Action)
+
+-- Internal API
+
+addCommands : Map CommandId [Command] -> Commands -> Map CommandId [Command]
+addCommands m (Commands cid cmds) = Map.insert cid cmds m
+
+insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
+insertTpl cid tpl acs = acs { activeContracts = (cid, tpl) :: acs.activeContracts }
+
+deleteTpl : AnyContractId -> ACS -> ACS
+deleteTpl cid acs = acs { activeContracts = filter (\(cid', _) -> cid /= cid') acs.activeContracts }
+
+lookupTpl : Template a => AnyContractId -> ACS -> Optional a
+lookupTpl cid acs = do
+  (_, tpl) <- find ((cid ==) . fst) $ acs.activeContracts
+  fromAnyTemplate tpl
+
+applyEvent : Event -> ACS -> ACS
+applyEvent ev acs = case ev of
+  CreatedEvent (Created _ cid tpl) -> insertTpl cid tpl acs
+  ArchivedEvent (Archived _ cid) -> deleteTpl cid acs
+
+applyTransaction : Transaction -> ACS -> ACS
+applyTransaction (Transaction _ _ evs) acs = foldl (flip applyEvent) acs evs
+
+runRule
+  : (Party -> ACS -> Time -> Map CommandId [Command] -> s -> TriggerA ())
+  -> Time
+  -> TriggerState s
+  -> (TriggerState s, [Commands])
+runRule rule time state =
+  let (_, aState) =
+        runTriggerA
+          (rule state.party state.acs time state.commandsInFlight state.userState)
+          (TriggerAState state.commandsInFlight [] state.acs.pendingContracts state.nextCommandId)
+      commandsInFlight = foldl addCommands state.commandsInFlight aState.emittedCommands
+      acs = state.acs { pendingContracts = aState.pendingContracts }
+  in (state { nextCommandId = aState.nextCommandId, commandsInFlight, acs }, aState.emittedCommands)
+
+runTriggerA : TriggerA a -> TriggerAState -> (a, TriggerAState)
+runTriggerA (TriggerA f) s =
+  let (a, s') = runState f s
+  in (a, s' { emittedCommands = reverse s'.emittedCommands })
+
+data TriggerAState = TriggerAState
+  { commandsInFlight : Map CommandId [Command]
+  -- This is not modified during a run (new commands end up in emittedCommands)
+  -- but for simplicity we keep it in TriggerAState instead of layering a
+  -- Reader on top of it.
+  -- This will be used for dedupCreateCmd/dedupExerciseCmd helpers.
+  , emittedCommands : [Commands]
+  -- ^ Emitted commands in reverse because I can’t be bothered to implement a dlist.
+  , pendingContracts : Map CommandId [AnyContractId]
+  -- ^ Map from command ids to the contract ids marked pending by that command.
+  , nextCommandId : Int
+  -- ^ Command id used for the next submit
+  }
+
+data TriggerState s = TriggerState
+  { acs : ACS
+  , party : Party
+  , userState : s
+  , commandsInFlight : Map CommandId [Command]
+  , nextCommandId : Int
+  }

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -8,6 +8,7 @@ import DA.Action
 import DA.Assert
 import qualified DA.Next.Map as Map
 import Daml.Trigger
+import Daml.Trigger.Assert
 
 template T
   with


### PR DESCRIPTION
Move trigger testing functionality into the module `Daml.Trigger.Assert`, as discussed [here](https://github.com/digital-asset/daml/pull/4233#discussion_r371658966).
Requires extracting part of Daml.Trigger into Daml.Trigger.Internal to get access to internal data constructors and functionality

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
