### PR TITLE
Generate module references at the same time as conversion.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -189,7 +189,7 @@ generateSrcFromLf env = noLoc mod
             pure [mkConDecl env thisModule occName $ RecCon (noLoc fields')]
         LF.DataVariant cons -> do
             cons' <- mapM (secondM (convType env)) cons
-            pure $
+            pure
                 [ mkConDecl env thisModule (occNameFor conName) (details ty)
                 | (conName, ty) <- cons'
                 ]
@@ -197,7 +197,7 @@ generateSrcFromLf env = noLoc mod
             when (length cons == 1) (void $ mkGhcType env "DamlEnum")
                 -- ^ Single constructor enums spawn a reference to
                 -- GHC.Types.DamlEnum in the daml-preprocessor.
-            pure $
+            pure
                 [ mkConDecl env thisModule (occNameFor conName) (PrefixCon [])
                 | conName <- cons
                 ]

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -64,7 +64,8 @@ runGen (Gen m) = runWriter m
 emitModRef :: ModRef -> Gen ()
 emitModRef = Gen . tell . Set.singleton
 
--- | Extract all data defintions from a daml-lf module and generate a haskell source file from it.
+-- | Extract all data definitions from a daml-lf module and generate
+-- a haskell source file from it.
 generateSrcFromLf ::
        Env
     -> ParsedSource

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -472,16 +472,16 @@ mkStableType env unitId modName tyName = do
         . mkOrig ghcMod $ mkOccName varName tyName
 
 mkGhcType :: Env -> String -> Gen (HsType GhcPs)
-mkGhcType env = mkStableType env primUnitId
-    (LF.ModuleName ["GHC", "Types"])
+mkGhcType env = mkStableType env primUnitId $
+    LF.ModuleName ["GHC", "Types"]
 
 mkLfInternalType :: Env -> String -> Gen (HsType GhcPs)
-mkLfInternalType env = mkStableType env damlStdlibUnitId
-    (LF.ModuleName ["DA", "Internal", "LF"])
+mkLfInternalType env = mkStableType env damlStdlibUnitId $
+    LF.ModuleName ["DA", "Internal", "LF"]
 
 mkLfInternalPrelude :: Env -> String -> Gen (HsType GhcPs)
-mkLfInternalPrelude env = mkStableType env damlStdlibUnitId
-    (LF.ModuleName ["DA", "Internal", "Prelude"])
+mkLfInternalPrelude env = mkStableType env damlStdlibUnitId $
+    LF.ModuleName ["DA", "Internal", "Prelude"]
 
 mkTyConTypeUnqual :: TyCon -> HsType GhcPs
 mkTyConTypeUnqual tyCon = HsTyVar noExt NotPromoted . noLoc $ mkRdrUnqual (occName name)


### PR DESCRIPTION
This PR changes how module references are generated in DataDependencies. That's all.

Instead of generating them separately, we now generate them while converting declarations from LF to DAML. The main advantage of this approach is that module references and declarations cannot get out of sync, as we don't have to duplicate that logic.

Apologies for the large PR.