### PR TITLE
Pass uninitialized mkOptions to initPackageDb

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -382,6 +382,11 @@ execIde telemetry (Debug debug) enableScenarioService options =
                       f loggerH
                   Undecided -> f loggerH
           dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+          initPackageDb options (InitPkgDb True)
+          -- initPackageDb assumes that options does not call mkOptions.
+          -- TODO Burn mkOptions with lots of fire. It is impossible to use
+          -- it correctly since calling it twice will break everything
+          -- and there is no indicator of whether it has already been called.
           options <- mkOptions options
               { optScenarioService = enableScenarioService
               , optSkipScenarioValidation = SkipScenarioValidation True
@@ -391,7 +396,6 @@ execIde telemetry (Debug debug) enableScenarioService options =
               , optThreads = 0
               , optDlintUsage = DlintEnabled dlintDataDir True
               }
-          initPackageDb options (InitPkgDb True)
           scenarioServiceConfig <- readScenarioServiceConfig
           withLogger $ \loggerH ->
               withScenarioService' enableScenarioService loggerH scenarioServiceConfig $ \mbScenarioService -> do


### PR DESCRIPTION
`initPackageDb` assumes that `Options` has not yet been initialized
and calls `mkOptions` itself. Each call to `mkOptions` appends the LF
version to the package db dir which means that calling it twice as we
did in `execIde` results in pkg dbs of the form dir/1.7/1.7 which is
obviously not what we want.

This is just the fix, I’m sufficiently annoyed by this now, that I’ll
spend some time tomorrow to kill mkOptions completely but for now this
at least fixes the SDK on master.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
