### PR TITLE
@daml/react: Stop useQuery from reloading indefinitely

### DIFF
--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -28,16 +28,18 @@ const loadQuery = async <T extends object>(state: DamlLedgerState, template: Tem
   state.dispatch(setQueryResult(template, query, contracts));
 }
 
-const emptyQueryFactory = <T extends object>(): Query<T> => ({} as Query<T>);
-
 export type QueryResult<T extends object, K> = {
   contracts: CreateEvent<T, K>[];
   loading: boolean;
 }
 
+// NOTE(MH): Since `{} !== {}`, we need a stable reference to `{}` for `useMemo`
+// to work in `useQuery` when using the default value for `queryFactory`.
+const emptyQuery = {};
+
 /// React Hook for a query against the `/contracts/search` endpoint of the JSON API.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = emptyQueryFactory, queryDeps?: readonly any[]): QueryResult<T, K> => {
+export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = () => emptyQuery as Query<T>, queryDeps?: readonly any[]): QueryResult<T, K> => {
   const state = useDamlState();
   const query = useMemo(queryFactory, queryDeps);
   const contracts = LedgerStore.getQueryResult(state.store, template, query);


### PR DESCRIPTION
Since `{} !== {}` in JavaScript, the `useQuery` hook used to indefinitely
reload all contracts when called without its second and third parameter.
Having a stable name for `{}` fixes the issue. Manual tests on
`create-daml-app` confirm this. An automated test suite for `@daml/react`
is still under develeopment.

This fixes #4301.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4315)
<!-- Reviewable:end -->
