### PR TITLE
resources: Throw upon acquiring the implicit ExecutionContext.

### DIFF
--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ExecutorServiceResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ExecutorServiceResourceOwner.scala
@@ -15,12 +15,21 @@ class ExecutorServiceResourceOwner[T <: ExecutorService](acquireExecutorService:
     Resource(
       Future {
         val executorService = acquireExecutorService()
+        // If we try and release an executor service which is itself being used to power the
+        // releasing, we end up in a deadlock—the executor can't shut down, and therefore
+        // `awaitTermination `never completes. We mitigate this by attempting to catch the problem
+        // early and fail with a meaningful exception.
         executionContext match {
           case context: ExecutionContextExecutorService =>
             if (executorService == context) {
               throw new CannotAcquireExecutionContext()
             }
             // Ugly, but important so that we make sure we're not going to end up in deadlock.
+            // This calls a method on the private `ExecutionContextExecutorServiceImpl` class to get
+            // the underlying executor, then compares it. If you're using a custom
+            // `ExecutionContextExecutorService`, it probably won't follow the same API, so this
+            // will silently ignore it. This means it'll acquire happily but deadlock on release.
+            // We can't cover everything in these checks, unfortunately.
             try {
               val contextExecutor =
                 context.getClass.getMethod("executor").invoke(context).asInstanceOf[ExecutorService]

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ExecutorServiceResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ExecutorServiceResourceOwner.scala
@@ -5,17 +5,51 @@ package com.digitalasset.resources
 
 import java.util.concurrent.{ExecutorService, TimeUnit}
 
-import scala.concurrent.{ExecutionContext, Future}
+import com.digitalasset.resources.ExecutorServiceResourceOwner._
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 
 class ExecutorServiceResourceOwner[T <: ExecutorService](acquireExecutorService: () => T)
     extends ResourceOwner[T] {
   override def acquire()(implicit executionContext: ExecutionContext): Resource[T] =
     Resource(
-      Future(acquireExecutorService()),
+      Future {
+        val executorService = acquireExecutorService()
+        executionContext match {
+          case context: ExecutionContextExecutorService =>
+            if (executorService == context) {
+              throw new CannotAcquireExecutionContext()
+            }
+            // Ugly, but important so that we make sure we're not going to end up in deadlock.
+            try {
+              val contextExecutor =
+                context.getClass.getMethod("executor").invoke(context).asInstanceOf[ExecutorService]
+              if (executorService == contextExecutor) {
+                throw new CannotAcquireExecutionContext()
+              }
+            } catch {
+              case _: NoSuchMethodException =>
+            }
+          case context: ExecutorService =>
+            if (executorService == context) {
+              throw new CannotAcquireExecutionContext()
+            }
+          case _ =>
+        }
+        executorService
+      },
       executorService =>
         Future {
           executorService.shutdown()
           val _ = executorService.awaitTermination(Long.MaxValue, TimeUnit.SECONDS)
       }
     )
+}
+
+object ExecutorServiceResourceOwner {
+
+  class CannotAcquireExecutionContext
+      extends RuntimeException(
+        "The execution context used by resource acquisition cannot itself be acquired. This is to prevent deadlock upon release.")
+
 }


### PR DESCRIPTION
If we try and release an executor service which is itself being used to
power the releasing, we end up in a deadlock—the executor can't shut
down, and therefore `awaitTermination` never completes.

Fixing this is hard, but banning it is easy.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
