### PR TITLE
Remove mkOptions and defaultOptionsIO

### DIFF
--- a/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/GHC/Damldoc/Tests.hs
@@ -253,12 +253,9 @@ damldocExpect importPathM testname input check =
 -- | Generate the docs for a given input file and optional import directory.
 runDamldoc :: FilePath -> Maybe FilePath -> IO ModuleDoc
 runDamldoc testfile importPathM = do
-    opts <- fmap (\opt -> opt {optHaddock=Haddock True}) $ defaultOptionsIO Nothing
-
-    let opts' = opts
-          { optImportPath =
-              maybe id (:) importPathM $
-                  optImportPath opts
+    let opts = (defaultOptions Nothing)
+          { optHaddock = Haddock True
+          , optImportPath = maybeToList importPathM
           }
 
     let diagLogger = \case
@@ -269,7 +266,7 @@ runDamldoc testfile importPathM = do
     mbResult <- runMaybeT $ extractDocs
         defaultExtractOptions
         diagLogger
-        (toCompileOpts opts' (IdeReportProgress False))
+        (toCompileOpts opts (IdeReportProgress False))
         [toNormalizedFilePath testfile]
 
     case mbResult of

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -59,6 +59,7 @@ da_haskell_library(
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-visual",
         "//compiler/scenario-service/client",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -49,6 +49,7 @@ import qualified Development.IDE.Core.API         as API
 import qualified Development.IDE.Core.Rules.Daml  as API
 import qualified Development.IDE.Types.Diagnostics as D
 import qualified Development.IDE.Types.Location as D
+import DA.Bazel.Runfiles
 import DA.Daml.Compiler.Scenario as SS
 import Development.IDE.Core.Rules.Daml
 import Development.IDE.Types.Logger
@@ -170,7 +171,8 @@ pattern EventVirtualResourceNoteSet vr note <-
 -- | Run shake test on freshly initialised shake service.
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
-    options <- defaultOptionsIO Nothing
+    dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+    let options = (defaultOptions Nothing) { optDlintUsage = DlintEnabled dlintDataDir False }
     virtualResources <- newTVarIO Map.empty
     virtualResourcesNotes <- newTVarIO Map.empty
     let eventLogger (EventVirtualResourceChanged vr doc) = do

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -205,9 +205,10 @@ wOptsUnset =
   , Opt_WarnOverflowedLiterals -- this does not play well with -ticky and the error message is misleading
   ]
 
+newtype GhcVersionHeader = GhcVersionHeader FilePath
 
-adjustDynFlags :: Options -> FilePath -> FilePath -> DynFlags -> DynFlags
-adjustDynFlags options@Options{..} versionHeader tmpDir dflags
+adjustDynFlags :: Options -> GhcVersionHeader -> FilePath -> DynFlags -> DynFlags
+adjustDynFlags options@Options{..} (GhcVersionHeader versionHeader) tmpDir dflags
   =
   -- Generally, the lexer's "haddock mode" is disabled (`Haddock
   -- False` is the default option. In this case, we run the lexer in
@@ -282,8 +283,8 @@ setThisInstalledUnitId unitId dflags =
 setImports :: [FilePath] -> DynFlags -> DynFlags
 setImports paths dflags = dflags { importPaths = paths }
 
-locateGhcVersionHeader :: IO FilePath
-locateGhcVersionHeader = locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
+locateGhcVersionHeader :: IO GhcVersionHeader
+locateGhcVersionHeader = GhcVersionHeader <$> locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
 
 -- | Configures the @DynFlags@ for this session to DAML-1.2
 --  compilation:

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -31,6 +31,7 @@ import System.Directory
 import System.FilePath
 import qualified DA.Daml.LF.Ast.Version as LF
 
+import DA.Bazel.Runfiles
 import DA.Daml.Options.Types
 import DA.Daml.Preprocessor
 import Development.IDE.GHC.Util
@@ -45,7 +46,7 @@ toCompileOpts options@Options{..} reportProgress =
             env <- runGhcFast $ do
                 setupDamlGHC options
                 GHC.getSession
-            pkg <- generatePackageState optPackageDbs optHideAllPkgs optPackageImports
+            pkg <- generatePackageState optDamlLfVersion optPackageDbs optHideAllPkgs optPackageImports
             dflags <- checkDFlags options $ setPackageDynFlags pkg $ hsc_dflags env
             hscenv <- newHscEnvEq env{hsc_dflags = dflags}
             return $ const $ return hscenv
@@ -95,12 +96,12 @@ getPackageDynFlags DynFlags{..} = PackageDynFlags
     , pdfThisUnitIdInsts = thisUnitIdInsts_
     }
 
-generatePackageState :: [FilePath] -> Bool -> [PackageFlag] -> IO PackageDynFlags
-generatePackageState paths hideAllPkgs pkgImports = do
-  let dflags = setPackageImports hideAllPkgs pkgImports $ setPackageDbs paths fakeDynFlags
+generatePackageState :: LF.Version -> [FilePath] -> Bool -> [PackageFlag] -> IO PackageDynFlags
+generatePackageState lfVersion paths hideAllPkgs pkgImports = do
+  versionedPaths <- getPackageDbs lfVersion paths
+  let dflags = setPackageImports hideAllPkgs pkgImports $ setPackageDbs versionedPaths fakeDynFlags
   (newDynFlags, _) <- initPackages dflags
   pure $ getPackageDynFlags newDynFlags
-
 
 setPackageDbs :: [FilePath] -> DynFlags -> DynFlags
 setPackageDbs paths dflags =
@@ -205,8 +206,8 @@ wOptsUnset =
   ]
 
 
-adjustDynFlags :: Options -> FilePath -> DynFlags -> DynFlags
-adjustDynFlags options@Options{..} tmpDir dflags
+adjustDynFlags :: Options -> FilePath -> FilePath -> DynFlags -> DynFlags
+adjustDynFlags options@Options{..} versionHeader tmpDir dflags
   =
   -- Generally, the lexer's "haddock mode" is disabled (`Haddock
   -- False` is the default option. In this case, we run the lexer in
@@ -234,7 +235,7 @@ adjustDynFlags options@Options{..} tmpDir dflags
     debugLevel = 1,
     ghcLink = NoLink, hscTarget = HscNothing, -- avoid generating .o or .hi files
     {-, dumpFlags = Opt_D_ppr_debug `EnumSet.insert` dumpFlags dflags -- turn on debug output from GHC-}
-    ghcVersionFile = optGhcVersionFile
+    ghcVersionFile = Just versionHeader
   }
   where
     apply f xs d = foldl' f d xs
@@ -281,7 +282,8 @@ setThisInstalledUnitId unitId dflags =
 setImports :: [FilePath] -> DynFlags -> DynFlags
 setImports paths dflags = dflags { importPaths = paths }
 
-
+locateGhcVersionHeader :: IO FilePath
+locateGhcVersionHeader = locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
 
 -- | Configures the @DynFlags@ for this session to DAML-1.2
 --  compilation:
@@ -293,7 +295,8 @@ setImports paths dflags = dflags { importPaths = paths }
 setupDamlGHC :: GhcMonad m => Options -> m ()
 setupDamlGHC options@Options{..} = do
   tmpDir <- liftIO getTemporaryDirectory
-  modifyDynFlags $ adjustDynFlags options tmpDir
+  versionHeader <- liftIO locateGhcVersionHeader
+  modifyDynFlags $ adjustDynFlags options versionHeader tmpDir
 
   unless (null optGhcCustomOpts) $ do
     damlDFlags <- getSessionDynFlags

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -205,9 +205,8 @@ data CmdArgs = Damldoc
 
 exec :: CmdArgs -> IO ()
 exec Damldoc{..} = do
-    opts <- mkOptions cOptions
     runDamlDoc DamldocOptions
-        { do_ideOptions = toCompileOpts opts { optHaddock=Haddock True}
+        { do_ideOptions = toCompileOpts cOptions { optHaddock=Haddock True}
             (IdeReportProgress False)
         , do_diagsLogger = diagnosticsLogger
         , do_outputPath = cOutputPath
@@ -216,7 +215,7 @@ exec Damldoc{..} = do
         , do_inputFiles = map toNormalizedFilePath cMainFiles
         , do_docTemplate = cTemplate
         , do_transformOptions = transformOptions
-        , do_docTitle = T.pack <$> optMbPackageName opts
+        , do_docTitle = T.pack <$> optMbPackageName cOptions
         , do_combine = cCombine
         , do_extractOptions = cExtractOptions
         }

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -41,12 +41,10 @@ newtype UseColor = UseColor {getUseColor :: Bool}
 
 -- | Test a DAML file.
 execTest :: [NormalizedFilePath] -> UseColor -> Maybe FilePath -> Options -> IO ()
-execTest inFiles color mbJUnitOutput cliOptions = do
-    loggerH <- getLogger cliOptions "test"
-    opts <- mkOptions cliOptions
+execTest inFiles color mbJUnitOutput opts = do
+    loggerH <- getLogger opts "test"
     withDamlIdeState opts loggerH diagnosticsLogger $ \h -> do
-        let lfVersion = optDamlLfVersion cliOptions
-        testRun h inFiles lfVersion color mbJUnitOutput
+        testRun h inFiles (optDamlLfVersion opts) color mbJUnitOutput
         diags <- getDiagnostics h
         when (any (\(_, _, diag) -> Just DsError == _severity diag) diags) exitFailure
 

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -266,7 +266,6 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     <*> pure False
     <*> pure (Haddock False)
     <*> optCppPath
-    <*> pure Nothing
     <*> pure (IncrementalBuild False)
   where
     optImportPath :: Parser [FilePath]

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -107,7 +107,7 @@ doctestHeader =
 shouldGenerate :: [T.Text] -> [T.Text] -> Assertion
 shouldGenerate input expected = withTempFile $ \tmpFile -> do
     T.writeFileUtf8 tmpFile $ T.unlines $ testModuleHeader <> input
-    opts <- fmap (\opts -> opts{optHaddock=Haddock True}) $ defaultOptionsIO Nothing
+    let opts = (defaultOptions Nothing) {optHaddock=Haddock True}
     vfs <- makeVFSHandle
     ideState <- initialise def mainRule (pure $ LSP.IdInt 0) (const $ pure ()) noLogging (toCompileOpts opts (IdeReportProgress False)) vfs
     Just pm <- runAction ideState $ use GetParsedModule $ toNormalizedFilePath tmpFile

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -126,12 +126,12 @@ getIntegrationTests registerTODO scenarioService version = do
     let outdir = "compiler/damlc/output"
     createDirectoryIfMissing True outdir
 
-    opts <- defaultOptionsIO (Just version)
-    opts <- pure $ opts
-        { optThreads = 0
-        , optSkipScenarioValidation = SkipScenarioValidation False
-        , optCoreLinting = True
-        }
+    dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
+    let opts = (defaultOptions (Just version))
+          { optThreads = 0
+          , optCoreLinting = True
+          , optDlintUsage = DlintEnabled dlintDataDir False
+          }
 
     -- initialise the compiler service
     vfs <- makeVFSHandle

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -21,10 +21,6 @@ main = do
     setEnv "TASTY_NUM_THREADS" "1" True
     defaultMain tests
 
--- execTest will call mkOptions internally. Since each call to mkOptions
--- appends the LF version to the package db paths, it is important that we use
--- defaultOptions instead of defaultOptionsIO since the version suffix is otherwise
--- appended twice.
 opts :: Options
 opts = defaultOptions Nothing
 


### PR DESCRIPTION
`mkOptions` is a terrible API and this PR burns it with lots of :fire:.

The only thing that I didn’t simply move around is the validation
logic in `mkOptions` which validates that some directories
exist. Given that I’ve never actually see this be useful and the
options to set these directories (package dbs, import paths) are
internal I don’t think we actually gain anything from this.

I’ve also killed defaultOptionsIO which was a very confusing wrapper
around `mkOptions` that in addition to calling `mkOptions` also
enabled DLint. This was only used in tests, so I’ve enabled DLint in
the tests that need this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
