### PR TITLE
Ensure that diagnostics in buildDar are not lost

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -121,7 +121,10 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
             bytes <- BSL.readFile pSrc
             -- in the dalfInput case we interpret pSrc as the filepath pointing to the dalf.
             pure $ Just $ createArchive pkgConf "" bytes [] (toNormalizedFilePath ".") [] [] []
-        else runAction service $
+        -- We need runActionSync here to ensure that diagnostics are printed to the terminal.
+        -- Otherwise runAction can return before the diagnostics have been printed and we might die
+        -- without ever seeing diagnostics.
+        else runActionSync service $
              runMaybeT $ do
                  files <- getDamlFiles pSrc
                  opts <- lift getIdeOptions

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -449,7 +449,7 @@ tests damlc repl davlDar = testGroup "Packaging" $
             ]
           (exitCode, _, stderr) <- readProcessWithExitCode damlc ["build", "--project-root", projDir] ""
           exitCode @?= ExitFailure 1
-          assertBool ("non-exhaustive error in " <> stderr) ("non-exhaustive" `isInfixOf` stderr)
+          assertBool ("Expected \"non-exhaustive\" error in stderr but got: " <> show stderr) ("non-exhaustive" `isInfixOf` stderr)
     ] <>
     [ damlcTestTests damlc
     , lfVersionTests damlc


### PR DESCRIPTION
We have seen a couple of flaky tests runs on CI in the packaging test
caused by this. It is easy to reproduce if you add a delay in
diagnosticsLogger before printing the diagnostics which makes this
failure reproducible. With this patch, the diagnostics are always
printed even with a delay.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
