### PR TITLE
sandbox: Make sure we exit cleanly if the API server fails to start.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
@@ -29,6 +29,7 @@ object SandboxMain extends App {
     server.failure.foreach { exception =>
       logger.error(
         s"Shutting down Sandbox application due to an initialization error:\n${exception.getMessage}")
+      closeServer()
       sys.exit(1)
     }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -129,7 +129,9 @@ final class SandboxServer(config: => SandboxConfig) extends AutoCloseable {
   def failure: Option[Throwable] =
     Await
       .result(
-        sandboxState.asFuture.transformWith(Future.successful)(DirectExecutionContext),
+        sandboxState.asFuture
+          .flatMap(_.apiServer.asFuture)(DirectExecutionContext)
+          .transformWith(Future.successful)(DirectExecutionContext),
         AsyncTolerance)
       .failed
       .toOption


### PR DESCRIPTION
Previously we were only cleaning up and exiting if loading the DAML packages failed. Now we also handle API server errors.

An example of where this might happen is if the ledger ID specified is different to the existing ledger ID, causing an error.

One day we'll kill the ResetService and all of this will go away. One day…

### Changelog

- **[Sandbox]** Fix an error that stops the server from exiting cleanly if API server initialization fails.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
