### PR TITLE
Disable release step on macos

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -14,6 +14,14 @@ step() {
 
 cd "$(dirname "$0")"/..
 
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Simulating release step..."
+    echo "##vso[task.setvariable variable=has_released;isOutput=true]true"
+    echo "##vso[task.setvariable variable=release_tag]$(cat VERSION)"
+    exit 0
+fi
+
+
 step "loading dev-env"
 
 eval "$(dev-env/bin/dade assist)"
@@ -27,13 +35,6 @@ step "set up temporary location"
 release_dir="$(mktemp -d)"
 step "temporary release directory is ${release_dir}"
 
-EXTRA_ARGS=""
-
-if [[ "$(uname)" == "Darwin" ]]; then
-    EXTRA_ARGS="--ignore-missing-deps"
-fi
-
-
 if [[ "${BUILD_SOURCEBRANCHNAME:-}" == "master" ]]; then
     # set up bintray credentials
     mkdir -p ~/.jfrog
@@ -41,9 +42,9 @@ if [[ "${BUILD_SOURCEBRANCHNAME:-}" == "master" ]]; then
     unset JFROG_CONFIG_CONTENT
 
     step "run release script (with --upload)"
-    ./bazel-bin/release/release --artifacts release/artifacts.yaml --upload --log-level debug --release-dir "${release_dir}" $EXTRA_ARGS
+    ./bazel-bin/release/release --artifacts release/artifacts.yaml --upload --log-level debug --release-dir "${release_dir}"
 else
     step "run release script (dry run)"
-    ./bazel-bin/release/release --artifacts release/artifacts.yaml --log-level debug --release-dir "${release_dir}" $EXTRA_ARGS
+    ./bazel-bin/release/release --artifacts release/artifacts.yaml --log-level debug --release-dir "${release_dir}"
     step "release artifacts got stored in ${release_dir}"
 fi

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -115,7 +115,7 @@ if [ "$SKIP_JARS" -eq "0" ]; then
 
     bazel build //release:release
     tmp=$(mktemp -d)
-    "$REPO_ROOT/bazel-bin/release/release" --artifacts "$REPO_ROOT/release/artifacts.yaml" --release-dir $tmp --all-artifacts --install-head-jars
+    "$REPO_ROOT/bazel-bin/release/release" --artifacts "$REPO_ROOT/release/artifacts.yaml" --release-dir $tmp --install-head-jars
 
     mv "$REPO_ROOT/VERSION.head-build-in-progress" "$REPO_ROOT/VERSION"
     trap - EXIT

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -24,9 +24,7 @@ data Options = Options
   , optsSlackReleaseMessageFile :: Maybe FilePath
   , optsFullLogging :: Bool
   , optsLogLevel :: LogLevel
-  , optsAllArtifacts :: AllArtifacts
   , optsLocallyInstallJars :: Bool
-  , optsIgnoreMissingDeps :: IgnoreMissingDeps
   } deriving (Eq, Show)
 
 optsParser :: Parser Options
@@ -37,9 +35,7 @@ optsParser = Options
   <*> option (Just <$> str) (long "slack-release-message" <> help "if present will write out what to write in slack. if there are no releases the file will be empty" <> value Nothing)
   <*> switch (long "full-logging" <> help "full logging detail")
   <*> option readLogLevel (long "log-level" <> metavar "debug|info|warn|error (default: info)" <> help "Specify log level during release run" <> value LevelInfo )
-  <*> (AllArtifacts <$> switch (long "all-artifacts" <> help "Produce all artifacts including platform-independent artifacts on MacOS"))
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")
-  <*> (IgnoreMissingDeps <$> switch (long "ignore-missing-deps" <> help "Do not check for missing Maven dependencies"))
 
   where
     readLogLevel :: ReadM LogLevel

--- a/release/src/Types.hs
+++ b/release/src/Types.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE ConstraintKinds  #-}
 module Types (
-    AllArtifacts(..),
     ArtifactId,
     ArtifactType,
     CIException(..),
@@ -11,7 +10,6 @@ module Types (
     BintrayPackage(..),
     GitRev,
     GroupId,
-    IgnoreMissingDeps(..),
     MavenAllowUnsecureTls(..),
     MavenCoords(..),
     MavenUpload(..),
@@ -19,7 +17,6 @@ module Types (
     MonadCI,
     OS(..),
     PerformUpload(..),
-    PlatformDependent(..),
     TextVersion,
     Version(..),
     VersionChange(..),
@@ -79,22 +76,8 @@ data MavenCoords = MavenCoords
     , artifactType :: !ArtifactType
     } deriving Show
 
-newtype PlatformDependent = PlatformDependent{getPlatformDependent :: Bool}
-    deriving (Eq, Show, FromJSON)
-
 newtype MavenUpload = MavenUpload { getMavenUpload :: Bool }
     deriving (Eq, Show, FromJSON)
-
--- | If this is True, we produce all artifacts even platform independent artifacts on MacOS.
--- This is useful for testing purposes.
-newtype AllArtifacts = AllArtifacts Bool
-    deriving (Eq, Show)
-
--- | If True, we do not check for missing deps.
--- This is significantly faster and deps checking is platform independent
--- so we only run it on Linux which is usually faster than the MacOS build.
-newtype IgnoreMissingDeps = IgnoreMissingDeps { getIgnoreMissingDeps :: Bool }
-    deriving (Eq, Show)
 
 -- execution
 type MonadCI m = (MonadIO m, MonadMask m, MonadLogger m,


### PR DESCRIPTION
Originally we ran the release step on both Linux and MacOS to handle
platform dependent artifacts, in particular, damlc.jar. However, we
don’t have any platform dependent artifacts that are uploaded as part
of the release script anymore and I hope we will never have to add any
in the future.

So this PR, removes the code for handling platform dependent artifacts
in the release step and disables the release step on MacOS (while
still setting the variables like we do on Windows).

Currently the release step still costs us ~2 minutes on MacOS which is
already our slowest platform so hopefully this will speed things up a
bit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
