### PR TITLE
Move `damlc test` tests out of packaging tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -46,13 +46,14 @@ da_haskell_test(
     name = "damlc-test",
     srcs = ["src/DamlcTest.hs"],
     data = [
-        "//compiler/damlc/pkg-db",
-        "//compiler/scenario-service/server:scenario_service_jar",
+        "//compiler/damlc",
     ],
     hackage_deps = [
         "base",
+        "directory",
         "extra",
-        "ghcide",
+        "filepath",
+        "process",
         "tasty",
         "tasty-hunit",
     ],
@@ -60,8 +61,10 @@ da_haskell_test(
     src_strip_prefix = "tests",
     visibility = ["//visibility:private"],
     deps = [
+        "//:sdk-version-hs-lib",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-opts:daml-opts-types",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -451,8 +451,7 @@ tests damlc repl davlDar = testGroup "Packaging" $
           exitCode @?= ExitFailure 1
           assertBool ("Expected \"non-exhaustive\" error in stderr but got: " <> show stderr) ("non-exhaustive" `isInfixOf` stderr)
     ] <>
-    [ damlcTestTests damlc
-    , lfVersionTests damlc
+    [ lfVersionTests damlc
     , dataDependencyTests damlc repl davlDar
     ]
   where
@@ -503,56 +502,6 @@ lfVersionTests damlc = testGroup "LF version dependencies"
               assertBool ("Expected LF version <=" <> show version <> " but got " <> show (LF.packageLfVersion pkg) <> " in " <> path) $
                   LF.packageLfVersion pkg <= version
     | version <- LF.supportedOutputVersions
-    ]
-
-damlcTestTests :: FilePath -> TestTree
-damlcTestTests damlc = testGroup "damlc test" $
-    [ testCase "damlc test --files outside of project" $ withTempDir $ \projDir -> do
-          writeFileUTF8 (projDir </> "Main.daml") $ unlines
-            [ "daml 1.2"
-            , "module Main where"
-            , "test = scenario do"
-            , "  assert True"
-            ]
-          (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", projDir </> "Main.daml"] ""
-          exitCode @?= ExitSuccess
-          assertBool ("Succeeding scenario in " <> stdout) ("Main.daml:test: ok" `isInfixOf` stdout)
-          stderr @?= ""
-    ] <>
-    [ testCase ("damlc test " <> unwords (args "") <> " in project") $ withTempDir $ \projDir -> do
-          createDirectoryIfMissing True (projDir </> "a")
-          writeFileUTF8 (projDir </> "a" </> "daml.yaml") $ unlines
-            [ "sdk-version: " <> sdkVersion
-            , "name: a"
-            , "version: 0.0.1"
-            , "source: ."
-            , "dependencies: [daml-prim, daml-stdlib]"
-            ]
-          writeFileUTF8 (projDir </> "a" </> "A.daml") $ unlines
-            [ "daml 1.2 module A where"
-            , "a = 1"
-            ]
-          callProcessSilent damlc ["build", "--project-root", projDir </> "a"]
-          createDirectoryIfMissing True (projDir </> "b")
-          writeFileUTF8 (projDir </> "b" </> "daml.yaml") $ unlines
-            [ "sdk-version: " <> sdkVersion
-            , "name: b"
-            , "version: 0.0.1"
-            , "source: ."
-            , "dependencies: [daml-prim, daml-stdlib, " <> show (projDir </> "a/.daml/dist/a-0.0.1.dar") <> "]"
-            ]
-          writeFileUTF8 (projDir </> "b" </> "B.daml") $ unlines
-            [ "daml 1.2 module B where"
-            , "import A"
-            , "b = a"
-            , "test = scenario do"
-            , "  assert True"
-            ]
-          (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ("test" : "--project-root" : (projDir </> "b") : args projDir) ""
-          stderr @?= ""
-          assertBool ("Succeeding scenario in " <> stdout) ("B.daml:test: ok" `isInfixOf` stdout)
-          exitCode @?= ExitSuccess
-    | args <- [\projDir -> ["--files", projDir </> "b" </> "B.daml"], const []]
     ]
 
 darPackageIds :: FilePath -> IO [LF.PackageId]

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -4,31 +4,34 @@ module DamlcTest
    ( main
    ) where
 
-import Control.Exception
+import Control.Monad
+import Data.List.Extra
 import qualified Data.Text.Extended as T
+import System.Directory
 import System.Environment.Blank
-import System.IO.Extra
 import System.Exit
+import System.FilePath
+import System.IO.Extra
+import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import qualified DA.Cli.Damlc.Test as Damlc
-import DA.Daml.Options.Types
-import Development.IDE.Types.Location
+import DA.Bazel.Runfiles
+import SdkVersion
 
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
-    defaultMain tests
+    damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
+    defaultMain (tests damlc)
 
-opts :: Options
-opts = defaultOptions Nothing
-
-tests :: TestTree
-tests = testGroup
-    "damlc test"
+tests :: FilePath -> TestTree
+tests damlc = testGroup "damlc test" $
     [ testCase "Non-existent file" $ do
-        shouldThrow (Damlc.execTest ["foobar"] (Damlc.UseColor False) Nothing opts)
+          (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", "foobar"] ""
+          stdout @?= ""
+          assertInfixOf "does not exist" stderr
+          exitCode @?= ExitFailure 1
     , testCase "File with compile error" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -36,7 +39,10 @@ tests = testGroup
               , "module Foo where"
               , "abc"
               ]
-            shouldThrowExitFailure (Damlc.execTest [toNormalizedFilePath path] (Damlc.UseColor False) Nothing opts)
+            (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", path] ""
+            stdout @?= ""
+            assertInfixOf "Parse error" stderr
+            exitCode @?= ExitFailure 1
     , testCase "File with failing scenario" $ do
         withTempFile $ \path -> do
             T.writeFileUtf8 path $ T.unlines
@@ -44,19 +50,68 @@ tests = testGroup
               , "module Foo where"
               , "x = scenario $ assert False"
               ]
-            shouldThrowExitFailure (Damlc.execTest [toNormalizedFilePath path] (Damlc.UseColor False) Nothing opts)
+            (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", path] ""
+            stdout @?= ""
+            assertInfixOf "Scenario execution failed" stderr
+            exitCode @?= ExitFailure 1
+    , testCase "damlc test --files outside of project" $ withTempDir $ \projDir -> do
+          writeFileUTF8 (projDir </> "Main.daml") $ unlines
+            [ "daml 1.2"
+            , "module Main where"
+            , "test = scenario do"
+            , "  assert True"
+            ]
+          (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", projDir </> "Main.daml"] ""
+          exitCode @?= ExitSuccess
+          assertBool ("Succeeding scenario in " <> stdout) ("Main.daml:test: ok" `isInfixOf` stdout)
+          stderr @?= ""
+    ] <>
+    [ testCase ("damlc test " <> unwords (args "") <> " in project") $ withTempDir $ \projDir -> do
+          createDirectoryIfMissing True (projDir </> "a")
+          writeFileUTF8 (projDir </> "a" </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: a"
+            , "version: 0.0.1"
+            , "source: ."
+            , "dependencies: [daml-prim, daml-stdlib]"
+            ]
+          writeFileUTF8 (projDir </> "a" </> "A.daml") $ unlines
+            [ "daml 1.2 module A where"
+            , "a = 1"
+            ]
+          callProcessSilent damlc ["build", "--project-root", projDir </> "a"]
+          createDirectoryIfMissing True (projDir </> "b")
+          writeFileUTF8 (projDir </> "b" </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: b"
+            , "version: 0.0.1"
+            , "source: ."
+            , "dependencies: [daml-prim, daml-stdlib, " <> show (projDir </> "a/.daml/dist/a-0.0.1.dar") <> "]"
+            ]
+          writeFileUTF8 (projDir </> "b" </> "B.daml") $ unlines
+            [ "daml 1.2 module B where"
+            , "import A"
+            , "b = a"
+            , "test = scenario do"
+            , "  assert True"
+            ]
+          (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ("test" : "--project-root" : (projDir </> "b") : args projDir) ""
+          stderr @?= ""
+          assertBool ("Succeeding scenario in " <> stdout) ("B.daml:test: ok" `isInfixOf` stdout)
+          exitCode @?= ExitSuccess
+    | args <- [\projDir -> ["--files", projDir </> "b" </> "B.daml"], const []]
     ]
 
-shouldThrowExitFailure :: IO () -> IO ()
-shouldThrowExitFailure a = do
-    r <- try a
-    case r of
-        Left (ExitFailure _) -> pure ()
-        _ -> assertFailure "Expected program to fail with non-zero exit code."
+-- | Only displays stdout and stderr on errors
+-- TODO Move this in a shared testing-utils library
+callProcessSilent :: FilePath -> [String] -> IO ()
+callProcessSilent cmd args = do
+    (exitCode, out, err) <- readProcessWithExitCode cmd args ""
+    unless (exitCode == ExitSuccess) $ do
+      hPutStrLn stderr $ "Failure: Command \"" <> cmd <> " " <> unwords args <> "\" exited with " <> show exitCode
+      hPutStrLn stderr $ unlines ["stdout:", out]
+      hPutStrLn stderr $ unlines ["stderr: ", err]
+      exitFailure
 
-shouldThrow :: IO () -> IO ()
-shouldThrow a = do
-    r <- try a
-    case r of
-        Left (_ :: SomeException) -> pure ()
-        Right _ -> assertFailure "Expected program to throw an IOException."
+assertInfixOf :: String -> String -> Assertion
+assertInfixOf needle haystack = assertBool ("Expected " <> show needle <> " in output but but got " <> show haystack) (needle `isInfixOf` haystack)


### PR DESCRIPTION
The packaging tests are already one of our slowest test suites and
damlc test takes quite a while since it has to spin up the scenario
service.

We already have tests for damlc tests so this PR moves the tests from
the packaging test suite that are specific to `damlc test` to those
tests which should balance things a bit better.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
