### PR TITLE
Engine: scenario runner prefixes fresh nodeIds and contractIds with #

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -448,7 +448,7 @@ prettyLocation world (Location mbPkgId modName sline scol eline _ecol _definitio
 
 prettyTxId :: Int32 -> Doc SyntaxClass
 prettyTxId txid =
-  linkToIdSC ("n" <> TE.show txid) $ char '#' <> string (show txid)
+  linkToIdSC ("n" <> TE.show txid) $ string (show txid)
 
 linkToIdSC :: T.Text -> Doc SyntaxClass -> Doc SyntaxClass
 linkToIdSC targetId =
@@ -462,15 +462,15 @@ prettyNodeId :: NodeId -> Doc SyntaxClass
 prettyNodeId (NodeId nodeId) =
     idSC ("n" <> TL.toStrict nodeId)
   $ annotateSC ConstructorSC
-  $ char '#' <> text (TL.toStrict nodeId)
+  $ text (TL.toStrict nodeId)
 
 prettyNodeIdLink :: NodeId -> Doc SyntaxClass
 prettyNodeIdLink (NodeId nodeId) =
-  linkToIdSC ("n" <> TL.toStrict nodeId) $ char '#' <> text (TL.toStrict nodeId)
+  linkToIdSC ("n" <> TL.toStrict nodeId) $ text (TL.toStrict nodeId)
 
 prettyContractId :: TL.Text -> Doc SyntaxClass
 prettyContractId coid =
-  linkToIdSC ("n" <> TL.toStrict coid) $ char '#' <> ltext coid
+  linkToIdSC ("n" <> TL.toStrict coid) $ ltext coid
 
 linkSC :: T.Text -> T.Text -> Doc SyntaxClass -> Doc SyntaxClass
 linkSC url title = annotateSC (LinkSC url title)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -328,7 +328,7 @@ object Pretty {
   }
 
   def prettyLedgerNodeId(n: L.ScenarioNodeId): Doc =
-    char('#') + text(n)
+    text(n)
 
   def prettyContractInst(coinst: ContractInst[Transaction.Value[ContractId]]): Doc =
     (prettyIdentifier(coinst.template) / text("with:") &
@@ -339,14 +339,14 @@ object Pretty {
 
   def prettyContractId(coid: ContractId): Doc =
     coid match {
-      case AbsoluteContractId(acoid) => char('#') + text(acoid)
-      case RelativeContractId(rcoid, _) => char('#') + str(rcoid)
+      case AbsoluteContractId(acoid) => text(acoid)
+      case RelativeContractId(rcoid, _) => str(rcoid)
     }
 
   def prettyActiveContracts(c: L.LedgerData): Doc = {
     def ltNodeId(a: AbsoluteContractId, b: AbsoluteContractId): Boolean = {
-      val ap = a.coid.split(':')
-      val bp = b.coid.split(':')
+      val ap = a.coid.drop(1).split(':')
+      val bp = b.coid.drop(1).split(':')
       Try(ap(0).toInt < bp(0).toInt || (ap(0).toInt == bp(0).toInt && ap(1).toInt < bp(1).toInt))
         .getOrElse(false)
     }
@@ -416,7 +416,7 @@ object Pretty {
         }) +
           text(constructor)
       case ValueText(t) => char('"') + text(t) + char('"')
-      case ValueContractId(AbsoluteContractId(acoid)) => char('#') + text(acoid)
+      case ValueContractId(AbsoluteContractId(acoid)) => text(acoid)
       case ValueContractId(RelativeContractId(rcoid, _)) =>
         char('~') + text(rcoid.toString)
       case ValueUnit => text("<unit>")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -62,12 +62,13 @@ object Ledger {
     crash(s"Not expecting to find a contract id here, but found '$cid'")
 
   private val `:` = LedgerString.assertFromString(":")
+  private val `#` = LedgerString.assertFromString("#")
 
   case class ScenarioTransactionId(index: Int) extends Ordered[ScenarioTransactionId] {
     def next: ScenarioTransactionId = ScenarioTransactionId(index + 1)
     val id: TransactionIdString = TransactionIdString.fromLong(index.toLong)
     override def compare(that: ScenarioTransactionId): Int = index compare that.index
-    def makeCommitPrefix: LedgerString = LedgerString.concat(id, `:`)
+    def makeCommitPrefix: LedgerString = LedgerString.concat(`#`, id, `:`)
   }
 
   /** Errors */

--- a/daml-lf/tests/scenario/daml-1.dev/no-contract-ids-in-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/daml-1.dev/no-contract-ids-in-keys/EXPECTED.ledger
@@ -1,1 +1,1 @@
-Error: CRASH: Unexpected contract id in key: AbsoluteContractId(0:0)
+Error: CRASH: Unexpected contract id in key: AbsoluteContractId(#0:0)


### PR DESCRIPTION
The scenario runner prefixes `nodeId` and `contractId` with '#'. 
With this, we avoid the users of the scenario runner to consistently prefix those ids on their own.

This advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
