### PR TITLE
daml-lf: drop TransactionIdString

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -191,8 +191,4 @@ object Ref {
   val ContractIdString: LedgerString.type = LedgerString
   type ContractIdString = ContractIdString.T
 
-  /** Identifiers for transactions. */
-  val TransactionIdString: LedgerString.type = LedgerString
-  type TransactionIdString = TransactionIdString.T
-
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -65,7 +65,7 @@ object Ledger {
 
   case class ScenarioTransactionId(index: Int) extends Ordered[ScenarioTransactionId] {
     def next: ScenarioTransactionId = ScenarioTransactionId(index + 1)
-    val id: TransactionIdString = TransactionIdString.fromLong(index.toLong)
+    val id: LedgerString = LedgerString.fromLong(index.toLong)
     override def compare(that: ScenarioTransactionId): Int = index compare that.index
     def makeCommitPrefix: LedgerString = LedgerString.concat(id, `:`)
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/package.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/package.scala
@@ -22,4 +22,7 @@ package object ledger {
   val EventId: LedgerString.type = LedgerString
   type EventId = EventId.T
 
+  val TransactionId: LedgerString.type = LedgerString
+  type TransactionId = LedgerString.T
+
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -235,7 +235,7 @@ object domain {
 
   sealed trait TransactionIdTag
 
-  type TransactionId = Ref.TransactionIdString @@ TransactionIdTag
+  type TransactionId = Ref.LedgerString @@ TransactionIdTag
   val TransactionId: Tag.TagOf[TransactionIdTag] = Tag.of[TransactionIdTag]
 
   sealed trait ContractIdTag

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -64,8 +64,8 @@ package object v1 {
   type ParticipantId = Ref.LedgerString
 
   /** Identifiers for transactions. */
-  val TransactionIdString: Ref.TransactionIdString.type = Ref.TransactionIdString
-  type TransactionId = Ref.TransactionIdString
+  val TransactionId: Ref.LedgerString.type = Ref.LedgerString
+  type TransactionId = Ref.LedgerString
 
   /** Identifiers used to correlate submission with results. */
   val CommandId: Ref.LedgerString.type = Ref.LedgerString

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.platform.events
 
-import com.digitalasset.daml.lf.data.Ref.{LedgerString, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.LedgerString
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.types.Ledger
 import com.digitalasset.daml.lf.value.{Value => Lf}
@@ -14,9 +14,9 @@ object EventIdFormatter {
   private val `#` = LedgerString.assertFromString("#")
   private val `:` = LedgerString.assertFromString(":")
 
-  case class TransactionIdWithIndex(transactionId: TransactionIdString, nodeId: Transaction.NodeId)
+  case class TransactionIdWithIndex(transactionId: LedgerString, nodeId: Transaction.NodeId)
 
-  def makeAbsCoid(transactionId: TransactionIdString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
+  def makeAbsCoid(transactionId: LedgerString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
     coid match {
       case a @ Lf.AbsoluteContractId(_) => a
       case Lf.RelativeContractId(txnid, _) =>
@@ -24,14 +24,14 @@ object EventIdFormatter {
     }
 
   // this method defines the EventId format used by the sandbox
-  def fromTransactionId(transactionId: TransactionIdString, nid: Transaction.NodeId): LedgerString =
+  def fromTransactionId(transactionId: LedgerString, nid: Transaction.NodeId): LedgerString =
     fromTransactionId(transactionId, nid.name)
 
   /** When loading a scenario we get already absolute nids from the ledger -- still prefix them with the transaction
     * id, just to be safe.
     */
   def fromTransactionId(
-      transactionId: TransactionIdString,
+      transactionId: LedgerString,
       nid: Ledger.ScenarioNodeId,
   ): LedgerString =
     LedgerString.concat(`#`, transactionId, `:`, nid)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -8,13 +8,13 @@ import akka.stream.scaladsl.Source
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1.Configuration
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
+import com.digitalasset.ledger.api.domain.{LedgerId, TransactionId, PartyDetails}
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.platform.metrics.timedFuture
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
@@ -65,7 +65,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     timedFuture(Metrics.lookupKey, ledger.lookupKey(key, forParty))
 
   override def lookupTransaction(
-      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
     timedFuture(Metrics.lookupTransaction, ledger.lookupTransaction(transactionId))
 
   override def parties: Future[List[PartyDetails]] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -6,14 +6,14 @@ package com.digitalasset.platform.sandbox.stores
 import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.AbsoluteContractInst
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.ledger.api.domain.PartyDetails
-import com.digitalasset.ledger.{EventId, WorkflowId}
+import com.digitalasset.ledger.{EventId, TransactionId, WorkflowId}
 import com.digitalasset.platform.store.Contract.{ActiveContract, DivulgedContract}
 import com.digitalasset.platform.store.{
   ActiveLedgerState,
@@ -107,7 +107,7 @@ case class InMemoryActiveLedgerState(
     copy(parties = newParties.map(p => p -> PartyDetails(p, None, isLocal = true)).toMap ++ parties)
 
   override def divulgeAlreadyCommittedContracts(
-      transactionId: TransactionIdString,
+      transactionId: TransactionId,
       global: Relation[AbsoluteContractId, Party],
       referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)])
     : InMemoryActiveLedgerState =
@@ -156,7 +156,7 @@ case class InMemoryActiveLedgerState(
     */
   def addTransaction(
       let: Instant,
-      transactionId: TransactionIdString,
+      transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
       transaction: GenTransaction.WithTxValue[EventId, AbsoluteContractId],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -207,8 +207,7 @@ object ScenarioLoader {
     }
   }
 
-  private val transactionIdPrefix =
-    Ref.TransactionIdString.assertFromString(s"scenario-transaction-")
+  private val transactionIdPrefix = Ref.LedgerString.assertFromString(s"scenario-transaction-")
   private val workflowIdPrefix = Ref.LedgerString.assertFromString(s"scenario-workflow-")
   private val scenarioLoader = Ref.LedgerString.assertFromString("scenario-loader")
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/LedgerEntries.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.digitalasset.daml.lf.data.Ref.TransactionIdString
+import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.RangeSource
 import org.slf4j.LoggerFactory
@@ -69,8 +69,8 @@ private[ledger] class LedgerEntries[T](identify: T => String) {
 
   def ledgerEnd: Long = state.get().ledgerEnd
 
-  def toTransactionId: TransactionIdString =
-    TransactionIdString.assertFromString(ledgerEnd.toString)
+  def toLedgerString: Ref.LedgerString =
+    Ref.LedgerString.fromLong(ledgerEnd)
 
   def getEntryAt(offset: Long): Option[T] =
     state.get.items.get(offset)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerState.scala
@@ -6,11 +6,12 @@ package com.digitalasset.platform.store
 import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.AbsoluteContractInst
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.ledger.TransactionId
 import com.digitalasset.platform.store.Contract.ActiveContract
 
 sealed abstract class LetLookup
@@ -66,7 +67,7 @@ trait ActiveLedgerState[+Self] { this: ActiveLedgerState[Self] =>
     * method.
     */
   def divulgeAlreadyCommittedContracts(
-      transactionId: TransactionIdString,
+      transactionId: TransactionId,
       global: Relation[AbsoluteContractId, Party],
       referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)]): Self
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -6,13 +6,13 @@ package com.digitalasset.platform.store
 import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.AbsoluteContractInst
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Node => N}
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
-import com.digitalasset.ledger.{EventId, WorkflowId}
+import com.digitalasset.ledger.{EventId, TransactionId, WorkflowId}
 import com.digitalasset.platform.events.EventIdFormatter
 import com.digitalasset.platform.store.Contract.ActiveContract
 import com.digitalasset.platform.store.SequencingError.PredicateType.{Exercise, Fetch}
@@ -68,7 +68,7 @@ class ActiveLedgerStateManager[ALS](initialState: => ALS)(
     */
   def addTransaction(
       let: Instant,
-      transactionId: TransactionIdString,
+      transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
       transaction: GenTransaction.WithTxValue[EventId, AbsoluteContractId],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -8,14 +8,14 @@ import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.v1.Configuration
 import com.digitalasset.daml.lf.archive.Decode
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.domain.LedgerId
+import com.digitalasset.ledger.api.domain.{LedgerId, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.RangeSource
@@ -80,9 +80,9 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
       .lookupActiveOrDivulgedContract(contractId, forParty)
 
   override def lookupTransaction(
-      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]] =
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
     ledgerDao
-      .lookupTransaction(transactionId)
+      .lookupTransaction(TransactionId.unwrap(transactionId))
 
   override def parties: Future[List[domain.PartyDetails]] =
     ledgerDao.getParties

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Contract.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Contract.scala
@@ -5,11 +5,11 @@ package com.digitalasset.platform.store
 
 import java.time.Instant
 
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.transaction.Node.KeyWithMaintainers
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst, VersionedValue}
-import com.digitalasset.ledger.{EventId, WorkflowId}
+import com.digitalasset.ledger.{EventId, TransactionId, WorkflowId}
 
 /** A contract that is part of the [[ActiveLedgerState]].
   * Depending on where the contract came from, other metadata may be available.
@@ -20,13 +20,13 @@ sealed abstract class Contract {
   def contract: ContractInst[VersionedValue[AbsoluteContractId]]
 
   /** For each party, the transaction id at which the contract was divulged */
-  def divulgences: Map[Party, TransactionIdString]
+  def divulgences: Map[Party, TransactionId]
 
   /** Returns the new divulgences after the contract has been divulged to the given parties at the given transaction */
   def divulgeTo(
       parties: Set[Party],
-      transactionId: TransactionIdString
-  ): Map[Party, TransactionIdString] =
+      transactionId: TransactionId
+  ): Map[Party, TransactionId] =
     parties.foldLeft(divulgences)((m, e) => if (m.contains(e)) m else m + (e -> transactionId))
 }
 
@@ -42,7 +42,7 @@ object Contract {
       id: Value.AbsoluteContractId,
       contract: ContractInst[VersionedValue[AbsoluteContractId]],
       /** For each party, the transaction id at which the contract was divulged */
-      divulgences: Map[Party, TransactionIdString],
+      divulgences: Map[Party, TransactionId],
   ) extends Contract
 
   /**
@@ -51,12 +51,12 @@ object Contract {
   final case class ActiveContract(
       id: Value.AbsoluteContractId,
       let: Instant, // time when the contract was committed
-      transactionId: TransactionIdString, // transaction id where the contract originates
+      transactionId: TransactionId, // transaction id where the contract originates
       eventId: EventId,
       workflowId: Option[WorkflowId], // workflow id from where the contract originates
       contract: ContractInst[VersionedValue[AbsoluteContractId]],
       witnesses: Set[Party],
-      divulgences: Map[Party, TransactionIdString], // for each party, the transaction id at which the contract was divulged
+      divulgences: Map[Party, TransactionId], // for each party, the transaction id at which the contract was divulged
       key: Option[KeyWithMaintainers[VersionedValue[Nothing]]],
       signatories: Set[Party],
       observers: Set[Party],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -7,13 +7,13 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1.Configuration
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
+import com.digitalasset.ledger.api.domain.{LedgerId, TransactionId, PartyDetails}
 import com.digitalasset.ledger.api.health.ReportsHealth
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.store.entries.{
@@ -45,7 +45,7 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
   def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]]
 
   def lookupTransaction(
-      transactionId: TransactionIdString): Future[Option[(Long, LedgerEntry.Transaction)]]
+      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]]
 
   // Party management
   def parties: Future[List[PartyDetails]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -21,13 +21,7 @@ import com.daml.ledger.participant.state.v1.{
   TransactionId
 }
 import com.digitalasset.daml.lf.archive.Decode
-import com.digitalasset.daml.lf.data.Ref.{
-  ContractIdString,
-  LedgerString,
-  PackageId,
-  Party,
-  TransactionIdString
-}
+import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString, PackageId, Party}
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.transaction.Node.{GlobalKey, KeyWithMaintainers}
@@ -818,7 +812,7 @@ private class JdbcLedgerDao(
         }
 
         override def divulgeAlreadyCommittedContracts(
-            transactionId: TransactionIdString,
+            transactionId: TransactionId,
             global: Relation[AbsoluteContractId, Party],
             divulgedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)])
           : AcsStoreAcc = {
@@ -1094,7 +1088,7 @@ private class JdbcLedgerDao(
 
   case class ParsedEntry(
       typ: String,
-      transactionId: Option[TransactionIdString],
+      transactionId: Option[TransactionId],
       commandId: Option[CommandId],
       applicationId: Option[ApplicationId],
       submitter: Option[Party],
@@ -1282,7 +1276,7 @@ private class JdbcLedgerDao(
   private def mapContractDetails(
       contractResult: (
           ContractIdString,
-          Option[TransactionIdString],
+          Option[LedgerString],
           Option[EventId],
           Option[WorkflowId],
           Option[Date],
@@ -1360,7 +1354,7 @@ private class JdbcLedgerDao(
       .toSet
 
   private def lookupDivulgences(coid: String)(
-      implicit conn: Connection): Map[Party, TransactionIdString] =
+      implicit conn: Connection): Map[Party, TransactionId] =
     SQL_SELECT_DIVULGENCE
       .on("contract_id" -> coid)
       .as(DivulgenceParser.*)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
@@ -5,7 +5,7 @@ package com.digitalasset.platform.store.entries
 
 import java.time.Instant
 
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
@@ -26,7 +26,7 @@ object LedgerEntry {
 
   final case class Transaction(
       commandId: Option[CommandId],
-      transactionId: TransactionIdString,
+      transactionId: TransactionId,
       applicationId: Option[ApplicationId],
       submittingParty: Option[Party],
       workflowId: Option[WorkflowId],

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -12,8 +12,8 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import anorm.SqlParser._
 import anorm.{BatchSql, Macro, NamedParameter, RowParser, SQL, SqlParser}
-import com.daml.ledger.participant.state.v1.AbsoluteContractInst
-import com.digitalasset.daml.lf.data.Ref.{Party, TransactionIdString}
+import com.daml.ledger.participant.state.v1.{AbsoluteContractInst, TransactionId}
+import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.engine.Blinding
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
@@ -367,7 +367,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
         }
 
         override def divulgeAlreadyCommittedContracts(
-            transactionId: TransactionIdString,
+            transactionId: TransactionId,
             global: Relation[AbsoluteContractId, Party],
             referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)]) = {
           val divulgenceParams = global
@@ -488,7 +488,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
 
   case class ParsedEntry(
       typ: String,
-      transactionId: Option[TransactionIdString],
+      transactionId: Option[TransactionId],
       commandId: Option[CommandId],
       applicationId: Option[ApplicationId],
       submitter: Option[Party],

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/events/EventIdFormatterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/events/EventIdFormatterSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.{Matchers, WordSpec}
 class EventIdFormatterSpec extends WordSpec with Matchers with ScalaFutures {
 
   "EventIdFormatter" should {
-    val transactionId: Ref.TransactionIdString = Ref.TransactionIdString.fromInt(42)
+    val transactionId: Ref.LedgerString = Ref.LedgerString.fromInt(42)
     val index: Transaction.NodeId = Transaction.NodeId(42)
     val referenceEventID = s"#$transactionId:${index.index}"
 


### PR DESCRIPTION
In this PR we drop the type `TransactionIdString` which was not properly use anyway. 
In the same time we clean a bit the usage of `TransactionId` in the ledger

this advances the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
