### PR TITLE
Update to Bazel 2.0.0

### DIFF
--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -1,12 +1,12 @@
 {
   "homepage": "https://bazel.build",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-windows-x86_64.zip",
-      "hash": "6ef3b5756ba9d8b26fc599884800aa9c55948478f9574540acba7112e0329db2"
+      "url": "https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-windows-x86_64.zip",
+      "hash": "83d0e987fa84ac5085c1fe1cc8fd36f5c2bd7b0a3e84b346c2093b19cfa35a57"
     }
   },
   "depends": [

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -53,7 +53,14 @@ let shared = rec {
 
   sass = pkgs.sass;
 
-  sphinx183 = pkgs.python3Packages.sphinx;
+  # sphinx 2.2.2 causes build failures of //docs:pdf-docs.
+  sphinx183 = pkgs.python3Packages.sphinx.overridePythonAttrs (attrs: rec {
+    version = "1.8.3";
+    src = attrs.src.override {
+      inherit version;
+      sha256 = "c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8";
+    };
+  });
 
   # Custom combination of latex packages for our latex needs
   texlive = pkgs.texlive.combine {

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -17,6 +17,7 @@ let
         sha256 = "1jcyd9jy7kz5zfch25s4inwlivb1y1w52fzfjy5ra5vcnp3hmqyr";
         fetchSubmodules = true;
       };
+      patches = [];
     });
     ephemeralpg = pkgs.ephemeralpg.overrideAttrs(oldAttrs: {
       installPhase = ''

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -17,6 +17,8 @@ let
         sha256 = "1jcyd9jy7kz5zfch25s4inwlivb1y1w52fzfjy5ra5vcnp3hmqyr";
         fetchSubmodules = true;
       };
+      # Upstream nixpkgs applies patches that are incompatbile with our version
+      # of grpc. So, we disable them.
       patches = [];
     });
     ephemeralpg = pkgs.ephemeralpg.overrideAttrs(oldAttrs: {

--- a/nix/nixpkgs/default.src.json
+++ b/nix/nixpkgs/default.src.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
-  "rev": "efce3c1367d1b3227cef8854d520d888d9c482d1",
-  "sha256": "0hsgp802829k04ryga7ny6vf75bllpmn530v4y4f66n454i4kzfa"
+  "rev": "42a195919a10ce70309c3666dfe8206e380fae1b",
+  "sha256": "1iy3iz91xx58k9wgswalipa8gxxdafqq82lisg6s16ml8y232f00"
 }


### PR DESCRIPTION
- Updates Bazel in the Windows dev-env
- Updates nixpkgs to update Bazel
- Pin sphinx at 1.8.3 as the new 2.2.2 in nixpkgs causes build failures in `//docs:pdf-docs`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
