### PR TITLE
fix ci alerts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,15 @@ jobs:
     steps:
       - bash: |
           set -euo pipefail
-          echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse 'HEAD^2')"
-          echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse 'HEAD^1')"
-          echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git merge-base --fork-point 'HEAD^1' 'HEAD^2')"
+          if [ "$(Build.Reason)" == "PullRequest" ]; then
+              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse 'HEAD^2')"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse 'HEAD^1')"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git merge-base --fork-point 'HEAD^1' 'HEAD^2')"
+          else
+              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse HEAD)"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD)"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git rev-parse HEAD)"
+          fi
         name: out
 
   - job: check_standard_change_label
@@ -491,7 +497,7 @@ jobs:
           PR_BRANCH: $(pr.branch)
 
   - job: notify_user
-    condition: always()
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     dependsOn:
       - git_sha
       - collect_build_data
@@ -515,7 +521,7 @@ jobs:
               curl -XPOST \
                    -i \
                    -H 'Content-Type: application/json' \
-                   --data "{\"text\":\"<@${USER_ID}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pulls/$(pr.num)|PR $(pr.num)> has completed with status ${MESSAGE}.\"}" \
+                   --data "{\"text\":\"<@${USER_ID}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has completed with status ${MESSAGE}.\"}" \
                    $(Slack.team-daml-ci)
           }
 


### PR DESCRIPTION
PR #4286 introduced new jobs that do not work well when ran against the master branch, rather than as part of a PR. This hopefully fixes that, though it's hard to test for obvious reasons.

CHANGELOG_BEGIN
CHANGELOG_END