### PR TITLE
daml2ts: Import modules referenced by key types

### DIFF
--- a/language-support/ts/codegen/tests/daml/T.daml
+++ b/language-support/ts/codegen/tests/daml/T.daml
@@ -7,3 +7,10 @@ template T with
     party: Party
   where
     signatory party
+
+    -- This key expression is interesting because it is the only place in this
+    -- module where we reference the module defining the `Tuple2` type. Thus,
+    -- this test would if we forgot to import modules only refernced by key
+    -- types.
+    key (party, party): (Party, Party)
+    maintainer key._1


### PR DESCRIPTION
Currently, we're not tracking references from key types. This becomes a
problem if the key is the only place referencing a module.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4362)
<!-- Reviewable:end -->
