### PR TITLE
Make Transaction/Node/VersionnedValue mapContractId LF private

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -228,19 +228,14 @@ final class Engine {
 
   // A safe cast of a value to a value which uses only absolute contract IDs.
   // In particular, the cast will succeed for all values contained in the root nodes of a Transaction produced by submit
-  private[this] def asValueWithAbsoluteContractIds[Cid](
-      v: Value[Cid]): Result[Value[Value.AbsoluteContractId]] =
-    try {
-      ResultDone(
-        v.mapContractId {
-          case rcoid: Value.RelativeContractId =>
-            throw ValidationError(s"unexpected relative contract id $rcoid")
-          case acoid: Value.AbsoluteContractId => acoid
-        }
+  private[this] def asValueWithAbsoluteContractIds(
+      v: Value[Value.ContractId]
+  ): Result[Value[Value.AbsoluteContractId]] =
+    v.ensureNoRelCid
+      .fold(
+        rcoid => ResultError(ValidationError(s"unexpected relative contract id $rcoid")),
+        ResultDone(_)
       )
-    } catch {
-      case err: ValidationError => ResultError(err)
-    }
 
   private[this] def asAbsoluteContractId(coid: Value.ContractId): Result[Value.AbsoluteContractId] =
     coid match {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -90,8 +90,9 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create RangeOfInts",
         seed = hash("testLargeTransactionOneContract:create", txSize))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(_, x, _, _, _, _, _) =>
-        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
+        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+      case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListContainerExerciseCmd(rangeOfIntsTemplateId, contractId)
@@ -118,8 +119,9 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create RangeOfInts",
         seed = hash("testLargeTransactionManySmallContracts:create", num))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(_, x, _, _, _, _, _) =>
-        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
+        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+      case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListOfIntContainers(rangeOfIntsTemplateId, contractId)
@@ -146,8 +148,9 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create ListUtil",
         seed = hash("testLargeChoiceArgument:create", size))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(_, x, _, _, _, _, _) =>
-        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
+        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+      case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = sizeExerciseCmd(listUtilTemplateId, contractId)(size)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -1,0 +1,123 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+package value
+
+import com.digitalasset.daml.lf.data.Ref
+
+import scala.language.higherKinds
+import scala.util.control.NoStackTrace
+
+sealed trait CidMapper[-A1, +A2, Fun] {
+
+  def map(f: Fun): A1 => A2
+
+}
+
+object CidMapper {
+
+  def trivialMapper[X, Fun]: CidMapper[X, X, Fun] =
+    new CidMapper[X, X, Fun] {
+      override def map(f: Fun): X => X = identity
+    }
+
+  private[value] def basicInstance[Cid1, Cid2]: CidMapper[Cid1, Cid2, Cid1 => Cid2] =
+    new CidMapper[Cid1, Cid2, Cid1 => Cid2] {
+      override def map(f: Cid1 => Cid2): Cid1 => Cid2 = f
+    }
+
+  type RelCidResolverMapper[-A1, +A2] =
+    CidMapper[A1, A2, Value.ContractId => Value.AbsoluteContractId]
+
+  type NoCidMapper[-A1, +A2] = CidMapper[A1, A2, Value.ContractId => Nothing]
+
+  type NoRelCidMapper[-A1, +A2] = CidMapper[A1, A2, Value.ContractId => Value.AbsoluteContractId]
+
+}
+
+trait CidContainer[+A] {
+
+  import CidMapper._
+
+  protected val self: A
+
+  def resolveRelCid[B](f: Value.RelativeContractId => Ref.ContractIdString)(
+      implicit mapper: RelCidResolverMapper[A, B],
+  ): B =
+    mapper.map({
+      case acoid: Value.AbsoluteContractId => acoid
+      case rcoid: Value.RelativeContractId => Value.AbsoluteContractId(f(rcoid))
+    })(self)
+
+  def ensureNoCid[B](
+      implicit mapper: NoCidMapper[A, B]
+  ): Either[Value.ContractId, B] = {
+    case class Ball(x: Value.ContractId) extends Throwable with NoStackTrace
+    try {
+      Right(mapper.map(coid => throw Ball(coid))(self))
+    } catch {
+      case Ball(coid) => Left(coid)
+    }
+  }
+
+  def assertNoCid[B](message: Value.ContractId => String)(
+      implicit mapper: NoCidMapper[A, B]
+  ): B =
+    data.assertRight(ensureNoCid.left.map(message))
+
+  def ensureNoRelCid[B](
+      implicit mapper: NoRelCidMapper[A, B]
+  ): Either[Value.RelativeContractId, B] = {
+    case class Ball(x: Value.RelativeContractId) extends Throwable with NoStackTrace
+    try {
+      Right(mapper.map({
+        case acoid: Value.AbsoluteContractId => acoid
+        case rcoid: Value.RelativeContractId => throw Ball(rcoid)
+      })(self))
+    } catch {
+      case Ball(coid) => Left(coid)
+    }
+  }
+
+  def assertNoRelCid[B](message: Value.ContractId => String)(
+      implicit mapper: NoRelCidMapper[A, B]
+  ): B =
+    data.assertRight(ensureNoRelCid.left.map(message))
+
+}
+
+trait CidContainer1[F[_]] {
+
+  private[lf] def map1[A, B](f: A => B): F[A] => F[B]
+
+  final implicit def cidMapperInstance[A1, A2, Fun](
+      implicit mapper: CidMapper[A1, A2, Fun]
+  ): CidMapper[F[A1], F[A2], Fun] =
+    new CidMapper[F[A1], F[A2], Fun] {
+      override def map(f: Fun): F[A1] => F[A2] =
+        map1[A1, A2](mapper.map(f))
+    }
+
+}
+
+trait CidContainer3[F[_, _, _]] {
+
+  private[lf] def map3[A1, B1, C1, A2, B2, C2](
+      f1: A1 => A2,
+      f2: B1 => B2,
+      f3: C1 => C2,
+  ): F[A1, B1, C1] => F[A2, B2, C2]
+
+  final implicit def cidMapperInstance[A1, B1, C1, A2, B2, C2, Fun](
+      implicit mapper1: CidMapper[A1, A2, Fun],
+      mapper2: CidMapper[B1, B2, Fun],
+      mapper3: CidMapper[C1, C2, Fun],
+  ): CidMapper[F[A1, B1, C1], F[A2, B2, C2], Fun] =
+    new CidMapper[F[A1, B1, C1], F[A2, B2, C2], Fun] {
+      override def map(f: Fun): F[A1, B1, C1] => F[A2, B2, C2] = {
+        map3[A1, B1, C1, A2, B2, C2](mapper1.map(f), mapper2.map(f), mapper3.map(f))
+      }
+    }
+
+}

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -332,7 +332,7 @@ class TransactionCoderSpec
       }
 
   private def changeAllValueVersions(tx: Tx.Transaction, ver: ValueVersion): Tx.Transaction =
-    tx.mapContractIdAndValue(identity, _.copy(version = ver))
+    tx.map3(identity, identity, _.copy(version = ver))
 
   def withoutExerciseResult[Nid, Cid, Val](gn: GenNode[Nid, Cid, Val]): GenNode[Nid, Cid, Val] =
     gn match {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -22,19 +22,19 @@ class TransactionVersionSpec extends WordSpec with Matchers {
     }
 
     "pick version 2 when confronted with newer data" in {
-      val usingOptional = dummyCreateTransaction mapContractIdAndValue (identity, v =>
+      val usingOptional = dummyCreateTransaction map3 (identity, identity, v =>
         ValueOptional(Some(v)): Value[String])
       assignVersion(assignValueVersions(usingOptional)) shouldBe TransactionVersion("2")
     }
 
     "pick version 7 when confronted with exercise result" in {
-      val hasExerciseResult = dummyExerciseWithResultTransaction mapContractIdAndValue (identity, v =>
+      val hasExerciseResult = dummyExerciseWithResultTransaction map3 (identity, identity, v =>
         ValueOptional(Some(v)): Value[String])
       assignVersion(assignValueVersions(hasExerciseResult)) shouldBe TransactionVersion("7")
     }
 
     "pick version 2 when confronted with exercise result" in {
-      val hasExerciseResult = dummyExerciseTransaction mapContractIdAndValue (identity, v =>
+      val hasExerciseResult = dummyExerciseTransaction map3 (identity, identity, v =>
         ValueOptional(Some(v)): Value[String])
       assignVersion(assignValueVersions(hasExerciseResult)) shouldBe TransactionVersion("2")
     }
@@ -44,7 +44,7 @@ class TransactionVersionSpec extends WordSpec with Matchers {
   private[this] def assignValueVersions[Nid, Cid, Cid2](
       t: GenTransaction[Nid, Cid, Value[Cid2]],
   ): GenTransaction[Nid, Cid, VersionedValue[Cid2]] =
-    t mapContractIdAndValue (identity, v =>
+    t map3 (identity, identity, v =>
       asVersionedValue(v) fold (e =>
         fail(s"We didn't write traverse for GenTransaction: $e"), identity))
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -49,7 +49,7 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
     import org.scalacheck.Arbitrary
     type T = VersionedValue[Unnatural[ContractId]]
     implicit val arbT: Arbitrary[T] =
-      Arbitrary(versionedValueGen map (_ mapContractId (Unnatural(_))))
+      Arbitrary(versionedValueGen.map(VersionedValue.map1(Unnatural(_))))
 
     scalaz.scalacheck.ScalazProperties.equal.laws[T].properties foreach {
       case (s, p) => s in check(p)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
@@ -40,6 +40,7 @@ object PlatformTypes {
   type ExerciseEvent[Nid, Cid] = E.ExerciseEvent[Nid, Cid, T.Transaction.Value[Cid]]
   val ExerciseEvent: E.ExerciseEvent.type = E.ExerciseEvent
 
+  @deprecated("use resolveRelCid/ensureNoCid/ensureNoRelCid", since = "0.13.52")
   def mapContractIdAndValue[Nid, Cid, Cid2](tx: GenTransaction[Nid, Cid])(
       f: Cid => Cid2): GenTransaction[Nid, Cid2] =
     tx.mapContractIdAndValue(f, _.mapContractId(f))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -238,14 +238,9 @@ object KeyValueConsumption {
 
   private def makeCommittedTransaction(
       txId: DamlLogEntryId,
-      tx: SubmittedTransaction): CommittedTransaction = {
-    tx
+      tx: SubmittedTransaction): CommittedTransaction =
     /* Assign absolute contract ids */
-      .mapContractIdAndValue(
-        toAbsCoid(txId, _),
-        _.mapContractId(toAbsCoid(txId, _))
-      )
-  }
+    tx.resolveRelCid(toAbsCoid(txId, _))
 
   @throws(classOf[Err])
   private def parseLedgerString(what: String)(s: String): Ref.LedgerString =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -231,7 +231,7 @@ private[kvutils] case class ProcessTransactionSubmission(
             blindingInfo.localDisclosure(NodeId(key.getContractId.getNodeId.toInt))
           cs.addAllLocallyDisclosedTo((localDisclosure: Iterable[String]).asJava)
           val absCoInst =
-            createNode.coinst.mapValue(_.mapContractId(Conversions.toAbsCoid(entryId, _)))
+            createNode.coinst.resolveRelCid(Conversions.toAbsCoid(entryId, _))
           cs.setContractInstance(
             Conversions.encodeContractInstance(absCoInst)
           )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
@@ -16,6 +16,9 @@ object EventIdFormatter {
 
   case class TransactionIdWithIndex(transactionId: LedgerString, nodeId: Transaction.NodeId)
 
+  def makeAbs(transactionId: LedgerString)(rcoid: Lf.RelativeContractId): LedgerString =
+    fromTransactionId(transactionId, rcoid.txnid)
+
   def makeAbsCoid(transactionId: LedgerString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
     coid match {
       case a @ Lf.AbsoluteContractId(_) => a

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -212,7 +212,7 @@ private final class SqlLedger(
         EventIdFormatter.makeAbsCoid(transactionId)
 
       val mappedTx = transaction
-        .mapContractIdAndValue(toAbsCoid, _.mapContractId(toAbsCoid))
+        .resolveRelCid(EventIdFormatter.makeAbs(transactionId))
         .mapNodeId(EventIdFormatter.fromTransactionId(transactionId, _))
 
       val blindingInfo = Blinding.blind(transaction)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -146,8 +146,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                   transactionId = transactionId,
                   eventId = nodeId,
                   workflowId = workflowId,
-                  contract = nc.coinst.mapValue(
-                    _.mapContractId(EventIdFormatter.makeAbsCoid(transactionId))),
+                  contract = nc.coinst.resolveRelCid(EventIdFormatter.makeAbs(transactionId)),
                   witnesses = disclosure(nodeId),
                   // we need to `getOrElse` here because the `Nid` might include absolute
                   // contract ids, and those are never present in the local disclosure.
@@ -155,8 +154,8 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                     .getOrElse(nodeId, Set.empty) diff nc.stakeholders).toList
                     .map(p => p -> transactionId)
                     .toMap,
-                  key = nc.key.map(_.mapValue(_.mapContractId(coid =>
-                    throw new IllegalStateException(s"Contract ID $coid found in contract key")))),
+                  key =
+                    nc.key.map(_.assertNoCid(coid => s"Contract ID $coid found in contract key")),
                   signatories = nc.signatories,
                   observers = nc.stakeholders.diff(nc.signatories),
                   agreementText = nc.coinst.agreementText
@@ -198,8 +197,11 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                 )
               case nlkup: N.NodeLookupByKey.WithTxValue[AbsoluteContractId] =>
                 // Check that the stored lookup result matches the current result
-                val key = nlkup.key.key.mapContractId(coid =>
-                  throw new IllegalStateException(s"Contract ID $coid found in contract key"))
+                val key = nlkup.key.key.ensureNoCid.fold(
+                  coid =>
+                    throw new IllegalStateException(s"Contract ID $coid found in contract key"),
+                  identity
+                )
                 val gk = GlobalKey(nlkup.templateId, key)
                 val nodeParties = nlkup.key.maintainers
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1334,7 +1334,11 @@ private class JdbcLedgerDao(
             val keyValue = valueSerializer
               .deserializeValue(ByteStreams.toByteArray(keyStream))
               .getOrElse(sys.error(s"failed to deserialize key value! cid:$coid"))
-              .mapContractId(coid => sys.error(s"Found contract ID $coid in a contract key"))
+              .ensureNoCid
+              .fold(
+                coid => sys.error(s"Found contract ID $coid in a contract key"),
+                identity,
+              )
             KeyWithMaintainers(keyValue, keyMaintainers)
           }),
           signatories,

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -702,7 +702,6 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
             val toCoid: AbsoluteContractId => ContractId = identity
             val unmappedTx: Transaction.Transaction = tx.transaction
               .mapNodeId(EventIdFormatter.split(_).get.nodeId)
-              .mapContractIdAndValue(toCoid, _.mapContractId(toCoid))
 
             val blindingInfo = Blinding.blind(unmappedTx)
             val mappedLocalDivulgence = blindingInfo.localDivulgence.map {

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -58,8 +58,7 @@ class V3__Recompute_Key_Hash extends BaseJavaMigration {
         val key = ValueSerializer
           .deserializeValue(rows.getBytes("contract_key"))
           .fold(err => throw new IllegalArgumentException(err.errorMessage), identity)
-          .mapContractId(coid =>
-            throw new IllegalArgumentException(s"Found contract ID $coid in contract key"))
+          .assertNoCid(coid => s"Found contract ID $coid in contract key")
 
         hasNext = rows.next()
 


### PR DESCRIPTION
**Pure internal changes**

In this PR we change depreacte the `mapContractId` method from the LF container (e.g `Transaction`/`Node`/`VersionnedValue`) in order to control better how contractId are generate outside the engine. 

This PR advances the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
