### PR TITLE
Shut down when stdin is closed.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -21,6 +21,16 @@ main =
         exitFailure
   where
     parserPrefs = prefs showHelpOnError
+    -- Note that we do not close on stdin here.
+    -- The reason for this is that this would result in us terminating the child
+    -- process, e.g., daml-helper using TerminateProcess on Windows which does
+    -- not give it a chance to cleanup. Therefore, we only do this in daml-helper
+    -- which starts long-running server processes like sandbox via run-jar.
+    -- This means that closing stdin won’t work for things like daml test
+    -- but that seems acceptable for now.
+    -- In theory, process groups or job control might provide a solution
+    -- but as Ben Gamari noticed, this is horribly unreliable https://gitlab.haskell.org/ghc/ghc/issues/17777
+    -- so we are likely to make things worse rather than better.
     go = do
          installSignalHandlers
          command <- customExecParser parserPrefs (info (commandParser <**> helper) idm)

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -21,17 +21,7 @@ main =
         exitFailure
   where
     parserPrefs = prefs showHelpOnError
-    -- Note that we do not close on stdin here.
-    -- The reason for this is that this would result in us terminating the child
-    -- process, e.g., daml-helper using TerminateProcess on Windows which does
-    -- not give it a chance to cleanup. Therefore, we only do this in daml-helper
-    -- which starts long-running server processes like sandbox via run-jar.
-    -- This means that closing stdin won’t work for things like daml test
-    -- but that seems acceptable for now.
-    -- In theory, process groups or job control might provide a solution
-    -- but as Ben Gamari noticed, this is horribly unreliable https://gitlab.haskell.org/ghc/ghc/issues/17777
-    -- so we are likely to make things worse rather than better.
-    go = do
+    go = withCloseOnStdin $ do
          installSignalHandlers
          command <- customExecParser parserPrefs (info (commandParser <**> helper) idm)
          runCommand command

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -29,7 +29,7 @@ import Safe
 
 -- | Run the assistant and exit.
 main :: IO ()
-main = displayErrors $ do
+main = displayErrors $ withCloseOnStdin $ do
     installSignalHandlers
     builtinCommandM <- tryBuiltinCommand
     case builtinCommandM of

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -29,7 +29,17 @@ import Safe
 
 -- | Run the assistant and exit.
 main :: IO ()
-main = displayErrors $ withCloseOnStdin $ do
+-- Note that we do not close on stdin here.
+-- The reason for this is that this would result in us terminating the child
+-- process, e.g., daml-helper using TerminateProcess on Windows which does
+-- not give it a chance to cleanup. Therefore, we only do this in daml-helper
+-- which starts long-running server processes like sandbox via run-jar.
+-- This means that closing stdin won’t work for things like daml test
+-- but that seems acceptable for now.
+-- In theory, process groups or job control might provide a solution
+-- but as Ben Gamari noticed, this is horribly unreliable https://gitlab.haskell.org/ghc/ghc/issues/17777
+-- so we are likely to make things worse rather than better.
+main = displayErrors $ do
     installSignalHandlers
     builtinCommandM <- tryBuiltinCommand
     case builtinCommandM of

--- a/libs-haskell/da-hs-base/src/DA/Signals.hs
+++ b/libs-haskell/da-hs-base/src/DA/Signals.hs
@@ -33,9 +33,7 @@ installSignalHandlers = do
 withCloseOnStdin :: IO a -> IO a
 withCloseOnStdin a = do
     mainThread <- myThreadId
-    -- We close stdin at the end to avoid potential issues
-    -- with isEOF blocking on Windows.
-    withAsync (go mainThread) (const $ a `finally` hClose stdin)
+    withAsync (go mainThread) (const a)
   where go mainThread = do
             b <- isEOF
             if b

--- a/libs-haskell/da-hs-base/src/DA/Signals.hs
+++ b/libs-haskell/da-hs-base/src/DA/Signals.hs
@@ -38,4 +38,4 @@ withCloseOnStdin a = do
             b <- isEOF
             if b
                 then throwTo mainThread UserInterrupt
-                else go mainThread
+                else threadDelay 1000000 >> go mainThread


### PR DESCRIPTION
changelog_begin

- [DAML Assistant] The DAML assistant will now shut down long-running
  processes like sandbox when stdin is
  closed. This is mainly useful on Windows, where process APIs often
  kill the process in a way that does not allow it to do any cleanup, in
  particular, we cannot stop child processes.

changelog_end

For now, the logic for this is only in daml-helper which is the only
thing starting long-running processes (in particular sandbox). There
is a long inline-comment explaining why this is not on the assistant
itself.

fixes #4168

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
