### PR TITLE
kvutils|ledger|sandbox: Replace uses of `scala.App` with `def main`.

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/ReferenceServer.scala
@@ -19,75 +19,74 @@ import com.digitalasset.platform.apiserver.{ApiServerConfig, StandaloneApiServer
 import com.digitalasset.platform.indexer.{IndexerConfig, StandaloneIndexerServer}
 import com.digitalasset.resources.akka.AkkaResourceOwner
 import com.digitalasset.resources.{ProgramResource, ResourceOwner}
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-object ReferenceServer extends App {
-  val logger = LoggerFactory.getLogger("indexed-kvutils")
+object ReferenceServer {
+  private implicit val system: ActorSystem = ActorSystem("indexed-kvutils")
+  private implicit val materializer: Materializer = Materializer(system)
+  private implicit val executionContext: ExecutionContext = system.dispatcher
 
-  val config =
-    Cli
-      .parse(
-        args,
-        binaryName = "damlonx-reference-server",
-        description = "A fully compliant DAML Ledger API server backed by an in-memory store.",
-      )
-      .getOrElse(sys.exit(1))
+  def main(args: Array[String]): Unit = {
+    val config =
+      Cli
+        .parse(
+          args,
+          binaryName = "damlonx-reference-server",
+          description = "A fully compliant DAML Ledger API server backed by an in-memory store.",
+        )
+        .getOrElse(sys.exit(1))
 
-  implicit val system: ActorSystem = ActorSystem("indexed-kvutils")
-  implicit val materializer: Materializer = Materializer(system)
-  implicit val executionContext: ExecutionContext = system.dispatcher
-
-  val owner = newLoggingContext { implicit logCtx =>
-    for {
-      // Take ownership of the actor system and materializer so they're cleaned up properly.
-      // This is necessary because we can't declare them as implicits within a `for` comprehension.
-      _ <- AkkaResourceOwner.forActorSystem(() => system)
-      _ <- AkkaResourceOwner.forMaterializer(() => materializer)
-      ledger <- ResourceOwner
-        .forCloseable(() => new InMemoryKVParticipantState(config.participantId))
-      _ <- ResourceOwner.sequenceIgnoringValues(config.archiveFiles.map { file =>
-        val submissionId = SubmissionId.assertFromString(UUID.randomUUID().toString)
-        for {
-          dar <- ResourceOwner
-            .forTry(() =>
-              DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
-                .readArchiveFromFile(file))
-          _ <- ResourceOwner
-            .forCompletionStage(() => ledger.uploadPackages(submissionId, dar.all, None))
-        } yield ()
-      })
-      _ <- startIndexerServer(config, readService = ledger)
-      _ <- startApiServer(
-        config,
-        readService = ledger,
-        writeService = ledger,
-        authService = AuthServiceWildcard,
-      )
-      _ <- ResourceOwner.sequenceIgnoringValues(
-        for ((extraParticipantId, port, jdbcUrl) <- config.extraParticipants) yield {
-          val participantConfig = config.copy(
-            port = port,
-            participantId = extraParticipantId,
-            jdbcUrl = jdbcUrl,
-          )
+    val owner = newLoggingContext { implicit logCtx =>
+      for {
+        // Take ownership of the actor system and materializer so they're cleaned up properly.
+        // This is necessary because we can't declare them as implicits within a `for` comprehension.
+        _ <- AkkaResourceOwner.forActorSystem(() => system)
+        _ <- AkkaResourceOwner.forMaterializer(() => materializer)
+        ledger <- ResourceOwner
+          .forCloseable(() => new InMemoryKVParticipantState(config.participantId))
+        _ <- ResourceOwner.sequenceIgnoringValues(config.archiveFiles.map { file =>
+          val submissionId = SubmissionId.assertFromString(UUID.randomUUID().toString)
           for {
-            _ <- startIndexerServer(participantConfig, readService = ledger)
-            _ <- startApiServer(
-              participantConfig,
-              readService = ledger,
-              writeService = ledger,
-              authService = AuthServiceWildcard,
-            )
+            dar <- ResourceOwner
+              .forTry(() =>
+                DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
+                  .readArchiveFromFile(file))
+            _ <- ResourceOwner
+              .forCompletionStage(() => ledger.uploadPackages(submissionId, dar.all, None))
           } yield ()
-        }
-      )
-    } yield ()
-  }
+        })
+        _ <- startIndexerServer(config, readService = ledger)
+        _ <- startApiServer(
+          config,
+          readService = ledger,
+          writeService = ledger,
+          authService = AuthServiceWildcard,
+        )
+        _ <- ResourceOwner.sequenceIgnoringValues(
+          for ((extraParticipantId, port, jdbcUrl) <- config.extraParticipants) yield {
+            val participantConfig = config.copy(
+              port = port,
+              participantId = extraParticipantId,
+              jdbcUrl = jdbcUrl,
+            )
+            for {
+              _ <- startIndexerServer(participantConfig, readService = ledger)
+              _ <- startApiServer(
+                participantConfig,
+                readService = ledger,
+                writeService = ledger,
+                authService = AuthServiceWildcard,
+              )
+            } yield ()
+          }
+        )
+      } yield ()
+    }
 
-  new ProgramResource(owner).run()
+    new ProgramResource(owner).run()
+  }
 
   private def startIndexerServer(config: Config, readService: ReadService)(
       implicit logCtx: LoggingContext

--- a/ledger/api-server-damlonx/reference-v2/src/test/lib/scala/com/daml/ledger/api/server/damlonx/reference/v2/EphemeralPostgresReferenceServerMain.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/test/lib/scala/com/daml/ledger/api/server/damlonx/reference/v2/EphemeralPostgresReferenceServerMain.scala
@@ -5,8 +5,10 @@ package com.daml.ledger.api.server.damlonx.reference.v2
 
 import com.digitalasset.testing.postgresql.PostgresAround
 
-object EphemeralPostgresReferenceServerMain extends App with PostgresAround {
-  startEphemeralPostgres()
-  sys.addShutdownHook(stopAndCleanUpPostgres())
-  ReferenceServer.main(args ++ List("--jdbc-url", postgresFixture.jdbcUrl))
+object EphemeralPostgresReferenceServerMain extends PostgresAround {
+  def main(args: Array[String]): Unit = {
+    startEphemeralPostgres()
+    sys.addShutdownHook(stopAndCleanUpPostgres())
+    ReferenceServer.main(args ++ Array("--jdbc-url", postgresFixture.jdbcUrl))
+  }
 }

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/Main.scala
@@ -8,7 +8,9 @@ import com.digitalasset.resources.ProgramResource
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object Main extends App {
-  new ProgramResource(
-    Runner("In-Memory Ledger", InMemoryLedgerReaderWriter.owner(_, _)).owner(args)).run()
+object Main {
+  def main(args: Array[String]): Unit = {
+    new ProgramResource(
+      Runner("In-Memory Ledger", InMemoryLedgerReaderWriter.owner(_, _)).owner(args)).run()
+  }
 }

--- a/ledger/ledger-on-posix-filesystem/src/main/scala/com/daml/ledger/on/filesystem/posix/Main.scala
+++ b/ledger/ledger-on-posix-filesystem/src/main/scala/com/daml/ledger/on/filesystem/posix/Main.scala
@@ -14,8 +14,10 @@ import scopt.OptionParser
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object Main extends App {
-  new ProgramResource(Runner("File System Ledger", FileSystemLedgerFactory).owner(args)).run()
+object Main {
+  def main(args: Array[String]): Unit = {
+    new ProgramResource(Runner("File System Ledger", FileSystemLedgerFactory).owner(args)).run()
+  }
 
   case class ExtraConfig(root: Option[Path])
 

--- a/ledger/ledger-on-posix-filesystem/src/test/lib/scala/com/daml/ledger/on/filesystem/posix/MainWithEphemeralDirectory.scala
+++ b/ledger/ledger-on-posix-filesystem/src/test/lib/scala/com/daml/ledger/on/filesystem/posix/MainWithEphemeralDirectory.scala
@@ -13,8 +13,10 @@ import com.digitalasset.resources.{ProgramResource, Resource, ResourceOwner}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-object MainWithEphemeralDirectory extends App {
-  new ProgramResource(Runner("Ephemeral File System Ledger", owner _).owner(args)).run()
+object MainWithEphemeralDirectory {
+  def main(args: Array[String]): Unit = {
+    new ProgramResource(Runner("Ephemeral File System Ledger", owner _).owner(args)).run()
+  }
 
   def owner(
       ledgerId: LedgerId,

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Main.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Main.scala
@@ -12,8 +12,10 @@ import scopt.OptionParser
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object Main extends App {
-  new ProgramResource(Runner("SQL Ledger", SqlLedgerFactory).owner(args)).run()
+object Main {
+  def main(args: Array[String]): Unit = {
+    new ProgramResource(Runner("SQL Ledger", SqlLedgerFactory).owner(args)).run()
+  }
 
   case class ExtraConfig(jdbcUrl: Option[String])
 

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
@@ -14,12 +14,12 @@ import scopt.OptionParser
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object MainWithEphemeralDirectory extends App {
-  val DirectoryPattern = "%DIR"
+object MainWithEphemeralDirectory {
+  private val DirectoryPattern = "%DIR"
 
-  val directory = Files.createTempDirectory("ledger-on-sql-ephemeral-")
-
-  new ProgramResource(Runner("SQL Ledger", TestLedgerFactory).owner(args)).run()
+  def main(args: Array[String]): Unit = {
+    new ProgramResource(Runner("SQL Ledger", TestLedgerFactory).owner(args)).run()
+  }
 
   object TestLedgerFactory extends LedgerFactory[SqlLedgerReaderWriter, ExtraConfig] {
     override val defaultExtraConfig: ExtraConfig = SqlLedgerFactory.defaultExtraConfig
@@ -32,6 +32,7 @@ object MainWithEphemeralDirectory extends App {
         participantId: ParticipantId,
         config: ExtraConfig,
     )(implicit materializer: Materializer): ResourceOwner[SqlLedgerReaderWriter] = {
+      val directory = Files.createTempDirectory("ledger-on-sql-ephemeral-")
       val jdbcUrl = config.jdbcUrl.map(_.replace(DirectoryPattern, directory.toString))
       SqlLedgerFactory.owner(ledgerId, participantId, config.copy(jdbcUrl = jdbcUrl))
     }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -13,11 +13,12 @@ import scopt.OptionParser
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object MainWithEphemeralPostgresql extends App with PostgresAround {
-  startEphemeralPostgres()
-  sys.addShutdownHook(stopAndCleanUpPostgres())
-
-  new ProgramResource(Runner("SQL Ledger", PostgresqlLedgerFactory).owner(args)).run()
+object MainWithEphemeralPostgresql extends PostgresAround {
+  def main(args: Array[String]): Unit = {
+    startEphemeralPostgres()
+    sys.addShutdownHook(stopAndCleanUpPostgres())
+    new ProgramResource(Runner("SQL Ledger", PostgresqlLedgerFactory).owner(args)).run()
+  }
 
   object PostgresqlLedgerFactory extends LedgerFactory[SqlLedgerReaderWriter, Unit] {
     override val defaultExtraConfig: Unit = ()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
@@ -11,14 +11,16 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.ExecutionContext
 
-object SandboxMain extends App {
+object SandboxMain {
   private implicit val executionContext: ExecutionContext = DirectExecutionContext
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  Cli.parse(args).fold(sys.exit(1)) { config =>
-    setGlobalLogLevel(config.logLevel)
-    new ProgramResource(SandboxServer.owner(config)).run()
+  def main(args: Array[String]): Unit = {
+    Cli.parse(args).fold(sys.exit(1)) { config =>
+      setGlobalLogLevel(config.logLevel)
+      new ProgramResource(SandboxServer.owner(config)).run()
+    }
   }
 
   // Copied from language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Main.scala
@@ -31,5 +33,4 @@ object SandboxMain extends App {
         logger.warn(s"Sandbox verbosity cannot be set to requested $verbosity")
     }
   }
-
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/EphemeralPostgresSandboxMain.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/EphemeralPostgresSandboxMain.scala
@@ -6,8 +6,10 @@ package com.digitalasset.platform.sandbox.persistence
 import com.digitalasset.platform.sandbox.SandboxMain
 import com.digitalasset.testing.postgresql.PostgresAround
 
-object EphemeralPostgresSandboxMain extends App with PostgresAround {
-  startEphemeralPostgres()
-  sys.addShutdownHook(stopAndCleanUpPostgres())
-  SandboxMain.main(args ++ List("--sql-backend-jdbcurl", postgresFixture.jdbcUrl))
+object EphemeralPostgresSandboxMain extends PostgresAround {
+  def main(args: Array[String]): Unit = {
+    startEphemeralPostgres()
+    sys.addShutdownHook(stopAndCleanUpPostgres())
+    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", postgresFixture.jdbcUrl))
+  }
 }

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
@@ -14,7 +14,7 @@ import scala.util.control.NonFatal
 class ProgramResource[T](owner: ResourceOwner[T]) {
   private val logger = ContextualizedLogger.get(getClass)
 
-  def run()(implicit executionContext: ExecutionContext): Resource[T] = {
+  def run()(implicit executionContext: ExecutionContext): Unit = {
     newLoggingContext { implicit logCtx =>
       val resource = owner.acquire()
 
@@ -35,8 +35,6 @@ class ProgramResource[T](owner: ResourceOwner[T]) {
           Await.result(resource.release(), AsyncTimeout)
           System.exit(1)
       }
-
-      resource
     }
   }
 }


### PR DESCRIPTION
`App` is fairly problematic. It depends on `DelayedInit`, which is
deprecated because it has some surprising behavior.

Best to avoid it for anything more than a simple demo application.

Details: https://github.com/scala/bug/issues/4330

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
