### PR TITLE
Remove reference to Node.js bindings

### DIFF
--- a/docs/source/app-dev/bindings-js.rst
+++ b/docs/source/app-dev/bindings-js.rst
@@ -1,9 +1,0 @@
-.. Copyright (c) 2020 The DAML Authors. All rights reserved.
-.. SPDX-License-Identifier: Apache-2.0
-
-Node.js bindings
-################
-
-The documentation for the Node.js bindings has been moved to `digital-asset.github.io/daml-js <http://digital-asset.github.io/daml-js/>`__. 
-
-You can also try the Node.js bindings tutorial, which is at `github.com/digital-asset/ex-tutorial-nodejs <https://github.com/digital-asset/ex-tutorial-nodejs>`__.

--- a/docs/source/app-dev/bindings-x-lang/index.rst
+++ b/docs/source/app-dev/bindings-x-lang/index.rst
@@ -15,8 +15,6 @@ Digital Asset currently provides bindings for the following programming language
 
 - :doc:`Scala </app-dev/bindings-scala/index>`
 
-- :doc:`JavaScript (Node.js) </app-dev/bindings-js>`
-
 You can create bindings for any programming language supported by `gRPC <https://grpc.io/docs/>`_.
 
 What do we mean by "bindings"? Bindings for a language consist of two main components:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,6 @@ DAML SDK documentation
    app-dev/index
    app-dev/bindings-java/index
    app-dev/bindings-scala/index
-   app-dev/bindings-js
    app-dev/grpc/index
    app-dev/bindings-x-lang/index
    app-dev/app-arch


### PR DESCRIPTION
The Node.js bindings are in a stale and unmantained state, I suggest we stop advertising them.

CHANGELOG_BEGIN
[Documentation] Removed reference to Node.js bindings
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
