### PR TITLE
@daml/react: Add proper useExerciseByKey hook

### DIFF
--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -112,20 +112,20 @@ export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): [(
   return [exercise, loading];
 }
 
-/// React Hook that returns a function to exercise a choice and a boolean
+/// React Hook that returns a function to exercise a choice by key and a boolean
 /// indicator whether the exercise is currently running.
-export const usePseudoExerciseByKey = <T extends object, C, R>(choice: Choice<T, C, R>): [(key: Query<T>, argument: C) => Promise<R>, boolean] => {
+export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): [(key: K, argument: C) => Promise<R>, boolean] => {
   const [loading, setLoading] = useState(false);
   const state = useDamlState();
 
-  const exercise = async (key: Query<T>, argument: C) => {
+  const exerciseByKey = async (key: K, argument: C) => {
     setLoading(true);
     const [result, events] = await state.ledger.exerciseByKey(choice, key, argument);
     state.dispatch(addEvents(events));
     setLoading(false);
     return result;
   }
-  return [exercise, loading];
+  return [exerciseByKey, loading];
 }
 
 /// React Hook to reload all queries currently present in the store.


### PR DESCRIPTION
And remove the old quirky `usePseudoExerciseByKey` hook.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4368)
<!-- Reviewable:end -->
