### PR TITLE
fix Windows CI node startup script

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -81,6 +81,7 @@ Invoke-WebRequest https://dl.google.com/cloudagents/windows/StackdriverLogging-v
 .\StackdriverLogging-v1-9.exe /S /D="C:\Stackdriver\Logging\"
 
 # Install chocolatey
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 iex (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
 
 # Install git, bash


### PR DESCRIPTION
This is an attempt to apply a potential fix discovered as part of the investigation in #4370. The issue seems to be that Chocolatey is using a protocol deemed not secure enough and disabled in recent Windows images (our node creation script dynamically selects the lmatest "Windows 2016" server image from GCP).