### PR TITLE
Fall back to regular bash completions for command arguments

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -50,6 +50,7 @@ da_haskell_library(
         "http-conduit",
         "lens",
         "optparse-applicative",
+        "process",
         "safe",
         "safe-exceptions",
         "semver",

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -183,7 +183,7 @@ requote s =
           -- If it's true escapable, strip the
           -- slashes, as we're going to strong
           -- escape instead.
-          | x `elem` ("$`\"\\\n" :: [Char]) = x : goX xs
+          | x `elem` ("$`\"\\\n" :: String) = x : goX xs
           | otherwise = '\\' : x : goX xs
         -- We've ended quoted section, so we
         -- don't recurse on goX, it's done.


### PR DESCRIPTION
This addresses the first part of #4369 by falling back to the bash completions.

I sadly still haven’t figured out how we can stop to completing to a
directory if the command also exists as a directory.

changelog_begin

- [DAML Assistant] Bash and Zsh completions will now fall back to
  regular file completions after the command argument.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
