### PR TITLE
fix status in Slack notifications

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -506,6 +506,7 @@ jobs:
     variables:
       pr.num: $[ variables['System.PullRequest.PullRequestNumber'] ]
       branch_sha: $[ dependencies.git_sha.outputs['out.branch'] ]
+      status: $[ dependencies.collect_build_data.result ]
     steps:
       - checkout: none
       - bash: |
@@ -535,7 +536,7 @@ jobs:
           }
 
           if user_registered; then
-              tell_slack "$(Agent.JobStatus)" "$(user_id)"
+              tell_slack "$(status)" "$(user_id)"
           else
               echo "User $(user_id) did not opt in for notifications."
           fi


### PR DESCRIPTION
The `$(Agent.JobStatus)` variable unfortunately only tracks the status of the current _job_, whereas what we really want here is the status of the whole build. Azure does not have an easy way to do that, but fortunately we already have logic to determine the current build status in `collect_build_data`, so here we can just piggyback on that.