### PR TITLE
language-support/ts generate package in commonjs format

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -699,6 +699,8 @@ yarn_install(
         "eslint/index.bzl": "def eslint_test(*args, **kwargs):\n    pass",
         "jest-cli/BUILD.bazel": 'exports_files(["index.bzl"])',
         "jest-cli/index.bzl": "def jest_test(*args, **kwargs):\n    pass",
+        "typescript/BUILD.bazel": 'exports_files(["index.bzl"])',
+        "typescript/index.bzl": "def tsc(*args, **kwargs):\n    pass",
     },
 )
 

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//language-support/ts:eslint.bzl", "eslint_test")
@@ -44,6 +45,29 @@ eslint_test(
     ),
 )
 
+tsc(
+    name = "daml-ledger.commonjs",
+    data = ["index.ts"] + [
+        "tsconfig.json",
+    ] + [
+        "//language-support/ts/daml-types",
+        "@language_support_ts_deps//@mojotech/json-type-validation",
+        "@language_support_ts_deps//cross-fetch",
+    ],
+    outs = [
+        s.replace(".ts", ext)
+        for ext in [".js", ".d.ts"]
+        for s in ["index.ts"]
+    ],
+    args = [
+        "--outDir",
+        "$(RULEDIR)",
+        "--project",
+        "$(location tsconfig.json)",
+        "--declaration",
+    ],
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -53,7 +77,7 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        "daml-ledger",
+        ":daml-ledger.commonjs",
         ":license",
     ],
 ) if not is_windows else None

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -3,23 +3,15 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//language-support/ts:defs.bzl", "ts_commonjs_library")
+load("//language-support/ts:defs.bzl", "da_ts_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
 
-ts_library(
+da_ts_library(
     name = "daml-ledger",
-    srcs = glob(["**/*.ts"]),
-    data = [
-        ":LICENSE",
-        ":README.md",
-        ":package.json",
-    ],
+    srcs = ["index.ts"],
     module_name = "@daml/ledger",
-    node_modules = "@language_support_ts_deps//:node_modules",
-    tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
     deps = [
         "//language-support/ts/daml-types",
@@ -45,18 +37,6 @@ eslint_test(
     ),
 )
 
-ts_commonjs_library(
-    name = "daml-ledger.commonjs",
-    srcs = ["index.ts"],
-    deps = [
-        "//language-support/ts/daml-types:daml-types.commonjs",
-        "@language_support_ts_deps//@mojotech/json-type-validation",
-        "@language_support_ts_deps//cross-fetch",
-    ],
-    module_name = "@daml/ledger",
-    visibility = ["//visibility:public"],
-)
-
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -66,7 +46,7 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        ":daml-ledger.commonjs",
+        ":daml-ledger",
         ":license",
     ],
 ) if not is_windows else None

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -49,10 +49,12 @@ ts_commonjs_library(
     name = "daml-ledger.commonjs",
     srcs = ["index.ts"],
     deps = [
-        "//language-support/ts/daml-types",
+        "//language-support/ts/daml-types:daml-types.commonjs",
         "@language_support_ts_deps//@mojotech/json-type-validation",
         "@language_support_ts_deps//cross-fetch",
     ],
+    module_name = "@daml/ledger",
+    visibility = ["//visibility:public"],
 )
 
 pkg_npm(

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -3,9 +3,9 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("//language-support/ts:defs.bzl", "ts_commonjs_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
 
@@ -45,26 +45,13 @@ eslint_test(
     ),
 )
 
-tsc(
+ts_commonjs_library(
     name = "daml-ledger.commonjs",
-    data = ["index.ts"] + [
-        "tsconfig.json",
-    ] + [
+    srcs = ["index.ts"],
+    deps = [
         "//language-support/ts/daml-types",
         "@language_support_ts_deps//@mojotech/json-type-validation",
         "@language_support_ts_deps//cross-fetch",
-    ],
-    outs = [
-        s.replace(".ts", ext)
-        for ext in [".js", ".d.ts"]
-        for s in ["index.ts"]
-    ],
-    args = [
-        "--outDir",
-        "$(RULEDIR)",
-        "--project",
-        "$(location tsconfig.json)",
-        "--declaration",
     ],
 )
 

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -52,10 +52,12 @@ ts_commonjs_library(
     name = "daml-react.commonjs",
     srcs = glob(["**/*.ts"]),
     deps = [
-        "//language-support/ts/daml-ledger",
-        "//language-support/ts/daml-types",
+        "//language-support/ts/daml-ledger:daml-ledger.commonjs",
+        "//language-support/ts/daml-types:daml-types.commonjs",
         "@language_support_ts_deps//:node_modules",
     ],
+    module_name = "@daml/react",
+    visibility = ["//visibility:public"],
 )
 
 pkg_npm(

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -3,26 +3,18 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//language-support/ts:defs.bzl", "ts_commonjs_library")
+load("//language-support/ts:defs.bzl", "da_ts_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("//language-support/ts:jest.bzl", "jest_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
 
-ts_library(
+da_ts_library(
     name = "daml-react",
     srcs = glob([
         "**/*.ts",
     ]),
-    data = [
-        ":LICENSE",
-        ":README.md",
-        ":package.json",
-    ],
     module_name = "@daml/react",
-    node_modules = "@language_support_ts_deps//:node_modules",
-    tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
     deps = [
         "//language-support/ts/daml-ledger",
@@ -48,18 +40,6 @@ eslint_test(
     ]),
 )
 
-ts_commonjs_library(
-    name = "daml-react.commonjs",
-    srcs = glob(["**/*.ts"]),
-    deps = [
-        "//language-support/ts/daml-ledger:daml-ledger.commonjs",
-        "//language-support/ts/daml-types:daml-types.commonjs",
-        "@language_support_ts_deps//:node_modules",
-    ],
-    module_name = "@daml/react",
-    visibility = ["//visibility:public"],
-)
-
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -69,23 +49,16 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        ":daml-react.commonjs",
+        ":daml-react",
         ":license",
     ],
 ) if not is_windows else None
-
-# we use the output js files for the jest test below.
-filegroup(
-    name = "daml-react.js",
-    srcs = [":daml-react"],
-    output_group = "es5_sources",
-)
 
 jest_test(
     name = "test",
     # Use the js outputs because jest cannot resolve imports in the ts_library
     # despite moduleNameMapper.
-    srcs = [":daml-react.js"],
+    srcs = [":daml-react"],
     jest_config = ":jest.config.js",
     deps = [
         "//language-support/ts/daml-ledger",

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -3,9 +3,9 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("//language-support/ts:defs.bzl", "ts_commonjs_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("//language-support/ts:jest.bzl", "jest_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
@@ -48,27 +48,13 @@ eslint_test(
     ]),
 )
 
-ts_src = glob(["**/*.ts"])
-tsc(
+ts_commonjs_library(
     name = "daml-react.commonjs",
-    data = ts_src + [
-        "tsconfig.json",
-    ] + [
+    srcs = glob(["**/*.ts"]),
+    deps = [
         "//language-support/ts/daml-ledger",
         "//language-support/ts/daml-types",
         "@language_support_ts_deps//:node_modules",
-    ],
-    outs = [
-        s.replace(".ts", ext)
-        for ext in [".js", ".d.ts"]
-        for s in ts_src
-    ],
-    args = [
-        "--outDir",
-        "$(RULEDIR)",
-        "--project",
-        "$(location tsconfig.json)",
-        "--declaration",
     ],
 )
 

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//language-support/ts:eslint.bzl", "eslint_test")
@@ -47,6 +48,30 @@ eslint_test(
     ]),
 )
 
+ts_src = glob(["**/*.ts"])
+tsc(
+    name = "daml-react.commonjs",
+    data = ts_src + [
+        "tsconfig.json",
+    ] + [
+        "//language-support/ts/daml-ledger",
+        "//language-support/ts/daml-types",
+        "@language_support_ts_deps//:node_modules",
+    ],
+    outs = [
+        s.replace(".ts", ext)
+        for ext in [".js", ".d.ts"]
+        for s in ts_src
+    ],
+    args = [
+        "--outDir",
+        "$(RULEDIR)",
+        "--project",
+        "$(location tsconfig.json)",
+        "--declaration",
+    ],
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -56,7 +81,7 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        "daml-react",
+        ":daml-react.commonjs",
         ":license",
     ],
 ) if not is_windows else None

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -4,9 +4,9 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@language_support_ts_deps//eslint:index.bzl", "eslint_test")
-load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@os_info//:os_info.bzl", "is_windows")
+load("//language-support/ts:defs.bzl", "ts_commonjs_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("//language-support/ts:jest.bzl", "jest_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
@@ -47,24 +47,11 @@ eslint_test(
     tsconfig = "tsconfig.eslint.json",
 )
 
-tsc(
+ts_commonjs_library(
     name = "daml-types.commonjs",
-    data = ["index.ts"] + [
-        "tsconfig.json",
-    ] + [
+    srcs = ["index.ts"],
+    deps = [
         "@language_support_ts_deps//@mojotech/json-type-validation",
-    ],
-    outs = [
-        s.replace(".ts", ext)
-        for ext in [".js", ".d.ts"]
-        for s in ["index.ts"]
-    ],
-    args = [
-        "--outDir",
-        "$(RULEDIR)",
-        "--project",
-        "$(location tsconfig.json)",
-        "--declaration",
     ],
 )
 

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -4,6 +4,7 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@language_support_ts_deps//eslint:index.bzl", "eslint_test")
+load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//language-support/ts:eslint.bzl", "eslint_test")
@@ -46,6 +47,27 @@ eslint_test(
     tsconfig = "tsconfig.eslint.json",
 )
 
+tsc(
+    name = "daml-types.commonjs",
+    data = ["index.ts"] + [
+        "tsconfig.json",
+    ] + [
+        "@language_support_ts_deps//@mojotech/json-type-validation",
+    ],
+    outs = [
+        s.replace(".ts", ext)
+        for ext in [".js", ".d.ts"]
+        for s in ["index.ts"]
+    ],
+    args = [
+        "--outDir",
+        "$(RULEDIR)",
+        "--project",
+        "$(location tsconfig.json)",
+        "--declaration",
+    ],
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -55,7 +77,7 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        "daml-types",
+        ":daml-types.commonjs",
         ":license",
     ],
 ) if not is_windows else None

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -4,23 +4,16 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@language_support_ts_deps//eslint:index.bzl", "eslint_test")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@os_info//:os_info.bzl", "is_windows")
-load("//language-support/ts:defs.bzl", "ts_commonjs_library")
+load("//language-support/ts:defs.bzl", "da_ts_library")
 load("//language-support/ts:eslint.bzl", "eslint_test")
 load("//language-support/ts:jest.bzl", "jest_test")
 load("@sdk_version//:sdk_version.bzl", "sdk_version")
 
-ts_library(
+da_ts_library(
     name = "daml-types",
-    srcs = glob(["**/*.ts"]),
-    data = [
-        ":LICENSE",
-        ":README.md",
-        ":package.json",
-    ],
+    srcs = ["index.ts"],
     module_name = "@daml/types",
-    node_modules = "@language_support_ts_deps//:node_modules",
     tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
     deps = [
@@ -47,16 +40,6 @@ eslint_test(
     tsconfig = "tsconfig.eslint.json",
 )
 
-ts_commonjs_library(
-    name = "daml-types.commonjs",
-    srcs = ["index.ts"],
-    deps = [
-        "@language_support_ts_deps//@mojotech/json-type-validation",
-    ],
-    module_name = "@daml/types",
-    visibility = ["//visibility:public"],
-)
-
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -66,7 +49,7 @@ pkg_npm(
     substitutions = {"0.0.0-SDKVERSION": sdk_version},
     visibility = ["//visibility:public"],
     deps = [
-        ":daml-types.commonjs",
+        ":daml-types",
         ":license",
     ],
 ) if not is_windows else None

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -53,6 +53,8 @@ ts_commonjs_library(
     deps = [
         "@language_support_ts_deps//@mojotech/json-type-validation",
     ],
+    module_name = "@daml/types",
+    visibility = ["//visibility:public"],
 )
 
 pkg_npm(

--- a/language-support/ts/defs.bzl
+++ b/language-support/ts/defs.bzl
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@language_support_ts_deps//typescript:index.bzl", "tsc")
+
+def ts_commonjs_library(
+        name,
+        tsconfig = "tsconfig.json",
+        srcs = [],
+        deps = [],
+        **kwargs):
+    """Build a typescript library.
+
+    Invokes tsc and generates definitions and commonjs files.
+
+    Attrs:
+      name: A unique name for the rule.
+      tsconfig: The tsconfig.json file.
+        The "files" attribute defines the typescript sources.
+      srcs: The typescript source files.
+        Defines which files are visible to the typescript compiler.
+      deps: Typescript library dependencies.
+    """
+    tsc(
+        name = name,
+        data = [tsconfig] + srcs + deps,
+        outs = [
+            s.replace(".ts", ext)
+            for ext in [".js", ".d.ts"]
+            for s in srcs
+        ],
+        args = [
+            "--outDir",
+            "$(RULEDIR)",
+            "--project",
+            "$(location %s)" % tsconfig,
+            "--declaration",
+        ],
+    )

--- a/language-support/ts/defs.bzl
+++ b/language-support/ts/defs.bzl
@@ -3,11 +3,30 @@
 
 load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 
+def _ts_commonjs_library_impl(ctx):
+    return [
+        DefaultInfo(
+            files = depset(ctx.files.srcs),
+            runfiles = ctx.runfiles(files = ctx.files.srcs),
+        ),
+    ]
+
+_ts_commonjs_library_rule = rule(
+    _ts_commonjs_library_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "module_name": attr.string(),
+        "module_root": attr.string(),
+    },
+)
+
 def ts_commonjs_library(
         name,
         tsconfig = "tsconfig.json",
         srcs = [],
         deps = [],
+        module_name = "",
+        module_root = "",
         **kwargs):
     """Build a typescript library.
 
@@ -20,15 +39,18 @@ def ts_commonjs_library(
       srcs: The typescript source files.
         Defines which files are visible to the typescript compiler.
       deps: Typescript library dependencies.
+      module_name: The import name of this library. E.g. @daml/types.
+      module_root: Treat sources as rooted under module_name.
     """
+    outs = [
+        s.replace(".ts", ext)
+        for ext in [".js", ".d.ts"]
+        for s in srcs
+    ]
     tsc(
-        name = name,
+        name = "_%s_commonjs" % name,
         data = [tsconfig] + srcs + deps,
-        outs = [
-            s.replace(".ts", ext)
-            for ext in [".js", ".d.ts"]
-            for s in srcs
-        ],
+        outs = outs,
         args = [
             "--outDir",
             "$(RULEDIR)",
@@ -36,4 +58,16 @@ def ts_commonjs_library(
             "$(location %s)" % tsconfig,
             "--declaration",
         ],
+        **kwargs
+    )
+    # rules_nodejs does import remapping based on the module_name attribute.
+    # The tsc macro is an instance of npm_package_bin under the covers which
+    # doesn't take a module_name attribute. So, we use this wrapper rule to be
+    # able to set the module_name attribute.
+    _ts_commonjs_library_rule(
+        name = name,
+        srcs = outs,
+        module_name = module_name,
+        module_root = module_root,
+        **kwargs
     )

--- a/language-support/ts/defs.bzl
+++ b/language-support/ts/defs.bzl
@@ -3,7 +3,7 @@
 
 load("@language_support_ts_deps//typescript:index.bzl", "tsc")
 
-def _ts_commonjs_library_impl(ctx):
+def _da_ts_library_impl(ctx):
     return [
         DefaultInfo(
             files = depset(ctx.files.srcs),
@@ -11,16 +11,17 @@ def _ts_commonjs_library_impl(ctx):
         ),
     ]
 
-_ts_commonjs_library_rule = rule(
-    _ts_commonjs_library_impl,
+_da_ts_library_rule = rule(
+    _da_ts_library_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(allow_files = True),
         "module_name": attr.string(),
         "module_root": attr.string(),
     },
 )
 
-def ts_commonjs_library(
+def da_ts_library(
         name,
         tsconfig = "tsconfig.json",
         srcs = [],
@@ -48,7 +49,7 @@ def ts_commonjs_library(
         for s in srcs
     ]
     tsc(
-        name = "_%s_commonjs" % name,
+        name = "_%s_tsc" % name,
         data = [tsconfig] + srcs + deps,
         outs = outs,
         args = [
@@ -60,13 +61,17 @@ def ts_commonjs_library(
         ],
         **kwargs
     )
+
     # rules_nodejs does import remapping based on the module_name attribute.
     # The tsc macro is an instance of npm_package_bin under the covers which
     # doesn't take a module_name attribute. So, we use this wrapper rule to be
     # able to set the module_name attribute.
-    _ts_commonjs_library_rule(
+    _da_ts_library_rule(
         name = name,
         srcs = outs,
+        # We don't do anything with the deps, but they are needed for
+        # rules_nodejs's tracking of transitive dependencies.
+        deps = deps,
         module_name = module_name,
         module_root = module_root,
         **kwargs


### PR DESCRIPTION
The npm packages generated by rules_nodejs' native ts_library rule use
the UMD package format. This breaks webpack which attempts to determine
dependencies by static code analysis and fails on UMD. To avoid this we
call `tsc` directly to ensure generation of commonjs modules.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
