### PR TITLE
ci: temp machines for scheduled killing experiment

### DIFF
--- a/infra/TEMP_KILLABLE_vsts_agent_linux.tf
+++ b/infra/TEMP_KILLABLE_vsts_agent_linux.tf
@@ -1,0 +1,56 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+resource "google_compute_region_instance_group_manager" "temp-killable" {
+  provider           = "google-beta"
+  name               = "temp-killable"
+  base_instance_name = "temp-killable"
+  region             = "${local.region}"
+  target_size        = 3
+
+  version {
+    name              = "temp-killable"
+    instance_template = "${google_compute_instance_template.temp-killable.self_link}"
+  }
+
+  update_policy {
+    type            = "PROACTIVE"
+    minimal_action  = "REPLACE"
+    max_surge_fixed = 3
+    min_ready_sec   = 60
+  }
+}
+
+resource "google_compute_instance_template" "temp-killable" {
+  name_prefix  = "killable-"
+  machine_type = "n1-standard-1"
+  labels       = "${local.labels}"
+
+  disk {
+    disk_size_gb = 20
+    disk_type    = "pd-ssd"
+    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  network_interface {
+    network = "default"
+
+    // Ephemeral IP to get access to the Internet
+    access_config {}
+  }
+
+  service_account {
+    email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
+    scopes = ["cloud-platform"]
+  }
+
+  scheduling {
+    automatic_restart   = false
+    on_host_maintenance = "TERMINATE"
+    preemptible         = true
+  }
+}

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -19,6 +19,7 @@ resource "google_project_iam_custom_role" "periodic-killer" {
   role_id = "killCiNodesEveryNight"
   title   = "Permissions to list & kill CI nodes every night"
   permissions = [
+    "compute.instances.delete",
     "compute.instances.list",
     "compute.zones.list",
   ]

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -27,7 +27,7 @@ resource "google_project_iam_custom_role" "periodic-killer" {
 
 resource "google_compute_instance" "periodic-killer" {
   name         = "periodic-killer"
-  machine_type = "n1-standard-1"
+  machine_type = "f1-micro"
   zone         = "us-east4-a"
 
   boot_disk {
@@ -70,7 +70,7 @@ CRON
 chmod +x /root/periodic-kill.sh
 
 cat <<CRONTAB >> /etc/crontab
-* * * * * root /root/periodic-kill.sh
+*/30 * * * * root /root/periodic-kill.sh
 CRONTAB
 
 STARTUP

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file defines a machine meant to destroy/recreate all our CI nodes every
+# night.
+
+resource "google_compute_instance" "periodic-killer" {
+  name         = "periodic-killer"
+  machine_type = "n1-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1804-lts"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    // Ephemeral IP to get access to the Internet
+    access_config {}
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  metadata_startup_script = <<STARTUP
+set -euxo pipefail
+
+apt-get update
+apt-get install -y curl jq
+
+curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-270.0.0-linux-x86_64.tar.gz | tar xz
+export PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
+
+STARTUP
+}

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -19,6 +19,7 @@ resource "google_project_iam_custom_role" "periodic-killer" {
   role_id = "killCiNodesEveryNight"
   title   = "Permissions to list & kill CI nodes every night"
   permissions = [
+    "compute.instances.list",
     "compute.zones.list",
   ]
 }

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -25,6 +25,7 @@ resource "google_compute_instance" "periodic-killer" {
   service_account {
     scopes = ["https://www.googleapis.com/auth/compute"]
   }
+  allow_stopping_for_update = true
 
   metadata_startup_script = <<STARTUP
 set -euxo pipefail

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -7,6 +7,7 @@
 resource "google_compute_instance" "periodic-killer" {
   name         = "periodic-killer"
   machine_type = "n1-standard-1"
+  zone         = "us-east4-a"
 
   boot_disk {
     initialize_params {

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -60,17 +60,17 @@ cat <<CRON > /root/periodic-kill.sh
 set -euo pipefail
 
 PREFIX=temp-killable
-MACHINES=\$(gcloud compute instances list --format=json | jq -c '.[] | select(.name | startswith("'\$PREFIX'")) | [.name, .zone]')
+MACHINES=\$(/snap/bin/gcloud compute instances list --format=json | jq -c '.[] | select(.name | startswith("'\$PREFIX'")) | [.name, .zone]')
 
 for m in \$MACHINES; do
-    gcloud -q compute instances delete \$(echo \$m | jq -r '.[0]') --zone=\$(echo \$m | jq -r '.[1]')
+    /snap/bin/gcloud -q compute instances delete \$(echo \$m | jq -r '.[0]') --zone=\$(echo \$m | jq -r '.[1]')
 done
 CRON
 
 chmod +x /root/periodic-kill.sh
 
 cat <<CRONTAB >> /etc/crontab
-* * * * * /root/periodic-kill.sh
+* * * * * root /root/periodic-kill.sh
 CRONTAB
 
 STARTUP

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -4,6 +4,18 @@
 # This file defines a machine meant to destroy/recreate all our CI nodes every
 # night.
 
+resource "google_service_account" "periodic-killer" {
+  account_id = "periodic-killer"
+}
+
+resource "google_project_iam_custom_role" "tf-write-state" {
+  role_id = "killCiNodesEveryNight"
+  title   = "Permissions to list & kill CI nodes every night"
+  permissions = [
+    "compute.zones.list",
+  ]
+}
+
 resource "google_compute_instance" "periodic-killer" {
   name         = "periodic-killer"
   machine_type = "n1-standard-1"
@@ -23,7 +35,8 @@ resource "google_compute_instance" "periodic-killer" {
   }
 
   service_account {
-    scopes = ["https://www.googleapis.com/auth/compute"]
+    email  = "${google_service_account.periodic-killer.email}"
+    scopes = ["cloud-platform"]
   }
   allow_stopping_for_update = true
 

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -60,10 +60,10 @@ cat <<CRON > /root/periodic-kill.sh
 set -euo pipefail
 
 PREFIX=temp-killable
-MACHINES=$(gcloud compute instances list --format=json | jq -c '.[] | select(.name | startswith("'$PREFIX'")) | [.name, .zone]')
+MACHINES=\$(gcloud compute instances list --format=json | jq -c '.[] | select(.name | startswith("'\$PREFIX'")) | [.name, .zone]')
 
-for m in $MACHINES; do
-    gcloud -q compute instances delete $(echo $m | jq -r '.[0]') --zone=$(echo $m | jq -r '.[1]')
+for m in \$MACHINES; do
+    gcloud -q compute instances delete \$(echo \$m | jq -r '.[0]') --zone=\$(echo \$m | jq -r '.[1]')
 done
 CRON
 

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -8,7 +8,14 @@ resource "google_service_account" "periodic-killer" {
   account_id = "periodic-killer"
 }
 
-resource "google_project_iam_custom_role" "tf-write-state" {
+resource "google_project_iam_member" "periodic-killer" {
+  # should reference google_project_iam_custom_role.periodic-killer.id or
+  # something, but for whatever reason that's not exposed.
+  role   = "projects/da-dev-gcp-daml-language/roles/killCiNodesEveryNight"
+  member = "serviceAccount:${google_service_account.periodic-killer.email}"
+}
+
+resource "google_project_iam_custom_role" "periodic-killer" {
   role_id = "killCiNodesEveryNight"
   title   = "Permissions to list & kill CI nodes every night"
   permissions = [

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -23,7 +23,7 @@ resource "google_compute_instance" "periodic-killer" {
   }
 
   service_account {
-    scopes = []
+    scopes = ["https://www.googleapis.com/auth/compute"]
   }
 
   metadata_startup_script = <<STARTUP


### PR DESCRIPTION
Based on our discussions last week, I am exploring ways to move us to permanent machines instead of preemptible ones. This should drastically reduce the number of "cancelled" jobs.

The end goal is to have:

1. An instance group (per OS) that defines the actual CI nodes; this would be pretty much the same as the existing ones, but with `preemptible` set to false.
2. A separate machine that, on a cron (say at 4AM UTC), destroys all the CI nodes.

The hope is that the group managers, which are set to maintain a 10 nodes, will then recreate the "missing" nodes using their normal starting procedure.

However, there are a lot of unknowns I would like to explore, and I need a playground for that. This is where this PR comes in. As it stands, it creates one "killer" machine and a temporary group manager. I will use these to experiment with the GCP API in various ways without interfering with the real CI nodes.

This experimentation will likely require multiple `terraform apply` with multiple different versions of the associated files, as well as connecting to the machines and running various commands directly from them. I will ensure all of that only affects the new machines created as part of this PR, and therefore believe we do not need to go through a separate round of approval for each change.

Once I have finished experimenting, I will create a new PR to clean up the temporary resources created with this one and hopefully set up a more permanent solution.