### PR TITLE
ensure archive of a key happens to left of create of same key in each WebSocket result block

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -814,6 +814,8 @@ After submitting an ``Iou_Split`` exercise, which creates two contracts
 and archives the one above, the same stream will eventually produce::
 
     [{
+        "archived": "#1:0"
+    }, {
         "created": {
             "observers": [],
             "agreementText": "",
@@ -843,8 +845,6 @@ and archives the one above, the same stream will eventually produce::
             "contractId": "#2:2",
             "templateId": "6cc82609ede6576e5092e8c89a2c7a658efe15ae1347fc38eb316f787fa132bc:Iou:Iou"
         }
-    }, {
-        "archived": "#1:0"
     }]
 
 If any template IDs are found not to resolve, the first non-heartbeat
@@ -873,7 +873,11 @@ Some notes on behavior:
    ``created`` first or the ``archived`` first and be guaranteed to get
    the same results.
 
-3. You will almost certainly receive contract IDs in ``archived`` that
+3. Within a given array, if an ``archived`` and ``created`` refer to
+   contracts with the same template ID and key, the ``archived`` is
+   guaranteed to occur before the ``created``.
+
+4. You will almost certainly receive contract IDs in ``archived`` that
    you never received a ``created`` for.  These are contracts that
    query filtered out, but for which the server no longer is aware of
    that.  You can safely ignore these.  However, such "phantom archives"
@@ -881,7 +885,7 @@ Some notes on behavior:
    if you are keeping a more global dataset outside the context of this
    specific search, you can use that archival information as you wish.
 
-4. Within a single response array, the order of ``created`` and
+5. Within a single response array, the order of ``created`` and
    ``archived`` is undefined and does not imply that any element
    occurred "before" or "after" any other one.  As specified in note #2,
    order of application of changes doesn't matter; you will get the same

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -874,8 +874,8 @@ Some notes on behavior:
    the same results.
 
 3. Within a given array, if an ``archived`` and ``created`` refer to
-   contracts with the same template ID and key, the ``archived`` is
-   guaranteed to occur before the ``created``.
+   contracts with the same template ID and contract key, the
+   ``archived`` is guaranteed to occur before the ``created``.
 
 4. You will almost certainly receive contract IDs in ``archived`` that
    you never received a ``created`` for.  These are contracts that

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -56,10 +56,9 @@ object WebSocketService {
     import json.JsonProtocol._, spray.json._
     def render(implicit lfv: LfV <~< JsValue): JsValue = {
       def inj[V: JsonWriter](ctor: String) = (v: V) => JsObject(ctor -> v.toJson)
-      type RF[+i] = Vector[domain.ActiveContract[i]]
       JsArray(
-        Liskov.co[RF, LfV, JsValue](lfv)(step.inserts).map(inj("created"))
-          ++ step.deletes.map(inj("archived"))
+        step.deletes.iterator.map(inj("archived")).toVector
+          ++ Liskov.co[StepAndErrors, LfV, JsValue](lfv)(this).step.inserts.map(inj("created"))
           ++ errors.map(inj[String]("error") compose (_.message)))
     }
 


### PR DESCRIPTION
Fixes #4354.

```rst
CHANGELOG_BEGIN
- [JSON API - Experimental] In websocket endpoints, if a 'created' and 'archived' contract
  in the same result array share a contract key, the 'archived' is guaranteed to occur
  earlier in the array than the 'created'.
  See `issue #4354 <https://github.com/digital-asset/daml/issues/4354>`_.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
