### PR TITLE
Remove '.' from output of daml build

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -526,6 +526,12 @@ initPackageDb opts (InitPkgDb shouldInit) =
             withPackageConfig defaultProjectPath $ \PackageConfigFields {..} ->
                 createProjectPackageDb opts pSdkVersion pDependencies pDataDependencies
 
+createDarFile :: FilePath -> Zip.ZipArchive () -> IO ()
+createDarFile fp dar = do
+    createDirectoryIfMissing True $ takeDirectory fp
+    Zip.createArchive fp dar
+    putStrLn $ "Created " <> fp <> "."
+
 execBuild :: ProjectOpts -> Options -> Maybe FilePath -> IncrementalBuild -> InitPkgDb -> Command
 execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
   Command Build (Just projectOpts) effect
@@ -549,9 +555,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
                             (FromDalf False)
                     dar <- mbErr "ERROR: Creation of DAR file failed." mbDar
                     let fp = targetFilePath $ pkgNameVersion pName pVersion
-                    createDirectoryIfMissing True $ takeDirectory fp
-                    Zip.createArchive fp dar
-                    putStrLn $ "Created " <> fp <> "."
+                    createDarFile fp dar
             where
                 targetFilePath name = fromMaybe (distDir </> name <.> "dar") mbOutFile
 
@@ -605,10 +609,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
             Nothing -> do
                 hPutStrLn stderr "ERROR: Creation of DAR file failed."
                 exitFailure
-            Just dar -> do
-              createDirectoryIfMissing True $ takeDirectory targetFilePath
-              Zip.createArchive targetFilePath dar
-              putStrLn $ "Created " <> targetFilePath <> "."
+            Just dar -> createDarFile targetFilePath dar
     -- This is somewhat ugly but our CLI parser guarantees that this will always be present.
     -- We could parametrize CliOptions by whether the package name is optional
     -- but I don’t think that is worth the complexity of carrying around a type parameter.

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -573,7 +573,7 @@ execClean projectOpts =
                     removeAndWarn damlArtifactDir
                     putStrLn "Removed build artifacts."
 
-execPackage:: ProjectOpts
+execPackage :: ProjectOpts
             -> FilePath -- ^ input file
             -> Options
             -> Maybe FilePath

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -530,7 +530,7 @@ createDarFile :: FilePath -> Zip.ZipArchive () -> IO ()
 createDarFile fp dar = do
     createDirectoryIfMissing True $ takeDirectory fp
     Zip.createArchive fp dar
-    putStrLn $ "Created " <> fp <> "."
+    putStrLn $ "Created " <> fp
 
 execBuild :: ProjectOpts -> Options -> Maybe FilePath -> IncrementalBuild -> InitPkgDb -> Command
 execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =


### PR DESCRIPTION
I often copy the dar file path into my clipboard with a double click (in iTerm2). I have to delete the full stop every time. This annoys me.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
