### PR TITLE
DAML-LF: Remove node seed from nodeId

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -256,7 +256,7 @@ final class Engine {
       node: GenNode.WithTxValue[Transaction.NodeId, Cid]): Result[(Type, SpeedyCommand)] = {
 
     node match {
-      case NodeCreate(nodeSeed, coid @ _, coinst, optLoc @ _, sigs @ _, stks @ _, key @ _) =>
+      case NodeCreate(nodeSeed @ _, coid @ _, coinst, optLoc @ _, sigs @ _, stks @ _, key @ _) =>
         val identifier = coinst.template
         asValueWithAbsoluteContractIds(coinst.arg.value).flatMap(
           absArg => commandPreprocessor.preprocessCreate(identifier, absArg)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -256,13 +256,14 @@ final class Engine {
       node: GenNode.WithTxValue[Transaction.NodeId, Cid]): Result[(Type, SpeedyCommand)] = {
 
     node match {
-      case NodeCreate(coid @ _, coinst, optLoc @ _, sigs @ _, stks @ _, key @ _) =>
+      case NodeCreate(nodeSeed, coid @ _, coinst, optLoc @ _, sigs @ _, stks @ _, key @ _) =>
         val identifier = coinst.template
         asValueWithAbsoluteContractIds(coinst.arg.value).flatMap(
           absArg => commandPreprocessor.preprocessCreate(identifier, absArg)
         )
 
       case NodeExercises(
+          nodeSeed @ _,
           coid,
           template,
           choice,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -922,6 +922,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       bobView.nodes.size shouldBe 2
       findNodeByIdx(bobView.nodes, 0).getOrElse(fail("node not found")) match {
         case NodeExercises(
+            nodeSeed @ _,
             coid,
             _,
             choice,
@@ -944,7 +945,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       }
 
       findNodeByIdx(bobView.nodes, 1).getOrElse(fail("node not found")) match {
-        case NodeCreate(_, coins, _, _, stakeholders, _) =>
+        case NodeCreate(nodeSeed @ _, _, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -955,7 +956,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
       claraView.nodes.size shouldBe 1
       findNodeByIdx(claraView.nodes, 1).getOrElse(fail("node not found")) match {
-        case NodeCreate(_, coins, _, _, stakeholders, _) =>
+        case NodeCreate(nodeSeed @ _, _, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -1127,7 +1128,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         case (nid, n) =>
           val fetchTx = GenTx(HashMap(nid -> n), ImmArray(nid), None, seed)
           val Right(reinterpreted) = engine
-            .reinterpret(nid.discriminator, n.requiredAuthorizers, Seq(n), let)
+            .reinterpret(None, n.requiredAuthorizers, Seq(n), let)
             .consume(lookupContract, lookupPackage, lookupKey)
           (fetchTx isReplayedBy reinterpreted) shouldBe true
       }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -90,7 +90,8 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create RangeOfInts",
         seed = hash("testLargeTransactionOneContract:create", txSize))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x, _, _, _, _, _) =>
+        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListContainerExerciseCmd(rangeOfIntsTemplateId, contractId)
@@ -117,7 +118,8 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create RangeOfInts",
         seed = hash("testLargeTransactionManySmallContracts:create", num))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x, _, _, _, _, _) =>
+        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListOfIntContainers(rangeOfIntsTemplateId, contractId)
@@ -144,7 +146,8 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         cmdReference = "create ListUtil",
         seed = hash("testLargeChoiceArgument:create", size))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
-      case N.NodeCreate(x, _, _, _, _, _) => pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
+      case N.NodeCreate(_, x, _, _, _, _, _) =>
+        pcs.toAbsoluteContractId(pcs.transactionCounter - 1)(x)
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = sizeExerciseCmd(listUtilTemplateId, contractId)(size)
@@ -187,7 +190,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
       }
 
     newContracts.count {
-      case N.NodeCreate(_, _, _, _, _, _) => true
+      case N.NodeCreate(_, _, _, _, _, _, _) => true
       case n @ _ => fail(s"Unexpected match: $n")
     } shouldBe expectedNumberOfContracts
   }
@@ -306,7 +309,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     }
 
     createNode match {
-      case N.NodeCreate(_, x: ContractInst[_], _, _, _, _) => x
+      case N.NodeCreate(_, _, x: ContractInst[_], _, _, _, _) => x
       case n @ _ => fail(s"Unexpected match: $n")
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -200,6 +200,7 @@ object Ledger {
     node match {
       case nc: NodeCreate.WithTxValue[ContractId] =>
         NodeCreate[AbsoluteContractId, Transaction.Value[AbsoluteContractId]](
+          nodeSeed = nc.nodeSeed,
           coid = contractIdToAbsoluteContractId(commitPrefix, nc.coid),
           coinst = nc.coinst.copy(arg = makeAbsolute(commitPrefix, nc.coinst.arg)),
           optLocation = nc.optLocation,
@@ -218,6 +219,7 @@ object Ledger {
         )
       case nex: NodeExercises.WithTxValue[Transaction.NodeId, ContractId] =>
         NodeExercises[ScenarioNodeId, AbsoluteContractId, Transaction.Value[AbsoluteContractId]](
+          nodeSeed = nex.nodeSeed,
           targetCoid = contractIdToAbsoluteContractId(commitPrefix, nex.targetCoid),
           templateId = nex.templateId,
           choiceId = nex.choiceId,

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -303,7 +303,7 @@ object ValueGenerators {
       signatories <- genNonEmptyParties
       stakeholders <- genNonEmptyParties
       key <- Gen.option(keyWithMaintainersGen)
-    } yield NodeCreate(coid, coinst, None, signatories, stakeholders, key)
+    } yield NodeCreate(None, coid, coinst, None, signatories, stakeholders, key)
   }
 
   val fetchNodeGen: Gen[NodeFetch[ContractId]] = {
@@ -337,6 +337,7 @@ object ValueGenerators {
       maintainers <- genNonEmptyParties
     } yield
       NodeExercises(
+        None,
         targetCoid,
         templateId,
         choiceId,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -303,7 +303,7 @@ object TransactionCoder {
           else if (txVersion precedes minKeyOrLookupByKey)
             Left(DecodeError(s"$txVersion is too old to support NodeCreate's `key` field"))
           else decodeKeyWithMaintainers(decodeVal, protoCreate.getKeyWithMaintainers).map(Some(_))
-        } yield (ni, NodeCreate(c, ci, None, signatories, stakeholders, key))
+        } yield (ni, NodeCreate(None, c, ci, None, signatories, stakeholders, key))
       case NodeTypeCase.FETCH =>
         val protoFetch = protoNode.getFetch
         for {
@@ -389,6 +389,7 @@ object TransactionCoder {
           (
             ni,
             NodeExercises[Nid, Cid, Val](
+              None,
               targetCoid = targetCoid,
               templateId = templateId,
               choiceId = choiceName,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf
 package value
 
-import com.digitalasset.daml.lf.data.Ref.{ContractIdString, Identifier, LedgerString, Name}
+import com.digitalasset.daml.lf.data.Ref.{ContractIdString, Identifier, Name}
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.LanguageVersion
 
@@ -316,20 +316,7 @@ object Value {
   /** The constructor is private so that we make sure that only this object constructs
     * node ids -- we don't want external code to manipulate them.
     */
-  final case class NodeId(index: Int, discriminator: Option[crypto.Hash] = None) extends Equals {
-    val name: LedgerString = LedgerString.assertFromString(index.toString)
-
-    override def equals(other: Any): Boolean = other match {
-      case that: NodeId if (this.discriminator == that.discriminator) =>
-        this.discriminator.isDefined || this.index == that.index
-      case _ =>
-        false
-    }
-
-    override def hashCode(): Int =
-      discriminator.fold(index.hashCode)(_.hashCode())
-
-  }
+  final case class NodeId(index: Int)
 
   /*** Keys cannot contain contract ids */
   type Key = Value[Nothing]

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -261,8 +261,9 @@ class TransactionCoderSpec
 
     "do tx with a lot of root nodes" in {
       val node: Node.NodeCreate[String, VersionedValue[String]] = Node.NodeCreate(
-        "test-cid",
-        ContractInst(
+        nodeSeed = None,
+        coid = "test-cid",
+        coinst = ContractInst(
           Identifier(
             PackageId.assertFromString("pkg-id"),
             QualifiedName.assertFromString("Test:Name"),
@@ -273,10 +274,10 @@ class TransactionCoderSpec
           ),
           ("agreement"),
         ),
-        None,
-        Set(Party.assertFromString("alice")),
-        Set(Party.assertFromString("alice"), Party.assertFromString("bob")),
-        None,
+        optLocation = None,
+        signatories = Set(Party.assertFromString("alice")),
+        stakeholders = Set(Party.assertFromString("alice"), Party.assertFromString("bob")),
+        key = None,
       )
       val nodes = ImmArray((1 to 10000).map { nid =>
         (nid.toString, node)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -126,28 +126,30 @@ object TransactionSpec {
       hasExerciseResult: Boolean = true,
   ): NodeExercises[String, String, Value[String]] =
     NodeExercises(
-      "dummyCoid",
-      Ref.Identifier(
+      nodeSeed = None,
+      targetCoid = "dummyCoid",
+      templateId = Ref.Identifier(
         PackageId.assertFromString("-dummyPkg-"),
         QualifiedName.assertFromString("DummyModule:dummyName"),
       ),
-      "dummyChoice",
-      None,
-      true,
-      Set.empty,
-      V.ValueUnit,
-      Set.empty,
-      Set.empty,
-      Set.empty,
-      children,
-      if (hasExerciseResult) Some(V.ValueUnit) else None,
-      None,
+      choiceId = "dummyChoice",
+      optLocation = None,
+      consuming = true,
+      actingParties = Set.empty,
+      chosenValue = V.ValueUnit,
+      stakeholders = Set.empty,
+      signatories = Set.empty,
+      controllers = Set.empty,
+      children = children,
+      exerciseResult = if (hasExerciseResult) Some(V.ValueUnit) else None,
+      key = None,
     )
 
   val dummyCreateNode: NodeCreate[String, Value[String]] =
     NodeCreate(
-      "dummyCoid",
-      ContractInst(
+      nodeSeed = None,
+      coid = "dummyCoid",
+      coinst = ContractInst(
         Ref.Identifier(
           PackageId.assertFromString("-dummyPkg-"),
           QualifiedName.assertFromString("DummyModule:dummyName"),
@@ -155,10 +157,10 @@ object TransactionSpec {
         V.ValueUnit,
         ("dummyAgreement"),
       ),
-      None,
-      Set.empty,
-      Set.empty,
-      None,
+      optLocation = None,
+      signatories = Set.empty,
+      stakeholders = Set.empty,
+      key = None,
     )
 
   private implicit def toChoiceName(s: String): Ref.Name = Ref.Name.assertFromString(s)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -25,18 +25,19 @@ class ProjectionsSpec extends WordSpec with Matchers {
 
   def makeCreateNode(cid: ContractId, signatories: Set[Party], stakeholders: Set[Party]) =
     Node.NodeCreate(
-      cid,
-      ContractInst(
+      nodeSeed = None,
+      coid = cid,
+      coinst = ContractInst(
         Identifier(
           PackageId.assertFromString("some-package"),
           QualifiedName.assertFromString("Foo:Bar")),
         VersionedValue(ValueVersions.acceptedVersions.last, ValueText("foo")),
         "agreement"
       ),
-      None,
-      signatories,
-      stakeholders,
-      None
+      optLocation = None,
+      signatories = signatories,
+      stakeholders = stakeholders,
+      key = None
     )
 
   def makeExeNode(
@@ -46,20 +47,21 @@ class ProjectionsSpec extends WordSpec with Matchers {
       stakeholders: Set[Party],
       children: ImmArray[NodeId]) =
     Node.NodeExercises(
-      target,
-      Identifier(
+      nodeSeed = None,
+      targetCoid = target,
+      templateId = Identifier(
         PackageId.assertFromString("some-package"),
         QualifiedName.assertFromString("Foo:Bar")),
-      Name.assertFromString("someChoice"),
-      None,
-      true,
-      actingParties,
-      VersionedValue(ValueVersions.acceptedVersions.last, ValueText("foo")),
-      stakeholders,
-      signatories,
-      children,
-      None,
-      None
+      choiceId = Name.assertFromString("someChoice"),
+      optLocation = None,
+      consuming = true,
+      actingParties = actingParties,
+      chosenValue = VersionedValue(ValueVersions.acceptedVersions.last, ValueText("foo")),
+      stakeholders = stakeholders,
+      signatories = signatories,
+      children = children,
+      exerciseResult = None,
+      key = None
     )
 
   def project(tx: Transaction) = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
@@ -25,7 +25,7 @@ object EventIdFormatter {
 
   // this method defines the EventId format used by the sandbox
   def fromTransactionId(transactionId: LedgerString, nid: Transaction.NodeId): LedgerString =
-    fromTransactionId(transactionId, nid.name)
+    fromTransactionId(transactionId, LedgerString.fromInt(nid.index))
 
   /** When loading a scenario we get already absolute nids from the ledger -- still prefix them with the transaction
     * id, just to be safe.

--- a/ledger/sandbox/src/main/scala/db/migration/h2database/V5_1__Populate_Event_Data.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/h2database/V5_1__Populate_Event_Data.scala
@@ -55,7 +55,7 @@ class V5_1__Populate_Event_Data extends BaseJavaMigration {
     val data = txs.flatMap {
       case (txId, tx) =>
         tx.nodes.collect {
-          case (eventId, NodeCreate(cid, _, _, signatories, stakeholders, _)) =>
+          case (eventId, NodeCreate(nodeSeed @ _, cid, _, _, signatories, stakeholders, _)) =>
             (cid, eventId, signatories, stakeholders -- signatories)
         }
     }

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
@@ -55,7 +55,7 @@ class V10_1__Populate_Event_Data extends BaseJavaMigration {
     val data = txs.flatMap {
       case (txId, tx) =>
         tx.nodes.collect {
-          case (eventId, NodeCreate(cid, _, _, signatories, stakeholders, _)) =>
+          case (eventId, NodeCreate(nodeSeed @ _, cid, _, _, signatories, stakeholders, _)) =>
             (cid, eventId, signatories, stakeholders -- signatories)
         }
     }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -135,16 +135,17 @@ class ImplicitPartyAdditionIT
           "create-signatory",
           "CmdId1",
           NodeCreate(
-            AbsoluteContractId("cId1"),
-            ContractInst(
+            nodeSeed = None,
+            coid = AbsoluteContractId("cId1"),
+            coinst = ContractInst(
               templateId1,
               textValue("some text"),
               "agreement"
             ),
-            None,
-            Set("create-signatory"),
-            Set("create-stakeholder"),
-            Some(KeyWithMaintainers(textValue("some text"), Set("create-signatory")))
+            optLocation = None,
+            signatories = Set("create-signatory"),
+            stakeholders = Set("create-stakeholder"),
+            key = Some(KeyWithMaintainers(textValue("some text"), Set("create-signatory")))
           )
         )
         exerciseResult <- publishSingleNodeTx(
@@ -152,19 +153,20 @@ class ImplicitPartyAdditionIT
           "exercise-signatory",
           "CmdId2",
           NodeExercises(
-            AbsoluteContractId("cId1"),
-            templateId1,
-            Ref.ChoiceName.assertFromString("choice"),
-            None,
-            false,
-            Set("exercise-signatory"),
-            textValue("choice value"),
-            Set("exercise-stakeholder"),
-            Set("exercise-signatory"),
-            Set("exercise-signatory"),
-            ImmArray.empty,
-            None,
-            None
+            nodeSeed = None,
+            targetCoid = AbsoluteContractId("cId1"),
+            templateId = templateId1,
+            choiceId = Ref.ChoiceName.assertFromString("choice"),
+            optLocation = None,
+            consuming = false,
+            actingParties = Set("exercise-signatory"),
+            chosenValue = textValue("choice value"),
+            stakeholders = Set("exercise-stakeholder"),
+            signatories = Set("exercise-signatory"),
+            controllers = Set("exercise-signatory"),
+            children = ImmArray.empty,
+            exerciseResult = None,
+            key = None
           )
         )
         fetchResult <- publishSingleNodeTx(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -172,12 +172,13 @@ class JdbcLedgerDaoSpec
         GenTransaction(
           HashMap(
             event1 -> NodeCreate(
-              absCid,
-              someContractInstance,
-              None,
-              Set(alice, bob),
-              Set(alice, bob),
-              Some(keyWithMaintainers)
+              nodeSeed = None,
+              coid = absCid,
+              coinst = someContractInstance,
+              optLocation = None,
+              signatories = Set(alice, bob),
+              stakeholders = Set(alice, bob),
+              key = Some(keyWithMaintainers)
             )),
           ImmArray(event1),
           None
@@ -477,12 +478,13 @@ class JdbcLedgerDaoSpec
         GenTransaction(
           HashMap(
             event1 -> NodeCreate(
-              absCid,
-              someContractInstance,
-              None,
-              Set(alice, bob),
-              Set(alice, bob),
-              Some(keyWithMaintainers)
+              nodeSeed = None,
+              coid = absCid,
+              coinst = someContractInstance,
+              optLocation = None,
+              signatories = Set(alice, bob),
+              stakeholders = Set(alice, bob),
+              key = Some(keyWithMaintainers)
             )),
           ImmArray(event1),
           None
@@ -524,12 +526,13 @@ class JdbcLedgerDaoSpec
         GenTransaction(
           HashMap(
             event1 -> NodeCreate(
-              absCid,
-              someContractInstance,
-              None,
-              Set(alice, bob),
-              Set(alice, bob),
-              None
+              nodeSeed = None,
+              coid = absCid,
+              coinst = someContractInstance,
+              optLocation = None,
+              signatories = Set(alice, bob),
+              stakeholders = Set(alice, bob),
+              key = None
             ),
             event2 -> NodeFetch(
               absCid,
@@ -578,12 +581,13 @@ class JdbcLedgerDaoSpec
           GenTransaction(
             HashMap(
               (s"event$id": EventId) -> NodeCreate(
-                absCid,
-                someContractInstance,
-                None,
-                Set(alice, bob),
-                Set(alice, bob),
-                None
+                nodeSeed = None,
+                coid = absCid,
+                coinst = someContractInstance,
+                optLocation = None,
+                signatories = Set(alice, bob),
+                stakeholders = Set(alice, bob),
+                key = None
               )),
             ImmArray[EventId](s"event$id"),
             None
@@ -606,21 +610,24 @@ class JdbcLedgerDaoSpec
           GenTransaction(
             HashMap(
               (s"event$id": EventId) -> NodeExercises(
-                targetCid,
-                someTemplateId,
-                Ref.Name.assertFromString("choice"),
-                None,
+                nodeSeed = None,
+                targetCoid = targetCid,
+                templateId = someTemplateId,
+                choiceId = Ref.Name.assertFromString("choice"),
+                optLocation = None,
                 consuming = true,
-                Set(alice),
-                VersionedValue(ValueVersions.acceptedVersions.head, ValueText("some choice value")),
-                Set(alice, bob),
-                Set(alice, bob),
-                ImmArray.empty,
-                Some(
+                actingParties = Set(alice),
+                chosenValue = VersionedValue(
+                  ValueVersions.acceptedVersions.head,
+                  ValueText("some choice value")),
+                stakeholders = Set(alice, bob),
+                signatories = Set(alice, bob),
+                children = ImmArray.empty,
+                exerciseResult = Some(
                   VersionedValue(
                     ValueVersions.acceptedVersions.head,
                     ValueText("some exercise result"))),
-                None
+                key = None
               )),
             ImmArray[EventId](s"event$id"),
             None
@@ -781,12 +788,13 @@ class JdbcLedgerDaoSpec
           GenTransaction(
             HashMap(
               (s"event$id": EventId) -> NodeCreate(
-                AbsoluteContractId(s"contractId$id"),
-                someContractInstance,
-                None,
-                Set(party),
-                Set(party),
-                Some(
+                nodeSeed = None,
+                coid = AbsoluteContractId(s"contractId$id"),
+                coinst = someContractInstance,
+                optLocation = None,
+                signatories = Set(party),
+                stakeholders = Set(party),
+                key = Some(
                   KeyWithMaintainers(
                     VersionedValue(ValueVersions.acceptedVersions.head, ValueText(key)),
                     Set(party)))
@@ -815,6 +823,7 @@ class JdbcLedgerDaoSpec
           GenTransaction(
             HashMap(
               (s"event$id": EventId) -> NodeExercises(
+                nodeSeed = None,
                 targetCoid = AbsoluteContractId(s"contractId$cid"),
                 templateId = someTemplateId,
                 choiceId = Ref.ChoiceName.assertFromString("Archive"),


### PR DESCRIPTION
**This is a purely internal change**

In this PR, we change back the internal DAML-LF NodeId to integer. 
We move the nodeSeed in the Exercise and Create Node (other node do not need seed).

This PR advance the state of #3830  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
