### PR TITLE
Fix the flaky ledger-on-sql test on Windows.

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf.data
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
-import java.time.{Instant, LocalDate, ZoneId}
+import java.time.{Duration, Instant, LocalDate, ZoneId}
 import java.util.concurrent.TimeUnit
 
 import scalaz.std.anyVal._
@@ -91,6 +91,13 @@ object Time {
       val seconds = TimeUnit.MICROSECONDS.toSeconds(micros)
       val microsOfSecond = micros - TimeUnit.SECONDS.toMicros(seconds)
       Instant.ofEpochSecond(seconds, TimeUnit.MICROSECONDS.toNanos(microsOfSecond))
+    }
+
+    @throws[IllegalArgumentException]
+    def add(duration: Duration): Timestamp = {
+      val secondsInMicros = TimeUnit.SECONDS.toMicros(duration.getSeconds)
+      val nanosecondsInMicros = TimeUnit.NANOSECONDS.toMicros(duration.getNano.toLong)
+      addMicros(secondsInMicros + nanosecondsInMicros)
     }
 
     @throws[IllegalArgumentException]

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -3,14 +3,14 @@
 
 package com.digitalasset.daml.lf.data
 
-import scalaz.Order
-import scalaz.std.anyVal._
-import scalaz.syntax.order._
-
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
 import java.time.{Instant, LocalDate, ZoneId}
 import java.util.concurrent.TimeUnit
+
+import scalaz.std.anyVal._
+import scalaz.syntax.order._
+import scalaz.{Order, Ordering}
 
 import scala.util.Try
 
@@ -28,9 +28,6 @@ object Time {
   object Date {
 
     type T = Date
-
-    private def apply(days: Int): Date =
-      new Date(days)
 
     private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_DATE.withZone(ZoneId.of("Z"))
@@ -74,8 +71,10 @@ object Time {
 
     implicit val `Time.Date Order`: Order[Date] = new Order[Date] {
       override def equalIsNatural = true
-      override def equal(x: Date, y: Date) = x == y
-      override def order(x: Date, y: Date) = x.days ?|? y.days
+
+      override def equal(x: Date, y: Date): Boolean = x == y
+
+      override def order(x: Date, y: Date): Ordering = x.days ?|? y.days
     }
 
   }
@@ -102,9 +101,6 @@ object Time {
   object Timestamp {
 
     type T = Timestamp
-
-    private def apply(micros: Long): Timestamp =
-      new Timestamp(micros)
 
     private val formatter: DateTimeFormatter =
       DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("Z"))
@@ -156,8 +152,10 @@ object Time {
 
     implicit val `Time.Timestamp Order`: Order[Timestamp] = new Order[Timestamp] {
       override def equalIsNatural = true
-      override def equal(x: Timestamp, y: Timestamp) = x == y
-      override def order(x: Timestamp, y: Timestamp) = x.micros ?|? y.micros
+
+      override def equal(x: Timestamp, y: Timestamp): Boolean = x == y
+
+      override def order(x: Timestamp, y: Timestamp): Ordering = x.micros ?|? y.micros
     }
   }
 

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/TimeSpec.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf.data
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
-import java.time.{Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate}
 import java.util.concurrent.TimeUnit
 
 import com.digitalasset.daml.lf.data.Time._
@@ -84,6 +84,24 @@ class TimeSpec extends FreeSpec with Matchers with TableDrivenPropertyChecks {
       Timestamp.fromString(Instant.parse(max).plusMillis(1).toString) shouldBe 'left
       Timestamp.fromString(min) shouldBe 'right
       Timestamp.fromString(Instant.parse(min).plusMillis(-1).toString) shouldBe 'left
+    }
+
+    "add increments the timestamp" in {
+      val timestamp = Timestamp.assertFromString("2019-04-04T08:33:38.123456Z")
+      val incrementedTimestamp = timestamp.add(Duration.ofNanos(1234567000))
+      incrementedTimestamp.toString shouldBe "2019-04-04T08:33:39.358023Z"
+    }
+
+    "add increments the timestamp even when the duration can't be turned into nanoseconds" in {
+      val timestamp = Timestamp.Epoch
+      val incrementedTimestamp = timestamp.add(Duration.ofNanos(Long.MaxValue).plusNanos(1))
+      incrementedTimestamp.toString shouldBe "2262-04-11T23:47:16.854775Z"
+    }
+
+    "addMicros increments the timestamp" in {
+      val timestamp = Timestamp.assertFromString("2019-04-04T08:33:38.123456Z")
+      val incrementedTimestamp = timestamp.addMicros(1234567)
+      incrementedTimestamp.toString shouldBe "2019-04-04T08:33:39.358023Z"
     }
 
     "addMicros throws an error if it overflows" in {

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -363,7 +363,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
         lic <- ps.getLedgerInitialConditions().runWith(Sink.head)
         _ <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(1.second),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = newSubmissionId(),
             config = lic.config.copy(
               generation = lic.config.generation + 1,
@@ -435,7 +435,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
         // Submit an initial configuration change
         _ <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(1.second),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = newSubmissionId(),
             config = lic.config.copy(
               generation = lic.config.generation + 1,
@@ -446,7 +446,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
         // Submit another configuration change that uses stale "current config".
         _ <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(1.second),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = newSubmissionId(),
             config = lic.config.copy(
               generation = lic.config.generation + 1,
@@ -480,7 +480,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
         // Submit an initial configuration change
         result1 <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(1.second),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = submissionIds._1,
             config = lic.config.copy(
               generation = lic.config.generation + 1,
@@ -490,7 +490,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
         // this is a duplicate, which fails silently
         result2 <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(2.seconds),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = submissionIds._1,
             config = lic.config.copy(
               generation = lic.config.generation + 2,
@@ -499,7 +499,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
           .toScala
         result3 <- ps
           .submitConfiguration(
-            maxRecordTime = inTheFuture(2.seconds),
+            maxRecordTime = inTheFuture(10.seconds),
             submissionId = submissionIds._2,
             config = lic.config.copy(
               generation = lic.config.generation + 2,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.participant.state.kvutils
 import java.io.File
 import java.time.Duration
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 import akka.stream.scaladsl.Sink
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase._
@@ -595,13 +594,13 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
     Offset(Array(first + startIndex, rest: _*))
 
   private def inTheFuture(duration: FiniteDuration): Timestamp =
-    rt.addMicros(duration.toMicros)
+    rt.add(Duration.ofNanos(duration.toNanos))
 }
 
 object ParticipantStateIntegrationSpecBase {
   type ParticipantState = ReadService with WriteService
 
-  private val DefaultIdleTimeout = FiniteDuration(5, TimeUnit.SECONDS)
+  private val DefaultIdleTimeout = 5.seconds
   private val emptyTransaction: SubmittedTransaction =
     GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 


### PR DESCRIPTION
Turns out this is just due to a very short MRT window in the KVUtils integration tests. _(test start time + 1 second)_ is fine for a fast machine, but on a slow machine with a lot going on, it's too tight.

I've increased it to 10 seconds. I also refactored the way we compute them to make sure it's readable, because I find it difficult to figure out how long _(1 followed by lots of zeroes) microseconds_ is in human-comprehensible time durations.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
