### PR TITLE
Extend telemetry data to log when users ignored the telemetry popup

### DIFF
--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -234,6 +234,9 @@ export function createLanguageClient(config: vscode.WorkspaceConfiguration, tele
         args.push('--telemetry');
     } else if (telemetryConsent === false){
         args.push('--optOutTelemetry')
+    } else if (telemetryConsent == undefined) {
+        // The user has not made an explicit choice.
+        args.push('--telemetry-ignored')
     }
     const extraArgsString = config.get("extraArguments", "").trim();
     // split on an empty string returns an array with a single empty string

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -372,15 +372,18 @@ execIde telemetry (Debug debug) enableScenarioService options =
             threshold
             "LanguageServer"
           let withLogger f = case telemetry of
-                  OptedIn ->
+                  TelemetryOptedIn ->
                     let logOfInterest prio = prio `elem` [Logger.Telemetry, Logger.Warning, Logger.Error] in
                     Logger.GCP.withGcpLogger logOfInterest loggerH $ \gcpState loggerH' -> do
                       Logger.GCP.logMetaData gcpState
                       f loggerH'
-                  OptedOut -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
+                  TelemetryOptedOut -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
                       Logger.GCP.logOptOut gcpState
                       f loggerH
-                  Undecided -> f loggerH
+                  TelemetryIgnored -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
+                      Logger.GCP.logIgnored gcpState
+                      f loggerH
+                  TelemetryDisabled -> f loggerH
           dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
           options <- pure options
               { optScenarioService = enableScenarioService


### PR DESCRIPTION
Previously, we did not send any message when users simply clicked away
the telemetry popup. Now we send a special message similar to the
opt-out message which only includes the machine id.

I’ve also changed the opt-out message to include the machine id.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
