### PR TITLE
Expose time in DAML script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -14,6 +14,7 @@ module Daml.Script
   , exerciseCmd
   , exerciseByKeyCmd
   , createAndExerciseCmd
+  , getTime
   ) where
 
 import Prelude hiding (submit, submitMustFail)
@@ -72,6 +73,7 @@ data ScriptF a
   = Submit (SubmitCmd a)
   | Query (QueryACS a)
   | AllocParty (AllocateParty a)
+  | GetTime (Time -> a)
   deriving Functor
 
 data QueryACS a = QueryACS
@@ -100,6 +102,10 @@ allocateParty displayName = Script $ Free (AllocParty $ AllocateParty displayNam
 -- using the party management service.
 allocatePartyOn : Text -> Text -> Script Party
 allocatePartyOn displayName participant = Script $ Free (AllocParty $ AllocateParty displayName (Some participant) pure)
+
+-- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
+instance HasTime Script where
+  getTime = Script $ Free (GetTime pure)
 
 data SubmitFailure = SubmitFailure
   { status : Int

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -78,7 +78,7 @@ object RunnerMain {
           fileContent.parseJson
         })
 
-        val runner = new Runner(dar, applicationId, commandUpdater)
+        val runner = new Runner(dar, applicationId, commandUpdater, timeProvider)
         val participantParams = config.participantConfig match {
           case Some(file) => {
             val source = Source.fromFile(file)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -74,7 +74,7 @@ object TestMain extends StrictLogging {
         implicit val materializer: Materializer = Materializer(system)
         implicit val ec: ExecutionContext = system.dispatcher
 
-        val runner = new Runner(dar, applicationId, commandUpdater)
+        val runner = new Runner(dar, applicationId, commandUpdater, timeProvider)
         val (participantParams, participantCleanup) = config.participantConfig match {
           case Some(file) =>
             val source = Source.fromFile(file)

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -46,6 +46,7 @@ ScriptTest:test3 SUCCESS
 ScriptTest:test4 SUCCESS
 ScriptTest:testCreateAndExercise SUCCESS
 ScriptTest:testKey SUCCESS
+ScriptTest:time SUCCESS
 EOF
 )"
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -139,3 +139,10 @@ failingTest = do
   cid <- submit alice $ createCmd (C alice 42)
   submit alice $ exerciseCmd cid ShouldFail
   pure ()
+
+time : Script (Time, Time)
+time = do
+  t1 <- getTime
+  t2 <- getTime
+  assert (t1 <= t2)
+  pure (t1, t2)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -171,6 +171,35 @@ case class TestCreateAndExercise(dar: Dar[(PackageId, Package)], runner: TestRun
   }
 }
 
+case class Time(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:time"))
+  def runTests() = {
+    runner.genericTest(
+      "Time",
+      scriptId,
+      None,
+      result =>
+        result match {
+          case SRecord(_, _, vals) if vals.size == 2 =>
+            for {
+              t0 <- vals.get(0) match {
+                case STimestamp(t0) => Right(t0)
+                case _ => Left(s"Expected STimeStamp but got ${vals.get(0)})")
+              }
+              t1 <- vals.get(1) match {
+                case STimestamp(t1) => Right(t1)
+                case _ => Left(s"Expected STimeStamp but got ${vals.get(1)})")
+              }
+              r <- if (!(t0 <= t1))
+                Left(s"Second getTime call $t1 should have happened after first $t0")
+              else Right(())
+            } yield r
+          case v => Left(s"Expected SUnit but got $v")
+      }
+    )
+  }
+}
+
 // Runs the example from the docs to make sure it doesn’t produce a runtime error.
 case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptExample:test"))
@@ -223,14 +252,15 @@ object SingleParticipant {
           Participants(Some(ApiParameters("localhost", config.ledgerPort)), Map.empty, Map.empty)
 
         val runner = new TestRunner(participantParams, dar, config.wallclockTime)
-        Test0(dar, runner).runTests()
-        Test1(dar, runner).runTests()
-        Test2(dar, runner).runTests()
-        Test3(dar, runner).runTests()
-        Test4(dar, runner).runTests()
-        TestKey(dar, runner).runTests()
-        TestCreateAndExercise(dar, runner).runTests()
-        ScriptExample(dar, runner).runTests()
+        // Test0(dar, runner).runTests()
+        // Test1(dar, runner).runTests()
+        // Test2(dar, runner).runTests()
+        // Test3(dar, runner).runTests()
+        // Test4(dar, runner).runTests()
+        // TestKey(dar, runner).runTests()
+        // TestCreateAndExercise(dar, runner).runTests()
+        Time(dar, runner).runTests()
+      // ScriptExample(dar, runner).runTests()
     }
   }
 }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -252,15 +252,15 @@ object SingleParticipant {
           Participants(Some(ApiParameters("localhost", config.ledgerPort)), Map.empty, Map.empty)
 
         val runner = new TestRunner(participantParams, dar, config.wallclockTime)
-        // Test0(dar, runner).runTests()
-        // Test1(dar, runner).runTests()
-        // Test2(dar, runner).runTests()
-        // Test3(dar, runner).runTests()
-        // Test4(dar, runner).runTests()
-        // TestKey(dar, runner).runTests()
-        // TestCreateAndExercise(dar, runner).runTests()
+        Test0(dar, runner).runTests()
+        Test1(dar, runner).runTests()
+        Test2(dar, runner).runTests()
+        Test3(dar, runner).runTests()
+        Test4(dar, runner).runTests()
+        TestKey(dar, runner).runTests()
+        TestCreateAndExercise(dar, runner).runTests()
         Time(dar, runner).runTests()
-      // ScriptExample(dar, runner).runTests()
+        ScriptExample(dar, runner).runTests()
     }
   }
 }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -60,14 +60,10 @@ class TestRunner(
     sslContext = None
   )
   val ttl = java.time.Duration.ofSeconds(30)
-  val commandUpdater = if (wallclockTime) {
-    new CommandUpdater(timeProviderO = Some(TimeProvider.UTC), ttl = ttl, overrideTtl = true)
-  } else {
-    new CommandUpdater(
-      timeProviderO = Some(TimeProvider.Constant(Instant.EPOCH)),
-      ttl = ttl,
-      overrideTtl = true)
-  }
+  val timeProvider: TimeProvider =
+    if (wallclockTime) { TimeProvider.Constant(Instant.EPOCH) } else TimeProvider.UTC
+  val commandUpdater =
+    new CommandUpdater(timeProviderO = Some(timeProvider), ttl = ttl, overrideTtl = true)
 
   def genericTest[A](
       // test name
@@ -87,7 +83,7 @@ class TestRunner(
 
     val clientsF = Runner.connect(participantParams, clientConfig)
 
-    val runner = new Runner(dar, applicationId, commandUpdater)
+    val runner = new Runner(dar, applicationId, commandUpdater, timeProvider)
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -61,7 +61,7 @@ class TestRunner(
   )
   val ttl = java.time.Duration.ofSeconds(30)
   val timeProvider: TimeProvider =
-    if (wallclockTime) { TimeProvider.Constant(Instant.EPOCH) } else TimeProvider.UTC
+    if (wallclockTime) TimeProvider.UTC else TimeProvider.Constant(Instant.EPOCH)
   val commandUpdater =
     new CommandUpdater(timeProviderO = Some(timeProvider), ttl = ttl, overrideTtl = true)
 


### PR DESCRIPTION
changelog_begin

- [DAML Script] Add a ``HasTime`` instance for ``Script`` which allows
  you to get the current time (UTC in wallclock mode, UNIX epoch otherwise)

changelog_end

fixes #4200 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
