### PR TITLE
Add `sleep` function to DAML script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -15,10 +15,12 @@ module Daml.Script
   , exerciseByKeyCmd
   , createAndExerciseCmd
   , getTime
+  , sleep
   ) where
 
 import Prelude hiding (submit, submitMustFail)
 import DA.Optional
+import DA.Time
 
 -- | A free monad
 data Free f a
@@ -74,6 +76,7 @@ data ScriptF a
   | Query (QueryACS a)
   | AllocParty (AllocateParty a)
   | GetTime (Time -> a)
+  | Sleep (SleepRec a)
   deriving Functor
 
 data QueryACS a = QueryACS
@@ -93,6 +96,11 @@ data AllocateParty a = AllocateParty
   , continue : Party -> a
   } deriving Functor
 
+data SleepRec a = SleepRec
+  { duration : RelTime
+  , continue : () -> a
+  } deriving Functor
+
 -- | Allocate a party with the given display name
 -- using the party management service.
 allocateParty : Text -> Script Party
@@ -106,6 +114,15 @@ allocatePartyOn displayName participant = Script $ Free (AllocParty $ AllocatePa
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where
   getTime = Script $ Free (GetTime pure)
+
+-- | Sleep for the given duration.
+--
+-- This is primarily useful in tests
+-- where you repeatedly call `query` until a certain state is reached.
+--
+-- Note that this will sleep for the same duration in both wallcock and static time mode.
+sleep : RelTime -> Script ()
+sleep duration = Script $ Free (Sleep $ SleepRec duration pure)
 
 data SubmitFailure = SubmitFailure
   { status : Int

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -47,6 +47,7 @@ ScriptTest:test4 SUCCESS
 ScriptTest:testCreateAndExercise SUCCESS
 ScriptTest:testKey SUCCESS
 ScriptTest:time SUCCESS
+ScriptTest:sleepTest SUCCESS
 EOF
 )"
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -6,6 +6,7 @@ daml 1.2
 module ScriptTest where
 
 import Prelude hiding (getParty, submit, submitMustFail)
+import DA.Time
 
 import Daml.Script
 
@@ -146,3 +147,12 @@ time = do
   t2 <- getTime
   assert (t1 <= t2)
   pure (t1, t2)
+
+sleepTest : Script (Time, Time, Time)
+sleepTest = do
+  t1 <- getTime
+  sleep (seconds 1)
+  t2 <- getTime
+  sleep (seconds 2)
+  t3 <- getTime
+  pure (t1, t2, t3)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.lf.engine.script.test
 
 import java.io.File
+import java.time.Duration
 import scalaz.syntax.traverse._
 import spray.json._
 
@@ -182,19 +183,42 @@ case class Time(dar: Dar[(PackageId, Package)], runner: TestRunner) {
         result match {
           case SRecord(_, _, vals) if vals.size == 2 =>
             for {
-              t0 <- vals.get(0) match {
-                case STimestamp(t0) => Right(t0)
-                case _ => Left(s"Expected STimeStamp but got ${vals.get(0)})")
-              }
-              t1 <- vals.get(1) match {
-                case STimestamp(t1) => Right(t1)
-                case _ => Left(s"Expected STimeStamp but got ${vals.get(1)})")
-              }
+              t0 <- TestRunner.assertSTimestamp(vals.get(0))
+              t1 <- TestRunner.assertSTimestamp(vals.get(1))
               r <- if (!(t0 <= t1))
                 Left(s"Second getTime call $t1 should have happened after first $t0")
               else Right(())
             } yield r
           case v => Left(s"Expected SUnit but got $v")
+      }
+    )
+  }
+}
+
+case class Sleep(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:sleepTest"))
+  def runTests() = {
+    runner.genericTest(
+      "Sleep",
+      scriptId,
+      None, {
+        case SRecord(_, _, vals) if vals.size == 3 =>
+          for {
+            t0 <- TestRunner.assertSTimestamp(vals.get(0))
+            t1 <- TestRunner.assertSTimestamp(vals.get(1))
+            t2 <- TestRunner.assertSTimestamp(vals.get(2))
+            _ <- if (Duration
+                .between(t0.toInstant, t1.toInstant)
+                .compareTo(Duration.ofSeconds(1)) < 0 && runner.wallclockTime)
+              Left(s"Difference between $t0 and $t1 should be more than 1 second")
+            else Right(())
+            _ <- if (Duration
+                .between(t1.toInstant, t2.toInstant)
+                .compareTo(Duration.ofSeconds(2)) < 0 && runner.wallclockTime)
+              Left(s"Difference between $t1 and $t2 should be more than 2 seconds")
+            else Right(())
+          } yield ()
+        case v => Left(s"Expected SUnit but got $v")
       }
     )
   }
@@ -260,6 +284,7 @@ object SingleParticipant {
         TestKey(dar, runner).runTests()
         TestCreateAndExercise(dar, runner).runTests()
         Time(dar, runner).runTests()
+        Sleep(dar, runner).runTests()
         ScriptExample(dar, runner).runTests()
     }
   }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -44,6 +44,10 @@ object TestRunner {
       Left(s"$note: Expected $expected and $actual to be different")
     }
   }
+  def assertSTimestamp(v: SValue) = v match {
+    case SValue.STimestamp(t) => Right(t)
+    case _ => Left(s"Expected STimestamp but got $v")
+  }
 }
 
 class TestRunner(


### PR DESCRIPTION
changelog_begin

- [DAML Script - Experimental] Add a ``sleep`` funciton that pauses
  the script for the given duration. This is primarily useful in tests
  where you repeatedly call ``query`` until a certain state is
  reached.

changelog_end

fixes #4199

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
