### PR TITLE
Engine: fork method to resolve contractIds

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -232,7 +232,7 @@ private[data] final class IdStringImpl extends IdString {
   // Prefixed with "$0" which is not a valid substring of ContractIdV0.
   override type ContractIdStringV1 = String
   override val ContractIdStringV1: StringModule[ContractIdStringV1] =
-    new MatchingStringModule("""\$0[0-9a-f]{64}[A-Za-z0-9:\-_]{189}""")
+    new MatchingStringModule("""\$0[0-9a-f]{64}[A-Za-z0-9:\-_]{0,189}""")
 
   /** Identifier for a contractIs, union of `ContractIdStringV0` and `ContractIdStringV1` */
   override type ContractIdString = String

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
@@ -89,7 +89,7 @@ final case class ExerciseEvent[Nid, Cid, Val](
     exerciseResult: Option[Val])
     extends Event[Nid, Cid, Val]
 
-object Event extends value.CidContainer3[Event] {
+object Event extends value.CidContainer3WithDefaultCidResolver[Event] {
 
   override private[lf] def map3[Nid, Cid, Val, Nid2, Cid2, Val2](
       f1: Nid => Nid2,
@@ -253,7 +253,7 @@ object Event extends value.CidContainer3[Event] {
     Events(relevantRoots, Map() ++ evts)
   }
 
-  object Events extends value.CidContainer3[Events] {
+  object Events extends value.CidContainer3WithDefaultCidResolver[Events] {
     override private[lf] def map3[Nid, Cid, Val, Nid2, Cid2, Val2](
         f1: Nid => Nid2,
         f2: Cid => Cid2,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -27,11 +27,11 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
   private val txCounter: AtomicInteger = new AtomicInteger(0)
 
   def update(tx: GenTransaction.WithTxValue[NodeId, ContractId]): Unit =
-    updateWithAbsoluteContractId(tx.resolveRelCid(toContractIdString(txCounter.get)))
+    updateWithAbsoluteContractId(tx.resolveRelCidV0(toContractIdString(txCounter.get)))
 
-  def toContractIdString(txCounter: Int)(r: RelativeContractId): Ref.ContractIdString =
+  def toContractIdString(txCounter: Int)(r: RelativeContractId): Ref.ContractIdStringV0 =
     // It is safe to concatenate numbers and "-" to form a valid ContractId
-    Ref.ContractIdString.assertFromString(s"$txCounter-${r.txnid.index}")
+    Ref.ContractIdStringV0.assertFromString(s"$txCounter-${r.txnid.index}")
 
   def updateWithAbsoluteContractId(
       tx: GenTransaction.WithTxValue[NodeId, AbsoluteContractId]): Unit =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -191,7 +191,7 @@ object Ledger {
       nodes = enrichedTx.nodes.map {
         case (nodeId, node) =>
           ScenarioNodeId(commitPrefix, nodeId) -> node
-            .resolveRelCid(makeAbs)
+            .resolveRelCidV0(makeAbs)
             .mapNodeId(ScenarioNodeId(commitPrefix, _))
       }(breakOut),
       explicitDisclosure = enrichedTx.explicitDisclosure.map {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -49,7 +49,9 @@ object Node {
     def requiredAuthorizers: Set[Party]
   }
 
-  object GenNode extends WithTxValue3[GenNode] with value.CidContainer3[GenNode] {
+  object GenNode
+      extends WithTxValue3[GenNode]
+      with value.CidContainer3WithDefaultCidResolver[GenNode] {
     override private[lf] def map3[A1, A2, A3, B1, B2, B3](
         f1: A1 => B1,
         f2: A2 => B2,
@@ -258,7 +260,7 @@ object Node {
       KeyWithMaintainers.map1(f)(this)
   }
 
-  object KeyWithMaintainers extends value.CidContainer1[KeyWithMaintainers] {
+  object KeyWithMaintainers extends value.CidContainer1WithDefaultCidResolver[KeyWithMaintainers] {
     implicit def equalInstance[Val: Equal]: Equal[KeyWithMaintainers[Val]] =
       ScalazEqual.withNatural(Equal[Val].equalIsNatural) { (a, b) =>
         import a._

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -329,7 +329,7 @@ final case class GenTransaction[Nid, +Cid, +Val](
     }
 }
 
-object GenTransaction extends value.CidContainer3[GenTransaction] {
+object GenTransaction extends value.CidContainer3WithDefaultCidResolver[GenTransaction] {
   type WithTxValue[Nid, +Cid] = GenTransaction[Nid, Cid, Transaction.Value[Cid]]
 
   case class NotWellFormedError[Nid](nid: Nid, reason: NotWellFormedErrorReason)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -94,9 +94,9 @@ trait CidContainer[+A] {
   protected val self: A
 
   final def resolveRelCidV0[B](f: Value.RelativeContractId => Ref.ContractIdStringV0)(
-      implicit mapper: RelCidV0Resolver[A, B]
+      implicit resolver: RelCidV0Resolver[A, B]
   ): B =
-    mapper.map(f)(self)
+    resolver.map(f)(self)
 
   final def resolveRelCidV1[B](
       f: Value.RelativeContractId => Either[String, Ref.ContractIdStringV1])(
@@ -105,25 +105,25 @@ trait CidContainer[+A] {
     resolver.traverse[String](f)(self)
 
   final def ensureNoCid[B](
-      implicit mapper: NoCidChecker[A, B]
+      implicit checker: NoCidChecker[A, B]
   ): Either[Value.ContractId, B] =
-    mapper.traverse[Value.ContractId](Left(_))(self)
+    checker.traverse[Value.ContractId](Left(_))(self)
 
   final def assertNoCid[B](message: Value.ContractId => String)(
-      implicit mapper: NoCidChecker[A, B]
+      implicit checker: NoCidChecker[A, B]
   ): B =
     data.assertRight(ensureNoCid.left.map(message))
 
   final def ensureNoRelCid[B](
-      implicit mapper: NoRelCidChecker[A, B]
+      implicit checker: NoRelCidChecker[A, B]
   ): Either[Value.RelativeContractId, B] =
-    mapper.traverse[Value.RelativeContractId] {
+    checker.traverse[Value.RelativeContractId] {
       case acoid: Value.AbsoluteContractId => Right(acoid)
       case rcoid: Value.RelativeContractId => Left(rcoid)
     }(self)
 
   final def assertNoRelCid[B](message: Value.ContractId => String)(
-      implicit mapper: NoRelCidChecker[A, B]
+      implicit checker: NoRelCidChecker[A, B]
   ): B =
     data.assertRight(ensureNoRelCid.left.map(message))
 
@@ -160,9 +160,9 @@ trait CidContainer1WithDefaultCidResolver[F[_]] extends CidContainer1[F] {
   import CidMapper._
 
   final implicit def cidResolverInstance[A1, A2, OutputId](
-      implicit mapper1: RelCidResolver[A1, A2, OutputId],
+      implicit resolver1: RelCidResolver[A1, A2, OutputId],
   ): RelCidResolver[F[A1], F[A2], OutputId] =
-    cidMapperInstance(mapper1)
+    cidMapperInstance(resolver1)
 
 }
 
@@ -201,9 +201,9 @@ trait CidContainer3WithDefaultCidResolver[F[_, _, _]] extends CidContainer3[F] {
   import CidMapper._
 
   final implicit def cidResolverInstance[A1, B1, C1, A2, B2, C2, OutputId](
-      implicit mapper1: RelCidResolver[A1, A2, OutputId],
-      mapper2: RelCidResolver[B1, B2, OutputId],
-      mapper3: RelCidResolver[C1, C2, OutputId],
+      implicit resolver1: RelCidResolver[A1, A2, OutputId],
+      resolver2: RelCidResolver[B1, B2, OutputId],
+      resolver3: RelCidResolver[C1, C2, OutputId],
   ): RelCidResolver[F[A1, B1, C1], F[A2, B2, C2], OutputId] =
     cidMapperInstance
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -14,7 +14,8 @@ sealed abstract class CidMapper[-A1, +A2, In, Out] {
 
   def map(f: In => Out): A1 => A2
 
-  // We cheat using exceptions
+  // We cheat using exceptions, to get a cheap implementation of traverse using the `map` function above.
+  // In practice, we abort the traversal using an exception as soon as we find an input we cannot map.
   def traverse[L](f: In => Either[L, Out]): A1 => Either[L, A2] = {
     case class Ball(x: L) extends Throwable with NoStackTrace
     a =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -10,42 +10,69 @@ import com.digitalasset.daml.lf.transaction.VersionTimeline
 import scala.language.higherKinds
 import scala.util.control.NoStackTrace
 
-sealed trait CidMapper[-A1, +A2, Fun] {
+sealed abstract class CidMapper[-A1, +A2, In, Out] {
 
-  def map(f: Fun): A1 => A2
+  def map(f: In => Out): A1 => A2
 
+  private[value] type UnsafeEither[L, R]
+
+  // here we emulate a traverse like function.
+  private[value] def traverse[L](
+      f: (L => UnsafeEither[L, Out], Out => UnsafeEither[L, Out]) => In => UnsafeEither[L, Out]
+  ): A1 => Either[L, A2]
+
+}
+
+private sealed abstract class CidMapperImpl[A1, A2, In, Out] extends CidMapper[A1, A2, In, Out] {
+
+  private[value] final type UnsafeEither[L, R] = R
+
+  // We cheat using exception
+  private[value] final def traverse[L](
+      f: (L => UnsafeEither[L, Out], Out => UnsafeEither[L, Out]) => In => UnsafeEither[L, Out]
+  ): A1 => Either[L, A2] = {
+    case class Ball(x: L) extends Throwable with NoStackTrace
+    a =>
+      def left(x: L): UnsafeEither[L, Out] = throw Ball(x)
+      def right(a: Out): UnsafeEither[L, Out] = a
+      try {
+        Right(map(f(left, right))(a))
+      } catch {
+        case Ball(x) => Left(x)
+      }
+  }
 }
 
 object CidMapper {
 
-  type CidChecker[-A1, +A2, AllowCid] = CidMapper[A1, A2, Value.ContractId => AllowCid]
+  type CidChecker[-A1, +A2, AllowCid] = CidMapper[A1, A2, Value.ContractId, AllowCid]
 
   type NoCidChecker[-A1, +A2] = CidChecker[A1, A2, Nothing]
 
   type NoRelCidChecker[-A1, +A2] = CidChecker[A1, A2, Value.AbsoluteContractId]
 
   type RelCidResolver[-A1, +A2, Id] =
-    CidMapper[A1, A2, Value.RelativeContractId => Id]
+    CidMapper[A1, A2, Value.RelativeContractId, Id]
 
   type RelCidV0Resolver[-A1, +A2] =
-    CidMapper[A1, A2, Value.RelativeContractId => Ref.ContractIdStringV0]
+    CidMapper[A1, A2, Value.RelativeContractId, Ref.ContractIdStringV0]
 
   type RelCidV1Resolver[-A1, +A2] =
-    CidMapper[A1, A2, Value.RelativeContractId => Ref.ContractIdStringV1]
+    CidMapper[A1, A2, Value.RelativeContractId, Ref.ContractIdStringV1]
 
-  def trivialMapper[X, Fun]: CidMapper[X, X, Fun] =
-    new CidMapper[X, X, Fun] {
-      override def map(f: Fun): X => X = identity
+  def trivialMapper[X, In, Out]: CidMapper[X, X, In, Out] =
+    new CidMapperImpl[X, X, In, Out] {
+      override def map(f: In => Out): X => X = identity
     }
 
-  private[value] def basicMapperInstance[Cid1, Cid2]: CidMapper[Cid1, Cid2, Cid1 => Cid2] =
-    new CidMapper[Cid1, Cid2, Cid1 => Cid2] {
+  private[value] def basicMapperInstance[Cid1, Cid2]: CidMapper[Cid1, Cid2, Cid1, Cid2] =
+    new CidMapperImpl[Cid1, Cid2, Cid1, Cid2] {
       override def map(f: Cid1 => Cid2): Cid1 => Cid2 = f
     }
 
   private[value] def basicCidResolverInstance[Id <: Ref.ContractIdString]
     : RelCidResolver[Value.ContractId, Value.AbsoluteContractId, Id] =
-    new RelCidResolver[Value.ContractId, Value.AbsoluteContractId, Id] {
+    new CidMapperImpl[Value.ContractId, Value.AbsoluteContractId, Value.RelativeContractId, Id] {
       override def map(
           f: Value.RelativeContractId => Id,
       ): Value.ContractId => Value.AbsoluteContractId = {
@@ -57,18 +84,22 @@ object CidMapper {
   private[value] def valueVersionCidV1Resolver[A1, A2](
       implicit resolver: RelCidV1Resolver[A1, A2],
   ): RelCidV1Resolver[Value.VersionedValue[A1], Value.VersionedValue[A2]] =
-    new RelCidV1Resolver[Value.VersionedValue[A1], Value.VersionedValue[A2]] {
+    new CidMapperImpl[
+      Value.VersionedValue[A1],
+      Value.VersionedValue[A2],
+      Value.RelativeContractId,
+      Ref.ContractIdStringV1,
+    ] {
       override def map(
           f: Value.RelativeContractId => Ref.ContractIdStringV1,
       ): Value.VersionedValue[A1] => Value.VersionedValue[A2] = {
         case Value.VersionedValue(version, value) =>
           Value.VersionedValue(
             version = VersionTimeline.maxVersion(version, ValueVersions.minContractIdV1),
-            value = value.resolveRelCidV1(f),
+            value = value.map1(resolver.map(f)),
           )
       }
     }
-
 }
 
 trait CidContainer[+A] {
@@ -78,25 +109,20 @@ trait CidContainer[+A] {
   protected val self: A
 
   final def resolveRelCidV0[B](f: Value.RelativeContractId => Ref.ContractIdStringV0)(
-      implicit mapper: RelCidResolver[A, B, Ref.ContractIdStringV0],
+      implicit mapper: RelCidV0Resolver[A, B]
   ): B =
     mapper.map(f)(self)
 
-  final def resolveRelCidV1[B](f: Value.RelativeContractId => Ref.ContractIdStringV1)(
-      implicit mapper: RelCidResolver[A, B, Ref.ContractIdStringV1],
-  ): B =
-    mapper.map(f)(self)
+  final def resolveRelCidV1[B](
+      f: Value.RelativeContractId => Either[String, Ref.ContractIdStringV1])(
+      implicit resolver: RelCidV1Resolver[A, B],
+  ): Either[String, B] =
+    resolver.traverse[String]((left, right) => f(_).fold(left, right))(self)
 
   final def ensureNoCid[B](
       implicit mapper: NoCidChecker[A, B]
-  ): Either[Value.ContractId, B] = {
-    case class Ball(x: Value.ContractId) extends Throwable with NoStackTrace
-    try {
-      Right(mapper.map(coid => throw Ball(coid))(self))
-    } catch {
-      case Ball(coid) => Left(coid)
-    }
-  }
+  ): Either[Value.ContractId, B] =
+    mapper.traverse[Value.ContractId]((left, _) => cid => left(cid))(self)
 
   final def assertNoCid[B](message: Value.ContractId => String)(
       implicit mapper: NoCidChecker[A, B]
@@ -105,17 +131,11 @@ trait CidContainer[+A] {
 
   final def ensureNoRelCid[B](
       implicit mapper: NoRelCidChecker[A, B]
-  ): Either[Value.RelativeContractId, B] = {
-    case class Ball(x: Value.RelativeContractId) extends Throwable with NoStackTrace
-    try {
-      Right(mapper.map({
-        case acoid: Value.AbsoluteContractId => acoid
-        case rcoid: Value.RelativeContractId => throw Ball(rcoid)
-      })(self))
-    } catch {
-      case Ball(coid) => Left(coid)
-    }
-  }
+  ): Either[Value.RelativeContractId, B] =
+    mapper.traverse[Value.RelativeContractId]((left, right) => {
+      case acoid: Value.AbsoluteContractId => right(acoid)
+      case rcoid: Value.RelativeContractId => left(rcoid)
+    })(self)
 
   final def assertNoRelCid[B](message: Value.ContractId => String)(
       implicit mapper: NoRelCidChecker[A, B]
@@ -130,23 +150,23 @@ trait CidContainer1[F[_]] {
 
   private[lf] def map1[A, B](f: A => B): F[A] => F[B]
 
-  protected final def cidMapperInstance[A1, A2, Fun](
-      implicit mapper: CidMapper[A1, A2, Fun]
-  ): CidMapper[F[A1], F[A2], Fun] =
-    new CidMapper[F[A1], F[A2], Fun] {
-      override def map(f: Fun): F[A1] => F[A2] =
+  protected final def cidMapperInstance[A1, A2, In, Out](
+      implicit mapper: CidMapper[A1, A2, In, Out]
+  ): CidMapper[F[A1], F[A2], In, Out] =
+    new CidMapperImpl[F[A1], F[A2], In, Out] {
+      override def map(f: In => Out): F[A1] => F[A2] =
         map1[A1, A2](mapper.map(f))
     }
 
   final implicit def noCidCheckerInstance[A1, A2](
       implicit checker1: NoCidChecker[A1, A2],
   ): NoCidChecker[F[A1], F[A2]] =
-    cidMapperInstance
+    cidMapperInstance[A1, A2, Value.ContractId, Nothing]
 
   final implicit def noRelCidCheckerInstance[A1, A2](
       implicit checker1: NoRelCidChecker[A1, A2],
   ): NoRelCidChecker[F[A1], F[A2]] =
-    cidMapperInstance
+    cidMapperInstance[A1, A2, Value.ContractId, Value.AbsoluteContractId]
 
 }
 
@@ -157,7 +177,7 @@ trait CidContainer1WithDefaultCidResolver[F[_]] extends CidContainer1[F] {
   final implicit def cidResolverInstance[A1, A2, OutputId](
       implicit mapper1: RelCidResolver[A1, A2, OutputId],
   ): RelCidResolver[F[A1], F[A2], OutputId] =
-    cidMapperInstance
+    cidMapperInstance(mapper1)
 
 }
 
@@ -171,13 +191,13 @@ trait CidContainer3[F[_, _, _]] {
       f3: C1 => C2,
   ): F[A1, B1, C1] => F[A2, B2, C2]
 
-  protected final def cidMapperInstance[A1, B1, C1, A2, B2, C2, Fun](
-      implicit mapper1: CidMapper[A1, A2, Fun],
-      mapper2: CidMapper[B1, B2, Fun],
-      mapper3: CidMapper[C1, C2, Fun],
-  ): CidMapper[F[A1, B1, C1], F[A2, B2, C2], Fun] =
-    new CidMapper[F[A1, B1, C1], F[A2, B2, C2], Fun] {
-      override def map(f: Fun): F[A1, B1, C1] => F[A2, B2, C2] = {
+  protected final def cidMapperInstance[A1, B1, C1, A2, B2, C2, In, Out](
+      implicit mapper1: CidMapper[A1, A2, In, Out],
+      mapper2: CidMapper[B1, B2, In, Out],
+      mapper3: CidMapper[C1, C2, In, Out],
+  ): CidMapper[F[A1, B1, C1], F[A2, B2, C2], In, Out] =
+    new CidMapperImpl[F[A1, B1, C1], F[A2, B2, C2], In, Out] {
+      override def map(f: In => Out): F[A1, B1, C1] => F[A2, B2, C2] = {
         map3[A1, B1, C1, A2, B2, C2](mapper1.map(f), mapper2.map(f), mapper3.map(f))
       }
     }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -376,7 +376,8 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
   final case class NodeId(index: Int)
 
   object NodeId {
-    implicit def cidMapperInstance[Fun]: CidMapper[NodeId, NodeId, Fun] = CidMapper.trivialMapper
+    implicit def cidMapperInstance[In, Out]: CidMapper[NodeId, NodeId, In, Out] =
+      CidMapper.trivialMapper
   }
 
   /*** Keys cannot contain contract ids */

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -27,6 +27,7 @@ object ValueVersions
   private[value] val minEnum = ValueVersion("5")
   private[value] val minNumeric = ValueVersion("6")
   private[value] val minGenMap = ValueVersion("7")
+  private[value] val minContractIdV1 = ValueVersion("7")
 
   def assignVersion[Cid](v0: Value[Cid]): Either[String, ValueVersion] = {
     import VersionTimeline.{maxVersion => maxVV}

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -90,7 +90,7 @@ class HashSpec extends WordSpec with Matchers {
       val hash = "ea24627f5b014af67dbedb13d950e60be7f96a1a5bd9fb1a3b9a85b7fa9db4bc"
       val value = complexRecordT.inj(complexRecordV)
       val name = defRef("module", "name")
-      Hash.hashContractKey(GlobalKey(name, value)).toLedgerString shouldBe hash
+      Hash.hashContractKey(GlobalKey(name, value)).toHexaString shouldBe hash
     }
 
     "be deterministic and thread safe" in {
@@ -542,7 +542,7 @@ class HashSpec extends WordSpec with Matchers {
             .builder(Hash.Purpose.Testing)
             .addTypedValue(value)
             .build
-            .toLedgerString
+            .toHexaString
           s"${value.toString}$sep $hash"
         }
         .mkString("", sep, sep)
@@ -554,7 +554,7 @@ class HashSpec extends WordSpec with Matchers {
   "Hash.fromString" should {
     "convert properly string" in {
       val s = "01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086"
-      Hash.assertFromString(s).toLedgerString shouldBe s
+      Hash.assertFromString(s).toHexaString shouldBe s
     }
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -7,7 +7,8 @@ import java.time.{Duration, Instant}
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1.{PackageId, SubmittedTransaction, SubmitterInfo}
-import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString, Party}
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.data.Ref.{LedgerString, Party}
 import com.digitalasset.daml.lf.data.Time
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.transaction._
@@ -35,12 +36,12 @@ private[state] object Conversions {
   def packageStateKey(packageId: PackageId): DamlStateKey =
     DamlStateKey.newBuilder.setPackageId(packageId).build
 
-  def toAbsCoid(txId: DamlLogEntryId, coid: RelativeContractId): ContractIdString = {
+  def toAbsCoid(txId: DamlLogEntryId, coid: RelativeContractId): Ref.ContractIdStringV0 = {
     val hexTxId =
       BaseEncoding.base16.encode(txId.getEntryId.toByteArray)
     // NOTE(JM): Must be in sync with [[absoluteContractIdToLogEntryId]] and
     // [[absoluteContractIdToStateKey]].
-    ContractIdString.assertFromString(s"$hexTxId:${coid.txnid.index}")
+    Ref.ContractIdStringV0.assertFromString(s"$hexTxId:${coid.txnid.index}")
   }
 
   def absoluteContractIdToLogEntryId(acoid: AbsoluteContractId): (DamlLogEntryId, Int) =
@@ -87,7 +88,7 @@ private[state] object Conversions {
   def decodeContractId(coid: DamlContractId): AbsoluteContractId = {
     val hexTxId =
       BaseEncoding.base16.encode(coid.getEntryId.getEntryId.toByteArray)
-    AbsoluteContractId(ContractIdString.assertFromString(s"$hexTxId:${coid.getNodeId}"))
+    AbsoluteContractId(Ref.ContractIdString.assertFromString(s"$hexTxId:${coid.getNodeId}"))
   }
 
   def stateKeyToContractId(key: DamlStateKey): AbsoluteContractId = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -240,7 +240,7 @@ object KeyValueConsumption {
       txId: DamlLogEntryId,
       tx: SubmittedTransaction): CommittedTransaction =
     /* Assign absolute contract ids */
-    tx.resolveRelCid(toAbsCoid(txId, _))
+    tx.resolveRelCidV0(toAbsCoid(txId, _))
 
   @throws(classOf[Err])
   private def parseLedgerString(what: String)(s: String): Ref.LedgerString =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -231,7 +231,7 @@ private[kvutils] case class ProcessTransactionSubmission(
             blindingInfo.localDisclosure(NodeId(key.getContractId.getNodeId.toInt))
           cs.addAllLocallyDisclosedTo((localDisclosure: Iterable[String]).asJava)
           val absCoInst =
-            createNode.coinst.resolveRelCid(Conversions.toAbsCoid(entryId, _))
+            createNode.coinst.resolveRelCidV0(Conversions.toAbsCoid(entryId, _))
           cs.setContractInstance(
             Conversions.encodeContractInstance(absCoInst)
           )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -67,7 +67,7 @@ object Ledger {
 
     // First we "commit" the transaction by converting all relative contractIds to absolute ones
     val committedTransaction: GenTransaction.WithTxValue[NodeId, AbsoluteContractId] =
-      transaction.resolveRelCid(EventIdFormatter.makeAbs(transactionId))
+      transaction.resolveRelCidV0(EventIdFormatter.makeAbs(transactionId))
 
     // here we just need to align the type for blinding
     val blindingInfo = Blinding.blind(committedTransaction)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -139,7 +139,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                   transactionId = transactionId,
                   eventId = nodeId,
                   workflowId = workflowId,
-                  contract = nc.coinst.resolveRelCid(EventIdFormatter.makeAbs(transactionId)),
+                  contract = nc.coinst.resolveRelCidV0(EventIdFormatter.makeAbs(transactionId)),
                   witnesses = disclosure(nodeId),
                   // The divulgences field used to be filled with data coming from the `localDivulgence` field of the blinding info.
                   // But this field is always empty in transactions with only absolute contract ids.


### PR DESCRIPTION
**Purely internal changes**

In this PR we split the `resolveRelCid` of LF container in two method
* `resolveCidV0`: to resolve the relative contract ids in legacy absolute contract id 
* `resolveCidV1`: to  resolve the relative contract ids in new compareble absolute contract Id

This PR advance the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
