### PR TITLE
DAML-LF: constrain cid in transaction/value decode/encoder

### DIFF
--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -61,7 +61,7 @@ object ValueGenerators {
     }
   )
 
-  val defaultValEncode: TransactionCoder.EncodeVal[Tx.Value[Tx.TContractId]] =
+  val defaultValEncode: TransactionCoder.EncodeVal[Tx.TContractId] =
     a => ValueCoder.encodeVersionedValueWithCustomVersion(defaultCidEncode, a).map((a.version, _))
 
   val defaultNidDecode: String => Either[ValueCoder.DecodeError, NodeId] = s => {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -5,13 +5,13 @@ package com.digitalasset.daml.lf
 package transaction
 
 import com.digitalasset.daml.lf.EitherAssertions
-import com.digitalasset.daml.lf.data.ImmArray
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party, QualifiedName}
 import com.digitalasset.daml.lf.transaction.Node.{GenNode, NodeCreate, NodeExercises, NodeFetch}
 import com.digitalasset.daml.lf.transaction.{Transaction => Tx, TransactionOuterClass => proto}
 import com.digitalasset.daml.lf.value.Value.{ContractId, ContractInst, ValueParty, VersionedValue}
 import com.digitalasset.daml.lf.value.ValueCoder.{DecodeCid, DecodeError, EncodeCid, EncodeError}
-import com.digitalasset.daml.lf.value.{ValueVersion, ValueVersions}
+import com.digitalasset.daml.lf.value.{Value, ValueVersion, ValueVersions}
 import com.digitalasset.daml.lf.transaction.TransactionVersions._
 import com.digitalasset.daml.lf.transaction.VersionTimeline.Implicits._
 import org.scalatest.prop.PropertyChecks
@@ -276,25 +276,26 @@ class TransactionCoderSpec
     }
 
     "do tx with a lot of root nodes" in {
-      val node: Node.NodeCreate[String, VersionedValue[String]] = Node.NodeCreate(
-        nodeSeed = None,
-        coid = "test-cid",
-        coinst = ContractInst(
-          Identifier(
-            PackageId.assertFromString("pkg-id"),
-            QualifiedName.assertFromString("Test:Name"),
+      val node =
+        Node.NodeCreate[Value.AbsoluteContractId, Value.VersionedValue[Value.AbsoluteContractId]](
+          nodeSeed = None,
+          coid = absCid("test-cid"),
+          coinst = ContractInst(
+            Identifier(
+              PackageId.assertFromString("pkg-id"),
+              QualifiedName.assertFromString("Test:Name"),
+            ),
+            VersionedValue(
+              ValueVersions.acceptedVersions.last,
+              ValueParty(Party.assertFromString("francesco")),
+            ),
+            ("agreement"),
           ),
-          VersionedValue(
-            ValueVersions.acceptedVersions.last,
-            ValueParty(Party.assertFromString("francesco")),
-          ),
-          ("agreement"),
-        ),
-        optLocation = None,
-        signatories = Set(Party.assertFromString("alice")),
-        stakeholders = Set(Party.assertFromString("alice"), Party.assertFromString("bob")),
-        key = None,
-      )
+          optLocation = None,
+          signatories = Set(Party.assertFromString("alice")),
+          stakeholders = Set(Party.assertFromString("alice"), Party.assertFromString("bob")),
+          key = None,
+        )
       val nodes = ImmArray((1 to 10000).map { nid =>
         (nid.toString, node)
       })
@@ -303,14 +304,17 @@ class TransactionCoderSpec
         roots = nodes.map(_._1),
         optUsedPackages = None,
       )
+      def decodeCid(s: String) =
+        Ref.ContractIdString.fromString(s).left.map(DecodeError).map(Value.AbsoluteContractId)
+      def encodeCid(cid: Value.AbsoluteContractId) = cid.coid
       tx shouldEqual TransactionCoder
         .decodeVersionedTransaction(
           Right(_),
-          DecodeCid(Right(_), { case (s, _) => Right(s) }),
+          DecodeCid(decodeCid, { case (s, _) => decodeCid(s) }),
           TransactionCoder
             .encodeTransaction(
               identity[String],
-              EncodeCid(identity[String], (s: String) => (s, false)),
+              EncodeCid(encodeCid, (s: Value.AbsoluteContractId) => (encodeCid(s), false)),
               tx,
             )
             .right
@@ -378,5 +382,8 @@ class TransactionCoderSpec
         .compose(condApply(minExerciseResult, withoutExerciseResult)),
     )
   }
+
+  private def absCid(s: String): Value.AbsoluteContractId =
+    Value.AbsoluteContractId(Ref.ContractIdString.assertFromString(s))
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -346,14 +346,14 @@ private[state] object Conversions {
     nid => Right(NodeId(nid.toInt))
   private val nidEncoder: TransactionCoder.EncodeNid[NodeId] =
     nid => nid.index.toString
-  private val valEncoder: TransactionCoder.EncodeVal[Transaction.Value[ContractId]] =
+  private val valEncoder: TransactionCoder.EncodeVal[ContractId] =
     a => ValueCoder.encodeVersionedValueWithCustomVersion(cidEncoder, a).map((a.version, _))
   private val valDecoder: ValueOuterClass.VersionedValue => Either[
     ValueCoder.DecodeError,
     Transaction.Value[ContractId]] =
     a => ValueCoder.decodeVersionedValue(cidDecoder, a)
 
-  private val absValEncoder: TransactionCoder.EncodeVal[Transaction.Value[AbsoluteContractId]] =
+  private val absValEncoder: TransactionCoder.EncodeVal[AbsoluteContractId] =
     a => ValueCoder.encodeVersionedValueWithCustomVersion(absCidEncoder, a).map((a.version, _))
 
   private val absValDecoder: ValueOuterClass.VersionedValue => Either[

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/serialization/ContractSerializer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/serialization/ContractSerializer.scala
@@ -26,13 +26,13 @@ object ContractSerializer extends ContractSerializer {
   override def serializeContractInstance(coinst: ContractInst[VersionedValue[AbsoluteContractId]])
     : Either[ValueCoder.EncodeError, Array[Byte]] =
     TransactionCoder
-      .encodeContractInstance[VersionedValue[AbsoluteContractId]](defaultValEncode, coinst)
+      .encodeContractInstance[AbsoluteContractId](defaultValEncode, coinst)
       .map(_.toByteArray())
 
   override def deserializeContractInstance(
       blob: Array[Byte]): Either[DecodeError, ContractInst[VersionedValue[AbsoluteContractId]]] =
     TransactionCoder
-      .decodeContractInstance[VersionedValue[AbsoluteContractId]](
+      .decodeContractInstance[AbsoluteContractId](
         defaultValDecode,
         TransactionOuterClass.ContractInstance.parseFrom(
           Decode.damlLfCodedInputStreamFromBytes(blob, Reader.PROTOBUF_RECURSION_LIMIT)))
@@ -57,7 +57,7 @@ object ContractSerializer extends ContractSerializer {
     }
   )
 
-  private val defaultValEncode: TransactionCoder.EncodeVal[VersionedValue[AbsoluteContractId]] =
+  private val defaultValEncode: TransactionCoder.EncodeVal[AbsoluteContractId] =
     a => ValueCoder.encodeVersionedValueWithCustomVersion(defaultCidEncode, a).map((a.version, _))
 
   private val defaultValDecode: ValueOuterClass.VersionedValue => Either[


### PR DESCRIPTION
**Pure internal change**

We constrain the `ContractId` in the transaction/value decode/encoder to be actual `Value` `ContactId`. 

Ths PR advances the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
