### PR TITLE
standard change extract script

### DIFF
--- a/ci/cron/monthly.yaml
+++ b/ci/cron/monthly.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Azure Pipelines file, see https://aka.ms/yaml
+
+# Do not run on PRs
+pr: none
+
+# Do not run on merge to master
+trigger: none
+
+# Run on schedule: first Monday of each month at 4AM UTC
+schedules:
+  - cron: '0 4 1-7 * Mon'
+    displayName: monthly
+    branches:
+      include:
+        - master
+    always: true
+
+jobs:
+  - job: std_change_notif
+    timeoutInMinutes: 20
+    pool:
+      name: 'linux-pool'
+    steps:
+      - checkout: self
+      - bash: |
+          set -euo pipefail
+
+          eval "$(./dev-env/bin/dade-assist)"
+
+          A_MONTH_AGO=$(date -I -d "now - 1 month")
+          REPORT_MONTH=${A_MONTH_AGO:0:7}
+
+          ./report-std-change.sh $REPORT_MONTH
+
+          curl -H 'Content-Type: application/json' \
+               -i \
+               -XPOST \
+               $(Slack.team-daml-ci) \
+               --data "{\"text\": \"<@U6XMLDZEX> Here is the list of \\\"Standard Changes\\\" for the daml repo, month of ${REPORT_MONTH}. Please forward to security@digitalasset.com.\", \"attachments\": [{\"text\": \"\`\`\`$(cat std-change-report-daml-${REPORT_MONTH}.csv | jq -sR | sed 's/^"//' | sed 's/"$//')\`\`\`\"}]}"
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)

--- a/report-std-change.sh
+++ b/report-std-change.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -euo pipefail
+
+AUTH="Authorization: token $GITHUB_TOKEN"
+MONTH=$1
+START="$MONTH-01T00:00:00+00:00"
+END="$(date -Is -u -d "$START + 1 month")"
+FULL="$(${FULL+false})"
+FILE="${2:-std-change-report-daml-$MONTH.csv}"
+
+SHA_LIST=$(git log --format=%H --after $START --before $END | tac)
+
+echo "Found $(echo $SHA_LIST | wc -w) commits. First: $(echo $SHA_LIST | sed 's/ /\n/g' | head -1), last: $(echo $SHA_LIST | sed 's/ /\n/g' | tail -1)."
+
+TMP=$(mktemp -d)
+
+echo -n "Getting data for each commit..."
+
+mkdir -p "$TMP/commits"
+
+curl -H "$AUTH" \
+     -H "Accept: application/vnd.github.groot-preview+json" \
+     --output "$TMP/commits/#1" \
+     -s \
+     "https://api.github.com/repos/digital-asset/daml/commits/{$(echo $SHA_LIST | sed 's/ /,/g')}/pulls"
+
+echo " done."
+
+PR_LIST=$(for sha in $SHA_LIST; do cat $TMP/commits/$sha | jq -r '.[] | .number'; done)
+
+echo -n "Getting PR data for each commit..."
+ mkdir -p "$TMP/pulls"
+
+curl -H "$AUTH" \
+     --output "$TMP/pulls/#1" \
+     -s \
+     "https://api.github.com/repos/digital-asset/daml/pulls/{$(echo $PR_LIST | sed 's/ /,/g')}"
+
+echo " done."
+
+echo -n "Getting issue data for each PR..."
+
+mkdir -p "$TMP/issues"
+
+curl -H "$AUTH" \
+     --output "$TMP/issues/#1" \
+     -s \
+     "https://api.github.com/repos/digital-asset/daml/issues/{$(echo $PR_LIST | sed 's/ /,/g')}"
+
+echo " done."
+
+mkdir -p "$TMP/approvers"
+
+echo -n "Getting approvers data..."
+
+curl -H "$AUTH" \
+     --output "$TMP/approvers/#1" \
+     -s \
+     "https://api.github.com/repos/digital-asset/daml/pulls/{$(echo $PR_LIST | sed 's/ /,/g')}/reviews"
+
+echo " done."
+
+echo "Writing export to $FILE..."
+
+echo "\"date merged\",\"date opened\",\"title\",\"author\",\"approvers\",\"merger\",\"change type\",\"sha\",\"commit link\",\"PR\",\"PR link\"" > "$FILE"
+for sha in $SHA_LIST; do
+    PR_URL=$(cat $TMP/commits/$sha | jq -r '.[] | .url')
+    PR=$(cat $TMP/commits/$sha | jq -r '.[] | .number')
+    OPEN_DATE=$(cat $TMP/pulls/$PR | jq ".created_at")
+    MERGE_DATE=$(cat $TMP/pulls/$PR | jq ".merged_at")
+    AUTHOR=$(cat $TMP/pulls/$PR | jq '.user.login')
+    MERGER=$(cat $TMP/pulls/$PR | jq '.merged_by.login')
+    PR_LINK="https://github.com/digital-asset/daml/pull/$PR"
+    COMMIT_LINK="https://github.com/digital-asset/daml/commit/$sha"
+    TITLE=$(cat $TMP/pulls/$PR | jq '.title')
+    CHANGE_TYPE=$(cat $TMP/issues/$PR | jq 'if [.labels[] | .name] | contains(["Standard-Change"]) then "Standard-Change" else "Routine-Change" end')
+    APPROVERS=$(cat $TMP/approvers/$PR | jq '[.[] | select(.state=="APPROVED") | .user.login] | join(";")')
+    if [ "$CHANGE_TYPE" = '"Standard-Change"' ] || [ "$FULL" = "true" ]; then
+        echo "$MERGE_DATE,$OPEN_DATE,$TITLE,$AUTHOR,$APPROVERS,$MERGER,$CHANGE_TYPE,\"$sha\",\"$COMMIT_LINK\",\"$PR\",\"$PR_LINK\"" >> "$FILE"
+    fi
+done
+


### PR DESCRIPTION
As part of our SOC2/ISO certification, we need to be able to evidence a list of "Standard Changes" for the DAML SDK project. This commit adds a script that extracts, for a given month, the list of Standard Changes that happened along with relevant information (author, reviewer, etc.).

It also adds a definition for a monthly cron job on Azure to run the script and send the result to Slack, @-mentioning @hurryabit.