### PR TITLE
Enhanced completions for the assistant

### DIFF
--- a/daml-assistant/daml-project-config/DA/Daml/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Config.hs
@@ -63,8 +63,8 @@ sdkVersionFromSdkConfig :: SdkConfig -> Either ConfigError SdkVersion
 sdkVersionFromSdkConfig = querySdkConfigRequired ["version"]
 
 -- | Read sdk config to get list of sdk commands.
-listSdkCommands :: SdkConfig -> Either ConfigError [SdkCommandInfo]
-listSdkCommands = querySdkConfigRequired ["commands"]
+listSdkCommands :: SdkPath -> EnrichedCompletion -> SdkConfig -> Either ConfigError [SdkCommandInfo]
+listSdkCommands sdkPath enriched sdkConf = fmap (map (\f -> f sdkPath enriched)) $ querySdkConfigRequired ["commands"] sdkConf
 
 -- | Query the daml config by passing a path to the desired property.
 -- See 'queryConfig' for more details.

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Config.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Config.hs
@@ -64,7 +64,7 @@ sdkVersionFromSdkConfig = querySdkConfigRequired ["version"]
 
 -- | Read sdk config to get list of sdk commands.
 listSdkCommands :: SdkPath -> EnrichedCompletion -> SdkConfig -> Either ConfigError [SdkCommandInfo]
-listSdkCommands sdkPath enriched sdkConf = fmap (map (\f -> f sdkPath enriched)) $ querySdkConfigRequired ["commands"] sdkConf
+listSdkCommands sdkPath enriched sdkConf = map (\f -> f sdkPath enriched) <$> querySdkConfigRequired ["commands"] sdkConf
 
 -- | Query the daml config by passing a path to the desired property.
 -- See 'queryConfig' for more details.

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Types.hs
@@ -142,7 +142,7 @@ data SdkCommandInfo = SdkCommandInfo
     } deriving (Eq, Show)
 
 data ForwardCompletion
-    = Forward EnrichedCompletion -- ^ Forwhat completions
+    = Forward EnrichedCompletion -- ^ Forward completions
     | NoForward -- ^ No forwarding, fall back to basic completion
     deriving (Eq, Show)
 
@@ -157,8 +157,8 @@ instance Y.FromJSON (SdkPath -> EnrichedCompletion -> SdkCommandInfo) where
     parseJSON = Y.withObject "SdkCommandInfo" $ \p -> do
         name <- p Y..: "name"
         path <- p Y..: "path"
-        args <-  fmap (fromMaybe (SdkCommandArgs [])) (p Y..:? "args")
-        desc <-  p Y..:? "desc"
+        args <- fmap (fromMaybe (SdkCommandArgs [])) (p Y..:? "args")
+        desc <- p Y..:? "desc"
         completion <- fromMaybe False <$> p Y..:? "completion"
         return $ \sdkPath enriched -> SdkCommandInfo
           name

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -4,36 +4,45 @@ commands:
   path: daml-helper/daml-helper
   desc: "Launch DAML Studio"
   args: ["studio"]
+  completion: true
 - name: new
   path: daml-helper/daml-helper
   desc: "Create a new DAML project"
   args: ["new"]
+  completion: true
 - name: migrate
   path: daml-helper/daml-helper
   args: ["migrate"]
+  completion: true
 - name: init
   path: daml-helper/daml-helper
   desc: "Configure a folder as a DAML project"
   args: ["init"]
+  completion: true
 - name: build
   path: damlc/damlc
   args: ["build", "--project-check"]
   desc: "Build the DAML project into a DAR file"
+  completion: true
 - name: test
   path: damlc/damlc
   args: ["test"]
   desc: "Run the scenarios in the given DAML file and all dependencies"
+  completion: true
 - name: start
   path: daml-helper/daml-helper
   args: ["start"]
   desc: "Launch Sandbox and Navigator for current DAML project"
+  completion: true
 - name: clean
   path: damlc/damlc
   args: ["clean", "--project-check"]
   desc: "Delete build artifacts from project folder"
+  completion: true
 - name: damlc
   path: damlc/damlc
   desc: "Run the DAML compiler"
+  completion: true
 - name: sandbox
   path: daml-helper/daml-helper
   desc: "Launch the Sandbox"
@@ -50,14 +59,17 @@ commands:
   path: daml-helper/daml-helper
   desc: "Interact with a DAML ledger (experimental)"
   args: ["ledger"]
+  completion: true
 - name: codegen
   path: daml-helper/daml-helper
   desc: "Run a language bindings code generation tool"
   args: ["codegen"]
+  completion: true
 - name: deploy
   path: daml-helper/daml-helper
   desc: "Deploy DAML project to a ledger (experimental)"
   args: ["deploy"]
+  completion: true
 - name: ide
   path: damlc/damlc
   args: ["lax", "ide"]


### PR DESCRIPTION
This is more of a proposal to see if we want to go down this route. It does add a bit of complexity and seems somewhat hacky but I think the end result does look fairly nice: https://asciinema.org/a/ny1JmgHadcjTImGcecKgxS9K8

Things to do before this could be merged:

1. Add something like a `completions: boolean` field to `sdk-config.yaml` to only enable this logic for processes that use `optparse-applicative`.
2. Fallback to the default bash logic if the command does not use optparse-applicative.
3. Figure out when to pass `--bash-completion-enriched` (that’s what ZSH and fish use) and when not to. The easiest solution is probably just calling `getArgs` at the beginning to check if it’s in there.

changelog_begin

- [DAML Assistant] The assistant can now do completions for SDK
  commands, e.g., ``daml ledger upl<TAB>`` will complete to ``daml
  ledger upload-dar``.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
