### PR TITLE
Removing treatment of local divulgence blinding info

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
@@ -50,7 +50,7 @@ class CommandExecutorImpl(engine: Engine, getPackage: PackageId => Future[Option
       .map { submission =>
         (for {
           updateTx <- submission
-          blindingInfo <- Blinding
+          _ <- Blinding
             .checkAuthorizationAndBlind(updateTx, Set(submitter))
         } yield
           (

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -283,11 +283,8 @@ class JdbcIndexer private[indexer] (
             EventIdFormatter.fromTransactionId(transactionId, nodeId) -> parties
         }
 
-        val mappedLocalDivulgence = blindingInfo.localDivulgence.map {
-          case (nodeId, parties) =>
-            EventIdFormatter.fromTransactionId(transactionId, nodeId) -> parties
-        }
-
+        // local blinding info only contains values on transactions with relative contractIds.
+        // this does not happen here (see type of transaction: GenTransaction.WithTxValue[NodeId, Value.AbsoluteContractId])
         assert(blindingInfo.localDivulgence.isEmpty)
 
         val pt = PersistenceEntry.Transaction(
@@ -300,11 +297,9 @@ class JdbcIndexer private[indexer] (
             transactionMeta.ledgerEffectiveTime.toInstant,
             recordTime.toInstant,
             transaction
-              .resolveRelCid(EventIdFormatter.makeAbs(transactionId))
               .mapNodeId(EventIdFormatter.fromTransactionId(transactionId, _)),
             mappedDisclosure
           ),
-          mappedLocalDivulgence,
           blindingInfo.globalDivulgence,
           divulgedContracts.map(c => c.contractId -> c.contractInst)
         )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -161,7 +161,6 @@ case class InMemoryActiveLedgerState(
       submitter: Option[Party],
       transaction: GenTransaction.WithTxValue[EventId, AbsoluteContractId],
       disclosure: Relation[EventId, Party],
-      localDivulgence: Relation[EventId, Party],
       globalDivulgence: Relation[AbsoluteContractId, Party],
       referencedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)]
   ): Either[Set[SequencingError], InMemoryActiveLedgerState] =
@@ -172,7 +171,6 @@ case class InMemoryActiveLedgerState(
       submitter,
       transaction,
       disclosure,
-      localDivulgence,
       globalDivulgence,
       referencedContracts)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -7,8 +7,16 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.Ref.Party
+import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.engine.Blinding
+import com.digitalasset.daml.lf.transaction.GenTransaction
+import com.digitalasset.daml.lf.transaction.Transaction.NodeId
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
+import com.digitalasset.ledger.EventId
+import com.digitalasset.platform.events.EventIdFormatter
 import com.digitalasset.platform.store.ReadOnlyLedger
 
 import scala.concurrent.Future
@@ -45,4 +53,40 @@ trait Ledger extends ReadOnlyLedger {
       config: Configuration
   ): Future[SubmissionResult]
 
+}
+
+object Ledger {
+
+  type TransactionForIndex =
+    GenTransaction[EventId, AbsoluteContractId, Value.VersionedValue[AbsoluteContractId]]
+  type DisclosureForIndex = Map[EventId, Set[Party]]
+  type GlobalDivulgence = Relation[AbsoluteContractId, Party]
+
+  def convertToCommittedTransaction(transactionId: TransactionId, transaction: SubmittedTransaction)
+    : (TransactionForIndex, DisclosureForIndex, GlobalDivulgence) = {
+
+    // First we "commit" the transaction by converting all relative contractIds to absolute ones
+    val committedTransaction: GenTransaction.WithTxValue[NodeId, AbsoluteContractId] =
+      transaction.resolveRelCid(EventIdFormatter.makeAbs(transactionId))
+
+    // here we just need to align the type for blinding
+    val blindingInfo = Blinding.blind(committedTransaction)
+
+    // At this point there should be no local-divulgences
+    assert(
+      blindingInfo.localDivulgence.isEmpty,
+      s"Encountered non-empty local divulgence. This is a bug! [transactionId={$transactionId}, blindingInfo={${blindingInfo.localDivulgence}}"
+    )
+
+    // convert LF NodeId to Index EventId
+    val disclosureForIndex: Map[EventId, Set[Party]] = blindingInfo.disclosure.map {
+      case (nodeId, parties) =>
+        EventIdFormatter.fromTransactionId(transactionId, nodeId) -> parties
+    }
+
+    val transactionForIndex: TransactionForIndex =
+      committedTransaction.mapNodeId(EventIdFormatter.fromTransactionId(transactionId, _))
+
+    (transactionForIndex, disclosureForIndex, blindingInfo.globalDivulgence)
+  }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -246,7 +246,6 @@ object ScenarioLoader {
           Some(richTransaction.committer),
           tx,
           mappedExplicitDisclosure,
-          mappedLocalImplicitDisclosure,
           mappedGlobalImplicitDisclosure,
           List.empty
         ) match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -141,8 +141,8 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                   workflowId = workflowId,
                   contract = nc.coinst.resolveRelCid(EventIdFormatter.makeAbs(transactionId)),
                   witnesses = disclosure(nodeId),
-                  // we need to `getOrElse` here because the `Nid` might include absolute
-                  // contract ids, and those are never present in the local disclosure.
+                  // The divulgences field used to be filled with data coming from the `localDivulgence` field of the blinding info.
+                  // But this field is always empty in transactions with only absolute contract ids.
                   divulgences = Map.empty,
                   key =
                     nc.key.map(_.assertNoCid(coid => s"Contract ID $coid found in contract key")),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/PersistenceEntry.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/PersistenceEntry.scala
@@ -7,7 +7,6 @@ import com.daml.ledger.participant.state.v1.AbsoluteContractInst
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.data.Relation.Relation
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
-import com.digitalasset.ledger.EventId
 import com.digitalasset.platform.store.entries.LedgerEntry
 
 /**
@@ -24,7 +23,6 @@ object PersistenceEntry {
 
   final case class Transaction(
       entry: LedgerEntry.Transaction,
-      localDivulgence: Relation[EventId, Party],
       globalDivulgence: Relation[AbsoluteContractId, Party],
       divulgedContracts: List[(AbsoluteContractId, AbsoluteContractInst)]
   ) extends PersistenceEntry

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -617,55 +617,12 @@ private class JdbcLedgerDao(
         )
       }
 
-      // Part 3: insert divulgences into the 'contract_divulgences' table
-      val hasNonLocalDivulgence =
-        contracts.exists(c => c.divulgences.exists(d => d._2 != c.transactionId))
-      if (hasNonLocalDivulgence) {
-        // There is at least one contract that was divulged to some party after it was commited.
-        // This happens when writing contracts produced by the scenario loader.
-        // Since we only have the transaction IDs when the contract was divulged, we need to look up the corresponding
-        // ledger offsets.
-        val namedDivulgenceParams = contracts
-          .flatMap(
-            c =>
-              c.divulgences.map(
-                w =>
-                  Seq[NamedParameter](
-                    "contract_id" -> c.id.coid,
-                    "party" -> w._1,
-                    "transaction_id" -> w._2
-                ))
-          )
-          .toArray
-
-        if (!namedDivulgenceParams.isEmpty) {
-          executeBatchSql(
-            queries.SQL_BATCH_INSERT_DIVULGENCES_FROM_TRANSACTION_ID,
-            namedDivulgenceParams
-          )
-        }
-      } else {
-        val namedDivulgenceParams = contracts
-          .flatMap(
-            c =>
-              c.divulgences.map(
-                w =>
-                  Seq[NamedParameter](
-                    "contract_id" -> c.id.coid,
-                    "party" -> w._1,
-                    "ledger_offset" -> offset,
-                    "transaction_id" -> c.transactionId
-                ))
-          )
-          .toArray
-
-        if (!namedDivulgenceParams.isEmpty) {
-          executeBatchSql(
-            queries.SQL_BATCH_INSERT_DIVULGENCES,
-            namedDivulgenceParams
-          )
-        }
-      }
+      // Part 3: formerly: insert divulgences into the 'contract_divulgences' table
+      assert(
+        contracts.forall(_.divulgences.isEmpty),
+        "Encountered non-empty local divulgence. This is a bug!")
+      // when storing contracts, the `divulgences` field is only used to store local divulgences.
+      // since local divulgences in a committed transaction are non-existent, there is nothing to do here.
 
       // Part 4: insert key maintainers into the 'contract_key_maintainers' table
       val namedKeyMaintainerParams = contracts
@@ -763,7 +720,6 @@ private class JdbcLedgerDao(
       offset: Long,
       submitter: Option[Party],
       tx: Transaction,
-      localDivulgence: Relation[EventId, Party],
       globalDivulgence: Relation[AbsoluteContractId, Party],
       divulgedContracts: List[(Value.AbsoluteContractId, AbsoluteContractInst)])(
       implicit connection: Connection): Option[RejectionReason] = tx match {
@@ -850,7 +806,6 @@ private class JdbcLedgerDao(
         submitter,
         transaction,
         disclosure,
-        localDivulgence,
         globalDivulgence,
         divulgedContracts
       )
@@ -952,11 +907,7 @@ private class JdbcLedgerDao(
 
     def insertEntry(le: PersistenceEntry)(implicit conn: Connection): PersistenceResponse =
       le match {
-        case PersistenceEntry.Transaction(
-            tx,
-            localDivulgence,
-            globalDivulgence,
-            divulgedContracts) =>
+        case PersistenceEntry.Transaction(tx, globalDivulgence, divulgedContracts) =>
           Try {
             storeTransaction(offset, tx, txBytes)
 
@@ -967,7 +918,6 @@ private class JdbcLedgerDao(
               offset,
               tx.submittingParty,
               tx,
-              localDivulgence,
               globalDivulgence,
               divulgedContracts)
               .flatMap { rejectionReason =>

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -193,7 +193,6 @@ class JdbcLedgerDaoSpec
           externalOffset,
           PersistenceEntry.Transaction(
             transaction,
-            Map.empty,
             Map(
               absCid -> Set(
                 Ref.Party.assertFromString("Alice"),
@@ -498,7 +497,7 @@ class JdbcLedgerDaoSpec
           offset,
           offset + 1,
           None,
-          PersistenceEntry.Transaction(transaction, Map.empty, Map.empty, List.empty))
+          PersistenceEntry.Transaction(transaction, Map.empty, List.empty))
         entry <- ledgerDao.lookupLedgerEntry(offset)
         endingOffset <- ledgerDao.lookupLedgerEnd()
       } yield {
@@ -555,7 +554,7 @@ class JdbcLedgerDaoSpec
           offset,
           offset + 1,
           None,
-          PersistenceEntry.Transaction(transaction, Map.empty, Map.empty, List.empty))
+          PersistenceEntry.Transaction(transaction, Map.empty, List.empty))
         entry <- ledgerDao.lookupLedgerEntry(offset)
         endingOffset <- ledgerDao.lookupLedgerEnd()
       } yield {
@@ -644,7 +643,7 @@ class JdbcLedgerDaoSpec
             offset,
             offset + 1,
             None,
-            PersistenceEntry.Transaction(t, Map.empty, Map.empty, List.empty))
+            PersistenceEntry.Transaction(t, Map.empty, List.empty))
           .map(_ => ())
       }
 
@@ -656,7 +655,7 @@ class JdbcLedgerDaoSpec
             offset,
             offset + 1,
             None,
-            PersistenceEntry.Transaction(t, Map.empty, Map.empty, List.empty))
+            PersistenceEntry.Transaction(t, Map.empty, List.empty))
           .map(_ => ())
       }
 
@@ -805,7 +804,6 @@ class JdbcLedgerDaoSpec
           Map((s"event$id": EventId) -> Set(party))
         ),
         Map.empty,
-        Map.empty,
         List.empty
       )
 
@@ -848,7 +846,6 @@ class JdbcLedgerDaoSpec
           Map((s"event$id": EventId) -> Set(party))
         ),
         Map.empty,
-        Map.empty,
         List.empty
       )
 
@@ -879,7 +876,6 @@ class JdbcLedgerDaoSpec
           Map((s"event$id": EventId) -> Set(party))
         ),
         Map.empty,
-        Map.empty,
         List.empty
       )
 
@@ -909,7 +905,6 @@ class JdbcLedgerDaoSpec
           ),
           Map((s"event$id": EventId) -> Set(party))
         ),
-        Map.empty,
         Map.empty,
         List.empty
       )


### PR DESCRIPTION
In a committed transaction (i.e. a transaction with only absolute
contract ids), local divulgence is a non-concept.
Therefore local divulgences don't need to be treated and all code
related to it can be removed.

This also removes some duplication between InMemoryLedger and SqlLedger.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
