### PR TITLE
reference-v2: Make IndexerIT less flaky.

### DIFF
--- a/ledger/api-server-damlonx/reference-v2/BUILD.bazel
+++ b/ledger/api-server-damlonx/reference-v2/BUILD.bazel
@@ -4,7 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
-    "da_scala_test",
+    "da_scala_test_suite",
 )
 load(
     "//ledger/ledger-api-test-tool:conformance.bzl",
@@ -57,9 +57,8 @@ da_scala_binary(
     ],
 )
 
-da_scala_test(
+da_scala_test_suite(
     name = "reference-v2-tests",
-    size = "small",
     srcs = glob(["src/test/suite/**/*.scala"]),
     data = [
         "//ledger/test-common:Test-stable.dar",

--- a/ledger/api-server-damlonx/reference-v2/src/test/resources/logback-test.xml
+++ b/ledger/api-server-damlonx/reference-v2/src/test/resources/logback-test.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %level %logger{10}: %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <appender name="MEM" class="com.digitalasset.platform.testing.LogCollector">
         <test>com.daml.ledger.api.server.damlonx.reference.v2.IndexerIT</test>
     </appender>
 
     <logger name="com.digitalasset.platform.indexer.RecoveringIndexer" level="INFO">
-        <appender-ref ref="MEM" />
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="MEM"/>
     </logger>
 
 </configuration>

--- a/ledger/api-server-damlonx/reference-v2/src/test/suite/scala/com/daml/ledger/api/server/damlonx/reference/v2/IndexerIT.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/test/suite/scala/com/daml/ledger/api/server/damlonx/reference/v2/IndexerIT.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.api.server.damlonx.reference.v2
 
+import java.time.Instant
+import java.time.temporal.ChronoUnit.SECONDS
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -164,8 +166,11 @@ class IndexerIT extends AsyncWordSpec with Matchers with BeforeAndAfterEach {
               Level.ERROR -> "Error while running indexer, restart scheduled after 10 seconds",
             )))
         }
+        timeBeforeStop = Instant.now()
         _ <- server.release()
+        timeAfterStop = Instant.now()
       } yield {
+        SECONDS.between(timeBeforeStop, timeAfterStop) should be <= 5L
         // stopping the server and logging the error can happen in either order
         readLog() should contain theSameElementsInOrderAs Seq(
           Level.INFO -> "Starting Indexer Server",


### PR DESCRIPTION
If the indexer restart delay is too short, `RecoveringIndexer` will still wait a second. This is not an issue in production, because the delay is typically 10 seconds, but in tests, where we use 100 milliseconds, it's enough to make the test flaky.

We need to wait in one-second increments to allow for quick cancellation; we don't want the user to have to wait 10 seconds if the process is terminated while restarting.

The fix is to take the minimum of 1 second and the remaining restart time.

This also adds STDOUT logging back into the tests; it was invaluable when debugging the issue.

I am not including a changelog entry, because this only affects tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
