### PR TITLE
Disable http2 with Nix to work around segfaults

### DIFF
--- a/bazel_tools/nixpkgs-disable-http2.patch
+++ b/bazel_tools/nixpkgs-disable-http2.patch
@@ -1,0 +1,25 @@
+diff --git a/nixpkgs/nixpkgs.bzl b/nixpkgs/nixpkgs.bzl
+index 263bb37..d363dfb 100644
+--- a/nixpkgs/nixpkgs.bzl
++++ b/nixpkgs/nixpkgs.bzl
+@@ -88,7 +88,7 @@ def _nixpkgs_package_impl(repository_ctx):
+         "The NIX_PATH environment variable is not inherited."
+     )
+ 
+-    expr_args = []
++    expr_args = ["--option", "http2", "false"]
+     if repository_ctx.attr.nix_file and repository_ctx.attr.nix_file_content:
+         fail("Specify one of 'nix_file' or 'nix_file_content', but not both.")
+     elif repository_ctx.attr.nix_file:
+diff --git a/nixpkgs/nixpkgs.bzl b/nixpkgs/nixpkgs.bzl
+index 263bb37..3360b9b 100644
+--- a/nixpkgs/nixpkgs.bzl
++++ b/nixpkgs/nixpkgs.bzl
+@@ -117,6 +117,7 @@ def _nixpkgs_package_impl(repository_ctx):
+         "bazel-support/nix-out-link",
+     ])
+ 
++    expr_args.extend(["--option", "http2", "false"])
+     expr_args.extend(repository_ctx.attr.nixopts)
+ 
+     # If repositories is not set, leave empty so nix will fail

--- a/deps.bzl
+++ b/deps.bzl
@@ -72,6 +72,16 @@ def daml_deps():
             strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
             sha256 = rules_nixpkgs_sha256,
+            patches = [
+                # On CI and locally we observe occasional segmantation faults
+                # of nix. A known issue since Nix 2.2.2 is that HTTP2 support
+                # can cause such segmentation faults. Since Nix 2.3.2 it is
+                # possible to disable HTTP2 via a command-line flag, which
+                # reportedly solves the issue. See
+                # https://github.com/NixOS/nix/issues/2733#issuecomment-518324335
+                "@com_github_digital_asset_daml//bazel_tools:nixpkgs-disable-http2.patch",
+            ],
+            patch_args = ["-p1"],
         )
 
     if "com_github_madler_zlib" not in native.existing_rules():

--- a/dev-env/bin/dade-freeze
+++ b/dev-env/bin/dade-freeze
@@ -18,4 +18,5 @@ fi
 DADE_REPO_ROOT="$DADE_CURRENT_SCRIPT_DIR/../../"
 VERSION=$(cat "$DADE_REPO_ROOT/dev-env/VERSION")
 semver bump $BUMP $VERSION > "$DADE_REPO_ROOT/dev-env/VERSION"
-nix-build "$DADE_REPO_ROOT/nix" -A cached.dev-env --no-out-link
+# Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+nix-build --option http2 false "$DADE_REPO_ROOT/nix" -A cached.dev-env --no-out-link

--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -57,7 +57,8 @@ dadeBaseHash() {
 
 # List tools defined in dade
 dadeListTools() {
-    cat $(nix-build $DADE_BASE_ROOT/nix -A dade.tools-list)
+    # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+    cat $(nix-build --option http2 false $DADE_BASE_ROOT/nix -A dade.tools-list)
 }
 
 # dadeGetOutput get output of a target
@@ -108,7 +109,8 @@ buildTool() {
     errcho "Building tools.${attr}${forced}..."
     # Allow to fail, so we can capture outpath and to capture the exit code too.
     set +e
-    outpath=$(nix-build "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
+    # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+    outpath=$(nix-build --option http2 false "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
     local dade_build_exit_code=$?
     set -e
     if [[ "$dade_build_exit_code" != "0" ]]; then

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -121,7 +121,8 @@ if [[ $(uname -v) =~ 'Ubuntu' ]]; then
     (
         export LC_ALL=C
         unset NIX_PATH
-        out=$(nix-build --no-out-link -Q "${DADE_DEVENV_DIR}/../nix" -I "${TMP_NIX_PATH}" -A pkgs.glibcLocales)
+        # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+        out=$(nix-build --option http2 false --no-out-link -Q "${DADE_DEVENV_DIR}/../nix" -I "${TMP_NIX_PATH}" -A pkgs.glibcLocales)
         echo "export LOCALE_ARCHIVE=\"${out}/lib/locale/locale-archive\""
     )
 fi


### PR DESCRIPTION
On CI and locally we observe occasional segmantation faults of nix. A known issue since Nix 2.2.2 is that HTTP2 support can cause such segmentation faults. Since Nix 2.3.2 it is possible to disable HTTP2 via a command-line flag, which reportedly solves the issue. See https://github.com/NixOS/nix/issues/2733#issuecomment-518324335

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
