### PR TITLE
Fix flakiness in packaging tests

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -183,7 +183,7 @@ haddockParse diagsLogger opts f = MaybeT $ do
   vfs <- makeVFSHandle
   service <- Service.initialise def Service.mainRule (pure $ LSP.IdInt 0) diagsLogger noLogging opts vfs
   Service.setFilesOfInterest service (Set.fromList f)
-  Service.runAction service $
+  Service.runActionSync service $
              runMaybeT $
              do deps <- Service.usesE Service.GetDependencies f
                 Service.usesE Service.TypeCheck $ nubOrd $ f ++ concatMap Service.transitiveModuleDeps deps

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/State/API/Testing.hs
@@ -564,10 +564,10 @@ graphTest wrld pkg expectedGraph = do
 expectedGraph :: D.NormalizedFilePath -> ExpectedGraph -> ShakeTest ()
 expectedGraph damlFilePath expectedGraph = do
     ideState <- ShakeTest $ Reader.asks steService
-    mbDalf <- liftIO $ API.runAction ideState (API.getDalf damlFilePath)
+    mbDalf <- liftIO $ API.runActionSync ideState (API.getDalf damlFilePath)
     expectNoErrors
     Just lfPkg <- pure mbDalf
-    wrld <- Reader.liftIO $ API.runAction ideState (API.worldForFile damlFilePath)
+    wrld <- Reader.liftIO $ API.runActionSync ideState (API.worldForFile damlFilePath)
     graphTest wrld lfPkg expectedGraph
 
 -- | Example testing scenario.

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -29,8 +29,8 @@ import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text.Extended as T
-import Development.IDE.Core.Service (runAction)
-import Development.IDE.Core.Shake
+import Development.IDE.Core.Rules (useNoFileE)
+import Development.IDE.Core.Service (runActionSync)
 import Development.IDE.Types.Location
 import "ghc-lib-parser" Module (UnitId, primUnitId, stringToUnitId, unitIdString,)
 import qualified Module as GHC
@@ -101,8 +101,10 @@ createProjectPackageDb opts thisSdkVer deps dataDeps = do
         \ExtractedDar{..} -> installDar dbPath edConfFiles edDalfs edSrcs
 
     loggerH <- getLogger opts "generate package maps"
-    (stablePkgs, dependencies) <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> runAction ide $
-        (,) <$> useNoFile_ GenerateStablePackages <*> useNoFile_ GeneratePackageMap
+    mbRes <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> runActionSync ide $ runMaybeT $
+        (,) <$> useNoFileE GenerateStablePackages
+            <*> useNoFileE GeneratePackageMap
+    (stablePkgs, dependencies) <- maybe (fail "Failed to generate package info") pure mbRes
     let stablePkgIds :: Set LF.PackageId
         stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stablePkgs
     -- This includes both SDK dependencies like daml-prim and daml-stdlib but also DARs specified
@@ -241,7 +243,7 @@ generateAndInstallIfaceFiles dalf src opts workDir dbPath projectPackageDatabase
             }
 
     res <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide ->
-        runAction ide $
+        runActionSync ide $
         -- Setting ifDir to . means that the interface files will end up directly next to
         -- the source files which is what we want here.
         writeIfacesAndHie

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -56,10 +56,10 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
 
     -- take the transitive closure of all imports and run on all of them
     -- If some dependencies can't be resolved we'll get a Diagnostic out anyway, so don't worry
-    deps <- runAction h $ mapM getDependencies inFiles
+    deps <- runActionSync h $ mapM getDependencies inFiles
     let files = nubOrd $ concat $ inFiles : catMaybes deps
 
-    results <- runAction h $
+    results <- runActionSync h $
         Shake.forP files $ \file -> do
             mbScenarioResults <- runScenarios file
             results <- case mbScenarioResults of

--- a/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTest.hs
@@ -110,5 +110,5 @@ shouldGenerate input expected = withTempFile $ \tmpFile -> do
     let opts = (defaultOptions Nothing) {optHaddock=Haddock True}
     vfs <- makeVFSHandle
     ideState <- initialise def mainRule (pure $ LSP.IdInt 0) (const $ pure ()) noLogging (toCompileOpts opts (IdeReportProgress False)) vfs
-    Just pm <- runAction ideState $ use GetParsedModule $ toNormalizedFilePath tmpFile
+    Just pm <- runActionSync ideState $ use GetParsedModule $ toNormalizedFilePath tmpFile
     genModuleContent (getDocTestModule pm) @?= T.unlines (doctestHeader <> expected)


### PR DESCRIPTION
We need to use runActionSync everywhere except for the IDE.  Pretty
sure I’ve fixed all cases of those. We also need to use useE instead
of use_ since apparently exceptions shortcircuit shake meaning that
runActionSync doesn’t actually do sync. I’ve only fixed the cases that
we hit in the tests so we probably should do a more thorough pass
after this (I want to get this merged soon since it is quite flaky on
master).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
