### PR TITLE
Allow overriding the default TTL of 30s

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -83,6 +83,8 @@ From a DAML project directory:
             Optional application ID to use for ledger registration. Defaults to HTTP-JSON-API-Gateway
       --package-reload-interval <value>
             Optional interval to poll for package updates. Examples: 500ms, 5s, 10min, 1h, 1d. Defaults to 5 seconds
+      --default-ttl <value>
+            Optional Time to Live interval to set if not provided in the command. Examples: 30s, 1min, 1h. Defaults to 30 seconds
       --max-inbound-message-size <value>
             Optional max inbound message size in bytes. Defaults to 4194304
       --query-store-jdbc-config "driver=<JDBC driver class name>,url=<JDBC connection url>,user=<user>,password=<password>,createSchema=<true|false>"
@@ -92,7 +94,7 @@ From a DAML project directory:
             user -- database user name,
             password -- database user password,
             createSchema -- boolean flag, if set to true, the process will re-create database schema and terminate immediately.
-        Example: "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false"
+            Example: "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false"
       --static-content "prefix=<URL prefix>,directory=<directory>"
             DEV MODE ONLY (not recommended for production). Optional static content configuration string. Contains comma-separated key-value pairs. Where:
             prefix -- URL prefix,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -38,7 +38,7 @@ class CommandService(
     submitAndWaitForTransaction: LedgerClientJwt.SubmitAndWaitForTransaction,
     submitAndWaitForTransactionTree: LedgerClientJwt.SubmitAndWaitForTransactionTree,
     timeProvider: TimeProvider,
-    defaultTimeToLive: Duration = 30.seconds)(implicit ec: ExecutionContext)
+    defaultTimeToLive: FiniteDuration)(implicit ec: ExecutionContext)
     extends StrictLogging {
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -28,7 +28,8 @@ private[http] final case class Config(
     jdbcConfig: Option[JdbcConfig] = None,
     staticContentConfig: Option[StaticContentConfig] = None,
     accessTokenFile: Option[Path] = None,
-    wsConfig: Option[WebsocketConfig] = None
+    wsConfig: Option[WebsocketConfig] = None,
+    defaultTtl: FiniteDuration = HttpService.DefaultTimeToLive
 )
 
 private[http] object Config {
@@ -45,6 +46,8 @@ private[http] object Config {
 }
 
 private[http] abstract class ConfigCompanion[A](name: String) {
+
+  protected val indent: String = List.fill(8)(" ").mkString
 
   def create(x: Map[String, String]): Either[String, A]
 
@@ -103,12 +106,12 @@ private[http] object JdbcConfig extends ConfigCompanion[JdbcConfig]("JdbcConfig"
 
   lazy val help: String =
     "Contains comma-separated key-value pairs. Where:\n" +
-      "\tdriver -- JDBC driver class name, only org.postgresql.Driver supported right now,\n" +
-      "\turl -- JDBC connection URL, only jdbc:postgresql supported right now,\n" +
-      "\tuser -- database user name,\n" +
-      "\tpassword -- database user password,\n" +
-      "\tcreateSchema -- boolean flag, if set to true, the process will re-create database schema and terminate immediately.\n" +
-      "\tExample: " + helpString(
+      s"${indent}driver -- JDBC driver class name, only org.postgresql.Driver supported right now,\n" +
+      s"${indent}url -- JDBC connection URL, only jdbc:postgresql supported right now,\n" +
+      s"${indent}user -- database user name,\n" +
+      s"${indent}password -- database user password,\n" +
+      s"${indent}createSchema -- boolean flag, if set to true, the process will re-create database schema and terminate immediately.\n" +
+      s"${indent}Example: " + helpString(
       "org.postgresql.Driver",
       "jdbc:postgresql://localhost:5432/test?&ssl=true",
       "postgres",
@@ -163,9 +166,9 @@ private[http] object WebsocketConfig extends ConfigCompanion[WebsocketConfig]("W
 
   lazy val help: String =
     "Contains comma-separated key-value pairs. Where:\n" +
-      "\tmaxDuration -- Maximum websocket session duration in minutes\n" +
-      "\theartBeatPer -- Server-side heartBeat interval in seconds\n" +
-      "\tExample: " + helpString("120", "5")
+      s"${indent}maxDuration -- Maximum websocket session duration in minutes\n" +
+      s"${indent}heartBeatPer -- Server-side heartBeat interval in seconds\n" +
+      s"${indent}Example: " + helpString("120", "5")
 
   lazy val usage: String = helpString(
     "<Maximum websocket session duration in minutes>",
@@ -203,9 +206,9 @@ private[http] object StaticContentConfig
 
   lazy val help: String =
     "Contains comma-separated key-value pairs. Where:\n" +
-      "\tprefix -- URL prefix,\n" +
-      "\tdirectory -- local directory that will be mapped to the URL prefix.\n" +
-      "\tExample: " + helpString("static", "./static-content")
+      s"${indent}prefix -- URL prefix,\n" +
+      s"${indent}directory -- local directory that will be mapped to the URL prefix.\n" +
+      s"${indent}Example: " + helpString("static", "./static-content")
 
   lazy val usage: String = helpString("<URL prefix>", "<directory>")
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -49,6 +49,7 @@ import scala.util.control.NonFatal
 object HttpService extends StrictLogging {
 
   val DefaultPackageReloadInterval: FiniteDuration = FiniteDuration(5, "s")
+  val DefaultTimeToLive: FiniteDuration = FiniteDuration(30, "s")
   val DefaultMaxInboundMessageSize: Int = 4194304
 
   private type ET[A] = EitherT[Future, Error, A]
@@ -67,6 +68,7 @@ object HttpService extends StrictLogging {
       staticContentConfig: Option[StaticContentConfig] = None,
       packageReloadInterval: FiniteDuration = DefaultPackageReloadInterval,
       maxInboundMessageSize: Int = DefaultMaxInboundMessageSize,
+      defaultTtl: FiniteDuration = DefaultTimeToLive,
       validateJwt: EndpointsCompanion.ValidateJwt = decodeJwt,
   )(
       implicit asys: ActorSystem,
@@ -111,6 +113,7 @@ object HttpService extends StrictLogging {
         LedgerClientJwt.submitAndWaitForTransaction(client),
         LedgerClientJwt.submitAndWaitForTransactionTree(client),
         TimeProvider.UTC,
+        defaultTtl
       )
 
       contractsService = new ContractsService(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -50,6 +50,7 @@ object Main extends StrictLogging {
         s", jdbcConfig=${config.jdbcConfig.shows}" +
         s", staticContentConfig=${config.staticContentConfig.shows}" +
         s", accessTokenFile=${config.accessTokenFile.toString}" +
+        s", defaultTtl=${config.defaultTtl.toString}" +
         ")")
 
     implicit val asys: ActorSystem = ActorSystem("http-json-ledger-api")
@@ -58,7 +59,7 @@ object Main extends StrictLogging {
       new AkkaExecutionSequencerPool("clientPool")(asys)
     implicit val ec: ExecutionContext = asys.dispatcher
 
-    def terminate() = discard { Await.result(asys.terminate(), 10.seconds) }
+    def terminate(): Unit = discard { Await.result(asys.terminate(), 10.seconds) }
 
     val contractDao = config.jdbcConfig.map(c => ContractDao(c.driver, c.url, c.user, c.password))
 
@@ -80,17 +81,18 @@ object Main extends StrictLogging {
 
     val serviceF: Future[HttpService.Error \/ ServerBinding] =
       HttpService.start(
-        config.ledgerHost,
-        config.ledgerPort,
-        config.applicationId,
-        config.address,
-        config.httpPort,
-        config.wsConfig,
-        config.accessTokenFile,
-        contractDao,
-        config.staticContentConfig,
-        config.packageReloadInterval,
-        config.maxInboundMessageSize
+        ledgerHost = config.ledgerHost,
+        ledgerPort = config.ledgerPort,
+        applicationId = config.applicationId,
+        address = config.address,
+        httpPort = config.httpPort,
+        wsConfig = config.wsConfig,
+        accessTokenFile = config.accessTokenFile,
+        contractDao = contractDao,
+        staticContentConfig = config.staticContentConfig,
+        packageReloadInterval = config.packageReloadInterval,
+        maxInboundMessageSize = config.maxInboundMessageSize,
+        defaultTtl = config.defaultTtl,
       )
 
     discard {
@@ -169,6 +171,13 @@ object Main extends StrictLogging {
         .text(
           s"Optional interval to poll for package updates. Examples: 500ms, 5s, 10min, 1h, 1d. " +
             s"Defaults to ${Config.Empty.packageReloadInterval.toString}")
+
+      opt[Duration]("default-ttl")
+        .action((x, c) => c.copy(defaultTtl = FiniteDuration(x.length, x.unit)))
+        .optional()
+        .text(
+          s"Optional Time to Live interval to set if not provided in the command. Examples: 30s, 1min, 1h. " +
+            s"Defaults to ${Config.Empty.defaultTtl.toString}")
 
       opt[Int]("max-inbound-message-size")
         .action((x, c) => c.copy(maxInboundMessageSize = x))


### PR DESCRIPTION
Closes: #3848

Added a command line option to allow overriding default TTL.
``--default-ttl <value>`` Optional Time to Live interval to set if not provided in the command. Examples: 30s, 1min, 1h. Defaults to 30 seconds

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
