### PR TITLE
Disable list comprehension hints

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -419,8 +419,6 @@
 
     # LIST COMP
 
-    - hint: {lhs: "if b then [x] else []", rhs: "[x | b]", name: Use list comprehension}
-    - hint: {lhs: "if b then [] else [x]", rhs: "[x | not b]", name: Use list comprehension}
     - hint: {lhs: "[x | x <- y]", rhs: "y", side: isVar x, name: Redundant list comprehension}
 
     # TUPLE


### PR DESCRIPTION
These two hints don't make sense in daml (due to strictness).