### PR TITLE
rename "contracts" to "events" in JSON API exercise response

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -431,7 +431,7 @@ HTTP Response
         "status": 200,
         "result": {
             "exerciseResult": "#201:1",
-            "contracts": [
+            "events": [
                 {
                     "archived": {
                         "contractId": "#124:0",

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -470,7 +470,7 @@ Where:
 - ``result`` field contains contract choice execution details:
 
     + ``exerciseResult`` field contains the return value of the exercised contract choice,
-    + ``contracts`` contains an array of contracts that were archived and created as part of the choice execution. The array may contain: **zero or many** ``{"archived": {...}}`` and **zero or many** ``{"created": {...}}`` elements. The order of the contracts is the same as on the ledger.
+    + ``events`` contains an array of contracts that were archived and created as part of the choice execution. The array may contain: **zero or many** ``{"archived": {...}}`` and **zero or many** ``{"created": {...}}`` elements. The order of the contracts is the same as on the ledger.
 
 
 Exercise by Contract Key

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -215,12 +215,12 @@ class Ledger {
     };
     const json = await this.submit('command/exercise', payload);
     // Decode the server response into a tuple.
-    const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<object>[]}> = jtv.object({
+    const responseDecoder: jtv.Decoder<{exerciseResult: R; events: Event<object>[]}> = jtv.object({
       exerciseResult: choice.resultDecoder(),
-      contracts: jtv.array(decodeEventUnknown),
+      events: jtv.array(decodeEventUnknown),
     });
-    const {exerciseResult, contracts} = jtv.Result.withException(responseDecoder.run(json));
-    return [exerciseResult, contracts];
+    const {exerciseResult, events} = jtv.Result.withException(responseDecoder.run(json));
+    return [exerciseResult, events];
   }
 
   /**
@@ -238,12 +238,12 @@ class Ledger {
     };
     const json = await this.submit('command/exercise', payload);
     // Decode the server response into a tuple.
-    const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<object>[]}> = jtv.object({
+    const responseDecoder: jtv.Decoder<{exerciseResult: R; events: Event<object>[]}> = jtv.object({
       exerciseResult: choice.resultDecoder(),
-      contracts: jtv.array(decodeEventUnknown),
+      events: jtv.array(decodeEventUnknown),
     });
-    const {exerciseResult, contracts} = jtv.Result.withException(responseDecoder.run(json));
-    return [exerciseResult, contracts];
+    const {exerciseResult, events} = jtv.Result.withException(responseDecoder.run(json));
+    return [exerciseResult, events];
   }
 
   /**

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -106,7 +106,7 @@ object domain {
 
   final case class ExerciseResponse[+LfV](
       exerciseResult: LfV,
-      contracts: List[Contract[LfV]],
+      events: List[Contract[LfV]],
   )
 
   object PartyDetails {
@@ -477,11 +477,11 @@ object domain {
       )(f: A => G[B]): G[ExerciseResponse[B]] = {
         import scalaz.syntax.applicative._
         val gb: G[B] = f(fa.exerciseResult)
-        val gbs: G[List[Contract[B]]] = fa.contracts.traverse(_.traverse(f))
-        ^(gb, gbs) { (exerciseResult, contracts) =>
+        val gbs: G[List[Contract[B]]] = fa.events.traverse(_.traverse(f))
+        ^(gb, gbs) { (exerciseResult, events) =>
           ExerciseResponse(
             exerciseResult = exerciseResult,
-            contracts = contracts,
+            events = events,
           )
         }
       }


### PR DESCRIPTION
Fixes #4385.

```rst
CHANGELOG_BEGIN
- [JSON API - Experimental] Exercise response field "contracts" renamed to "events".
  See `issue #4385 <https://github.com/digital-asset/daml/issues/4385>`_.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
