### PR TITLE
with `archived` responses from WS streams, include template ID alongside contract ID

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -861,7 +861,10 @@ After submitting an ``Iou_Split`` exercise, which creates two contracts
 and archives the one above, the same stream will eventually produce::
 
     [{
-        "archived": "#1:0"
+        "archived": {
+            "contractId": "#1:0",
+            "templateId": "b70bbfbc77a4790f66d4840cb19f657dd20848f5e2f64e39ad404a6cbd98cf75:Iou:Iou"
+        }
     }, {
         "created": {
             "observers": [],

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -115,6 +115,9 @@ da_scala_test(
         ":Account.dar",
         "//docs:quickstart-model.dar",
     ],
+    plugins = [
+        "@maven//:org_spire_math_kind_projector_2_12",
+    ],
     resources = glob(["src/test/resources/**/*"]),
     scalacopts = hj_scalacopts,
     deps = [

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -257,7 +257,7 @@ class ContractsService(
       }
       .fold(empty) {
         case ((errL, stepL), (errR, stepR)) =>
-          (errL ++ errR, appendForgettingDeletes(stepL, stepR)(_.contractId.unwrap))
+          (errL ++ errR, appendForgettingDeletes(stepL, stepR))
       }
       .mapConcat {
         case (err, inserts) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -7,7 +7,6 @@ import akka.NotUsed
 import akka.stream.scaladsl._
 import akka.stream.Materializer
 import com.digitalasset.daml.lf
-import com.digitalasset.http.ContractsFetch.InsertDeleteStep
 import com.digitalasset.http.LedgerClientJwt.Terminates
 import com.digitalasset.http.dbbackend.ContractDao
 import com.digitalasset.http.domain.{GetActiveContractsRequest, JwtPayload, TemplateId}
@@ -16,6 +15,7 @@ import com.digitalasset.http.query.ValuePredicate
 import com.digitalasset.http.util.ApiValueToLfValueConverter
 import com.digitalasset.http.util.FutureUtil.toFuture
 import util.Collections._
+import util.InsertDeleteStep
 import com.digitalasset.jwt.domain.Jwt
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => api}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -23,7 +23,6 @@ import com.digitalasset.util.ExceptionOps._
 import com.typesafe.scalalogging.StrictLogging
 import scalaz.syntax.show._
 import scalaz.syntax.std.option._
-import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 import scalaz.{-\/, Show, \/, \/-}
 import spray.json.JsValue
@@ -278,7 +277,7 @@ class ContractsService(
       party: lar.Party,
       templateIds: List[domain.TemplateId.RequiredPkg],
       terminates: Terminates = Terminates.AtLedgerEnd,
-  ): Source[InsertDeleteStep[api.event.CreatedEvent], NotUsed] = {
+  ): Source[InsertDeleteStep.LAV1, NotUsed] = {
 
     val txnFilter = util.Transactions.transactionFilterFor(party, templateIds)
     val source = getActiveContracts(jwt, txnFilter, true)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -71,7 +71,7 @@ object WebSocketService {
     }
 
     def append[P >: Pos, A >: LfV](o: StepAndErrors[P, A]): StepAndErrors[P, A] =
-      StepAndErrors(errors ++ o.errors, step.appendWithCid(o.step)(_._1.contractId.unwrap))
+      StepAndErrors(errors ++ o.errors, step append o.step)
 
     def mapLfv[A](f: LfV => A): StepAndErrors[Pos, A] =
       copy(step = step mapPreservingIds (_ leftMap (_ map f)))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -10,10 +10,10 @@ import akka.stream.Materializer
 import com.digitalasset.http.EndpointsCompanion._
 import com.digitalasset.http.domain.{JwtPayload, SearchForeverRequest}
 import com.digitalasset.http.json.{DomainJsonDecoder, DomainJsonEncoder, JsonProtocol, SprayJson}
-import ContractsFetch.InsertDeleteStep
 import com.digitalasset.http.LedgerClientJwt.Terminates
 import util.ApiValueToLfValueConverter.apiValueToLfValue
 import util.Collections._
+import util.InsertDeleteStep
 import json.JsonProtocol.LfValueCodec.{apiValueToJsValue => lfValueToJsValue}
 import query.ValuePredicate.{LfV, TypeLookup}
 import com.digitalasset.jwt.domain.Jwt

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http
+package util
+
+import com.digitalasset.http.dbbackend.Queries.DBContract
+import scalaz.Liskov
+import scalaz.Liskov.<~<
+
+private[http] final case class InsertDeleteStep[+C](inserts: Vector[C], deletes: Set[String]) {
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  def append[CC >: C](
+      o: InsertDeleteStep[CC],
+  )(implicit cid: CC <~< DBContract[Any, Any, Any, Any]): InsertDeleteStep[CC] =
+    appendWithCid(o)(
+      Liskov.contra1_2[Function1, DBContract[Any, Any, Any, Any], CC, String](cid)(_.contractId),
+    )
+
+  def appendWithCid[CC >: C](o: InsertDeleteStep[CC])(cid: CC => String): InsertDeleteStep[CC] =
+    InsertDeleteStep(
+      InsertDeleteStep.appendForgettingDeletes(inserts, o)(cid),
+      deletes union o.deletes,
+    )
+
+  def nonEmpty: Boolean = inserts.nonEmpty || deletes.nonEmpty
+
+  /** Results undefined if cid(d) != cid(c) */
+  def mapPreservingIds[D](f: C => D): InsertDeleteStep[D] = copy(inserts = inserts map f)
+}
+
+private[http] object InsertDeleteStep {
+  def appendForgettingDeletes[C](leftInserts: Vector[C], right: InsertDeleteStep[C])(
+      cid: C => String,
+  ): Vector[C] =
+    (if (right.deletes.isEmpty) leftInserts
+     else leftInserts.filter(c => !right.deletes(cid(c)))) ++ right.inserts
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
@@ -26,23 +26,23 @@ class InsertDeleteStepTest
   behavior of "InsertDeleteStep.appendWithCid"
 
   it should "never insert a deleted item" in forAll { (x: IDS, y: IDS) =>
-    val xy = x |+| y.copy(inserts = y.inserts filterNot Cid.subst(x.deletes))
-    xy.inserts.toSet intersect Cid.subst(xy.deletes) shouldBe empty
+    val xy = x |+| y.copy(inserts = y.inserts filterNot Cid.subst(x.deletes.keySet))
+    xy.inserts.toSet intersect Cid.subst(xy.deletes.keySet) shouldBe empty
   }
 
   it should "preserve every left delete" in forAll { (x: IDS, y: IDS) =>
     val xy = x |+| y
-    xy.deletes should contain allElementsOf x.deletes
+    xy.deletes.keySet should contain allElementsOf x.deletes.keySet
   }
 
   it should "preserve at least right deletes absent in left inserts" in forAll { (x: IDS, y: IDS) =>
     val xy = x |+| y
     // xy.deletes _may_ contain x.inserts; it is semantically irrelevant
-    xy.deletes should contain allElementsOf (y.deletes -- Cid.unsubst(x.inserts))
+    xy.deletes.keySet should contain allElementsOf (y.deletes.keySet -- Cid.unsubst(x.inserts))
   }
 
   it should "preserve append absent deletes" in forAll { (x: Vector[Cid], y: Vector[Cid]) =>
-    val xy = InsertDeleteStep(x, Set.empty) |+| InsertDeleteStep(y, Set.empty)
+    val xy = InsertDeleteStep(x, Map.empty[String, Unit]) |+| InsertDeleteStep(y, Map.empty)
     xy.inserts should ===(x ++ y)
   }
 }
@@ -51,7 +51,7 @@ object InsertDeleteStepTest {
   import org.scalacheck.{Arbitrary, Gen, Shrink}
   import Arbitrary.arbitrary
 
-  type IDS = InsertDeleteStep[Cid]
+  type IDS = InsertDeleteStep[Unit, Cid]
   sealed trait Alpha
   type Cid = String @@ Alpha
   val Cid = Tag.of[Alpha]
@@ -62,19 +62,19 @@ object InsertDeleteStepTest {
   private implicit val `IDS monoid`
     : Monoid[IDS] = Monoid instance (_.append(_)(Cid.unwrap), InsertDeleteStep(
     Vector.empty,
-    Set.empty,
+    Map.empty,
   ))
 
   implicit val `IDS arb`: Arbitrary[IDS] =
-    Arbitrary(arbitrary[(Vector[Cid], Set[Cid])] map {
+    Arbitrary(arbitrary[(Vector[Cid], Map[Cid, Unit])] map {
       case (is, ds) =>
-        InsertDeleteStep(is filterNot ds, Cid unsubst ds)
+        InsertDeleteStep(is filterNot ds.keySet, Cid.unsubst[Map[?, Unit], String](ds))
     })
 
   implicit val `IDS shr`: Shrink[IDS] =
-    Shrink.xmap[(Vector[Cid], Set[Cid]), IDS](
-      { case (is, ds) => InsertDeleteStep(is, Cid unsubst ds) },
-      step => (step.inserts, Cid subst step.deletes),
+    Shrink.xmap[(Vector[Cid], Map[Cid, Unit]), IDS](
+      { case (is, ds) => InsertDeleteStep(is, Cid.unsubst[Map[?, Unit], String](ds)) },
+      step => (step.inserts, Cid.subst[Map[?, Unit], String](step.deletes)),
     )
 
   implicit val `IDS eq`: Equal[IDS] = Equal.equalA

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
@@ -60,7 +60,7 @@ object InsertDeleteStepTest {
     Gen.alphaUpperChar map (_.toString))
 
   private implicit val `IDS monoid`
-    : Monoid[IDS] = Monoid instance (_.appendWithCid(_)(Cid.unwrap), InsertDeleteStep(
+    : Monoid[IDS] = Monoid instance (_.append(_)(Cid.unwrap), InsertDeleteStep(
     Vector.empty,
     Set.empty,
   ))

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
@@ -1,24 +1,23 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.http
+package com.digitalasset.http.util
 
 import com.digitalasset.daml.lf.data.FlatSpecCheckLaws
-import ContractsFetch.InsertDeleteStep
 
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.{@@, Equal, Monoid, Tag}
-import scalaz.syntax.semigroup._
 import scalaz.scalacheck.ScalazProperties
+import scalaz.syntax.semigroup._
+import scalaz.{@@, Equal, Monoid, Tag}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-class ContractsFetchTest
+class InsertDeleteStepTest
     extends FlatSpec
     with Matchers
     with FlatSpecCheckLaws
     with GeneratorDrivenPropertyChecks {
-  import ContractsFetchTest._
+  import InsertDeleteStepTest._
 
   behavior of "InsertDeleteStep append monoid"
 
@@ -48,7 +47,7 @@ class ContractsFetchTest
   }
 }
 
-object ContractsFetchTest {
+object InsertDeleteStepTest {
   import org.scalacheck.{Arbitrary, Gen, Shrink}
   import Arbitrary.arbitrary
 


### PR DESCRIPTION
Thus making the 'archived' response similar to that from exercise. Fixes #4383.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
