### PR TITLE
Rename JSON API endpoints, add version prefix

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -743,7 +743,7 @@ withJsonApi (SandboxPort sandboxPort) (JsonApiPort jsonApiPort) args a = do
         let headers =
                 [ ("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsZWRnZXJJZCI6Ik15TGVkZ2VyIiwiYXBwbGljYXRpb25JZCI6ImZvb2JhciIsInBhcnR5IjoiQWxpY2UifQ.4HYfzjlYr1ApUDot0a6a4zB49zS_jrwRUOCkAiPMqo0")
                 ] :: HTTP.RequestHeaders
-        waitForHttpServer (putStr "." *> threadDelay 500000) ("http://localhost:" <> show jsonApiPort <> "/contracts/search") headers
+        waitForHttpServer (putStr "." *> threadDelay 500000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
         a ph
 
 -- | Whether `daml start` should open a browser automatically.

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -538,8 +538,8 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
                   let headers =
                           [ ("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsZWRnZXJJZCI6Ik15TGVkZ2VyIiwiYXBwbGljYXRpb25JZCI6ImZvb2JhciIsInBhcnR5IjoiQWxpY2UifQ.4HYfzjlYr1ApUDot0a6a4zB49zS_jrwRUOCkAiPMqo0")
                           ] :: RequestHeaders
-                  waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/contracts/search") headers
-                  req <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/contracts/search"
+                  waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
+                  req <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
                   req <- pure req { requestHeaders = headers }
                   manager <- newManager defaultManagerSettings
                   resp <- httpLbs req manager

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -289,7 +289,7 @@ See the request documentation below on how to create an instance of ``Iou`` cont
 HTTP Request
 ------------
 
-- URL: ``/command/create``
+- URL: ``/v1/create``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -394,7 +394,7 @@ The JSON command below, demonstrates how to exercise ``Iou_Transfer`` choice on 
 HTTP Request
 ------------
 
-- URL: ``/command/exercise``
+- URL: ``/v1/exercise``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -493,7 +493,7 @@ The JSON command below, demonstrates how to exercise ``Archive`` choice on ``Acc
 HTT Request
 -----------
 
-- URL: ``/command/exercise``
+- URL: ``/v1/exercise``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -526,7 +526,7 @@ Fetch Contract by Contract ID
 HTTP Request
 ------------
 
-- URL: ``/contracts/lookup``
+- URL: ``/v1/fetch``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -589,7 +589,7 @@ Fetch Contract by Key
 HTTP Request
 ------------
 
-- URL: ``/contracts/lookup``
+- URL: ``/v1/fetch``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -658,7 +658,7 @@ Note that the retrieved contracts do not get persisted into query store database
 HTTP Request
 ------------
 
-- URL: ``/contracts/search``
+- URL: ``/v1/query``
 - Method: ``GET``
 - Content: <EMPTY>
 
@@ -675,7 +675,7 @@ List currently active contracts that match a given query.
 HTTP Request
 ------------
 
-- URL: ``/contracts/search``
+- URL: ``/v1/query``
 - Method: ``POST``
 - Content-Type: ``application/json``
 - Content:
@@ -776,7 +776,7 @@ Nonempty HTTP Response with Unknown Template IDs Warning
 Fetch All Known Parties
 =======================
 
-- URL: ``/parties``
+- URL: ``/v1/parties``
 - Method: ``GET``
 - Content: <EMPTY>
 
@@ -804,7 +804,7 @@ Streaming API
 Contracts Query Stream
 ----------------------
 
-- URL: ``/contracts/searchForever``
+- URL: ``/v1/stream/query``
 - Scheme: ``ws``
 - Protocol: ``WebSocket``
 
@@ -911,7 +911,7 @@ stream will continue in these cases, rather than terminating.
 Some notes on behavior:
 
 1. Each result array means "this is what would have changed if you just
-   polled ``/contracts/search`` iteratively."  In particular, just as
+   polled ``/v1/query`` iteratively."  In particular, just as
    polling search can "miss" contracts (as a create and archive can be
    paired between polls), such contracts may or may not appear in any
    result object.
@@ -944,7 +944,7 @@ Some notes on behavior:
 Fetch by Key Contracts Stream
 -----------------------------
 
-- URL: ``/stream/fetch``
+- URL: ``/v1/stream/fetch``
 - Scheme: ``ws``
 - Protocol: ``WebSocket``
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -12,7 +12,7 @@ tracker
 <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
 or `on Slack <https://hub.daml.com/slack/>`_.
 
-Please keep in mind that the presence of **/v1** prefix in the the URLs below, does not mean that the endpoint interfaces are stabilized.
+Please keep in mind that the presence of **/v1** prefix in the the URLs below does not mean that the endpoint interfaces are stabilized.
 
 The **JSON API** provides a significantly simpler way than :doc:`the Ledger
 API </app-dev/index>` to interact with a ledger by providing *basic active contract set functionality*:

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -12,6 +12,8 @@ tracker
 <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
 or `on Slack <https://hub.daml.com/slack/>`_.
 
+Please keep in mind that the presence of *v1* prefix in the the URLs below does not mean that the endpoints are stable.
+
 The **JSON API** provides a significantly simpler way than :doc:`the Ledger
 API </app-dev/index>` to interact with a ledger by providing *basic active contract set functionality*:
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -12,7 +12,7 @@ tracker
 <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
 or `on Slack <https://hub.daml.com/slack/>`_.
 
-Please keep in mind that the presence of *v1* prefix in the the URLs below does not mean that the endpoints are stable.
+Please keep in mind that the presence of **/v1** prefix in the the URLs below, does not mean that the endpoint interfaces are stabilized.
 
 The **JSON API** provides a significantly simpler way than :doc:`the Ledger
 API </app-dev/index>` to interact with a ledger by providing *basic active contract set functionality*:

--- a/docs/source/json-api/search-query-language.rst
+++ b/docs/source/json-api/search-query-language.rst
@@ -1,10 +1,10 @@
 .. Copyright (c) 2020 The DAML Authors. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-/contracts/search query language
-################################
+Query language
+##############
 
-The body of ``POST /contracts/search`` looks like so::
+The body of ``POST /query`` looks like so::
 
   {"templateIds": [...template IDs...],
    "query": {...query elements...}}

--- a/docs/source/json-api/search-query-language.rst
+++ b/docs/source/json-api/search-query-language.rst
@@ -4,7 +4,7 @@
 Query language
 ##############
 
-The body of ``POST /query`` looks like so::
+The body of ``POST /v1/query`` looks like so::
 
   {"templateIds": [...template IDs...],
    "query": {...query elements...}}

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -145,7 +145,7 @@ class Ledger {
    */
   async query<T extends object, K, I extends string>(template: Template<T, K, I>, query?: Query<T>): Promise<CreateEvent<T, K, I>[]> {
     const payload = {templateIds: [template.templateId], query};
-    const json = await this.submit('contracts/search', payload);
+    const json = await this.submit('v1/query', payload);
     return jtv.Result.withException(jtv.array(decodeCreateEvent(template)).run(json));
   }
 
@@ -165,7 +165,7 @@ class Ledger {
       templateId: template.templateId,
       contractId,
     };
-    const json = await this.submit('contracts/lookup', payload);
+    const json = await this.submit('v1/fetch', payload);
     return jtv.Result.withException(jtv.oneOf(jtv.constant(null), decodeCreateEvent(template)).run(json));
   }
 
@@ -180,7 +180,7 @@ class Ledger {
       templateId: template.templateId,
       key,
     };
-    const json = await this.submit('contracts/lookup', payload);
+    const json = await this.submit('v1/fetch', payload);
     return jtv.Result.withException(jtv.oneOf(jtv.constant(null), decodeCreateEvent(template)).run(json));
   }
 
@@ -199,7 +199,7 @@ class Ledger {
       templateId: template.templateId,
       payload,
     };
-    const json = await this.submit('command/create', command);
+    const json = await this.submit('v1/create', command);
     return jtv.Result.withException(decodeCreateEvent(template).run(json));
   }
 
@@ -213,7 +213,7 @@ class Ledger {
       choice: choice.choiceName,
       argument,
     };
-    const json = await this.submit('command/exercise', payload);
+    const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
     const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<object>[]}> = jtv.object({
       exerciseResult: choice.resultDecoder(),
@@ -236,7 +236,7 @@ class Ledger {
       choice: choice.choiceName,
       argument,
     };
-    const json = await this.submit('command/exercise', payload);
+    const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
     const responseDecoder: jtv.Decoder<{exerciseResult: R; contracts: Event<object>[]}> = jtv.object({
       exerciseResult: choice.resultDecoder(),

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -37,7 +37,7 @@ export type QueryResult<T extends object, K> = {
 // to work in `useQuery` when using the default value for `queryFactory`.
 const emptyQuery = {};
 
-/// React Hook for a query against the `/contracts/search` endpoint of the JSON API.
+/// React Hook for a query against the `/query` endpoint of the JSON API.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = () => emptyQuery as Query<T>, queryDeps?: readonly any[]): QueryResult<T, K> => {
   const state = useDamlState();
@@ -69,7 +69,7 @@ export type FetchResult<T extends object, K> = {
   loading: boolean;
 }
 
-/// React Hook for a lookup by key against the `/contracts/lookup` endpoint of the JSON API.
+/// React Hook for a lookup by key against the `/fetch` endpoint of the JSON API.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useFetchByKey = <T extends object, K>(template: Template<T, K>, keyFactory: () => K, keyDeps?: readonly any[]): FetchResult<T, K> => {
   const state = useDamlState();

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -144,7 +144,7 @@ class Endpoints(
 
         (jwt, jwtPayload, reqBody) = input
 
-        _ = logger.debug(s"/va1/fetch reqBody: $reqBody")
+        _ = logger.debug(s"/v1/fetch reqBody: $reqBody")
 
         cl <- either(
           decoder

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -54,7 +54,7 @@ class Endpoints(
     command orElse contracts orElse parties
 
   lazy val command: PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    case req @ HttpRequest(POST, Uri.Path("/command/create"), _, _, _) =>
+    case req @ HttpRequest(POST, Uri.Path("/v1/create"), _, _, _) =>
       val et: ET[JsValue] = for {
         t3 <- FutureUtil.eitherT(input(req)): ET[(Jwt, JwtPayload, String)]
 
@@ -76,7 +76,7 @@ class Endpoints(
 
       httpResponse(et)
 
-    case req @ HttpRequest(POST, Uri.Path("/command/exercise"), _, _, _) =>
+    case req @ HttpRequest(POST, Uri.Path("/v1/exercise"), _, _, _) =>
       val et: ET[JsValue] = for {
         t3 <- eitherT(input(req)): ET[(Jwt, JwtPayload, String)]
 
@@ -138,13 +138,13 @@ class Endpoints(
     SprayJson.encode(as).leftMap(e => ServerError(e.shows))
 
   lazy val contracts: PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    case req @ HttpRequest(POST, Uri.Path("/contracts/lookup"), _, _, _) =>
+    case req @ HttpRequest(POST, Uri.Path("/v1/fetch"), _, _, _) =>
       val et: ET[JsValue] = for {
         input <- FutureUtil.eitherT(input(req)): ET[(Jwt, JwtPayload, String)]
 
         (jwt, jwtPayload, reqBody) = input
 
-        _ = logger.debug(s"/contracts/lookup reqBody: $reqBody")
+        _ = logger.debug(s"/va1/fetch reqBody: $reqBody")
 
         cl <- either(
           decoder
@@ -152,7 +152,7 @@ class Endpoints(
             .leftMap(e => InvalidUserInput(e.shows))
         ): ET[domain.ContractLocator[LfValue]]
 
-        _ = logger.debug(s"/contracts/lookup cl: $cl")
+        _ = logger.debug(s"/v1/fetch cl: $cl")
 
         ac <- eitherT(
           handleFutureFailure(contractsService.lookup(jwt, jwtPayload, cl))
@@ -166,7 +166,7 @@ class Endpoints(
 
       httpResponse(et)
 
-    case req @ HttpRequest(GET, Uri.Path("/contracts/search"), _, _, _) =>
+    case req @ HttpRequest(GET, Uri.Path("/v1/query"), _, _, _) =>
       val sourceF: Future[Error \/ SearchResult[Error \/ JsValue]] = input(req).map {
         _.map {
           case (jwt, jwtPayload, _) =>
@@ -184,7 +184,7 @@ class Endpoints(
 
       httpResponse(sourceF)
 
-    case req @ HttpRequest(POST, Uri.Path("/contracts/search"), _, _, _) =>
+    case req @ HttpRequest(POST, Uri.Path("/v1/query"), _, _, _) =>
       val sourceF: Future[Error \/ SearchResult[Error \/ JsValue]] = input(req).map {
         _.flatMap {
           case (jwt, jwtPayload, reqBody) =>
@@ -209,7 +209,7 @@ class Endpoints(
   }
 
   lazy val parties: PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    case req @ HttpRequest(GET, Uri.Path("/parties"), _, _, _) =>
+    case req @ HttpRequest(GET, Uri.Path("/v1/parties"), _, _, _) =>
       val et: ET[JsValue] = for {
         _ <- FutureUtil.eitherT(input(req)): ET[(Jwt, JwtPayload, String)]
         ps <- rightT(partiesService.allParties()): ET[List[domain.PartyDetails]]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -55,7 +55,7 @@ class WebsocketEndpoints(
   import WebsocketEndpoints._
 
   lazy val transactionWebSocket: PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    case req @ HttpRequest(GET, Uri.Path("/contracts/searchForever"), _, _, _) =>
+    case req @ HttpRequest(GET, Uri.Path("/v1/stream/query"), _, _, _) =>
       Future.successful(
         (for {
           upgradeReq <- req.header[UpgradeToWebSocket] \/> InvalidUserInput(
@@ -74,7 +74,7 @@ class WebsocketEndpoints(
           .valueOr(httpResponseError),
       )
 
-    case req @ HttpRequest(GET, Uri.Path("/stream/fetch"), _, _, _) =>
+    case req @ HttpRequest(GET, Uri.Path("/v1/stream/fetch"), _, _, _) =>
       Future.successful(
         (for {
           upgradeReq <- req.header[UpgradeToWebSocket] \/> InvalidUserInput(

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -32,7 +32,7 @@ class HttpServiceWithPostgresIntTest
     password = jdbcConfig_.password
   )
 
-  "contracts/search persists all active contracts" in withHttpService { (uri, encoder, _) =>
+  "query persists all active contracts" in withHttpService { (uri, encoder, _) =>
     searchWithQuery(
       searchDataSet,
       jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -51,8 +51,8 @@ class WebsocketServiceIntegrationTest
   private val validSubprotocol = Option(s"""$tokenPrefix${jwt.value},$wsProtocol""")
 
   List(
-    SimpleScenario("query", Uri.Path("/contracts/searchForever"), baseQueryFlow),
-    SimpleScenario("fetch", Uri.Path("/stream/fetch"), baseFetchFlow)
+    SimpleScenario("query", Uri.Path("/v1/stream/query"), baseQueryFlow),
+    SimpleScenario("fetch", Uri.Path("/v1/stream/fetch"), baseFetchFlow)
   ).foreach { scenario =>
     s"${scenario.id} request with valid protocol token should allow client subscribe to stream" in withHttpService {
       (uri, _, _) =>
@@ -87,7 +87,7 @@ class WebsocketServiceIntegrationTest
   private def singleClientQueryStream(serviceUri: Uri, query: String) = {
     val webSocketFlow = Http().webSocketClientFlow(
       WebSocketRequest(
-        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/contracts/searchForever")),
+        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/query")),
         subprotocol = validSubprotocol))
     Source
       .single(TextMessage(query))
@@ -97,7 +97,7 @@ class WebsocketServiceIntegrationTest
   private def singleClientFetchStream(serviceUri: Uri, request: String) = {
     val webSocketFlow = Http().webSocketClientFlow(
       WebSocketRequest(
-        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/stream/fetch")),
+        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/fetch")),
         subprotocol = validSubprotocol))
     Source
       .single(TextMessage(request))
@@ -107,7 +107,7 @@ class WebsocketServiceIntegrationTest
   private def initialIouCreate(serviceUri: Uri) = {
     val payload = TestUtil.readFile("it/iouCreateCommand.json")
     TestUtil.postJsonStringRequest(
-      serviceUri.withPath(Uri.Path("/command/create")),
+      serviceUri.withPath(Uri.Path("/v1/create")),
       payload,
       headersWithAuth)
   }
@@ -244,7 +244,7 @@ class WebsocketServiceIntegrationTest
             case (NothingYet, ContractDelta(Vector((ctid, ct)), Vector())) =>
               (ctid: String) shouldBe (iouCid.unwrap: String)
               TestUtil.postJsonRequest(
-                uri.withPath(Uri.Path("/command/exercise")),
+                uri.withPath(Uri.Path("/v1/exercise")),
                 exercisePayload(ctid),
                 headersWithAuth) map {
                 case (statusCode, respBody) =>


### PR DESCRIPTION
Combining two breaking changes:
Closes: #4289
Closes: #3145
```
CHANGELOG_BEGIN

[JSON API - Experimental] Rename JSON API endpoints. See #4289 and #3145
    /command/create => /v1/create
    /command/exercise => /v1/exercise
    /contracts/lookup => /v1/fetch
    /contracts/search => /v1/query
    /contracts/searchForever => /v1/stream/query
    /contracts/lookupForever => /v1/stream/fetch
    /parties => /v1/parties

CHANGELOG_END
```
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
