### PR TITLE
Fix indexing of transactions referencing divulged contracts

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1219,11 +1219,10 @@ private class JdbcLedgerDao(
     ~ str("signatories").?
     ~ str("observers").? map flatten)
 
-  private val ContractLetParser = (ledgerString("id")
-    ~ date("effective_at").? map flatten)
-
   private val SQL_SELECT_CONTRACT =
     SQL(queries.SQL_SELECT_CONTRACT)
+
+  private val ContractLetParser = date("effective_at").?
 
   private val SQL_SELECT_CONTRACT_LET =
     SQL("""
@@ -1265,9 +1264,9 @@ private class JdbcLedgerDao(
     SQL_SELECT_CONTRACT_LET
       .on("contract_id" -> contractId.coid)
       .as(ContractLetParser.singleOpt)
-      .flatMap {
-        case (_, None) => Some(LetUnknown)
-        case (_, Some(let)) => Some(Let(let.toInstant))
+      .map {
+        case None => LetUnknown
+        case Some(let) => Let(let.toInstant)
       }
 
   override def lookupActiveOrDivulgedContract(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1220,8 +1220,7 @@ private class JdbcLedgerDao(
     ~ str("observers").? map flatten)
 
   private val ContractLetParser = (ledgerString("id")
-    ~ date("effective_at").?
-    ~ long("archive_offset").? map flatten)
+    ~ date("effective_at").? map flatten)
 
   private val SQL_SELECT_CONTRACT =
     SQL(queries.SQL_SELECT_CONTRACT)
@@ -1234,7 +1233,7 @@ private class JdbcLedgerDao(
         |left join ledger_entries le on c.transaction_id = le.transaction_id
         |where
         |  cd.id={contract_id} and
-        |  ((le.effective_at is not null and c.archive_offset is null) or le.effective_at is null)
+        |  (le.effective_at is null or c.archive_offset is null)
         | """.stripMargin)
 
   private val SQL_SELECT_WITNESS =
@@ -1267,9 +1266,8 @@ private class JdbcLedgerDao(
       .on("contract_id" -> contractId.coid)
       .as(ContractLetParser.singleOpt)
       .flatMap {
-        case (_, None, None) => Some(LetUnknown)
-        case (_, Some(let), None) => Some(Let(let.toInstant))
-        case (_, _, Some(archiveOffset @ _)) => None
+        case (_, None) => Some(LetUnknown)
+        case (_, Some(let)) => Some(Let(let.toInstant))
       }
 
   override def lookupActiveOrDivulgedContract(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -1106,10 +1106,13 @@ class JdbcLedgerDaoSpec
 
     "be able to use divulged contract in later transaction" in {
       val let = Instant.now
-      val emptyTxWithDivulgedContracts = PersistenceEntry.Transaction(
+      val offset1 = nextOffset()
+      val offset2 = nextOffset()
+      val offset3 = nextOffset()
+      def emptyTxWithDivulgedContracts(id: Long) = PersistenceEntry.Transaction(
         LedgerEntry.Transaction(
-          Some("commandId0"),
-          "transactionId0",
+          Some(s"commandId$id"),
+          s"transactionId$id",
           Some("applicationId"),
           Some(alice),
           Some("workflowId"),
@@ -1119,26 +1122,36 @@ class JdbcLedgerDaoSpec
           Map.empty
         ),
         Map.empty,
-        Map(AbsoluteContractId("contractId0") -> Set(bob)),
-        List(AbsoluteContractId("contractId0") -> someContractInstance)
+        Map(AbsoluteContractId(s"contractId$id") -> Set(bob)),
+        List(AbsoluteContractId(s"contractId$id") -> someContractInstance)
       )
-      val offset1 = nextOffset()
-      val offset2 = nextOffset()
-      for {
-        // First store a transaction that only divulges the contract to bob.
-        _ <- ledgerDao.storeLedgerEntry(offset1, offset1 + 1, None, emptyTxWithDivulgedContracts)
 
-        // Next try and fetch the divulged contract. LedgerDao should be able to look up the divulged contract
-        // and index the transaction without finding the contract metadata (LET) for it.
+      for {
+        // First try and index a transaction fetching a completely unknown contract.
+        _ <- ledgerDao.storeLedgerEntry(offset1, offset1 + 1, None, txFetch(let, offset1, bob, 0))
+        res1 <- ledgerDao.lookupLedgerEntryAssert(offset1)
+
+        // Then index a transaction that just divulges the contract to bob.
         _ <- ledgerDao.storeLedgerEntry(
           offset2,
           offset2 + 1,
           None,
-          txFetch(let.plusSeconds(1), 1, bob, 0))
+          emptyTxWithDivulgedContracts(offset2))
+        res2 <- ledgerDao.lookupLedgerEntryAssert(offset2)
 
-        res1 <- ledgerDao.lookupLedgerEntry(offset2)
+        // Finally try and fetch the divulged contract. LedgerDao should be able to look up the divulged contract
+        // and index the transaction without finding the contract metadata (LET) for it, as long as the contract
+        // exists in contract_data.
+        _ <- ledgerDao.storeLedgerEntry(
+          offset3,
+          offset3 + 1,
+          None,
+          txFetch(let.plusSeconds(1), offset3, bob, offset2))
+        res3 <- ledgerDao.lookupLedgerEntryAssert(offset3)
       } yield {
-        res1 shouldBe a[LedgerEntry.Transaction]
+        res1 shouldBe a[LedgerEntry.Rejection]
+        res2 shouldBe a[LedgerEntry.Transaction]
+        res3 shouldBe a[LedgerEntry.Transaction]
       }
     }
   }


### PR DESCRIPTION
When a transaction referenced a divulged contract that had no contract
metadata (e.g. it was only known to the participant via divulgence),
the indexer failed with InactiveDependencyError.
    
This fixes the issue by modifying lookupContractLet query to return
LetUnknown if the contract is known, but has no metadata.
    
No changelog entry to add as this bug did not affect any users as this
surfaced with privacy extensions. Canton not affected as they always
include divulged contracts, even if they already have been divulged.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
