### PR TITLE
Update CI nix version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ jobs:
               cd /nix
               tar xzf $(nix-cache-path)/nix.tar.gz
               cd $DIR
-              curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
+              curl -sfL https://nixos.org/releases/nix/nix-2.3.2/install | bash
           fi
         displayName: restore cache
       - bash: echo $(git log -n1 --pretty=format:%H azure-pipelines.yml $(find . -name \*.bazel -or -name \*.bzl -or -name WORKSPACE -or -name BUILD)) >> $(bazel-repo-cache-key)
@@ -306,7 +306,7 @@ jobs:
 
           sudo mkdir -p /nix
           sudo chown $USER /nix
-          curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
+          curl -sfL https://nixos.org/releases/nix/nix-2.3.2/install | bash
           eval "$(dev-env/bin/dade-assist)"
           GCS_KEY=$(mktemp)
           cleanup () {

--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -23,8 +23,7 @@ if [[ ! -e /nix ]]; then
   sudo mkdir -m 0755 /nix
   sudo chown "$(id -u):$(id -g)" /nix
 
-  # 2.2.2 seems to segfault on MacOS in CI so for now we use 2.2.1.
-  curl -sfL https://nixos.org/releases/nix/nix-2.2.1/install | bash
+  curl -sfL https://nixos.org/releases/nix/nix-2.3.2/install | bash
 fi
 
 # shellcheck source=../dev-env/lib/ensure-nix

--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -14,3 +14,6 @@ gc-keep-derivations = true
 
 # NOTE(D3): This is needed in order to run nix commands on monorepo from a Docker container.
 build-users-group =
+
+# Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
+http2 = false

--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -57,8 +57,7 @@ dadeBaseHash() {
 
 # List tools defined in dade
 dadeListTools() {
-    # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
-    cat $(nix-build --option http2 false $DADE_BASE_ROOT/nix -A dade.tools-list)
+    cat $(nix-build $DADE_BASE_ROOT/nix -A dade.tools-list)
 }
 
 # dadeGetOutput get output of a target
@@ -109,8 +108,7 @@ buildTool() {
     errcho "Building tools.${attr}${forced}..."
     # Allow to fail, so we can capture outpath and to capture the exit code too.
     set +e
-    # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
-    outpath=$(nix-build --option http2 false "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
+    outpath=$(nix-build "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
     local dade_build_exit_code=$?
     set -e
     if [[ "$dade_build_exit_code" != "0" ]]; then

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -121,8 +121,7 @@ if [[ $(uname -v) =~ 'Ubuntu' ]]; then
     (
         export LC_ALL=C
         unset NIX_PATH
-        # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
-        out=$(nix-build --option http2 false --no-out-link -Q "${DADE_DEVENV_DIR}/../nix" -I "${TMP_NIX_PATH}" -A pkgs.glibcLocales)
+        out=$(nix-build --no-out-link -Q "${DADE_DEVENV_DIR}/../nix" -I "${TMP_NIX_PATH}" -A pkgs.glibcLocales)
         echo "export LOCALE_ARCHIVE=\"${out}/lib/locale/locale-archive\""
     )
 fi


### PR DESCRIPTION
For `--option http2 false` to take effect requires Nix 2.3.2.

This was meant to be included in https://github.com/digital-asset/daml/pull/4427 but I must have missed it during `git rebase`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
