### PR TITLE
Support multiple-packages in `damlc ide`

### DIFF
--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -56,6 +56,7 @@ da_haskell_library(
         "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-doctest",
         "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-visual",
         "//compiler/scenario-service/client",

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -25,6 +25,7 @@ import GHC.Generics (Generic)
 import "ghc-lib-parser" Module (UnitId)
 import Development.IDE.Core.Service.Daml
 
+import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Development.IDE.Core.RuleTypes
 
@@ -56,7 +57,11 @@ type instance RuleResult GeneratePackage = WhnfPackage
 type instance RuleResult GenerateRawPackage = WhnfPackage
 type instance RuleResult GeneratePackageDeps = WhnfPackage
 
-
+newtype GeneratePackageMapFun = GeneratePackageMapFun (FilePath -> Action ([FileDiagnostic], Map UnitId LF.DalfPackage))
+instance Show GeneratePackageMapFun where show _ = "GeneratePackageMapFun"
+instance NFData GeneratePackageMapFun where rnf !_ = ()
+-- | This matches how GhcSessionIO is handled in ghcide.
+type instance RuleResult GeneratePackageMapIO = GeneratePackageMapFun
 type instance RuleResult GeneratePackageMap = Map UnitId LF.DalfPackage
 type instance RuleResult GenerateStablePackages = Map (UnitId, LF.ModuleName) LF.DalfPackage
 
@@ -153,6 +158,11 @@ data GeneratePackageMap = GeneratePackageMap
 instance Binary   GeneratePackageMap
 instance Hashable GeneratePackageMap
 instance NFData   GeneratePackageMap
+
+data GeneratePackageMapIO = GeneratePackageMapIO deriving (Eq, Show, Typeable, Generic)
+instance Hashable GeneratePackageMapIO
+instance NFData   GeneratePackageMapIO
+instance Binary   GeneratePackageMapIO
 
 data GenerateStablePackages = GenerateStablePackages
    deriving (Eq, Show, Typeable, Generic)

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/Visualize.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/Visualize.hs
@@ -36,7 +36,7 @@ onCommand ide execParsms = case execParsms of
             Just mod -> do
                     logInfo (ideLogger ide) "Generating visualization for current daml project"
                     WhnfPackage package <- runAction ide (use_ GeneratePackage mod)
-                    pkgMap <- runAction ide (useNoFile_ GeneratePackageMap)
+                    pkgMap <- runAction ide (use_ GeneratePackageMap mod)
                     let modules = NM.toList $ LF.packageModules package
                     let extpkgs = map LF.dalfPackagePkg $ Map.elems pkgMap
                     let wrld = LF.initWorldSelf extpkgs package

--- a/compiler/damlc/daml-opts/BUILD.bazel
+++ b/compiler/damlc/daml-opts/BUILD.bazel
@@ -36,6 +36,7 @@ da_haskell_library(
     srcs = ["daml-opts/DA/Daml/Options.hs"],
     hackage_deps = [
         "base",
+        "containers",
         "directory",
         "extra",
         "filepath",
@@ -44,6 +45,7 @@ da_haskell_library(
         "ghcide",
         "mtl",
         "text",
+        "shake",
     ],
     src_strip_prefix = "daml-opts",
     visibility = ["//visibility:public"],
@@ -51,6 +53,7 @@ da_haskell_library(
         ":daml-opts-types",
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-preprocessor",
+        "//daml-assistant:daml-project-config",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -11,16 +11,22 @@ module DA.Daml.Options
     ( toCompileOpts
     , generatePackageState
     , fakeDynFlags
+    , findProjectRoot
+    , memoIO
     , PackageDynFlags(..)
     ) where
 
-import Control.Monad
+import Control.Exception
+import Control.Concurrent.Extra
+import Control.Monad.Extra
 import qualified CmdLineParser as Cmd (warnMsg)
 import Data.IORef
 import Data.List
 import DynFlags (parseDynamicFilePragma)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Config (cProjectVersion)
+import Development.Shake (Action)
 import qualified Platform as P
 import qualified EnumSet
 import GHC                         hiding (convertLit)
@@ -35,6 +41,8 @@ import System.FilePath
 import qualified DA.Daml.LF.Ast.Version as LF
 
 import DA.Bazel.Runfiles
+import DA.Daml.Project.Consts
+import DA.Daml.Project.Util
 import DA.Daml.Options.Types
 import DA.Daml.Preprocessor
 import Development.IDE.GHC.Util hiding (fakeDynFlags)
@@ -45,14 +53,7 @@ toCompileOpts :: Options -> Ghcide.IdeReportProgress -> Ghcide.IdeOptions
 toCompileOpts options@Options{..} reportProgress =
     Ghcide.IdeOptions
       { optPreprocessor = if optIsGenerated then generatedPreprocessor else damlPreprocessor optMbPackageName
-      , optGhcSession = do
-            env <- runGhcFast $ do
-                setupDamlGHC options
-                GHC.getSession
-            pkg <- generatePackageState optDamlLfVersion optPackageDbs optHideAllPkgs optPackageImports
-            dflags <- checkDFlags options $ setPackageDynFlags pkg $ hsc_dflags env
-            hscenv <- newHscEnvEq env{hsc_dflags = dflags}
-            return $ const $ return hscenv
+      , optGhcSession = getDamlGhcSession options
       , optPkgLocationOpts = Ghcide.IdePkgLocationOptions
           { optLocateHieFile = locateInPkgDb "hie"
           , optLocateSrcFile = locateInPkgDb "daml"
@@ -78,6 +79,48 @@ toCompileOpts options@Options{..} reportProgress =
                 else Nothing
       | otherwise = pure Nothing
 
+getDamlGhcSession :: Options -> IO (FilePath -> Action HscEnvEq)
+getDamlGhcSession options@Options{..} = do
+    findProjectRoot <- memoIO findProjectRoot
+    getSession <- memoIO $ \mbProjectRoot -> do
+        env <- runGhcFast $ do
+            setupDamlGHC options
+            GHC.getSession
+        pkg <- generatePackageState optDamlLfVersion mbProjectRoot optPackageDbs optHideAllPkgs optPackageImports
+        dflags <- checkDFlags options $ setPackageDynFlags pkg $ hsc_dflags env
+        newHscEnvEq env{hsc_dflags = dflags}
+    pure $ \file -> liftIO $ getSession =<< findProjectRoot file
+
+-- | Find the daml.yaml given a starting file or directory.
+findProjectRoot :: FilePath -> IO (Maybe FilePath)
+findProjectRoot file = do
+    isFile <- doesFileExist (takeDirectory file)
+    let dir = if isFile then takeDirectory file else file
+    findM hasProjectConfig (ascendants dir)
+  where
+    hasProjectConfig :: FilePath -> IO Bool
+    hasProjectConfig p = doesFileExist (p </> projectConfigName)
+
+
+-- | Memoize an IO function, with the characteristics:
+--
+--   * If multiple people ask for a result simultaneously, make sure you only compute it once.
+--
+--   * If there are exceptions, repeatedly reraise them.
+--
+--   * If the caller is aborted (async exception) finish computing it anyway.
+--
+-- This matches the memoIO function in ghcide.
+memoIO :: Ord a => (a -> IO b) -> IO (a -> IO b)
+memoIO op = do
+    ref <- newVar Map.empty
+    return $ \k -> join $ mask_ $ modifyVar ref $ \mp ->
+        case Map.lookup k mp of
+            Nothing -> do
+                res <- onceFork $ op k
+                return (Map.insert k res mp, res)
+            Just res -> return (mp, res)
+
 -- | The subset of @DynFlags@ computed by package initialization.
 data PackageDynFlags = PackageDynFlags
     { pdfPkgDatabase :: !(Maybe [(FilePath, [PackageConfig])])
@@ -99,9 +142,9 @@ getPackageDynFlags DynFlags{..} = PackageDynFlags
     , pdfThisUnitIdInsts = thisUnitIdInsts_
     }
 
-generatePackageState :: LF.Version -> [FilePath] -> Bool -> [PackageFlag] -> IO PackageDynFlags
-generatePackageState lfVersion paths hideAllPkgs pkgImports = do
-  versionedPaths <- getPackageDbs lfVersion paths
+generatePackageState :: LF.Version -> Maybe FilePath -> [FilePath] -> Bool -> [PackageFlag] -> IO PackageDynFlags
+generatePackageState lfVersion mbProjRoot paths hideAllPkgs pkgImports = do
+  versionedPaths <- getPackageDbs lfVersion mbProjRoot paths
   let dflags = setPackageImports hideAllPkgs pkgImports $ setPackageDbs versionedPaths fakeDynFlags
   (newDynFlags, _) <- initPackages dflags
   pure $ getPackageDynFlags newDynFlags

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -33,6 +33,7 @@ da_haskell_test(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-hs-lib",
         "//compiler/damlc/daml-ide-core",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/test-utils",

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -26,6 +26,7 @@ da_haskell_test(
         "mtl",
         "network-uri",
         "parser-combinators",
+        "process",
         "tasty",
         "tasty-hunit",
         "text",

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -20,6 +20,7 @@ import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import Language.Haskell.LSP.Types.Lens
 import Network.URI
+import SdkVersion
 import System.Directory
 import System.Environment.Blank
 import System.FilePath
@@ -656,7 +657,7 @@ multiPackageTests damlc = testGroup "multi-package"
           step "build a"
           createDirectoryIfMissing True (dir </> "a")
           writeFileUTF8 (dir </> "a" </> "daml.yaml") $ unlines
-              [ "sdk-version: ignored"
+              [ "sdk-version: " <> sdkVersion
               , "name: a"
               , "version: 0.0.1"
               , "source: ."
@@ -671,7 +672,7 @@ multiPackageTests damlc = testGroup "multi-package"
           step "build b"
           createDirectoryIfMissing True (dir </> "b")
           writeFileUTF8 (dir </> "b" </> "daml.yaml") $ unlines
-              [ "sdk-version: ignored"
+              [ "sdk-version: " <> sdkVersion
               , "name: b"
               , "version: 0.0.1"
               , "source: ."
@@ -686,7 +687,7 @@ multiPackageTests damlc = testGroup "multi-package"
           withCurrentDirectory (dir </> "b") $ callProcess damlc ["build", "-o", dir </> "b" </> "b.dar"]
           step "run language server"
           writeFileUTF8 (dir </> "daml.yaml") $ unlines
-              [ "sdk-version: ignored"
+              [ "sdk-version: " <> sdkVersion
               ]
           withCurrentDirectory dir $ runSessionWithConfig conf (damlc <> " ide --scenarios=yes") fullCaps' dir $ do
               docA <- openDoc ("a" </> "A.daml") "daml"

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -329,3 +329,44 @@ to exercise the contract the following error would occur:
 To fix this issue the party 'Bob' should be made a controlling party in one of the choices.
 
 
+Working with multiple packages
+******************************
+
+Often a DAML project consists of multiple packages, e.g., one
+containing your templates and one containing a DAML trigger so that
+you can keep the templates stable while modifying the trigger.  It is
+possible to work on multiple packages in a single session of DAML
+studio but you have to keep some things in mind. You can see the
+directory structure of a simple multi-package project consisting of
+two packages ``pkga`` and ``pkgb`` below:
+
+.. code-block:: none
+
+    .
+    ├── daml.yaml
+    ├── pkga
+    │   ├── daml
+    │   │   └── A.daml
+    │   └── daml.yaml
+    └── pkgb
+        ├── daml
+        │   └── B.daml
+        └── daml.yaml
+
+``pkga`` and ``pkgb`` are regular DAML projects with a ``daml.yaml``
+and a DAML module. In addition to the ``daml.yaml`` files for the
+respective packages, you also need to add a ``daml.yaml`` to the root
+of your project. This file only needs to specify the SDK version:
+
+.. code-block:: yaml
+
+    sdk-version: 0.13.51
+
+You can then open DAML Studio once in the root of your project and
+work on files in both packages. Note that if ``pkgb`` refers to
+``pkga.dar`` in its ``dependencies`` field, changes will not be picked
+up automatically. This is always the case even if you open DAML Studio
+in ``pkgb``. However, for multi-package projects there is an
+additional caveat: You have to both rebuild ``pkga.dar`` using ``daml
+build`` and then build ``pkgb`` using ``daml build`` before restarting
+DAML Studio.


### PR DESCRIPTION
changelog_begin

- [DAML Studio] You can now open DAML Studio in the root of a
  multi-package project instead of opening it separately for each
  package. Take a look at the documentation for details on how to set
  this up.

changelog_end

There are a few caveats here:

1. You need a ``daml.yaml`` in the root of your project directory. I
think this is somewhat sensible but we should add a warning to VSCode
if you open it in a directory that does not have a ``daml.yaml`` (in a
separate PR).

2. Changes are not picked up accross dependencies. This is a larger
undertaking and given the current setup simply impossible (we don’t
know that the source files of one package belong to the DAR referenced
in the ``dependencies`` field of the other package. We can make this a
bit better by at least detecting that the ``.dar`` has changed but
let’s do that separately.

3. Since ``daml init`` runs once on startup, it will run in the root
directory instead of initializing the package db of the individual
packages. This is fixable but will conflict with #4391 so let’s
address this separately.

I’ve added docs to the daml studio section that explain the caveats.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
