### PR TITLE
Fix memory leak when using the reset service

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -93,7 +93,8 @@ object TestMain extends StrictLogging {
                 timeProviderType = config.timeProviderType,
               )
               val sandboxResource = SandboxServer.owner(sandboxConfig).acquire()
-              val sandboxPort = Await.result(sandboxResource.asFuture.flatMap(_.port), Duration.Inf)
+              val sandboxPort =
+                Await.result(sandboxResource.asFuture.flatMap(_.portF), Duration.Inf)
               (ApiParameters("localhost", sandboxPort), () => sandboxResource.release())
             } else {
               (

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
@@ -44,8 +44,8 @@ object TestUtil {
       timeProviderType = TimeProviderType.WallClock,
       timeModel = TimeModel.reasonableDefault
     )
-    val server = new SandboxServerResource(config)
-    val client = new SandboxClientResource(() => server.value)
+    val server = SandboxServerResource(config)
+    val client = new SandboxClientResource(() => server.value.port)
     server.setup()
     client.setup()
     try {

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
@@ -45,8 +45,8 @@ object TestUtil {
       timeModel = TimeModel.reasonableDefault
     )
     val server = SandboxServerResource(config)
-    val client = new SandboxClientResource(() => server.value.port)
     server.setup()
+    val client = new SandboxClientResource(server.value.port)
     client.setup()
     try {
       testCode(client.value)

--- a/ledger-api/testing-utils/BUILD.bazel
+++ b/ledger-api/testing-utils/BUILD.bazel
@@ -22,6 +22,7 @@ da_scala_library(
         "//ledger-api/rs-grpc-bridge",
         "//libs-scala/direct-execution-context",
         "//libs-scala/grpc-utils",
+        "//libs-scala/resources",
         "@maven//:com_google_guava_guava",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ManagedResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ManagedResource.scala
@@ -15,7 +15,7 @@ abstract class ManagedResource[Value: ClassTag] extends Resource[Value] {
 
   protected def destruct(resource: Value): Unit
 
-  override def value: Value = {
+  final override def value: Value = {
     val res = resourceRef.get()
     if (res != null) res
     else
@@ -23,7 +23,7 @@ abstract class ManagedResource[Value: ClassTag] extends Resource[Value] {
         s"Attempted to read non-initialized resource of class ${implicitly[ClassTag[Value]].runtimeClass.getName}")
   }
 
-  override def setup(): Unit = {
+  final override def setup(): Unit = {
     resourceRef.updateAndGet(
       (resource: Value) =>
         if (resource == null) construct()
@@ -31,7 +31,7 @@ abstract class ManagedResource[Value: ClassTag] extends Resource[Value] {
     ()
   }
 
-  override def close(): Unit = {
+  final override def close(): Unit = {
     resourceRef.updateAndGet { (resource: Value) =>
       if (resource != null) {
         destruct(resource)

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/OwnedResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/OwnedResource.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.ledger.api.testing.utils
+
+import com.digitalasset.dec.DirectExecutionContext
+import com.digitalasset.resources
+
+import scala.concurrent.Await
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.reflect.ClassTag
+
+class OwnedResource[T: ClassTag](
+    owner: resources.ResourceOwner[T],
+    acquisitionTimeout: FiniteDuration = 10.seconds,
+    releaseTimeout: FiniteDuration = 10.seconds,
+) extends ManagedResource[T] {
+  private var resource: resources.Resource[T] = _
+
+  override def construct(): T = {
+    resource = owner.acquire()(DirectExecutionContext)
+    Await.result(resource.asFuture, acquisitionTimeout)
+  }
+
+  override def destruct(value: T): Unit = {
+    Await.result(resource.release(), releaseTimeout)
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -67,7 +67,7 @@ object SandboxServer {
   def owner(config: SandboxConfig): ResourceOwner[SandboxState] = new ResourceOwner[SandboxState] {
     override def acquire()(implicit executionContext: ExecutionContext): Resource[SandboxState] = {
       for {
-        server <- ResourceOwner.forTry(() => Try(new SandboxServer(config))).acquire()
+        server <- ResourceOwner.forTryCloseable(() => Try(new SandboxServer(config))).acquire()
         _ <- server.sandboxState.apiServer
       } yield server.sandboxState
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -334,9 +334,7 @@ final class SandboxServer(config: SandboxConfig) extends AutoCloseable {
 
   }
 
-  private def start(port: Option[Port] = None)(
-      implicit executionContext: ExecutionContext
-  ): Future[SandboxState] = {
+  private def start()(implicit executionContext: ExecutionContext): Future[SandboxState] = {
     val packageStore = loadDamlPackages()
     for {
       metrics <- metricsResource.asFuture
@@ -347,7 +345,7 @@ final class SandboxServer(config: SandboxConfig) extends AutoCloseable {
         metrics,
         packageStore,
         SqlStartMode.ContinueIfExists,
-        currentPort = port,
+        currentPort = None,
       )
       new SandboxState(materializer, metrics, packageStore, apiServerResource)
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -47,7 +47,6 @@ import com.digitalasset.platform.sandbox.stores.{
 import com.digitalasset.platform.services.time.TimeProviderType
 import com.digitalasset.resources.akka.AkkaResourceOwner
 import com.digitalasset.resources.{Resource, ResourceOwner}
-import com.google.common.annotations.VisibleForTesting
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt
@@ -169,7 +168,7 @@ final class SandboxServer(config: SandboxConfig) extends AutoCloseable {
     } yield materializer
   }
 
-  @VisibleForTesting
+  // Visible so we can test that we drop the reference properly in ResetServiceIT.
   @volatile
   private[sandbox] var sandboxState: Future[SandboxState] =
     start()(DirectExecutionContext)

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
@@ -13,7 +13,7 @@ import io.netty.channel.EventLoopGroup
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.util.concurrent.DefaultThreadFactory
 
-class SandboxClientResource(port: () => Int) extends Resource[Channel] {
+class SandboxClientResource(port: Int) extends Resource[Channel] {
   @volatile
   private var eventLoopGroup: EventLoopGroup = _
   @volatile
@@ -24,7 +24,7 @@ class SandboxClientResource(port: () => Int) extends Resource[Channel] {
   override def setup(): Unit = {
     eventLoopGroup = createEventLoopGroup("api-client")
     val channelBuilder: NettyChannelBuilder = NettyChannelBuilder
-      .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, port()))
+      .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, port))
     channelBuilder.eventLoopGroup(eventLoopGroup)
     channelBuilder.usePlaintext()
     channelBuilder.directExecutor()

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.sandbox.services
+
+import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.TimeUnit
+
+import com.digitalasset.ledger.api.testing.utils.Resource
+import io.grpc.netty.NettyChannelBuilder
+import io.grpc.{Channel, ManagedChannel}
+import io.netty.channel.EventLoopGroup
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.util.concurrent.DefaultThreadFactory
+
+class SandboxClientResource(port: () => Int) extends Resource[Channel] {
+  @volatile
+  private var eventLoopGroup: EventLoopGroup = _
+  @volatile
+  private var channel: ManagedChannel = _
+
+  override def value: Channel = channel
+
+  override def setup(): Unit = {
+    eventLoopGroup = createEventLoopGroup("api-client")
+    val channelBuilder: NettyChannelBuilder = NettyChannelBuilder
+      .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, port()))
+    channelBuilder.eventLoopGroup(eventLoopGroup)
+    channelBuilder.usePlaintext()
+    channelBuilder.directExecutor()
+    channel = channelBuilder.build()
+  }
+
+  override def close(): Unit = {
+    channel.shutdown()
+    if (!channel.awaitTermination(5L, TimeUnit.SECONDS)) {
+      sys.error(
+        "Unable to shutdown channel to a remote API under tests. Unable to recover. Terminating.")
+    }
+    if (!eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).await(10L, TimeUnit.SECONDS)) {
+      sys.error("Unable to shutdown event loop. Unable to recover. Terminating.")
+    }
+    channel = null
+    eventLoopGroup = null
+  }
+
+  private def createEventLoopGroup(threadPoolName: String): NioEventLoopGroup = {
+    val threadFactory = new DefaultThreadFactory(s"$threadPoolName-grpc-eventloop", true)
+    val parallelism = Runtime.getRuntime.availableProcessors
+    new NioEventLoopGroup(parallelism, threadFactory)
+  }
+}

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxClientResource.scala
@@ -32,7 +32,7 @@ class SandboxClientResource(port: () => Int) extends Resource[Channel] {
   }
 
   override def close(): Unit = {
-    channel.shutdown()
+    channel.shutdownNow()
     if (!channel.awaitTermination(5L, TimeUnit.SECONDS)) {
       sys.error(
         "Unable to shutdown channel to a remote API under tests. Unable to recover. Terminating.")

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
@@ -99,13 +99,13 @@ trait SandboxFixture extends SuiteResource[Unit] with BeforeAndAfterAll {
 
   protected def scenario: Option[String] = None
 
-  protected def getSandboxPort: Int = serverResource.value
+  protected def getSandboxPort: Int = serverResource.value.port
 
   protected def channel: Channel = clientResource.value
 
-  protected lazy val serverResource = new SandboxServerResource(config)
+  protected lazy val serverResource = SandboxServerResource(config)
 
-  protected lazy val clientResource = new SandboxClientResource(() => serverResource.value)
+  protected lazy val clientResource = new SandboxClientResource(() => getSandboxPort)
 
   protected override lazy val suiteResource: Resource[Unit] = new Resource[Unit] {
     override val value: Unit = ()

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
@@ -23,6 +23,7 @@ import com.digitalasset.ledger.api.v1.ledger_identity_service.{
 import com.digitalasset.ledger.api.v1.testing.time_service.TimeServiceGrpc
 import com.digitalasset.ledger.client.services.testing.time.StaticTime
 import com.digitalasset.platform.common.LedgerIdMode
+import com.digitalasset.platform.sandbox.SandboxServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.platform.services.time.TimeProviderType
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -103,21 +104,25 @@ trait SandboxFixture extends SuiteResource[Unit] with BeforeAndAfterAll {
 
   protected def channel: Channel = clientResource.value
 
-  protected lazy val serverResource = SandboxServerResource(config)
+  protected var serverResource: Resource[SandboxServer] = _
 
-  protected lazy val clientResource = new SandboxClientResource(() => getSandboxPort)
+  protected var clientResource: Resource[Channel] = _
 
   protected override lazy val suiteResource: Resource[Unit] = new Resource[Unit] {
     override val value: Unit = ()
 
     override def setup(): Unit = {
+      serverResource = SandboxServerResource(config)
       serverResource.setup()
+      clientResource = new SandboxClientResource(getSandboxPort)
       clientResource.setup()
     }
 
     override def close(): Unit = {
       clientResource.close()
+      clientResource = null
       serverResource.close()
+      serverResource = null
     }
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
@@ -46,7 +46,7 @@ trait SandboxFixture extends SuiteResource[Channel] with BeforeAndAfterAll {
     Executors.newSingleThreadExecutor(
       new ThreadFactoryBuilder()
         .setDaemon(true)
-        .setNameFormat(s"${actorSystemName}-thread-pool-worker-%d")
+        .setNameFormat(s"$actorSystemName-thread-pool-worker-%d")
         .setUncaughtExceptionHandler((thread, _) =>
           logger.error(s"got an uncaught exception on thread: ${thread.getName}"))
         .build()))
@@ -101,7 +101,7 @@ trait SandboxFixture extends SuiteResource[Channel] with BeforeAndAfterAll {
 
   protected def scenario: Option[String] = None
 
-  private lazy val sandboxResource = new SandboxServerResource(config)
+  protected lazy val sandboxResource = new SandboxServerResource(config)
 
   protected override lazy val suiteResource: Resource[Channel] = sandboxResource
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
@@ -20,7 +20,7 @@ class SandboxServerResource(config: => SandboxConfig) extends Resource[Channel] 
   @volatile
   private var channel: ManagedChannel = _
   @volatile
-  private var sandboxServer: SandboxServer = _
+  var sandboxServer: SandboxServer = _
 
   override def value: Channel = channel
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
@@ -3,22 +3,11 @@
 
 package com.digitalasset.platform.sandbox.services
 
-import com.digitalasset.ledger.api.testing.utils.Resource
+import com.digitalasset.ledger.api.testing.utils.{OwnedResource, Resource}
 import com.digitalasset.platform.sandbox.SandboxServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
 
-class SandboxServerResource(config: => SandboxConfig) extends Resource[Int] {
-  @volatile
-  var sandboxServer: SandboxServer = _
-
-  override def value: Int = sandboxServer.port
-
-  override def setup(): Unit = {
-    sandboxServer = new SandboxServer(config)
-  }
-
-  override def close(): Unit = {
-    sandboxServer.close()
-    sandboxServer = null
-  }
+object SandboxServerResource {
+  def apply(config: SandboxConfig): Resource[SandboxServer] =
+    new OwnedResource(SandboxServer.owner(config))
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxServerResource.scala
@@ -3,61 +3,22 @@
 
 package com.digitalasset.platform.sandbox.services
 
-import java.util.concurrent.TimeUnit
-
 import com.digitalasset.ledger.api.testing.utils.Resource
 import com.digitalasset.platform.sandbox.SandboxServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
-import io.grpc.netty.NettyChannelBuilder
-import io.grpc.{Channel, ManagedChannel}
-import io.netty.channel.EventLoopGroup
-import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.util.concurrent.DefaultThreadFactory
 
-class SandboxServerResource(config: => SandboxConfig) extends Resource[Channel] {
-  @volatile
-  private var eventLoopGroup: EventLoopGroup = _
-  @volatile
-  private var channel: ManagedChannel = _
+class SandboxServerResource(config: => SandboxConfig) extends Resource[Int] {
   @volatile
   var sandboxServer: SandboxServer = _
 
-  override def value: Channel = channel
+  override def value: Int = sandboxServer.port
 
   override def setup(): Unit = {
     sandboxServer = new SandboxServer(config)
-    eventLoopGroup = createEventLoopGroup("api-client")
-
-    channel = {
-      val channelBuilder: NettyChannelBuilder = NettyChannelBuilder
-        .forAddress("127.0.0.1", sandboxServer.port)
-      channelBuilder.eventLoopGroup(eventLoopGroup)
-      channelBuilder.usePlaintext()
-      channelBuilder.directExecutor()
-      channelBuilder.build()
-    }
-  }
-
-  private def createEventLoopGroup(threadPoolName: String): NioEventLoopGroup = {
-    val threadFactory = new DefaultThreadFactory(s"$threadPoolName-grpc-eventloop", true)
-    val parallelism = Runtime.getRuntime.availableProcessors
-    new NioEventLoopGroup(parallelism, threadFactory)
   }
 
   override def close(): Unit = {
-    channel.shutdownNow()
-    if (!channel.awaitTermination(5L, TimeUnit.SECONDS)) {
-      sys.error(
-        "Unable to shutdown channel to a remote API under tests. Unable to recover. Terminating.")
-    }
-    if (!eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).await(10L, TimeUnit.SECONDS)) {
-      sys.error("Unable to shutdown event loop. Unable to recover. Terminating.")
-    }
     sandboxServer.close()
-    channel = null
-    eventLoopGroup = null
     sandboxServer = null
   }
-
-  def getPort: Int = sandboxServer.port
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -174,7 +174,7 @@ final class ResetServiceIT
       }
 
       "clear out all garbage" in {
-        val state = new WeakReference(sandboxResource.sandboxServer.sandboxState)
+        val state = new WeakReference(serverResource.sandboxServer.sandboxState)
         for {
           lid <- fetchLedgerId()
           _ <- reset(lid)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -174,7 +174,7 @@ final class ResetServiceIT
       }
 
       "clear out all garbage" in {
-        val state = new WeakReference(serverResource.sandboxServer.sandboxState)
+        val state = new WeakReference(serverResource.value.sandboxState)
         for {
           lid <- fetchLedgerId()
           _ <- reset(lid)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -180,8 +180,7 @@ final class ResetServiceIT
           _ <- reset(lid)
         } yield {
           System.gc()
-          state.get.isEmpty shouldBe true
-          succeed
+          state.get should be(None)
         }
       }
     }


### PR DESCRIPTION
Don't hold on to old resources when resetting.

### Changelog

- **[Sandbox]** Fixed a memory leak when using the ResetService; not everything was cleaned up correctly.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
