### PR TITLE
Test tool flags: participant-shuffle and no-wait-for-parties

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -150,6 +150,7 @@ object Cli {
     opt[Unit]("no-wait-for-parties")
       .action((_, c) => c.copy(waitForParties = false))
       .text("""Do not wait for parties to be allocated on all participants.""")
+      .hidden()
 
     opt[Unit]("shuffle-participants")
       .action((_, c) => c.copy(shuffleParticipants = true))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -147,6 +147,10 @@ object Cli {
       .action((_, c) => c.copy(allTests = true))
       .text("""Run all default and optional tests. Respects the --exclude flag.""")
 
+    opt[Unit]("no-wait-for-parties")
+      .action((_, c) => c.copy(waitForParties = false))
+      .text("""Do not wait for parties to be allocated on all participants.""")
+
     opt[Unit]("list")
       .action((_, c) => c.copy(listTests = true))
       .text("""Lists all available tests that can be used in the include and exclude options.""")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -151,6 +151,11 @@ object Cli {
       .action((_, c) => c.copy(waitForParties = false))
       .text("""Do not wait for parties to be allocated on all participants.""")
 
+    opt[Unit]("shuffle-participants")
+      .action((_, c) => c.copy(shuffleParticipants = true))
+      .text("""Shuffle the list of participants used in a test.
+          |By default participants are used in the order they're given.""".stripMargin)
+
     opt[Unit]("list")
       .action((_, c) => c.copy(listTests = true))
       .text("""Lists all available tests that can be used in the include and exclude options.""")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -22,6 +22,7 @@ final case class Config(
     included: Set[String],
     listTests: Boolean,
     allTests: Boolean,
+    waitForParties: Boolean,
 )
 
 object Config {
@@ -40,5 +41,6 @@ object Config {
     included = Set.empty,
     listTests = false,
     allTests = false,
+    waitForParties = true
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -23,6 +23,7 @@ final case class Config(
     listTests: Boolean,
     allTests: Boolean,
     waitForParties: Boolean,
+    shuffleParticipants: Boolean,
 )
 
 object Config {
@@ -41,6 +42,7 @@ object Config {
     included = Set.empty,
     listTests = false,
     allTests = false,
-    waitForParties = true
+    waitForParties = true,
+    shuffleParticipants = false
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -112,6 +112,7 @@ object LedgerApiTestTool {
         config.tlsConfig,
         config.commandSubmissionTtlScaleFactor,
         config.loadScaleFactor,
+        config.waitForParties,
       ),
       testsToRun.values.toVector,
       identifierSuffix,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -109,10 +109,11 @@ object LedgerApiTestTool {
     val runner = new LedgerTestSuiteRunner(
       LedgerSessionConfiguration(
         config.participants,
+        config.shuffleParticipants,
         config.tlsConfig,
         config.commandSubmissionTtlScaleFactor,
         config.loadScaleFactor,
-        config.waitForParties,
+        config.waitForParties
       ),
       testsToRun.values.toVector,
       identifierSuffix,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -31,21 +31,21 @@ private[testtool] final class LedgerSession(
               config.waitForParties),
           )
       })
-      .map(sessions => sessions.map(endpointIdProvider() -> _))
+      .map(_.map(endpointIdProvider() -> _))
 
   private[testtool] def createTestContext(
       applicationId: String,
       identifierSuffix: String,
   ): Future[LedgerTestContext] =
     participantSessions.flatMap { sessions =>
-      val sessions2 =
-        if (config.shuffleParticipants) scala.util.Random.shuffle(sessions)
-        else sessions
       Future
-        .sequence(sessions2.map {
-          case (endpointId, session) =>
-            session.createTestContext(endpointId, applicationId, identifierSuffix)
-        })
+        .sequence(
+          (if (config.shuffleParticipants) scala.util.Random.shuffle(sessions) else sessions)
+            .map {
+              case (endpointId, session) =>
+                session.createTestContext(endpointId, applicationId, identifierSuffix)
+            }
+        )
         .map(new LedgerTestContext(_))
     }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -23,7 +23,12 @@ private[testtool] final class LedgerSession(
       .sequence(config.participants.map {
         case (host, port) =>
           participantSessionManager.getOrCreate(
-            ParticipantSessionConfiguration(host, port, config.ssl, config.commandTtlFactor),
+            ParticipantSessionConfiguration(
+              host,
+              port,
+              config.ssl,
+              config.commandTtlFactor,
+              config.waitForParties),
           )
       })
       .map(sessions => sessions.map(endpointIdProvider() -> _))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -33,8 +33,9 @@ private[testtool] final class LedgerSession(
       identifierSuffix: String,
   ): Future[LedgerTestContext] =
     participantSessions.flatMap { sessions =>
+      val shuffledSessions = scala.util.Random.shuffle(sessions)
       Future
-        .sequence(sessions.map {
+        .sequence(shuffledSessions.map {
           case (endpointId, session) =>
             session.createTestContext(endpointId, applicationId, identifierSuffix)
         })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -38,9 +38,11 @@ private[testtool] final class LedgerSession(
       identifierSuffix: String,
   ): Future[LedgerTestContext] =
     participantSessions.flatMap { sessions =>
-      val shuffledSessions = scala.util.Random.shuffle(sessions)
+      val sessions2 =
+        if (config.shuffleParticipants) scala.util.Random.shuffle(sessions)
+        else sessions
       Future
-        .sequence(shuffledSessions.map {
+        .sequence(sessions2.map {
           case (endpointId, session) =>
             session.createTestContext(endpointId, applicationId, identifierSuffix)
         })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -7,8 +7,9 @@ import com.digitalasset.ledger.api.tls.TlsConfiguration
 
 private[testtool] final case class LedgerSessionConfiguration(
     participants: Vector[(String, Int)],
+    shuffleParticipants: Boolean,
     ssl: Option[TlsConfiguration],
     commandTtlFactor: Double,
     loadScaleFactor: Double,
-    waitForParties: Boolean, /** Allow synchronizing party allocation across participants */
+    waitForParties: Boolean /** Allow synchronizing party allocation across participants */
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -10,4 +10,5 @@ private[testtool] final case class LedgerSessionConfiguration(
     ssl: Option[TlsConfiguration],
     commandTtlFactor: Double,
     loadScaleFactor: Double,
+    waitForParties: Boolean, /** Allow synchronizing party allocation across participants */
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -85,6 +85,7 @@ private[participant] final class ParticipantSession(
         end,
         services,
         ttl,
+        config.waitForParties
       )
 
   private[testtool] def close(): Unit = {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
@@ -10,5 +10,5 @@ private[testtool] final case class ParticipantSessionConfiguration(
     port: Int,
     ssl: Option[TlsConfiguration],
     commandTtlFactor: Double,
-    waitForParties: Boolean
+    waitForParties: Boolean,
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
@@ -10,4 +10,5 @@ private[testtool] final case class ParticipantSessionConfiguration(
     port: Int,
     ssl: Option[TlsConfiguration],
     commandTtlFactor: Double,
+    waitForParties: Boolean
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -219,12 +219,12 @@ private[testtool] final class ParticipantTestContext private[participant] (
           .sequence(participants.map(otherParticipant => {
             otherParticipant
               .listParties()
-              .map(actualParties => {
+              .map { actualParties =>
                 assert(
                   expectedParties.subsetOf(actualParties),
                   s"Parties from $this never appeared on $otherParticipant.",
                 )
-              })
+              }
           }))
           .map(_ => ())
       }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -100,6 +100,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
     referenceOffset: LedgerOffset,
     services: LedgerServices,
     ttl: Duration,
+    waitForPartiesEnabled: Boolean
 )(implicit ec: ExecutionContext) {
 
   import ParticipantTestContext._
@@ -210,21 +211,26 @@ private[testtool] final class ParticipantTestContext private[participant] (
   def waitForParties(
       otherParticipants: Iterable[ParticipantTestContext],
       expectedParties: Set[Party],
-  ): Future[Unit] = eventually {
-    val participants = otherParticipants.toSet + this
-    Future
-      .sequence(participants.map(otherParticipant => {
-        otherParticipant
-          .listParties()
-          .map(actualParties => {
-            assert(
-              expectedParties.subsetOf(actualParties),
-              s"Parties from $this never appeared on $otherParticipant.",
-            )
-          })
-      }))
-      .map(_ => ())
-  }
+  ): Future[Unit] =
+    if (waitForPartiesEnabled) {
+      eventually {
+        val participants = otherParticipants.toSet + this
+        Future
+          .sequence(participants.map(otherParticipant => {
+            otherParticipant
+              .listParties()
+              .map(actualParties => {
+                assert(
+                  expectedParties.subsetOf(actualParties),
+                  s"Parties from $this never appeared on $otherParticipant.",
+                )
+              })
+          }))
+          .map(_ => ())
+      }
+    } else {
+      Future.successful(())
+    }
 
   def activeContracts(
       request: GetActiveContractsRequest,


### PR DESCRIPTION
This pull requests adds two new exciting flags:
- *--participant-shuffle*: Shuffle the list of participants before the test. Allowing the tool to spread the load over all the given participants rather then always using the first ones. Most tests only use at most two participants, which leaves most unused.
- *--no-wait-for-parties*: Do not wait for party allocations to appear on other participants. This flag is needed with privacy-preserving ledgers that do not show party allocations to non-submitting participants.

FYI: @mziolekda @miklos-da @fabiotudone-da  we'll need the *--no-wait-for-parties* flag with privacy-preserving stuff going forward. We'll have a discussion next week on what's a cleaner approach.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
