### PR TITLE
add redirect for getting started guide

### DIFF
--- a/docs/redirects.map
+++ b/docs/redirects.map
@@ -560,3 +560,5 @@ genindex.html
 tools.html -> /tools/assistant.html
 examples.html -> /examples/bond-trading/index.html
 search.html
+getting-started/installation.htm -> /getting-started/installation.html
+gsg -> /getting-started/installation.html


### PR DESCRIPTION
We've created a cool video that happens to have the wrong link in it (missing `l` in the extension), and changing videos is more expensive than changing text files.

Also, the current URL is a tad long, so I've added a shorter one.

Note: as this is part of the docs bundle (actually generating an HTML redirect page), this won't be live until next version is published.