### PR TITLE
Encode tuples as records in the JSON API docs, add a new test

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -504,7 +504,10 @@ HTT Request
 
     {
         "templateId": "Account:Account",
-        "key": ["Alice", "abc123"],
+        "key": {
+            "_1": "Alice",
+            "_2": "abc123"
+        },
         "choice": "Archive",
         "argument": {}
     }
@@ -600,7 +603,10 @@ HTTP Request
 
     {
         "templateId": "Account:Account",
-        "key": ["Alice", "abc123"]
+        "key": {
+            "_1": "Alice",
+            "_2": "abc123"
+        }
     }
 
 Contract Not Found HTTP Response
@@ -979,8 +985,8 @@ Example:
 .. code-block:: json
 
     [
-        {"templateId": "Account:Account", "key": ["Alice", "abc123"]},
-        {"templateId": "Account:Account", "key": ["Alice", "def345"]}
+        {"templateId": "Account:Account", "key": {"_1": "Alice", "_2": "abc123"}},
+        {"templateId": "Account:Account", "key": {"_1": "Alice", "_2": "def345"}}
     ]
 
 The output stream has the same format as the output from the `Contracts Query Stream`_. We further guarantee that for every ``archived`` event appearing on the stream there has been a matching ``created`` event earlier in the stream.


### PR DESCRIPTION
tuples are formatted as records in the response, so this way input format matches the output

Closes: #4418

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
