### PR TITLE
Fix laoding typo

### DIFF
--- a/language-support/ts/daml-react/templateStore.ts
+++ b/language-support/ts/daml-react/templateStore.ts
@@ -38,7 +38,7 @@ export const empty = <T extends object, K>(): Store<T, K> => ({
 
 export const setAllLoading = <T extends object, K>(store: Store<T, K>): Store<T, K> => ({
   queryResults: store.queryResults.map((res) => ({...res, loading: true})),
-  fetchByKeyResults: store.fetchByKeyResults.map((res) => ({...res, laoding: true})),
+  fetchByKeyResults: store.fetchByKeyResults.map((res) => ({...res, loading: true})),
 });
 
 export const setQueryLoading = <T extends object, K>(store: Store<T, K>, query: Query<T>): Store<T, K> => ({


### PR DESCRIPTION
Not sure why the typechecker didn't catch this one.
I'm assuming this was changing an unused `laoding` field and the real
`loading` field was never used (or inaccurate) for `fetchByKeyResults`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
