### PR TITLE
Remove dependency on ghcide’s fakeDynFlags

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -45,6 +45,7 @@ da_haskell_library(
         "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-doctest",
         "//compiler/damlc/daml-ide-core",
+        "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-preprocessor",
         "//compiler/scenario-service/client",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -18,7 +18,6 @@ import Data.Maybe
 import Data.Either
 import qualified Data.NameMap as NM
 import qualified Data.Text as T
-import Development.IDE.GHC.Util
 import Development.IDE.Types.Location
 import Safe
 import System.FilePath
@@ -40,6 +39,7 @@ import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Ast.Type as LF
 import qualified DA.Daml.LF.TypeChecker.Check as LF
 import qualified DA.Daml.LF.TypeChecker.Env as LF
+import DA.Daml.Options
 
 import DA.Daml.Preprocessor.Generics
 import SdkVersion


### PR DESCRIPTION
`fakeDynFlags` has been removed from ghcide. We still need it since we
set up our environment in weird ways and want it to be platform
independent so this PR just copies the definition into `daml`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
