### PR TITLE
Try to get package name from manifest (if not provided)

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -59,6 +59,9 @@ sh_test(
             "ts/generated/src/daml/**",
         ],
     ),
+    tags = [
+        "exclusive",  # Due to the use of hardcoded ports in 'build-and-lint.sh'.
+    ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
     ],


### PR DESCRIPTION
- Also, mark `build-and-lint` "exclusive".

With this change, if `daml2ts` is not provided with a `main-package-name`, it will try to infer a package name from the manifest of the DAR it's given.