### PR TITLE
Require explicit time mode for DAML script and DAML trigger

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -52,7 +52,13 @@ object RunnerConfig {
       .action { (t, c) =>
         c.copy(timeProviderType = TimeProviderType.WallClock)
       }
-      .text("Use wall clock time (UTC). When not provided, static time is used.")
+      .text("Use wall clock time (UTC).")
+
+    opt[Unit]('s', "static-time")
+      .action { (t, c) =>
+        c.copy(timeProviderType = TimeProviderType.Static)
+      }
+      .text("Use static time.")
 
     opt[Long]("ttl")
       .action { (t, c) =>
@@ -73,6 +79,8 @@ object RunnerConfig {
         failure("Cannot specify both --ledger-host and --participant-config")
       } else if (c.ledgerHost.isEmpty && c.participantConfig.isEmpty) {
         failure("Must specify either --ledger-host or --participant-config")
+      } else if (c.timeProviderType == null) {
+        failure("Must specify either --wall-clock-time or --static-time")
       } else {
         success
       }
@@ -87,7 +95,7 @@ object RunnerConfig {
         ledgerHost = None,
         ledgerPort = None,
         participantConfig = None,
-        timeProviderType = TimeProviderType.Static,
+        timeProviderType = null,
         commandTtl = Duration.ofSeconds(30L),
         inputFile = None,
       )

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -179,10 +179,10 @@ them away using ``map snd``.
    :end-before: -- TEST_QUERIES_END
 
 To run our script, we first build it with ``daml build`` and then run
-it by pointing to the DAR, the name of our script and the host and
-port our ledger is running on.
+it by pointing to the DAR, the name of our script, the host and
+port our ledger is running on and the time mode of the ledger.
 
-``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:test --ledger-host localhost --ledger-port 6865``
+``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:test --ledger-host localhost --ledger-port 6865 --static-time``
 
 Up to now, we have worked with parties that we have allocated in the
 test. We can also pass in the path to a file containing
@@ -193,7 +193,7 @@ the input in the :doc:`/json-api/lf-value-specification`.
 
 We can then initialize our ledger passing in the json file via ``--input-file``.
 
-``daml script daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json``
+``daml script daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json --static-time``
 
 If you open Navigator, you can now see the contracts that have been created.
 

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -240,13 +240,14 @@ Now we are ready to run the trigger using ``daml trigger``:
 
 .. code-block:: sh
 
-    daml trigger --dar .daml/dist/copy-trigger-0.0.1.dar --trigger-name CopyTrigger:copyTrigger --ledger-host localhost --ledger-port 6865 --ledger-party Alice
+    daml trigger --dar .daml/dist/copy-trigger-0.0.1.dar --trigger-name CopyTrigger:copyTrigger --ledger-host localhost --ledger-port 6865 --ledger-party Alice --static-time
 
 The first argument specifies the ``.dar`` file that we have just
 built. The second argument specifies the identifier of the trigger
 using the syntax ``ModuleName:identifier``. Finally, we need to
-specify the ledger host, port and the party that our trigger is executed
-as.
+specify the ledger host, port, the party that our trigger is executed
+as, and the time mode of the ledger which is the sandbox default, i.e,
+static time.
 
 Now open Navigator at http://localhost:7500/.
 

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -50,7 +50,13 @@ object RunnerConfig {
       .action { (t, c) =>
         c.copy(timeProviderType = TimeProviderType.WallClock)
       }
-      .text("Use wall clock time (UTC). When not provided, static time is used.")
+      .text("Use wall clock time (UTC).")
+
+    opt[Unit]('s', "static-time")
+      .action { (t, c) =>
+        c.copy(timeProviderType = TimeProviderType.Static)
+      }
+      .text("Use static time.")
 
     opt[Long]("ttl")
       .action { (t, c) =>
@@ -83,6 +89,8 @@ object RunnerConfig {
           failure("Missing option --ledger-port")
         } else if (c.ledgerParty == null) {
           failure("Missing option --ledger-party")
+        } else if (c.timeProviderType == null) {
+          failure("Must specify either --wall-clock-time or --static-time")
         } else {
           success
         }
@@ -98,7 +106,7 @@ object RunnerConfig {
         ledgerHost = null,
         ledgerPort = 0,
         ledgerParty = null,
-        timeProviderType = TimeProviderType.Static,
+        timeProviderType = null,
         commandTtl = Duration.ofSeconds(30L),
         accessTokenFile = None,
       )


### PR DESCRIPTION
This should provide a better migration path for people that still rely
on static time by forcing them to make this explicit. Given that both
DAML script and DAML triggers are still experimental, I’m not marking
this as a breaking change

changelog_begin

- [DAML Script - Experimental] The time mode must now always be
  specified explicitly. Use ``--static-time`` to recover the previous
  default time mode.

- [DAML Triggers - Experimental] The time mode must now always be
  specified explicitly. Use ``--static-time`` to recover the previous
  default time mode.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
