### PR TITLE
Return proper code for invalid authentication

### DIFF
--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/AuthSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/AuthSpec.scala
@@ -109,9 +109,9 @@ final class AuthSpec
 
   behavior of "Extractor against a Ledger API protected by authentication"
 
-  it should "fail immediately with a PERMISSION_DENIED if no token is provided" in {
+  it should "fail immediately with a UNAUTHENTICATED if no token is provided" in {
     extractor(noAuth).run().failed.collect {
-      case GrpcException.PERMISSION_DENIED() => succeed
+      case GrpcException.UNAUTHENTICATED() => succeed
     }
   }
 

--- a/language-support/java/bindings-rxjava/BUILD.bazel
+++ b/language-support/java/bindings-rxjava/BUILD.bazel
@@ -89,6 +89,9 @@ da_scala_test_suite(
     data = [
         ":bindings-integration-tests-model-latest.dar",
     ],
+    resources = [
+        ":src/test/resources/logback-test.xml",
+    ],
     deps = [
         ":bindings-integration-tests-model-latest.jar",
         ":bindings-java-tests-lib",

--- a/language-support/java/bindings-rxjava/src/test/resources/logback-test.xml
+++ b/language-support/java/bindings-rxjava/src/test/resources/logback-test.xml
@@ -1,21 +1,10 @@
 <configuration>
-    <logger name="com.daml.ledger.javaapi" level="info" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>test.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="info">
-        <!--<appender-ref ref="FILE" />-->
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/ActiveContractClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/ActiveContractClientImplTest.scala
@@ -87,7 +87,7 @@ class ActiveContractClientImplTest
 
   "ActiveContractClientImpl.getActiveContracts" should "fail with insufficient authorization" in {
     ledgerServices.withACSClient(Observable.empty(), mockedAuthService) { (acsClient, _) =>
-      expectPermissionDenied {
+      expectUnauthenticated {
         acsClient
           .getActiveContracts(filterFor(someParty), false, emptyToken)
           .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandClientImplTest.scala
@@ -162,22 +162,22 @@ class CommandClientImplTest
   it should "deny access without token" in {
     withCommandClient(mockedAuthService) { (client, _) =>
       withClue("submitAndWait") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           submitAndWait(client)(dummyCommands, someParty, None)
         }
       }
       withClue("submitAndWaitForTransaction") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           submitAndWaitForTransaction(client)(dummyCommands, someParty, None)
         }
       }
       withClue("submitAndWaitForTransactionId") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           submitAndWaitForTransactionId(client)(dummyCommands, someParty, None)
         }
       }
       withClue("submitAndWaitForTransactionTree") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           submitAndWaitForTransactionTree(client)(dummyCommands, someParty, None)
         }
       }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandCompletionClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandCompletionClientImplTest.scala
@@ -123,7 +123,7 @@ class CommandCompletionClientImplTest
   it should "deny access without token" in {
     toAuthenticatedServer { client =>
       withClue("completionStream") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           client
             .completionStream("appId", LedgerBegin.getInstance(), Set(someParty).asJava)
             .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -131,7 +131,7 @@ class CommandCompletionClientImplTest
         }
       }
       withClue("completionStream unbounded") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           client
             .completionStream("appId", Set(someParty).asJava)
             .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -139,7 +139,7 @@ class CommandCompletionClientImplTest
         }
       }
       withClue("completionEnd") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           client.completionEnd().blockingGet()
         }
       }
@@ -169,7 +169,7 @@ class CommandCompletionClientImplTest
         }
       }
       withClue("completionEnd") {
-        expectPermissionDenied {
+        expectUnauthenticated {
           client.completionEnd(emptyToken).blockingGet()
         }
       }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandSubmissionClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/CommandSubmissionClientImplTest.scala
@@ -98,7 +98,7 @@ class CommandSubmissionClientImplTest
 
   it should "fail without a token" in {
     toAuthenticatedServer { client =>
-      expectPermissionDenied {
+      expectUnauthenticated {
         submitDummyCommand(client)
       }
     }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerConfigurationClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerConfigurationClientImplTest.scala
@@ -53,7 +53,7 @@ final class LedgerConfigurationClientImplTest
     }
 
   it should "deny access without a token" in {
-    expectPermissionDenied {
+    expectUnauthenticated {
       toAuthenticatedServer(
         _.getLedgerConfiguration
           .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -62,7 +62,7 @@ final class LedgerConfigurationClientImplTest
   }
 
   it should "deny access with insufficient authorization" in {
-    expectPermissionDenied {
+    expectUnauthenticated {
       toAuthenticatedServer(
         _.getLedgerConfiguration(emptyToken)
           .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerIdentityClientTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/LedgerIdentityClientTest.scala
@@ -33,7 +33,7 @@ final class LedgerIdentityClientTest extends FlatSpec with Matchers with AuthMat
 
   it should "deny ledger-id queries with insufficient authorization" in ledgerServices
     .withLedgerIdentityClient(mockedAuthService) { (binding, _) =>
-      expectPermissionDenied {
+      expectUnauthenticated {
         binding
           .getLedgerIdentity(emptyToken)
           .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/PackageClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/PackageClientImplTest.scala
@@ -57,7 +57,7 @@ class PackageClientImplTest extends FlatSpec with Matchers with AuthMatchers wit
         .getPackage("")
         .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
         .blockingGet()
-      getPackage.getArchivePayload shouldBe ByteString.EMPTY.toByteArray()
+      getPackage.getArchivePayload shouldBe ByteString.EMPTY.toByteArray
       getPackage.getArchivePayload shouldBe defaultGetPackageResponse.archivePayload.toByteArray
     }
   }
@@ -111,7 +111,7 @@ class PackageClientImplTest extends FlatSpec with Matchers with AuthMatchers wit
 
   behavior of "Authorization"
 
-  def toAuthenticatedServer(fn: PackageClient => Any): Any =
+  private def toAuthenticatedServer(fn: PackageClient => Any): Any =
     ledgerServices.withPackageClient(
       listPackageResponseFuture(),
       defaultGetPackageResponseFuture,
@@ -122,21 +122,21 @@ class PackageClientImplTest extends FlatSpec with Matchers with AuthMatchers wit
 
   it should "deny access without token" in {
     withClue("getPackage") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.getPackage("...").blockingGet()
         }
       }
     }
     withClue("getPackageStatus") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.getPackageStatus("...").blockingGet()
         }
       }
     }
     withClue("listPackages") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.listPackages().blockingFirst()
         }
@@ -146,21 +146,21 @@ class PackageClientImplTest extends FlatSpec with Matchers with AuthMatchers wit
 
   it should "deny access without sufficient authorization" in {
     withClue("getPackage") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.getPackage("...", emptyToken).blockingGet()
         }
       }
     }
     withClue("getPackageStatus") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.getPackageStatus("...", emptyToken).blockingGet()
         }
       }
     }
     withClue("listPackages") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           client.listPackages(emptyToken).blockingFirst()
         }
@@ -186,15 +186,18 @@ class PackageClientImplTest extends FlatSpec with Matchers with AuthMatchers wit
     }
   }
 
-  def listPackageResponse(pids: String*) = new ListPackagesResponse(pids)
+  private def listPackageResponse(pids: String*) = new ListPackagesResponse(pids)
 
-  def listPackageResponseFuture(pids: String*) = Future.successful(listPackageResponse(pids: _*))
+  private def listPackageResponseFuture(pids: String*) =
+    Future.successful(listPackageResponse(pids: _*))
 
-  val defaultGetPackageResponsePayload = ByteString.EMPTY
-  val defaultGetPackageResponse =
+  private val defaultGetPackageResponsePayload = ByteString.EMPTY
+  private val defaultGetPackageResponse =
     new GetPackageResponse(HashFunction.values.head, defaultGetPackageResponsePayload)
-  val defaultGetPackageResponseFuture = Future.successful(defaultGetPackageResponse)
-  val defaultGetPackageStatusResponse = new GetPackageStatusResponse(PackageStatus.values.head)
-  val defaultGetPackageStatusResponseFuture = Future.successful(defaultGetPackageStatusResponse)
+  private val defaultGetPackageResponseFuture = Future.successful(defaultGetPackageResponse)
+  private val defaultGetPackageStatusResponse = new GetPackageStatusResponse(
+    PackageStatus.values.head)
+  private val defaultGetPackageStatusResponseFuture =
+    Future.successful(defaultGetPackageStatusResponse)
 
 }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TimeClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TimeClientImplTest.scala
@@ -98,14 +98,14 @@ final class TimeClientImplTest
 
   it should "deny access without a token" in {
     withClue("getTime") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer {
           _.getTime().blockingFirst()
         }
       }
     }
     withClue("setTime") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer { client =>
           val t = Instant.now()
           client.setTime(t, t.plusSeconds(1)).blockingGet()
@@ -116,7 +116,7 @@ final class TimeClientImplTest
 
   it should "deny access with insufficient authorization" in {
     withClue("getTime") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer {
           _.getTime(emptyToken).blockingFirst()
         }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
@@ -289,7 +289,7 @@ final class TransactionsClientImplTest
 
   it should "deny access without a token" in {
     withClue("getTransactions specifying end") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(
           _.getTransactions(ledgerBegin, ledgerEnd, filterFor(someParty), false)
             .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -299,7 +299,7 @@ final class TransactionsClientImplTest
       }
     }
     withClue("getTransactions without specifying end") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(
           _.getTransactions(ledgerBegin, filterFor(someParty), false)
             .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -309,7 +309,7 @@ final class TransactionsClientImplTest
       }
     }
     withClue("getTransactionsTree specifying end") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(
           _.getTransactionsTrees(ledgerBegin, ledgerEnd, filterFor(someParty), false)
             .timeout(TestConfiguration.timeoutInSeconds, TimeUnit.SECONDS)
@@ -319,28 +319,28 @@ final class TransactionsClientImplTest
       }
     }
     withClue("getTransactionByEventId") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(_.getTransactionByEventId("...", Set(someParty).asJava).blockingGet())
       }
     }
     withClue("getTransactionById") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(_.getTransactionById("...", Set(someParty).asJava).blockingGet())
       }
     }
     withClue("getFlatTransactionByEventId") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(
           _.getFlatTransactionByEventId("...", Set(someParty).asJava).blockingGet())
       }
     }
     withClue("getFlatTransactionById") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(_.getFlatTransactionById("...", Set(someParty).asJava).blockingGet())
       }
     }
     withClue("getLedgerEnd") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(_.getLedgerEnd.blockingGet())
       }
     }
@@ -416,7 +416,7 @@ final class TransactionsClientImplTest
       }
     }
     withClue("getLedgerEnd") {
-      expectPermissionDenied {
+      expectUnauthenticated {
         toAuthenticatedServer(_.getLedgerEnd(emptyToken).blockingGet())
       }
     }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthService.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthService.scala
@@ -21,10 +21,10 @@ import java.util.concurrent.CompletionStage
   */
 trait AuthService {
 
-  /** Converts gRPC request metadata into a set of [[Claims]].
-    *
-    *  @param headers All HTTP headers attached to the request.
-    *
+  /**
+    * Return empty [[Claims]] to reject requests with a UNAUTHENTICATED error status.
+    * Return [[Claims]] with only a single [[ClaimPublic]] claim to reject all non-public requests with a PERMISSION_DENIED status.
+    * Return a failed future to reject requests with an INTERNAL error status.
     */
   def decodeMetadata(headers: io.grpc.Metadata): CompletionStage[Claims]
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -37,8 +37,11 @@ trait ErrorFactories {
   def unimplemented(description: String): StatusRuntimeException =
     grpcError(Status.UNIMPLEMENTED.withDescription(description))
 
-  def permissionDenied(description: String): StatusRuntimeException =
-    grpcError(Status.PERMISSION_DENIED.withDescription(description))
+  def permissionDenied(): StatusRuntimeException =
+    grpcError(Status.PERMISSION_DENIED)
+
+  def unauthenticated(): StatusRuntimeException =
+    grpcError(Status.UNAUTHENTICATED)
 
   def resourceExhausted(description: String): StatusRuntimeException =
     grpcError(Status.RESOURCE_EXHAUSTED.withDescription(description))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/AdminServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/AdminServiceCallAuthTests.scala
@@ -10,10 +10,10 @@ trait AdminServiceCallAuthTests extends ServiceCallAuthTests {
   private val signedIncorrectly = Option(toHeader(adminToken, UUID.randomUUID.toString))
 
   it should "deny calls with an invalid signature" in {
-    expectPermissionDenied(serviceCallWithToken(signedIncorrectly))
+    expectUnauthenticated(serviceCallWithToken(signedIncorrectly))
   }
   it should "deny calls with an expired admin token" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsAdminExpired))
+    expectUnauthenticated(serviceCallWithToken(canReadAsAdminExpired))
   }
   it should "deny calls with a read-only token" in {
     expectPermissionDenied(serviceCallWithToken(canReadAsRandomParty))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/PublicServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/PublicServiceCallAuthTests.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.sandbox.auth
 trait PublicServiceCallAuthTests extends ServiceCallAuthTests {
 
   it should "deny calls with an expired read-only token" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsRandomPartyExpired))
+    expectUnauthenticated(serviceCallWithToken(canReadAsRandomPartyExpired))
   }
   it should "allow calls with explicitly non-expired read-only token" in {
     expectSuccess(serviceCallWithToken(canReadAsRandomPartyExpiresTomorrow))
@@ -16,7 +16,7 @@ trait PublicServiceCallAuthTests extends ServiceCallAuthTests {
   }
 
   it should "deny calls with an expired read/write token" in {
-    expectPermissionDenied(serviceCallWithToken(canActAsRandomPartyExpired))
+    expectUnauthenticated(serviceCallWithToken(canActAsRandomPartyExpired))
   }
   it should "allow calls with explicitly non-expired read/write token" in {
     expectSuccess(serviceCallWithToken(canActAsRandomPartyExpiresTomorrow))
@@ -26,7 +26,7 @@ trait PublicServiceCallAuthTests extends ServiceCallAuthTests {
   }
 
   it should "deny calls with an expired admin token" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsAdminExpired))
+    expectUnauthenticated(serviceCallWithToken(canReadAsAdminExpired))
   }
   it should "allow calls with explicitly non-expired admin token" in {
     expectSuccess(serviceCallWithToken(canReadAsAdminExpiresTomorrow))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadOnlyServiceCallAuthTests.scala
@@ -16,7 +16,7 @@ trait ReadOnlyServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   def successfulBehavior: Future[Any] => Future[Assertion] = expectSuccess(_: Future[Any])
 
   it should "deny calls with an expired read-only token" in {
-    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorExpired))
+    expectUnauthenticated(serviceCallWithToken(canReadAsMainActorExpired))
   }
   it should "allow calls with explicitly non-expired read-only token" in {
     successfulBehavior(serviceCallWithToken(canReadAsMainActorExpiresTomorrow))
@@ -26,7 +26,7 @@ trait ReadOnlyServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   }
 
   it should "deny calls with an expired read/write token" in {
-    expectPermissionDenied(serviceCallWithToken(canActAsMainActorExpired))
+    expectUnauthenticated(serviceCallWithToken(canActAsMainActorExpired))
   }
   it should "allow calls with explicitly non-expired read/write token" in {
     successfulBehavior(serviceCallWithToken(canActAsMainActorExpiresTomorrow))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -6,7 +6,7 @@ package com.digitalasset.platform.sandbox.auth
 trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
 
   it should "deny calls with an expired read/write token" in {
-    expectPermissionDenied(serviceCallWithToken(canActAsMainActorExpired))
+    expectUnauthenticated(serviceCallWithToken(canActAsMainActorExpired))
   }
   it should "allow calls with explicitly non-expired read/write token" in {
     expectSuccess(serviceCallWithToken(canActAsMainActorExpiresTomorrow))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
@@ -39,6 +39,9 @@ trait ServiceCallAuthTests
   protected def expectPermissionDenied(f: Future[Any]): Future[Assertion] =
     expectFailure(f, Status.Code.PERMISSION_DENIED)
 
+  protected def expectUnauthenticated(f: Future[Any]): Future[Assertion] =
+    expectFailure(f, Status.Code.UNAUTHENTICATED)
+
   protected def expectFailure(f: Future[Any], code: Status.Code): Future[Assertion] =
     f.failed.collect {
       case GrpcException(GrpcStatus(`code`, _), _) => succeed
@@ -52,8 +55,8 @@ trait ServiceCallAuthTests
 
   behavior of serviceCallName
 
-  it should "deny unauthorized calls" in {
-    expectPermissionDenied(serviceCallWithToken(None))
+  it should "deny unauthenticated calls" in {
+    expectUnauthenticated(serviceCallWithToken(None))
   }
 
   protected val canActAsRandomParty =

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -20,7 +20,7 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
     expectPermissionDenied(serviceCallWithToken(canReadAsRandomParty))
   }
   it should "deny calls with an invalid signature" in {
-    expectPermissionDenied(serviceCallWithToken(signedIncorrectly))
+    expectUnauthenticated(serviceCallWithToken(signedIncorrectly))
   }
 
   protected val canReadAsMainActor =


### PR DESCRIPTION
CHANGELOG_BEGIN
[Sandbox] If authentication is enabled, requests without a valid
authentication are going to be rejected with an ``UNAUTHENTICATED``
return code instead of ``PERMISSION_DENIED``.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
