### PR TITLE
Wrap function types in parentheses for data-dependencies

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -499,7 +499,7 @@ convType env =
             ty2' <- convType env ty2
             pure $ if isConstraint ty1
                 then HsQualTy noExt (noLoc [noLoc ty1']) (noLoc ty2')
-                else HsFunTy noExt (noLoc ty1') (noLoc ty2')
+                else HsParTy noExt (noLoc $ HsFunTy noExt (noLoc ty1') (noLoc ty2'))
 
         LF.TSynApp LF.Qualified{..} lfArgs -> do
             ghcMod <- genModule env qualPackage qualModule
@@ -509,7 +509,7 @@ convType env =
                 tyvar = HsTyVar noExt NotPromoted . noLoc
                     . mkOrig ghcMod . mkOccName clsName $ T.unpack tyname
             args <- mapM (convType env) lfArgs
-            pure $ foldl (HsAppTy noExt . noLoc) tyvar (map noLoc args)
+            pure $ HsParTy noExt (noLoc $ foldl (HsAppTy noExt . noLoc) tyvar (map noLoc args))
 
         LF.TCon LF.Qualified {..}
           | qualModule == LF.ModuleName ["DA", "Types"]

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1046,6 +1046,8 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               , "  where"
               , "    signatory p"
               , "data AnyWrapper = AnyWrapper { getAnyWrapper : AnyTemplate }"
+
+              , "data FunT a b = FunT (a -> b)"
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -1061,7 +1063,7 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
           writeFileUTF8 (projb </> "src" </> "B.daml") $ unlines
               [ "daml 1.2"
               , "module B where"
-              , "import A ( Foo (foo), Bar (..), usingFoo, Q (..), usingEq, R(R), P(P), AnyWrapper(..) )"
+              , "import A ( Foo (foo), Bar (..), usingFoo, Q (..), usingEq, R(R), P(P), AnyWrapper(..), FunT(..) )"
               , "import DA.Assert"
               , "import DA.Record"
               , ""
@@ -1099,6 +1101,9 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               , "  p <- getParty \"p\""
               , "  let t = P p"
               , "  fromAnyTemplate (AnyWrapper $ toAnyTemplate t).getAnyWrapper === Some t"
+              -- reference to T
+              , "foobar : FunT Int Text"
+              , "foobar = FunT show"
               ]
           writeFileUTF8 (projb </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion


### PR DESCRIPTION
This fixes a bug where `data X = X (a -> b)` was reconstructed as
`data X = X a -> b` which is a syntax error.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
