### PR TITLE
Add allocatePartyWithHint(On) to DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -96,7 +96,7 @@ query p = Script $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(
 
 data AllocateParty a = AllocateParty
   { displayName : Text
-  , idHint : Optional Text
+  , idHint : Text
   , participant : Optional Text
   , continue : Party -> a
   } deriving Functor
@@ -117,7 +117,7 @@ newtype ParticipantName = ParticipantName { participantName : Text }
 allocateParty : Text -> Script Party
 allocateParty displayName = Script $ Free $ AllocParty $ AllocateParty
   { displayName
-  , idHint = None
+  , idHint = ""
   , participant = None
   , continue = pure
   }
@@ -127,7 +127,7 @@ allocateParty displayName = Script $ Free $ AllocParty $ AllocateParty
 allocatePartyWithHint : Text -> PartyIdHint -> Script Party
 allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
-  , idHint = Some idHint
+  , idHint = idHint
   , participant = None
   , continue = pure
   }
@@ -137,7 +137,7 @@ allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free $ AllocPa
 allocatePartyOn : Text -> ParticipantName -> Script Party
 allocatePartyOn displayName (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
-  , idHint = None
+  , idHint = ""
   , participant = Some participant
   , continue = pure
   }
@@ -147,7 +147,7 @@ allocatePartyOn displayName (ParticipantName participant) = Script $ Free $ Allo
 allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
 allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
-  , idHint = Some idHint
+  , idHint = idHint
   , participant = Some participant
   , continue = pure
   }

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -115,42 +115,42 @@ newtype ParticipantName = ParticipantName { participantName : Text }
 -- | Allocate a party with the given display name
 -- using the party management service.
 allocateParty : Text -> Script Party
-allocateParty displayName = Script $ Free (AllocParty $ AllocateParty
+allocateParty displayName = Script $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = None
   , participant = None
   , continue = pure
-  })
+  }
 
 -- | Allocate a party with the given display name and id hint
 -- using the party management service.
 allocatePartyWithHint : Text -> PartyIdHint -> Script Party
-allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free (AllocParty $ AllocateParty
+allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = Some idHint
   , participant = None
   , continue = pure
-  })
+  }
 
 -- | Allocate a party with the given display name
 -- on the specified participant using the party management service.
 allocatePartyOn : Text -> ParticipantName -> Script Party
-allocatePartyOn displayName (ParticipantName participant) = Script $ Free (AllocParty $ AllocateParty
+allocatePartyOn displayName (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = None
   , participant = Some participant
   , continue = pure
-  })
+  }
 
 -- | Allocate a party with the given display name and id hint
 -- on the specified participant using the party management service.
 allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
-allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ Free (AllocParty $ AllocateParty
+allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = Some idHint
   , participant = Some participant
   , continue = pure
-  })
+  }
 
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -7,8 +7,12 @@ module Daml.Script
   , submit
   , submitMustFail
   , query
+  , PartyIdHint (..)
+  , ParticipantName (..)
   , allocateParty
+  , allocatePartyWithHint
   , allocatePartyOn
+  , allocatePartyWithHintOn
   , Commands
   , createCmd
   , exerciseCmd
@@ -92,6 +96,7 @@ query p = Script $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(
 
 data AllocateParty a = AllocateParty
   { displayName : Text
+  , idHint : Optional Text
   , participant : Optional Text
   , continue : Party -> a
   } deriving Functor
@@ -101,15 +106,51 @@ data SleepRec a = SleepRec
   , continue : () -> a
   } deriving Functor
 
--- | Allocate a party with the given display name
--- using the party management service.
-allocateParty : Text -> Script Party
-allocateParty displayName = Script $ Free (AllocParty $ AllocateParty displayName None pure)
+-- | A hint to the backing participant what party id to allocate.
+-- Must be a valid PartyIdString (as described in @value.proto@).
+newtype PartyIdHint = PartyIdHint { partyIdHint : Text }
+
+newtype ParticipantName = ParticipantName { participantName : Text }
 
 -- | Allocate a party with the given display name
 -- using the party management service.
-allocatePartyOn : Text -> Text -> Script Party
-allocatePartyOn displayName participant = Script $ Free (AllocParty $ AllocateParty displayName (Some participant) pure)
+allocateParty : Text -> Script Party
+allocateParty displayName = Script $ Free (AllocParty $ AllocateParty
+  { displayName
+  , idHint = None
+  , participant = None
+  , continue = pure
+  })
+
+-- | Allocate a party with the given display name and id hint
+-- using the party management service.
+allocatePartyWithHint : Text -> PartyIdHint -> Script Party
+allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free (AllocParty $ AllocateParty
+  { displayName
+  , idHint = Some idHint
+  , participant = None
+  , continue = pure
+  })
+
+-- | Allocate a party with the given display name
+-- on the specified participant using the party management service.
+allocatePartyOn : Text -> ParticipantName -> Script Party
+allocatePartyOn displayName (ParticipantName participant) = Script $ Free (AllocParty $ AllocateParty
+  { displayName
+  , idHint = None
+  , participant = Some participant
+  , continue = pure
+  })
+
+-- | Allocate a party with the given display name and id hint
+-- on the specified participant using the party management service.
+allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
+allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ Free (AllocParty $ AllocateParty
+  { displayName
+  , idHint = Some idHint
+  , participant = Some participant
+  , continue = pure
+  })
 
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -389,12 +389,17 @@ class Runner(
             }
             case SVariant(_, "AllocParty", v) => {
               v match {
-                case SRecord(_, _, vals) if vals.size == 3 => {
+                case SRecord(_, _, vals) if vals.size == 4 => {
                   val displayName = vals.get(0) match {
                     case SText(value) => value
                     case v => throw new ConverterException(s"Expected SText but got $v")
                   }
-                  val participantName = vals.get(1) match {
+                  val partyIdHint = vals.get(1) match {
+                    case SOptional(Some(SText(t))) => Some(t)
+                    case SOptional(None) => None
+                    case v => throw new ConverterException(s"Expected SOptional(SText) but got $v")
+                  }
+                  val participantName = vals.get(2) match {
                     case SOptional(Some(SText(t))) => Some(Participant(t))
                     case SOptional(None) => None
                     case v => throw new ConverterException(s"Expected SOptional(SText) but got $v")
@@ -403,9 +408,9 @@ class Runner(
                     case Left(err) => throw new RuntimeException(err)
                     case Right(client) => client
                   }
-                  val continue = vals.get(2)
+                  val continue = vals.get(3)
                   val f =
-                    client.partyManagementClient.allocateParty(None, Some(displayName))
+                    client.partyManagementClient.allocateParty(partyIdHint, Some(displayName))
                   f.flatMap(allocRes => {
                     val party = allocRes.party
                     participantName match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -395,9 +395,8 @@ class Runner(
                     case v => throw new ConverterException(s"Expected SText but got $v")
                   }
                   val partyIdHint = vals.get(1) match {
-                    case SOptional(Some(SText(t))) => Some(t)
-                    case SOptional(None) => None
-                    case v => throw new ConverterException(s"Expected SOptional(SText) but got $v")
+                    case SText(t) => t
+                    case v => throw new ConverterException(s"Expected SText but got $v")
                   }
                   val participantName = vals.get(2) match {
                     case SOptional(Some(SText(t))) => Some(Participant(t))
@@ -410,7 +409,7 @@ class Runner(
                   }
                   val continue = vals.get(3)
                   val f =
-                    client.partyManagementClient.allocateParty(partyIdHint, Some(displayName))
+                    client.partyManagementClient.allocateParty(Some(partyIdHint), Some(displayName))
                   f.flatMap(allocRes => {
                     val party = allocRes.party
                     participantName match {

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -38,6 +38,7 @@ fi
 
 EXPECTED="$($SORT <<'EOF'
 MultiTest:multiTest SUCCESS
+MultiTest:partyIdHintTest SUCCESS
 ScriptExample:test SUCCESS
 ScriptTest:failingTest FAILURE (com.digitalasset.daml.lf.speedy.SError$DamlEUserError)
 ScriptTest:test0 SUCCESS
@@ -47,6 +48,7 @@ ScriptTest:test4 SUCCESS
 ScriptTest:testCreateAndExercise SUCCESS
 ScriptTest:testKey SUCCESS
 ScriptTest:time SUCCESS
+ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
 EOF
 )"

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -35,3 +35,9 @@ multiTest = do
   cid <- submit alice $ createCmd (TProposal alice bob)
   r <- submit bob $ exerciseCmd cid Accept
   pure (snd r)
+
+partyIdHintTest : Script (Party, Party)
+partyIdHintTest = do
+  alice <- allocatePartyWithHintOn "alice" (PartyIdHint "alice") (ParticipantName "one")
+  bob <- allocatePartyWithHintOn "bob" (PartyIdHint "bob") (ParticipantName "two")
+  pure (alice, bob)

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -30,8 +30,8 @@ template TProposal
 
 multiTest : Script Int
 multiTest = do
-  alice <- allocatePartyOn "alice" "one"
-  bob <- allocatePartyOn "bob" "two"
+  alice <- allocatePartyOn "alice" (ParticipantName "one")
+  bob <- allocatePartyOn "bob" (ParticipantName "two")
   cid <- submit alice $ createCmd (TProposal alice bob)
   r <- submit bob $ exerciseCmd cid Accept
   pure (snd r)

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -156,3 +156,9 @@ sleepTest = do
   sleep (seconds 2)
   t3 <- getTime
   pure (t1, t2, t3)
+
+partyIdHintTest : Script (Party, Party)
+partyIdHintTest = do
+  carol <- allocatePartyWithHint "carol" (PartyIdHint "carol")
+  dan <- allocatePartyWithHint "dan" (PartyIdHint "dan")
+  pure (carol, dan)


### PR DESCRIPTION
Closes #4472 

- Adds `allocatePartyWithHint` and `allocatePartyWithHintOn` to specify the `party_id_hint` from DAML script.
- Wraps the `PartyIdHint` and `ParticipantName` arguments in `newtype` wrappers to avoid confusing and error-prone types such as `allocatePartyWithHintOn : Text -> Text -> Text -> Script Party`.
- Adds test cases for the single and multi participant cases.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
