### PR TITLE
Handle multiple constraints on an instance in data-dependencies

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1048,6 +1048,9 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               , "data AnyWrapper = AnyWrapper { getAnyWrapper : AnyTemplate }"
 
               , "data FunT a b = FunT (a -> b)"
+
+              , "instance (Foo a, Foo b) => Foo (a,b) where"
+              , "  foo x = (foo x, foo x)"
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -1083,6 +1086,7 @@ dataDependencyTests damlc repl davlDar = testGroup "Data Dependencies" $
               , "testInstanceImport = scenario do"
               , "  foo 10 === 10" -- Foo Int
               , "  bar 20 === 20" -- Bar Int
+              , "  foo 10 === (10, 10)" -- Foo (a, b)
               , "  Q1 === Q1" -- (Eq Q, Show Q)
               , "  (Q1 <= Q2) === True" -- Ord Q
               -- test importing of HasField instances


### PR DESCRIPTION
Previously we translated `instance (Foo a, Foo b) => Foo (a, b) where`
into `instance Foo a => Foo b => Foo (a, b)` which is a syntax
error. We already did this correctly for `HasField` so this PR mostly
just shuffles things around to always use the non-HasField specific
parts.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
