### PR TITLE
@daml/ledger: Add workaround for websocket proxying issues

### DIFF
--- a/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/generated/src/__tests__/test.ts
@@ -68,7 +68,7 @@ afterAll(() => {
 });
 
 test('create + fetch & exercise', async () => {
-  const ledger = new Ledger(ALICE_TOKEN, `http://localhost:${JSON_API_PORT}/`);
+  const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: `http://localhost:${JSON_API_PORT}/`});
   const aliceStream = ledger.streamQuery(Main.Person, {party: ALICE_PARTY});
   const aliceIterator = pEvent.iterator(aliceStream, 'events', {rejectionEvents: ['close']});
   const aliceIteratorNext = async () => {

--- a/language-support/ts/daml-react/DamlLedger.ts
+++ b/language-support/ts/daml-react/DamlLedger.ts
@@ -10,18 +10,20 @@ import { reducer } from './reducer';
 
 type Props = {
   token: string;
+  httpBaseUrl?: string;
+  wsBaseUrl?: string;
   party: Party;
 }
 
-const DamlLedger: React.FC<Props> = (props) => {
+const DamlLedger: React.FC<Props> = ({token, httpBaseUrl, wsBaseUrl, party, children}) => {
   const [store, dispatch] = useReducer(reducer, LedgerStore.empty());
   const state = useMemo(() => ({
     store,
     dispatch,
-    party: props.party,
-    ledger: new Ledger(props.token),
-  }), [props.party, props.token, store, dispatch]);
-  return React.createElement(DamlLedgerContext.Provider, {value: state}, props.children);
+    party,
+    ledger: new Ledger({token, httpBaseUrl, wsBaseUrl}),
+  }), [party, token, httpBaseUrl, wsBaseUrl, store, dispatch]);
+  return React.createElement(DamlLedgerContext.Provider, {value: state}, children);
 }
 
 export default DamlLedger;


### PR DESCRIPTION
Unfortunately, the development server of `create-react-app` does not
proxy websockets properly. Thus, we need to connect to the JSON API
directly when using it. This now be done by setting the
`REACT_APP_JSON_API_PORT` environment variable in `.env.development`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4503)
<!-- Reviewable:end -->
