### PR TITLE
[Engine] Adding a specific type for ParticipantId

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -85,6 +85,8 @@ sealed abstract class IdString {
     * lowercase hex-encoded hash of the package contents found in the DAML LF Archive. */
   type PackageId <: String
 
+  type ParticipantId <: String
+
   /**
     * Used to reference to leger objects like legacy contractIds, ledgerIds,
     * transactionId, ... We use the same type for those ids, because we
@@ -104,6 +106,7 @@ sealed abstract class IdString {
   val Name: StringModule[Name]
   val Party: ConcatenableStringModule[Party]
   val PackageId: ConcatenableStringModule[PackageId]
+  val ParticipantId: StringModule[ParticipantId]
   val LedgerString: ConcatenableStringModule[LedgerString]
   val ContractIdStringV0: ConcatenableStringModule[ContractIdStringV0]
   val ContractIdStringV1: StringModule[ContractIdStringV1]
@@ -219,6 +222,9 @@ private[data] final class IdStringImpl extends IdString {
   override type LedgerString = String
   override val LedgerString: ConcatenableStringModule[LedgerString] =
     new ConcatenableMatchingStringModule("._:-#/ ".contains(_), 255)
+
+  override type ParticipantId = String
+  override val ParticipantId = LedgerString
 
   /**
     * Legacy contractIds.

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -41,6 +41,9 @@ object Ref {
   type LedgerString = IdString.LedgerString
   val LedgerString: IdString.LedgerString.type = IdString.LedgerString
 
+  type ParticipantId = IdString.ParticipantId
+  val ParticipantId: IdString.ParticipantId.type = IdString.ParticipantId
+
   /* Location annotation */
   case class Location(
       packageId: PackageId,

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/Config.scala
@@ -8,7 +8,6 @@ import java.nio.file.Path
 
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.api.util.TimeProvider
-import com.digitalasset.daml.lf.data.Ref.LedgerString
 import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.indexer.IndexerStartupMode
 
@@ -42,7 +41,7 @@ object Config {
       timeProvider = TimeProvider.UTC,
       jdbcUrl = "",
       tlsConfig = None,
-      participantId = LedgerString.assertFromString("standalone-participant"),
+      participantId = ParticipantId.assertFromString("standalone-participant"),
       extraParticipants = Vector.empty,
       startupMode = IndexerStartupMode.MigrateAndStart,
     )

--- a/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/main/scala/com/daml/ledger/api/server/damlonx/reference/v2/cli/Cli.scala
@@ -13,6 +13,9 @@ object Cli {
   private implicit val ledgerStringRead: Read[Ref.LedgerString] =
     Read.stringRead.map(Ref.LedgerString.assertFromString)
 
+  private implicit val participantIdRead: Read[Ref.ParticipantId] =
+    Read.stringRead.map(Ref.ParticipantId.assertFromString)
+
   private implicit def tripleRead[A, B, C](
       implicit readA: Read[A],
       readB: Read[B],
@@ -54,11 +57,11 @@ object Cli {
       opt[String]("jdbc-url")
         .text("The JDBC URL to the postgres database used for the indexer and the index")
         .action((u, c) => c.copy(jdbcUrl = u))
-      opt[Ref.LedgerString]("participant-id")
+      opt[Ref.ParticipantId]("participant-id")
         .optional()
         .text("The participant id given to all components of a ledger api server")
         .action((p, c) => c.copy(participantId = p))
-      opt[(Ref.LedgerString, Int, String)]('P', "extra-participant")
+      opt[(Ref.ParticipantId, Int, String)]('P', "extra-participant")
         .optional()
         .unbounded()
         .text("A list of triples in the form `<participant-id>,<port>,<index-jdbc-url>` to spin up multiple nodes backed by the same in-memory ledger")

--- a/ledger/api-server-damlonx/reference-v2/src/test/suite/scala/com/daml/ledger/api/server/damlonx/reference/v2/IndexerIT.scala
+++ b/ledger/api-server-damlonx/reference-v2/src/test/suite/scala/com/daml/ledger/api/server/damlonx/reference/v2/IndexerIT.scala
@@ -189,7 +189,7 @@ class IndexerIT extends AsyncWordSpec with Matchers with BeforeAndAfterEach {
       restartDelay: FiniteDuration = 100.millis,
   ): (ParticipantState, Resource[Unit], Resource[LedgerDao]) = {
     val id = UUID.randomUUID()
-    val participantId: ParticipantId = LedgerString.assertFromString(s"participant-$id")
+    val participantId = ParticipantId.assertFromString(s"participant-$id")
     val ledgerId = LedgerString.assertFromString(s"ledger-$id")
     val participantState = newParticipantState(participantId, ledgerId)
     val jdbcUrl =

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/PartyManagementClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/PartyManagementClient.scala
@@ -38,7 +38,7 @@ final class PartyManagementClient(service: PartyManagementServiceStub)(
     LedgerClient
       .stub(service, token)
       .getParticipantId(PartyManagementClient.getParticipantIdRequest)
-      .map(r => ParticipantId(Ref.LedgerString.assertFromString(r.participantId)))
+      .map(r => ParticipantId(Ref.ParticipantId.assertFromString(r.participantId)))
 
   def listKnownParties(token: Option[String] = None): Future[List[PartyDetails]] =
     LedgerClient

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -256,7 +256,7 @@ object domain {
 
   sealed trait ParticipantIdTag
 
-  type ParticipantId = Ref.LedgerString @@ ParticipantIdTag
+  type ParticipantId = Ref.ParticipantId @@ ParticipantIdTag
   val ParticipantId: Tag.TagOf[ParticipantIdTag] = Tag.of[ParticipantIdTag]
 
   sealed trait ApplicationIdTag

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -655,7 +655,7 @@ object ParticipantStateIntegrationSpecBase {
     GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 
   private val participantId: ParticipantId =
-    Ref.LedgerString.assertFromString("in-memory-participant")
+    Ref.ParticipantId.assertFromString("in-memory-participant")
   private val sourceDescription = Some("provided by test")
 
   private val darReader = DarReader { case (_, is) => Try(DamlLf.Archive.parseFrom(is)) }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1.Configuration
-import com.digitalasset.daml.lf.data.Ref.LedgerString.assertFromString
+import com.digitalasset.daml.lf.data.Ref
 import org.scalatest.{Matchers, WordSpec}
 
 class KVUtilsConfigSpec extends WordSpec with Matchers {
@@ -19,13 +19,12 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
 
     "be able to build, pack, unpack and parse" in {
       val subm = KeyValueSubmission.unpackDamlSubmission(
-        KeyValueSubmission.packDamlSubmission(
-          KeyValueSubmission.configurationToSubmission(
-            maxRecordTime = theRecordTime,
-            submissionId = assertFromString("foobar"),
-            participantId = assertFromString("participant"),
-            config = theDefaultConfig
-          )))
+        KeyValueSubmission.packDamlSubmission(KeyValueSubmission.configurationToSubmission(
+          maxRecordTime = theRecordTime,
+          submissionId = Ref.LedgerString.assertFromString("foobar"),
+          participantId = Ref.ParticipantId.assertFromString("participant"),
+          config = theDefaultConfig
+        )))
 
       val configSubm = subm.getConfigurationSubmission
       Conversions.parseTimestamp(configSubm.getMaximumRecordTime) shouldEqual theRecordTime
@@ -37,14 +36,14 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
       for {
         logEntry <- submitConfig(
           configModify = c => c.copy(generation = c.generation + 1),
-          submissionId = assertFromString("submission0")
+          submissionId = Ref.LedgerString.assertFromString("submission0")
         )
         newConfig <- getConfiguration
 
         // Change again, but without bumping generation.
         logEntry2 <- submitConfig(
           configModify = c => c.copy(generation = c.generation),
-          submissionId = assertFromString("submission1")
+          submissionId = Ref.LedgerString.assertFromString("submission1")
         )
         newConfig2 <- getConfiguration
 
@@ -67,7 +66,7 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
           configModify = { c =>
             c.copy(generation = c.generation + 1)
           },
-          submissionId = assertFromString("some-submission-id")
+          submissionId = Ref.LedgerString.assertFromString("some-submission-id")
         )
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_REJECTION_ENTRY
@@ -85,7 +84,7 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
           c.copy(
             generation = c.generation + 1
           )
-        }, submissionId = assertFromString("submission-id-1"))
+        }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
 
         //
         // A well authorized submission
@@ -96,7 +95,7 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
             c.copy(
               generation = c.generation + 1,
             )
-          }, submissionId = assertFromString("submission-id-2"))
+          }, submissionId = Ref.LedgerString.assertFromString("submission-id-2"))
         }
 
         //
@@ -108,7 +107,7 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
             c.copy(
               generation = c.generation + 1,
             )
-          }, submissionId = assertFromString("submission-id-3"))
+          }, submissionId = Ref.LedgerString.assertFromString("submission-id-3"))
         }
 
       } yield {
@@ -129,13 +128,13 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
           c.copy(
             generation = c.generation + 1
           )
-        }, submissionId = assertFromString("submission-id-1"))
+        }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
 
         logEntry1 <- submitConfig({ c =>
           c.copy(
             generation = c.generation + 1,
           )
-        }, submissionId = assertFromString("submission-id-1"))
+        }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
 
       } yield {
         logEntry0.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
@@ -154,13 +153,13 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
           c.copy(
             generation = c.generation + 1
           )
-        }, submissionId = assertFromString("submission-id-1"))
+        }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
 
         _ <- submitConfig({ c =>
           c.copy(
             generation = c.generation + 1,
           )
-        }, submissionId = assertFromString("submission-id-1"))
+        }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -81,7 +81,7 @@ object TestHelpers {
   }
 
   def mkParticipantId(n: Int): ParticipantId =
-    Ref.LedgerString.assertFromString(s"participant-$n")
+    Ref.ParticipantId.assertFromString(s"participant-$n")
 
   def randomLedgerString: Ref.LedgerString =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
@@ -86,7 +86,7 @@ object IntegrityCheck extends App {
           Conversions.parseTimestamp(logEntry.getRecordTime),
           defaultConfig,
           submission,
-          Ref.LedgerString.assertFromString(entry.getParticipantId),
+          Ref.ParticipantId.assertFromString(entry.getParticipantId),
           inputState
       ))
     total_t_commit += t_commit

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -60,8 +60,8 @@ package object v1 {
   type LedgerId = String
 
   /** Identifier for the participant, MUST match regexp [a-zA-Z0-9-]. */
-  val ParticipantId: Ref.LedgerString.type = Ref.LedgerString
-  type ParticipantId = Ref.LedgerString
+  val ParticipantId: Ref.ParticipantId.type = Ref.ParticipantId
+  type ParticipantId = Ref.ParticipantId
 
   /** Identifiers for transactions. */
   val TransactionId: Ref.LedgerString.type = Ref.LedgerString

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -147,7 +147,7 @@ final class SandboxServer(config: SandboxConfig) extends AutoCloseable {
 
   // Name of this participant
   // TODO: Pass this info in command-line (See issue #2025)
-  val participantId: ParticipantId = Ref.LedgerString.assertFromString("sandbox-participant")
+  val participantId: ParticipantId = Ref.ParticipantId.assertFromString("sandbox-participant")
 
   private val authService: AuthService = config.authService.getOrElse(AuthServiceWildcard)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -175,7 +175,7 @@ object Runner {
   private val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
   private val ParticipantId: v1.ParticipantId =
-    Ref.LedgerString.assertFromString("sandbox-participant")
+    Ref.ParticipantId.assertFromString("sandbox-participant")
 
   private val InMemoryLedgerJdbcUrl =
     "jdbc:sqlite:file:ledger?mode=memory&cache=shared"

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -14,13 +14,7 @@ import anorm.{
   SqlParser,
   ToStatement
 }
-import com.digitalasset.daml.lf.data.Ref.{
-  ContractIdString,
-  LedgerString,
-  PackageId,
-  ParticipantId,
-  Party
-}
+import com.digitalasset.daml.lf.data.Ref
 
 object Conversions {
 
@@ -40,48 +34,48 @@ object Conversions {
 
   // Parties
 
-  implicit def columnToParty(implicit c: Column[String]): Column[Party] =
-    stringColumnToX(Party.fromString)(c)
+  implicit def columnToParty(implicit c: Column[String]): Column[Ref.Party] =
+    stringColumnToX(Ref.Party.fromString)(c)
 
-  implicit def partyToStatement(implicit strToStm: ToStatement[String]): ToStatement[Party] =
+  implicit def partyToStatement(implicit strToStm: ToStatement[String]): ToStatement[Ref.Party] =
     subStringToStatement(strToStm)
 
-  def party(columnName: String)(implicit c: Column[String]): RowParser[Party] =
-    SqlParser.get[Party](columnName)(columnToParty(c))
+  def party(columnName: String)(implicit c: Column[String]): RowParser[Ref.Party] =
+    SqlParser.get[Ref.Party](columnName)(columnToParty(c))
 
   // PackageIds
 
-  implicit def columnToPackageId(implicit c: Column[String]): Column[PackageId] =
-    stringColumnToX(PackageId.fromString)(c)
+  implicit def columnToPackageId(implicit c: Column[String]): Column[Ref.PackageId] =
+    stringColumnToX(Ref.PackageId.fromString)(c)
 
   implicit def packageIdToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[PackageId] =
+      implicit strToStm: ToStatement[String]): ToStatement[Ref.PackageId] =
     subStringToStatement(strToStm)
 
-  def packageId(columnName: String)(implicit c: Column[String]): RowParser[PackageId] =
-    SqlParser.get[PackageId](columnName)(columnToPackageId(c))
+  def packageId(columnName: String)(implicit c: Column[String]): RowParser[Ref.PackageId] =
+    SqlParser.get[Ref.PackageId](columnName)(columnToPackageId(c))
 
   // LedgerStrings
 
-  implicit def columnToLedgerString(implicit c: Column[String]): Column[LedgerString] =
-    stringColumnToX(LedgerString.fromString)(c)
+  implicit def columnToLedgerString(implicit c: Column[String]): Column[Ref.LedgerString] =
+    stringColumnToX(Ref.LedgerString.fromString)(c)
 
   implicit def ledgerStringToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[LedgerString] =
+      implicit strToStm: ToStatement[String]): ToStatement[Ref.LedgerString] =
     subStringToStatement(strToStm)
 
-  implicit def columnToParticipantId(implicit c: Column[String]): Column[ParticipantId] =
-    stringColumnToX(ParticipantId.fromString)(c)
+  implicit def columnToParticipantId(implicit c: Column[String]): Column[Ref.ParticipantId] =
+    stringColumnToX(Ref.ParticipantId.fromString)(c)
 
   implicit def participantToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[ParticipantId] =
+      implicit strToStm: ToStatement[String]): ToStatement[Ref.ParticipantId] =
     subStringToStatement(strToStm)
 
-  implicit def columnToContractId(implicit c: Column[String]): Column[ContractIdString] =
-    stringColumnToX(ContractIdString.fromString)(c)
+  implicit def columnToContractId(implicit c: Column[String]): Column[Ref.ContractIdString] =
+    stringColumnToX(Ref.ContractIdString.fromString)(c)
 
   implicit def contractIdToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[ContractIdString] =
+      implicit strToStm: ToStatement[String]): ToStatement[Ref.ContractIdString] =
     subStringToStatement(strToStm)
 
   def emptyStringToNullColumn(implicit c: Column[String]): Column[String] = new Column[String] {
@@ -91,26 +85,26 @@ object Conversions {
     }
   }
 
-  def ledgerString(columnName: String)(implicit c: Column[String]): RowParser[LedgerString] =
-    SqlParser.get[LedgerString](columnName)(columnToLedgerString(c))
+  def ledgerString(columnName: String)(implicit c: Column[String]): RowParser[Ref.LedgerString] =
+    SqlParser.get[Ref.LedgerString](columnName)(columnToLedgerString(c))
 
   implicit def ledgerStringMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[LedgerString] =
+      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[Ref.LedgerString] =
     subStringMetaParameter(strParamMetaData)
 
-  def participantId(columnName: String)(implicit c: Column[String]): RowParser[ParticipantId] =
-    SqlParser.get[ParticipantId](columnName)(columnToParticipantId(c))
+  def participantId(columnName: String)(implicit c: Column[String]): RowParser[Ref.ParticipantId] =
+    SqlParser.get[Ref.ParticipantId](columnName)(columnToParticipantId(c))
 
   implicit def participantIdMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[ParticipantId] =
+      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[Ref.ParticipantId] =
     subStringMetaParameter(strParamMetaData)
 
   def contractIdString(columnName: String)(
-      implicit c: Column[String]): RowParser[ContractIdString] =
-    SqlParser.get[ContractIdString](columnName)(columnToContractId(c))
+      implicit c: Column[String]): RowParser[Ref.ContractIdString] =
+    SqlParser.get[Ref.ContractIdString](columnName)(columnToContractId(c))
 
-  implicit def contractIdStringMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[ContractIdString] =
+  implicit def contractIdStringMetaParameter(implicit strParamMetaData: ParameterMetaData[String])
+    : ParameterMetaData[Ref.ContractIdString] =
     subStringMetaParameter(strParamMetaData)
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -14,7 +14,13 @@ import anorm.{
   SqlParser,
   ToStatement
 }
-import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString, PackageId, Party}
+import com.digitalasset.daml.lf.data.Ref.{
+  ContractIdString,
+  LedgerString,
+  PackageId,
+  ParticipantId,
+  Party
+}
 
 object Conversions {
 
@@ -64,6 +70,13 @@ object Conversions {
       implicit strToStm: ToStatement[String]): ToStatement[LedgerString] =
     subStringToStatement(strToStm)
 
+  implicit def columnToParticipantId(implicit c: Column[String]): Column[ParticipantId] =
+    stringColumnToX(ParticipantId.fromString)(c)
+
+  implicit def participantToStatement(
+      implicit strToStm: ToStatement[String]): ToStatement[ParticipantId] =
+    subStringToStatement(strToStm)
+
   implicit def columnToContractId(implicit c: Column[String]): Column[ContractIdString] =
     stringColumnToX(ContractIdString.fromString)(c)
 
@@ -83,6 +96,13 @@ object Conversions {
 
   implicit def ledgerStringMetaParameter(
       implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[LedgerString] =
+    subStringMetaParameter(strParamMetaData)
+
+  def participantId(columnName: String)(implicit c: Column[String]): RowParser[ParticipantId] =
+    SqlParser.get[ParticipantId](columnName)(columnToParticipantId(c))
+
+  implicit def participantIdMetaParameter(
+      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[ParticipantId] =
     subStringMetaParameter(strParamMetaData)
 
   def contractIdString(columnName: String)(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -191,7 +191,7 @@ private class JdbcLedgerDao(
           val config = Configuration
             .decode(configBytes)
             .fold(err => sys.error(s"Failed to decode configuration: $err"), identity)
-          val participantId = LedgerString
+          val participantId = ParticipantId
             .fromString(participantIdRaw)
             .fold(
               err => sys.error(s"Failed to decode participant id in configuration entry: $err"),
@@ -382,7 +382,7 @@ private class JdbcLedgerDao(
     (long("ledger_offset") ~
       date("recorded_at") ~
       ledgerString("submission_id").? ~
-      ledgerString("participant_id").? ~
+      participantId("participant_id").? ~
       party("party").? ~
       str("display_name").? ~
       str("typ") ~

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -66,7 +66,7 @@ class ImplicitPartyAdditionIT
   override def timeLimit: Span = scaled(60.seconds)
 
   private val ledgerId: LedgerId = LedgerId("ledgerId")
-  private val participantId: ParticipantId = Ref.LedgerString.assertFromString("participantId")
+  private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("participantId")
   private val timeProvider = TimeProvider.Constant(Instant.EPOCH.plusSeconds(10))
 
   private val templateId1: Ref.Identifier = Ref.Identifier(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -59,7 +59,7 @@ class TransactionMRTComplianceIT
   override def timeLimit: Span = scaled(60.seconds)
 
   val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("ledgerId"))
-  private val participantId: ParticipantId = Ref.LedgerString.assertFromString("participantId")
+  private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("participantId")
   val timeProvider = TimeProvider.Constant(Instant.EPOCH.plusSeconds(10))
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -41,7 +41,7 @@ class SqlLedgerSpec
   private val queueDepth = 128
 
   private val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("TheLedger"))
-  private val participantId: ParticipantId = Ref.LedgerString.assertFromString("TheParticipant")
+  private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("TheParticipant")
 
   private val createdLedgers = mutable.Buffer[Resource[Ledger]]()
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -297,7 +297,7 @@ class JdbcLedgerDaoSpec
           None,
           Instant.EPOCH,
           s"submission-$offset",
-          Ref.LedgerString.assertFromString("participant-0"),
+          Ref.ParticipantId.assertFromString("participant-0"),
           defaultConfig,
           None
         )
@@ -313,7 +313,7 @@ class JdbcLedgerDaoSpec
 
     "be able to persist configuration rejection" in {
       val offset = nextOffset()
-      val participantId = Ref.LedgerString.assertFromString("participant-0")
+      val participantId = Ref.ParticipantId.assertFromString("participant-0")
       for {
         startingConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2))
         proposedConfig = startingConfig.getOrElse(defaultConfig)
@@ -342,7 +342,7 @@ class JdbcLedgerDaoSpec
 
     "refuse to persist invalid configuration entry" in {
       val offset0 = nextOffset()
-      val participantId = Ref.LedgerString.assertFromString("participant-0")
+      val participantId = Ref.ParticipantId.assertFromString("participant-0")
       for {
         config <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).getOrElse(defaultConfig))
 


### PR DESCRIPTION
**Purely internal changes**

In this PR we introduce a new specific type for `ParticipantId`. 
It uses the exact same syntactic restrictions that `LedgerString` but it is a separate type.

This advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
