### PR TITLE
Simplified API fixes

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -54,12 +54,10 @@ final class InMemoryLedgerReaderWriter(
 
   private val lockCurrentState = new Semaphore(1, true)
 
-  private val validator = SubmissionValidator.create(
-    new InMemoryLedgerStateAccess(participantId),
-    () => sequentialLogEntryId.next())
+  private val validator =
+    SubmissionValidator.create(InMemoryLedgerStateAccess, () => sequentialLogEntryId.next())
 
-  private class InMemoryLedgerStateAccess(theParticipantId: ParticipantId)
-      extends LedgerStateAccess {
+  private object InMemoryLedgerStateAccess extends LedgerStateAccess {
     override def inTransaction[T](body: LedgerStateOperations => Future[T]): Future[T] =
       Future
         .successful(lockCurrentState.acquire())
@@ -68,8 +66,6 @@ final class InMemoryLedgerReaderWriter(
           case _ =>
             lockCurrentState.release()
         }
-
-    override def participantId: String = theParticipantId
   }
 
   private object InMemoryLedgerStateOperations extends BatchingLedgerStateOperations {
@@ -99,7 +95,7 @@ final class InMemoryLedgerReaderWriter(
 
   override def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult] = {
     validator
-      .validateAndCommit(envelope, correlationId, currentRecordTime())
+      .validateAndCommit(envelope, correlationId, currentRecordTime(), participantId)
       .map {
         case SubmissionValidated => SubmissionResult.Acknowledged
         case MissingInputState(_) => SubmissionResult.InternalError("Missing input state")

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -43,7 +43,7 @@ private[memory] class InMemoryState(
 )
 
 final class InMemoryLedgerReaderWriter(
-    ledgerId: LedgerId,
+    override val ledgerId: LedgerId,
     override val participantId: ParticipantId,
     dispatcher: Dispatcher[Index],
 )(implicit executionContext: ExecutionContext)
@@ -115,8 +115,6 @@ final class InMemoryLedgerReaderWriter(
         ),
       )
       .mapConcat { case (_, updates) => updates }
-
-  override def retrieveLedgerId(): LedgerId = ledgerId
 
   override def currentHealth(): HealthStatus = Healthy
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -35,7 +35,7 @@ import scala.collection.immutable.TreeSet
 import scala.concurrent.{ExecutionContext, Future}
 
 class SqlLedgerReaderWriter(
-    ledgerId: LedgerId = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
+    override val ledgerId: LedgerId = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
     val participantId: ParticipantId,
     database: Database,
     dispatcher: Dispatcher[Index],
@@ -52,8 +52,6 @@ class SqlLedgerReaderWriter(
 
   // TODO: implement
   override def currentHealth(): HealthStatus = Healthy
-
-  override def retrieveLedgerId(): LedgerId = ledgerId
 
   override def events(offset: Option[Offset]): Source[LedgerRecord, NotUsed] =
     dispatcher

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReader.scala
@@ -55,7 +55,7 @@ class KeyValueParticipantStateReader(reader: LedgerReader)(implicit materializer
 
   private def createLedgerInitialConditions(): LedgerInitialConditions =
     LedgerInitialConditions(
-      reader.retrieveLedgerId(),
+      reader.ledgerId(),
       LedgerReader.DefaultConfiguration,
       Time.Timestamp.Epoch)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerReader.scala
@@ -11,7 +11,12 @@ import com.digitalasset.ledger.api.health.ReportsHealth
 trait LedgerReader extends ReportsHealth {
   def events(offset: Option[Offset]): Source[LedgerRecord, NotUsed]
 
-  def retrieveLedgerId(): LedgerId
+  /**
+    * Get the ledger's ID from which this reader instance streams events.
+    * Should not be a blocking operation.
+    * @return  ID of the ledger from which this reader streams events
+    */
+  def ledgerId(): LedgerId
 }
 
 object LedgerReader {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -13,11 +13,6 @@ trait LedgerStateAccess {
     * @tparam T type of result returned after execution
     */
   def inTransaction[T](body: LedgerStateOperations => Future[T]): Future[T]
-
-  /**
-    * @return ID of the participant accessing the backing store.
-    */
-  def participantId: String
 }
 
 trait LedgerStateOperations {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -120,8 +120,8 @@ class SubmissionValidator(
     Envelope.open(envelope) match {
       case Right(Envelope.SubmissionMessage(submission)) =>
         val declaredInputs = submission.getInputDamlStateList.asScala
+        val inputKeysAsBytes = declaredInputs.map(keyToBytes)
         ledgerStateAccess.inTransaction { stateOperations =>
-          val inputKeysAsBytes = declaredInputs.map(keyToBytes)
           for {
             readStateValues <- stateOperations.readState(inputKeysAsBytes)
             readStateInputs = readStateValues.zip(declaredInputs).map {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -32,7 +32,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val instance = SubmissionValidator.create(new FakeStateAccess(mockStateOperations))
-      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime()).map {
+      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId()).map {
         case SubmissionValidated => succeed
         case _ => fail
       }
@@ -45,7 +45,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       val instance = SubmissionValidator.create(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
         checkForMissingInputs = true)
-      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime()).map {
+      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId()).map {
         case MissingInputState(keys) => keys should have size 1
         case _ => fail
       }
@@ -54,10 +54,12 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     "return invalid submission for invalid envelope" in {
       val mockStateOperations = mock[LedgerStateOperations]
       val instance = SubmissionValidator.create(new FakeStateAccess(mockStateOperations))
-      instance.validate(Array[Byte](1, 2, 3), "aCorrelationId", newRecordTime()).map {
-        case ValidationError(reason) => reason should include("Failed to parse")
-        case _ => fail
-      }
+      instance
+        .validate(Array[Byte](1, 2, 3), "aCorrelationId", newRecordTime(), aParticipantId())
+        .map {
+          case ValidationError(reason) => reason should include("Failed to parse")
+          case _ => fail
+        }
     }
 
     "return invalid submission in case exception is thrown during processing of submission" in {
@@ -69,6 +71,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
           damlLogEntryId: DamlLogEntryId,
           recordTime: Timestamp,
           damlSubmission: DamlSubmission,
+          participantId: ParticipantId,
           inputState: Map[DamlStateKey, Option[DamlStateValue]]): LogEntryAndState =
         throw new IllegalArgumentException("Validation failed")
 
@@ -77,7 +80,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
           new FakeStateAccess(mockStateOperations),
           failingProcessSubmission,
           () => aLogEntryId())
-      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime()).map {
+      instance.validate(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId()).map {
         case ValidationError(reason) => reason should include("Validation failed")
         case _ => fail
       }
@@ -98,23 +101,25 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       val mockLogEntryIdGenerator = mockFunctionReturning(expectedLogEntryId)
       val instance = new SubmissionValidator(
         new FakeStateAccess(mockStateOperations),
-        SubmissionValidator.processSubmission(aParticipantId()),
+        SubmissionValidator.processSubmission,
         mockLogEntryIdGenerator)
-      instance.validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime()).map {
-        case SubmissionValidated =>
-          verify(mockLogEntryIdGenerator, times(1)).apply()
-          verify(mockStateOperations, times(0)).writeState(any[RawKeyValuePairs]())
-          logEntryValueCaptor.getAllValues should have size 1
-          logEntryIdCaptor.getAllValues should have size 1
-          val actualLogEntryIdBytes = ByteString
-            .copyFrom(logEntryIdCaptor.getValue.asInstanceOf[RawBytes])
-          val expectedLogEntryIdBytes = ByteString.copyFrom(expectedLogEntryId.toByteArray)
-          actualLogEntryIdBytes should be(expectedLogEntryIdBytes)
-          ByteString
-            .copyFrom(logEntryValueCaptor.getValue.asInstanceOf[RawBytes]) should not equal ByteString
-            .copyFrom(logEntryIdCaptor.getValue.asInstanceOf[RawBytes])
-        case _ => fail
-      }
+      instance
+        .validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId())
+        .map {
+          case SubmissionValidated =>
+            verify(mockLogEntryIdGenerator, times(1)).apply()
+            verify(mockStateOperations, times(0)).writeState(any[RawKeyValuePairs]())
+            logEntryValueCaptor.getAllValues should have size 1
+            logEntryIdCaptor.getAllValues should have size 1
+            val actualLogEntryIdBytes = ByteString
+              .copyFrom(logEntryIdCaptor.getValue.asInstanceOf[RawBytes])
+            val expectedLogEntryIdBytes = ByteString.copyFrom(expectedLogEntryId.toByteArray)
+            actualLogEntryIdBytes should be(expectedLogEntryIdBytes)
+            ByteString
+              .copyFrom(logEntryValueCaptor.getValue.asInstanceOf[RawBytes]) should not equal ByteString
+              .copyFrom(logEntryIdCaptor.getValue.asInstanceOf[RawBytes])
+          case _ => fail
+        }
     }
 
     "write marshalled key-value pairs to ledger" in {
@@ -130,17 +135,19 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates(1))
       val instance = new SubmissionValidator(
         new FakeStateAccess(mockStateOperations),
-        (_, _, _, _) => logEntryAndStateResult,
+        (_, _, _, _, _) => logEntryAndStateResult,
         () => aLogEntryId())
-      instance.validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime()).map {
-        case SubmissionValidated =>
-          writtenKeyValuesCaptor.getAllValues should have size 1
-          val writtenKeyValues = writtenKeyValuesCaptor.getValue.asInstanceOf[RawKeyValuePairs]
-          writtenKeyValues should have size 1
-          Try(SubmissionValidator.bytesToStateValue(writtenKeyValues.head._2)).isSuccess shouldBe true
-          logEntryCaptor.getAllValues should have size 1
-        case _ => fail
-      }
+      instance
+        .validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId())
+        .map {
+          case SubmissionValidated =>
+            writtenKeyValuesCaptor.getAllValues should have size 1
+            val writtenKeyValues = writtenKeyValuesCaptor.getValue.asInstanceOf[RawKeyValuePairs]
+            writtenKeyValues should have size 1
+            Try(SubmissionValidator.bytesToStateValue(writtenKeyValues.head._2)).isSuccess shouldBe true
+            logEntryCaptor.getAllValues should have size 1
+          case _ => fail
+        }
     }
 
     "return invalid submission if state cannot be written" in {
@@ -154,12 +161,14 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates(1))
       val instance = new SubmissionValidator(
         new FakeStateAccess(mockStateOperations),
-        (_, _, _, _) => logEntryAndStateResult,
+        (_, _, _, _, _) => logEntryAndStateResult,
         () => aLogEntryId())
-      instance.validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime()).map {
-        case ValidationError(reason) => reason should include("Write error")
-        case _ => fail
-      }
+      instance
+        .validateAndCommit(anEnvelope(), "aCorrelationId", newRecordTime(), aParticipantId())
+        .map {
+          case ValidationError(reason) => reason should include("Write error")
+          case _ => fail
+        }
     }
   }
 
@@ -212,8 +221,6 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       extends LedgerStateAccess {
     override def inTransaction[T](body: LedgerStateOperations => Future[T]): Future[T] =
       body(mockStateOperations)
-
-    override def participantId: String = "aParticipantId"
   }
 
 }


### PR DESCRIPTION
Summary of changes:
* Removed `LedgerStateAccess.participantId` so that we can reuse submission validators.
* Renamed `LedgerReader.retrieveLedgerId` to `ledgerId` to be in line with naming conventions..

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
