### PR TITLE
A first draft at telemetry for daml-assistant.

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -373,16 +373,20 @@ execIde telemetry (Debug debug) enableScenarioService options =
             -- performance will be significatly impacted by large log output.
             threshold
             "LanguageServer"
-          let withLogger f = case telemetry of
+          let gcpConfig = Logger.GCP.GCPConfig
+                  { gcpConfigTag = "ide"
+                  , gcpConfigDamlPath = Nothing
+                  }
+              withLogger f = case telemetry of
                   TelemetryOptedIn ->
                     let logOfInterest prio = prio `elem` [Logger.Telemetry, Logger.Warning, Logger.Error] in
-                    Logger.GCP.withGcpLogger logOfInterest loggerH $ \gcpState loggerH' -> do
+                    Logger.GCP.withGcpLogger gcpConfig logOfInterest loggerH $ \gcpState loggerH' -> do
                       Logger.GCP.logMetaData gcpState
                       f loggerH'
-                  TelemetryOptedOut -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
+                  TelemetryOptedOut -> Logger.GCP.withGcpLogger gcpConfig (const False) loggerH $ \gcpState loggerH -> do
                       Logger.GCP.logOptOut gcpState
                       f loggerH
-                  TelemetryIgnored -> Logger.GCP.withGcpLogger (const False) loggerH $ \gcpState loggerH -> do
+                  TelemetryIgnored -> Logger.GCP.withGcpLogger gcpConfig (const False) loggerH $ \gcpState loggerH -> do
                       Logger.GCP.logIgnored gcpState
                       f loggerH
                   TelemetryDisabled -> f loggerH

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -381,6 +381,7 @@ execIde telemetry (Debug debug) enableScenarioService options =
                   TelemetryOptedIn ->
                     let logOfInterest prio = prio `elem` [Logger.Telemetry, Logger.Warning, Logger.Error] in
                     Logger.GCP.withGcpLogger gcpConfig logOfInterest loggerH $ \gcpState loggerH' -> do
+                      Logger.GCP.setOptIn gcpState
                       Logger.GCP.logMetaData gcpState
                       f loggerH'
                   TelemetryOptedOut -> Logger.GCP.withGcpLogger gcpConfig (const False) loggerH $ \gcpState loggerH -> do

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -89,6 +89,7 @@ da_haskell_binary(
         "safe-exceptions",
         "typed-process",
         "text",
+        "unordered-containers",
     ],
     main_function = "DA.Daml.Assistant.main",
     src_strip_prefix = "exe",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -82,6 +82,7 @@ da_haskell_binary(
     hackage_deps = [
         "aeson",
         "base",
+        "containers",
         "directory",
         "extra",
         "filepath",

--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -80,6 +80,7 @@ da_haskell_binary(
     name = "daml",
     srcs = ["exe/DA/Daml/Assistant.hs"],
     hackage_deps = [
+        "aeson",
         "base",
         "directory",
         "extra",

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -281,17 +281,18 @@ withLogger damlPath k = do
             { gcpConfigTag = "assistant"
             , gcpConfigDamlPath = Just (unwrapDamlPath damlPath)
             }
-
         optedOutPath = unwrapDamlPath damlPath </> ".opted_out"
+        optedInPath = unwrapDamlPath damlPath </> ".opted_in"
 
     isOptedOut <- doesPathExist optedOutPath
-    if isOptedOut
+    isOptedIn <- doesPathExist optedInPath
+    if isOptedIn && not isOptedOut
         then
-            k L.makeNopHandle
-        else do
             L.withGcpLogger gcpConfig logOfInterest L.makeNopHandle $ \gcpState logger -> do
                 L.logMetaData gcpState
                 k logger
+        else
+            k L.makeNopHandle
 
 -- | Get the arguments to `daml` and anonimize all but the first.
 -- That way, the daml command doesn't get accidentally anonimized.

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -30,9 +30,8 @@ import Control.Exception.Safe
 import Data.Maybe
 
 -- | Calculate the environment variables in which to run daml commands.
-getDamlEnv :: IO Env
-getDamlEnv = do
-    envDamlPath <- getDamlPath
+getDamlEnv :: DamlPath -> IO Env
+getDamlEnv envDamlPath = do
     envDamlAssistantSdkVersion <- getDamlAssistantSdkVersion
     envDamlAssistantPath <- getDamlAssistantPath envDamlPath envDamlAssistantSdkVersion
     envProjectPath <- getProjectPath
@@ -212,5 +211,3 @@ getDispatchEnv Env{..} = do
                (versionToString . unwrapDamlAssistantSdkVersion)
                envDamlAssistantSdkVersion)
            ]
-
-

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -320,7 +320,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envProjectPath = Just $ ProjectPath (base </> "proj")
                     }
             env <- withEnv [] (getDispatchEnv denv1)
-            denv2 <- withEnv (fmap (fmap Just) env) getDamlEnv
+            denv2 <- withEnv (fmap (fmap Just) env) (getDamlEnv =<< getDamlPath)
             Tasty.assertEqual "daml envs" denv1 denv2
 
     , Tasty.testCase "getDispatchEnv should override getDamlEnv (2)" $ do
@@ -335,7 +335,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
                     , envProjectPath = Nothing
                     }
             env <- withEnv [] (getDispatchEnv denv1)
-            denv2 <- withEnv (fmap (fmap Just) env) getDamlEnv
+            denv2 <- withEnv (fmap (fmap Just) env) (getDamlEnv =<< getDamlPath)
             Tasty.assertEqual "daml envs" denv1 denv2
     ]
 

--- a/libs-haskell/da-hs-base/tests/DataLimit.hs
+++ b/libs-haskell/da-hs-base/tests/DataLimit.hs
@@ -20,7 +20,7 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "Telemetry data limiter"
     [ withResource homeDir (\mbHome -> whenJust mbHome unsetEnv) $ \getHomeDir ->
-      withResource (initialiseGcpState makeNopHandle) (\gcp -> removeFile (sentDataFile gcp)) $ \getGcp ->
+      withResource (initialiseGcpState (GCPConfig "test" Nothing) makeNopHandle) (\gcp -> removeFile (sentDataFile gcp)) $ \getGcp ->
           testCase "Check that limit is triggered" $ do
              _ <- getHomeDir
              gcp <- getGcp


### PR DESCRIPTION
For now, this only reports command-line arguments and errors in the assistant.

This change respects the opt-out preference by checking if `$DAML_HOME/.opted_out` is present. The `.opted_out` file is automatically created based on the IDE's opt-out preferences, so this seems acceptable to me.

It also removes any file paths in the command args before reporting them, to prevent leaking user data.