### PR TITLE
Return list of key-value pairs when reading ledger state

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -73,9 +73,9 @@ final class InMemoryLedgerReaderWriter(
   }
 
   private object InMemoryLedgerStateOperations extends BatchingLedgerStateOperations {
-    override def readState(keys: Seq[Key]): Future[Seq[Option[Value]]] =
+    override def readState(keys: Seq[Key]): Future[Seq[(Key, Option[Value])]] =
       Future.successful {
-        keys.map(keyBytes => currentState.state.get(ByteString.copyFrom(keyBytes)))
+        keys.map(keyBytes => keyBytes -> currentState.state.get(ByteString.copyFrom(keyBytes)))
       }
 
     override def writeState(keyValuePairs: Seq[(Key, Value)]): Future[Unit] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -114,7 +114,7 @@ class SubmissionValidator(
           for {
             readStateValues <- stateOperations.readState(inputKeysAsBytes)
             readStateInputs = readStateValues.zip(declaredInputs).map {
-              case (valueBytes, key) => (key, valueBytes.map(bytesToStateValue))
+              case ((_, valueBytes), key) => (key, valueBytes.map(bytesToStateValue))
             }
             damlLogEntryId = allocateLogEntryId()
             readInputs: Map[DamlStateKey, Option[DamlStateValue]] = readStateInputs.toMap

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -167,7 +167,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     DamlLogEntry
       .newBuilder()
       .setPartyAllocationEntry(
-        DamlPartyAllocationEntry.newBuilder().setParty("aParty").setParticipantId("aParticipant"))
+        DamlPartyAllocationEntry.newBuilder().setParty("aParty").setParticipantId(aParticipantId()))
       .build()
 
   private def aLogEntryId(): DamlLogEntryId = SubmissionValidator.allocateRandomLogEntryId()

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -30,7 +30,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     "return success in case of no errors during processing of submission" in {
       val mockStateOperations = mock[LedgerStateOperations]
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
-        .thenReturn(Future.successful(Seq((aStateKey(), Some(aStateValue())))))
+        .thenReturn(Future.successful(aStateKeyValuePair()))
       val instance = SubmissionValidator.create(new FakeStateAccess(mockStateOperations))
       instance.validate(anEnvelope(), "aCorrelationId", newRecordTime()).map {
         case SubmissionValidated => succeed
@@ -63,7 +63,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     "return invalid submission in case exception is thrown during processing of submission" in {
       val mockStateOperations = mock[BatchingLedgerStateOperations]
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
-        .thenReturn(Future.successful(Seq((aStateKey(), Some(aStateValue())))))
+        .thenReturn(Future.successful(aStateKeyValuePair()))
 
       def failingProcessSubmission(
           damlLogEntryId: DamlLogEntryId,
@@ -88,7 +88,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     "write marshalled log entry to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations]
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
-        .thenReturn(Future.successful(Seq((aStateKey(), Some(aStateValue())))))
+        .thenReturn(Future.successful(aStateKeyValuePair()))
       val logEntryValueCaptor = ArgumentCaptor.forClass(classOf[RawBytes])
       val logEntryIdCaptor = ArgumentCaptor.forClass(classOf[RawBytes])
       when(
@@ -120,7 +120,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
     "write marshalled key-value pairs to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations]
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
-        .thenReturn(Future.successful(Seq((aStateKey(), Some(aStateValue())))))
+        .thenReturn(Future.successful(aStateKeyValuePair()))
       val writtenKeyValuesCaptor = ArgumentCaptor.forClass(classOf[RawKeyValuePairs])
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture()))
         .thenReturn(Future.successful(()))
@@ -148,7 +148,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
       when(mockStateOperations.writeState(any[RawKeyValuePairs]()))
         .thenThrow(new IllegalArgumentException("Write error"))
       when(mockStateOperations.readState(any[Seq[RawBytes]]()))
-        .thenReturn(Future.successful(Seq((aStateKey(), Some(aStateValue())))))
+        .thenReturn(Future.successful(aStateKeyValuePair()))
       when(mockStateOperations.appendToLog(any[RawBytes](), any[RawBytes]()))
         .thenReturn(Future.successful(()))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates(1))
@@ -188,8 +188,8 @@ class SubmissionValidatorSpec extends AsyncWordSpec with MockitoSugar with Match
   private def aStateKey(): RawBytes =
     SubmissionValidator.keyToBytes(DamlStateKey.getDefaultInstance)
 
-  private def aStateValue(): RawBytes =
-    SubmissionValidator.valueToBytes(DamlStateValue.getDefaultInstance)
+  private def aStateKeyValuePair(): Seq[(RawBytes, Option[RawBytes])] =
+    Seq((aStateKey(), Some(SubmissionValidator.valueToBytes(DamlStateValue.getDefaultInstance))))
 
   private def anEnvelope(): RawBytes = {
     val submission = DamlSubmission


### PR DESCRIPTION
Summary of changes:
* `LedgerStateOperations.readState` now has to return a list of key-value pairs instead of just the list of values read.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
