### PR TITLE
Fix error messages on incorrect --package flags

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -558,4 +558,15 @@ currentSdkPrefix :: String
 currentSdkPrefix = "CurrentSdk"
 
 exposePackage :: GHC.UnitId -> Bool -> [(GHC.ModuleName, GHC.ModuleName)] -> PackageFlag
-exposePackage unitId exposeImplicit mods = ExposePackage "--package " (UnitIdArg unitId) (ModRenaming exposeImplicit mods)
+exposePackage unitId exposeImplicit mods = ExposePackage ("--package " <> show (showPackageFlag unitId exposeImplicit mods)) (UnitIdArg unitId) (ModRenaming exposeImplicit mods)
+
+-- | This is only used in error messages.
+showPackageFlag :: GHC.UnitId -> Bool -> [(GHC.ModuleName, GHC.ModuleName)] -> String
+showPackageFlag unitId exposeImplicit mods = concat
+    [ unitIdString unitId
+    , if exposeImplicit then " with " else ""
+    , if null mods then "" else "(" <> intercalate ", " (map showRenaming mods) <> ")"
+    ]
+  where showRenaming (a, b)
+          | a == b = GHC.moduleNameString a
+          | otherwise = GHC.moduleNameString a <> " as " <> GHC.moduleNameString b

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -300,12 +300,12 @@ optionsParser numProcessors enableScenarioService parsePkgName = Options
     --  * @--package foo with (A as B)@ is @ModRenaming True [("A", "B")]@
     readPackageImport :: ReadM PackageFlag
     readPackageImport = maybeReader $ \str ->
-        case filter ((=="").snd) (R.readP_to_S parse str) of
+        case filter ((=="").snd) (R.readP_to_S (parse str) str) of
             [(r, "")] -> Just r
             _ -> Nothing
-      where parse = do
+      where parse str = do
                 pkg_arg <- tok GHC.parseUnitId
-                let mk_expose = ExposePackage "--package " (UnitIdArg pkg_arg)
+                let mk_expose = ExposePackage ("--package " <> str) (UnitIdArg pkg_arg)
                 do _ <- tok $ R.string "with"
                    fmap (mk_expose . ModRenaming True) parseRns
                  R.<++ fmap (mk_expose . ModRenaming False) parseRns


### PR DESCRIPTION
The string needs to include the full flag instead of only including
--package. Otherwise you get rather unhelpful error messages.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
