### PR TITLE
pin Terraform plugin versions

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,11 +11,21 @@ terraform {
 provider "google" {
   project = "da-dev-gcp-daml-language"
   region  = "us-east4"
+  version = "3.5"
 }
 
 provider "google-beta" {
   project = "da-dev-gcp-daml-language"
   region  = "us-east4"
+  version = "3.5"
+}
+
+provider "secret" {
+  version = "1.1"
+}
+
+provider "template" {
+  version = "2.1.2"
 }
 
 data "google_project" "current" {


### PR DESCRIPTION
We're currently depending on a floating "latest", which is often a bad idea. Today my machine decided to upgrade the google plugin,w hich is no specifying some new fields for the GCS objects, and therefore `terraform plan` doe snot look clean anymore, even though there has been no change to the terraform files (nor to the infrastructure).

This PR aims to make our Terraform setup more reproducible by pinning Terraform plugin versions. It's also a way to track the application of the "new" Terraform setup, as it is technically a standard change (though hopefully a very safe one).