### PR TITLE
Disable scaladoc on the MacOS CI

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -405,7 +405,7 @@ def _create_scaladoc_jar(**kwargs):
             srcs = kwargs["srcs"],
             scalacopts = kwargs.get("scalacopts", []),
             generated_srcs = kwargs.get("generated_srcs", []),
-            tags = ["dont-run-on-darwin"],
+            tags = ["scaladoc"],
         )
 
 def da_scala_library(name, unused_dependency_checker_mode = "error", **kwargs):

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -405,6 +405,7 @@ def _create_scaladoc_jar(**kwargs):
             srcs = kwargs["srcs"],
             scalacopts = kwargs.get("scalacopts", []),
             generated_srcs = kwargs.get("generated_srcs", []),
+            tags = ["dont-run-on-darwin"],
         )
 
 def da_scala_library(name, unused_dependency_checker_mode = "error", **kwargs):

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,11 @@ export LC_ALL=en_US.UTF-8
 
 ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 
+tag_filter=""
+if [[ "$execution_log_postfix" == "_Darwin" ]]; then
+  tag_filter="-dont-run-on-darwin"
+fi
+
 # Bazel test only builds targets that are dependencies of a test suite
 # so do a full build first.
 (
@@ -22,12 +27,8 @@ ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
   # overload machines.
   # This also appears to be what Google uses internally, see
   # https://github.com/bazelbuild/bazel/issues/6394#issuecomment-436234594.
-  bazel build -j 200 //...
+  bazel build -j 200 //... --build_tag_filters "$tag_filter"
 )
-tag_filter=""
-if [[ "$execution_log_postfix" == "_Darwin" ]]; then
-  tag_filter="-dont-run-on-darwin"
-fi
 bazel test -j 200 //... --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 
 tag_filter=""
 if [[ "$execution_log_postfix" == "_Darwin" ]]; then
-  tag_filter="-dont-run-on-darwin"
+  tag_filter="-dont-run-on-darwin,-scaladoc"
 fi
 
 # Bazel test only builds targets that are dependencies of a test suite
@@ -29,7 +29,7 @@ fi
   # https://github.com/bazelbuild/bazel/issues/6394#issuecomment-436234594.
   bazel build -j 200 //... --build_tag_filters "$tag_filter"
 )
-bazel test -j 200 //... --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
+bazel test -j 200 //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null
 # Check that we can load damlc in ghci

--- a/language-support/codegen-main/BUILD.bazel
+++ b/language-support/codegen-main/BUILD.bazel
@@ -68,6 +68,7 @@ pom_file(
 scaladoc_jar(
     name = "shaded_binary_scaladoc",
     srcs = [],
+    tags = ["dont-run-on-darwin"],
     deps = [],
 ) if is_windows == False else None
 

--- a/language-support/codegen-main/BUILD.bazel
+++ b/language-support/codegen-main/BUILD.bazel
@@ -68,7 +68,7 @@ pom_file(
 scaladoc_jar(
     name = "shaded_binary_scaladoc",
     srcs = [],
-    tags = ["dont-run-on-darwin"],
+    tags = ["scaladoc"],
     deps = [],
 ) if is_windows == False else None
 

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -113,7 +113,7 @@ pom_file(
 scaladoc_jar(
     name = "shaded_binary_scaladoc",
     srcs = [],
-    tags = ["dont-run-on-darwin"],
+    tags = ["scaladoc"],
     deps = [],
 ) if is_windows == False else None
 

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -113,6 +113,7 @@ pom_file(
 scaladoc_jar(
     name = "shaded_binary_scaladoc",
     srcs = [],
+    tags = ["dont-run-on-darwin"],
     deps = [],
 ) if is_windows == False else None
 

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -321,6 +321,7 @@ pom_file(
 scaladoc_jar(
     name = "ledger-api-scalapb_scaladoc",
     srcs = [],
+    tags = ["dont-run-on-darwin"],
     deps = [],
 ) if is_windows == False else None
 

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -321,7 +321,7 @@ pom_file(
 scaladoc_jar(
     name = "ledger-api-scalapb_scaladoc",
     srcs = [],
-    tags = ["dont-run-on-darwin"],
+    tags = ["scaladoc"],
     deps = [],
 ) if is_windows == False else None
 


### PR DESCRIPTION
It is still built by default locally.

fixes #4441

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
