### PR TITLE
Make hijacked docs links update the location hash

### DIFF
--- a/docs/theme/js/theme.js
+++ b/docs/theme/js/theme.js
@@ -486,8 +486,16 @@ $(document).ready(function () {
         if ($(window).width() < 1600) {
             $('.content-menu').toggleClass('collapsed');
         }
-        var position = $($(this).attr('href')).offset().top;
-        $("html, body").animate({scrollTop: position}, "slow");
+        var href = $(this).attr('href');
+        // Special treatment for going back to the top since those links
+        // don't have an id and just go to #
+        var position = href === "#" ? 0 : $(href).offset().top;
+        $("html, body").animate(
+          {scrollTop: position},
+          "slow",
+          function () {
+            window.location.hash = href;
+          });
         ev.preventDefault();
     });
     // sections padding


### PR DESCRIPTION
If you click on a section title, we hijack the link to animate
it. However, we did not update the location hash. This makes it quite
annoying to copy links to a specific section.

This PR sets the jquery animate callback to update the hash as
well. I’ve also included a small fix for the link on the section title
which previously produced an error in the JS console since "#" is not
a valid jquery selector.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
