### PR TITLE
Reduce data surface exposed by LedgerDao interface

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -277,14 +277,11 @@ abstract class LedgerBackedIndexService(
   override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
     ledger.getLfPackage(packageId)
 
-  // ContractStore
   override def lookupActiveContract(
       submitter: Ref.Party,
       contractId: AbsoluteContractId,
   ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
-    ledger
-      .lookupContract(contractId, submitter)
-      .map(_.map(_.contract))(DEC)
+    ledger.lookupContract(contractId, submitter)
 
   override def lookupContractKey(
       submitter: Party,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -12,9 +12,9 @@ import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, TransactionId, PartyDetails}
+import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.platform.metrics.timedFuture
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
@@ -24,7 +24,7 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
-import com.digitalasset.platform.store.{Contract, LedgerSnapshot, ReadOnlyLedger}
+import com.digitalasset.platform.store.{LedgerSnapshot, ReadOnlyLedger}
 
 import scala.concurrent.Future
 
@@ -58,7 +58,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
 
   override def lookupContract(
       contractId: Value.AbsoluteContractId,
-      forParty: Party): Future[Option[Contract]] =
+      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
     timedFuture(Metrics.lookupContract, ledger.lookupContract(contractId, forParty))
 
   override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -20,7 +20,8 @@ import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party}
 import com.digitalasset.daml.lf.data.{ImmArray, Time}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
@@ -44,7 +45,7 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
-import com.digitalasset.platform.store.{Contract, LedgerSnapshot}
+import com.digitalasset.platform.store.LedgerSnapshot
 import org.slf4j.LoggerFactory
 import scalaz.Tag
 
@@ -113,9 +114,12 @@ class InMemoryLedger(
   override def lookupContract(
       contractId: AbsoluteContractId,
       forParty: Party
-  ): Future[Option[Contract]] =
+  ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
     Future.successful(this.synchronized {
-      acs.activeContracts.get(contractId).filter(ac => acs.isVisibleForDivulgees(ac.id, forParty))
+      acs.activeContracts
+        .get(contractId)
+        .filter(ac => acs.isVisibleForDivulgees(ac.id, forParty))
+        .map(_.contract)
     })
 
   override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -11,7 +11,8 @@ import com.digitalasset.daml.lf.archive.Decode
 import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain
@@ -75,9 +76,8 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
   override def lookupContract(
       contractId: AbsoluteContractId,
       forParty: Party
-  ): Future[Option[Contract]] =
-    ledgerDao
-      .lookupActiveOrDivulgedContract(contractId, forParty)
+  ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
+    ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty)
 
   override def lookupTransaction(
       transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -11,9 +11,9 @@ import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, TransactionId, PartyDetails}
+import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.ReportsHealth
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.store.entries.{
@@ -40,7 +40,7 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
 
   def lookupContract(
       contractId: Value.AbsoluteContractId,
-      forParty: Party): Future[Option[Contract]]
+      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]]
 
   def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -11,7 +11,8 @@ import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId, TransactionId}
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party}
 import com.digitalasset.daml.lf.transaction.Node
-import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
@@ -24,7 +25,7 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
-import com.digitalasset.platform.store.{Contract, LedgerSnapshot, PersistenceEntry}
+import com.digitalasset.platform.store.{LedgerSnapshot, PersistenceEntry}
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -47,7 +48,7 @@ trait LedgerReadDao extends ReportsHealth {
   /** Looks up an active or divulged contract if it is visible for the given party. Archived contracts must not be returned by this method */
   def lookupActiveOrDivulgedContract(
       contractId: AbsoluteContractId,
-      forParty: Party): Future[Option[Contract]]
+      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]]
 
   /** Looks up the current ledger configuration, if it has been set. */
   def lookupLedgerConfiguration(): Future[Option[(Long, Configuration)]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId, Trans
 import com.digitalasset.daml.lf.data.Ref.{LedgerString, PackageId, Party}
 import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails}
 import com.digitalasset.ledger.api.health.HealthStatus
@@ -25,7 +26,7 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
-import com.digitalasset.platform.store.{Contract, LedgerSnapshot, PersistenceEntry}
+import com.digitalasset.platform.store.{LedgerSnapshot, PersistenceEntry}
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -61,7 +62,7 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
 
   override def lookupActiveOrDivulgedContract(
       contractId: Value.AbsoluteContractId,
-      forParty: Party): Future[Option[Contract]] =
+      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
     timedFuture(
       Metrics.lookupActiveContract,
       ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty))

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -44,7 +44,6 @@ import com.digitalasset.ledger.api.domain.{
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.logging.LoggingContext.newLoggingContext
 import com.digitalasset.platform.participant.util.EventFilter
-import com.digitalasset.platform.store.Contract.ActiveContract
 import com.digitalasset.platform.store.entries.{ConfigurationEntry, LedgerEntry}
 import com.digitalasset.platform.store.{DbType, FlywayMigrations, PersistenceEntry}
 import com.digitalasset.resources.Resource
@@ -146,21 +145,6 @@ class JdbcLedgerDaoSpec
         Set(alice)
       )
 
-      val contract = ActiveContract(
-        absCid,
-        let,
-        txId,
-        event1,
-        Some(workflowId),
-        someContractInstance,
-        Set(alice, bob),
-        Map(alice -> txId, bob -> txId),
-        Some(keyWithMaintainers),
-        Set(alice, bob),
-        Set.empty,
-        someContractInstance.agreementText
-      )
-
       val transaction = LedgerEntry.Transaction(
         Some("commandId1"),
         txId,
@@ -204,7 +188,7 @@ class JdbcLedgerDaoSpec
         externalLedgerEnd <- ledgerDao.lookupExternalLedgerEnd()
       } yield {
         result1 shouldEqual None
-        result2 shouldEqual Some(contract)
+        result2 shouldEqual Some(someContractInstance)
         externalLedgerEnd shouldEqual externalOffset
       }
     }


### PR DESCRIPTION
The `Ledger` and `LedgerDao` interfaces are changed to only expose `ContractInst`s instead of `Contract`s when performing a single active contract lookup: this operation is only need for interpretation, which throws away the extra data anyway.

This change _does not_ attempt at minimizing the data read from the participant storage and defers it to a second PR to facilitate readability for reviewers.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
