### PR TITLE
Fix flaky lsp tests

### DIFF
--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -303,7 +303,7 @@ requestTests run _runScenarios = testGroup "requests"
               [ "daml 1.2"
               , "module Main where"
               , "single = scenario do"
-              , "  assert (True == True)"
+              , "  assert True"
               ]
           lenses <- getCodeLenses main'
           Just escapedFp <- pure $ escapeURIString isUnescapedInURIComponent <$> uriToFilePath (main' ^. uri)


### PR DESCRIPTION
I’ve failed to reproduce this locally so far but on CI we sometimes
get the DLint warning that `True == True` is redundant before we get the
parse error which results in the tests failing. There is no reason why
we need to use `True == True` here anyway so the fix is to simply
replace it by `True`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
