### PR TITLE
Use the contract key hasher in kvutils

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -157,7 +157,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
   def convertGlobalKey(globalKey: N.GlobalKey): GlobalKey = {
     GlobalKey.newBuilder
       .setTemplateId(convertIdentifier(globalKey.templateId))
-      .setKey(convertValue(globalKey.key.value))
+      .setKey(convertValue(globalKey.key))
       .build
   }
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -118,7 +118,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     key match {
       case GlobalKey(
           BasicTests_WithKey,
-          Value.VersionedValue(_, ValueRecord(_, ImmArray((_, p), (_, ValueInt64(42))))),
+          ValueRecord(_, ImmArray((_, p), (_, ValueInt64(42)))),
           hash @ _) if p == ValueParty(alice) =>
         Some(AbsoluteContractId("1"))
       case _ =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -118,8 +118,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     key match {
       case GlobalKey(
           BasicTests_WithKey,
-          Value.VersionedValue(_, ValueRecord(_, ImmArray((_, p), (_, ValueInt64(42))))))
-          if p == ValueParty(alice) =>
+          Value.VersionedValue(_, ValueRecord(_, ImmArray((_, p), (_, ValueInt64(42))))),
+          hash @ _) if p == ValueParty(alice) =>
         Some(AbsoluteContractId("1"))
       case _ =>
         None

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -123,7 +123,7 @@ object Pretty {
       case ScenarioErrorCommitError(CommitError.FailedAuthorizations(fas)) =>
         (text("due to failed authorizations:") / prettyFailedAuthorizations(fas)).nested(4)
       case ScenarioErrorCommitError(CommitError.UniqueKeyViolation(gk)) =>
-        (text("due to unique key violation for key:") & prettyVersionedValue(false)(gk.gk.key) & text(
+        (text("due to unique key violation for key:") & prettyValue(false)(gk.gk.key) & text(
           "for template",
         ) & prettyIdentifier(gk.gk.templateId))
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1041,7 +1041,7 @@ object SBuiltin {
       checkToken(args.get(1))
       val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
       checkLookupMaintainers(templateId, machine, keyWithMaintainers.maintainers)
-      val gkey = GlobalKey(templateId, keyWithMaintainers.key)
+      val gkey = GlobalKey(templateId, keyWithMaintainers.key.value)
       // check if we find it locally
       machine.ptx.keys.get(gkey) match {
         case Some(mbCoid) =>
@@ -1112,7 +1112,7 @@ object SBuiltin {
       checkToken(args.get(1))
       val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
       checkLookupMaintainers(templateId, machine, keyWithMaintainers.maintainers)
-      val gkey = GlobalKey(templateId, keyWithMaintainers.key)
+      val gkey = GlobalKey(templateId, keyWithMaintainers.key.value)
       // check if we find it locally
       machine.ptx.keys.get(gkey) match {
         case Some(None) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -78,7 +78,7 @@ object Ledger {
   }
 
   @inline
-  def assertNoContractId(key: VersionedValue[Value.ContractId]): VersionedValue[Nothing] =
+  def assertNoContractId(key: Value[Value.ContractId]): Value[Nothing] =
     key.ensureNoCid.fold(
       cid => crash(s"Not expecting to find a contract id here, but found '$cid'"),
       identity,
@@ -1155,7 +1155,7 @@ object Ledger {
                           val gk = GlobalKey(
                             nc.coinst.template,
                             // FIXME: we probably should never crash here !
-                            assertNoContractId(keyWithMaintainers.key),
+                            assertNoContractId(keyWithMaintainers.key.value),
                           )
                           newCache1.activeKeys.get(gk) match {
                             case None => Right(newCache1.addKey(gk, nc.coid))
@@ -1197,7 +1197,7 @@ object Ledger {
                                 GlobalKey(
                                   ex.templateId,
                                   // FIXME: we probably should'nt crash here !
-                                  assertNoContractId(keyWithMaintainers.key),
+                                  assertNoContractId(keyWithMaintainers.key.value),
                                 ),
                               )
                           }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -247,7 +247,7 @@ object Hash {
   def hashContractKey(key: Node.GlobalKey): Hash =
     builder(Hash.Purpose.ContractKey)
       .addIdentifier(key.templateId)
-      .addTypedValue(key.key.value)
+      .addTypedValue(key.key)
       .build
 
   def deriveSubmissionSeed(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -10,6 +10,7 @@ import java.util
 
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time, Utf8}
 import com.digitalasset.daml.lf.transaction.Node
+import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.value.Value
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -71,7 +72,7 @@ object Hash {
   implicit val HashOrdering: Ordering[Hash] =
     ((hash1, hash2) => implicitly[Ordering[Iterable[Byte]]].compare(hash1.bytes, hash2.bytes))
 
-  private[crypto] sealed abstract class Builder {
+  private[crypto] sealed abstract class Builder(purpose: Purpose) {
 
     protected def update(a: Array[Byte]): Unit
 
@@ -154,7 +155,11 @@ object Hash {
         case Value.ValueText(v) =>
           add(v)
         case Value.ValueContractId(v) =>
-          add(v.coid)
+          purpose match {
+            case Purpose.ContractKey =>
+              sys.error("Hashing of contract id for contract keys is not supported")
+            case _ => add(v.coid)
+          }
         case Value.ValueOptional(None) =>
           add(0)
         case Value.ValueOptional(Some(v)) =>
@@ -190,7 +195,7 @@ object Hash {
 
   // package private for testing purpose.
   // Do not call this method from outside Hash object/
-  private[crypto] def builder(purpose: Purpose): Builder = new Builder {
+  private[crypto] def builder(purpose: Purpose): Builder = new Builder(purpose) {
 
     private val md = MessageDigest.getInstance("SHA-256")
 
@@ -207,7 +212,7 @@ object Hash {
 
   private val hMacAlgorithm = "HmacSHA256"
 
-  private[crypto] def hMacBuilder(key: Hash): Builder = new Builder {
+  private[crypto] def hMacBuilder(key: Hash): Builder = new Builder(Purpose.PrivateKey) {
 
     private val mac: Mac = Mac.getInstance(hMacAlgorithm)
 
@@ -238,16 +243,26 @@ object Hash {
   def assertFromString(s: String): Hash =
     data.assertRight(fromString(s))
 
+  def fromBytes(a: Array[Byte]): Either[String, Hash] =
+    Either.cond(
+      a.length == underlyingHashLength,
+      new Hash(a.clone()),
+      s"hash should have ${underlyingHashLength} bytes, found ${a.length}",
+    )
+
+  def assertFromBytes(a: Array[Byte]): Hash =
+    data.assertRight(fromBytes(a))
+
   def hashPrivateKey(s: String): Hash =
     builder(Purpose.PrivateKey).add(s).build
 
   // This function assumes that key is well typed, i.e. :
-  // 1 - `key.identifier` is the identifier for a template with a key of type τ
-  // 2 - `key.key` is a value of type τ
-  def hashContractKey(key: Node.GlobalKey): Hash =
+  // 1 - `templateId` is the identifier for a template with a key of type τ
+  // 2 - `key` is a value of type τ
+  def hashContractKey(templateId: Identifier, key: Value[Nothing]): Hash =
     builder(Hash.Purpose.ContractKey)
-      .addIdentifier(key.templateId)
-      .addTypedValue(key.key)
+      .addIdentifier(templateId)
+      .addTypedValue(key)
       .build
 
   def deriveSubmissionSeed(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -9,7 +9,6 @@ import java.security.{MessageDigest, SecureRandom}
 import java.util
 
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time, Utf8}
-import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.value.Value
 import javax.crypto.Mac
@@ -55,6 +54,9 @@ object Hash {
       new Hash(a.clone()),
       s"hash should have ${underlyingHashLength} bytes, found ${a.length}",
     )
+
+  def assertFromBytes(a: Array[Byte]): Hash =
+    data.assertRight(fromBytes(a))
 
   def secureRandom(seed: Array[Byte]): () => Hash = {
     val random = new SecureRandom(seed)
@@ -242,16 +244,6 @@ object Hash {
 
   def assertFromString(s: String): Hash =
     data.assertRight(fromString(s))
-
-  def fromBytes(a: Array[Byte]): Either[String, Hash] =
-    Either.cond(
-      a.length == underlyingHashLength,
-      new Hash(a.clone()),
-      s"hash should have ${underlyingHashLength} bytes, found ${a.length}",
-    )
-
-  def assertFromBytes(a: Array[Byte]): Hash =
-    data.assertRight(fromBytes(a))
 
   def hashPrivateKey(s: String): Hash =
     builder(Purpose.PrivateKey).add(s).build

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -6,7 +6,8 @@ package transaction
 
 import com.digitalasset.daml.lf.data.{ImmArray, ScalazEqual}
 import com.digitalasset.daml.lf.data.Ref._
-import com.digitalasset.daml.lf.value.Value.{ContractInst, VersionedValue}
+import com.digitalasset.daml.lf.value.Value
+import com.digitalasset.daml.lf.value.Value.ContractInst
 
 import scala.language.higherKinds
 import scalaz.Equal
@@ -345,7 +346,7 @@ object Node {
   /** Useful in various circumstances -- basically this is what a ledger implementation must use as
     * a key.
     */
-  case class GlobalKey(templateId: Identifier, key: VersionedValue[Nothing])
+  case class GlobalKey(templateId: Identifier, key: Value[Nothing])
 
   sealed trait WithTxValue2[F[+ _, + _]] {
     type WithTxValue[+Cid] = F[Cid, Transaction.Value[Cid]]

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -348,11 +348,11 @@ object Node {
     * a key. The 'hash' should be used when storing the key as value serialization is not guaranteed
     * to be stable over time (e.g. a new encoding might be introduced).
     */
-  case class GlobalKey private (templateId: Identifier, key: Value[Nothing], hash: Hash)
+  sealed abstract case class GlobalKey(templateId: Identifier, key: Value[Nothing], hash: Hash)
 
   object GlobalKey {
     def apply(templateId: Identifier, key: Value[Nothing]): GlobalKey =
-      GlobalKey(templateId, key, Hash.hashContractKey(templateId, key))
+      new GlobalKey(templateId, key, Hash.hashContractKey(templateId, key)) {}
   }
 
   sealed trait WithTxValue2[F[+ _, + _]] {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.lf
 package transaction
 
+import com.digitalasset.daml.lf.crypto.Hash
 import com.digitalasset.daml.lf.data.{ImmArray, ScalazEqual}
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.value.Value
@@ -344,9 +345,15 @@ object Node {
     }(recorded, isReplayedBy)
 
   /** Useful in various circumstances -- basically this is what a ledger implementation must use as
-    * a key.
+    * a key. The 'hash' should be used when storing the key as value serialization is not guaranteed
+    * to be stable over time (e.g. a new encoding might be introduced).
     */
-  case class GlobalKey(templateId: Identifier, key: Value[Nothing])
+  case class GlobalKey private (templateId: Identifier, key: Value[Nothing], hash: Hash)
+
+  object GlobalKey {
+    def apply(templateId: Identifier, key: Value[Nothing]): GlobalKey =
+      GlobalKey(templateId, key, Hash.hashContractKey(templateId, key))
+  }
 
   sealed trait WithTxValue2[F[+ _, + _]] {
     type WithTxValue[+Cid] = F[Cid, Transaction.Value[Cid]]

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -653,7 +653,7 @@ object Transaction {
         key match {
           case None => Right((cid, ptx))
           case Some(kWithM) =>
-            val ck = GlobalKey(coinst.template, kWithM.key)
+            val ck = GlobalKey(coinst.template, kWithM.key.value)
             Right((cid, ptx.copy(keys = ptx.keys.updated(ck, Some(cid)))))
         }
       }
@@ -735,7 +735,7 @@ object Transaction {
               consumedBy = if (consuming) consumedBy.updated(targetId, nodeId) else consumedBy,
               keys = mbKey match {
                 case Some(kWithM) if consuming =>
-                  keys.updated(GlobalKey(templateId, kWithM.key), None)
+                  keys.updated(GlobalKey(templateId, kWithM.key.value), None)
                 case _ => keys
               },
             ),

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -219,7 +219,7 @@ object ValueCoder {
     ValueVersions
       .isAcceptedVersion(vs)
       .fold[Either[DecodeError, ValueVersion]](
-        Left(DecodeError(s"Unsupported value version '$vs'")))(
+        Left(DecodeError(s"Unsupported value version $vs")))(
         v => Right(v),
       )
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -218,8 +218,7 @@ object ValueCoder {
   private def decodeVersion(vs: String): Either[DecodeError, ValueVersion] =
     ValueVersions
       .isAcceptedVersion(vs)
-      .fold[Either[DecodeError, ValueVersion]](
-        Left(DecodeError(s"Unsupported value version $vs")))(
+      .fold[Either[DecodeError, ValueVersion]](Left(DecodeError(s"Unsupported value version $vs")))(
         v => Right(v),
       )
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -218,7 +218,8 @@ object ValueCoder {
   private def decodeVersion(vs: String): Either[DecodeError, ValueVersion] =
     ValueVersions
       .isAcceptedVersion(vs)
-      .fold[Either[DecodeError, ValueVersion]](Left(DecodeError(s"Unsupported value version $vs")))(
+      .fold[Either[DecodeError, ValueVersion]](
+        Left(DecodeError(s"Unsupported value version '$vs'")))(
         v => Right(v),
       )
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -567,7 +567,4 @@ class HashSpec extends WordSpec with Matchers {
       ),
     )
 
-  private implicit def addVersion[Cid](v: Value[Cid]): VersionedValue[Cid] =
-    VersionedValue(ValueVersion("4"), v)
-
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -5,10 +5,9 @@ package com.digitalasset.daml.lf
 package crypto
 
 import com.digitalasset.daml.lf.data.{Decimal, Numeric, Ref, SortedLookupList, Time}
-import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.TypedValueGenerators.{RNil, ValueAddend => VA}
 import com.digitalasset.daml.lf.value.Value._
-import com.digitalasset.daml.lf.value.{Value, ValueVersion}
+import com.digitalasset.daml.lf.value.Value
 import org.scalatest.{Matchers, WordSpec}
 import shapeless.record.{Record => HRecord}
 import shapeless.syntax.singleton._
@@ -90,16 +89,16 @@ class HashSpec extends WordSpec with Matchers {
       val hash = "ea24627f5b014af67dbedb13d950e60be7f96a1a5bd9fb1a3b9a85b7fa9db4bc"
       val value = complexRecordT.inj(complexRecordV)
       val name = defRef("module", "name")
-      Hash.hashContractKey(GlobalKey(name, value)).toHexaString shouldBe hash
+      Hash.hashContractKey(name, value).toHexaString shouldBe hash
     }
 
     "be deterministic and thread safe" in {
       // Compute many hashes in parallel, check that they are all equal
       // Note: intentionally does not reuse value instances
       val hashes = Vector
-        .fill(1000)(GlobalKey(defRef("module", "name"), complexRecordT.inj(complexRecordV)))
+        .fill(1000)(defRef("module", "name") -> complexRecordT.inj(complexRecordV))
         .par
-        .map(Hash.hashContractKey)
+        .map(Function.tupled(Hash.hashContractKey))
 
       hashes.toSet.size shouldBe 1
     }
@@ -108,8 +107,8 @@ class HashSpec extends WordSpec with Matchers {
       // Same value but different template ID should produce a different hash
       val value = VA.text.inj("A")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(defRef("AA", "A"), value))
-      val hash2 = Hash.hashContractKey(GlobalKey(defRef("A", "AA"), value))
+      val hash1 = Hash.hashContractKey(defRef("AA", "A"), value)
+      val hash2 = Hash.hashContractKey(defRef("A", "AA"), value)
 
       hash1 should !==(hash2)
     }
@@ -122,8 +121,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -137,8 +136,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -151,8 +150,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -165,8 +164,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -178,8 +177,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -192,8 +191,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -206,8 +205,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -218,8 +217,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -230,8 +229,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -242,8 +241,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -254,8 +253,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -266,8 +265,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -278,8 +277,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -292,8 +291,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(GlobalKey(tid, value1))
-      val hash2 = Hash.hashContractKey(GlobalKey(tid, value2))
+      val hash1 = Hash.hashContractKey(tid, value1)
+      val hash2 = Hash.hashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
@@ -158,7 +158,7 @@ object KeyHasher extends KeyHasher {
     putString(digest, key.templateId.qualifiedName.toString())
 
     // Note: We do not emit the type as it is implied by the template ID.
-    putValue(digest, key.key.value)
+    putValue(digest, key.key)
 
     digest.digest()
   }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -398,8 +398,10 @@ message DamlContractKey {
   // The DAML template identifier of the contract that created this key.
   com.digitalasset.daml.lf.value.Identifier template_id = 1;
 
-  // The contract key itself.
-  com.digitalasset.daml.lf.value.VersionedValue key = 2;
+  reserved 2; // This was key serialized as a VersionedValue. Replaced by hash.
+
+  // Hash of the contract key value, produced by KeyHasher.
+  bytes hash = 3;
 }
 
 // Stored information about a given party.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -84,7 +84,7 @@ private[kvutils] object InputsAndEffects {
 
           case create: NodeCreate[ContractId, VersionedValue[ContractId]] =>
             create.key.foreach { keyWithMaintainers =>
-              inputs += contractKeyToStateKey(
+              inputs += globalKeyToStateKey(
                 GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key.value)))
             }
 
@@ -95,7 +95,7 @@ private[kvutils] object InputsAndEffects {
             // We need both the contract key state and the contract state. The latter is used to verify
             // that the submitter can access the contract.
             lookup.result.foreach(addContractInput)
-            inputs += contractKeyToStateKey(
+            inputs += globalKeyToStateKey(
               GlobalKey(lookup.templateId, forceNoContractIds(lookup.key.key.value)))
         }
 
@@ -123,7 +123,7 @@ private[kvutils] object InputsAndEffects {
                 .fold(effects.updatedContractKeys)(
                   keyWithMaintainers =>
                     effects.updatedContractKeys +
-                      (contractKeyToStateKey(
+                      (globalKeyToStateKey(
                         GlobalKey(
                           create.coinst.template,
                           forceNoContractIds(keyWithMaintainers.key.value))) ->
@@ -148,7 +148,7 @@ private[kvutils] object InputsAndEffects {
                   .fold(effects.updatedContractKeys)(
                     key =>
                       effects.updatedContractKeys +
-                        (contractKeyToStateKey(
+                        (globalKeyToStateKey(
                           GlobalKey(exe.templateId, forceNoContractIds(key.key.value))) ->
                           DamlContractKeyState.newBuilder.build)
                   )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -85,7 +85,7 @@ private[kvutils] object InputsAndEffects {
           case create: NodeCreate[ContractId, VersionedValue[ContractId]] =>
             create.key.foreach { keyWithMaintainers =>
               inputs += contractKeyToStateKey(
-                GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key)))
+                GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key.value)))
             }
 
           case exe: NodeExercises[_, ContractId, _] =>
@@ -96,7 +96,7 @@ private[kvutils] object InputsAndEffects {
             // that the submitter can access the contract.
             lookup.result.foreach(addContractInput)
             inputs += contractKeyToStateKey(
-              GlobalKey(lookup.templateId, forceNoContractIds(lookup.key.key)))
+              GlobalKey(lookup.templateId, forceNoContractIds(lookup.key.key.value)))
         }
 
         inputs ++= partyInputs(node.informeesOfNode)
@@ -126,7 +126,7 @@ private[kvutils] object InputsAndEffects {
                       (contractKeyToStateKey(
                         GlobalKey(
                           create.coinst.template,
-                          forceNoContractIds(keyWithMaintainers.key))) ->
+                          forceNoContractIds(keyWithMaintainers.key.value))) ->
                         DamlContractKeyState.newBuilder
                           .setContractId(encodeRelativeContractId(
                             entryId,
@@ -149,7 +149,7 @@ private[kvutils] object InputsAndEffects {
                     key =>
                       effects.updatedContractKeys +
                         (contractKeyToStateKey(
-                          GlobalKey(exe.templateId, forceNoContractIds(key.key))) ->
+                          GlobalKey(exe.templateId, forceNoContractIds(key.key.value))) ->
                           DamlContractKeyState.newBuilder.build)
                   )
               )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -20,7 +20,6 @@ import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.ValueOuterClass
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.platform.common.metrics.VarGauge
-import com.digitalasset.platform.store.serialization.KeyHasher
 import com.google.protobuf.ByteString
 import org.slf4j.LoggerFactory
 
@@ -289,7 +288,8 @@ object KeyValueCommitting {
       key: ValueOuterClass.VersionedValue): DamlStateKey = {
     // NOTE(JM): The deserialization of the values is meant to be temporary. With the removal of relative
     // contract ids from kvutils submissions we will be able to up-front compute the outputs without having
-    // to allocate a log entry id and we can directly place the output keys into the submission.
+    // to allocate a log entry id and we can directly place the output keys into the submission and do not need
+    // to compute outputs from serialized transaction.
     val contractKey =
       GlobalKey(
         decodeIdentifier(templateId),
@@ -300,9 +300,8 @@ object KeyValueCommitting {
       .setContractKey(
         DamlContractKey.newBuilder
           .setTemplateId(templateId)
-          .setHash(ByteString.copyFrom(KeyHasher.hashKey(contractKey))))
+          .setHash(ByteString.copyFrom(contractKey.hash.toByteArray)))
       .build
-
   }
 
   private def verifyStateUpdatesAgainstPreDeclaredOutputs(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -7,6 +7,10 @@ package com.daml.ledger.participant.state.kvutils
   * and the changelog of kvutils.
   *
   * Changes:
+  * [after 100.13.52]: *BACKWARDS INCOMPATIBLE*
+  * - Use hash for serializing contract keys instead of serializing the value, as
+  *   the value serialization is not guaranteed to be stable over time.
+  *
   * [after 100.13.39]:
   * - logEntryToAsyncResponse has now been removed as all requests
   *   now have event based responses.
@@ -51,5 +55,5 @@ object Version {
     * when the protobuf default value for a field is insufficient and must be filled in during decoding.
     * Handling of older versions is handled by [[Envelope.open]] which performs the migration to latest version.
     */
-  val version: Long = 0
+  val version: Long = 1
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -7,7 +7,13 @@ import com.codahale.metrics
 import com.codahale.metrics.{Counter, Timer}
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, commandDedupKey, _}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.kvutils.{Conversions, Err, InputsAndEffects, DamlStateMap}
+import com.daml.ledger.participant.state.kvutils.{
+  ContractKeyHash,
+  Conversions,
+  DamlStateMap,
+  Err,
+  InputsAndEffects
+}
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId, RejectionReason}
 import com.digitalasset.daml.lf.archive.Decode
 import com.digitalasset.daml.lf.archive.Reader.ParseError
@@ -17,6 +23,7 @@ import com.digitalasset.daml.lf.engine.{Blinding, Engine}
 import com.digitalasset.daml.lf.transaction.Node.{GlobalKey, NodeCreate, NodeExercises}
 import com.digitalasset.daml.lf.transaction.{BlindingInfo, GenTransaction}
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractId, NodeId, VersionedValue}
+import com.digitalasset.platform.store.serialization.KeyHasher
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -76,13 +83,13 @@ private[kvutils] case class ProcessTransactionSubmission(
   // Pull all keys from referenced contracts. We require this for 'fetchByKey' calls
   // which are not evidenced in the transaction itself and hence the contract key state is
   // not included in the inputs.
-  private lazy val knownKeys: Map[GlobalKey, AbsoluteContractId] =
+  private lazy val knownKeys: Map[ContractKeyHash, AbsoluteContractId] =
     inputState.collect {
       case (key, Some(value))
           if value.hasContractState
             && value.getContractState.hasContractKey
             && contractIsActiveAndVisibleToSubmitter(value.getContractState) =>
-        Conversions.decodeContractKey(value.getContractState.getContractKey) ->
+        Conversions.decodeContractKey(value.getContractState.getContractKey)._2 ->
           Conversions.stateKeyToContractId(key)
     }
 
@@ -186,7 +193,7 @@ private[kvutils] case class ProcessTransactionSubmission(
               (_nodeId, exe: NodeExercises[_, _, VersionedValue[ContractId]]))
               if exe.key.isDefined && exe.consuming =>
             val stateKey = Conversions.contractKeyToStateKey(
-              GlobalKey(exe.templateId, Conversions.forceNoContractIds(exe.key.get.key)))
+              GlobalKey(exe.templateId, Conversions.forceNoContractIds(exe.key.get.key.value)))
             (allUnique, existingKeys - stateKey)
 
           case (
@@ -194,7 +201,9 @@ private[kvutils] case class ProcessTransactionSubmission(
               (_nodeId, create: NodeCreate[_, VersionedValue[ContractId]]))
               if create.key.isDefined =>
             val stateKey = Conversions.contractKeyToStateKey(
-              GlobalKey(create.coinst.template, Conversions.forceNoContractIds(create.key.get.key)))
+              GlobalKey(
+                create.coinst.template,
+                Conversions.forceNoContractIds(create.key.get.key.value)))
 
             (allUnique && !existingKeys.contains(stateKey), existingKeys + stateKey)
 
@@ -265,7 +274,7 @@ private[kvutils] case class ProcessTransactionSubmission(
               Conversions.encodeContractKey(
                 GlobalKey(
                   createNode.coinst.template,
-                  Conversions.forceNoContractIds(keyWithMaintainers.key)
+                  Conversions.forceNoContractIds(keyWithMaintainers.key.value)
                 )
               ))
           }
@@ -374,8 +383,9 @@ private[kvutils] case class ProcessTransactionSubmission(
   }
 
   private def lookupKey(key: GlobalKey): Option[AbsoluteContractId] = {
+    val keyHash = KeyHasher.hashKey(key)
     inputState
-      .get(Conversions.contractKeyToStateKey(key))
+      .get(Conversions.contractKeyToStateKey(key)) // FIXME(JM): reuse keyHash
       .flatMap {
         _.flatMap { value =>
           for {
@@ -388,8 +398,8 @@ private[kvutils] case class ProcessTransactionSubmission(
       }
       // If the key was not in state inputs, then we look whether any of the accessed contracts
       // has the key we're looking for. This happens with "fetchByKey" where the key lookup
-      // is not evidenced in the transaction.
-      .orElse(knownKeys.get(key))
+      // is not evidenced in the transaction. The activeness of the contract is checked when it is fetched.
+      .orElse(knownKeys.get(keyHash))
   }
 
   private def buildRejectionLogEntry(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -48,7 +48,7 @@ package com.daml.ledger.participant.state
   *
   * 3. The [[InMemoryKVParticipantState.stateUpdates]] emits a new update event from the new state of the ledger
   *  by retrieving the [[DamlLogEntry]] pointed to by the latest commit and transforms it into [[v1.Update]]
-  *  using [[KeyValueConsumption.logEntryToUpdate]], and pairs it with an offset corresponding to the
+  *  using [[com.daml.ledger.participant.state.kvutils.KeyValueConsumption.logEntryToUpdate]], and pairs it with an offset corresponding to the
   *  position of the commit (the "block height" if you will).
   *
   */
@@ -56,7 +56,5 @@ package object kvutils {
   import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
-
-  type ContractKeyHash = Array[Byte]
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -56,4 +56,7 @@ package object kvutils {
   import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
+
+  type ContractKeyHash = Array[Byte]
+
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -156,7 +156,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                       acc = Some(acc.addContract(activeContract, None)),
                       parties = parties.union(nodeParties))
                   case Some(key) =>
-                    val gk = GlobalKey(activeContract.contract.template, key.key)
+                    val gk = GlobalKey(activeContract.contract.template, key.key.value)
                     if (acc.lookupContractByKey(gk).isDefined) {
                       AddTransactionState(
                         None,
@@ -192,7 +192,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
                     throw new IllegalStateException(s"Contract ID $coid found in contract key"),
                   identity
                 )
-                val gk = GlobalKey(nlkup.templateId, key)
+                val gk = GlobalKey(nlkup.templateId, key.value)
                 val nodeParties = nlkup.key.maintainers
 
                 submitter match {

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -62,7 +62,7 @@ class V3__Recompute_Key_Hash extends BaseJavaMigration {
 
         hasNext = rows.next()
 
-        contractId -> GlobalKey(templateId, key)
+        contractId -> GlobalKey(templateId, key.value)
       }
     }
 

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -61,7 +61,6 @@ class V3__Recompute_Key_Hash extends BaseJavaMigration {
           .assertNoCid(coid => s"Found contract ID $coid in contract key")
 
         hasNext = rows.next()
-
         contractId -> GlobalKey(templateId, key.value)
       }
     }


### PR DESCRIPTION
Use the Hash.scala contract key hashing to serialize contract keys
in kvutils instead of serializing them as VersionedValues (which isn't guaranteed
to be stable over time).

As discussed with @remyhaemmerle-da, use `Value` instead of `VersionedValue` in `GlobalKey`, and add `hash` to it.

One downside currently is that we need to deserialize a value when computing transaction outputs.
This I expect to be cleaned up when we remove relative contract ids and kvutils will know the transaction outputs up-front when producing the submission message.

TODO:
- [x] Add changelog
- [x] Coordinate the backwards incompatibility of this change with downstream consumers

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
