### PR TITLE
[daml-lf] remove contract-id-string v1

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -511,6 +511,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val submitResult = engine
         .submit(Commands(party, ImmArray(command), let, "test"), participant, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
+      remy.log(interpretResult)
+      remy.log(submitResult)
       interpretResult shouldBe 'right
       (interpretResult |@| submitResult)(_ isReplayedBy _) shouldBe Right(true)
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.google.common.io.BaseEncoding
@@ -253,6 +254,12 @@ object KeyValueConsumption {
   private def parseParticipantId(what: String)(s: String): Ref.ParticipantId =
     Ref.ParticipantId
       .fromString(s)
+      .fold(err => throw Err.DecodeError(what, s"Cannot parse '$s': $err"), identity)
+
+  @throws(classOf[Err])
+  private def parseHash(what: String)(s: ByteString): crypto.Hash =
+    crypto.Hash
+      .fromBytes(s.toByteArray)
       .fold(err => throw Err.DecodeError(what, s"Cannot parse '$s': $err"), identity)
 
   @throws(classOf[Err])

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -195,8 +195,8 @@ object Cli {
     opt[Unit]("sortable-contract-ids")
       .hidden()
       .optional()
-      .text("(Experimental) use new sortable contract ids")
-      .action( (_, config) => config.copy(useSortableCid = true))
+        .text("(Experimental) use new sortable contract ids")
+        .action( (_, config) => config.copy(useSortableCid = true))
 
     help("help").text("Print the usage text")
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -33,7 +33,7 @@ final case class SandboxConfig(
     eagerPackageLoading: Boolean,
     logLevel: Level,
     authService: Option[AuthService],
-    useSortableCid: Boolean
+    useSortableCid: Boolean,
 )
 
 object SandboxConfig {
@@ -58,6 +58,6 @@ object SandboxConfig {
       eagerPackageLoading = false,
       logLevel = Level.INFO,
       authService = None,
-      useSortableCid = false
+      useSortableCid = false,
     )
 }


### PR DESCRIPTION
In this PR we get rid of contract-id-string-v1 which was introduced in #4221.

This advances the state of #3830 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
