### PR TITLE
Make DAML's (>>) operator lazy in its second argument

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -87,6 +87,11 @@ class Functor f => Applicative f where
 -- by the first. This is like sequencing operators (such as the semicolon)
 -- in imperative languages.
 (>>) : Action m => m a -> m b -> m b
+-- NOTE(MH): We need an `Action` constraint here rather than an `Applicative`
+-- constrait since the conversion to DAML-LF rewrites `A >> B` into
+-- `A >>= \_ -> B`. This is to make `(>>)` lazy in its second argument and
+-- hence give `do A; B` the desired semantics where `B` is not evaluated if
+-- `A` short-circuits the monad computation..
 (>>) = (*>)
 infixl 1 >>
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -86,7 +86,7 @@ class Functor f => Applicative f where
 -- | Sequentially compose two actions, discarding any value produced
 -- by the first. This is like sequencing operators (such as the semicolon)
 -- in imperative languages.
-(>>) : Applicative m => m a -> m b -> m b
+(>>) : Action m => m a -> m b -> m b
 (>>) = (*>)
 infixl 1 >>
 

--- a/compiler/damlc/daml-stdlib-src/DA/Validation.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Validation.daml
@@ -71,16 +71,8 @@ instance Applicative (Validation err) where
     Errors e1 *> Success _ = Errors e1
     Errors e1 *> Errors e2 = Errors (e1 <> e2)
 
-instance Action (Validation err) where
-    (Success x) >>= k = k x
-    (Errors e) >>= k = Errors e
-
-instance ActionFail (Validation Text) where
-    fail = Errors . singleton
-
 -- | Convert an `Optional t` into a `Validation Text t`, or
 -- more generally into an `m t` for any `ActionFail` type `m`.
-(<?>) : ActionFail m => Optional b -> Text -> m b
-None <?> s = fail s
+(<?>) : Optional b -> Text -> Validation Text b
+None <?> s = invalid s
 Some v <?> _ = pure v
-

--- a/compiler/damlc/tests/daml-test-files/LazyDo.daml
+++ b/compiler/damlc/tests/daml-test-files/LazyDo.daml
@@ -1,5 +1,5 @@
 daml 1.2
-module SemiLazy where
+module LazyDo where
 
 import DA.Assert
 

--- a/compiler/damlc/tests/daml-test-files/SemiLazy.daml
+++ b/compiler/damlc/tests/daml-test-files/SemiLazy.daml
@@ -1,0 +1,25 @@
+daml 1.2
+module SemiLazy where
+
+import DA.Assert
+
+none: Optional a
+none = do
+  None
+  error "optional"
+
+empty: [Bool]
+empty = do
+  []
+  error "list"
+
+left: Either () Party
+left = do
+  Left ()
+  error "either"
+
+main = scenario do
+  none === (None @Int)
+  none === (None @Text)
+  empty === []
+  left === Left ()

--- a/compiler/damlc/tests/daml-test-files/Validation.daml
+++ b/compiler/damlc/tests/daml-test-files/Validation.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+{-# LANGUAGE ApplicativeDo #-}
 daml 1.2
 module Validation where
 
@@ -16,6 +17,6 @@ main = scenario do
   let v = run do
       head l <?> "fail"
       y <- tail l <?> "fail"
-      pure $ length y
+      return (length y)
   v === Left (NonEmpty with hd = "fail"; tl = ["fail"])
   pure ()


### PR DESCRIPTION
Currently, when you write
```haskell
do
  Left "wanted"
  error "unwanted"
```
your computation fails with an exception coming from the `error "unwanted"`
call. However, `do`-notation suggests that you actually never get there but
rather bail out at the `Left "wanted"` line. The cause of this mismatch is
that GHC desugars the code above to
```haskell
Left "wanted" >> error "unwanted"
```
and since DAML is strict, we evaluate `error "unwanted"` _before_ evaluating
the application of `(>>)`.

This PR solves the problem by rewriting all expressions of the form `A >> B`,
and hence those of the form `do A; B` as well, to `A >>= \_ -> B`. This gives
the desired semantics with `(>>)` being lazy in its second argument.

However, these semantics only make sense for `Action`s (aka monads). Thus, we
need to restrict the constraint on `(>>)` from `Applicative` to `Action`.
(This is in line with what Haskell does.)

Moreover, the `Action` instance of the `Validation` applicative would lead
to undesriable behavior when using `do`-notation. Thus, we also drop this
`Action` instance and hence force the usage of the `ApplicativeDo` language
extension when using `do`-notation for `Validation`.

CHANGELOG_BEGIN

- [DAML Compiler] Fix a bug that caused expressions of the form ``do A; B``
  to be too strict in ``B`` for ``Action``\ s other than ``Update`` and
  ``Scenario``. For instance, when you called the function

  .. code-block:: daml

    invert: Decimal -> Either Text Decimal
    invert x = do
      assertMsg "trying to invert 0.0" (x /= 0.0)
      return (1.0 / x)

  at ``0.0``, it failed with the exception
  ``CRASH: Attempt to divide 1.0000000000 by 0.0000000000.``
  instead of returning the desired ``Left "trying to invert 0.0"``.
  Now, calling ``invert 0.0`` will return the latter and work for all
  ``Action``\ s the same way.
- [DAML Stdlib] Restrict the ``(>>)`` operator to instances of ``Action``
  and make it lazy in its second argument. This is part of fixing the
  compiler bug regarding ``do A; B``.
- [DAML Stdlib] Remove the ``Action`` and ``ActionFail`` instances for
  ``Validation`` in ``DA.Validation``. After fixing the compiler bug
  regarding ``do A; B``, these instances would exhibit undesirable
  short-circuiting behavior. Please enable the ``ApplicativeDo`` language
  extension if you want to use ``Validation`` with ``do``-notation and
  replace ``fail`` for ``Validation Text`` with ``DA.Validation.invalid``.

CHANGELOG_END