### PR TITLE
DAML-LF: cleanup transaction version

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -9,7 +9,7 @@ class EngineInfoTest extends WordSpec with Matchers {
   EngineInfo.getClass.getSimpleName should {
     "show supported LF, Transaction and Value versions" in {
       EngineInfo.show shouldBe
-        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; Value versions: 1, 2, 3, 4, 5, 6, 7"
+        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.dev; Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9; Value versions: 1, 2, 3, 4, 5, 6, 7"
     }
 
     "toString returns the same value as show" in {

--- a/daml-lf/interpreter/src/main/lf/internal.lf
+++ b/daml-lf/interpreter/src/main/lf/internal.lf
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module INTERNAL {
+
+   record UNIT = {};
+
+   variant OPTION (a: *) = NONE: INTERNAL:UNIT | SOME: a ;
+
+}

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -25,7 +25,6 @@ object TransactionVersions
   private[transaction] val minExerciseResult = TransactionVersion("7")
   private[transaction] val minContractKeyInExercise = TransactionVersion("8")
   private[transaction] val minMaintainersInExercise = TransactionVersion("9")
-  private[transaction] val minContractIdV1 = TransactionVersion("10")
 
   def assignVersion(
       a: GenTransaction[_, Value.ContractId, VersionedValue[Value.ContractId]],
@@ -82,17 +81,6 @@ object TransactionVersions
         minMaintainersInExercise
       else
         minVersion,
-      if (a.transactionSeed.isDefined || a.nodes.values.exists {
-          case Node.NodeCreate(nodeSeed, _, _, _, _, _, _) =>
-            nodeSeed.isDefined
-          case Node.NodeExercises(nodeSeed, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
-            nodeSeed.isDefined
-          case _ =>
-            false
-        })
-        minContractIdV1
-      else
-        minVersion
     )
   }
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -59,7 +59,7 @@ object VersionTimeline {
       // FIXME https://github.com/digital-asset/daml/issues/2256
       //  * change the following line when LF 1.8 is frozen.
       //  * do not insert line after this once until 1.8 is frozen.
-      This(Both(ValueVersion("7"), TransactionVersion("10"))),
+      This(This(ValueVersion("7"))),
       // add new versions above this line (but see more notes below)
       That(LanguageVersion(LMV.V1, Dev)),
       // do *not* backfill to make more Boths, because such would


### PR DESCRIPTION
We clean transaction versions. Concretely, we drop the transaction version 10 which is currently not necessary (and not use in production).  

This advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
