### PR TITLE
Introduce new time model fields

### DIFF
--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -499,6 +499,9 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)
                   Duration.ofSeconds(123),
                   Duration.ofSeconds(123),
                   Duration.ofSeconds(123),
+                  Duration.ofSeconds(123),
+                  Duration.ofSeconds(123),
+                  Duration.ofSeconds(123),
                 ).get,
               ),
             )

--- a/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
+++ b/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
@@ -7,6 +7,7 @@
 //
 // version summary:
 // * 1: initial version
+// * 2: added new fields for the new ledger time model
 //
 
 syntax = "proto3";
@@ -42,4 +43,15 @@ message LedgerTimeModel {
   // The maximum allowed time to live for a transaction.
   // Must be greater than the derived minimum time to live.
   google.protobuf.Duration max_ttl = 3;
+
+  // The expected average latency of a transaction, i.e., the average time
+  // from submitting the transaction to a WriteService and the transaction
+  // being assigned a record time.
+  google.protobuf.Duration avg_transaction_latency = 4;
+
+  // The minimimum skew between ledger time and record time: lt_TX >= rt_TX - minSkew
+  google.protobuf.Duration min_skew = 5;
+
+  // The maximum skew between ledger time and record time: lt_TX <= rt_TX + maxSkew
+  google.protobuf.Duration max_skew = 6;
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
@@ -53,7 +53,10 @@ object Configuration {
       TimeModel(
         maxClockSkew = parseDuration(tm.getMaxClockSkew),
         minTransactionLatency = parseDuration(tm.getMinTransactionLatency),
-        maxTtl = parseDuration(tm.getMaxTtl)
+        maxTtl = parseDuration(tm.getMaxTtl),
+        avgTransactionLatency = parseDuration(tm.getAvgTransactionLatency),
+        minSkew = parseDuration(tm.getMinSkew),
+        maxSkew = parseDuration(tm.getMaxSkew),
       ).toEither.left.map(e => s"decodeTimeModel: ${e.getMessage}")
   }
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
@@ -70,6 +70,9 @@ object Configuration {
           .setMaxClockSkew(buildDuration(tm.maxClockSkew))
           .setMinTransactionLatency(buildDuration(tm.minTransactionLatency))
           .setMaxTtl(buildDuration(tm.maxTtl))
+          .setAvgTransactionLatency(buildDuration(tm.avgTransactionLatency))
+          .setMinSkew(buildDuration(tm.minSkew))
+          .setMaxSkew(buildDuration(tm.maxSkew))
       )
       .build
   }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TimeModel.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TimeModel.scala
@@ -88,7 +88,7 @@ object TimeModel {
     require(!maxTtl.isNegative, "Negative max TTL")
     require(!maxClockSkew.isNegative, "Negative max clock skew")
     require(!maxTtl.minus(maxClockSkew).isNegative, "Max TTL must be greater than max clock skew")
-    require(!minSkew.isNegative, "Negative average transaction latency")
+    require(!avgTransactionLatency.isNegative, "Negative average transaction latency")
     require(!minSkew.isNegative, "Negative min skew")
     require(!maxSkew.isNegative, "Negative max skew")
     new TimeModel(

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/TimeModelTest.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/TimeModelTest.scala
@@ -12,7 +12,14 @@ class TimeModelTest extends WordSpec with Matchers {
   private val referenceTime = Instant.EPOCH
   private val epsilon = Duration.ofMillis(10L)
   private val timeModel =
-    TimeModel(Duration.ofSeconds(1L), Duration.ofSeconds(1L), Duration.ofSeconds(30L)).get
+    TimeModel(
+      minTransactionLatency = Duration.ofSeconds(1L),
+      maxClockSkew = Duration.ofSeconds(1L),
+      maxTtl = Duration.ofSeconds(30L),
+      avgTransactionLatency = Duration.ofSeconds(0L),
+      minSkew = Duration.ofSeconds(30L),
+      maxSkew = Duration.ofSeconds(30L),
+    ).get
 
   private val referenceMrt = referenceTime.plus(timeModel.maxTtl)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -148,7 +148,10 @@ final class ApiConfigManagementService private (
       newTimeModel <- v1.TimeModel(
         minTransactionLatency = DurationConversion.fromProto(pMinTransactionLatency),
         maxClockSkew = DurationConversion.fromProto(pMaxClockSkew),
-        maxTtl = DurationConversion.fromProto(pMaxTtl)
+        maxTtl = DurationConversion.fromProto(pMaxTtl),
+        avgTransactionLatency = java.time.Duration.ZERO,
+        minSkew = java.time.Duration.ZERO,
+        maxSkew = java.time.Duration.ZERO,
       ) match {
         case Failure(err) => Left(ErrorFactories.invalidArgument(err.toString))
         case Success(ok) => Right(ok)


### PR DESCRIPTION
This PR introduces new fields to the participant state `TimeModel`.

The plan is to:
- Add the new time model fields (this PR)
- Allow Canton and DAML-on-X to start implementing time model checks based on the new time model
- Remove the old time model fields (together with MRT) when the ledger API server implements the new time model.