### PR TITLE
@daml/ledger: Compute accumulated state in Ledger.stream* methods

### DIFF
--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -48,8 +48,10 @@ template Person with
     name: Text
     party: Party
     age: Int
+    friends: [Party]
   where
     signatory party
+    observer friends
 
     key (party, age): (Party, Int)
     maintainer key._1


### PR DESCRIPTION
Instead of only streaming the events we now primarily stream the set of
active contracts for the `Ledger.streamQuery` methods and the contract
pointed to by the key for the `Ledger.streamFetchByKey` method. The
events that lead to the latest state change are streamed as the second
argument to the event handler as well.

We also rename the event name from `'events'` to `'change'` since the
former is not longer accurate and also confusing and the latter captures
the generality of the streams we deal with here.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
