### PR TITLE
increase linux pool

### DIFF
--- a/infra/vsts_agent_linux.tf
+++ b/infra/vsts_agent_linux.tf
@@ -18,7 +18,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-linux" {
   name               = "vsts-agent-linux"
   base_instance_name = "vsts-agent-linux"
   region             = "${local.region}"
-  target_size        = 6
+  target_size        = 8
 
   version {
     name              = "vsts-agent-linux"


### PR DESCRIPTION
We've had a number of jobs waiting for >10 minutes at the busiest times of the day since we switched to 6 nodes, so increasing back a bit.

I don't have very good visibility through the Azure UI, but it looks like all of the jobs queued (and not running) right now are very short ones so hopefully 8 should be enough.