### PR TITLE
Support type-level strings in DAML.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -10,6 +10,7 @@ module DA.Daml.Compiler.DataDependencies
     ) where
 
 import DA.Pretty
+import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans.Writer.CPS
 import Data.List.Extra
@@ -597,11 +598,8 @@ convType env reexported =
             args <- mapM (convType env reexported) lfArgs
             pure $ HsParTy noExt (noLoc $ foldl (HsAppTy noExt . noLoc) tyvar (map noLoc args))
 
-        LF.TApp (LF.TCon LF.Qualified {..}) (LF.TStruct fields)
-            | qualModule == LF.ModuleName ["DA", "Internal", "PromotedText"]
-            , ["PromotedText"] <- LF.unTypeConName qualObject
-            , [(LF.FieldName text, LF.TUnit)] <- fields
-            -> pure $ HsTyLit noExt (HsStrTy NoSourceText (mkFastString $ T.unpack text))
+        ty | Just text <- getPromotedText ty ->
+            pure $ HsTyLit noExt (HsStrTy NoSourceText (mkFastString $ T.unpack text))
 
         LF.TCon LF.Qualified {..}
             | qualModule == LF.ModuleName ["DA", "Types"]
@@ -966,15 +964,7 @@ getDFunSig (valName, valType) = do
             (symbolTy : dfhArgs) <- Just dfhArgs
             -- We handle both the old state where symbol was translated to unit
             -- and new state where it is translated to PromotedText.
-            dfhField <- case symbolTy of
-                LF.TUnit ->
-                    getFieldArg valName
-                LF.TCon (LF.Qualified _ (LF.ModuleName ["DA", "Internal", "Erased"]) (LF.TypeConName ["Erased"])) -> -- we probably don't need this case, unless an LF version comes out before PromotedText is added to DAML.
-                    getFieldArg valName
-                LF.TApp (LF.TCon (LF.Qualified _ (LF.ModuleName ["DA", "Internal", "PromotedText"]) (LF.TypeConName ["PromotedText"]))) (LF.TStruct [(LF.FieldName t, LF.TUnit)]) ->
-                    Just t
-                _ ->
-                    Nothing
+            dfhField <- getPromotedText symbolTy <|> getFieldArg valName
             guard (not $ T.null dfhField)
             Just DFunHeadHasField {..}
         else Just DFunHeadNormal {..}
@@ -1029,3 +1019,18 @@ convDFunSig env reexported DFunSig{..} = do
       . HsForAllTy noExt binders . noLoc
       . HsQualTy noExt (noLoc (map noLoc context)) . noLoc
       $ foldl (HsAppTy noExt . noLoc) cls (map noLoc args)
+
+getPromotedText :: LF.Type -> Maybe T.Text
+getPromotedText = \case
+    LF.TApp (LF.TCon LF.Qualified {..}) argTy
+        | qualPackage == LF.PRImport (LF.PackageId "d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97")
+        , qualModule == LF.ModuleName ["DA", "Internal", "PromotedText"]
+        , ["PromotedText"] <- LF.unTypeConName qualObject
+        ->
+            case argTy of
+                LF.TStruct [(LF.FieldName text, LF.TUnit)]
+                    | T.length text >= 1 && T.head text == '_' ->
+                        Just (T.tail text) -- strip leading underscore
+                _ ->
+                    error ("Unexpected argument type to DA.Internal.PromotedText: " <> show argTy)
+    _ -> Nothing

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -520,21 +520,27 @@ generateStablePackages lfVersion fp = do
         -- sandboxing which resulted in newly added files being picked up from other PRs.
         -- Given that this list doesn’t change too often and you will get a compile error
         -- if you forget to update it, we hardcode it here.
-        let dalfs =
-                map (fp </>) $
-                map ("daml-prim" </>) [ "DA-Internal-Erased.dalf", "DA-Types.dalf", "GHC-Prim.dalf", "GHC-Tuple.dalf", "GHC-Types.dalf"] <>
-                map ("daml-stdlib" </>)
-                  [ "DA-Internal-Any.dalf"
-                  , "DA-Internal-Template.dalf"
-                  , "DA-Date-Types.dalf"
-                  , "DA-NonEmpty-Types.dalf"
-                  , "DA-Time-Types.dalf"
-                  , "DA-Semigroup-Types.dalf"
-                  , "DA-Monoid-Types.dalf"
-                  , "DA-Validation-Types.dalf"
-                  , "DA-Logic-Types.dalf"
-                  , "DA-Internal-Down.dalf"
-                  ]
+        let dalfs = map (fp </>) $ concat
+                [ map ("daml-prim" </>)
+                    [ "DA-Internal-Erased.dalf"
+                    , "DA-Internal-PromotedText.dalf"
+                    , "DA-Types.dalf"
+                    , "GHC-Prim.dalf"
+                    , "GHC-Tuple.dalf"
+                    , "GHC-Types.dalf"]
+                , map ("daml-stdlib" </>)
+                    [ "DA-Internal-Any.dalf"
+                    , "DA-Internal-Template.dalf"
+                    , "DA-Date-Types.dalf"
+                    , "DA-NonEmpty-Types.dalf"
+                    , "DA-Time-Types.dalf"
+                    , "DA-Semigroup-Types.dalf"
+                    , "DA-Monoid-Types.dalf"
+                    , "DA-Validation-Types.dalf"
+                    , "DA-Logic-Types.dalf"
+                    , "DA-Internal-Down.dalf"
+                    ]
+                ]
         forM dalfs $ \dalf -> do
             let packagePath = takeFileName $ takeDirectory dalf
             let unitId = stringToUnitId $ if packagePath == "daml-stdlib"

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1418,9 +1418,13 @@ erasedTy env = do
 
 -- | Type-level strings are represented in DAML-LF via the PromotedText type. This is
 -- For example, the type-level string @"foo"@ will be represented by the type
--- @PromotedText {"foo": Unit}@. This allows us to preserve all the information we need
+-- @PromotedText {"_foo": Unit}@. This allows us to preserve all the information we need
 -- to reconstruct `HasField` instances in data-dependencies without resorting to
 -- name-based hacks.
+--
+-- Note: It's fine to put arbitrary non-empty strings in field names, because we mangle
+-- the field names in daml-lf-proto to encode undesired characters. We later reconstruct
+-- the original string during unmangling. See DA.Daml.LF.Mangling for more details.
 promotedTextTy :: Env -> T.Text -> ConvertM LF.Type
 promotedTextTy env text = do
     pkgRef <- packageNameToPkgRef env "daml-prim"
@@ -1428,7 +1432,7 @@ promotedTextTy env text = do
         (TCon . rewriteStableQualified env $ Qualified pkgRef
             (mkModName ["DA", "Internal", "PromotedText"])
             (mkTypeCon ["PromotedText"]))
-        (TStruct [(FieldName text, TUnit)])
+        (TStruct [(FieldName ("_" <> text), TUnit)])
 
 -- | Rewrite an a qualified name into a reference into one of the hardcoded
 -- stable packages if there is one.

--- a/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
+++ b/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 {-# LANGUAGE NoImplicitPrelude #-}
 daml 1.2
 module DA.Internal.PromotedText
@@ -10,11 +13,14 @@ import GHC.Types()
 --
 -- A type-level string "foo" will be represented as
 -- `PromotedText {"foo": Unit}` in DAML-LF, where
--- `{"foo": Unit}` is an LF struct with a single field
--- of unit type. The field name is what is taken as the
--- string name. There's no way to construct the requisite
--- LF struct directly in DAML.
+-- `{"_foo": Unit}` is an LF struct with a single field
+-- of unit type. The field name represents the type-level
+-- string, after adding an underscore and some name
+-- mangling. See daml-lf-proto and daml-lf-conversion for
+-- more details.
 --
--- In DAML, instead of using this type, you should just use
--- type-level strings directly.
+-- Note that there's no way to construct the requisite
+-- LF struct directly in DAML. In DAML, instead of using
+-- this type, you should just use type-level strings
+-- directly.
 data PromotedText t

--- a/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
+++ b/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
@@ -1,0 +1,20 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+daml 1.2
+module DA.Internal.PromotedText
+  ( PromotedText
+  ) where
+
+import GHC.Types()
+
+-- | Proxy type used to support type-level strings in DAML.
+--
+-- A type-level string "foo" will be represented as
+-- `PromotedText {"foo": Unit}` in DAML-LF, where
+-- `{"foo": Unit}` is an LF struct with a single field
+-- of unit type. The field name is what is taken as the
+-- string name. There's no way to construct the requisite
+-- LF struct directly in DAML.
+--
+-- In DAML, instead of using this type, you should just use
+-- type-level strings directly.
+data PromotedText t

--- a/compiler/damlc/daml-prim-src/LibraryModules.daml
+++ b/compiler/damlc/daml-prim-src/LibraryModules.daml
@@ -10,6 +10,7 @@ daml 1.2
 module LibraryModules where
 
 import DA.Internal.Erased
+import DA.Internal.PromotedText
 import Data.String
 import Control.Exception.Base
 import GHC.Base

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -333,6 +333,7 @@ baseImports =
            , "GHC.Types"
            , "DA.Types"
            , "DA.Internal.Erased"
+           , "DA.Internal.PromotedText"
            , "GHC.Err"
            , "Data.String"
            ]

--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -30,6 +30,7 @@ genrule(
         "daml-prim/GHC-Prim.dalf",
         "daml-prim/GHC-Tuple.dalf",
         "daml-prim/DA-Internal-Erased.dalf",
+        "daml-prim/DA-Internal-PromotedText.dalf",
         "daml-prim/DA-Types.dalf",
         "daml-stdlib/DA-Internal-Template.dalf",
         "daml-stdlib/DA-Internal-Any.dalf",
@@ -47,6 +48,7 @@ genrule(
       $(location :generate-stable-package) --module GHC.Prim -o $(location daml-prim/GHC-Prim.dalf)
       $(location :generate-stable-package) --module GHC.Tuple -o $(location daml-prim/GHC-Tuple.dalf)
       $(location :generate-stable-package) --module DA.Internal.Erased -o $(location daml-prim/DA-Internal-Erased.dalf)
+      $(location :generate-stable-package) --module DA.Internal.PromotedText -o $(location daml-prim/DA-Internal-PromotedText.dalf)
       $(location :generate-stable-package) --module DA.Types -o $(location daml-prim/DA-Types.dalf)
       $(location :generate-stable-package) --module DA.Time.Types -o $(location daml-stdlib/DA-Time-Types.dalf)
       $(location :generate-stable-package) --module DA.NonEmpty.Types -o $(location daml-stdlib/DA-NonEmpty-Types.dalf)
@@ -69,6 +71,7 @@ filegroup(
     name = "stable-packages",
     srcs = [
         "daml-prim/DA-Internal-Erased.dalf",
+        "daml-prim/DA-Internal-PromotedText.dalf",
         "daml-prim/DA-Types.dalf",
         "daml-prim/GHC-Prim.dalf",
         "daml-prim/GHC-Tuple.dalf",

--- a/compiler/damlc/stable-packages/src/GenerateStablePackage.hs
+++ b/compiler/damlc/stable-packages/src/GenerateStablePackage.hs
@@ -80,6 +80,8 @@ main = do
       writePackage daInternalDown optOutputPath
     ModuleName ["DA", "Internal", "Erased"] ->
       writePackage daInternalErased optOutputPath
+    ModuleName ["DA", "Internal", "PromotedText"] ->
+      writePackage daInternalPromotedText optOutputPath
     _ -> fail $ "Unknown module: " <> show optModule
 
 writePackage :: Package -> FilePath -> IO ()
@@ -505,6 +507,23 @@ daInternalErased = Package version1_6 $ NM.singleton Module
     erasedTyCon = mkTypeCon ["Erased"]
     types = NM.fromList
       [ DefDataType Nothing erasedTyCon (IsSerializable False) [] $ DataVariant []
+      ]
+
+daInternalPromotedText :: Package
+daInternalPromotedText = Package version1_6 $ NM.singleton Module
+  { moduleName = modName
+  , moduleSource = Nothing
+  , moduleFeatureFlags = daml12FeatureFlags
+  , moduleSynonyms = NM.empty
+  , moduleDataTypes = types
+  , moduleValues = NM.empty
+  , moduleTemplates = NM.empty
+  }
+  where
+    modName = mkModName ["DA", "Internal", "PromotedText"]
+    ptextTyCon = mkTypeCon ["PromotedText"]
+    types = NM.fromList
+      [ DefDataType Nothing ptextTyCon (IsSerializable False) [(mkTypeVar "t", KStar)] $ DataVariant []
       ]
 
 mkSelectorDef :: ModuleName -> TypeConName -> [(TypeVarName, Kind)] -> FieldName -> Type -> DefValue

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1048,6 +1048,8 @@ dataDependencyTests damlc repl davlDar oldProjDar = testGroup "Data Dependencies
               -- (i.e. this tests type-level strings across data-dependencies)
               , "usesHasField : (HasField \"a_field\" a b) => a -> b"
               , "usesHasField = getField @\"a_field\""
+              , "usesHasFieldEmpty : (HasField \"\" a b) => a -> b"
+              , "usesHasFieldEmpty = getField @\"\""
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -1063,7 +1065,7 @@ dataDependencyTests damlc repl davlDar oldProjDar = testGroup "Data Dependencies
           writeFileUTF8 (projb </> "src" </> "B.daml") $ unlines
               [ "daml 1.2"
               , "module B where"
-              , "import A ( Foo (foo), Bar (..), usingFoo, Q (..), usingEq, R(R), P(P), AnyWrapper(..), FunT(..), OptionalT(..), ActionTrans(..), usesHasField )"
+              , "import A ( Foo (foo), Bar (..), usingFoo, Q (..), usingEq, R(R), P(P), AnyWrapper(..), FunT(..), OptionalT(..), ActionTrans(..), usesHasField, usesHasFieldEmpty )"
               , "import DA.Assert"
               , "import DA.Record"
               , ""
@@ -1111,6 +1113,8 @@ dataDependencyTests damlc repl davlDar oldProjDar = testGroup "Data Dependencies
               -- type-level string test
               , "usesHasFieldIndirectly : HasField \"a_field\" a b => a -> b"
               , "usesHasFieldIndirectly = usesHasField"
+              , "usesHasFieldEmptyIndirectly : HasField \"\" a b => a -> b"
+              , "usesHasFieldEmptyIndirectly = usesHasFieldEmpty"
               ]
           writeFileUTF8 (projb </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion

--- a/compiler/damlc/tests/src/stable-packages.sh
+++ b/compiler/damlc/tests/src/stable-packages.sh
@@ -46,6 +46,7 @@ $DAMLC build --project-root $DIR -o $DIR/out.dar
 $DIFF -u -b <($DAMLC inspect-dar $DIR/out.dar | sed '1,/following packages/d' | head -n -1) <(cat <<EOF
 
 daml-prim-DA-Internal-Erased-76bf0fd12bd945762a01f8fc5bbcdfa4d0ff20f8762af490f8f41d6237c6524f "76bf0fd12bd945762a01f8fc5bbcdfa4d0ff20f8762af490f8f41d6237c6524f"
+daml-prim-DA-Internal-PromotedText-d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97 "d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97"
 daml-prim-DA-Types-40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7 "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7"
 daml-prim-GHC-Prim-e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b "e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b"
 daml-prim-GHC-Tuple-6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d "6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d"

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -129,7 +129,7 @@ tListPackages withSandbox = testCase "listPackages" $ run withSandbox $ \pid _te
     lid <- getLedgerIdentity
     pids <- listPackages lid
     liftIO $ do
-        assertEqual "#packages" 18 (length pids)
+        assertEqual "#packages" 19 (length pids)
         assertBool "The pid is listed" (pid `elem` pids)
 
 tGetPackage :: SandboxTest

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -35,7 +35,7 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.length == 18)
+    assert(interfaces.length == 19)
     assert(pkgPrefixes == Map.empty)
   }
 
@@ -48,8 +48,8 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.map(_.packageId).length == 18)
-    assert(pkgPrefixes.size == 18)
+    assert(interfaces.map(_.packageId).length == 19)
+    assert(pkgPrefixes.size == 19)
     assert(pkgPrefixes.values.forall(_ == "PREFIX"))
   }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -60,7 +60,7 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
         logEntry <- submitArchives("test-stable-submission", testStablePackages.all: _*).map(_._2)
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
-        logEntry.getPackageUploadEntry.getArchivesCount shouldEqual 17
+        logEntry.getPackageUploadEntry.getArchivesCount shouldEqual 18
       }
     }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -436,7 +436,7 @@ class JdbcLedgerDaoSpec
         firstUploadResult shouldBe PersistenceResponse.Ok
         secondUploadResult shouldBe PersistenceResponse.Ok
         loadedPackages.values.flatMap(_.sourceDescription.toList) should contain theSameElementsAs
-          Seq(firstDescription) ++ Seq.fill(16)(secondDescription)
+          Seq(firstDescription) ++ Seq.fill(17)(secondDescription)
       }
     }
 


### PR DESCRIPTION
This PR adds a `PromotedText` stable package, with `PromotedText` type, which is used to encode type-level strings from DAML into DAML-LF. The reason for this is to preserve the `HasField` instance argument. This PR adds a test that `HasField` is succesfully reconstructed in contexts, during data-dependencies, which wasn't possible before.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
