### PR TITLE
bind localhost for json-api and scenarios

### DIFF
--- a/compiler/scenario-service/server/BUILD.bazel
+++ b/compiler/scenario-service/server/BUILD.bazel
@@ -21,7 +21,6 @@ da_scala_binary(
     resources = glob(["src/main/resources/*"]),
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
-        "@maven//:io_grpc_grpc_netty",
     ],
     deps = [
         "//compiler/scenario-service/protos:scenario_service_java_proto",
@@ -35,6 +34,8 @@ da_scala_binary(
         "//daml-lf/validation",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -3,12 +3,14 @@
 
 package com.digitalasset.daml.lf.scenario
 
+import java.net.{InetAddress, InetSocketAddress}
 import java.util.logging.{Level, Logger}
 
 import com.digitalasset.daml.lf.archive.Decode.ParseError
 import com.digitalasset.daml.lf.scenario.api.v1.{Map => _, _}
 import io.grpc.stub.StreamObserver
-import io.grpc.{ServerBuilder, Status, StatusRuntimeException}
+import io.grpc.{Status, StatusRuntimeException}
+import io.grpc.netty.NettyServerBuilder
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.JavaConverters._
@@ -18,8 +20,8 @@ object ScenarioServiceMain extends App {
   // default to 128MB
   val maxMessageSize = args.headOption.map(_.toInt).getOrElse(128 * 1024 * 1024)
   val server =
-    ServerBuilder
-      .forPort(0) // any free port
+    NettyServerBuilder
+      .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, 0)) // any free port
       .addService(new ScenarioService())
       .maxInboundMessageSize(maxMessageSize)
       .build

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.http
 
 import java.io.File
+import java.net.InetAddress
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
@@ -20,7 +21,7 @@ import scala.util.Try
 private[http] final case class Config(
     ledgerHost: String,
     ledgerPort: Int,
-    address: String = "0.0.0.0",
+    address: String = InetAddress.getLoopbackAddress.getHostAddress,
     httpPort: Int,
     applicationId: ApplicationId = ApplicationId("HTTP-JSON-API-Gateway"),
     packageReloadInterval: FiniteDuration = HttpService.DefaultPackageReloadInterval,


### PR DESCRIPTION
Both were previously binding 0.0.0.0, which is inherently insecure. More importantly to me, that meant running `bazel test //...` essentially rendered my computer unusable for however long it took (which is _long_), as it kept popping up focus-stealing dialogs about whether or not I wanted to trust "java" to open an incoming network connection.

The ScenarioService does not seem to have an existing setup for CLI args and my Scala-fu is not good enough to add one, so I just changed the hard-coded path.

The JSON API already had an option, just with the wrong default. This is technically a breaking change, but I'm hoping to pass it under the "experimental" flag we still have on the JSON API.

CHANGELOG_BEGIN
- [JSON API - Experimental] ~BREAKING:~ As a security improvement, the JSON API server will now bind on ``127.0.0.1`` by default. Previous behaviour was to bind on ``0.0.0.0``; you can get that behaviour back by passing in the (existing) flag ``--address 0.0.0.0``.

- [DAML SDK] The Scenario Service will now bind on ``127.0.0.1``. Previous behaviour was to bind on ``0.0.0.0``.

CHANGELOG_END