### PR TITLE
Embed shake data-files via TH

### DIFF
--- a/bazel_tools/haskell-js-dgtable.patch
+++ b/bazel_tools/haskell-js-dgtable.patch
@@ -1,0 +1,46 @@
+diff --git a/js-dgtable.cabal b/js-dgtable.cabal
+index 37231b8..909c688 100644
+--- a/js-dgtable.cabal
++++ b/js-dgtable.cabal
+@@ -35,7 +35,8 @@ library
+     default-language: Haskell2010
+     hs-source-dirs:   src
+     build-depends:
+-        base == 4.*
++        base == 4.*,
++        file-embed
+ 
+     exposed-modules:
+         Language.Javascript.DGTable
+diff --git a/src/Language/Javascript/DGTable.hs b/src/Language/Javascript/DGTable.hs
+index f299c34..446bb6f 100644
+--- a/src/Language/Javascript/DGTable.hs
++++ b/src/Language/Javascript/DGTable.hs
+@@ -1,4 +1,4 @@
+-
++{-# LANGUAGE TemplateHaskell #-}
+ -- | Module for accessing minified jquery.dgtable code (<https://github.com/danielgindi/jquery.dgtable/>).
+ --   As an example:
+ --
+@@ -24,17 +24,20 @@
+ -- > dgTableContents :: BS.ByteString
+ -- > dgTableContents = $(embedFile =<< runIO DGTable.file)
+ module Language.Javascript.DGTable(
+-    version, file
++    version, file, fileContent
+     ) where
+ 
+ import qualified Paths_js_dgtable as Paths
+ import Data.Version
++import Data.FileEmbed
+ 
+ 
+ -- | A local file containing the minified jquery.dgtable code for 'version'.
+ file :: IO FilePath
+ file = Paths.getDataFileName "jquery.dgtable.min.js"
+ 
++fileContent = $(embedFile "javascript/jquery.dgtable.min.js")
++
+ -- | The version of jquery.dgtable provided by this package. Not necessarily the version of this package,
+ --   but the versions will match in the first three digits.
+ version :: Version

--- a/bazel_tools/haskell-js-flot.patch
+++ b/bazel_tools/haskell-js-flot.patch
@@ -1,0 +1,49 @@
+diff --git a/Language/Javascript/Flot.hs b/Language/Javascript/Flot.hs
+index aefee8b..cd73443 100644
+--- a/Language/Javascript/Flot.hs
++++ b/Language/Javascript/Flot.hs
+@@ -1,4 +1,5 @@
+ {-# LANGUAGE DeriveDataTypeable #-}
++{-# LANGUAGE TemplateHaskell #-}
+ 
+ -- | Module for accessing minified flot code (<http://www.flotcharts.org/>).
+ --   As an example:
+@@ -9,13 +10,14 @@
+ -- >     putStrLn $ "Flot version " ++ show Flot.version ++ " source:"
+ -- >     putStrLn =<< readFile =<< Flot.file Flot.Flot
+ module Language.Javascript.Flot(
+-    Flot(..), version, file
++    Flot(..), version, file, flotFileContent, flotStackFileContent
+     ) where
+ 
+ import qualified Paths_js_flot as Paths
+ import Data.Version
+ import Data.Data
+ import Data.Char
++import Data.FileEmbed
+ 
+ 
+ -- | The Flot code to obtain. Use 'Flot' for the base system and the other values
+@@ -42,6 +44,8 @@ data Flot
+ file :: Flot -> IO FilePath
+ file = Paths.getDataFileName . name
+ 
++flotFileContent = $(embedFile "javascript/jquery.flot.min.js")
++flotStackFileContent = $(embedFile "javascript/jquery.flot.stack.min.js")
+ 
+ name Flot = "jquery.flot.min.js"
+ name x = "jquery.flot." ++ map toLower (drop 4 $ show x) ++ ".min.js"
+diff --git a/js-flot.cabal b/js-flot.cabal
+index 2dabdb0..4b927df 100644
+--- a/js-flot.cabal
++++ b/js-flot.cabal
+@@ -48,7 +48,8 @@ source-repository head
+ library
+     default-language: Haskell2010
+     build-depends:
+-        base == 4.*
++        base == 4.*,
++        file-embed
+ 
+     exposed-modules:
+         Language.Javascript.Flot

--- a/bazel_tools/haskell-js-jquery.patch
+++ b/bazel_tools/haskell-js-jquery.patch
@@ -1,0 +1,48 @@
+diff --git a/js-jquery.cabal b/js-jquery.cabal
+index c159071..e58f88c 100644
+--- a/js-jquery.cabal
++++ b/js-jquery.cabal
+@@ -35,7 +35,8 @@ library
+     default-language: Haskell2010
+     hs-source-dirs:   src
+     build-depends:
+-        base == 4.*
++        base == 4.*,
++        file-embed
+ 
+     exposed-modules:
+         Language.Javascript.JQuery
+diff --git a/src/Language/Javascript/JQuery.hs b/src/Language/Javascript/JQuery.hs
+index 6badffd..97968ca 100644
+--- a/src/Language/Javascript/JQuery.hs
++++ b/src/Language/Javascript/JQuery.hs
+@@ -1,4 +1,4 @@
+-
++{-# LANGUAGE TemplateHaskell #-}
+ -- | Module for accessing minified jQuery code (<http://jquery.com/>).
+ --   As an example:
+ --
+@@ -24,12 +24,13 @@
+ -- > jQueryContents :: BS.ByteString
+ -- > jQueryContents = $(embedFile =<< runIO JQuery.file)
+ module Language.Javascript.JQuery(
+-    version, file, url
++    version, file, fileContent, url
+     ) where
+ 
+ import qualified Paths_js_jquery as Paths
+ import Data.List
+ import Data.Version
++import Data.FileEmbed
+ 
+ 
+ -- | A local file containing the minified jQuery code for 'version'.
+@@ -46,6 +47,8 @@ url = "//code.jquery.com/" ++ name
+ 
+ name = "jquery-" ++ intercalate "." (map show $ versionBranch version) ++ ".min.js"
+ 
++fileContent = $(embedFile $ "javascript/jquery-" ++ intercalate "." (map show $ take 3 $ versionBranch Paths.version) ++ ".min.js")
++
+ -- | The version of jQuery provided by this package. Not necessarily the version of this package,
+ --   but the versions will match in the first three digits.
+ version :: Version

--- a/bazel_tools/haskell-shake.patch
+++ b/bazel_tools/haskell-shake.patch
@@ -1,0 +1,19 @@
+diff --git a/src/General/Template.hs b/src/General/Template.hs
+index 5c1ec774..61701037 100755
+--- a/src/General/Template.hs
++++ b/src/General/Template.hs
+@@ -34,10 +34,10 @@ import Language.Haskell.TH.Syntax ( runIO )
+ 
+ libraries :: [(String, IO LBS.ByteString)]
+ libraries =
+-    [("jquery.js",            FILE(JQuery.file))
+-    ,("jquery.dgtable.js",    FILE(DGTable.file))
+-    ,("jquery.flot.js",       FILE(Flot.file Flot.Flot))
+-    ,("jquery.flot.stack.js", FILE(Flot.file Flot.FlotStack))
++    [("jquery.js",            pure $ LBS.fromStrict JQuery.fileContent)
++    ,("jquery.dgtable.js",    pure $ LBS.fromStrict DGTable.fileContent)
++    ,("jquery.flot.js",       pure $ LBS.fromStrict Flot.flotFileContent)
++    ,("jquery.flot.stack.js", pure $ LBS.fromStrict Flot.flotStackFileContent)
+     ]
+ 
+ 


### PR DESCRIPTION
This is a bit ugly but after spending some time digging into the
issues in rules_haskell around data-files, this seems like the most
sensible option especially given that we also want to ship them in the
SDK which woud require additional work even if we do fix it in
rules_haskell.

fixes #4457

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
