### PR TITLE
Extractor: only store contracts if a party is a stakeholder

### DIFF
--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -46,7 +46,7 @@ class Extractor[T](config: ExtractorConfig, target: T)(
     extends StrictLogging {
 
   private val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
-  private val parties = config.parties.widen[String]
+  private val parties: Set[String] = config.parties.toSet.map[String, Set[String]](identity)
 
   implicit val system: ActorSystem = ActorSystem()
   import system.dispatcher

--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -46,7 +46,7 @@ class Extractor[T](config: ExtractorConfig, target: T)(
     extends StrictLogging {
 
   private val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
-  private val parties = config.parties.toSet.map[String, Set[String]](identity)
+  private val parties = config.parties.widen[String]
 
   implicit val system: ActorSystem = ActorSystem()
   import system.dispatcher

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
@@ -32,9 +32,7 @@ object TransactionTreeTrimmer {
 
   private def exerciseEventOrStakeholder(parties: Set[String]): TreeEvent.Kind => Boolean = {
     case Kind.Created(event) =>
-      event.signatories.toSet.intersect(parties).nonEmpty || event.observers.toSet
-        .intersect(parties)
-        .nonEmpty
+      event.signatories.exists(parties) || event.observers.exists(parties)
     case Kind.Exercised(_) => true
     case Kind.Empty => false
   }

--- a/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/helpers/TransactionTreeTrimmer.scala
@@ -8,8 +8,12 @@ import com.digitalasset.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.digitalasset.ledger.api.v1.value.Identifier
 
 object TransactionTreeTrimmer {
-  def trim(templateIds: Set[Identifier]): TransactionTree => TransactionTree = {
-    val shouldKeep: TreeEvent.Kind => Boolean = containsTemplateId(templateIds.map(asTuple))
+  def trim(
+      parties: Set[String],
+      templateIds: Set[Identifier]): TransactionTree => TransactionTree = {
+    val shouldKeep: TreeEvent.Kind => Boolean = event =>
+      (templateIds.isEmpty || containsTemplateId(templateIds.map(asTuple))(event)) &&
+        exerciseEventOrStakeholder(parties)(event)
     transactionTree: TransactionTree =>
       {
         val eventsById = transactionTree.eventsById.filter(kv => shouldKeep(kv._2.kind))
@@ -23,6 +27,15 @@ object TransactionTreeTrimmer {
       templateIds: Set[(String, String, String)]): TreeEvent.Kind => Boolean = {
     case Kind.Created(event) => contains(templateIds)(event.templateId.map(asTuple))
     case Kind.Exercised(event) => contains(templateIds)(event.templateId.map(asTuple))
+    case Kind.Empty => false
+  }
+
+  private def exerciseEventOrStakeholder(parties: Set[String]): TreeEvent.Kind => Boolean = {
+    case Kind.Created(event) =>
+      event.signatories.toSet.intersect(parties).nonEmpty || event.observers.toSet
+        .intersect(parties)
+        .nonEmpty
+    case Kind.Exercised(_) => true
     case Kind.Empty => false
   }
 

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
@@ -12,14 +12,14 @@ import api.event
 import scalaz._
 import Scalaz._
 
-sealed trait Event
+sealed trait Event extends Serializable with Product
 
 final case class CreatedEvent(
     eventId: String,
     contractId: String,
     templateId: Identifier,
     createArguments: OfCid[V.ValueRecord],
-    witnessParties: Set[String]
+    stakeholders: Set[String]
 ) extends Event
 
 final case class ExercisedEvent(
@@ -66,7 +66,7 @@ object Event {
           apiEvent.contractId,
           templateId,
           createArguments,
-          apiEvent.witnessParties.toSet
+          (apiEvent.observers ++ apiEvent.signatories).toSet
         )
     }
   }

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -167,7 +167,7 @@ object Queries {
         ,package_id TEXT NOT NULL
         ,template TEXT NOT NULL
         ,create_arguments JSONB NOT NULL
-        ,witness_parties JSONB NOT NULL
+        ,stakeholders JSONB NOT NULL
         )
     """
 
@@ -196,7 +196,7 @@ object Queries {
           ${event.templateId.packageId},
           ${event.templateId.name},
           ${toJsonString(event.createArguments)}::jsonb,
-          ${toJsonString(event.witnessParties)}::jsonb
+          ${toJsonString(event.stakeholders)}::jsonb
         )
       """
   }
@@ -215,7 +215,7 @@ object Queries {
               ,_transaction_id TEXT NOT NULL
               ,_archived_by_transaction_id TEXT DEFAULT NULL
               ,_is_root_event BOOLEAN NOT NULL
-              ,_witness_parties JSONB NOT NULL
+              ,_stakeholders JSONB NOT NULL
               ${columnDefs}
             )
         """
@@ -246,7 +246,7 @@ object Queries {
         Fragment("?", transactionId), // _transaction_id
         Fragment.const("DEFAULT"), // _archived_by_transaction_id
         Fragment.const(if (isRoot) "TRUE" else "FALSE"), // _is_root_event
-        Fragment("?::jsonb", toJsonString(event.witnessParties)) // _witness_parties
+        Fragment("?::jsonb", toJsonString(event.stakeholders)) // _stakeholders
       )
 
       val contractArgColumns = event.createArguments.fields.map {

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/Types.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/Types.scala
@@ -28,7 +28,7 @@ trait Types {
       package_id: String,
       template: String,
       create_arguments: Json,
-      witness_parties: Json
+      stakeholders: Json
   )
 
   case class TransactionResult(

--- a/extractor/src/test/resources/damls/TransactionExample.daml
+++ b/extractor/src/test/resources/damls/TransactionExample.daml
@@ -33,6 +33,10 @@ template RightOfUseOffer
     controller tenant can
       Accept: ContractId RightOfUseAgreement
         do
+          -- we create this dummy template for landlord
+          -- so that we can later check that tenant doesn't see it
+          create DummyTemplateWeDontSubscribeFor
+            with party1=landlord; party2=landlord
           create RightOfUseAgreement
             with landlord; tenant; address; expirationDate
 

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionMultiTableSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionMultiTableSpec.scala
@@ -98,7 +98,7 @@ class TransactionMultiTableSpec
     archived_by_event_id1 shouldEqual Some(exercise.event_id)
 
     // ... while it resulted in `contract2`
-    exercise.child_event_ids shouldEqual List(event_id2).asJson
+    exercise.child_event_ids.asArray.toList.toVector.flatten should contain(event_id2.asJson)
     transaction_id2 shouldEqual transaction2.transaction_id
     // which is not archived
     archived_by_transaction_id2 shouldEqual None

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TransactionSingleTableSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest._
 import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-abstract class TransactionSingleTableSpec
+class TransactionSingleTableSpec
     extends FlatSpec
     with Suite
     with PostgresAroundAll
@@ -94,7 +94,8 @@ abstract class TransactionSingleTableSpec
     contract1.archived_by_event_id shouldEqual Some(exercise.event_id)
 
     // ... while it resulted in `contract2`
-    exercise.child_event_ids shouldEqual List(contract2.event_id).asJson
+    exercise.child_event_ids.asArray.toList.toVector.flatten should contain(
+      contract2.event_id.asJson)
     contract2.transaction_id shouldEqual transaction2.transaction_id
     // which is not archived
     contract2.archived_by_transaction_id shouldEqual None


### PR DESCRIPTION
```rst
CHANGELOG_BEGIN
- [Extractor (experimental)]: Contracts visible to a party without being a stakeholder are not stored anymore.
- [Extractor (experimental)]: Along with the previous change, the column ``contract.witness_parties`` has been renamed to ``contract.stakeholders``.
CHANGELOG_END
```

Contributes to #3498.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
