### PR TITLE
Allow custom commit workflow to be implemented for SubmissionValidator

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -61,18 +61,13 @@ class SubmissionValidator[LogResult](
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
-      transform: (DamlLogEntryId, StateMap, LogEntryAndState) => U
-  ): Future[Either[ValidationFailed, U]] = {
-    def applyTransformation(
-        logEntryId: DamlLogEntryId,
-        inputStates: StateMap,
-        logEntryAndState: LogEntryAndState,
-        stateOperations: LedgerStateOperations[LogResult],
-    ): Future[U] =
-      Future.successful(transform(logEntryId, inputStates, logEntryAndState))
-
-    runValidation(envelope, correlationId, recordTime, participantId, applyTransformation)
-  }
+      transform: (
+          DamlLogEntryId,
+          StateMap,
+          LogEntryAndState,
+          LedgerStateOperations[LogResult]) => Future[U]
+  ): Future[Either[ValidationFailed, U]] =
+    runValidation(envelope, correlationId, recordTime, participantId, transform)
 
   private def commit(
       logEntryId: DamlLogEntryId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -25,6 +25,8 @@ import scala.util.{Failure, Success, Try}
   * @param ledgerStateAccess defines how the validator retrieves/writes back state to the ledger
   * @param processSubmission defines how a log entry and state updates get generated from a submission
   * @param allocateLogEntryId  defines how new log entry IDs are being generated
+  * @param checkForMissingInputs  whether all inputs declared as the required inputs in the submission must be available
+  *                               in order to pass validation
   * @param executionContext  ExecutionContext to use when performing ledger state reads/writes
   */
 class SubmissionValidator[LogResult](


### PR DESCRIPTION
Summary of changes:
* Added parameter `LedgerStateOperations` to the passed transform function into `SubmissionValidator.validateAndTransform` and made it return a `Future`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
