### PR TITLE
Navigator: don't store divulged contracts

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -15,7 +15,7 @@ case class State(ledger: Ledger, packageRegistry: PackageRegistry)
 /** A DA party and its ledger view(s). */
 class PartyState(val name: ApiTypes.Party, val useDatabase: Boolean) {
   private val stateRef: AtomicReference[State] = new AtomicReference(
-    State(Ledger(None, useDatabase), new PackageRegistry))
+    State(Ledger(name, None, useDatabase), new PackageRegistry))
 
   def ledger: Ledger = stateRef.get.ledger
   def packageRegistry: PackageRegistry = stateRef.get.packageRegistry


### PR DESCRIPTION
```
CHANGELOG_BEGIN
- [Navigator]: Contracts visible to a party without being a stakeholder are not stored anymore.
CHANGELOG_END
```
Contributes to #3498.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
