### PR TITLE
Fall back on the builtin SDK version in damlc telemetry

### DIFF
--- a/libs-haskell/da-hs-base/BUILD.bazel
+++ b/libs-haskell/da-hs-base/BUILD.bazel
@@ -56,6 +56,7 @@ da_haskell_library(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-hs-lib",
         "//daml-assistant:daml-project-config",
     ],
 )


### PR DESCRIPTION
We have seen a few telemetry messages with the SDK version set to
`null` which is obviously not very useful. I suspect this is probably
because some users invoke damlc directly. This change is backwards
compatible since the ToJSON instance does encode `version = Just "x"` as
`"version" = "x"` and version = Nothing as `version = null`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
