### PR TITLE
Remove hardcoded number of packages from Java codegen test

### DIFF
--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -77,6 +77,8 @@ da_scala_test(
     deps = [
         ":lib",
         "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/interface",
         "//language-support/codegen-common",

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.nio.file.Files
 
 import com.digitalasset.daml.bazeltools.BazelRunfiles
+import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.codegen.backend.java.JavaBackend
 import com.digitalasset.daml.lf.codegen.conf.Conf
 import org.scalatest.{FlatSpec, Matchers}
@@ -19,6 +20,7 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
   def path(p: String) = new File(p).getAbsoluteFile.toPath
 
   val testDar = path(rlocation("language-support/java/codegen/test-daml.dar"))
+  val dar = DarReader().readArchiveFromFile(testDar.toFile).get
 
   val dummyOutputDir = Files.createTempDirectory("codegen")
 
@@ -48,8 +50,8 @@ class CodeGenRunnerTests extends FlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.map(_.packageId).length == 19)
-    assert(pkgPrefixes.size == 19)
+    assert(interfaces.map(_.packageId).length == dar.all.length)
+    assert(pkgPrefixes.size == dar.all.length)
     assert(pkgPrefixes.values.forall(_ == "PREFIX"))
   }
 }


### PR DESCRIPTION
This breaks everytime we change the number of packages in damlc which
is rather annoying.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
