### PR TITLE
[Engine] optimize conversion of Hash to String 

### DIFF
--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -31,7 +31,7 @@ da_scala_library(
 # the utilities from the tests.
 da_scala_test(
     name = "tests",
-    timeout = "long",
+    timeout = "moderate",
     srcs = glob(["src/test/**/*.scala"]),
     data = [
         "//daml-lf/tests:BasicTests.dar",

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -73,6 +73,7 @@ da_scala_library(
         ":value_java_proto",
         "//daml-lf/data",
         "//daml-lf/language",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -11,6 +11,7 @@ import java.util
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time, Utf8}
 import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.value.Value
+import com.google.common.io.BaseEncoding
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -20,18 +21,7 @@ final class Hash private (private val bytes: Array[Byte]) {
 
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexaString: String = {
-    import Hash._
-    // using `bytes.map("%02x" format _).mkString` is 300 times slower
-    val buff = Array.ofDim[Char](underlyingHashLength * 2)
-    var i = 0
-    while (i < underlyingHashLength) {
-      buff(i * 2) = HexaLookupTable((bytes(i) >> 4) & 0xF)
-      buff(i * 2 + 1) = HexaLookupTable(bytes(i) & 0xF)
-      i = i + 1
-    }
-    new String(buff)
-  }
+  def toHexaString: String = BaseEncoding.base16().encode(bytes)
 
   override def toString: String = s"Hash($toHexaString)"
 
@@ -304,8 +294,5 @@ object Hash {
       .add(submitTime.micros)
       .iterateOver(parties.toSeq.sorted[String].iterator, parties.size)(_ add _)
       .build
-
-  private val HexaLookupTable =
-    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -18,7 +18,7 @@ import javax.crypto.spec.SecretKeySpec
 import scala.util.control.NonFatal
 
 final class Hash private (private val bytes: Array[Byte]) {
-  
+
   def toByteArray: Array[Byte] = bytes.clone()
 
   def toHexaString: String = Hash.hexEncoding.encode(bytes)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -20,8 +20,18 @@ final class Hash private (private val bytes: Array[Byte]) {
 
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexaString: String =
-    bytes.map("%02x" format _).mkString
+  def toHexaString: String = {
+    import Hash._
+    // using `bytes.map("%02x" format _).mkString` is 300 times slower
+    val buff = Array.ofDim[Char](underlyingHashLength * 2)
+    var i = 0
+    while (i < underlyingHashLength) {
+      buff(i * 2) = HexaLookupTable((bytes(i) >> 4) & 0xF)
+      buff(i * 2 + 1) = HexaLookupTable(bytes(i) & 0xF)
+      i = i + 1
+    }
+    new String(buff)
+  }
 
   override def toString: String = s"Hash($toHexaString)"
 
@@ -294,5 +304,8 @@ object Hash {
       .add(submitTime.micros)
       .iterateOver(parties.toSeq.sorted[String].iterator, parties.size)(_ add _)
       .build
+
+  private val HexaLookupTable =
+    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -18,10 +18,10 @@ import javax.crypto.spec.SecretKeySpec
 import scala.util.control.NonFatal
 
 final class Hash private (private val bytes: Array[Byte]) {
-
+  
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexaString: String = BaseEncoding.base16().encode(bytes)
+  def toHexaString: String = Hash.hexEncoding.encode(bytes)
 
   override def toString: String = s"Hash($toHexaString)"
 
@@ -47,6 +47,8 @@ object Hash {
 
   private val version = 0.toByte
   private val underlyingHashLength = 32
+
+  private val hexEncoding = BaseEncoding.base16().lowerCase()
 
   def fromBytes(a: Array[Byte]): Either[String, Hash] =
     Either.cond(
@@ -231,7 +233,7 @@ object Hash {
   def fromString(s: String): Either[String, Hash] = {
     def error = s"Cannot parse hash $s"
     try {
-      val bytes = s.sliding(2, 2).map(Integer.parseInt(_, 16).toByte).toArray
+      val bytes = hexEncoding.decode(s)
       Either.cond(
         bytes.length == underlyingHashLength,
         new Hash(bytes),


### PR DESCRIPTION
Fix the performance regression spot by Moritz within the `LargeTransactionTest`.

We replace the `bytes.map("%02x" format _).mkString` an hard coded conversion. 
This improve the conversion by more than 200 times. 

The test run in 50.3s instead of 101.3s

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
