### PR TITLE
Push down completion requests to data access layer

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -14,7 +14,8 @@ import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails, TransactionId}
+import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.platform.metrics.timedFuture
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
@@ -35,7 +36,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val lookupContract: Timer = metrics.timer("daml.index.lookup_contract")
     val lookupKey: Timer = metrics.timer("daml.index.lookup_key")
     val lookupTransaction: Timer = metrics.timer("daml.index.lookup_transaction")
-    val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration ")
+    val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
     val parties: Timer = metrics.timer("daml.index.parties")
     val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
@@ -52,6 +53,13 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     ledger.ledgerEntries(offset, endOpt)
 
   override def ledgerEnd: Long = ledger.ledgerEnd
+
+  override def completions(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long],
+      applicationId: ApplicationId,
+      parties: Set[Party]): Source[(Long, domain.CompletionEvent), NotUsed] =
+    ledger.completions(beginInclusive, endExclusive, applicationId, parties)
 
   override def snapshot(filter: TemplateAwareFilter): Future[LedgerSnapshot] =
     ledger.snapshot(filter)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -110,7 +110,7 @@ class InMemoryLedger(
       parties: Set[Party]): Source[(Long, CompletionEvent), NotUsed] =
     entries
       .getSource(beginInclusive, endExclusive)
-      .collect { case (offset, InMemoryLedgerEntry(entry)) => offset -> entry }
+      .collect { case (offset, InMemoryLedgerEntry(entry)) => (offset + 1, entry) }
       .collect(CompletionFromTransaction(applicationId.unwrap, parties))
 
   override def ledgerEnd: Long = entries.ledgerEnd

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -26,6 +26,7 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
   CommandId,
+  CompletionEvent,
   LedgerId,
   PartyDetails,
   RejectionReason,
@@ -45,9 +46,10 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
-import com.digitalasset.platform.store.LedgerSnapshot
+import com.digitalasset.platform.store.{CompletionFromTransaction, LedgerSnapshot}
 import org.slf4j.LoggerFactory
 import scalaz.Tag
+import scalaz.syntax.tag.ToTagOps
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
@@ -100,6 +102,16 @@ class InMemoryLedger(
   private var acs = acs0
   private var deduplicator = Deduplicator()
   private var ledgerConfiguration: Option[Configuration] = None
+
+  override def completions(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long],
+      applicationId: ApplicationId,
+      parties: Set[Party]): Source[(Long, CompletionEvent), NotUsed] =
+    entries
+      .getSource(beginInclusive, endExclusive)
+      .collect { case (offset, InMemoryLedgerEntry(entry)) => offset -> entry }
+      .collect(CompletionFromTransaction(applicationId.unwrap, parties))
 
   override def ledgerEnd: Long = entries.ledgerEnd
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.store
+
+import com.daml.ledger.participant.state.v1.TransactionId
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.ledger.{ApplicationId, CommandId}
+import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.api.domain.CompletionEvent
+import com.digitalasset.ledger.api.domain.CompletionEvent.{CommandAccepted, CommandRejected}
+import com.digitalasset.platform.store.dao.LedgerDao
+import com.digitalasset.platform.store.entries.LedgerEntry
+
+// Turn a stream of transactions into a stream of completions for a given application and set of parties
+// TODO Remove this when:
+// TODO - the participant can read completions off the index directly AND
+// TODO - the in-memory sandbox is gone
+private[platform] object CompletionFromTransaction {
+
+  private def toApiOffset(offset: LedgerDao#LedgerOffset): domain.LedgerOffset.Absolute =
+    domain.LedgerOffset.Absolute(Ref.LedgerString.assertFromString(offset.toString))
+
+  private def toApiCommandId(commandId: CommandId): domain.CommandId =
+    domain.CommandId(commandId)
+
+  private def toApiTransactionId(transactionId: TransactionId): domain.TransactionId =
+    domain.TransactionId(transactionId)
+
+  // Filter completions for transactions for which we have the full submitter information: appId, submitter, cmdId
+  // This doesn't make a difference for the sandbox (because it represents the ledger backend + api server in single package).
+  // But for an api server that is part of a distributed ledger network, we might see
+  // transactions that originated from some other api server. These transactions don't contain the submitter information,
+  // and therefore we don't emit CommandAccepted completions for those
+  def apply(appId: ApplicationId, parties: Set[Ref.Party]): PartialFunction[
+    (LedgerDao#LedgerOffset, LedgerEntry),
+    (LedgerDao#LedgerOffset, CompletionEvent)] = {
+    case (
+        offset,
+        LedgerEntry.Transaction(
+          Some(cmdId),
+          transactionId,
+          Some(`appId`),
+          Some(submitter),
+          _,
+          _,
+          recordTime,
+          _,
+          _)) if parties(submitter) =>
+      offset -> CommandAccepted(
+        toApiOffset(offset),
+        recordTime,
+        toApiCommandId(cmdId),
+        toApiTransactionId(transactionId))
+    case (offset, LedgerEntry.Rejection(recordTime, commandId, `appId`, submitter, rejectionReason))
+        if parties(submitter) =>
+      offset -> CommandRejected(
+        toApiOffset(offset),
+        recordTime,
+        toApiCommandId(commandId),
+        rejectionReason)
+    case (offset, LedgerEntry.Checkpoint(recordedAt)) =>
+      offset -> CompletionEvent.Checkpoint(toApiOffset(offset), recordedAt)
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -7,13 +7,20 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.ledger.participant.state.v1.Configuration
+import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{LedgerId, PartyDetails, TransactionId}
+import com.digitalasset.ledger.api.domain.{
+  ApplicationId,
+  CompletionEvent,
+  LedgerId,
+  PartyDetails,
+  TransactionId
+}
 import com.digitalasset.ledger.api.health.ReportsHealth
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.store.entries.{
@@ -35,6 +42,12 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
       endExclusive: Option[Long]): Source[(Long, LedgerEntry), NotUsed]
 
   def ledgerEnd: Long
+
+  def completions(
+      beginInclusive: Option[Long],
+      endExclusive: Option[Long],
+      applicationId: ApplicationId,
+      parties: Set[Ref.Party]): Source[(Long, CompletionEvent), NotUsed]
 
   def snapshot(filter: TemplateAwareFilter): Future[LedgerSnapshot]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsReader.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.store.dao
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.ledger.ApplicationId
+import com.digitalasset.ledger.api.domain.CompletionEvent
+import com.digitalasset.platform.store.CompletionFromTransaction
+
+private[dao] object CommandCompletionsReader {
+
+  // Uses an existing LedgerReadDao to read completions from the ledger entries stream
+  // TODO Replace this to tap directly into the index
+  def apply(reader: LedgerReadDao): CommandCompletionsReader[LedgerDao#LedgerOffset] =
+    (from: Long, to: Long, appId: ApplicationId, parties: Set[Ref.Party]) =>
+      reader
+        .getLedgerEntries(from, to)
+        .map { case (offset, entry) => (offset + 1, entry) }
+        .collect(CompletionFromTransaction(appId, parties))
+}
+
+trait CommandCompletionsReader[LedgerOffset] {
+
+  /**
+    * Returns a stream of command completions
+    *
+    * TODO The current type parameter is to differentiate between checkpoints
+    * TODO and actual completions, it will change when we drop checkpoints
+    *
+    * TODO Drop the LedgerOffset from the source when we replace the Dispatcher mechanism
+    *
+    * @param startInclusive starting offset inclusive
+    * @param endExclusive   ending offset exclusive
+    * @return a stream of command completions tupled with their offset
+    */
+  def getCommandCompletions(
+      startInclusive: LedgerOffset,
+      endExclusive: LedgerOffset,
+      applicationId: ApplicationId,
+      parties: Set[Ref.Party]): Source[(LedgerOffset, CompletionEvent), NotUsed]
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1646,6 +1646,7 @@ private class JdbcLedgerDao(
     BatchSql(query, params.head, params.drop(1).toArray: _*).execute()
   }
 
+  override val completions: CommandCompletionsReader[LedgerOffset] = CommandCompletionsReader(this)
 }
 
 object JdbcLedgerDao {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -138,6 +138,8 @@ trait LedgerReadDao extends ReportsHealth {
       startInclusive: LedgerOffset,
       endExclusive: LedgerOffset): Source[(LedgerOffset, PackageLedgerEntry), NotUsed]
 
+  def completions: CommandCompletionsReader[LedgerOffset]
+
 }
 
 trait LedgerWriteDao extends ReportsHealth {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -117,6 +117,8 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
       startInclusive: LedgerOffset,
       endExclusive: LedgerOffset): Source[(LedgerOffset, ConfigurationEntry), NotUsed] =
     ledgerDao.getConfigurationEntries(startInclusive, endExclusive)
+
+  override val completions: CommandCompletionsReader[LedgerOffset] = ledgerDao.completions
 }
 
 class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: MetricRegistry)


### PR DESCRIPTION
This is largely a refactoring. The externally observable behavior is unchanged, but:

- a sub-dao is created for command completions (with the intent of breaking up the dao completely in future commits)
- the command completions dao can, in theory, directly fetch completions off the index
- in practice this is not implemented here to keep this PR as small as possible

Filtering ledger entries to get completions is moved to a function that is in turn used by:
- the ledger dao
- the in-memory sandbox

The plan for the former is to add a new table where completion-relevant data is stored so that it can be fetched quickly.

The plan for the latter is to get rid of it once DAML-on-SQL ships.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
