### PR TITLE
tell Gary when Azure fails to fetch commit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -397,7 +397,32 @@ jobs:
           # Note: this is going to get the PR branch commit, not the
           # result of the merge (i.e. this is not using the same commit as the
           # other jobs in this build).
-          git fetch origin $(branch_sha)
+          #
+          # We have seen errors getting this commit from GitHub, which we
+          # suspect are transient network errors, so adding simple exponential
+          # backoff to mitigate.
+          BACKOFF=1
+          tell_gary() {
+              curl -XPOST \
+                   -i \
+                   -H 'Content-Type: application/json' \
+                   --data "{\"text\":\"<@UEHSF89AQ> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has failed to fetch its commit $(branch_sha) up to BACKOFF=$BACKOFF.\"}" \
+                   $(Slack.team-daml-ci)
+          }
+          trap tell_gary EXIT
+          while !  git fetch origin $(branch_sha); do
+            if (( $BACKOFF > 500 )); then
+              echo "Could not get commit $(branch_sha); something is very wrong."
+              exit 1
+            else
+              sleep $BACKOFF
+              let "BACKOFF = $BACKOFF * 2"
+            fi
+          done
+          if (( $BACKOFF > 1 )); then
+              tell_gary
+          fi
+          trap - EXIT
           git checkout $(branch_sha)
 
           eval "$(./dev-env/bin/dade-assist)"
@@ -515,7 +540,31 @@ jobs:
       - bash: |
           set -euo pipefail
 
-          git fetch origin $(branch_sha)
+          # We have seen errors getting this commit from GitHub, which we
+          # suspect are transient network errors, so adding simple exponential
+          # backoff to mitigate.
+          BACKOFF=1
+          tell_gary() {
+              curl -XPOST \
+                   -i \
+                   -H 'Content-Type: application/json' \
+                   --data "{\"text\":\"<@UEHSF89AQ> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has failed to fetch its commit $(branch_sha) up to BACKOFF=$BACKOFF.\"}" \
+                   $(Slack.team-daml-ci)
+          }
+          trap tell_gary EXIT
+          while !  git fetch origin $(branch_sha); do
+            if (( $BACKOFF > 500 )); then
+              echo "Could not get commit $(branch_sha); something is very wrong."
+              exit 1
+            else
+              sleep $BACKOFF
+              let "BACKOFF = $BACKOFF * 2"
+            fi
+          done
+          if (( $BACKOFF > 1 )); then
+              tell_gary
+          fi
+          trap - EXIT
           git checkout $(branch_sha)
 
 


### PR DESCRIPTION
We have seen a number of failures recently where the collect_build_data and notify_user steps failed to fetch their branch commit from GitHub. Trying to reproduce locally doesn't work (i.e. fetching the same sha succeeds), so we're currently assuming transient network errors.

This PR adds a retry mechanism as well as a Slack message to help me keep tabs on the issue.

CHANGELOG_BEGIN
CHANGELOG_END