### PR TITLE
TypeScript: Make contract ids more type safe

### DIFF
--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -180,19 +180,26 @@ export const Date: Serializable<Date> = {
   decoder: jtv.string,
 }
 
+const ContractIdBrand: unique symbol = Symbol();
+
 /**
  * The counterpart of DAML's `ContractId T` type. We represent `ContractId`s
  * as strings. Their exact format of these strings depends on the ledger the
  * DAML application is running on.
+ *
+ * The purpose of the intersection with `{ [ContractIdBrand]: T }` is to
+ * prevent accidental use of a `ContractId<T>` when a `ContractId<U>` is
+ * needed (unless `T` is a subtype of `U`). This technique is known as
+ * "branding" in the TypeScript community.
  */
-export type ContractId<T> = string;
+export type ContractId<T> = string & { [ContractIdBrand]: T }
 
 /**
  * Companion object of the `ContractId` type.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const ContractId = <T>(_t: Serializable<T>): Serializable<ContractId<T>> => ({
-  decoder: jtv.string,
+  decoder: jtv.string as () => jtv.Decoder<ContractId<T>>,
 });
 
 /**


### PR DESCRIPTION
Currently, contract ids are simply presented by strings. Thus, it is very
easy to accidentally mix up contract ids of different templates. This PR
is an attempt to provide more safety in this regard. It prevents contract
ids of template types which are not in a _structural_ subtyping
relationship from being mixed up. This is far from perfect, but clearly
better than what we have now.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4614)
<!-- Reviewable:end -->
