### PR TITLE
Add package metadata to DAML-LF proto and the Haskell AST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -107,6 +107,20 @@ newtype PartyLiteral = PartyLiteral{unPartyLiteral :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
     deriving newtype (Hashable, NFData)
 
+-- | Human-readable name of a package. Must match the regex
+--
+-- > [a-zA-Z0-9_-]+
+newtype PackageName = PackageName{unPackageName :: T.Text}
+    deriving stock (Eq, Data, Generic, Ord, Show)
+    deriving newtype (Hashable, NFData)
+
+-- | Human-readable version of a package. Must match the regex
+--
+-- > [0-9]+(\.[0-9]+)*
+newtype PackageVersion = PackageVersion{unPackageVersion :: T.Text}
+    deriving stock (Eq, Data, Generic, Ord, Show)
+    deriving newtype (Hashable, NFData)
+
 -- | Reference to a package.
 data PackageRef
   = PRSelf
@@ -839,12 +853,20 @@ data Module = Module
   }
   deriving (Eq, Data, Generic, NFData, Show)
 
+
+data PackageMetadata = PackageMetadata
+    { packageName :: PackageName
+    , packageVersion :: PackageVersion
+    } deriving (Eq, Data, Generic, NFData, Show)
+
 -- | A package.
 data Package = Package
     { packageLfVersion :: Version
     , packageModules :: NM.NameMap Module
+    , packageMetadata :: Maybe PackageMetadata
     }
   deriving (Eq, Data, Generic, NFData, Show)
+
 
 -- | Type synonym for a reference to an LF value.
 type ValueRef = Qualified ExprValName

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -128,6 +128,8 @@ instance MonoTraversable ModuleRef TypeConName where monoTraverse _ = pure
 instance MonoTraversable ModuleRef TypeVarName where monoTraverse _ = pure
 instance MonoTraversable ModuleRef VariantConName where monoTraverse _ = pure
 instance MonoTraversable ModuleRef Version where monoTraverse _ = pure
+instance MonoTraversable ModuleRef PackageName where monoTraverse _ = pure
+instance MonoTraversable ModuleRef PackageVersion where monoTraverse _ = pure
 
 -- NOTE(MH): This is an optimization to avoid running into a dead end.
 instance {-# OVERLAPPING #-} MonoTraversable ModuleRef FilePath where monoTraverse _ = pure
@@ -178,6 +180,7 @@ instance MonoTraversable ModuleRef Template
 
 instance MonoTraversable ModuleRef FeatureFlags
 instance MonoTraversable ModuleRef Module
+instance MonoTraversable ModuleRef PackageMetadata
 instance MonoTraversable ModuleRef Package
 
 exprPartyLiteral

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -571,9 +571,19 @@ instance Pretty Module where
         | isEmpty prettyFlags = [keyword_ "module" <-> pretty modName <-> keyword_ "where"]
         | otherwise = [prettyFlags, keyword_ "module" <-> pretty modName <-> keyword_ "where"]
 
+instance Pretty PackageName where
+    pPrint = pretty . unPackageName
+
+instance Pretty PackageVersion where
+    pPrint = pretty . unPackageVersion
+
+instance Pretty PackageMetadata where
+    pPrint (PackageMetadata name version) = pretty name <> "-" <> pretty version
+
 instance Pretty Package where
-  pPrintPrec lvl _prec (Package version modules) =
+  pPrintPrec lvl _prec (Package version modules metadata) =
     vcat
       [ "daml-lf" <-> pPrintPrec lvl 0 version
+      , "metadata" <-> pPrintPrec lvl 0 metadata
       , vsep $ map (pPrintPrec lvl 0) (NM.toList modules)
       ]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -29,7 +29,7 @@ chcArgType :: TemplateChoice -> Type
 chcArgType = snd . chcArgBinder
 
 topoSortPackage :: Package -> Either [ModuleName] Package
-topoSortPackage (Package version mods) = do
+topoSortPackage pkg@Package{packageModules = mods} = do
   let isLocal (pkgRef, modName) = case pkgRef of
         PRSelf -> Just modName
         PRImport{} -> Nothing
@@ -41,7 +41,8 @@ topoSortPackage (Package version mods) = do
         -- NOTE(MH): A module referencing itself is not really a cycle.
         G.CyclicSCC [mod0] -> Right mod0
         G.CyclicSCC modCycle -> Left (map moduleName modCycle)
-  Package version . NM.fromList <$> traverse isAcyclic sccs
+  mods <- traverse isAcyclic sccs
+  pure pkg { packageModules = NM.fromList mods }
 
 data Arg
   = TmArg Expr

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/World.hs
@@ -70,7 +70,7 @@ initWorld :: [ExternalPackage] -> Version -> World
 initWorld importedPkgs version =
   World
     (foldl' insertPkg HMS.empty importedPkgs)
-    (Package version NM.empty)
+    (Package version NM.empty Nothing)
   where
     insertPkg hms (ExternalPackage pkgId pkg) = HMS.insert pkgId pkg hms
 
@@ -94,7 +94,7 @@ data LookupError
 
 lookupModule :: Qualified a -> World -> Either LookupError Module
 lookupModule (Qualified pkgRef modName _) (World importedPkgs selfPkg) = do
-  Package _version mods <- case pkgRef of
+  Package { packageModules = mods } <- case pkgRef of
     PRSelf -> pure selfPkg
     PRImport pkgId ->
       case HMS.lookup pkgId importedPkgs of

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -17,6 +17,7 @@ module DA.Daml.Compiler.Dar
 
 import qualified "zip" Codec.Archive.Zip as Zip
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
+import Control.Applicative
 import Control.Exception (assert)
 import Control.Monad.Extra
 import Control.Monad.IO.Class
@@ -226,8 +227,9 @@ mergePkgs ver pkgs =
              LF.Package
                  { LF.packageLfVersion = ver
                  , LF.packageModules = LF.packageModules pkg1 `NM.union` LF.packageModules pkg2
+                 , LF.packageMetadata = LF.packageMetadata pkg1 <|> LF.packageMetadata pkg2
                  })
-        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty }
+        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty, LF.packageMetadata = Nothing }
         pkgs
 
 -- | Find all DAML files below a given source root. If the source root is a file we interpret it as

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -50,8 +50,8 @@ newtype WhnfPackage = WhnfPackage { getWhnfPackage :: LF.Package }
     deriving Show
 
 instance NFData WhnfPackage where
-    rnf (WhnfPackage (LF.Package ver modules)) =
-        modules `seq` rnf ver
+    rnf (WhnfPackage (LF.Package ver modules metadata)) =
+        modules `seq` rnf ver `seq` rnf metadata
 
 type instance RuleResult GeneratePackage = WhnfPackage
 type instance RuleResult GenerateRawPackage = WhnfPackage

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
@@ -90,7 +90,9 @@ writeFileLf outFile lfPackage = do
 
 -- | Fails if there are any duplicate module names
 buildPackage :: HasCallStack => Maybe String -> Version -> [Module] -> Package
-buildPackage _mbPkgName version mods = Package version $ NM.fromList mods
+buildPackage _mbPkgName version mods =
+    -- TODO Set package metadata for new LF versions, see #4412
+    Package version (NM.fromList mods) Nothing
 
 instance Outputable Expr where
     ppr = text . renderPretty

--- a/compiler/damlc/stable-packages/src/GenerateStablePackage.hs
+++ b/compiler/damlc/stable-packages/src/GenerateStablePackage.hs
@@ -89,7 +89,7 @@ writePackage pkg path = do
   BS.writeFile path $ encodeArchive pkg
 
 ghcTypes :: Package
-ghcTypes = Package version1_6 $ NM.singleton Module
+ghcTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -110,7 +110,7 @@ ghcTypes = Package version1_6 $ NM.singleton Module
       }
 
 ghcPrim :: Package
-ghcPrim = Package version1_6 $ NM.singleton Module
+ghcPrim = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -138,8 +138,13 @@ ghcPrim = Package version1_6 $ NM.singleton Module
       , dvalBody = EEnumCon (qual (dataTypeCon dataVoid)) conName
       }
 
+package :: Version -> NM.NameMap Module -> Package
+package ver mods
+    | ver > version1_7 = error "Packages with LF version >= 1.7 need to have package metadata"
+    | otherwise = Package ver mods Nothing
+
 daTypes :: Package
-daTypes = Package version1_6 $ NM.singleton Module
+daTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -184,7 +189,7 @@ daTypes = Package version1_6 $ NM.singleton Module
     tupleWorkers = map tupleWorker [2..20]
 
 ghcTuple :: Package
-ghcTuple = Package version1_6 $ NM.singleton Module
+ghcTuple = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -207,7 +212,7 @@ ghcTuple = Package version1_6 $ NM.singleton Module
       ]
 
 daInternalTemplate :: Package
-daInternalTemplate = Package version1_6 $ NM.singleton Module
+daInternalTemplate = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -224,7 +229,7 @@ daInternalTemplate = Package version1_6 $ NM.singleton Module
       ]
 
 daInternalAny :: Package
-daInternalAny = Package version1_7 $ NM.singleton Module
+daInternalAny = package version1_7 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -247,7 +252,7 @@ daInternalAny = Package version1_7 $ NM.singleton Module
       ]
 
 daTimeTypes :: Package
-daTimeTypes = Package version1_6 $ NM.singleton Module
+daTimeTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -270,7 +275,7 @@ daTimeTypes = Package version1_6 $ NM.singleton Module
     usField = mkField "microseconds"
 
 daNonEmptyTypes :: Package
-daNonEmptyTypes = Package version1_6 $ NM.singleton Module
+daNonEmptyTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -297,7 +302,7 @@ daNonEmptyTypes = Package version1_6 $ NM.singleton Module
       ]
 
 daDateTypes :: Package
-daDateTypes = Package version1_6 $ NM.singleton Module
+daDateTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -337,7 +342,7 @@ daDateTypes = Package version1_6 $ NM.singleton Module
       ]
 
 daSemigroupTypes :: Package
-daSemigroupTypes = Package version1_6 $ NM.singleton Module
+daSemigroupTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -363,7 +368,7 @@ daSemigroupTypes = Package version1_6 $ NM.singleton Module
       ]
 
 daMonoidTypes :: Package
-daMonoidTypes = Package version1_6 $ NM.singleton Module
+daMonoidTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -404,7 +409,7 @@ daMonoidTypes = Package version1_6 $ NM.singleton Module
       ]
 
 daValidationTypes :: PackageId -> Package
-daValidationTypes nonEmptyPkgId = Package version1_6 $ NM.singleton Module
+daValidationTypes nonEmptyPkgId = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -435,7 +440,7 @@ daValidationTypes nonEmptyPkgId = Package version1_6 $ NM.singleton Module
       ]
 
 daLogicTypes :: Package
-daLogicTypes = Package version1_6 $ NM.singleton Module
+daLogicTypes = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -470,7 +475,7 @@ daLogicTypes = Package version1_6 $ NM.singleton Module
       ]
 
 daInternalDown :: Package
-daInternalDown = Package version1_6 $ NM.singleton Module
+daInternalDown = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -493,7 +498,7 @@ daInternalDown = Package version1_6 $ NM.singleton Module
       ]
 
 daInternalErased :: Package
-daInternalErased = Package version1_6 $ NM.singleton Module
+daInternalErased = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags
@@ -510,7 +515,7 @@ daInternalErased = Package version1_6 $ NM.singleton Module
       ]
 
 daInternalPromotedText :: Package
-daInternalPromotedText = Package version1_6 $ NM.singleton Module
+daInternalPromotedText = package version1_6 $ NM.singleton Module
   { moduleName = modName
   , moduleSource = Nothing
   , moduleFeatureFlags = daml12FeatureFlags

--- a/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
+++ b/compiler/damlc/tests/src/DA/Test/GenerateSimpleDalf.hs
@@ -117,6 +117,7 @@ main = do
     let pkg = Package
             { packageLfVersion = version
             , packageModules = NM.fromList [mod]
+            , packageMetadata = Nothing
             }
     let (bytes, hash) = encodeArchiveAndHash pkg
     BSL.writeFile file bytes

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -43,6 +43,7 @@
 //        2019-11-28: Rename Tuple to Struct
 //        2019-12-03: Add (experimental) text primitives.
 //        2019-12-05: Add Generic Equality builtin
+//        2020-02-20: Add PackageMetadata.
 
 syntax = "proto3";
 package daml_lf_1;
@@ -1454,5 +1455,5 @@ message Package {
   repeated Module modules = 1;
   repeated string interned_strings = 2; // *Available in versions >= 1.6*
   repeated InternedDottedName interned_dotted_names = 3; // *Available in versions >= 1.7*
-  PackageMetadata metadata = 4; // * Available in versions >= 1.dev*
+  PackageMetadata metadata = 4; // *Available in versions >= 1.dev* // *Required in versions >= 1.dev*
 }

--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -1445,8 +1445,14 @@ message InternedDottedName {
   repeated int32 segments_interned_str = 1; // *Available in versions >= 1.7*
 }
 
+message PackageMetadata {
+  int32 name_interned_str = 1; // *Available in versions >= 1.dev*
+  int32 version_interned_str = 2; // *Available in versions >= 1.dev*
+}
+
 message Package {
   repeated Module modules = 1;
   repeated string interned_strings = 2; // *Available in versions >= 1.6*
   repeated InternedDottedName interned_dotted_names = 3; // *Available in versions >= 1.7*
+  PackageMetadata metadata = 4; // * Available in versions >= 1.dev*
 }


### PR DESCRIPTION
This adds package metadata (currently only the package name and
version) to DAML-LF and the corresponding Haskell ASTs. This is useful
for debugging and “codegens” (typescript, damlc dependencies, …)

This PR does not yet add it to the Scala side or change the compiler
to actually produce this metadata.

Part of #4412

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
