### PR TITLE
Add subtractDays to the standard library

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Date.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Date.daml
@@ -8,6 +8,7 @@ module DA.Date
   ( DayOfWeek(..)
   , Month(..)
   , addDays
+  , subtractDays
   , subDate
   , dayOfWeek
   , fromGregorian
@@ -42,6 +43,12 @@ addDays : Date -> Int -> Date
 addDays d r =
     let dt = dateToDaysSinceEpoch d
     in daysSinceEpochToDate (dt + r)
+
+-- | Subtract the given number of days from a date.
+--
+-- `subtractDays d r` is equivalent to `addDays d (- r)`.
+subtractDays : Date -> Int -> Date
+subtractDays d r = addDays d (- r)
 
 -- | Returns the number of days between the two given dates.
 subDate : Date -> Date -> Int


### PR DESCRIPTION
`addDays d (- r)` looks a bit confusing and it’s not obvious that
negative numbers even work.

changelog_begin

- [DAML Standard Library] Add `subtractDays` to the DAML Standard Library.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
