### PR TITLE
Sandbox: Fix two race conditions on shutdown in ReadOnlySqlLedger.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -100,13 +100,15 @@ final class StandaloneApiServer(
         () => java.time.Clock.systemUTC.instant(),
         initialConditions.ledgerId,
         participantId)
-      indexService <- JdbcIndex(
-        initialConditions.config.timeModel,
-        domain.LedgerId(initialConditions.ledgerId),
-        participantId,
-        config.jdbcUrl,
-        metrics,
-      )(materializer, logCtx)
+      indexService <- JdbcIndex
+        .owner(
+          initialConditions.config.timeModel,
+          domain.LedgerId(initialConditions.ledgerId),
+          participantId,
+          config.jdbcUrl,
+          metrics,
+        )(materializer, logCtx)
+        .acquire()
       healthChecks = new HealthChecks(
         "index" -> indexService,
         "read" -> readService,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -10,24 +10,25 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.IndexService
 import com.daml.ledger.participant.state.v1.{ParticipantId, TimeModel}
-import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.logging.LoggingContext
-import com.digitalasset.resources.Resource
+import com.digitalasset.resources.ResourceOwner
 
 object JdbcIndex {
-  def apply(
+  def owner(
       timeModel: TimeModel,
       ledgerId: LedgerId,
       participantId: ParticipantId,
       jdbcUrl: String,
       metrics: MetricRegistry,
-  )(implicit mat: Materializer, logCtx: LoggingContext): Resource[IndexService] =
-    ReadOnlySqlLedger(jdbcUrl, ledgerId, metrics).map { ledger =>
-      new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
-        override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
-          // FIXME(JM): The indexer should on start set the default configuration.
-          Source.single(v2.LedgerConfiguration(timeModel.minTtl, timeModel.maxTtl))
+  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexService] =
+    ReadOnlySqlLedger
+      .owner(jdbcUrl, ledgerId, metrics)
+      .map { ledger =>
+        new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
+          override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
+            // FIXME(JM): The indexer should on start set the default configuration.
+            Source.single(v2.LedgerConfiguration(timeModel.minTtl, timeModel.maxTtl))
+        }
       }
-    }(DirectExecutionContext)
 }


### PR DESCRIPTION
It appears that there are two race conditions regarding the ledger end update mechanism.

1.  The dispatcher can keep firing for a little while even after we shut down the source, which can cause a spurious connection failure as it makes a query on a closed database connection.
2.  We don't wait for the sink to complete, which means, again, we could shut down the connection before the last `lookupLedgerEnd` query is issued.

This also makes sure we actually construct a new source if the updates fail. Previously we were re-using the same source, which looked like a crash-loop waiting to happen.

Tested by constructing `ReadOnlySqlLedger` and closing it in a loop, and watching for errors. I believe this will fix #3500, but I'd like @oliverse-da to verify.

I also changed `ReadOnlySqlServer` to construct a `ResourceOwner` rather than a `Resource`.

### Changelog

- **[Ledger API Server]** Fix a race condition on shutdown in which polling for the ledger end could continue even after the database connection was closed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
