### PR TITLE
@daml/ledger: Use {live: true} marker from JSON API

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -370,10 +370,12 @@ class Ledger {
         haveSeenEvents = true;
         emitter.emit('change', state, events);
       } else if (isRecordWith('heartbeat', json)) {
-        // NOTE(MH): If we receive the first heartbeat before any events, then
-        // it's very likely nothing in the ACS matches the query. We signal this
-        // by pretending we received an empty list of events. This never does
-        // any harm.
+        // NOTE(MH): Threre's nothing to be done with heartbeats.
+      } else if (isRecordWith('live', json) && json.live === true) {
+        // NOTE(MH): If we receive the marker indicating that we are switching
+        // from the ACS to the live stream and we haven't received any events
+        // yet, we signal this by pretending we received an empty list of
+        // events. This never does any harm.
         if (!haveSeenEvents) {
           haveSeenEvents = true;
           emitter.emit('change', state, []);
@@ -390,7 +392,7 @@ class Ledger {
     // 'close' event, which we need to handle anyway.
     ws.onclose = ({code, reason}) => {
       emitter.emit('close', {code, reason});
-    }
+    };
     // TODO(MH): Make types stricter.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const on = (type: string, listener: any) => emitter.on(type, listener);
@@ -399,7 +401,7 @@ class Ledger {
     const close = () => {
       emitter.removeAllListeners();
       ws.close();
-    }
+    };
     return {on, off, close};
   }
 


### PR DESCRIPTION
Currently, we're using the first heartbeat as a guesstimate when we're
switching from the ACS to the live stream. These days, the JSON API has
a marker, namely `{live: true}`, to indicate this switch. This PR,
makes use of that marker.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4628)
<!-- Reviewable:end -->
