### PR TITLE
Refactor handling of package names and versions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -140,9 +140,14 @@ genrule(
         SDK_VERSION=$$(cat $(location VERSION))
         cat > $@ <<EOF
 module SdkVersion where
-sdkVersion, damlStdlib :: String
+
+import Module (stringToUnitId, UnitId)
+
+sdkVersion :: String
 sdkVersion = "$$SDK_VERSION"
-damlStdlib = "daml-stdlib-" ++ sdkVersion
+
+damlStdlib :: UnitId
+damlStdlib = stringToUnitId ("daml-stdlib-" ++ sdkVersion)
 EOF
     """,
 )
@@ -150,7 +155,10 @@ EOF
 da_haskell_library(
     name = "sdk-version-hs-lib",
     srcs = [":sdk-version-hs"],
-    hackage_deps = ["base"],
+    hackage_deps = [
+        "base",
+        "ghc-lib-parser",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -7,6 +7,7 @@ da_haskell_library(
     name = "daml-lf-ast",
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
+        "aeson",
         "base",
         "bytestring",
         "containers",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -11,6 +11,7 @@ module DA.Daml.LF.Ast.Base(
     module DA.Daml.LF.Ast.Base
     ) where
 
+import Data.Aeson
 import Data.Hashable
 import Data.Data
 import GHC.Generics(Generic)
@@ -112,14 +113,14 @@ newtype PartyLiteral = PartyLiteral{unPartyLiteral :: T.Text}
 -- > [a-zA-Z0-9_-]+
 newtype PackageName = PackageName{unPackageName :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData)
+    deriving newtype (Hashable, NFData, FromJSON)
 
 -- | Human-readable version of a package. Must match the regex
 --
 -- > [0-9]+(\.[0-9]+)*
 newtype PackageVersion = PackageVersion{unPackageVersion :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData)
+    deriving newtype (Hashable, NFData, FromJSON)
 
 -- | Reference to a package.
 data PackageRef

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -97,10 +97,10 @@ newtype PackageSdkVersion = PackageSdkVersion
 
 -- | daml.yaml config fields specific to packaging.
 data PackageConfigFields = PackageConfigFields
-    { pName :: String
+    { pName :: LF.PackageName
     , pSrc :: String
     , pExposedModules :: Maybe [String]
-    , pVersion :: Maybe String
+    , pVersion :: Maybe LF.PackageVersion
     , pDependencies :: [String]
     , pDataDependencies :: [String]
     , pSdkVersion :: PackageSdkVersion
@@ -120,7 +120,8 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
         then do
             bytes <- BSL.readFile pSrc
             -- in the dalfInput case we interpret pSrc as the filepath pointing to the dalf.
-            pure $ Just $ createArchive pkgConf "" bytes [] (toNormalizedFilePath ".") [] [] []
+            -- Note that the package id is obviously wrong but this feature is not something we expose to users.
+            pure $ Just $ createArchive pkgConf (LF.PackageId "") bytes [] (toNormalizedFilePath ".") [] [] []
         -- We need runActionSync here to ensure that diagnostics are printed to the terminal.
         -- Otherwise runAction can return before the diagnostics have been printed and we might die
         -- without ever seeing diagnostics.
@@ -131,7 +132,7 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                  lfVersion <- lift getDamlLfVersion
                  pkg <- case optShakeFiles opts of
                      Nothing -> mergePkgs lfVersion <$> usesE GeneratePackage files
-                     Just _ -> generateSerializedPackage pName files
+                     Just _ -> generateSerializedPackage (pkgNameVersion pName pVersion) files
 
                  MaybeT $ finalPackageCheck (toNormalizedFilePath pSrc) pkg
 
@@ -144,7 +145,7 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                      error $
                      "The following modules are declared in exposed-modules but are not part of the DALF: " <>
                      show (S.toList missingExposed)
-                 let (dalf, pkgId) = encodeArchiveAndHash pkg
+                 let (dalf, LF.PackageId -> pkgId) = encodeArchiveAndHash pkg
                  -- For now, we don’t include ifaces and hie files in incremental mode.
                  -- The main reason for this is that writeIfacesAndHie is not yet ported to incremental mode
                  -- but it also makes creation of the archive slightly faster and those files are only required
@@ -159,13 +160,13 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                          [ (T.pack $ unitIdString unitId, LF.dalfPackageBytes pkg, LF.dalfPackageId pkg)
                          | (unitId, pkg) <- Map.toList dalfDependencies0
                          ]
-                 confFile <- liftIO $ mkConfFile pkgConf pkgModuleNames (T.unpack pkgId)
+                 confFile <- liftIO $ mkConfFile pkgConf pkgModuleNames pkgId
                  let dataFiles = [confFile]
                  srcRoot <- getSrcRoot pSrc
                  pure $
                      createArchive
                          pkgConf
-                         (T.unpack pkgId)
+                         pkgId
                          dalf
                          dalfDependencies
                          srcRoot
@@ -265,44 +266,32 @@ getDamlRootFiles srcRoot = do
         then liftIO $ damlFilesInDir srcRoot
         else pure [toNormalizedFilePath srcRoot]
 
-fullPkgName :: String -> Maybe String -> String -> String
-fullPkgName n mbV h =
-    case mbV of
-        Nothing -> n <> "-" <> h
-        Just v -> n <> "-" <> v <> "-" <> h
-
-pkgNameVersion :: String -> Maybe String -> String
-pkgNameVersion n mbV =
-    case mbV of
-        Nothing -> n
-        Just v -> n ++ "-" ++ v
-
 mkConfFile ::
-       PackageConfigFields -> [String] -> String -> IO (String, BS.ByteString)
+       PackageConfigFields -> [String] -> LF.PackageId -> IO (String, BS.ByteString)
 mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = do
     deps <- mapM darUnitId =<< expandSdkPackages pDependencies
     pure (confName, confContent deps)
   where
     darUnitId "daml-stdlib" = pure damlStdlib
-    darUnitId "daml-prim" = pure "daml-prim"
+    darUnitId "daml-prim" = pure $ stringToUnitId "daml-prim"
     darUnitId f
       -- This case is used by data-dependencies. DALF names are not affected by
       -- -o so this should be fine.
-      | takeExtension f == ".dalf" = pure $ dropExtension $ takeFileName f
+      | takeExtension f == ".dalf" = pure $ stringToUnitId $ dropExtension $ takeFileName f
     darUnitId darPath = do
         archive <- ZipArchive.toArchive . BSL.fromStrict  <$> BS.readFile darPath
         manifest <- either (\err -> fail $ "Failed to read manifest of " <> darPath <> ": " <> err) pure $ readDalfManifest archive
-        maybe (fail $ "Missing 'Name' attribute in manifest of " <> darPath) pure (packageName manifest)
-    confName = pkgNameVersion pName pVersion ++ ".conf"
+        maybe (fail $ "Missing 'Name' attribute in manifest of " <> darPath) (pure . stringToUnitId) (packageName manifest)
+    confName = unitIdString (pkgNameVersion pName pVersion) ++ ".conf"
     key = fullPkgName pName pVersion pkgId
     confContent deps =
         BSC.toStrict $
         BSC.pack $
         unlines $
-            [ "name: " ++ pName
-            , "id: " ++ pkgNameVersion pName pVersion
+            [ "name: " ++ T.unpack (LF.unPackageName pName)
+            , "id: " ++ unitIdString (pkgNameVersion pName pVersion)
             ]
-            ++ ["version: " ++ v | Just v <- [pVersion] ]
+            ++ ["version: " ++ T.unpack v | Just (LF.PackageVersion v) <- [pVersion] ]
             ++
             [ "exposed: True"
             , "exposed-modules: " ++
@@ -310,7 +299,7 @@ mkConfFile PackageConfigFields {..} pkgModuleNames pkgId = do
             , "import-dirs: ${pkgroot}" ++ "/" ++ key -- we really want '/' here
             , "library-dirs: ${pkgroot}" ++ "/" ++ key
             , "data-dir: ${pkgroot}" ++ "/" ++ key
-            , "depends: " ++ unwords deps
+            , "depends: " ++ unwords (map unitIdString deps)
             ]
 
 sinkEntryDeterministic
@@ -329,7 +318,7 @@ sinkEntryDeterministic compression sink sel = do
 -- | Helper to bundle up all files into a DAR.
 createArchive ::
        PackageConfigFields
-    -> String
+    -> LF.PackageId
     -> BSL.ByteString -- ^ DALF
     -> [(T.Text, BS.ByteString, LF.PackageId)] -- ^ DALF dependencies
     -> NormalizedFilePath -- ^ Source root directory
@@ -351,7 +340,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies srcRoot fileD
                     (ifaceDir </> fromNormalizedFilePath srcRoot)
         entry <- Zip.mkEntrySelector $ pkgName </> fromNormalizedFilePath (makeRelative' ifaceRoot mPath)
         sinkEntryDeterministic Zip.Deflate (sourceFile $ fromNormalizedFilePath mPath) entry
-    let dalfName = pkgName </> pkgNameVersion pName pVersion <> "-" <> pkgId <.> "dalf"
+    let dalfName = pkgName </> fullPkgName pName pVersion pkgId <.> "dalf"
     let dependencies =
             [ (pkgName </> T.unpack depName <> "-" <> (T.unpack $ LF.unPackageId depPkgId) <> ".dalf", BSL.fromStrict bs)
             | (depName, bs, depPkgId) <- dalfDependencies
@@ -377,7 +366,7 @@ createArchive PackageConfigFields {..} pkgId dalf dalfDependencies srcRoot fileD
         map (breakAt72Bytes . BSLUTF8.fromString)
             [ "Manifest-Version: 1.0"
             , "Created-By: damlc"
-            , "Name: " <> pkgNameVersion pName pVersion
+            , "Name: " <> unitIdString (pkgNameVersion pName pVersion)
             , "Sdk-Version: " <> unPackageSdkVersion pSdkVersion
             , "Main-Dalf: " <> toPosixFilePath location
             , "Dalfs: " <> intercalate ", " (map toPosixFilePath dalfs)

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -701,9 +701,6 @@ mkKindedTyVar name = noLoc .
 mkRdrName :: T.Text -> Located RdrName
 mkRdrName = noLoc . mkRdrUnqual . mkOccName varName . T.unpack
 
-damlStdlibUnitId :: UnitId
-damlStdlibUnitId = stringToUnitId damlStdlib
-
 sumProdRecords :: LF.Module -> MS.Map [T.Text] [(LF.FieldName, LF.Type)]
 sumProdRecords m =
     MS.fromList
@@ -725,11 +722,11 @@ mkGhcType env = mkStableType env primUnitId $
     LF.ModuleName ["GHC", "Types"]
 
 mkLfInternalType :: Env -> String -> Gen (HsType GhcPs)
-mkLfInternalType env = mkStableType env damlStdlibUnitId $
+mkLfInternalType env = mkStableType env damlStdlib $
     LF.ModuleName ["DA", "Internal", "LF"]
 
 mkLfInternalPrelude :: Env -> String -> Gen (HsType GhcPs)
-mkLfInternalPrelude env = mkStableType env damlStdlibUnitId $
+mkLfInternalPrelude env = mkStableType env damlStdlib $
     LF.ModuleName ["DA", "Internal", "Prelude"]
 
 mkTyConTypeUnqual :: TyCon -> HsType GhcPs
@@ -775,7 +772,10 @@ genericInstances env externPkgId =
       generateGenericInstanceFor
           (nameOccName genClassName)
           tcdLName
-          (T.unpack $ LF.unPackageId externPkgId)
+          -- NOTE (MK) Using the package id as the unit id
+          -- sounds very sketchy but is only used for a debugging
+          -- command that should be removed soon.
+          (stringToUnitId $ T.unpack $ LF.unPackageId externPkgId)
           (noLoc $
            mkModuleName $
            T.unpack $ LF.moduleNameString $ LF.moduleName $ envMod env)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1405,7 +1405,7 @@ qualify env m x = do
 
 qDA_Types :: Env -> a -> ConvertM (Qualified a)
 qDA_Types env a = do
-  pkgRef <- packageNameToPkgRef env "daml-prim"
+  pkgRef <- packageNameToPkgRef env primUnitId
   pure $ rewriteStableQualified env $ Qualified pkgRef (mkModName ["DA", "Types"]) a
 
 -- | Types of a kind not supported in DAML-LF, e.g., the DataKinds stuff from GHC.Generics
@@ -1413,7 +1413,7 @@ qDA_Types env a = do
 -- cases in data-dependencies.
 erasedTy :: Env -> ConvertM LF.Type
 erasedTy env = do
-    pkgRef <- packageNameToPkgRef env "daml-prim"
+    pkgRef <- packageNameToPkgRef env primUnitId
     pure $ TCon $ rewriteStableQualified env (Qualified pkgRef (mkModName ["DA", "Internal", "Erased"]) (mkTypeCon ["Erased"]))
 
 -- | Type-level strings are represented in DAML-LF via the PromotedText type. This is
@@ -1427,7 +1427,7 @@ erasedTy env = do
 -- the original string during unmangling. See DA.Daml.LF.Mangling for more details.
 promotedTextTy :: Env -> T.Text -> ConvertM LF.Type
 promotedTextTy env text = do
-    pkgRef <- packageNameToPkgRef env "daml-prim"
+    pkgRef <- packageNameToPkgRef env primUnitId
     pure $ TApp
         (TCon . rewriteStableQualified env $ Qualified pkgRef
             (mkModName ["DA", "Internal", "PromotedText"])
@@ -1470,9 +1470,8 @@ nameToPkgRef env x =
     thisUnitId = envModuleUnitId env
     pkgMap = envPkgMap env
 
-packageNameToPkgRef :: Env -> String -> ConvertM LF.PackageRef
-packageNameToPkgRef env =
-  convertUnitId (envModuleUnitId env) (envPkgMap env) . GHC.stringToUnitId
+packageNameToPkgRef :: Env -> UnitId -> ConvertM LF.PackageRef
+packageNameToPkgRef env = convertUnitId (envModuleUnitId env) (envPkgMap env)
 
 convertTyCon :: Env -> TyCon -> ConvertM LF.Type
 convertTyCon env t

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
@@ -17,6 +17,7 @@ import qualified Data.NameMap               as NM
 import qualified Data.Text                  as T
 import           GHC.Stack                  (HasCallStack)
 import Language.Haskell.LSP.Types
+import Module (UnitId)
 import           Outputable (Outputable(..), text)
 
 mkVar :: T.Text -> ExprVarName
@@ -89,7 +90,7 @@ writeFileLf outFile lfPackage = do
     BS.writeFile outFile $ Archive.encodeArchive lfPackage
 
 -- | Fails if there are any duplicate module names
-buildPackage :: HasCallStack => Maybe String -> Version -> [Module] -> Package
+buildPackage :: HasCallStack => Maybe UnitId -> Version -> [Module] -> Package
 buildPackage _mbPkgName version mods =
     -- TODO Set package metadata for new LF versions, see #4412
     Package version (NM.fromList mods) Nothing

--- a/compiler/damlc/daml-opts/BUILD.bazel
+++ b/compiler/damlc/daml-opts/BUILD.bazel
@@ -18,6 +18,7 @@ da_haskell_library(
         "ghc-lib-parser",
         "ghcide",
         "mtl",
+        "text",
     ],
     src_strip_prefix = "daml-opts-types",
     visibility = ["//visibility:public"],

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -56,13 +56,13 @@ mayImportInternal =
         ]
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: Maybe String -> GHC.ParsedSource -> IdePreprocessedSource
-damlPreprocessor mbPkgName x
+damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedSource -> IdePreprocessedSource
+damlPreprocessor mbUnitId x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = checkModuleName x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x
-        , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbPkgName $ enumTypePreprocessor "GHC.Types" x
+        , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
         }
     where
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -12,6 +12,7 @@ import DA.Daml.Options
 import DA.Daml.Options.Types
 import Development.IDE.Types.Location
 import Development.IDE.Types.Options
+import Module (unitIdString)
 
 import Options.Applicative
 import Data.List.Extra
@@ -215,7 +216,7 @@ exec Damldoc{..} = do
         , do_inputFiles = map toNormalizedFilePath cMainFiles
         , do_docTemplate = cTemplate
         , do_transformOptions = transformOptions
-        , do_docTitle = T.pack <$> optMbPackageName cOptions
+        , do_docTitle = T.pack . unitIdString <$> optUnitId cOptions
         , do_combine = cCombine
         , do_extractOptions = cExtractOptions
         }

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -257,8 +257,6 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     optImportPath <- optImportPath
     optPackageDbs <- optPackageDir
     let optStablePackages = Nothing
-    -- let optMbPackageName = (_ mbSplitUnitId)
-    -- optMbPackageVersion <- pure Nothing
     let optIfaceDir = Nothing
     optPackageImports <- many optPackageImport
     optShakeProfiling <- shakeProfilingOpt

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -10,8 +10,11 @@ import Options.Applicative.Extended
 import Safe (lastMay)
 import Data.List
 import Data.Maybe
+import qualified Data.Text as T
 import qualified DA.Pretty           as Pretty
+import DA.Daml.Compiler.DataDependencies (splitUnitId)
 import DA.Daml.Options.Types
+import qualified DA.Daml.LF.Ast.Base as LF
 import qualified DA.Daml.LF.Ast.Version as LF
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
@@ -89,8 +92,8 @@ targetFileNameOpt = option (Just <$> str) $
         <> long "dar-name"
         <> value Nothing
 
-packageNameOpt :: Parser String
-packageNameOpt = argument str $
+packageNameOpt :: Parser GHC.UnitId
+packageNameOpt = fmap GHC.stringToUnitId $ argument str $
        metavar "PACKAGE-NAME"
     <> help "Name of the DAML package"
 
@@ -232,37 +235,49 @@ dlintUsageOpt = fmap (fromMaybe DlintDisabled . lastMay) $
 optDebugLog :: Parser Bool
 optDebugLog = switch $ help "Enable debug output" <> long "debug"
 
-optPackageName :: Parser (Maybe String)
-optPackageName = optional $ strOption $
+optPackageName :: Parser (Maybe GHC.UnitId)
+optPackageName = optional $ fmap GHC.stringToUnitId $ strOption $
        metavar "PACKAGE-NAME"
     <> help "create package artifacts for the given package name"
     <> long "package-name"
 
 -- | Parametrized by the type of pkgname parser since we want that to be different for
 -- "package".
-optionsParser :: Int -> EnableScenarioService -> Parser (Maybe String) -> Parser Options
-optionsParser numProcessors enableScenarioService parsePkgName = Options
-    <$> optImportPath
-    <*> optPackageDir
-    <*> pure Nothing
-    <*> parsePkgName
-    <*> pure Nothing
-    <*> many optPackageImport
-    <*> shakeProfilingOpt
-    <*> optShakeThreads
-    <*> lfVersionOpt
-    <*> optDebugLog
-    <*> optGhcCustomOptions
-    <*> pure enableScenarioService
-    <*> pure (optSkipScenarioValidation $ defaultOptions Nothing)
-    <*> dlintUsageOpt
-    <*> optIsGenerated
-    <*> optNoDflagCheck
-    <*> pure False
-    <*> pure (Haddock False)
-    <*> optCppPath
-    <*> pure (IncrementalBuild False)
-    <*> pure (InferDependantPackages True)
+optionsParser :: Int -> EnableScenarioService -> Parser (Maybe GHC.UnitId) -> Parser Options
+optionsParser numProcessors enableScenarioService parsePkgName = do
+    let parseUnitId Nothing = (Nothing, Nothing)
+        parseUnitId (Just unitId) = case splitUnitId (GHC.unitIdString unitId) of
+            (name, mbVersion) ->
+                ( Just . LF.PackageName $ T.pack name
+                , fmap (LF.PackageVersion . T.pack) mbVersion
+                )
+    ~(optMbPackageName, optMbPackageVersion) <-
+        fmap parseUnitId parsePkgName
+
+    optImportPath <- optImportPath
+    optPackageDbs <- optPackageDir
+    let optStablePackages = Nothing
+    -- let optMbPackageName = (_ mbSplitUnitId)
+    -- optMbPackageVersion <- pure Nothing
+    let optIfaceDir = Nothing
+    optPackageImports <- many optPackageImport
+    optShakeProfiling <- shakeProfilingOpt
+    optThreads <- optShakeThreads
+    optDamlLfVersion <- lfVersionOpt
+    optDebug <- optDebugLog
+    optGhcCustomOpts <- optGhcCustomOptions
+    let optScenarioService = enableScenarioService
+    let optSkipScenarioValidation = SkipScenarioValidation False
+    optDlintUsage <- dlintUsageOpt
+    optIsGenerated <- optIsGenerated
+    optDflagCheck <- optNoDflagCheck
+    let optCoreLinting = False
+    let optHaddock = Haddock False
+    let optIncrementalBuild = IncrementalBuild False
+    let optInferDependantPackages = InferDependantPackages True
+    optCppPath <- optCppPath
+
+    return Options{..}
   where
     optImportPath :: Parser [FilePath]
     optImportPath =

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -221,6 +221,7 @@ da_haskell_test(
         "base",
         "bytestring",
         "extra",
+        "ghc-lib-parser",
         "filepath",
         "process",
         "safe-exceptions",

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -15,6 +15,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSL.Char8
 import Data.List.Extra
 import Data.Maybe
+import Module (unitIdString)
 import System.Directory.Extra
 import System.Environment.Blank
 import System.Exit
@@ -869,7 +870,7 @@ dataDependencyTests damlc repl davlDar oldProjDar = testGroup "Data Dependencies
             , "-o"
             , "FooGen.dalf"
             , "--package"
-            , damlStdlib <> " (DA.Internal.LF as CurrentSdk.DA.Internal.LF, DA.Internal.Prelude as CurrentSdk.DA.Internal.Prelude, DA.Internal.Template as CurrentSdk.DA.Internal.Template)"
+            , unitIdString damlStdlib <> " (DA.Internal.LF as CurrentSdk.DA.Internal.LF, DA.Internal.Prelude as CurrentSdk.DA.Internal.Prelude, DA.Internal.Template as CurrentSdk.DA.Internal.Template)"
             , "--package"
             , "daml-prim (DA.Types as CurrentSdk.DA.Types, GHC.Types as CurrentSdk.GHC.Types)"
             ]
@@ -1146,7 +1147,7 @@ dataDependencyTests damlc repl davlDar oldProjDar = testGroup "Data Dependencies
               , "build-options:"
               , " - --target=1.dev"
               , " - --package=daml-prim"
-              , " - --package=" <> damlStdlib
+              , " - --package=" <> unitIdString damlStdlib
               , " - --package=old-proj-0.0.1"
               ]
           writeFileUTF8 (tmpDir </> "Upgrade.daml") $ unlines


### PR DESCRIPTION
This is a preparatory refactoring PR in preparation for propagating
package metadata into DAML-LF. There are no actual changes in here.

Primarily the changes consist of 3 things:

1. In options, we split the `optMbPackageName` field which previously
contained the unit id into `optMbPackageName` and
`optMbPackageVersion`.
2. We use newtypes for names and versions and try to keep them pretty
much everywhere (the only place missing is `splitUnitId`, I’ll do that
separately).
3. We use `UnitId` where we want `name-version`.

As was probably to be expected, this surfaced some minor issues. They
are pretty much exclusively in debugging or “internal” commands so
I’ve mostly just added notes/todos.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
