### PR TITLE
Support authentication in DAML script

### DIFF
--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -29,6 +29,7 @@ da_scala_library(
         "//ledger/ledger-api-common",
         "//ledger/participant-state",
         "//ledger/sandbox",
+        "//libs-scala/auth-utils",
         "//libs-scala/resources",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.daml.lf.engine.script
 
+import java.nio.file.{Path, Paths}
 import java.io.File
 import java.time.Duration
 
@@ -17,6 +18,7 @@ case class RunnerConfig(
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
     inputFile: Option[File],
+    accessTokenFile: Option[Path],
 )
 
 object RunnerConfig {
@@ -72,6 +74,12 @@ object RunnerConfig {
       }
       .text("Path to a file containing the input value for the script in JSON format.")
 
+    opt[String]("access-token-file")
+      .action { (f, c) =>
+        c.copy(accessTokenFile = Some(Paths.get(f)))
+      }
+      .text("File from which the access token will be read, required to interact with an authenticated ledger")
+
     help("help").text("Print this usage text")
 
     checkConfig(c => {
@@ -100,6 +108,7 @@ object RunnerConfig {
         timeProviderType = null,
         commandTtl = Duration.ofSeconds(30L),
         inputFile = None,
+        accessTokenFile = None,
       )
     )
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -27,6 +27,7 @@ import com.digitalasset.ledger.client.configuration.{
 }
 import com.digitalasset.ledger.client.services.commands.CommandUpdater
 import com.digitalasset.platform.services.time.TimeProviderType
+import com.digitalasset.auth.TokenHolder
 
 object RunnerMain {
 
@@ -44,11 +45,16 @@ object RunnerMain {
           Identifier(dar.main._1, QualifiedName.assertFromString(config.scriptIdentifier))
 
         val applicationId = ApplicationId("Script Runner")
+        // Note (MK): For now, we only support using a single-token for everything.
+        // We might want to extend this to allow for multiple tokens, e.g., one token per party +
+        // one admin token for allocating parties.
+        val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
         val clientConfig = LedgerClientConfiguration(
           applicationId = ApplicationId.unwrap(applicationId),
           ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
           commandClient = CommandClientConfiguration.default,
-          sslContext = None
+          sslContext = None,
+          token = tokenHolder.flatMap(_.token),
         )
         val timeProvider: TimeProvider =
           config.timeProviderType match {

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -59,6 +59,7 @@ da_scala_library(
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_spray_spray_json_2_12",
@@ -69,7 +70,10 @@ da_scala_library(
 da_scala_binary(
     name = "test_client_single_participant",
     main_class = "com.digitalasset.daml.lf.engine.script.test.SingleParticipant",
-    deps = [":test-lib"],
+    deps = [
+        ":test-lib",
+        "//libs-scala/auth-utils",
+    ],
 )
 
 da_scala_binary(
@@ -98,6 +102,46 @@ client_server_test(
     server_args = [
         "-w",
         "--port=0",
+    ],
+    server_files = ["$(rootpath :script-test.dar)"],
+)
+
+AUTH_TOKEN = "I_CAN_HAZ_AUTH"
+
+# This is a genrule so we can replace it by something nicer that actually generates the token
+# from some readable input so we can change it more easily.
+# For now, this corresponds to a token that has admin set to false
+# and actAs to Alice, Bob
+genrule(
+    name = "test-auth-token",
+    outs = ["test-auth-token.jwt"],
+    cmd = """
+      cat <<EOF > $(location test-auth-token.jwt)
+Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsiYWRtaW4iOmZhbHNlLCJhY3RBcyI6WyJBbGljZSIsIkJvYiJdfX0.UYogXMZvmhzzjmsmKayaDsI2hGKh1T2Sz5l9h4tdgGM
+EOF
+    """,
+)
+
+client_server_test(
+    name = "test_wallclock_time_authenticated",
+    client = ":test_client_single_participant",
+    client_args = [
+        "-w",
+        "--access-token-file",
+    ],
+    client_files = [
+        "$(rootpath :test-auth-token.jwt)",
+        "$(rootpath :script-test.dar)",
+    ],
+    data = [
+        ":script-test.dar",
+        ":test-auth-token.jwt",
+    ],
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "-w",
+        "--port=0",
+        "--auth-jwt-hs256-unsafe={}".format(AUTH_TOKEN),
     ],
     server_files = ["$(rootpath :script-test.dar)"],
 )

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -162,3 +162,9 @@ partyIdHintTest = do
   carol <- allocatePartyWithHint "carol" (PartyIdHint "carol")
   dan <- allocatePartyWithHint "dan" (PartyIdHint "dan")
   pure (carol, dan)
+
+auth : (Party, Party) -> Script ()
+auth (alice, bob) = do
+  proposal <- submit alice $ createCmd (TProposal alice bob)
+  _ <- submit bob $ exerciseCmd proposal Accept
+  pure ()

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
@@ -104,7 +104,7 @@ object MultiParticipant {
           Map.empty
         )
 
-        val runner = new TestRunner(participantParams, dar, config.wallclockTime)
+        val runner = new TestRunner(participantParams, dar, config.wallclockTime, None)
         MultiTest(dar, runner).runTests()
         MultiPartyIdHintTest(dar, runner).runTests()
     }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -53,7 +53,8 @@ object TestRunner {
 class TestRunner(
     val participantParams: Participants[ApiParameters],
     val dar: Dar[(PackageId, Package)],
-    val wallclockTime: Boolean)
+    val wallclockTime: Boolean,
+    val token: Option[String])
     extends StrictLogging {
   val applicationId = ApplicationId("DAML Script Test Runner")
 
@@ -61,7 +62,8 @@ class TestRunner(
     applicationId = applicationId.unwrap,
     ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
     commandClient = CommandClientConfiguration.default,
-    sslContext = None
+    sslContext = None,
+    token = token,
   )
   val ttl = java.time.Duration.ofSeconds(30)
   val timeProvider: TimeProvider =


### PR DESCRIPTION
changelog_begin

- [DAML Script - Experimental] Support running DAML scripts against an
authenticated ledger. The token is passed via ``--access-token-file``.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
