### PR TITLE
ActiveContract stakeholder party enrichment (add displayName to signatories and observers)

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -354,7 +354,7 @@ HTTP Response
         "status": 200,
         "result": {
             "observers": [
-                {"identifier": "Bob"}
+                {"identifier": "Charlie"}
             ],
             "agreementText": "",
             "payload": {

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -822,11 +822,19 @@ HTTP Response
         "status": 200,
         "result": [
             {
-                "party": "Alice",
-                "isLocal": true
+                "identifier": "Alice",
+                "displayName": "Alice & Co., LLC"
+            },
+            {
+                "identifier": "Bob"
             }
         ]
     }
+
+Where
+
+- ``identifier`` -- a stable unique identifier of a DAML party,
+- ``displayName`` -- optional human readable name associated with the party. Might not be unique.
 
 Streaming API
 *************

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -353,17 +353,25 @@ HTTP Response
     {
         "status": 200,
         "result": {
-            "observers": [],
+            "observers": [
+                {"identifier": "Bob"}
+            ],
             "agreementText": "",
             "payload": {
-                "observers": [],
+                "observers": ["Charlie"],
                 "issuer": "Alice",
                 "amount": "999.99",
                 "currency": "USD",
                 "owner": "Alice"
             },
             "signatories": [
-                "Alice"
+                {
+                    "identifier": "Alice",
+                    "displayName": "Alice & Co., LLC"
+                },
+                {
+                    "identifier": "Bob"
+                }
             ],
             "contractId": "#124:0",
             "templateId": "11c8f3ace75868d28136adc5cfc1de265a9ee5ad73fe8f2db97510e3631096a2:Iou:Iou"
@@ -477,7 +485,10 @@ HTTP Response
                             "newOwner": "Alice"
                         },
                         "signatories": [
-                            "Alice"
+                            {
+                                "identifier": "Alice",
+                                "displayName": "Alice & Co., LLC"
+                            }
                         ],
                         "contractId": "#201:1",
                         "templateId": "11c8f3ace75868d28136adc5cfc1de265a9ee5ad73fe8f2db97510e3631096a2:Iou:IouTransfer"
@@ -590,7 +601,11 @@ Contract Found HTTP Response
     {
         "status": 200,
         "result": {
-            "observers": [],
+            "observers": [
+                {
+                    "identifier": "Bob", "displayName": "Bob & Co., LLC"
+                }
+            ],
             "agreementText": "",
             "payload": {
                 "iou": {
@@ -603,7 +618,9 @@ Contract Found HTTP Response
                 "newOwner": "Alice"
             },
             "signatories": [
-                "Alice"
+                {
+                    "identifier": "Alice"
+                }
             ],
             "contractId": "#201:1",
             "templateId": "11c8f3ace75868d28136adc5cfc1de265a9ee5ad73fe8f2db97510e3631096a2:Iou:IouTransfer"
@@ -666,7 +683,7 @@ Contract Found HTTP Response
                 }
             },
             "signatories": [
-                "Alice"
+                {"identifier": "Alice"}
             ],
             "key": {
                 "_1": "Alice",
@@ -756,7 +773,7 @@ Nonempty HTTP Response
                     "owner": "Alice"
                 },
                 "signatories": [
-                    "Alice"
+                    {"identifier": "Alice"}
                 ],
                 "contractId": "#52:0",
                 "templateId": "b10d22d6c2f2fae41b353315cf893ed66996ecb0abe4424ea6a81576918f658a:Iou:Iou"
@@ -794,7 +811,7 @@ Nonempty HTTP Response with Unknown Template IDs Warning
                     "owner": "Alice"
                 },
                 "signatories": [
-                    "Alice"
+                    {"identifier": "Alice"}
                 ],
                 "contractId": "#52:0",
                 "templateId": "b10d22d6c2f2fae41b353315cf893ed66996ecb0abe4424ea6a81576918f658a:Iou:Iou"
@@ -883,7 +900,7 @@ to :doc:`lf-value-specification`::
                         "owner": "Alice"
                     },
                     "signatories": [
-                        "Alice"
+                        {"identifier": "Alice"}
                     ],
                     "contractId": "#1:0",
                     "templateId": "b70bbfbc77a4790f66d4840cb19f657dd20848f5e2f64e39ad404a6cbd98cf75:Iou:Iou"
@@ -934,7 +951,7 @@ and archives the one above, the same stream will eventually produce::
                         "owner": "Alice"
                     },
                     "signatories": [
-                        "Alice"
+                        {"identifier": "Alice"}
                     ],
                     "contractId": "#2:1",
                     "templateId": "b70bbfbc77a4790f66d4840cb19f657dd20848f5e2f64e39ad404a6cbd98cf75:Iou:Iou"
@@ -956,7 +973,7 @@ and archives the one above, the same stream will eventually produce::
                         "owner": "Alice"
                     },
                     "signatories": [
-                        "Alice"
+                        {"identifier": "Alice"}
                     ],
                     "contractId": "#2:2",
                     "templateId": "b70bbfbc77a4790f66d4840cb19f657dd20848f5e2f64e39ad404a6cbd98cf75:Iou:Iou"

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
@@ -27,6 +27,8 @@ class PartiesService(listAllParties: () => Future[List[PartyDetails]])(
 object PartiesService {
   type ResolveParty = String => Option[domain.PartyDetails]
 
-  def buildPartiesMap(parties: List[domain.PartyDetails]): Map[domain.Party, domain.PartyDetails] =
+  type PartyMap = Map[domain.Party, domain.PartyDetails]
+
+  def buildPartiesMap(parties: List[domain.PartyDetails]): PartyMap =
     parties.map(x => (x.identifier, x))(breakOut)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
@@ -14,3 +14,7 @@ class PartiesService(listAllParties: () => Future[List[PartyDetails]])(
     listAllParties().map(ps => ps.map(p => domain.PartyDetails.fromLedgerApi(p)))
   }
 }
+
+object PartiesService {
+  type ResolveParty = String => Option[domain.PartyDetails]
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -71,7 +71,7 @@ object ContractDao {
       party: domain.Party,
       templateId: domain.TemplateId.RequiredPkg,
       predicate: doobie.Fragment)(
-      implicit log: LogHandler): ConnectionIO[Vector[domain.ActiveContract[JsValue]]] = {
+      implicit log: LogHandler): ConnectionIO[Vector[domain.ActiveContract.WithParty[JsValue]]] = {
     import doobie.postgres.implicits._
     for {
       tpId <- Queries.surrogateTemplateId(
@@ -86,7 +86,7 @@ object ContractDao {
 
   private def toDomain(templateId: domain.TemplateId.RequiredPkg)(
       a: Queries.DBContract[Unit, JsValue, JsValue, Vector[String]])
-    : domain.ActiveContract[JsValue] =
+    : domain.ActiveContract.WithParty[JsValue] =
     domain.ActiveContract(
       contractId = domain.ContractId(a.contractId),
       templateId = templateId,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -170,7 +170,7 @@ object domain {
   object Contract {
 
     type WithParty[+LfV] = Contract[domain.Party, LfV]
-    type withPartyDetails[+LfV] = Contract[domain.PartyDetails, LfV]
+    type WithPartyDetails[+LfV] = Contract[domain.PartyDetails, LfV]
 
     def fromTransaction(
         tx: lav1.transaction.Transaction,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -84,7 +84,7 @@ object domain {
       queries: NonEmptyList[GetActiveContractsRequest]
   )
 
-  case class PartyDetails(party: Party, displayName: Option[String], isLocal: Boolean)
+  case class PartyDetails(identifier: Party, displayName: Option[String])
 
   final case class CommandMeta(
       commandId: Option[CommandId],
@@ -112,7 +112,7 @@ object domain {
 
   object PartyDetails {
     def fromLedgerApi(p: com.digitalasset.ledger.api.domain.PartyDetails): PartyDetails =
-      PartyDetails(Party(p.party), p.displayName, p.isLocal)
+      PartyDetails(Party(p.party), p.displayName)
   }
 
   sealed trait OffsetTag
@@ -247,7 +247,7 @@ object domain {
   object ActiveContract {
 
     type WithParty[+LfV] = ActiveContract[domain.Party, LfV]
-    type withPartyDetails[+LfV] = ActiveContract[domain.Party, LfV]
+    type withPartyDetails[+LfV] = ActiveContract[domain.PartyDetails, LfV]
 
     def matchesKey(k: LfValue)(a: domain.ActiveContract.WithParty[LfValue]): Boolean =
       a.key.fold(false)(_ == k)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -170,7 +170,7 @@ object domain {
   object Contract {
 
     type WithParty[+LfV] = Contract[domain.Party, LfV]
-    type withPartyDetails[+LfV] = Contract[domain.Party, LfV]
+    type withPartyDetails[+LfV] = Contract[domain.PartyDetails, LfV]
 
     def fromTransaction(
         tx: lav1.transaction.Transaction,
@@ -247,7 +247,7 @@ object domain {
   object ActiveContract {
 
     type WithParty[+LfV] = ActiveContract[domain.Party, LfV]
-    type withPartyDetails[+LfV] = ActiveContract[domain.PartyDetails, LfV]
+    type WithPartyDetails[+LfV] = ActiveContract[domain.PartyDetails, LfV]
 
     def matchesKey(k: LfValue)(a: domain.ActiveContract.WithParty[LfValue]): Boolean =
       a.key.fold(false)(_ == k)
@@ -300,8 +300,8 @@ object domain {
       }
     }
 
-    implicit val rightTraverseInstance: Traverse[ActiveContract[Party, +?]] =
-      bitraverseInstance.rightTraverse[domain.Party]
+    implicit def rightTraverseInstance[P]: Traverse[ActiveContract[P, +?]] =
+      bitraverseInstance.rightTraverse[P]
 
     implicit def hasTemplateId[P]: HasTemplateId[ActiveContract[P, +?]] =
       new HasTemplateId[ActiveContract[P, +?]] {
@@ -494,7 +494,7 @@ object domain {
 
   object ExerciseResponse {
     type WithParty[+LfV] = ExerciseResponse[domain.Party, LfV]
-    type WithPartyDetails[+LfV] = ExerciseResponse[domain.Party, LfV]
+    type WithPartyDetails[+LfV] = ExerciseResponse[domain.PartyDetails, LfV]
 
     implicit val bitraverseInstance: Bitraverse[ExerciseResponse] =
       new Bitraverse[ExerciseResponse] {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -175,12 +175,12 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
     }
 
-  implicit val ContractFormat: RootJsonFormat[domain.Contract[domain.Party, JsValue]] =
-    new RootJsonFormat[domain.Contract[domain.Party, JsValue]] {
+  implicit val ContractFormat: RootJsonFormat[domain.Contract[domain.PartyDetails, JsValue]] =
+    new RootJsonFormat[domain.Contract[domain.PartyDetails, JsValue]] {
       private val archivedKey = "archived"
       private val activeKey = "created"
 
-      override def read(json: JsValue): domain.Contract[domain.Party, JsValue] = json match {
+      override def read(json: JsValue): domain.Contract[domain.PartyDetails, JsValue] = json match {
         case JsObject(fields) =>
           fields.toList match {
             case List((`archivedKey`, archived)) =>
@@ -194,15 +194,16 @@ object JsonProtocol extends DefaultJsonProtocol {
         case _ => deserializationError("Contract must be an object")
       }
 
-      override def write(obj: domain.Contract[domain.Party, JsValue]): JsValue =
+      override def write(obj: domain.Contract[domain.PartyDetails, JsValue]): JsValue =
         obj.value match {
           case -\/(archived) => JsObject(archivedKey -> ArchivedContractFormat.write(archived))
           case \/-(active) => JsObject(activeKey -> ActiveContractFormat.write(active))
         }
     }
 
-  implicit val ActiveContractFormat: RootJsonFormat[domain.ActiveContract[domain.Party, JsValue]] =
-    jsonFormat7(domain.ActiveContract.apply[domain.Party, JsValue])
+  implicit val ActiveContractFormat
+    : RootJsonFormat[domain.ActiveContract[domain.PartyDetails, JsValue]] =
+    jsonFormat7(domain.ActiveContract.apply[domain.PartyDetails, JsValue])
 
   implicit val ArchivedContractFormat: RootJsonFormat[domain.ArchivedContract] =
     jsonFormat2(domain.ArchivedContract.apply)
@@ -278,8 +279,8 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
 
   implicit val ExerciseResponseFormat
-    : RootJsonFormat[domain.ExerciseResponse[domain.Party, JsValue]] =
-    jsonFormat2(domain.ExerciseResponse[domain.Party, JsValue])
+    : RootJsonFormat[domain.ExerciseResponse[domain.PartyDetails, JsValue]] =
+    jsonFormat2(domain.ExerciseResponse[domain.PartyDetails, JsValue])
 
   implicit val StatusCodeFormat: RootJsonFormat[StatusCode] =
     new RootJsonFormat[StatusCode] {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -44,7 +44,7 @@ object JsonProtocol extends DefaultJsonProtocol {
     nela => JsArray(nela.map(_.toJson).list.toVector)
 
   implicit val PartyDetails: JsonFormat[domain.PartyDetails] =
-    jsonFormat3(domain.PartyDetails.apply)
+    jsonFormat2(domain.PartyDetails.apply)
 
   object LfValueCodec
       extends ApiCodecCompressed[AbsoluteContractId](

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -175,12 +175,12 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
     }
 
-  implicit val ContractFormat: RootJsonFormat[domain.Contract[JsValue]] =
-    new RootJsonFormat[domain.Contract[JsValue]] {
+  implicit val ContractFormat: RootJsonFormat[domain.Contract[domain.Party, JsValue]] =
+    new RootJsonFormat[domain.Contract[domain.Party, JsValue]] {
       private val archivedKey = "archived"
       private val activeKey = "created"
 
-      override def read(json: JsValue): domain.Contract[JsValue] = json match {
+      override def read(json: JsValue): domain.Contract[domain.Party, JsValue] = json match {
         case JsObject(fields) =>
           fields.toList match {
             case List((`archivedKey`, archived)) =>
@@ -194,14 +194,15 @@ object JsonProtocol extends DefaultJsonProtocol {
         case _ => deserializationError("Contract must be an object")
       }
 
-      override def write(obj: domain.Contract[JsValue]): JsValue = obj.value match {
-        case -\/(archived) => JsObject(archivedKey -> ArchivedContractFormat.write(archived))
-        case \/-(active) => JsObject(activeKey -> ActiveContractFormat.write(active))
-      }
+      override def write(obj: domain.Contract[domain.Party, JsValue]): JsValue =
+        obj.value match {
+          case -\/(archived) => JsObject(archivedKey -> ArchivedContractFormat.write(archived))
+          case \/-(active) => JsObject(activeKey -> ActiveContractFormat.write(active))
+        }
     }
 
-  implicit val ActiveContractFormat: RootJsonFormat[domain.ActiveContract[JsValue]] =
-    jsonFormat7(domain.ActiveContract.apply[JsValue])
+  implicit val ActiveContractFormat: RootJsonFormat[domain.ActiveContract[domain.Party, JsValue]] =
+    jsonFormat7(domain.ActiveContract.apply[domain.Party, JsValue])
 
   implicit val ArchivedContractFormat: RootJsonFormat[domain.ArchivedContract] =
     jsonFormat2(domain.ArchivedContract.apply)
@@ -261,7 +262,8 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
 
       override def read(
-          json: JsValue): domain.ExerciseCommand[JsValue, domain.ContractLocator[JsValue]] = {
+          json: JsValue
+      ): domain.ExerciseCommand[JsValue, domain.ContractLocator[JsValue]] = {
         val reference = ContractLocatorFormat.read(json)
         val choice = fromField[domain.Choice](json, "choice")
         val argument = fromField[JsValue](json, "argument")
@@ -275,8 +277,9 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
     }
 
-  implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
-    jsonFormat2(domain.ExerciseResponse[JsValue])
+  implicit val ExerciseResponseFormat
+    : RootJsonFormat[domain.ExerciseResponse[domain.Party, JsValue]] =
+    jsonFormat2(domain.ExerciseResponse[domain.Party, JsValue])
 
   implicit val StatusCodeFormat: RootJsonFormat[StatusCode] =
     new RootJsonFormat[StatusCode] {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
@@ -6,13 +6,9 @@ package com.digitalasset.http.util
 import java.time.Instant
 
 import com.digitalasset.api.util.TimestampConversion.fromInstant
-import com.digitalasset.http.CommandService.Error
-import com.digitalasset.http.domain.Contract
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => lav1}
 import com.typesafe.scalalogging.StrictLogging
-import scalaz.\/
-import scalaz.syntax.show._
 
 object Commands extends StrictLogging {
   def create(
@@ -79,8 +75,4 @@ object Commands extends StrictLogging {
 
     lav1.command_service.SubmitAndWaitRequest(Some(commands))
   }
-
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def contracts(tx: lav1.transaction.Transaction): Error \/ List[Contract[lav1.value.Value]] =
-    Contract.fromTransaction(tx).leftMap(e => Error('contracts, e.shows))
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
@@ -64,7 +64,7 @@ private[http] object InsertDeleteStep extends WithLAV1[InsertDeleteStep] {
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   object Cid {
     implicit val ofDBC: Cid[DBContract[Any, Any, Any, Any]] = _.contractId
-    implicit val ofAC: Cid[domain.ActiveContract[Any]] = _.contractId.unwrap
+    implicit val ofAC: Cid[domain.ActiveContract[Any, Any]] = _.contractId.unwrap
     implicit def ofFst[L](implicit L: Cid[L]): Cid[(L, Any)] = la => L(la._1)
     // ofFst and ofSnd should *not* both be defined, being incoherent together
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -757,7 +757,7 @@ abstract class AbstractHttpServiceIntegrationTest
                         inside(SprayJson.decode[List[domain.PartyDetails]](jsArray)) {
                           case \/-(partyDetails) =>
                             val partyNames: Set[String] =
-                              partyDetails.map(_.party.unwrap)(breakOut)
+                              partyDetails.map(_.identifier.unwrap)(breakOut)
                             partyNames should contain("Alice")
                         }
                     }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -69,10 +69,10 @@ object Generators {
   def contractLocatorGen[LfV](lfv: Gen[LfV]): Gen[domain.ContractLocator[LfV]] =
     inputContractRefGen(lfv) map (domain.ContractLocator.structure.from(_))
 
-  def contractGen: Gen[domain.Contract[JsValue]] =
+  def contractGen: Gen[domain.Contract.WithParty[JsValue]] =
     scalazEitherGen(archivedContractGen, activeContractGen).map(domain.Contract(_))
 
-  def activeContractGen: Gen[domain.ActiveContract[JsValue]] =
+  def activeContractGen: Gen[domain.ActiveContract.WithParty[JsValue]] =
     for {
       contractId <- contractIdGen
       templateId <- Generators.genDomainTemplateId
@@ -82,7 +82,7 @@ object Generators {
       observers <- Gen.listOf(partyGen)
       agreementText <- Gen.identifier
     } yield
-      domain.ActiveContract[JsValue](
+      domain.ActiveContract(
         contractId = contractId,
         templateId = templateId,
         key = key,

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -38,7 +38,7 @@ class HttpServiceWithPostgresIntTest
       jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
       uri,
       encoder
-    ).flatMap { searchResult: List[domain.ActiveContract.WithParty[JsValue]] =>
+    ).flatMap { searchResult: List[domain.ActiveContract.WithPartyDetails[JsValue]] =>
       discard { searchResult should have size 2 }
       discard { searchResult.map(getField("currency")) shouldBe List.fill(2)(JsString("EUR")) }
       selectAllDbContracts.flatMap { listFromDb =>
@@ -69,7 +69,7 @@ class HttpServiceWithPostgresIntTest
     dao.transact(q.to[List]).unsafeToFuture()
   }
 
-  private def getField(k: String)(a: domain.ActiveContract.WithParty[JsValue]): JsValue =
+  private def getField(k: String)(a: domain.ActiveContract[_, JsValue]): JsValue =
     a.payload.asJsObject().getFields(k) match {
       case Seq(x) => x
       case xs @ _ => fail(s"Expected exactly one value, got: $xs")

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -38,7 +38,7 @@ class HttpServiceWithPostgresIntTest
       jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
       uri,
       encoder
-    ).flatMap { searchResult: List[domain.ActiveContract[JsValue]] =>
+    ).flatMap { searchResult: List[domain.ActiveContract.WithParty[JsValue]] =>
       discard { searchResult should have size 2 }
       discard { searchResult.map(getField("currency")) shouldBe List.fill(2)(JsString("EUR")) }
       selectAllDbContracts.flatMap { listFromDb =>
@@ -69,7 +69,7 @@ class HttpServiceWithPostgresIntTest
     dao.transact(q.to[List]).unsafeToFuture()
   }
 
-  private def getField(k: String)(a: domain.ActiveContract[JsValue]): JsValue =
+  private def getField(k: String)(a: domain.ActiveContract.WithParty[JsValue]): JsValue =
     a.payload.asJsObject().getFields(k) match {
       case Seq(x) => x
       case xs @ _ => fail(s"Expected exactly one value, got: $xs")

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -76,9 +76,9 @@ class JsonProtocolTest
     }
     "can be serialized and deserialized back to the same object" in forAll(contractGen) {
       contract0 =>
-        val actual: SprayJson.Error \/ domain.Contract[JsValue] = for {
+        val actual: SprayJson.Error \/ domain.Contract.WithParty[JsValue] = for {
           jsValue <- SprayJson.encode(contract0)
-          contract <- SprayJson.decode[domain.Contract[JsValue]](jsValue)
+          contract <- SprayJson.decode[domain.Contract.WithParty[JsValue]](jsValue)
         } yield contract
 
         inside(actual) {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -76,9 +76,9 @@ class JsonProtocolTest
     }
     "can be serialized and deserialized back to the same object" in forAll(contractGen) {
       contract0 =>
-        val actual: SprayJson.Error \/ domain.Contract.WithParty[JsValue] = for {
+        val actual: SprayJson.Error \/ domain.Contract.WithPartyDetails[JsValue] = for {
           jsValue <- SprayJson.encode(contract0)
-          contract <- SprayJson.decode[domain.Contract.WithParty[JsValue]](jsValue)
+          contract <- SprayJson.decode[domain.Contract.WithPartyDetails[JsValue]](jsValue)
         } yield contract
 
         inside(actual) {


### PR DESCRIPTION
> we are only talking about signatories and observers, period. All other occurrences of party will stay the same

See #4512

### TODOs for the follow-up PR

- [ ] Memoize `com.digitalasset.http.PartiesService#resolveParty`, look for `// TODO(Leo) memoize it`
- [x] Implement sync enpoint party enrichment `com.digitalasset.http.Endpoints#enrichParties`
- [ ]  Implement `com.digitalasset.http.WebSocketService#enrichParty`, currently it does a conversion:
```
private def enrichParty(p: domain.Party): domain.PartyDetails =
       domain.PartyDetails(p, None)
```
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
