### PR TITLE
@daml/react: Make the test suite invokable by yarn test

### DIFF
--- a/language-support/ts/daml-react/jest.config.js
+++ b/language-support/ts/daml-react/jest.config.js
@@ -1,6 +1,29 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const moduleNameMapper = {
+  '^@daml/types$': '../daml-types',
+  '^@daml/ledger$': '../daml-ledger',
+  // $1 used for @daml/react/ledgerStore
+  '^@daml/react(.*)$': '../daml-react$1'
+};
+
+// Bazel workaround for:
+//
+//   Invalid hook call. Hooks can only be called inside of the body of a function component.
+//
+// By default the test-case loads `react/cjs/react.development.js` and
+// fails with the above error. A similar issue with `ts_devserver` suggests
+// that `rules_nodejs` bundles conflicting versions of react in some of the
+// artifacts. See https://github.com/bazelbuild/rules_nodejs/issues/1383 .
+//
+// We do not want to use this workaround when invoking the test with
+// `yarn test`. We us the existence of the environment variable
+// `TEST_WORKSPACE` as a proxy for whether the test was invoked from bazel.
+if (process.env.TEST_WORKSPACE !== undefined) {
+  moduleNameMapper['^react$'] = '<rootDir>/../../../node_modules/react/umd/react.development.js';
+}
+
 module.exports = {
   testEnvironment: "node",
   testMatch: [
@@ -11,20 +34,5 @@ module.exports = {
     "^.+\\.(ts|tsx)$": "ts-jest",
     "^.+\\.(js|jsx)$": "babel-jest"
   },
-  moduleNameMapper: {
-    // Workaround for:
-    //
-    //   Invalid hook call. Hooks can only be called inside of the body of a function component.
-    //
-    // By default the test-case loads `react/cjs/react.development.js` and
-    // fails with the above error. A similar issue with `ts_devserver` suggests
-    // that `rules_nodejs` bundles conflicting versions of react in some of the
-    // artifacts. See https://github.com/bazelbuild/rules_nodejs/issues/1383 .
-    '^react$': '<rootDir>/../../../node_modules/react/umd/react.development.js',
-    '^@daml/types$': '../daml-types',
-    '^@daml/ledger$': '../daml-ledger',
-    // $1 used for @daml/react/ledgerStore
-    '^@daml/react(.*)$': '../daml-react$1'
-  }
+  moduleNameMapper,
 }
-


### PR DESCRIPTION
Unfortunately, we need to work around some bazel issues which lead to
confliciting versions of react in our tests. This workaround cannot be
used the tests are invoked via `yarn test`. Thus, we only use it when
we the tests from bazel. We use the existence of the environment
variable `TEST_WORKSPACE` as a proxy for whether we run from bazel.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4646)
<!-- Reviewable:end -->
