### PR TITLE
Produce package metadata in damlc

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 module DA.Daml.LF.Ast.Util(module DA.Daml.LF.Ast.Util) where
 
+import Control.Monad
 import Data.Maybe
 import qualified Data.Text as T
 import           Control.Lens
@@ -18,6 +19,7 @@ import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.TypeLevelNat
 import DA.Daml.LF.Ast.Optics
 import DA.Daml.LF.Ast.Recursive
+import DA.Daml.LF.Ast.Version
 
 dvalName :: DefValue -> ExprValName
 dvalName = fst . dvalBinder
@@ -274,3 +276,8 @@ removeLocations :: Expr -> Expr
 removeLocations = cata $ \case
     ELocationF _loc e -> e
     b -> embed b
+
+getPackageMetadata :: Version -> PackageName -> Maybe PackageVersion -> Maybe PackageMetadata
+getPackageMetadata lfVer pkgName mbPkgVersion = do
+    guard (lfVer `supports` featurePackageMetadata)
+    Just (PackageMetadata pkgName (fromMaybe (PackageVersion "0.0.0") mbPkgVersion))

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -51,7 +51,7 @@ data Feature = Feature
     , featureMinVersion :: !Version
     , featureCppFlag :: !T.Text
         -- ^ CPP flag to test for availability of the feature.
-    }
+    } deriving Show
 
 featureNumeric :: Feature
 featureNumeric = Feature
@@ -95,6 +95,13 @@ featureTypeSynonyms = Feature
     , featureCppFlag = "DAML_TYPE_SYNONYMS"
     }
 
+featurePackageMetadata :: Feature
+featurePackageMetadata = Feature
+    { featureName = "Package metadata"
+    , featureMinVersion = versionDev
+    , featureCppFlag = "DAML_PACKAGE_METADATA"
+    }
+
 -- Unstable, experimental features. This should stay in 1.dev forever.
 -- Features implemented with this flag should be moved to a separate
 -- feature flag once the decision to add them permanently has been made.
@@ -112,6 +119,7 @@ allFeatures =
     , featureTypeRep
     , featureStringInterning
     , featureGenMap
+    , featurePackageMetadata
     , featureUnstable
     ]
 

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -815,7 +815,9 @@ encodeFeatureFlags FeatureFlags{..} = Just P.FeatureFlags
 -- each scenario module is wrapped in a proto package
 encodeScenarioModule :: Version -> Module -> P.Package
 encodeScenarioModule version mod =
-    encodePackage (Package version (NM.insert mod NM.empty) Nothing)
+    encodePackage (Package version (NM.insert mod NM.empty) metadata)
+  where
+    metadata = getPackageMetadata version (PackageName "scenario") Nothing
 
 encodeModule :: Module -> Encode P.Module
 encodeModule Module{..} = do

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -131,8 +131,8 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                  opts <- lift getIdeOptions
                  lfVersion <- lift getDamlLfVersion
                  pkg <- case optShakeFiles opts of
-                     Nothing -> mergePkgs lfVersion <$> usesE GeneratePackage files
-                     Just _ -> generateSerializedPackage (pkgNameVersion pName pVersion) files
+                     Nothing -> mergePkgs pName pVersion lfVersion <$> usesE GeneratePackage files
+                     Just _ -> generateSerializedPackage pName pVersion files
 
                  MaybeT $ finalPackageCheck (toNormalizedFilePath pSrc) pkg
 
@@ -221,8 +221,8 @@ getSrcRoot fileOrDir = do
           pure $ toNormalizedFilePath root
 
 -- | Merge several packages into one.
-mergePkgs :: LF.Version -> [WhnfPackage] -> LF.Package
-mergePkgs ver pkgs =
+mergePkgs :: LF.PackageName -> Maybe LF.PackageVersion -> LF.Version -> [WhnfPackage] -> LF.Package
+mergePkgs pkgName mbPkgVer ver pkgs =
     foldl'
         (\pkg1 (WhnfPackage pkg2) -> assert (LF.packageLfVersion pkg1 == ver) $
              LF.Package
@@ -230,7 +230,7 @@ mergePkgs ver pkgs =
                  , LF.packageModules = LF.packageModules pkg1 `NM.union` LF.packageModules pkg2
                  , LF.packageMetadata = LF.packageMetadata pkg1 <|> LF.packageMetadata pkg2
                  })
-        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty, LF.packageMetadata = Nothing }
+        LF.Package { LF.packageLfVersion = ver, LF.packageModules = NM.empty, LF.packageMetadata = LF.getPackageMetadata ver pkgName mbPkgVer }
         pkgs
 
 -- | Find all DAML files below a given source root. If the source root is a file we interpret it as


### PR DESCRIPTION
This PR adds the necessary infrastructure to produce package metadata
in `damlc`.

For `damlc build` this works exactly as expected. There are a few edge
cases where we don’t have names and/or versions (namely scenarios,
damlc compile and damlc package). We don’t really care about the
metadata for those anyway, so I’ve just set it some default value.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
