### PR TITLE
Relieve Ledger API DB thread pool of unnecessary work

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1432,14 +1432,19 @@ private class JdbcLedgerDao(
     )
 
   override def getParties: Future[List[PartyDetails]] =
-    dbDispatcher.executeSql("load_parties") { implicit conn =>
-      SQL_SELECT_PARTIES
-        .as(PartyDataParser.*)
-        // TODO: isLocal should be based on equality of participantId reported in an
-        // update and the id given to participant in a command-line argument
-        // (See issue #2026)
-        .map(d => PartyDetails(Party.assertFromString(d.party), d.displayName, isLocal = true))
-    }
+    dbDispatcher
+      .executeSql("load_parties") { implicit conn =>
+        SQL_SELECT_PARTIES
+          .as(PartyDataParser.*)
+      }
+      .map(
+        _.map(
+          d =>
+            // TODO: isLocal should be based on equality of participantId reported in an
+            // update and the id given to participant in a command-line argument
+            // (See issue #2026)
+            PartyDetails(Party.assertFromString(d.party), d.displayName, isLocal = true)))(
+        executionContext)
 
   private val SQL_INSERT_PARTY =
     SQL("""insert into parties(party, display_name, ledger_offset, explicit)
@@ -1490,17 +1495,18 @@ private class JdbcLedgerDao(
     )
 
   override def listLfPackages: Future[Map[PackageId, PackageDetails]] =
-    dbDispatcher.executeSql("load_packages") { implicit conn =>
-      SQL_SELECT_PACKAGES
-        .as(PackageDataParser.*)
-        .map(
+    dbDispatcher
+      .executeSql("load_packages") { implicit conn =>
+        SQL_SELECT_PACKAGES
+          .as(PackageDataParser.*)
+      }
+      .map(
+        _.map(
           d =>
             PackageId.assertFromString(d.packageId) -> PackageDetails(
               d.size,
               d.knownSince.toInstant,
-              d.sourceDescription))
-        .toMap
-    }
+              d.sourceDescription)).toMap)(executionContext)
 
   override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
     dbDispatcher


### PR DESCRIPTION
Smaller sibling of #4655

CHANGELOG_BEGIN
[Ledger API Server] Better usage of computing resources, should sustain heavier loads
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
