### PR TITLE
Highlight Typescript code snippets without tsx

### DIFF
--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -92,6 +92,7 @@ We can see examples of this in the ``MainView`` component.
 This is the React component that enables the main functionality of the app.
 
 .. literalinclude:: code/ui-before/MainView.tsx
+  :language: typescript
   :start-after: // USERS_BEGIN
   :end-before: // USERS_END
 
@@ -104,6 +105,7 @@ This is because the observers of a ``User`` contract are exactly the user's frie
 Another example is how we exercise the ``AddFriend`` choice of the ``User`` template.
 
 .. literalinclude:: code/ui-before/MainView.tsx
+  :language: typescript
   :start-after: // ADDFRIEND_BEGIN
   :end-before: // ADDFRIEND_END
 
@@ -114,6 +116,7 @@ For example, ``addFriend`` is passed to the ``UserList`` component as an argumen
 This gets triggered when you click the button next to a user's name in the "Network" panel.
 
 .. literalinclude:: code/ui-before/MainView.tsx
+  :language: typescript
   :start-after: // USERLIST_BEGIN
   :end-before: // USERLIST_END
 

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -112,6 +112,7 @@ The ``MainView`` component composes the different subcomponents (for our friends
 We first import our two new components.
 
 .. literalinclude:: code/ui-after/MainView.tsx
+  :language: typescript
   :start-after: // IMPORTS_BEGIN
   :end-before: // IMPORTS_END
 


### PR DESCRIPTION
The Typescript lexer seems be imported automatically, but does not work for actual tsx code.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
