### PR TITLE
Sandbox: Fix a bug in the ResetServiceIT `timedReset` function.

### DIFF
--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -42,7 +42,7 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
 
-import scala.concurrent.duration.{Duration, DurationInt, DurationLong}
+import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 import scala.concurrent.{Await, Future}
 import scala.ref.WeakReference
 
@@ -79,7 +79,7 @@ final class ResetServiceIT
       }
     } yield newLedgerId
 
-  private def timedReset(ledgerId: String): Future[(String, Duration)] = {
+  private def timedReset(ledgerId: String): Future[(String, FiniteDuration)] = {
     val start = System.nanoTime()
     reset(ledgerId).map(_ -> (System.nanoTime() - start).nanos)
   }
@@ -151,7 +151,8 @@ final class ResetServiceIT
                 for {
                   ledgerId <- ledgerIdF
                   _ <- submitAndExpectCompletions(ledgerId, numberOfCommands)
-                  (newLedgerId, timing) <- timedReset(ledgerId) if timing <= 5.seconds
+                  (newLedgerId, timing) <- timedReset(ledgerId)
+                  _ = timing should be <= 5.seconds
                 } yield newLedgerId
               }
               .take(numberOfAttempts)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -81,7 +81,7 @@ final class ResetServiceIT
 
   private def timedReset(ledgerId: String): Future[(String, Duration)] = {
     val start = System.nanoTime()
-    reset(ledgerId).zip(Future.successful((System.nanoTime() - start).nanos))
+    reset(ledgerId).map(_ -> (System.nanoTime() - start).nanos)
   }
 
   private def submitAndWait(req: SubmitAndWaitRequest): Future[Empty] =


### PR DESCRIPTION
It was computing the start and end times almost simultaneously.

Also makes the error message better on failure.

Hopefully this will make it easier to debug next time it flakes.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
