### PR TITLE
Use package metadata instead of file names to infer unit ids

### DIFF
--- a/compiler/daml-lf-ast/BUILD.bazel
+++ b/compiler/daml-lf-ast/BUILD.bazel
@@ -14,6 +14,8 @@ da_haskell_library(
         "deepseq",
         "Decimal",
         "extra",
+        "filepath",
+        "ghc-lib-parser",
         "hashable",
         "lens",
         "mtl",

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -313,7 +313,7 @@ stripPkgId baseName expectedPkgId = do
     guard $ pkgId == expectedPkgId
     pure unitId
 
--- | Take a string of the form daml-stdlib-"0.13.43" and split it into ("daml-stdlib", Just "0.13.43")
+-- | Take a string of the form "daml-stdlib-0.13.43" and split it into ("daml-stdlib", Just "0.13.43")
 splitUnitId :: UnitId -> (PackageName, Maybe PackageVersion)
 splitUnitId (unitIdString -> unitId) = fromMaybe (PackageName (T.pack unitId), Nothing) $ do
     (name, ver) <- stripInfixEnd "-" unitId

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -12,8 +12,10 @@ import           Control.Lens
 import           Control.Lens.Ast
 import           Data.Functor.Foldable
 import qualified Data.Graph as G
-import           Data.List.Extra (nubSort)
+import Data.List.Extra (nubSort, stripInfixEnd)
 import qualified Data.NameMap as NM
+import Module (UnitId, unitIdString, stringToUnitId)
+import System.FilePath
 
 import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.TypeLevelNat
@@ -281,3 +283,39 @@ getPackageMetadata :: Version -> PackageName -> Maybe PackageVersion -> Maybe Pa
 getPackageMetadata lfVer pkgName mbPkgVersion = do
     guard (lfVer `supports` featurePackageMetadata)
     Just (PackageMetadata pkgName (fromMaybe (PackageVersion "0.0.0") mbPkgVersion))
+
+-- | Given the name of a DALF and the decoded package return package metadata.
+--
+-- For newer DAML-LF versions this is taken directly from the
+-- package metadata in DAML-LF. For older versions, we instead infer
+-- metadata from the filename.
+packageMetadataFromFile :: FilePath -> Package -> PackageId -> (PackageName, Maybe PackageVersion)
+packageMetadataFromFile file pkg pkgId
+    | Just (PackageMetadata name version) <- packageMetadata pkg =
+          -- GHC insists on daml-prim not having a version so we filter it out.
+          (name, version <$ guard (name /= PackageName "daml-prim"))
+    | otherwise = splitUnitId (unitIdFromFile file pkgId)
+
+-- Get the name of a file and an expeted package id of the package, get the unit id
+-- by stripping away the package name at the end.
+-- E.g., if 'package-name-123abc' is given and the known package id is
+-- '123abc', then 'package-name' is returned as unit id.
+unitIdFromFile :: FilePath -> PackageId -> UnitId
+unitIdFromFile file (PackageId pkgId) =
+    (stringToUnitId . fromMaybe name . stripPkgId name . T.unpack) pkgId
+    where name = takeBaseName file
+
+-- Strip the package id from the end of a dalf file name
+-- TODO (drsk) This needs to become a hard error
+stripPkgId :: String -> String -> Maybe String
+stripPkgId baseName expectedPkgId = do
+    (unitId, pkgId) <- stripInfixEnd "-" baseName
+    guard $ pkgId == expectedPkgId
+    pure unitId
+
+-- | Take a string of the form daml-stdlib-"0.13.43" and split it into ("daml-stdlib", Just "0.13.43")
+splitUnitId :: UnitId -> (PackageName, Maybe PackageVersion)
+splitUnitId (unitIdString -> unitId) = fromMaybe (PackageName (T.pack unitId), Nothing) $ do
+    (name, ver) <- stripInfixEnd "-" unitId
+    guard $ all (`elem` '.' : ['0' .. '9']) ver
+    pure (PackageName (T.pack name), Just (PackageVersion (T.pack ver)))

--- a/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
+++ b/compiler/daml-lf-reader/src/DA/Daml/LF/Reader.hs
@@ -9,13 +9,9 @@ module DA.Daml.LF.Reader
     , Dalfs(..)
     , readDalfManifest
     , readDalfs
-    , stripPkgId
-    , parseUnitId
     ) where
 
 import "zip-archive" Codec.Archive.Zip
-import Control.Monad (guard)
-import qualified DA.Daml.LF.Ast as LF
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -23,8 +19,6 @@ import qualified Data.ByteString.UTF8 as BSUTF8
 import Data.Char
 import Data.Either.Extra
 import Data.List.Extra
-import Data.Maybe
-import qualified Data.Text as T
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Byte
@@ -128,18 +122,3 @@ getEntry :: Archive -> FilePath -> Either String BSL.ByteString
 getEntry dar path = case findEntryByPath path dar of
     Nothing -> Left $ "Could not find " <> path <> " in DAR"
     Just entry -> Right $ fromEntry entry
-
--- Strip the package id from the end of a dalf file name
--- TODO (drsk) This needs to become a hard error
-stripPkgId :: String -> String -> Maybe String
-stripPkgId baseName expectedPkgId = do
-    (unitId, pkgId) <- stripInfixEnd "-" baseName
-    guard $ pkgId == expectedPkgId
-    pure unitId
-
--- Get the unit id of a string, given an expected package id of the package, by stripping the
--- package id from the back. I.e. if 'package-name-123abc' is given and the known package id is
--- '123abc', then 'package-name' is returned as unit id.
-parseUnitId :: String -> LF.PackageId -> String
-parseUnitId name pkgId =
-    fromMaybe name $ stripPkgId name $ T.unpack $ LF.unPackageId pkgId

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -5,7 +5,6 @@ module DA.Daml.Compiler.DataDependencies
     ( Config (..)
     , generateSrcPkgFromLf
     , generateGenInstancesPkgFromLf
-    , splitUnitId
     , prefixDependencyModule
     ) where
 
@@ -440,7 +439,7 @@ generateSrcFromLf env = noLoc mod
                     -- need to use "this" instead of the package id.
                     if modRefUnitId == unitId
                         then "this"
-                        else T.unpack . LF.unPackageName . fst $ splitUnitId modRefUnitId
+                        else T.unpack . LF.unPackageName . fst $ LF.splitUnitId modRefUnitId
             , ideclSource = False
             , ideclSafe = False
             , ideclImplicit = False
@@ -847,13 +846,6 @@ generateGenInstanceModule env externPkgId qual
         [ "import qualified " <> modNameQual
         , "import qualified DA.Generics"
         ]
-
--- | Take a string of the form daml-stdlib-"0.13.43" and split it into ("daml-stdlib", Just "0.13.43")
-splitUnitId :: UnitId -> (LF.PackageName, Maybe LF.PackageVersion)
-splitUnitId (unitIdString -> unitId) = fromMaybe (LF.PackageName (T.pack unitId), Nothing) $ do
-    (name, ver) <- stripInfixEnd "-" unitId
-    guard $ all (`elem` '.' : ['0' .. '9']) ver
-    pure (LF.PackageName (T.pack name), Just (LF.PackageVersion (T.pack ver)))
 
 -- | Returns 'True' if an LF type contains a reference to an
 -- old-style typeclass. See 'tconIsOldTypeclass' for more details.

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -786,8 +786,7 @@ execMigrate projectOpts inFile1_ inFile2_ mbDir =
                   mainDalfEntry <- getEntry (mainDalfPath dalfManifest) dar
                   (mainPkgId, mainLfPkg) <-
                       decode $ BSL.toStrict $ ZipArchive.fromEntry mainDalfEntry
-                  let baseName = takeBaseName $ mainDalfPath dalfManifest
-                  let pkgName = parseUnitId baseName mainPkgId
+                  let pkgName = unitIdString (LF.unitIdFromFile (mainDalfPath dalfManifest) mainPkgId)
                   pure (pkgName, mainPkgId, mainLfPkg)
           -- generate upgrade modules and instances modules
           let eqModNames =

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -11,8 +11,8 @@ import Safe (lastMay)
 import Data.List
 import Data.Maybe
 import qualified DA.Pretty           as Pretty
-import DA.Daml.Compiler.DataDependencies (splitUnitId)
 import DA.Daml.Options.Types
+import DA.Daml.LF.Ast.Util (splitUnitId)
 import qualified DA.Daml.LF.Ast.Version as LF
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types


### PR DESCRIPTION
This PR adds a function that abstracts over whether we get metadata
from a filename (< 1.dev) or directly from the LF metadata.

There is more work to be done here, in particular, I want to clean up
the hacks around daml-prim/daml-stdlib but I’ll leave that for a
separate PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
