### PR TITLE
Make the completion service return API response directly

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
@@ -6,14 +6,16 @@ package com.digitalasset.platform.server.api.services.domain
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.domain.{CompletionEvent, LedgerOffset}
+import com.digitalasset.ledger.api.domain.LedgerOffset
 import com.digitalasset.ledger.api.messages.command.completion.CompletionStreamRequest
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 
 import scala.concurrent.Future
 
 trait CommandCompletionService {
 
-  def completionStreamSource(request: CompletionStreamRequest): Source[CompletionEvent, NotUsed]
+  def completionStreamSource(
+      request: CompletionStreamRequest): Source[CompletionStreamResponse, NotUsed]
 
   def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute]
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
@@ -46,8 +46,6 @@ class GrpcCommandCompletionService(
 )(implicit protected val esf: ExecutionSequencerFactory, protected val mat: Materializer)
     extends CommandCompletionServiceAkkaGrpc {
 
-  import GrpcCommandCompletionService.fillInWithDefaults
-
   private val validator = new CompletionServiceRequestValidator(ledgerId, partyNameChecker)
 
   override def completionStreamSource(
@@ -56,11 +54,7 @@ class GrpcCommandCompletionService(
       .validateCompletionStreamRequest(request)
       .fold(
         Source.failed[CompletionStreamResponse],
-        validatedRequest => {
-          service
-            .completionStreamSource(fillInWithDefaults(validatedRequest))
-            .map(toApiCompletion)
-        }
+        GrpcCommandCompletionService.fillInWithDefaults _ andThen service.completionStreamSource
       )
   }
 
@@ -76,39 +70,5 @@ class GrpcCommandCompletionService(
               CompletionEndResponse(Some(LedgerOffset(LedgerOffset.Value.Absolute(abs.value)))))(
               DirectExecutionContext)
       )
-
-  private def toApiCompletion(ce: domain.CompletionEvent): CompletionStreamResponse = {
-    val checkpoint = Some(
-      Checkpoint(
-        Some(fromInstant(ce.recordTime)),
-        Some(LedgerOffset(LedgerOffset.Value.Absolute(ce.offset.value)))))
-
-    ce match {
-      case CompletionEvent.CommandAccepted(_, _, commandId, transactionId) =>
-        CompletionStreamResponse(
-          checkpoint,
-          List(Completion(commandId.unwrap, Some(Status()), transactionId.unwrap))
-        )
-
-      case CompletionEvent.CommandRejected(_, _, commandId, reason) =>
-        CompletionStreamResponse(checkpoint, List(rejectionToCompletion(commandId, reason)))
-
-      case _: CompletionEvent.Checkpoint =>
-        CompletionStreamResponse(checkpoint)
-    }
-  }
-
-  private def rejectionToCompletion(commandId: CommandId, error: RejectionReason): Completion = {
-    val code = error match {
-      case _: RejectionReason.Inconsistent => Code.INVALID_ARGUMENT
-      case _: RejectionReason.OutOfQuota => Code.ABORTED
-      case _: RejectionReason.TimedOut => Code.ABORTED
-      case _: RejectionReason.Disputed => Code.INVALID_ARGUMENT
-      case _: RejectionReason.PartyNotKnownOnLedger => Code.INVALID_ARGUMENT
-      case _: RejectionReason.SubmitterCannotActViaParticipant => Code.PERMISSION_DENIED
-    }
-
-    Completion(commandId.unwrap, Some(Status(code.value(), error.description)), traceContext = None)
-  }
 
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
@@ -5,23 +5,17 @@ package com.digitalasset.platform.server.api.services.grpc
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import com.digitalasset.api.util.TimestampConversion.fromInstant
+import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.domain.{CommandId, CompletionEvent, LedgerId, RejectionReason}
-import com.digitalasset.ledger.api.v1.command_completion_service._
-import com.digitalasset.ledger.api.v1.completion.Completion
-import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
-import com.digitalasset.ledger.api.validation.{CompletionServiceRequestValidator, PartyNameChecker}
-import com.digitalasset.dec.DirectExecutionContext
-import com.digitalasset.platform.server.api.services.domain.CommandCompletionService
-import com.google.rpc.status.Status
-import io.grpc.Status.Code
-import scalaz.syntax.tag._
-
+import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.messages.command.completion.{
   CompletionStreamRequest => ValidatedCompletionStreamRequest
 }
+import com.digitalasset.ledger.api.v1.command_completion_service._
+import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
+import com.digitalasset.ledger.api.validation.{CompletionServiceRequestValidator, PartyNameChecker}
+import com.digitalasset.platform.server.api.services.domain.CommandCompletionService
 
 import scala.concurrent.Future
 

--- a/ledger/participant-state-index/BUILD.bazel
+++ b/ledger/participant-state-index/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/language",
         "//daml-lf/transaction",
+        "//ledger-api/grpc-definitions:ledger-api-scalapb",
         "//ledger/ledger-api-domain",
         "//ledger/ledger-api-health",
         "//ledger/participant-state",

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexCompletionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexCompletionsService.scala
@@ -6,7 +6,8 @@ package com.daml.ledger.participant.state.index.v2
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.ledger.api.domain.{ApplicationId, CompletionEvent, LedgerOffset}
+import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerOffset}
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 
 /**
   * Serves as a backend to implement
@@ -17,5 +18,5 @@ trait IndexCompletionsService extends LedgerEndService {
       begin: LedgerOffset,
       applicationId: ApplicationId,
       parties: Set[Ref.Party]
-  ): Source[CompletionEvent, NotUsed]
+  ): Source[CompletionStreamResponse, NotUsed]
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.participant.state.index.v2.IndexCompletionsService
 import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.ledger.api.domain
-import com.digitalasset.ledger.api.domain.{CompletionEvent, LedgerId, LedgerOffset}
+import com.digitalasset.ledger.api.domain.{LedgerId, LedgerOffset}
 import com.digitalasset.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.digitalasset.ledger.api.v1.command_completion_service._
 import com.digitalasset.ledger.api.validation.PartyNameChecker
@@ -37,7 +37,7 @@ final class ApiCommandCompletionService private (completionsService: IndexComple
   private val subscriptionIdCounter = new AtomicLong()
 
   override def completionStreamSource(
-      request: CompletionStreamRequest): Source[CompletionEvent, NotUsed] =
+      request: CompletionStreamRequest): Source[CompletionStreamResponse, NotUsed] =
     withEnrichedLoggingContext(logging.parties(request.parties), logging.offset(request.offset)) {
       implicit logCtx =>
         val subscriptionId = subscriptionIdCounter.getAndIncrement().toString

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -24,7 +24,6 @@ import com.digitalasset.dec.{DirectExecutionContext => DEC}
 import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
-  CompletionEvent,
   LedgerId,
   LedgerOffset,
   PackageEntry,
@@ -34,6 +33,7 @@ import com.digitalasset.ledger.api.domain.{
   TransactionId
 }
 import com.digitalasset.ledger.api.health.HealthStatus
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.participant.util.EventFilter
 import com.digitalasset.platform.server.api.validation.ErrorFactories
 import com.digitalasset.platform.store.Contract.ActiveContract
@@ -217,7 +217,7 @@ abstract class LedgerBackedIndexService(
       begin: LedgerOffset,
       applicationId: ApplicationId,
       parties: Set[Ref.Party]
-  ): Source[CompletionEvent, NotUsed] =
+  ): Source[CompletionStreamResponse, NotUsed] =
     new OffsetConverter().toAbsolute(begin).flatMapConcat {
       case LedgerOffset.Absolute(absBegin) =>
         ledger.completions(Option(absBegin.toLong), None, applicationId, parties).map(_._2)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -17,6 +17,7 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.metrics.timedFuture
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.store.entries.{
@@ -58,7 +59,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
       beginInclusive: Option[Long],
       endExclusive: Option[Long],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Long, domain.CompletionEvent), NotUsed] =
+      parties: Set[Party]): Source[(Long, CompletionStreamResponse), NotUsed] =
     ledger.completions(beginInclusive, endExclusive, applicationId, parties)
 
   override def snapshot(filter: TemplateAwareFilter): Future[LedgerSnapshot] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -14,7 +14,6 @@ import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -26,13 +26,13 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
   CommandId,
-  CompletionEvent,
   LedgerId,
   PartyDetails,
   RejectionReason,
   TransactionId
 }
 import com.digitalasset.ledger.api.health.{HealthStatus, Healthy}
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.packages.InMemoryPackageStore
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.sandbox.stores.InMemoryActiveLedgerState
@@ -107,7 +107,7 @@ class InMemoryLedger(
       beginInclusive: Option[Long],
       endExclusive: Option[Long],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Long, CompletionEvent), NotUsed] =
+      parties: Set[Party]): Source[(Long, CompletionStreamResponse), NotUsed] =
     entries
       .getSource(beginInclusive, endExclusive)
       .collect { case (offset, InMemoryLedgerEntry(entry)) => (offset + 1, entry) }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -18,6 +18,7 @@ import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerId, TransactionId}
 import com.digitalasset.ledger.api.health.HealthStatus
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.RangeSource
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
@@ -65,7 +66,7 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
       beginInclusive: Option[Long],
       endExclusive: Option[Long],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Long, domain.CompletionEvent), NotUsed] =
+      parties: Set[Party]): Source[(Long, CompletionStreamResponse), NotUsed] =
     dispatcher.startingAt(
       beginInclusive.getOrElse(0),
       RangeSource(ledgerDao.completions.getCommandCompletions(_, _, applicationId.unwrap, parties)),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
@@ -28,11 +28,11 @@ private[platform] object CompletionFromTransaction {
 
   private def toApiCheckpoint(
       recordedAt: Instant,
-      offset: LedgerDao#LedgerOffset): Option[Checkpoint] =
-    Option(
+      offset: LedgerDao#LedgerOffset): Some[Checkpoint] =
+    Some(
       Checkpoint(
-        recordTime = Option(fromInstant(recordedAt)),
-        offset = Option(LedgerOffset(LedgerOffset.Value.Absolute(offset.toString)))))
+        recordTime = Some(fromInstant(recordedAt)),
+        offset = Some(LedgerOffset(LedgerOffset.Value.Absolute(offset.toString)))))
 
   // We _rely_ on the following compiler flags for this to be safe:
   // * -Xno-patmat-analysis _MUST NOT_ be enabled
@@ -71,13 +71,13 @@ private[platform] object CompletionFromTransaction {
           _)) if parties(submitter) =>
       offset -> CompletionStreamResponse(
         checkpoint = toApiCheckpoint(recordedAt, offset),
-        Seq(Completion(commandId, Option(Status()), transactionId))
+        Seq(Completion(commandId, Some(Status()), transactionId))
       )
     case (offset, LedgerEntry.Rejection(recordTime, commandId, `appId`, submitter, reason))
         if parties(submitter) =>
       offset -> CompletionStreamResponse(
         checkpoint = toApiCheckpoint(recordTime, offset),
-        Seq(Completion(commandId, Option(Status(toErrorCode(reason).value(), reason.description))))
+        Seq(Completion(commandId, Some(Status(toErrorCode(reason).value(), reason.description))))
       )
     case (offset, LedgerEntry.Checkpoint(recordedAt)) =>
       offset -> CompletionStreamResponse(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
@@ -5,20 +5,10 @@ package com.digitalasset.platform.store
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.v1.TransactionId
 import com.digitalasset.api.util.TimestampConversion.fromInstant
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.ledger.{ApplicationId, CommandId}
-import com.digitalasset.ledger.api.domain
+import com.digitalasset.ledger.ApplicationId
 import com.digitalasset.ledger.api.domain.RejectionReason
-import com.digitalasset.ledger.api.domain.RejectionReason.{
-  Disputed,
-  Inconsistent,
-  OutOfQuota,
-  PartyNotKnownOnLedger,
-  SubmitterCannotActViaParticipant,
-  TimedOut
-}
 import com.digitalasset.ledger.api.v1.command_completion_service.{
   Checkpoint,
   CompletionStreamResponse
@@ -49,12 +39,12 @@ private[platform] object CompletionFromTransaction {
   // * -Xfatal-warnings _MUST_ be enabled
   private def toErrorCode(rejection: RejectionReason): Int = {
     import RejectionReason.{
-      Inconsistent,
       Disputed,
-      PartyNotKnownOnLedger,
+      Inconsistent,
       OutOfQuota,
-      TimedOut,
-      SubmitterCannotActViaParticipant
+      PartyNotKnownOnLedger,
+      SubmitterCannotActViaParticipant,
+      TimedOut
     }
     rejection match {
       case _: Inconsistent | _: Disputed | _: PartyNotKnownOnLedger =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
@@ -38,20 +38,13 @@ private[platform] object CompletionFromTransaction {
   // * -Xno-patmat-analysis _MUST NOT_ be enabled
   // * -Xfatal-warnings _MUST_ be enabled
   private def toErrorCode(rejection: RejectionReason): Int = {
-    import RejectionReason.{
-      Disputed,
-      Inconsistent,
-      OutOfQuota,
-      PartyNotKnownOnLedger,
-      SubmitterCannotActViaParticipant,
-      TimedOut
-    }
     rejection match {
-      case _: Inconsistent | _: Disputed | _: PartyNotKnownOnLedger =>
+      case _: RejectionReason.Inconsistent | _: RejectionReason.Disputed |
+          _: RejectionReason.PartyNotKnownOnLedger =>
         Code.INVALID_ARGUMENT.value()
-      case _: OutOfQuota | _: TimedOut =>
+      case _: RejectionReason.OutOfQuota | _: RejectionReason.TimedOut =>
         Code.ABORTED.value()
-      case _: SubmitterCannotActViaParticipant =>
+      case _: RejectionReason.SubmitterCannotActViaParticipant =>
         Code.PERMISSION_DENIED.value()
     }
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/CompletionFromTransaction.scala
@@ -37,15 +37,15 @@ private[platform] object CompletionFromTransaction {
   // We _rely_ on the following compiler flags for this to be safe:
   // * -Xno-patmat-analysis _MUST NOT_ be enabled
   // * -Xfatal-warnings _MUST_ be enabled
-  private def toErrorCode(rejection: RejectionReason): Int = {
+  private def toErrorCode(rejection: RejectionReason): Code = {
     rejection match {
       case _: RejectionReason.Inconsistent | _: RejectionReason.Disputed |
           _: RejectionReason.PartyNotKnownOnLedger =>
-        Code.INVALID_ARGUMENT.value()
+        Code.INVALID_ARGUMENT
       case _: RejectionReason.OutOfQuota | _: RejectionReason.TimedOut =>
-        Code.ABORTED.value()
+        Code.ABORTED
       case _: RejectionReason.SubmitterCannotActViaParticipant =>
-        Code.PERMISSION_DENIED.value()
+        Code.PERMISSION_DENIED
     }
   }
 
@@ -77,7 +77,7 @@ private[platform] object CompletionFromTransaction {
         if parties(submitter) =>
       offset -> CompletionStreamResponse(
         checkpoint = toApiCheckpoint(recordTime, offset),
-        Seq(Completion(commandId, Option(Status(toErrorCode(reason), reason.description))))
+        Seq(Completion(commandId, Option(Status(toErrorCode(reason).value(), reason.description))))
       )
     case (offset, LedgerEntry.Checkpoint(recordedAt)) =>
       offset -> CompletionStreamResponse(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -14,14 +14,9 @@ import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{AbsoluteContractId, ContractInst}
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.domain.{
-  ApplicationId,
-  CompletionEvent,
-  LedgerId,
-  PartyDetails,
-  TransactionId
-}
+import com.digitalasset.ledger.api.domain.{ApplicationId, LedgerId, PartyDetails, TransactionId}
 import com.digitalasset.ledger.api.health.ReportsHealth
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.participant.util.EventFilter.TemplateAwareFilter
 import com.digitalasset.platform.store.entries.{
   ConfigurationEntry,
@@ -47,7 +42,7 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
       beginInclusive: Option[Long],
       endExclusive: Option[Long],
       applicationId: ApplicationId,
-      parties: Set[Ref.Party]): Source[(Long, CompletionEvent), NotUsed]
+      parties: Set[Ref.Party]): Source[(Long, CompletionStreamResponse), NotUsed]
 
   def snapshot(filter: TemplateAwareFilter): Future[LedgerSnapshot]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsReader.scala
@@ -7,7 +7,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.ledger.ApplicationId
-import com.digitalasset.ledger.api.domain.CompletionEvent
+import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.platform.store.CompletionFromTransaction
 
 private[dao] object CommandCompletionsReader {
@@ -40,6 +40,6 @@ trait CommandCompletionsReader[LedgerOffset] {
       startInclusive: LedgerOffset,
       endExclusive: LedgerOffset,
       applicationId: ApplicationId,
-      parties: Set[Ref.Party]): Source[(LedgerOffset, CompletionEvent), NotUsed]
+      parties: Set[Ref.Party]): Source[(LedgerOffset, CompletionStreamResponse), NotUsed]
 
 }


### PR DESCRIPTION
Skip intermediate transformation to CompletionEvent and return the API
response directly. This approach will be followed by a new implementation
that directly stores to and retrieves from the index instead of using the
transaction stream and filtering it.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
