### PR TITLE
Add documentation for DAML repl and advertise it

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -253,7 +253,7 @@ cmdBuild numProcessors =
 cmdRepl :: Int -> Mod CommandFields Command
 cmdRepl numProcessors =
     command "repl" $ info (helper <*> cmd) $
-    progDesc "Launch the DAML Repl." <>
+    progDesc "Launch the DAML REPL." <>
     fullDesc
   where
     cmd =

--- a/docs/configs/pdf/index.rst
+++ b/docs/configs/pdf/index.rst
@@ -95,6 +95,7 @@ Experimental features
    json-api/index
    triggers/index
    daml-script/index
+   daml-repl/index
    tools/visual
    daml2ts/index
    getting-started/index

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -1,16 +1,16 @@
 .. Copyright (c) 2020 The DAML Authors. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-DAML Repl
+DAML REPL
 ###########
 
-**WARNING:** DAML Repl is an experimental feature that is actively
+**WARNING:** DAML REPL is an experimental feature that is actively
 being designed and is *subject to breaking changes*.
-We welcome feedback about DAML script on
+We welcome feedback about the DAML REPL on
 `our issue tracker <https://github.com/digital-asset/daml/issues/new>`_
 or `on Slack <https://hub.daml.com/slack/>`_.
 
-DAML Repl allows you to use the :doc:`/daml-script/index` API
+The DAML REPL allows you to use the :doc:`/daml-script/index` API
 interactively. This is useful for debugging and for interactively
 inspecting and manipulating a ledger.
 
@@ -35,7 +35,7 @@ wallclock mode. Static time is not supported in ``daml repl``.
    daml build
    daml sandbox --wall-clock-time --port=6865 .daml/dist/script-example-0.0.1.dar
 
-Now that the ledger has been started, you can launch the repl in a
+Now that the ledger has been started, you can launch the REPL in a
 separate terminal using the following command.
 
 .. code-block:: sh
@@ -45,7 +45,7 @@ separate terminal using the following command.
 The ``--ledger-host`` and ``--ledger-port`` parameters point to the
 host and port your ledger is running on. In addition to that, you also
 need to pass in the name of a DAR containing the templates and other
-definitions that will be accessible in the repl.
+definitions that will be accessible in the REPL.
 
 You should now see a prompt looking like
 

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -1,0 +1,121 @@
+.. Copyright (c) 2020 The DAML Authors. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+DAML Repl
+###########
+
+**WARNING:** DAML Repl is an experimental feature that is actively
+being designed and is *subject to breaking changes*.
+We welcome feedback about DAML script on
+`our issue tracker <https://github.com/digital-asset/daml/issues/new>`_
+or `on Slack <https://hub.daml.com/slack/>`_.
+
+DAML Repl allows you to use the :doc:`/daml-script/index` API
+interactively. This is useful for debugging and for interactively
+inspecting and manipulating a ledger.
+
+Usage
+=====
+
+First create a new project based on the ``script-example``
+template. Take a look at the documentation for
+:doc:`/daml-script/index` for details on this template.
+
+.. code-block:: sh
+
+   daml new script-example script-example # create a project called script-example based on the template
+   cd script-example # switch to the new project
+
+Now, build the project and start :doc:`/tools/sandbox`, the in-memory
+ledger included in the DAML SDK. Note that we are starting Sandbox in
+wallclock mode. Static time is not supported in ``daml repl``.
+
+.. code-block:: sh
+
+   daml build
+   daml sandbox --wall-clock-time --port=6865 .daml/dist/script-example-0.0.1.dar
+
+Now that the ledger has been started, you can launch the repl in a
+separate terminal using the following command.
+
+.. code-block:: sh
+
+   daml repl --ledger-host=localhost --ledger-port=6865 .daml/dist/repl-playground-0.0.1.dar
+
+The ``--ledger-host`` and ``--ledger-port`` parameters point to the
+host and port your ledger is running on. In addition to that, you also
+need to pass in the name of a DAR containing the templates and other
+definitions that will be accessible in the repl.
+
+You should now see a prompt looking like
+
+.. code-block:: none
+
+   daml>
+
+You can think of this prompt like a line in a ``do``-block of the
+``Script`` action. Each line of input has to have one of the following
+two forms:
+
+1. An expression ``expr`` of type ``Script a`` for some type ``a``. This
+   will execute the script ignoring the result.
+
+2. A binding of the form ``x <- expr`` where ``x`` is a variable name
+   and ``expr`` is an expression of type ``Script a``. This will
+   execute the script and bind the result to the variable ``x``. You
+   can then use ``x`` on subsequent lines.
+
+First create two parties: A party with the display name ``"Alice"``
+and the party id ``"alice"`` and a party with the display name
+``"Bob"`` and the party id ``"bob"``.
+
+.. code-block:: none
+
+   daml> alice <- allocatePartyWithHint "Alice" (PartyIdHint "alice")
+   daml> bob <- allocatePartyWithHint "Bob" (PartyIdHint "bob")
+
+Next, create a ``CoinProposal`` from ``Alice`` to ``Bob``
+
+.. code-block:: none
+
+   daml> submit alice (createCmd (CoinProposal (Coin alice bob)))
+
+As Bob, you can now get the list of active ``CoinProposal`` contracts
+using the ``query`` function. The ``debug : Show a => a -> Script ()``
+function can be used to print values.
+
+.. code-block:: none
+
+   daml> proposals <- query @CoinProposal bob
+   daml> debug proposals
+   [Daml.Script:39]: [(<contract-id>,CoinProposal {coin = Coin {issuer = 'alice', owner = 'bob'}})]
+
+Finally, accept all proposals using the ``forA`` function to iterate
+over them.
+
+.. code-block:: none
+
+   daml> forA proposals $ \(contractId, _) -> submit bob (exerciseCmd contractId Accept)
+
+Using the ``query`` function we can now verify that there is one
+``Coin`` and no ``CoinProposal``:
+
+.. code-block:: none
+
+   daml> coins <- query @Coin bob
+   daml> debug coins
+   [Daml.Script:39]: [(<contract-id>,Coin {issuer = 'alice', owner = 'bob'})]
+   daml> proposals <- query @CoinProposal bob
+   [Daml.Script:39]: []
+
+To exit ``daml repl`` press ``Control-D``.
+
+
+What is in scope at the prompt?
+===============================
+
+In the prompt, all modules from the main dalf of the DAR passed to
+``daml repl`` are imported. In addition to that the ``Daml.Script``
+module is imported and gives you access to the DAML Script API.
+
+At this point, it is not possible to import more modules.

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -40,7 +40,7 @@ separate terminal using the following command.
 
 .. code-block:: sh
 
-   daml repl --ledger-host=localhost --ledger-port=6865 .daml/dist/repl-playground-0.0.1.dar
+   daml repl --ledger-host=localhost --ledger-port=6865 .daml/dist/script-example-0.0.1.dar
 
 The ``--ledger-host`` and ``--ledger-port`` parameters point to the
 host and port your ledger is running on. In addition to that, you also

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -28,6 +28,8 @@ actual ledger. This means that you can use it to test automation
 logic, your UI but also for ledger initialization where scenarios
 cannot be used (with the exception of :doc:`/tools/sandbox`).
 
+You can also use DAML Script interactively using :doc:`/daml-repl/index`.
+
 Usage
 =====
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,7 @@ DAML SDK documentation
    json-api/index
    DAML Triggers <triggers/index>
    DAML Script <daml-script/index>
+   DAML Repl <daml-repl/index>
    tools/visual
    daml2ts/index
    getting-started/index

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -92,4 +92,4 @@ commands:
 - name: repl
   path: damlc/damlc
   args: ["repl"]
-  desc: "Launch the DAML repl (experimental)"
+  desc: "Launch the DAML REPL (experimental)"

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -92,3 +92,4 @@ commands:
 - name: repl
   path: damlc/damlc
   args: ["repl"]
+  desc: "Launch the DAML repl (experimental)"


### PR DESCRIPTION
This PR adds some simple docs for ``daml repl`` and adds it to the
release notes.

changelog_begin

- [DAML Repl - Experimental] A new ``daml repl`` command that allows
  you to use the ``DAML Script`` API interactively. Take a look at the
  `documentation <https://docs.daml.com/daml-repl/>`_ for more
  information.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
