### PR TITLE
Extend /v1/parties endpoint to support fetch by party IDs

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -803,6 +803,52 @@ Nonempty HTTP Response with Unknown Template IDs Warning
         "status": 200
     }
 
+Fetch Parties by their Identifiers
+**********************************
+
+- URL: ``/v1/parties``
+- Method: ``POST``
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    ["Alice", "Bob", "Dave"]
+
+If empty JSON array is passed: ``[]``, this endpoint will return all known parties.
+
+HTTP Response
+=============
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "status": 200,
+      "result": [
+        {
+          "identifier": "Alice",
+          "displayName": "Alice & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Bob",
+          "displayName": "Bob & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Dave",
+          "isLocal": true
+        }
+      ]
+    }
+
+- ``identifier`` -- a stable unique identifier of a DAML party,
+- ``displayName`` -- optional human readable name associated with the party. Might not be unique,
+- ``isLocal`` -- true if party is hosted by the backing participant.
+
 Fetch All Known Parties
 ***********************
 
@@ -819,14 +865,31 @@ HTTP Response
 .. code-block:: json
 
     {
-        "status": 200,
-        "result": [
-            {
-                "party": "Alice",
-                "isLocal": true
-            }
-        ]
+      "status": 200,
+      "result": [
+        {
+          "identifier": "Alice",
+          "displayName": "Alice & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Bob",
+          "displayName": "Bob & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Charlie",
+          "displayName": "Charlie & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Dave",
+          "isLocal": true
+        }
+      ]
     }
+
+The response is the same as for the POST method above.
 
 Streaming API
 *************

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -856,8 +856,6 @@ HTTP Response
 
 Please note that the order of the party objects in the response is not guaranteed to match the order of the passed party identifiers.
 
-An empty JSON array will be returned in the ``result`` element of the response if passed identifiers did not match any party.
-
 Where
 
 - ``identifier`` -- a stable unique identifier of a DAML party,

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -815,7 +815,16 @@ Fetch Parties by Identifiers
 
     ["Alice", "Bob", "Dave"]
 
-If empty JSON array is passed: ``[]``, this endpoint will return all known parties.
+If empty JSON array is passed: ``[]``, this endpoint returns BadRequest(400) error:
+
+.. code-block:: json
+
+    {
+      "status": 400,
+      "errors": [
+        "JsonReaderError. Cannot read JSON: <[]>. Cause: spray.json.DeserializationException: must be a list with at least 1 element"
+      ]
+    }
 
 HTTP Response
 =============
@@ -854,6 +863,40 @@ Where
 - ``identifier`` -- a stable unique identifier of a DAML party,
 - ``displayName`` -- optional human readable name associated with the party. Might not be unique,
 - ``isLocal`` -- true if party is hosted by the backing participant.
+
+HTTP Response with Unknown Parties Warning
+============================================
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "result": [
+        {
+          "identifier": "Alice",
+          "displayName": "Alice & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Bob",
+          "displayName": "Bob & Co. LLC",
+          "isLocal": true
+        },
+        {
+          "identifier": "Dave",
+          "displayName": "Dave & Co. LLC",
+          "isLocal": true
+        }
+      ],
+      "warnings": {
+        "unknownParties": [
+          "Erin"
+        ]
+      },
+      "status": 200
+    }
 
 Fetch All Known Parties
 ***********************

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -876,16 +876,6 @@ HTTP Response with Unknown Parties Warning
           "identifier": "Alice",
           "displayName": "Alice & Co. LLC",
           "isLocal": true
-        },
-        {
-          "identifier": "Bob",
-          "displayName": "Bob & Co. LLC",
-          "isLocal": true
-        },
-        {
-          "identifier": "Dave",
-          "displayName": "Dave & Co. LLC",
-          "isLocal": true
         }
       ],
       "warnings": {

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -803,8 +803,8 @@ Nonempty HTTP Response with Unknown Template IDs Warning
         "status": 200
     }
 
-Fetch Parties by their Identifiers
-**********************************
+Fetch Parties by Identifiers
+****************************
 
 - URL: ``/v1/parties``
 - Method: ``POST``

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -845,6 +845,12 @@ HTTP Response
       ]
     }
 
+Please note that the order of the party objects in the response is not guaranteed to match the order of the passed party identifiers.
+
+An empty JSON array will be returned in the ``result`` element of the response if passed identifiers did not match any party.
+
+Where
+
 - ``identifier`` -- a stable unique identifier of a DAML party,
 - ``displayName`` -- optional human readable name associated with the party. Might not be unique,
 - ``isLocal`` -- true if party is hosted by the backing participant.
@@ -858,36 +864,6 @@ Fetch All Known Parties
 
 HTTP Response
 =============
-
-- Content-Type: ``application/json``
-- Content:
-
-.. code-block:: json
-
-    {
-      "status": 200,
-      "result": [
-        {
-          "identifier": "Alice",
-          "displayName": "Alice & Co. LLC",
-          "isLocal": true
-        },
-        {
-          "identifier": "Bob",
-          "displayName": "Bob & Co. LLC",
-          "isLocal": true
-        },
-        {
-          "identifier": "Charlie",
-          "displayName": "Charlie & Co. LLC",
-          "isLocal": true
-        },
-        {
-          "identifier": "Dave",
-          "isLocal": true
-        }
-      ]
-    }
 
 The response is the same as for the POST method above.
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -19,7 +19,7 @@ import com.digitalasset.http.json.{
   ApiValueToJsValueConverter,
   DomainJsonDecoder,
   DomainJsonEncoder,
-  JsValueToApiValueConverter,
+  JsValueToApiValueConverter
 }
 import com.digitalasset.http.util.ApiValueToLfValueConverter
 import com.digitalasset.util.ExceptionOps._
@@ -32,7 +32,7 @@ import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.configuration.{
   CommandClientConfiguration,
   LedgerClientConfiguration,
-  LedgerIdRequirement,
+  LedgerIdRequirement
 }
 import com.digitalasset.ledger.client.services.pkg.PackageClient
 import com.digitalasset.ledger.service.LedgerReader
@@ -126,7 +126,7 @@ object HttpService extends StrictLogging {
         contractDao,
       )
 
-      partiesService = new PartiesService(() => client.partyManagementClient.listKnownParties())
+      partiesService = new PartiesService(LedgerClientJwt.listKnownParties(client))
 
       (encoder, decoder) = buildJsonCodecs(ledgerId, packageService)
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/LedgerClientJwt.scala
@@ -6,6 +6,7 @@ package com.digitalasset.http
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.digitalasset.jwt.domain.Jwt
+import com.digitalasset.ledger.api
 import com.digitalasset.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.digitalasset.ledger.api.v1.command_service.{
   SubmitAndWaitForTransactionResponse,
@@ -35,6 +36,9 @@ object LedgerClientJwt {
 
   type GetCreatesAndArchivesSince =
     (Jwt, TransactionFilter, LedgerOffset, Terminates) => Source[Transaction, NotUsed]
+
+  type ListKnownParties =
+    Jwt => Future[List[api.domain.PartyDetails]]
 
   private def bearer(jwt: Jwt): Some[String] = Some(s"Bearer ${jwt.value: String}")
 
@@ -97,4 +101,7 @@ object LedgerClientJwt {
       case _ => false
     }
   }
+
+  def listKnownParties(client: LedgerClient): ListKnownParties =
+    jwt => client.partyManagementClient.listKnownParties(bearer(jwt))
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
@@ -7,6 +7,7 @@ import com.digitalasset.ledger.api.domain.PartyDetails
 
 import scala.concurrent.{ExecutionContext, Future}
 import com.digitalasset.jwt.domain.Jwt
+import scalaz.OneAnd
 
 class PartiesService(listAllParties: Jwt => Future[List[PartyDetails]])(
     implicit ec: ExecutionContext) {
@@ -17,8 +18,10 @@ class PartiesService(listAllParties: Jwt => Future[List[PartyDetails]])(
   }
 
   // TODO(Leo) memoize this calls or listAllParties()?
-  def parties(jwt: Jwt, identifiers: Set[domain.Party]): Future[List[domain.PartyDetails]] = {
-    val ids: Set[String] = domain.Party.unsubst(identifiers)
+  def parties(
+      jwt: Jwt,
+      identifiers: OneAnd[Set, domain.Party]): Future[List[domain.PartyDetails]] = {
+    val ids: Set[String] = domain.Party.unsubst(identifiers.tail + identifiers.head)
     listAllParties(jwt).map { ps =>
       ps.collect { case p if ids(p.party) => domain.PartyDetails.fromLedgerApi(p) }
     }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PartiesService.scala
@@ -3,13 +3,12 @@
 
 package com.digitalasset.http
 
-import com.digitalasset.ledger.api.domain.PartyDetails
-
-import scala.concurrent.{ExecutionContext, Future}
 import com.digitalasset.jwt.domain.Jwt
 import scalaz.OneAnd
 
-class PartiesService(listAllParties: Jwt => Future[List[PartyDetails]])(
+import scala.concurrent.{ExecutionContext, Future}
+
+class PartiesService(listAllParties: LedgerClientJwt.ListKnownParties)(
     implicit ec: ExecutionContext) {
 
   // TODO(Leo) memoize this calls or listAllParties()?

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -83,7 +83,7 @@ object domain {
       queries: NonEmptyList[GetActiveContractsRequest]
   )
 
-  case class PartyDetails(party: Party, displayName: Option[String], isLocal: Boolean)
+  case class PartyDetails(identifier: Party, displayName: Option[String], isLocal: Boolean)
 
   final case class CommandMeta(
       commandId: Option[CommandId],

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -492,7 +492,7 @@ object domain {
 
   final case class OkResponse[R, W](
       result: R,
-      warnings: Option[W],
+      warnings: Option[W] = Option.empty[W],
       status: StatusCode = StatusCodes.OK,
   ) extends ServiceResponse
 
@@ -521,4 +521,6 @@ object domain {
 
   final case class UnknownTemplateIds(unknownTemplateIds: List[TemplateId.OptionalPkg])
       extends ServiceWarning
+
+  final case class UnknownParties(unknownParties: List[domain.Party]) extends ServiceWarning
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -146,14 +146,6 @@ object JsonProtocol extends DefaultJsonProtocol {
         deserializationError(s"$what requires either key or contractId field")
     }
 
-  // implicit val ContractLookupRequestFormat
-  //   : RootJsonReader[domain.ContractLookupRequest[JsValue]] = {
-  //   case JsObject(fields) =>
-  //     val id = decodeContractRef(fields, "ContractLookupRequest")
-  //     domain.ContractLookupRequest(id)
-  //   case _ => deserializationError("ContractLookupRequest must be an object")
-  // }
-
   implicit val EnrichedContractKeyFormat: RootJsonFormat[domain.EnrichedContractKey[JsValue]] =
     jsonFormat2(domain.EnrichedContractKey.apply[JsValue])
 
@@ -288,8 +280,8 @@ object JsonProtocol extends DefaultJsonProtocol {
       override def write(obj: StatusCode): JsValue = JsNumber(obj.intValue)
     }
 
-  implicit val OkResponseFormat: RootJsonFormat[domain.OkResponse[JsValue, JsValue]] = jsonFormat3(
-    domain.OkResponse[JsValue, JsValue])
+  implicit def OkResponseFormat[A: JsonFormat, B: JsonFormat]
+    : RootJsonFormat[domain.OkResponse[A, B]] = jsonFormat3(domain.OkResponse[A, B])
 
   implicit val ErrorResponseFormat: RootJsonFormat[domain.ErrorResponse[JsValue]] = jsonFormat2(
     domain.ErrorResponse[JsValue])
@@ -299,15 +291,22 @@ object JsonProtocol extends DefaultJsonProtocol {
       override def read(json: JsValue): domain.ServiceWarning = json match {
         case JsObject(fields) if fields.contains("unknownTemplateIds") =>
           UnknownTemplateIdsFormat.read(json)
+        case JsObject(fields) if fields.contains("unknownParties") =>
+          UnknownPartiesFormat.read(json)
         case _ =>
-          deserializationError(s"Expected JsObject(unknownTemplateIds -> JsArray(...)), got: $json")
+          deserializationError(
+            s"Expected JsObject(unknownTemplateIds | unknownParties -> JsArray(...)), got: $json")
       }
 
       override def write(obj: domain.ServiceWarning): JsValue = obj match {
         case x: domain.UnknownTemplateIds => UnknownTemplateIdsFormat.write(x)
+        case x: domain.UnknownParties => UnknownPartiesFormat.write(x)
       }
     }
 
   implicit val UnknownTemplateIdsFormat: RootJsonFormat[domain.UnknownTemplateIds] = jsonFormat1(
     domain.UnknownTemplateIds)
+
+  implicit val UnknownPartiesFormat: RootJsonFormat[domain.UnknownParties] = jsonFormat1(
+    domain.UnknownParties)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/SprayJson.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/SprayJson.scala
@@ -4,8 +4,12 @@
 package com.digitalasset.http.json
 
 import com.digitalasset.util.ExceptionOps._
-import scalaz.{-\/, Show, \/, \/-}
+import scalaz.syntax.bitraverse._
+import scalaz.syntax.traverse._
+import scalaz.{-\/, Bitraverse, Show, Traverse, \/, \/-}
 import spray.json.{JsValue, JsonReader, _}
+
+import scala.language.higherKinds
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 object SprayJson {
@@ -43,6 +47,25 @@ object SprayJson {
 
   def decode[A: JsonReader](a: JsValue): JsonReaderError \/ A =
     \/.fromTryCatchNonFatal(a.convertTo[A]).leftMap(e => JsonReaderError(a.toString, e.description))
+
+  def decode1[F[_], A](a: JsValue)(
+      implicit ev1: JsonReader[F[JsValue]],
+      ev2: Traverse[F],
+      ev3: JsonReader[A]): JsonReaderError \/ F[A] =
+    for {
+      fj <- decode[F[JsValue]](a)
+      fa <- fj.traverse(decode[A](_))
+    } yield fa
+
+  def decode2[F[_, _], A, B](a: JsValue)(
+      implicit ev1: JsonReader[F[JsValue, JsValue]],
+      ev2: Bitraverse[F],
+      ev3: JsonReader[A],
+      ev4: JsonReader[B]): JsonReaderError \/ F[A, B] =
+    for {
+      fjj <- decode[F[JsValue, JsValue]](a)
+      fab <- fjj.bitraverse(decode[A](_), decode[B](_))
+    } yield fab
 
   def encode[A: JsonWriter](a: A): JsonWriterError \/ JsValue = {
     import spray.json._

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.http.util
 
-import scalaz.{NonEmptyList, \/}
+import scalaz.{NonEmptyList, OneAnd, \/}
 
 import scala.collection.TraversableLike
 
@@ -31,4 +31,7 @@ object Collections {
     def collect[B](f: A PartialFunction B): Option[NonEmptyList[B]] =
       self.list.collect(f).toNel
   }
+
+  def toNonEmptySet[A](as: NonEmptyList[A]): OneAnd[Set, A] =
+    OneAnd(as.head, as.tail.foldLeft(Set.empty[A])(_ + _) - as.head)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Collections.scala
@@ -32,6 +32,8 @@ object Collections {
       self.list.collect(f).toNel
   }
 
-  def toNonEmptySet[A](as: NonEmptyList[A]): OneAnd[Set, A] =
-    OneAnd(as.head, as.tail.foldLeft(Set.empty[A])(_ + _) - as.head)
+  def toNonEmptySet[A](as: NonEmptyList[A]): OneAnd[Set, A] = {
+    import scalaz.syntax.foldable._
+    OneAnd(as.head, as.tail.toSet - as.head)
+  }
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -810,6 +810,21 @@ abstract class AbstractHttpServiceIntegrationTest
         }: Future[Assertion]
   }
 
+  "parties endpoint should error if empty array passed as input" in withHttpServiceAndClient {
+    (uri, _, _, _) =>
+      postJsonRequest(
+        uri = uri.withPath(Uri.Path("/v1/parties")),
+        JsArray(Vector.empty)
+      ).flatMap {
+        case (status, output) =>
+          status shouldBe StatusCodes.BadRequest
+          assertStatus(output, StatusCodes.BadRequest)
+          val errorMsg = expectedOneErrorMessage(output)
+          errorMsg should include("Cannot read JSON: <[]>")
+          errorMsg should include("must be a list with at least 1 element")
+      }: Future[Assertion]
+  }
+
   "fetch by contractId" in withHttpService { (uri, encoder, decoder) =>
     val command: domain.CreateCommand[v.Record] = iouCreateCommand()
 

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -89,10 +89,8 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
       .withHttpService[A](testId, List(dar1, dar2), jdbcConfig, staticContentConfig)
 
   protected def withHttpService[A](
-      f3: (Uri, DomainJsonEncoder, DomainJsonDecoder) => Future[A]): Future[A] =
-    HttpServiceTestFixture
-      .withHttpService[A](testId, List(dar1, dar2), jdbcConfig, staticContentConfig)((a, b, c, _) =>
-        f3(a, b, c))
+      f: (Uri, DomainJsonEncoder, DomainJsonDecoder) => Future[A]): Future[A] =
+    withHttpServiceAndClient((a, b, c, _) => f(a, b, c))
 
   protected def withLedger[A]: (LedgerClient => Future[A]) => Future[A] =
     HttpServiceTestFixture.withLedger[A](List(dar1, dar2), testId)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -808,7 +808,7 @@ abstract class AbstractHttpServiceIntegrationTest
                           partyDetails.size shouldBe partyIds.size - 1
                           val actualIds: Set[domain.Party] =
                             partyDetails.map(x => x.identifier)(breakOut)
-                          domain.Party.unsubst(actualIds) shouldBe partyIds.toSet
+                          domain.Party.unsubst(actualIds) shouldBe requestedPartyIds.toSet
                           val expected: Set[domain.PartyDetails] =
                             allocatedParties.toSet
                               .map(domain.PartyDetails.fromLedgerApi)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
@@ -45,7 +45,7 @@ object HttpServiceTestFixture {
       dars: List[File],
       jdbcConfig: Option[JdbcConfig],
       staticContentConfig: Option[StaticContentConfig]
-  )(testFn: (Uri, DomainJsonEncoder, DomainJsonDecoder) => Future[A])(
+  )(testFn: (Uri, DomainJsonEncoder, DomainJsonDecoder, LedgerClient) => Future[A])(
       implicit asys: ActorSystem,
       mat: Materializer,
       aesf: ExecutionSequencerFactory,
@@ -92,8 +92,9 @@ object HttpServiceTestFixture {
     val fa: Future[A] = for {
       (_, httpPort) <- httpServiceF
       (encoder, decoder) <- codecsF
+      client <- clientF
       uri = Uri.from(scheme = "http", host = "localhost", port = httpPort)
-      a <- testFn(uri, encoder, decoder)
+      a <- testFn(uri, encoder, decoder, client)
     } yield a
 
     fa.onComplete { _ =>


### PR DESCRIPTION
Closes #4512

- `GET` returns all known parties
- `POST` returns only parties specified in the input array, unknown parties reported as `warnings`, in the format consistent with `unknownTemplateIds`
- `POST` returns BadRequest(400) error if input array of party identifiers is empty: `[]`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
