### PR TITLE
Avoid opening a server to the world when finding a free port.

### DIFF
--- a/bazel_tools/client_server/tests/server.scala
+++ b/bazel_tools/client_server/tests/server.scala
@@ -3,8 +3,9 @@
 
 package com.digitalasset.bazeltools.clientservertest.tests
 
-import java.net._
 import java.io._
+import java.net._
+
 import scala.io._
 
 object Main extends App {
@@ -20,7 +21,7 @@ object Main extends App {
       .text("Something something")
   }
   val conf = argParser.parse(args, Conf("", "")).get
-  val server = new ServerSocket(0)
+  val server = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
 
   println(s"Writing port number ${server.getLocalPort} to file ${conf.portFile}")
   val w = new BufferedWriter(new FileWriter(conf.portFile))

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -400,7 +400,7 @@ def _create_scaladoc_jar(**kwargs):
 
         scaladoc_jar(
             name = kwargs["name"] + "_scaladoc",
-            deps = kwargs["deps"],
+            deps = kwargs.get("deps", []),
             plugins = plugins,
             srcs = kwargs["srcs"],
             scalacopts = kwargs.get("scalacopts", []),

--- a/language-support/scala/bindings-akka-testing/BUILD.bazel
+++ b/language-support/scala/bindings-akka-testing/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
     ],
     deps = [
         "//ledger-api/rs-grpc-bridge",
+        "//libs-scala/ports",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_config",

--- a/language-support/scala/bindings-akka-testing/src/main/scala/com/digitalasset/ledger/client/testing/RandomPorts.scala
+++ b/language-support/scala/bindings-akka-testing/src/main/scala/com/digitalasset/ledger/client/testing/RandomPorts.scala
@@ -3,8 +3,7 @@
 
 package com.digitalasset.ledger.client.testing
 
-import java.net.{InetAddress, ServerSocket}
-
+import com.digitalasset.ports.FreePort
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.annotation.tailrec
@@ -19,17 +18,12 @@ trait RandomPorts extends LazyLogging { self: AkkaTest =>
         logger.info(s"Using port $candidatePort")
         candidatePort
       } else {
-        var candidate: ServerSocket = null
-        try {
-          candidate = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
-        } finally {
-          candidate.close()
-        }
-        logger.info(s"Checking port ${candidate.getLocalPort}")
-        val isHighEnough = lowerBound.fold(true)(candidate.getLocalPort > _)
-        val isLowEnough = upperBound.fold(true)(candidate.getLocalPort < _)
+        val port = FreePort.find()
+        logger.info(s"Checking port $port")
+        val isHighEnough = lowerBound.fold(true)(port > _)
+        val isLowEnough = upperBound.fold(true)(port < _)
         if (isHighEnough && isLowEnough) {
-          tryNext(candidate.getLocalPort)
+          tryNext(port)
         } else {
           tryNext()
         }

--- a/language-support/scala/bindings-akka-testing/src/main/scala/com/digitalasset/ledger/client/testing/RandomPorts.scala
+++ b/language-support/scala/bindings-akka-testing/src/main/scala/com/digitalasset/ledger/client/testing/RandomPorts.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.ledger.client.testing
 
-import java.net.ServerSocket
+import java.net.{InetAddress, ServerSocket}
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -21,7 +21,7 @@ trait RandomPorts extends LazyLogging { self: AkkaTest =>
       } else {
         var candidate: ServerSocket = null
         try {
-          candidate = new ServerSocket(0)
+          candidate = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
         } finally {
           candidate.close()
         }

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/util/TestUtil.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/util/TestUtil.scala
@@ -3,11 +3,10 @@
 
 package com.digitalasset.codegen.util
 
-import com.digitalasset.daml.bazeltools.BazelRunfiles._
-
 import java.io.File
-import java.net.ServerSocket
+import java.net.{InetAddress, ServerSocket}
 
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
 import scalaz.{@@, Tag}
 
 import scala.util.Try
@@ -18,7 +17,7 @@ object TestUtil {
   val TestContext = Tag.of[TestContextTag]
 
   def findOpenPort(): Try[Int] = Try {
-    val socket = new ServerSocket(0)
+    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
     val result = socket.getLocalPort
     socket.close()
     result

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/util/TestUtil.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/util/TestUtil.scala
@@ -4,24 +4,14 @@
 package com.digitalasset.codegen.util
 
 import java.io.File
-import java.net.{InetAddress, ServerSocket}
 
 import com.digitalasset.daml.bazeltools.BazelRunfiles._
 import scalaz.{@@, Tag}
 
-import scala.util.Try
-
 object TestUtil {
   sealed trait TestContextTag
   type TestContext = String @@ TestContextTag
-  val TestContext = Tag.of[TestContextTag]
-
-  def findOpenPort(): Try[Int] = Try {
-    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
-    val result = socket.getLocalPort
-    socket.close()
-    result
-  }
+  val TestContext: Tag.TagOf[TestContextTag] = Tag.of[TestContextTag]
 
   def requiredResource(path: String): File = {
     val f = new File(rlocation(path)).getAbsoluteFile

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -140,6 +140,7 @@ da_scala_test(
         "//ledger/participant-state",
         "//ledger/sandbox",
         "//libs-scala/auth-utils",
+        "//libs-scala/ports",
         "//libs-scala/postgresql-testing",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_chuusai_shapeless_2_12",

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceTestFixture.scala
@@ -13,9 +13,7 @@ import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.http.dbbackend.ContractDao
 import com.digitalasset.http.json.{DomainJsonDecoder, DomainJsonEncoder}
 import com.digitalasset.http.util.FutureUtil
-import com.digitalasset.http.util.FutureUtil.toFuture
 import com.digitalasset.http.util.IdentifierConverters.apiLedgerId
-import com.digitalasset.http.util.TestUtil.findOpenPort
 import com.digitalasset.ledger.api.auth.AuthService
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
@@ -29,6 +27,7 @@ import com.digitalasset.platform.common.LedgerIdMode
 import com.digitalasset.platform.sandbox.SandboxServer
 import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.platform.services.time.TimeProviderType
+import com.digitalasset.ports.FreePort
 import scalaz._
 import scalaz.std.option._
 import scalaz.std.scalaFuture._
@@ -65,7 +64,7 @@ object HttpServiceTestFixture {
     val httpServiceF: Future[(ServerBinding, Int)] = for {
       (_, ledgerPort) <- ledgerF
       contractDao <- contractDaoF
-      httpPort <- toFuture(findOpenPort())
+      httpPort <- Future(FreePort.find())
       httpService <- stripLeft(
         HttpService.start(
           "localhost",

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/TestUtil.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/TestUtil.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.http.util
 
 import java.io.{BufferedWriter, File, FileWriter}
-import java.net.{InetAddress, ServerSocket}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -29,13 +28,6 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 object TestUtil extends LazyLogging {
-  def findOpenPort(): Try[Int] = Try {
-    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
-    val result = socket.getLocalPort
-    socket.close()
-    result
-  }
-
   def requiredFile(fileName: String): Try[File] = {
     val file = new File(fileName).getAbsoluteFile
     if (file.exists()) Success(file)
@@ -51,7 +43,7 @@ object TestUtil extends LazyLogging {
       }
     }
 
-  def readFile(resourcePath: String) =
+  def readFile(resourcePath: String): String =
     Try {
       val source = Source.fromResource(resourcePath)
       val content = source.getLines().mkString

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/TestUtil.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/TestUtil.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.http.util
 
 import java.io.{BufferedWriter, File, FileWriter}
-import java.net.ServerSocket
+import java.net.{InetAddress, ServerSocket}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -22,15 +22,15 @@ import akka.stream.Materializer
 import akka.util.ByteString
 import com.digitalasset.daml.lf.data.TryOps.Bracket.bracket
 import com.typesafe.scalalogging.LazyLogging
-import spray.json.JsValue
 import spray.json._
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 object TestUtil extends LazyLogging {
   def findOpenPort(): Try[Int] = Try {
-    val socket = new ServerSocket(0)
+    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
     val result = socket.getLocalPort
     socket.close()
     result

--- a/libs-scala/ports/BUILD.bazel
+++ b/libs-scala/ports/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 The DAML Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+)
+
+da_scala_library(
+    name = "ports",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.ports
+
+import java.net.{InetAddress, ServerSocket}
+
+object FreePort {
+  def find(): Int = {
+    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
+    try {
+      socket.getLocalPort
+    } finally {
+      // We have to release the port so that it can be used. Note that there is a small race window,
+      // as releasing the port then handing it to the server is not atomic. If this turns out to be
+      // an issue, we need to find an atomic way of doing that.
+      socket.close()
+    }
+  }
+}

--- a/libs-scala/postgresql-testing/BUILD.bazel
+++ b/libs-scala/postgresql-testing/BUILD.bazel
@@ -18,6 +18,7 @@ da_scala_library(
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
         "//ledger-api/testing-utils",
+        "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:commons_io_commons_io",
         "@maven//:org_scalactic_scalactic_2_12",

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -190,7 +190,7 @@ object PostgresAround {
   private val databaseName = "test"
 
   private def findFreePort(): Int = {
-    val s = new ServerSocket(0)
+    val s = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
     val port = s.getLocalPort
     // We have to release the port so the PostgreSQL server can use it. Note that there is a small
     // window for race, as releasing the port then handing it to the server is not atomic. If this

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -4,11 +4,12 @@
 package com.digitalasset.testing.postgresql
 
 import java.io.StringWriter
-import java.net.{InetAddress, ServerSocket}
+import java.net.InetAddress
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.atomic.AtomicBoolean
 
+import com.digitalasset.ports.FreePort
 import com.digitalasset.testing.postgresql.PostgresAround._
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.slf4j.LoggerFactory
@@ -27,7 +28,7 @@ trait PostgresAround {
     val tempDir = Files.createTempDirectory("postgres_test")
     val dataDir = tempDir.resolve("data")
     val confFile = Paths.get(dataDir.toString, "postgresql.conf")
-    val port = findFreePort()
+    val port = FreePort.find()
     val jdbcUrl = s"jdbc:postgresql://$hostName:$port/$databaseName?user=$userName"
     val logFile = Files.createFile(tempDir.resolve("postgresql.log"))
     postgresFixture = PostgresFixture(jdbcUrl, port, tempDir, dataDir, confFile, logFile)
@@ -188,16 +189,6 @@ object PostgresAround {
   private val hostName = InetAddress.getLoopbackAddress.getHostName
   private val userName = "test"
   private val databaseName = "test"
-
-  private def findFreePort(): Int = {
-    val s = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
-    val port = s.getLocalPort
-    // We have to release the port so the PostgreSQL server can use it. Note that there is a small
-    // window for race, as releasing the port then handing it to the server is not atomic. If this
-    // turns out to be an issue, we need to find an atomic way of doing that.
-    s.close()
-    port
-  }
 
   @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
   private class ProcessFailedException(


### PR DESCRIPTION
This is very annoying on macOS because we get a focus-stealing popup for a split second, asking for permission to allow the server through the firewall. The popup pretty much always disappears before it can even be read, when the server is closed.

This is almost certainly not an attack vector, because:
  - we only do this in tests,
  - the server is open for only a few milliseconds,
  - nothing is served,
  - and finding the port is tricky, because it's effectively random.

Nevertheless, it's very annoying.

We seem to do this in 4 different places, which I think is enough to remove the duplication, so I've also pulled out a Bazel package in `//libs-scala/ports`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
