### PR TITLE
Add init-script field to daml.yaml

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -49,6 +49,7 @@ data Command
       , sandboxOptions :: SandboxOptions
       , navigatorOptions :: NavigatorOptions
       , jsonApiOptions :: JsonApiOptions
+      , scriptOptions :: ScriptOptions
       , shutdownStdinClose :: Bool
       }
     | Deploy { flags :: LedgerFlags }
@@ -124,6 +125,7 @@ commandParser = subparser $ fold
         <*> (SandboxOptions <$> many (strOption (long "sandbox-option" <> metavar "SANDBOX_OPTION" <> help "Pass option to sandbox")))
         <*> (NavigatorOptions <$> many (strOption (long "navigator-option" <> metavar "NAVIGATOR_OPTION" <> help "Pass option to navigator")))
         <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
+        <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to DAML script interpreter")))
         <*> stdinCloseOpt
 
     deployCmdInfo = mconcat
@@ -274,6 +276,7 @@ runCommand = \case
             sandboxOptions
             navigatorOptions
             jsonApiOptions
+            scriptOptions
     Deploy {..} -> runDeploy flags
     LedgerListParties {..} -> runLedgerListParties flags json
     LedgerAllocateParties {..} -> runLedgerAllocateParties flags parties

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -99,6 +99,7 @@ da_haskell_test(
         "main-tester",
         "network",
         "unix-compat",
+        "unordered-containers",
         "process",
         "tar",
         "tar-conduit",

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -215,9 +215,6 @@ packagingTests = testGroup "packaging"
           , "  alice `submit` createCmd (T alice)"
           , "  pure ()"
           ]
-        withCurrentDirectory projDir $ do
-          callProcess "daml" ["build"]
-          callProcess "daml" ["damlc", "inspect-dar", ".daml/dist/init-script-example-1.0.dar"]
         sandboxPort :: Int <- fromIntegral <$> getFreePort
         jsonApiPort :: Int <- fromIntegral <$> getFreePort
         let startProc = shell $ unwords


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/4473

Adds a new field `init-script` to `daml.yaml`. If present `daml start` will execute the given identifier with `daml script` to initialize the ledger.

Users should use `allocatePartyWithHint` to allocate parties in the corresponding DAML script. The sandbox is going to use the hint as the actual party id. This way the parties are going to match the ones defined in the `parties` entry of `daml.yaml` and the ones displayed in the navigator.

A possible extension might be to expect/accept a function `[Party] -> Script ()` in `init-script` and pass it the list of parties defined in the `parties` field. @cocreature WDYT?

Adds an integration test to the daml-assistent integration-tests that used the JSON API to verify that a contract was created.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
