### PR TITLE
Split Ledger API Test Tool output

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -35,7 +35,7 @@ object LedgerApiTestTool {
     "UNEXPECTED UNCAUGHT EXCEPTION ON MAIN THREAD, GATHER THE STACKTRACE AND OPEN A _DETAILED_ TICKET DESCRIBING THE ISSUE HERE: https://github.com/digital-asset/daml/issues/new"
 
   private def exitCode(summaries: Vector[LedgerTestSummary], expectFailure: Boolean): Int =
-    if (summaries.exists(_.result.failure) == expectFailure) 0 else 1
+    if (summaries.exists(_.result.isRight) == expectFailure) 0 else 1
 
   private def printAvailableTests(): Unit = {
     println("Tests marked with * are run by default.\n")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -35,7 +35,7 @@ object LedgerApiTestTool {
     "UNEXPECTED UNCAUGHT EXCEPTION ON MAIN THREAD, GATHER THE STACKTRACE AND OPEN A _DETAILED_ TICKET DESCRIBING THE ISSUE HERE: https://github.com/digital-asset/daml/issues/new"
 
   private def exitCode(summaries: Vector[LedgerTestSummary], expectFailure: Boolean): Int =
-    if (summaries.exists(_.result.isRight) == expectFailure) 0 else 1
+    if (summaries.exists(_.result.isLeft) == expectFailure) 0 else 1
 
   private def printAvailableTests(): Unit = {
     println("Tests marked with * are run by default.\n")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSummary.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSummary.scala
@@ -7,5 +7,5 @@ final case class LedgerTestSummary(
     suite: String,
     test: String,
     configuration: LedgerSessionConfiguration,
-    result: Result,
+    result: Either[Result.Failure, Result.Success],
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -106,6 +106,7 @@ object Reporter {
       val (successes, failures) = results.partition(_.result.isRight)
 
       if (successes.nonEmpty) {
+        s.println()
         s.println(green("### SUCCESSES"))
         printReport(successes)
       }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -48,14 +48,7 @@ object Reporter {
       msg.lines.map(l => s"$indent$l").mkString("\n")
     }
 
-    override def report(results: Vector[LedgerTestSummary]): Unit = {
-      s.println()
-      s.println(blue("#" * 80))
-      s.println(blue("#"))
-      s.println(blue("# TEST REPORT"))
-      s.println(blue("#"))
-      s.println(blue("#" * 80))
-
+    private def printReport(results: Vector[LedgerTestSummary]): Unit =
       results.groupBy(_.suite).foreach {
         case (suite, summaries) =>
           s.println()
@@ -64,12 +57,12 @@ object Reporter {
           for (LedgerTestSummary(_, test, _, result) <- summaries) {
             s.print(cyan(s"- $test ... "))
             result match {
-              case Result.Succeeded(duration) =>
+              case Right(Result.Succeeded(duration)) =>
                 s.println(green(s"Success (${duration.toMillis} ms)"))
-              case Result.TimedOut => s.println(red(s"Timeout"))
-              case Result.Skipped(reason) =>
+              case Right(Result.Skipped(reason)) =>
                 s.println(yellow(s"Skipped (reason: $reason)"))
-              case Result.Failed(cause) =>
+              case Left(Result.TimedOut) => s.println(red(s"Timeout"))
+              case Left(Result.Failed(cause)) =>
                 val message =
                   extractRelevantLineNumber(cause).fold("Assertion failed") { lineHint =>
                     s"Assertion failed at line $lineHint"
@@ -85,7 +78,7 @@ object Reporter {
                   for (renderedStackTraceLine <- render(cause))
                     s.println(red(indented(renderedStackTraceLine)))
                 }
-              case Result.FailedUnexpectedly(cause) =>
+              case Left(Result.FailedUnexpectedly(cause)) =>
                 val prefix =
                   s"Unexpected failure (${cause.getClass.getSimpleName})"
                 val message =
@@ -100,6 +93,27 @@ object Reporter {
                 }
             }
           }
+      }
+
+    override def report(results: Vector[LedgerTestSummary]): Unit = {
+      s.println()
+      s.println(blue("#" * 80))
+      s.println(blue("#"))
+      s.println(blue("# TEST REPORT"))
+      s.println(blue("#"))
+      s.println(blue("#" * 80))
+
+      val (successes, failures) = results.partition(_.result.isRight)
+
+      if (successes.nonEmpty) {
+        s.println(green("### SUCCESSES"))
+        printReport(successes)
+      }
+
+      if (failures.nonEmpty) {
+        s.println()
+        s.println(red("### FAILURES"))
+        printReport(failures)
       }
     }
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
@@ -5,30 +5,17 @@ package com.daml.ledger.api.testtool.infrastructure
 
 import scala.concurrent.duration.Duration
 
-private[testtool] sealed trait Result {
-  def failure: Boolean
-}
-
 private[testtool] object Result {
 
-  final case class Succeeded(duration: Duration) extends Result {
-    val failure: Boolean = false
-  }
+  sealed trait Success
 
-  final case class Skipped(reason: String) extends Result {
-    val failure: Boolean = false
-  }
+  final case class Succeeded(duration: Duration) extends Success
+  final case class Skipped(reason: String) extends Success
 
-  case object TimedOut extends Result {
-    val failure: Boolean = true
-  }
+  sealed trait Failure
 
-  final case class Failed(cause: AssertionError) extends Result {
-    val failure: Boolean = true
-  }
-
-  final case class FailedUnexpectedly(cause: Throwable) extends Result {
-    val failure: Boolean = true
-  }
+  case object TimedOut extends Failure
+  final case class Failed(cause: AssertionError) extends Failure
+  final case class FailedUnexpectedly(cause: Throwable) extends Failure
 
 }


### PR DESCRIPTION
Makes failure pop up even without text coloring (e.g. on Azure Pipelines)

Many thanks to @garyverhaegen-da for the useful suggestion.

CHANGELOG_BEGIN
[DAML Ledger Integration Kit] Ledger API Test Tool now prints errors as a separate section
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
