### PR TITLE
daml2ts: Don't fest @daml/types from npmjs.com in tests

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -102,4 +102,4 @@ da_haskell_test(
         "//:sdk-version-hs-lib",
         "//libs-haskell/bazel-runfiles",
     ],
-)
+) if not is_windows else None

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -72,11 +72,15 @@ sh_test(
 da_haskell_test(
     name = "daml2ts",
     srcs = ["src/DA/Test/Daml2Ts.hs"],
-    args = ["$(rootpath //:yarn)"],
+    args = [
+        "$(location //:yarn)",
+        "$(location //language-support/ts/daml-types:npm_package)",
+    ],
     data = [
         "//:yarn",
         "//compiler/damlc",
         "//language-support/ts/codegen:daml2ts",
+        "//language-support/ts/daml-types:npm_package",
         "@davl//:released/davl-upgrade-v3-v4.dar",
         "@davl//:released/davl-upgrade-v4-v5.dar",
         "@davl//:released/davl-v3.dar",


### PR DESCRIPTION
We now copy the compiled version of `@daml/types` into the yarn
workspace instead of getting it from npmjs.com.

I verified that it works if I change the `VERSION` file to contain
0.13.55. Thus, we're definitely not going to npmjs.com.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4688)
<!-- Reviewable:end -->
