### PR TITLE
Upgrade to ghc-lib-8.8.1.20200225

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -88,7 +88,7 @@ import Development.IDE.Core.RuleTypes
 import "ghc-lib-parser" ErrUtils
 -- For dumps
 import "ghc-lib" GHC
-import "ghc-lib" HsDumpAst
+import "ghc-lib-parser" HsDumpAst
 import "ghc-lib" HscStats
 import "ghc-lib-parser" HscTypes
 import qualified "ghc-lib-parser" Outputable as GHC

--- a/compiler/damlc/tests/daml-test-files/DamlHasVersion.daml
+++ b/compiler/damlc/tests/daml-test-files/DamlHasVersion.daml
@@ -1,0 +1,15 @@
+daml 1.2
+module DamlHasVersion(T, main) where
+
+import DA.Functor
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+main : Scenario ()
+main = do
+  p <- getParty "p"
+  void (submit p $ create T with p)

--- a/compiler/damlc/tests/daml-test-files/DamlNoVersion.daml
+++ b/compiler/damlc/tests/daml-test-files/DamlNoVersion.daml
@@ -1,0 +1,14 @@
+module DamlNoVersion(T, main) where
+
+import DA.Functor
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+main : Scenario ()
+main = do
+  p <- getParty "p"
+  void (submit p $ create T with p)

--- a/compiler/damlc/tests/daml-test-files/MissingVersion.daml
+++ b/compiler/damlc/tests/daml-test-files/MissingVersion.daml
@@ -1,6 +1,0 @@
--- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
--- All rights reserved.
-
--- @ERROR range=1:1-1:1; Missing daml version
-
-module MissingVersion where -- intentionally empty

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -227,7 +227,7 @@ basicTests mbScenarioService = Tasty.testGroup "Basic tests"
             setFilesOfInterest [a]
             expectWarning (a,0,25) "The import of ‘B’ is redundant"
             setBufferModified a "???"
-            expectOneError (a,0,0) "Missing daml version"
+            expectOneError (a,0,0) "parse error on input"
 
     ,   testCase' "Loading two modules with the same name DEL-7175" $ do
             a <- makeFile "foo/Test.daml" "daml 1.2 module Test where"

--- a/stack-snapshot.yaml
+++ b/stack-snapshot.yaml
@@ -3,10 +3,10 @@
 
 resolver: lts-14.1
 packages:
-  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20200122.tar.gz
-    sha256: "7b77b8c6a9528e8e3856d783685dddc253c1e17d2b4bd52f7fd4363b65ce5adf"
-  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-8.8.1.20200122.tar.gz
-    sha256: "50d6942d35cef80a8159b4f593bca467e9186c7efcdbe010dfd2e654d90888bd"
+  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20200225.tar.gz
+    sha256: "31b6f1fc15d257e66d3264e62e229203087a2e799a9638f6d5ff6cc43ec0b4a4"
+  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-8.8.1.20200225.tar.gz
+    sha256: "2cd22db09fdcb9bb121bd6f85024aba437ca2796ebe16453d15cbf2cb192023c"
   - github: digital-asset/hlint
     commit: "258bc2b539730b0604d0feffed98636f25022d66"
     sha256: "bb3ad5cd059e2586b2246843693aa1aee4d9db40910378929bcb88f16d0615c4"


### PR DESCRIPTION
- Prelude `daml 1.2` is now optional;
- `HsDumpAst` now comes from `ghc-lib-parser`.
