### PR TITLE
Move directory functions to da-hs-bse

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -38,6 +38,7 @@ da_haskell_library(
     deps = [
         "//daml-assistant:daml-project-config",
         "//language-support/hs/bindings:hs-ledger",
+        "//libs-haskell/da-hs-base",
     ],
 )
 

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -79,6 +79,7 @@ import qualified Web.JWT as JWT
 import Data.Aeson
 import Data.Aeson.Text
 
+import DA.Directory
 import DA.Daml.Helper.Ledger as Ledger
 import DA.Daml.Project.Config
 import DA.Daml.Project.Consts

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Util.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Util.hs
@@ -4,17 +4,10 @@
 module DA.Daml.Project.Util
     ( fromRightM
     , fromMaybeM
-    , copyDirectory
-    , moveDirectory
     , ascendants
     ) where
 
-import Control.Exception.Safe
-import Control.Monad
-import GHC.IO.Exception
-import System.Directory.Extra
 import System.FilePath
-import System.IO.Error
 
 -- | Same as 'fromRight' but monadic in the applied function.
 fromRightM :: Applicative m => (a -> m b) -> Either a b -> m b
@@ -23,27 +16,6 @@ fromRightM f = either f pure
 -- | Same as 'fromMaybe' but monadic in the default.
 fromMaybeM :: Applicative m => m a -> Maybe a -> m a
 fromMaybeM d = maybe d pure
-
-copyDirectory :: FilePath -> FilePath -> IO ()
-copyDirectory src target = do
-    files <- listFilesRecursive src
-    forM_ files $ \file -> do
-        let baseName = makeRelative src file
-        let targetFile = target </> baseName
-        createDirectoryIfMissing True (takeDirectory targetFile)
-        copyFile file targetFile
-
--- Similar to `renameDirectory` but falls back to a non-atomic copy + delete
--- if renameDirectory is unsupported, e.g., because src and target are on different
--- filesystems.
-moveDirectory :: FilePath -> FilePath -> IO ()
-moveDirectory src target =
-    catchJust
-        (\ex -> guard (ioeGetErrorType ex == UnsupportedOperation))
-        (renameDirectory src target)
-        (const $ do
-             copyDirectory src target
-             removePathForcibly src)
 
 -- | Calculate the ascendants of a path, i.e. the successive parents of a path,
 -- including the path itself, all the way to its root. For example:
@@ -62,4 +34,3 @@ ascendants p =
     let p' = takeDirectory (dropTrailingPathSeparator p)
         ps = if p == p' then [] else ascendants p'
     in p : ps
-

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -11,6 +11,7 @@ module DA.Daml.Assistant.Install
     , uninstallVersion
     ) where
 
+import DA.Directory
 import DA.Daml.Assistant.Types
 import DA.Daml.Assistant.Util
 import qualified DA.Daml.Assistant.Install.Github as Github
@@ -18,7 +19,6 @@ import DA.Daml.Assistant.Install.Path
 import DA.Daml.Assistant.Install.Completion
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
-import DA.Daml.Project.Util
 import Safe
 import Data.List
 import Conduit

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -100,5 +100,6 @@ da_haskell_test(
     deps = [
         "//:sdk-version-hs-lib",
         "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
     ],
 ) if not is_windows else None

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
@@ -10,6 +10,7 @@ import System.Environment.Blank
 import System.Directory.Extra
 import System.Process
 import System.Exit
+import DA.Directory
 import DA.Bazel.Runfiles
 import Data.Maybe
 import Data.List.Extra
@@ -42,11 +43,6 @@ yarnInstall yarn damlTypes rootDir = do
   copyDirectory damlTypes (rootDir </> "daml-types")
   writePackageConfigs dummyTs
   withCurrentDirectory rootDir $ yarnProject' yarn ["install"]
-  where
-    copyDirectory from to = do
-      createDirectoryIfMissing True to
-      files <- listDirectory from
-      forM_ files $ \file -> copyFile (from </> file) (to </> file)
 
 tests :: FilePath -> FilePath -> FilePath -> FilePath -> FilePath -> TestTree
 tests rootDir yarn damlc daml2ts davl = testGroup "daml2Ts"

--- a/libs-haskell/da-hs-base/src/DA/Directory.hs
+++ b/libs-haskell/da-hs-base/src/DA/Directory.hs
@@ -1,0 +1,32 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Directory (copyDirectory, moveDirectory) where
+
+import Control.Monad
+import Control.Exception.Safe
+import GHC.IO.Exception
+import System.FilePath
+import System.Directory.Extra
+import System.IO.Error
+
+copyDirectory :: FilePath -> FilePath -> IO ()
+copyDirectory src target = do
+    files <- listFilesRecursive src
+    forM_ files $ \file -> do
+        let baseName = makeRelative src file
+        let targetFile = target </> baseName
+        createDirectoryIfMissing True (takeDirectory targetFile)
+        copyFile file targetFile
+
+-- Similar to `renameDirectory` but falls back to a non-atomic copy + delete
+-- if renameDirectory is unsupported, e.g., because src and target are on different
+-- filesystems.
+moveDirectory :: FilePath -> FilePath -> IO ()
+moveDirectory src target =
+    catchJust
+        (\ex -> guard (ioeGetErrorType ex == UnsupportedOperation))
+        (renameDirectory src target)
+        (const $ do
+             copyDirectory src target
+             removePathForcibly src)


### PR DESCRIPTION
This moves `copyDirectory` and `moveDirectory` from `da-project-config` to new module `DA.Directory` in `da-hs-bse`.