### PR TITLE
fix checkout release step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ jobs:
 
           if is_release_commit; then
               echo "##vso[task.setvariable variable=is_release;isOutput=true]true"
-              echo "##vso[task.setvariable variable=trigger_sha;isOutput=true]$(git rev-parse HEAD)"
+              echo "##vso[task.setvariable variable=trigger_sha;isOutput=true]$(branch_sha)"
               echo "##vso[task.setvariable variable=release_sha;isOutput=true]$(cat LATEST | awk '{print $1}')"
               echo "##vso[task.setvariable variable=release_tag;isOutput=true]$(cat LATEST | awk '{print $2}')"
           else


### PR DESCRIPTION
In the current setup, we expose HEAD as the trigger commit, but that is the merge commit with master. Since making a release takes a long time, this merge commit is likely to not exist anymore by the time we want to try a rerun (assuming a flaky build).

Release PRs are by definition (in the new system) independent of what's going on on master, so we should instead take the branch commit here when running on a PR.