### PR TITLE
narrow LF codeowners; add ledger-service codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,8 @@ azure-cron.yml      @garyverhaegen-da
 /daml-lf/spec/daml-lf-1.rst @remyhaemmerle-da @hurryabit @gerolf-da
 /daml-lf/validation/    @remyhaemmerle-da
 
+/ledger-service/    @leo-da @S11001001
+
 /ledger/      @gerolf-da @rautenrieth-da @stefanobaghino-da @SamirTalwar-DA
 /ledger-api/  @gerolf-da @rautenrieth-da @stefanobaghino-da @SamirTalwar-DA
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,13 +22,16 @@ azure-cron.yml      @garyverhaegen-da
 /ghc-lib/           @shayne-fletcher @cocreature
 
 # Runtime
-/daml-lf/               @leo-da @S11001001
 /daml-lf/governance.rst @gerolf-da @S11001001
 /daml-lf/archive/da/    @remyhaemmerle-da @hurryabit @gerolf-da
 /daml-lf/spec/value.rst @S11001001 @gerolf-da
 /daml-lf/spec/transaction.rst @S11001001 @gerolf-da
 /daml-lf/spec/daml-lf-1.rst @remyhaemmerle-da @hurryabit @gerolf-da
+/daml-lf/data-scalacheck/  @S11001001
+/daml-lf/transaction-scalacheck/  @S11001001
 /daml-lf/validation/    @remyhaemmerle-da
+/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ @S11001001
+/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/       @S11001001
 
 /ledger-service/    @leo-da @S11001001
 


### PR DESCRIPTION
It's useless to have a daml-lf codeowner; narrow it down. We also need a http-json codeowner (and the utilities surrounding it). I'd like people to explicitly request if they'd like my input rather than codeowners always forcing the issue; I've marked out versioning explicitly, though, because it requires so much care.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
