### PR TITLE
@daml/react: Remove loading indication from useExercise hook

### DIFF
--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -75,8 +75,7 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
   return result;
 }
 
-/// React Hook that returns a function to exercise a choice and a boolean
-/// indicator whether the exercise is currently running.
+/// React Hook that returns a function to exercise a choice by contract id.
 export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (cid: ContractId<T>, argument: C) => Promise<R> => {
   const state = useDamlState();
   const exercise = async (cid: ContractId<T>, argument: C) => {
@@ -86,8 +85,7 @@ export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (c
   return exercise;
 }
 
-/// React Hook that returns a function to exercise a choice by key and a boolean
-/// indicator whether the exercise is currently running.
+/// React Hook that returns a function to exercise a choice by key.
 export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): (key: K, argument: C) => Promise<R> => {
   const state = useDamlState();
   const exerciseByKey = async (key: K, argument: C) => {

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -77,32 +77,24 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
 
 /// React Hook that returns a function to exercise a choice and a boolean
 /// indicator whether the exercise is currently running.
-export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): [(cid: ContractId<T>, argument: C) => Promise<R>, boolean] => {
+export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (cid: ContractId<T>, argument: C) => Promise<R> => {
   const state = useDamlState();
-  const [loading, setLoading] = useState(false);
-
   const exercise = async (cid: ContractId<T>, argument: C) => {
-    setLoading(true);
     const [result] = await state.ledger.exercise(choice, cid, argument);
-    setLoading(false);
     return result;
   }
-  return [exercise, loading];
+  return exercise;
 }
 
 /// React Hook that returns a function to exercise a choice by key and a boolean
 /// indicator whether the exercise is currently running.
-export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): [(key: K, argument: C) => Promise<R>, boolean] => {
+export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): (key: K, argument: C) => Promise<R> => {
   const state = useDamlState();
-  const [loading, setLoading] = useState(false);
-
   const exerciseByKey = async (key: K, argument: C) => {
-    setLoading(true);
     const [result] = await state.ledger.exerciseByKey(choice, key, argument);
-    setLoading(false);
     return result;
   }
-  return [exerciseByKey, loading];
+  return exerciseByKey;
 }
 
 /// React Hook for a query against the `/v1/stream/query` endpoint of the JSON API.


### PR DESCRIPTION
The indicator was a stupid idea of mine in the first place. Sharing the
loading indicator between potentially concurrent calls to the function
returned by the hooks does not make any sense.

`useExerciseByKey` has the same problem and it's fixed here as well.

This fixes https://github.com/digital-asset/daml/issues/4568.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4708)
<!-- Reviewable:end -->
