### PR TITLE
fix release steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,13 @@ jobs:
       - bash: |
           set -euo pipefail
           if [ "$(Build.Reason)" == "PullRequest" ]; then
-              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse 'HEAD^2')"
-              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse 'HEAD^1')"
-              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git merge-base --fork-point 'HEAD^1' 'HEAD^2')"
+              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse HEAD^2)"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD^1)"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git merge-base $(git rev-parse HEAD^1) $(git rev-parse HEAD^2))"
           else
               echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse HEAD)"
-              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD)"
-              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git rev-parse HEAD)"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD^1)"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git rev-parse HEAD^1)"
           fi
         name: out
 
@@ -248,7 +248,7 @@ jobs:
 
           is_release_commit() {
               changed="$(git diff-tree --no-commit-id --name-only -r $(branch_sha) $(fork_sha) | sort)"
-              stable=$(printf "LATEST\ndocs/source/support/release-notes.rst")
+              stable=$(printf "LATEST\ndocs/source/support/release-notes.rst" | sort)
               snapshot="LATEST"
               [ "$snapshot" = "$changed" ] || [ "$stable" = "$changed" ]
           }


### PR DESCRIPTION
While flailing about randomly trying to reset the Windows cache yesterday, I noticed a couple issues with the current script:

- The `fork_point` calculation is just plain broken. Somehow our `set -euo pipefail` does not fail on subshell errors, but the existing command is just never going to work: it looks like `git` does not resolve refs on the `merge-base` command. It also looks like the `--fork-point` option is not what we want. I don't know how this happened.
- `sort` on my machine and on CI do not seem to behave the same with respect to upper/lower case ordering. To make the script independent of the specific sort order on the machine (probably controlled by the locale), we now sort both the actual and the expected list.

Finally, based on the failure to recognize a release commit once merged into master, I realized that of course computing the diff between a commit and itself will yield an empty diff. The `git_sha` step will now identify the "master" and "fork point" commits as the parent for a master build.

CHANGELOG_BEGIN
CHANGELOG_END