### PR TITLE
only run release if build succeeded

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -265,7 +265,8 @@ jobs:
 
   - job: windows_installer
     dependsOn: [ "check_for_release", "Windows" ]
-    condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+    condition: and(succeeded(),
+                   eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     pool:
       name: 'windows-pool'
@@ -319,7 +320,8 @@ jobs:
 
   - job: linux_tarball
     dependsOn: [ "check_for_release", "Linux" ]
-    condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+    condition: and(succeeded(),
+                   eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -370,7 +372,8 @@ jobs:
 
   - job: macos_tarball
     dependsOn: [ "check_for_release", "macOS" ]
-    condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+    condition: and(succeeded(),
+                   eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -403,7 +406,8 @@ jobs:
 
   - job: release
     dependsOn: [ "check_for_release", "linux_tarball", "macos_tarball", "windows_installer" ]
-    condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
+    condition: and(succeeded(),
+                   eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     pool:
       vmImage: "Ubuntu-16.04"


### PR DESCRIPTION
The default behaviour of an Azure job that has a dependency is to only run if the dependency has succeeded. However, that default behaviour is overridden if there is an exmplicit `condition` attribute.

This PR restores the expected behaviour that we only try to build a release tarball if the actual build has succeeded.