### PR TITLE
Disable pdf docs builds on macos

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 
 tag_filter=""
 if [[ "$execution_log_postfix" == "_Darwin" ]]; then
-  tag_filter="-dont-run-on-darwin,-scaladoc"
+  tag_filter="-dont-run-on-darwin,-scaladoc,-pdfdocs"
 fi
 
 # Bazel test only builds targets that are dependencies of a test suite

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -66,7 +66,7 @@ robustly_download_nix_packages :: IO ()
 robustly_download_nix_packages = do
     h (10 :: Integer)
     where
-        cmd = "nix-build nix -A tools -A cached"
+        cmd = "nix-build nix -A tools -A ci-cached"
         h n = do
             (exit, out, err) <- shell_exit_code cmd
             case (exit, n) of

--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -40,7 +40,7 @@ step "Building dev-env dependencies"
 NIX_FAILED=0
 for i in `seq 10`; do
     NIX_FAILED=0
-    nix-build nix -A tools -A cached 2>&1 | tee nix_log || NIX_FAILED=1
+    nix-build nix -A tools -A ci-cached 2>&1 | tee nix_log || NIX_FAILED=1
     # It should be in the last line but let’s use the last 3 and wildcards
     # to be robust against slight changes.
     if [[ $NIX_FAILED -ne 0 ]] &&

--- a/ci/dev-env-push.py
+++ b/ci/dev-env-push.py
@@ -104,7 +104,7 @@ def main():
         shutil.rmtree(nix_cache_dir)
 
     # copy to nix cache
-    cmd = ["nix", "copy", "--to", store_url, "-f", "./nix", "tools", "cached"]
+    cmd = ["nix", "copy", "--to", store_url, "-f", "./nix", "tools", "ci-cached"]
     log_cmd(cmd)
     proc = subprocess.run(
             cmd,

--- a/dev-env/bin/bibtex
+++ b/dev-env/bin/bibtex
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/dev-env/bin/latexmk
+++ b/dev-env/bin/latexmk
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/dev-env/bin/lualatex
+++ b/dev-env/bin/lualatex
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/dev-env/bin/makeindex
+++ b/dev-env/bin/makeindex
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/dev-env/bin/pdflatex
+++ b/dev-env/bin/pdflatex
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -324,6 +324,7 @@ genrule(
 
         # Move output to target
         mv DigitalAssetSDK.pdf ../$(location DigitalAssetSDK.pdf)""".format(sdk = sdk_version),
+    tags = ["pdfdocs"],
     tools =
         [
             "@texlive_nix//:bin/lualatex",
@@ -448,6 +449,7 @@ genrule(
         version = sdk_version,
     ),
     stamp = 1,
+    tags = ["pdfdocs"],
 ) if not is_windows else None
 
 filegroup(

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -150,13 +150,6 @@ in rec {
 
     sphinx183 = bazel_dependencies.sphinx183;
 
-    texlive   = bazel_dependencies.texlive;
-    bibtex    = bazel_dependencies.texlive;
-    latexmk   = bazel_dependencies.texlive;
-    makeindex = bazel_dependencies.texlive;
-    pdflatex  = bazel_dependencies.texlive;
-    lualatex  = bazel_dependencies.texlive;
-
     convert = bazel_dependencies.imagemagick;
 
     sass = bazel_dependencies.sass;
@@ -294,6 +287,12 @@ in rec {
     openssh = pkgs.openssh;
   }
   else {});
+
+  # On CI we only cache a subset of cached since we only build a subset of targets.
+  ci-cached =
+    if pkgs.stdenv.isDarwin
+    then builtins.removeAttrs cached ["texlive"]
+    else cached;
 
   # The build environment used for the 'da' package set above.
   # Exported here for testing purposes.


### PR DESCRIPTION
This disables the PDF docs builds on MacOS on CI (they are still built
locally by default) and removes them from the Nix closure by
introducing a separate ci-cached attribute that filters out texlive.

Since we built `nix-build nix -A tools -A cached` on CI, I’ve also
removed all the Tex stuff from tools which only means that it ends up
in PATH which nobody seems to care about.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
