### PR TITLE
Make completion service return checkpoints

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsTable.scala
@@ -61,8 +61,10 @@ object CommandCompletionsTable {
           from participant_command_completions
           where
             completion_offset between $startInclusive and $endExclusive and
-            application_id = ${applicationId: String} and
-            submitting_party in (${parties.asInstanceOf[Set[String]]})"""
+            (application_id is null or application_id = ${applicationId: String}) and
+            (submitting_party is null or submitting_party in (${parties
+      .asInstanceOf[Set[String]]}))
+          order by completion_offset asc"""
 
   // The insert will be prepared only if this entry contains all the information
   // necessary to be rendered as part of the completion service

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/CommandCompletionsTable.scala
@@ -44,6 +44,9 @@ object CommandCompletionsTable {
   val parser: RowParser[CompletionStreamResponse] =
     acceptedCommandParser | rejectedCommandParser | checkpointParser
 
+  // TODO The query has to account for checkpoint, which is why it
+  // TODO returns rows there the application_id and submitting_party
+  // TODO are null. Remove as soon as checkpoints are gone.
   def prepareGet(
       startInclusive: LedgerDao#LedgerOffset,
       endExclusive: LedgerDao#LedgerOffset,
@@ -61,9 +64,12 @@ object CommandCompletionsTable {
           from participant_command_completions
           where
             completion_offset between $startInclusive and $endExclusive and
-            (application_id is null or application_id = ${applicationId: String}) and
-            (submitting_party is null or submitting_party in (${parties
+            (
+              (application_id is null and submitting_party is null)
+              or
+              (application_id = ${applicationId: String} and submitting_party in (${parties
       .asInstanceOf[Set[String]]}))
+            )
           order by completion_offset asc"""
 
   // The insert will be prepared only if this entry contains all the information


### PR DESCRIPTION
The new table for #4681 and the query used to retrieve completions
currently does not return checkpoints. These do not have to match
the application_id and submitting_party query since those fields
are not populated.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
