### PR TITLE
[kvutils] use new contract id scheme

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -229,13 +229,13 @@ final class Engine {
         commands = commands.map(_._2),
         time = ledgerEffectiveTime
       )
-      validationResult <- if (tx isReplayedBy rtx)
+      validationResult <- if (tx isReplayedBy rtx) {
         ResultDone(())
-      else
+      } else {
         ResultError(
           ValidationError(
             s"recreated and original transaction mismatch $tx expected, but $rtx is recreated"))
-
+      }
     } yield validationResult
   }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -183,11 +183,16 @@ final class Engine {
     */
   def validate(
       tx: Transaction.Transaction,
-      ledgerEffectiveTime: Time.Timestamp
+      ledgerEffectiveTime: Time.Timestamp,
+      participantId: Ref.ParticipantId,
+      submissionSeed: Option[crypto.Hash] = None,
   ): Result[Unit] = {
     import scalaz.std.option._
     import scalaz.syntax.traverse.ToTraverseOps
     val commandTranslation = new CommandPreprocessor(_compiledPackages)
+    val transactionSeed = submissionSeed.map(
+      crypto.Hash.deriveTransactionSeed(_, participantId, ledgerEffectiveTime)
+    )
     //reinterpret
     for {
       requiredAuthorizers <- tx.roots
@@ -217,20 +222,20 @@ final class Engine {
         _compiledPackages,
         commands.map(_._2._2.templateId))
       rtx <- interpretCommands(
-        transactionSeed = tx.transactionSeed,
+        transactionSeed = transactionSeed,
         validating = true,
         checkSubmitterInMaintainers = checkSubmitterInMaintainers,
         submitters = submitters,
         commands = commands.map(_._2),
         time = ledgerEffectiveTime
       )
-      validationResult <- if (tx isReplayedBy rtx) {
+      validationResult <- if (tx isReplayedBy rtx)
         ResultDone(())
-      } else {
+      else
         ResultError(
           ValidationError(
             s"recreated and original transaction mismatch $tx expected, but $rtx is recreated"))
-      }
+
     } yield validationResult
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -188,13 +188,12 @@ case class PartialTransaction(
     */
   def finish: Either[PartialTransaction, Tx.Transaction] =
     context match {
-      case ContextRoot(transactionSeed, children) if aborted.isEmpty =>
+      case ContextRoot(_, children) if aborted.isEmpty =>
         Right(
           GenTransaction(
             nodes = nodes,
             roots = children.toImmArray,
             optUsedPackages = None,
-            transactionSeed = transactionSeed,
           ),
         )
       case _ =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -50,7 +50,7 @@ object Hash {
 
   private val hexEncoding = BaseEncoding.base16().lowerCase()
 
-  private case class HashingError(msg: String) extends Error with NoStackTrace
+  private case class HashingError(msg: String) extends Exception with NoStackTrace
 
   private def error(msg: String): Nothing =
     throw HashingError(msg)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -7,15 +7,15 @@ package crypto
 import java.nio.ByteBuffer
 import java.security.{MessageDigest, SecureRandom}
 import java.util
+import java.util.concurrent.atomic.AtomicLong
 
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time, Utf8}
-import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.value.Value
 import com.google.common.io.BaseEncoding
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-import scala.util.control.NonFatal
+import scala.util.control.{NoStackTrace, NonFatal}
 
 final class Hash private (private val bytes: Array[Byte]) {
 
@@ -50,6 +50,18 @@ object Hash {
 
   private val hexEncoding = BaseEncoding.base16().lowerCase()
 
+  private case class HashingError(msg: String) extends Error with NoStackTrace
+
+  private def error(msg: String): Nothing =
+    throw HashingError(msg)
+
+  private def handleError[X](x: => X): Either[String, X] =
+    try {
+      Right(x)
+    } catch {
+      case HashingError(msg) => Left(msg)
+    }
+
   def fromBytes(a: Array[Byte]): Either[String, Hash] =
     Either.cond(
       a.length == underlyingHashLength,
@@ -60,23 +72,40 @@ object Hash {
   def assertFromBytes(a: Array[Byte]): Hash =
     data.assertRight(fromBytes(a))
 
-  def secureRandom(seed: Array[Byte]): () => Hash = {
-    val random = new SecureRandom(seed)
+  // A pseudo random generator for Hash based on hmac
+  // We mix the given seed with time to mitigate very bad seed.
+  def random(seed: Array[Byte]): () => Hash = {
+    if (seed.length != underlyingHashLength)
+      throw new IllegalArgumentException(s"expected a 32 bytes seed, get ${seed.length} bytes.")
+    val counter = new AtomicLong
+    val seedWithTime =
+      hMacBuilder(new Hash(seed)).add(Time.Timestamp.now().micros).build
     () =>
-      {
-        val a = Array.ofDim[Byte](underlyingHashLength)
-        random.nextBytes(a)
-        new Hash(a)
-      }
+      hMacBuilder(seedWithTime).add(counter.getAndIncrement()).build
   }
 
+  def random(seed: Hash): () => Hash = random(seed.bytes)
+
+  // A pseudo random generator for Hash using the best available source of entropy to generate the seed.
   def secureRandom: () => Hash =
-    secureRandom(SecureRandom.getSeed(underlyingHashLength))
+    random(SecureRandom.getInstanceStrong.generateSeed(underlyingHashLength))
 
   implicit val HashOrdering: Ordering[Hash] =
     ((hash1, hash2) => implicitly[Ordering[Iterable[Byte]]].compare(hash1.bytes, hash2.bytes))
 
-  private[crypto] sealed abstract class Builder(purpose: Purpose) {
+  @throws[HashingError]
+  private[lf] val aCid2String: Value.ContractId => String = {
+    case (Value.AbsoluteContractId(cid)) =>
+      cid
+    case (Value.RelativeContractId(_)) =>
+      error("Hashing of relative contract id is not supported")
+  }
+
+  @throws[HashingError]
+  private[lf] val noCid2String: Value.ContractId => Nothing =
+    _ => error("Hashing of relative contract id is not supported in contract key")
+
+  private[crypto] sealed abstract class Builder(cid2String: Value.ContractId => String) {
 
     protected def update(a: Array[Byte]): Unit
 
@@ -107,6 +136,9 @@ object Hash {
       add(a.length).add(a)
     }
 
+    final def add(b: Boolean): this.type =
+      add(if (b) 1.toByte else 0.toByte)
+
     private val intBuffer = ByteBuffer.allocate(java.lang.Integer.BYTES)
 
     final def add(a: Int): this.type = {
@@ -127,6 +159,9 @@ object Hash {
     final def iterateOver[T](a: Iterator[T], size: Int)(f: (this.type, T) => this.type): this.type =
       a.foldLeft[this.type](add(size))(f)
 
+    final def iterateOver[T](a: Option[T])(f: (this.type, T) => this.type): this.type =
+      a.fold[this.type](add(0))(f(add(1), _))
+
     final def addDottedName(name: Ref.DottedName): this.type =
       iterateOver(name.segments)(_ add _)
 
@@ -136,15 +171,25 @@ object Hash {
     final def addIdentifier(id: Ref.Identifier): this.type =
       add(id.packageId).addQualifiedName(id.qualifiedName)
 
+    final def addStringSet[S <: String](set: Set[S]): this.type = {
+      val ss = set.toSeq.sorted[String]
+      iterateOver(ss.iterator, ss.size)(_ add _)
+    }
+
+    @throws[HashingError]
+    final def addCid(cid: Value.ContractId): this.type =
+      add(cid2String(cid))
+
     // In order to avoid hash collision, this should be used together
     // with an other data representing uniquely the type of `value`.
     // See for instance hash : Node.GlobalKey => SHA256Hash
-    final def addTypedValue(value: Value[Value.AbsoluteContractId]): this.type =
+    @throws[HashingError]
+    final def addTypedValue(value: Value[Value.ContractId]): this.type =
       value match {
         case Value.ValueUnit =>
           add(0.toByte)
         case Value.ValueBool(b) =>
-          add(if (b) 1.toByte else 0.toByte)
+          add(b)
         case Value.ValueInt64(v) =>
           add(v)
         case Value.ValueNumeric(v) =>
@@ -158,12 +203,8 @@ object Hash {
           add(v)
         case Value.ValueText(v) =>
           add(v)
-        case Value.ValueContractId(v) =>
-          purpose match {
-            case Purpose.ContractKey =>
-              sys.error("Hashing of contract id for contract keys is not supported")
-            case _ => add(v.coid)
-          }
+        case Value.ValueContractId(cid) =>
+          addCid(cid)
         case Value.ValueOptional(None) =>
           add(0)
         case Value.ValueOptional(Some(v)) =>
@@ -179,12 +220,11 @@ object Hash {
         case Value.ValueEnum(_, v) =>
           add(v)
         case Value.ValueGenMap(_) =>
-          sys.error("Hashing of generic map not implemented")
+          error("Hashing of generic map not implemented")
         // Struct: should never be encountered
         case Value.ValueStruct(_) =>
-          sys.error("Hashing of struct values is not supported")
+          error("Hashing of struct values is not supported")
       }
-
   }
 
   // The purpose of a hash serves to avoid hash collisions due to equal encodings for different objects.
@@ -199,7 +239,10 @@ object Hash {
 
   // package private for testing purpose.
   // Do not call this method from outside Hash object/
-  private[crypto] def builder(purpose: Purpose): Builder = new Builder(purpose) {
+  private[crypto] def builder(
+      purpose: Purpose,
+      cid2String: Value.ContractId => String,
+  ): Builder = new Builder(cid2String) {
 
     private val md = MessageDigest.getInstance("SHA-256")
 
@@ -216,7 +259,7 @@ object Hash {
 
   private val hMacAlgorithm = "HmacSHA256"
 
-  private[crypto] def hMacBuilder(key: Hash): Builder = new Builder(Purpose.PrivateKey) {
+  private[crypto] def hMacBuilder(key: Hash): Builder = new Builder(noCid2String) {
 
     private val mac: Mac = Mac.getInstance(hMacAlgorithm)
 
@@ -248,16 +291,26 @@ object Hash {
     data.assertRight(fromString(s))
 
   def hashPrivateKey(s: String): Hash =
-    builder(Purpose.PrivateKey).add(s).build
+    builder(Purpose.PrivateKey, noCid2String).add(s).build
 
   // This function assumes that key is well typed, i.e. :
   // 1 - `templateId` is the identifier for a template with a key of type τ
   // 2 - `key` is a value of type τ
-  def hashContractKey(templateId: Identifier, key: Value[Nothing]): Hash =
-    builder(Hash.Purpose.ContractKey)
+  @throws[HashingError]
+  def assertHashContractKey(templateId: Ref.Identifier, key: Value[Value.ContractId]): Hash =
+    builder(Purpose.ContractKey, noCid2String)
       .addIdentifier(templateId)
       .addTypedValue(key)
       .build
+
+  def safeHashContractKey(templateId: Ref.Identifier, key: Value[Nothing]): Hash =
+    assertHashContractKey(templateId, key)
+
+  def hashContractKey(
+      templateId: Ref.Identifier,
+      key: Value[Value.ContractId],
+  ): Either[String, Hash] =
+    handleError(assertHashContractKey(templateId, key))
 
   def deriveSubmissionSeed(
       nonce: Hash,
@@ -294,7 +347,7 @@ object Hash {
   ): Hash =
     hMacBuilder(nodeSeed)
       .add(submitTime.micros)
-      .iterateOver(parties.toSeq.sorted[String].iterator, parties.size)(_ add _)
+      .addStringSet(parties)
       .build
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -76,7 +76,8 @@ object Hash {
   // We mix the given seed with time to mitigate very bad seed.
   def random(seed: Array[Byte]): () => Hash = {
     if (seed.length != underlyingHashLength)
-      throw new IllegalArgumentException(s"expected a 32 bytes seed, get ${seed.length} bytes.")
+      throw new IllegalArgumentException(
+        s"Expected a $underlyingHashLength bytes seed, get ${seed.length} bytes.")
     val counter = new AtomicLong
     val seedWithTime =
       hMacBuilder(new Hash(seed)).add(Time.Timestamp.now().micros).build
@@ -181,7 +182,7 @@ object Hash {
       add(cid2String(cid))
 
     // In order to avoid hash collision, this should be used together
-    // with an other data representing uniquely the type of `value`.
+    // with another data representing uniquely the type of `value`.
     // See for instance hash : Node.GlobalKey => SHA256Hash
     @throws[HashingError]
     final def addTypedValue(value: Value[Value.ContractId]): this.type =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -282,18 +282,11 @@ object Node {
   ): Boolean =
     ScalazEqual.match2[recorded.type, isReplayedBy.type, Boolean](fallback = false) {
       case nc: NodeCreate[Cid, Val] => {
-        case NodeCreate(
-            nodeSeed2,
-            coid2,
-            coinst2,
-            optLocation2 @ _,
-            signatories2,
-            stakeholders2,
-            key2) =>
+        case NodeCreate(_, coid2, coinst2, optLocation2 @ _, signatories2, stakeholders2, key2) =>
           import nc._
           // NOTE(JM): Do not compare location annotations as they may differ due to
           // differing update expression constructed from the root node.
-          nodeSeed == nodeSeed2 && coid === coid2 && coinst === coinst2 &&
+          coid === coid2 && coinst === coinst2 &&
           signatories == signatories2 && stakeholders == stakeholders2 && key === key2
         case _ => false
       }
@@ -313,7 +306,7 @@ object Node {
       }
       case ne: NodeExercises[Nothing, Cid, Val] => {
         case NodeExercises(
-            nodeSeed2,
+            _,
             targetCoid2,
             templateId2,
             choiceId2,
@@ -329,7 +322,6 @@ object Node {
             key2,
             ) =>
           import ne._
-          nodeSeed == nodeSeed2 &&
           targetCoid === targetCoid2 && templateId == templateId2 && choiceId == choiceId2 &&
           consuming == consuming2 && actingParties == actingParties2 && chosenValue === chosenValue2 &&
           stakeholders == stakeholders2 && signatories == signatories2 && controllers == controllers2 &&
@@ -345,14 +337,24 @@ object Node {
     }(recorded, isReplayedBy)
 
   /** Useful in various circumstances -- basically this is what a ledger implementation must use as
-    * a key. The 'hash' should be used when storing the key as value serialization is not guaranteed
-    * to be stable over time (e.g. a new encoding might be introduced).
+    * a key. The 'hash' is guaranteed to be stable over time.
     */
-  sealed abstract case class GlobalKey(templateId: Identifier, key: Value[Nothing], hash: Hash)
+  final class GlobalKey private (
+      val templateId: Identifier,
+      val key: Value[Nothing],
+      val hash: Hash
+  ) extends {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: GlobalKey => this.hash == that.hash
+      case _ => false
+    }
+
+    override def hashCode(): Int = hash.hashCode()
+  }
 
   object GlobalKey {
     def apply(templateId: Identifier, key: Value[Nothing]): GlobalKey =
-      new GlobalKey(templateId, key, Hash.hashContractKey(templateId, key)) {}
+      new GlobalKey(templateId, key, Hash.safeHashContractKey(templateId, key))
   }
 
   sealed trait WithTxValue2[F[+ _, + _]] {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -89,7 +89,7 @@ class HashSpec extends WordSpec with Matchers {
       val hash = "ea24627f5b014af67dbedb13d950e60be7f96a1a5bd9fb1a3b9a85b7fa9db4bc"
       val value = complexRecordT.inj(complexRecordV)
       val name = defRef("module", "name")
-      Hash.hashContractKey(name, value).toHexaString shouldBe hash
+      Hash.assertHashContractKey(name, value).toHexaString shouldBe hash
     }
 
     "be deterministic and thread safe" in {
@@ -98,7 +98,7 @@ class HashSpec extends WordSpec with Matchers {
       val hashes = Vector
         .fill(1000)(defRef("module", "name") -> complexRecordT.inj(complexRecordV))
         .par
-        .map(Function.tupled(Hash.hashContractKey))
+        .map(Function.tupled(Hash.assertHashContractKey))
 
       hashes.toSet.size shouldBe 1
     }
@@ -107,8 +107,8 @@ class HashSpec extends WordSpec with Matchers {
       // Same value but different template ID should produce a different hash
       val value = VA.text.inj("A")
 
-      val hash1 = Hash.hashContractKey(defRef("AA", "A"), value)
-      val hash2 = Hash.hashContractKey(defRef("A", "AA"), value)
+      val hash1 = Hash.assertHashContractKey(defRef("AA", "A"), value)
+      val hash2 = Hash.assertHashContractKey(defRef("A", "AA"), value)
 
       hash1 should !==(hash2)
     }
@@ -121,8 +121,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -136,8 +136,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -150,8 +150,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -164,8 +164,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -177,8 +177,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -191,8 +191,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -205,8 +205,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -217,8 +217,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -229,8 +229,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -241,8 +241,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -253,8 +253,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -265,8 +265,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -277,8 +277,8 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
@@ -291,14 +291,14 @@ class HashSpec extends WordSpec with Matchers {
 
       val tid = defRef("module", "name")
 
-      val hash1 = Hash.hashContractKey(tid, value1)
-      val hash2 = Hash.hashContractKey(tid, value2)
+      val hash1 = Hash.assertHashContractKey(tid, value1)
+      val hash2 = Hash.assertHashContractKey(tid, value2)
 
       hash1 should !==(hash2)
     }
   }
 
-  "KeyHasher.putValue" should {
+  "KeyHasher.addValue" should {
 
     "stable " in {
 
@@ -538,7 +538,7 @@ class HashSpec extends WordSpec with Matchers {
       val actualOutput = testCases
         .map { value =>
           val hash = Hash
-            .builder(Hash.Purpose.Testing)
+            .builder(Hash.Purpose.Testing, Hash.aCid2String)
             .addTypedValue(value)
             .build
             .toHexaString

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -134,6 +134,7 @@ conformance_test(
     extra_data = glob(["test/main/resources/*"]),
     server = "//ledger/ledger-on-memory:app",
     server_args = [
+        "--contract-id-seeding=weak",
         "--participant participant-id=ssl-test,port=6865",
         "--crt $(rlocation $TEST_WORKSPACE/$(rootpath test/main/resources/server.crt))",
         "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath test/main/resources/ca.crt))",

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -103,6 +103,7 @@ conformance_test(
     ports = [6865],
     server = ":app",
     server_args = [
+        "--contract-id-seeding=weak",
         "--participant participant-id=example,port=6865",
     ],
     test_tool_args = [
@@ -121,6 +122,7 @@ conformance_test(
     ],
     server = ":app",
     server_args = [
+        "--contract-id-seeding=weak",
         "--participant participant-id=example1,port=6865",
         "--participant participant-id=example2,port=6866",
     ],
@@ -137,6 +139,7 @@ conformance_test(
     ports = [6865],
     server = ":app",
     server_args = [
+        "--contract-id-seeding=weak",
         "--participant participant-id=example,port=6865",
     ],
     test_tool_args = [

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -221,7 +221,10 @@ da_scala_test_suite(
             name = "conformance-test-{}".format(db["name"]),
             ports = [6865],
             server = ":conformance-test-{}-bin".format(db["name"]),
-            server_args = ["--participant participant-id=conformance-test,port=6865"] + db.get("conformance_test_server_args", []),
+            server_args = [
+                "--contract-id-seeding=weak",
+                "--participant participant-id=conformance-test,port=6865",
+            ] + db.get("conformance_test_server_args", []),
             tags = db.get("conformance_test_tags", []),
             test_tool_args = db.get("conformance_test_tool_args", []) + [
                 "--verbose",
@@ -234,7 +237,10 @@ da_scala_test_suite(
             name = "conformance-test-config-management-{}".format(db["name"]),
             ports = [6865],
             server = ":conformance-test-{}-bin".format(db["name"]),
-            server_args = ["--participant participant-id=conformance-test,port=6865"] + db.get("conformance_test_server_args", []),
+            server_args = [
+                "--contract-id-seeding=weak",
+                "--participant participant-id=conformance-test,port=6865",
+            ] + db.get("conformance_test_server_args", []),
             tags = db.get("conformance_test_tags", []),
             test_tool_args = db.get("conformance_test_tool_args", []) + [
                 "--verbose",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
-import com.daml.ledger.participant.state.v1.{ReadService, SubmissionId, WriteService}
+import com.daml.ledger.participant.state.v1.{ReadService, SeedService, SubmissionId, WriteService}
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.digitalasset.ledger.api.auth.AuthService
@@ -89,6 +89,7 @@ class Runner[T <: KeyValueLedger, Extra](name: String, factory: LedgerFactory[T,
         readService = ledger,
         writeService = ledger,
         authService = factory.authService(config),
+        seedService = Some(SeedService(config.seeding)),
       )
     } yield ()
 
@@ -108,6 +109,7 @@ class Runner[T <: KeyValueLedger, Extra](name: String, factory: LedgerFactory[T,
       readService: ReadService,
       writeService: WriteService,
       authService: AuthService,
+      seedService: Option[SeedService]
   )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Unit] =
     new StandaloneApiServer(
       factory.apiServerConfig(participantConfig, config),
@@ -118,5 +120,6 @@ class Runner[T <: KeyValueLedger, Extra](name: String, factory: LedgerFactory[T,
       authService,
       factory.apiServerMetricRegistry(participantConfig),
       factory.timeServiceBackend(config),
+      seedService,
     ).map(_ => ())
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -152,7 +152,7 @@ message DamlTransactionEntry {
   google.protobuf.Timestamp ledger_effective_time = 4;
 
   // The nonce used to generate contract ids
-  bytes submissionSeed = 5;
+  bytes submission_seed = 5;
 }
 
 // A transaction rejection entry.
@@ -324,7 +324,7 @@ message DamlStateValue {
     DamlContractState contract_state = 2;
     DamlCommandDedupValue command_dedup = 3;
     DamlPartyAllocation party = 4;
-    string contract_key_state = 5;
+    DamlContractKeyState contract_key_state = 5;
     DamlConfigurationEntry configuration_entry = 6;
     DamlSubmissionDedupValue submission_dedup = 7;
   }
@@ -360,9 +360,6 @@ message DamlSubmissionDedupKey {
 
   // Uploading participant's id.
   string participant_id = 3;
-
-  // Seed use for interpretation.
-  bytes submissionSeed = 4;
 }
 
 message DamlSubmissionDedupValue {
@@ -420,6 +417,13 @@ message DamlPartyAllocation {
   string participant_id = 1;
   // A display name associated with the given party.
   string display_name = 2;
+}
+
+// The state of a contract key.
+message DamlContractKeyState {
+  // The contract to which the key points to.
+  // If unset the key is inactive.
+  string contract_id = 1;
 }
 
 // A dump of a "kvutils" ledger, including submissions. Used by the integrity checker to test

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -150,6 +150,9 @@ message DamlTransactionEntry {
   // the bounds for valid timestamps in relation to the ledger record time
   // (the time at which the transaction is committed).
   google.protobuf.Timestamp ledger_effective_time = 4;
+
+  // The nonce used to generate contract ids
+  bytes submissionSeed = 5;
 }
 
 // A transaction rejection entry.
@@ -304,7 +307,7 @@ message DamlPartyAllocationRejectionEntry {
 message DamlStateKey {
   oneof key {
     string package_id = 1;
-    DamlContractId contract_id = 2;
+    string contract_id = 2;
     DamlCommandDedupKey command_dedup = 3;
     string party = 4;
     DamlContractKey contract_key = 5;
@@ -321,7 +324,7 @@ message DamlStateValue {
     DamlContractState contract_state = 2;
     DamlCommandDedupValue command_dedup = 3;
     DamlPartyAllocation party = 4;
-    DamlContractKeyState contract_key_state = 5;
+    string contract_key_state = 5;
     DamlConfigurationEntry configuration_entry = 6;
     DamlSubmissionDedupValue submission_dedup = 7;
   }
@@ -357,6 +360,9 @@ message DamlSubmissionDedupKey {
 
   // Uploading participant's id.
   string participant_id = 3;
+
+  // Seed use for interpretation.
+  bytes submissionSeed = 4;
 }
 
 message DamlSubmissionDedupValue {
@@ -414,13 +420,6 @@ message DamlPartyAllocation {
   string participant_id = 1;
   // A display name associated with the given party.
   string display_name = 2;
-}
-
-// The state of a contract key.
-message DamlContractKeyState {
-  // The contract to which the key points to.
-  // If unset the key is inactive.
-  DamlContractId contract_id = 1;
 }
 
 // A dump of a "kvutils" ledger, including submissions. Used by the integrity checker to test

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -330,11 +330,6 @@ message DamlStateValue {
   }
 }
 
-message DamlContractId {
-  DamlLogEntryId entry_id = 1;
-  int64 node_id = 2;
-}
-
 message DamlCommandDedupKey {
   string submitter = 1;
   string application_id = 2;

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -6,7 +6,8 @@ package com.daml.ledger.participant.state.kvutils
 import java.time.{Duration, Instant}
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.v1.{PackageId, SubmittedTransaction, SubmitterInfo}
+import com.daml.ledger.participant.state.v1.{PackageId, SubmitterInfo}
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.digitalasset.daml.lf.data.Time
@@ -45,57 +46,16 @@ private[state] object Conversions {
     Ref.ContractIdString.assertFromString(s"$hexTxId:${coid.txnid.index}")
   }
 
-  def absoluteContractIdToLogEntryId(acoid: AbsoluteContractId): (DamlLogEntryId, Int) =
-    acoid.coid.split(':').toList match {
-      case hexTxId :: nodeId :: Nil =>
-        DamlLogEntryId.newBuilder
-          .setEntryId(ByteString.copyFrom(BaseEncoding.base16.decode(hexTxId)))
-          .build -> nodeId.toInt
-      case _ =>
-        throw Err.DecodeError("AbsoluteContractIdToLogEntryId", s"Cannot parse '${acoid.coid}'")
-    }
-
-  def absoluteContractIdToStateKey(acoid: AbsoluteContractId): DamlStateKey =
-    acoid.coid.split(':').toList match {
-      case hexTxId :: nodeId :: Nil =>
-        DamlStateKey.newBuilder
-          .setContractId(
-            DamlContractId.newBuilder
-              .setEntryId(
-                DamlLogEntryId.newBuilder
-                  .setEntryId(ByteString.copyFrom(BaseEncoding.base16.decode(hexTxId)))
-                  .build)
-              .setNodeId(nodeId.toLong)
-              .build
-          )
-          .build
-      case _ =>
-        throw Err.DecodeError("AbsoluteContractIdToStakeKey", s"Cannot parse '${acoid.coid}'")
-    }
-
-  def relativeContractIdToStateKey(
-      entryId: DamlLogEntryId,
-      rcoid: RelativeContractId,
-  ): DamlStateKey =
+  def contractIdToStateKey(acoid: AbsoluteContractId): DamlStateKey =
     DamlStateKey.newBuilder
-      .setContractId(encodeRelativeContractId(entryId, rcoid))
+      .setContractId(acoid.coid)
       .build
 
-  def encodeRelativeContractId(entryId: DamlLogEntryId, rcoid: RelativeContractId): DamlContractId =
-    DamlContractId.newBuilder
-      .setEntryId(entryId)
-      .setNodeId(rcoid.txnid.index.toLong)
-      .build
+  def decodeContractId(coid: String): AbsoluteContractId =
+    AbsoluteContractId(Ref.ContractIdString.assertFromString(coid))
 
-  def decodeContractId(coid: DamlContractId): AbsoluteContractId = {
-    val hexTxId =
-      BaseEncoding.base16.encode(coid.getEntryId.getEntryId.toByteArray)
-    AbsoluteContractId(Ref.ContractIdString.assertFromString(s"$hexTxId:${coid.getNodeId}"))
-  }
-
-  def stateKeyToContractId(key: DamlStateKey): AbsoluteContractId = {
+  def stateKeyToContractId(key: DamlStateKey): AbsoluteContractId =
     decodeContractId(key.getContractId)
-  }
 
   def encodeGlobalKey(key: GlobalKey): DamlContractKey = {
     DamlContractKey.newBuilder
@@ -192,6 +152,15 @@ private[state] object Conversions {
   def parseTimestamp(ts: com.google.protobuf.Timestamp): Time.Timestamp =
     Time.Timestamp.assertFromInstant(Instant.ofEpochSecond(ts.getSeconds, ts.getNanos.toLong))
 
+  def parseHash(a: com.google.protobuf.ByteString): crypto.Hash =
+    crypto.Hash.assertFromBytes(a.toByteArray)
+
+  def parseOptHash(a: com.google.protobuf.ByteString): Option[crypto.Hash] =
+    if (a.isEmpty)
+      None
+    else
+      Some(crypto.Hash.assertFromBytes(a.toByteArray))
+
   def buildDuration(dur: Duration): com.google.protobuf.Duration = {
     com.google.protobuf.Duration.newBuilder
       .setSeconds(dur.getSeconds)
@@ -203,17 +172,17 @@ private[state] object Conversions {
     Duration.ofSeconds(dur.getSeconds, dur.getNanos.toLong)
   }
 
-  def encodeTransaction(tx: SubmittedTransaction): TransactionOuterClass.Transaction = {
+  def encodeTransaction(tx: Transaction.AbsTransaction): TransactionOuterClass.Transaction = {
     TransactionCoder
       .encodeTransaction(TransactionCoder.NidEncoder, ValueCoder.CidEncoder, tx)
       .fold(err => throw Err.EncodeError("Transaction", err.errorMessage), identity)
   }
 
-  def decodeTransaction(tx: TransactionOuterClass.Transaction): SubmittedTransaction = {
+  def decodeTransaction(tx: TransactionOuterClass.Transaction): Transaction.AbsTransaction = {
     TransactionCoder
       .decodeVersionedTransaction(
         TransactionCoder.NidDecoder,
-        ValueCoder.CidDecoder,
+        ValueCoder.AbsCidDecoder,
         tx
       )
       .fold(err => throw Err.DecodeError("Transaction", err.errorMessage), _.transaction)
@@ -268,22 +237,16 @@ private[state] object Conversions {
       entryId: DamlLogEntryId,
       coidString: String,
       coidStruct: ValueOuterClass.ContractId,
-  ): DamlStateKey = {
-
-    val result = ValueCoder.CidDecoder.decode(
-      sv = transactionVersion,
-      stringForm = coidString,
-      structForm = coidStruct,
-    )
-
-    result match {
-      case Left(err) =>
-        throw Err.DecodeError("ContractId", s"Cannot decode contract id: $err")
-      case Right(rcoid: RelativeContractId) =>
-        relativeContractIdToStateKey(entryId, rcoid)
-      case Right(acoid: AbsoluteContractId) =>
-        absoluteContractIdToStateKey(acoid)
-    }
-  }
+  ): DamlStateKey =
+    ValueCoder.AbsCidDecoder
+      .decode(
+        sv = transactionVersion,
+        stringForm = coidString,
+        structForm = coidStruct,
+      )
+      .fold(
+        err => throw Err.DecodeError("ContractId", s"Cannot decode contract id: $err"),
+        contractIdToStateKey
+      )
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -152,8 +152,8 @@ private[state] object Conversions {
   def parseTimestamp(ts: com.google.protobuf.Timestamp): Time.Timestamp =
     Time.Timestamp.assertFromInstant(Instant.ofEpochSecond(ts.getSeconds, ts.getNanos.toLong))
 
-  def parseHash(a: com.google.protobuf.ByteString): crypto.Hash =
-    crypto.Hash.assertFromBytes(a.toByteArray)
+  def parseHash(bytes: com.google.protobuf.ByteString): crypto.Hash =
+    crypto.Hash.assertFromBytes(bytes.toByteArray)
 
   def parseOptHash(a: com.google.protobuf.ByteString): Option[crypto.Hash] =
     if (a.isEmpty)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -217,7 +217,7 @@ object KeyValueConsumption {
       txEntry: DamlTransactionEntry,
       recordTime: Timestamp,
   ): Update.TransactionAccepted = {
-    val relTx = Conversions.decodeTransaction(txEntry.getTransaction)
+    val transaction = Conversions.decodeTransaction(txEntry.getTransaction)
     val hexTxId = parseLedgerString("TransactionId")(
       BaseEncoding.base16.encode(entryId.toByteArray)
     )
@@ -231,7 +231,7 @@ object KeyValueConsumption {
           .map(parseLedgerString("WorkflowId")),
         submissionSeed = parseOptHash(txEntry.getSubmissionSeed)
       ),
-      transaction = relTx,
+      transaction = transaction,
       transactionId = hexTxId,
       recordTime = recordTime,
       divulgedContracts = List.empty

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -229,19 +229,14 @@ object KeyValueConsumption {
         workflowId = Some(txEntry.getWorkflowId)
           .filter(_.nonEmpty)
           .map(parseLedgerString("WorkflowId")),
+        submissionSeed = parseOptHash(txEntry.getSubmissionSeed)
       ),
-      transaction = makeCommittedTransaction(entryId, relTx),
+      transaction = relTx,
       transactionId = hexTxId,
       recordTime = recordTime,
       divulgedContracts = List.empty
     )
   }
-
-  private def makeCommittedTransaction(
-      txId: DamlLogEntryId,
-      tx: SubmittedTransaction): CommittedTransaction =
-    /* Assign absolute contract ids */
-    tx.resolveRelCid(toAbsCoid(txId, _))
 
   @throws(classOf[Err])
   private def parseLedgerString(what: String)(s: String): Ref.LedgerString =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -36,10 +36,9 @@ object KeyValueSubmission {
     * @deprecated Use [[KeyValueCommitting.submissionOutputs]] instead. This function will be removed in later version.
     */
   def transactionOutputs(
-      entryId: DamlLogEntryId,
       tx: Transaction.AbsTransaction,
   ): List[DamlStateKey] = {
-    val effects = InputsAndEffects.computeEffects(entryId, tx)
+    val effects = InputsAndEffects.computeEffects(tx)
     effects.createdContracts.map(_._1) ++ effects.consumedContracts
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.participant.state.v1.{
   Configuration,
   ParticipantId,
   SubmissionId,
-  SubmittedTransaction,
   SubmitterInfo,
   TransactionMeta
 }
@@ -16,6 +15,7 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 import com.google.protobuf.ByteString
 import Conversions._
 import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.transaction.Transaction
 
 import scala.collection.JavaConverters._
 
@@ -35,7 +35,10 @@ object KeyValueSubmission {
     *
     * @deprecated Use [[KeyValueCommitting.submissionOutputs]] instead. This function will be removed in later version.
     */
-  def transactionOutputs(entryId: DamlLogEntryId, tx: SubmittedTransaction): List[DamlStateKey] = {
+  def transactionOutputs(
+      entryId: DamlLogEntryId,
+      tx: Transaction.AbsTransaction,
+  ): List[DamlStateKey] = {
     val effects = InputsAndEffects.computeEffects(entryId, tx)
     effects.createdContracts.map(_._1) ++ effects.consumedContracts
   }
@@ -44,7 +47,8 @@ object KeyValueSubmission {
   def transactionToSubmission(
       submitterInfo: SubmitterInfo,
       meta: TransactionMeta,
-      tx: SubmittedTransaction): DamlSubmission = {
+      tx: Transaction.AbsTransaction,
+  ): DamlSubmission = {
 
     val inputDamlStateFromTx = InputsAndEffects.computeInputs(tx)
     val encodedSubInfo = buildSubmitterInfo(submitterInfo)
@@ -60,6 +64,8 @@ object KeyValueSubmission {
           .setSubmitterInfo(encodedSubInfo)
           .setLedgerEffectiveTime(buildTimestamp(meta.ledgerEffectiveTime))
           .setWorkflowId(meta.workflowId.getOrElse(""))
+          .setSubmissionSeed(meta.submissionSeed.fold(ByteString.EMPTY)(x =>
+            ByteString.copyFrom(x.toByteArray)))
       )
       .build
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -7,6 +7,9 @@ package com.daml.ledger.participant.state.kvutils
   * and the changelog of kvutils.
   *
   * Changes:
+  * [after 100.13.55]: *BACKWARDS INCOMPATIBLE*
+  * - Remove use of relative contract ids. Introduces kvutils version 2.
+  *
   * [after 100.13.52]: *BACKWARDS INCOMPATIBLE*
   * - Use hash for serializing contract keys instead of serializing the value, as
   *   the value serialization is not guaranteed to be stable over time.
@@ -54,6 +57,16 @@ object Version {
     * Version should be incremented when semantics of fields change and migration of data is required or
     * when the protobuf default value for a field is insufficient and must be filled in during decoding.
     * Handling of older versions is handled by [[Envelope.open]] which performs the migration to latest version.
+    *
+    * Version history:
+    *   0: Initial version
+    *
+    *   1: Use hashing to serialize contract keys. Backwards incompatible to avoid having to do two lookups
+    *      of a single contract key.
+    *
+    *   2: Deprecate use of relative contract identifiers. The transaction is submitted with absolute contract
+    *      identifiers. Backwards incompatible to remove unnecessary traversal of the transaction when consuming
+    *      it and to make it possible to remove DamlLogEntryId.
     */
-  val version: Long = 1
+  val version: Long = 2
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -23,9 +23,14 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter)(
   override def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): CompletionStage[SubmissionResult] = {
+      transaction: SubmittedTransaction,
+  ): CompletionStage[SubmissionResult] = {
     val submission =
-      KeyValueSubmission.transactionToSubmission(submitterInfo, transactionMeta, transaction)
+      KeyValueSubmission.transactionToSubmission(
+        submitterInfo,
+        transactionMeta,
+        transaction.assertNoRelCid(cid => s"Unexpected relative contract id: $cid"),
+      )
     val correlationId = nextSubmissionId()
     commit(correlationId, submission)
   }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -13,9 +13,10 @@ import com.daml.ledger.participant.state.v1.Update._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.bazeltools.BazelRunfiles._
 import com.digitalasset.daml.lf.archive.DarReader
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.data.{ImmArray, InsertOrdSet, Ref}
-import com.digitalasset.daml.lf.transaction.GenTransaction
+import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.logging.LoggingContext
@@ -701,7 +702,7 @@ object ParticipantStateIntegrationSpecBase {
   type ParticipantState = ReadService with WriteService
 
   private val IdleTimeout = 5.seconds
-  private val emptyTransaction: SubmittedTransaction =
+  private val emptyTransaction: Transaction.AbsTransaction =
     GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 
   private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("test-participant")
@@ -719,10 +720,14 @@ object ParticipantStateIntegrationSpecBase {
   private def newSubmissionId(): SubmissionId =
     Ref.LedgerString.assertFromString(s"submission-${UUID.randomUUID()}")
 
-  private def transactionMeta(let: Timestamp) = TransactionMeta(
-    ledgerEffectiveTime = let,
-    workflowId = Some(Ref.LedgerString.assertFromString("tests")),
-  )
+  private def transactionMeta(let: Timestamp) =
+    TransactionMeta(
+      ledgerEffectiveTime = let,
+      workflowId = Some(Ref.LedgerString.assertFromString("tests")),
+      submissionSeed = Some(
+        crypto.Hash.assertFromString(
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
+    )
 
   private def matchPackageUpload(
       update: Update,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -8,9 +8,11 @@ import java.time.Duration
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.command.{Command, Commands}
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.engine.Engine
+import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml_lf_dev.DamlLf
 import scalaz.State
 import scalaz.syntax.traverse._
@@ -156,12 +158,12 @@ object KVTest {
 
   val minMRTDelta: Duration = theDefaultConfig.timeModel.minTtl
 
-  private val participant = Ref.ParticipantId.assertFromString("participant")
-
   def runCommand(
       submitter: Party,
+      submissionSeed: Option[crypto.Hash],
       additionalContractDataTy: String,
-      cmds: Command*): KVTest[SubmittedTransaction] =
+      cmds: Command*,
+  ): KVTest[Transaction.AbsTransaction] =
     for {
       s <- get[KVTestState]
       tx = s.engine
@@ -172,13 +174,13 @@ object KVTest {
             ledgerEffectiveTime = s.recordTime,
             commandsReference = "cmds-ref",
           ),
-          participantId = participant,
-          submissionSeed = None,
+          participantId = s.participantId,
+          submissionSeed = submissionSeed,
         )
         .consume(
           { coid =>
             s.damlState
-              .get(Conversions.absoluteContractIdToStateKey(coid))
+              .get(Conversions.contractIdToStateKey(coid))
               .map { v =>
                 Conversions.decodeContractInstance(v.getContractState.getContractInstance)
               }
@@ -189,17 +191,23 @@ object KVTest {
           }
         )
         .getOrElse(sys.error("Engine.submit fail"))
-    } yield tx
+    } yield tx.assertNoRelCid(_ => "Unexpected relative contract ids")
 
-  def runSimpleCommand(submitter: Party, cmds: Command*): KVTest[SubmittedTransaction] =
-    runCommand(submitter, defaultAdditionalContractDataTy, cmds: _*)
+  def runSimpleCommand(
+      submitter: Party,
+      submissionSeed: Option[crypto.Hash],
+      cmds: Command*,
+  ): KVTest[Transaction.AbsTransaction] =
+    runCommand(submitter, submissionSeed, defaultAdditionalContractDataTy, cmds: _*)
 
   def submitTransaction(
       submitter: Party,
-      tx: SubmittedTransaction,
+      tx: Transaction.AbsTransaction,
+      submissionSeed: Option[crypto.Hash],
       mrtDelta: Duration = minMRTDelta,
       letDelta: Duration = Duration.ZERO,
-      commandId: CommandId = randomLedgerString): KVTest[(DamlLogEntryId, DamlLogEntry)] =
+      commandId: CommandId = randomLedgerString,
+  ): KVTest[(DamlLogEntryId, DamlLogEntry)] =
     for {
       testState <- get[KVTestState]
       submInfo = SubmitterInfo(
@@ -212,7 +220,8 @@ object KVTest {
         submitterInfo = submInfo,
         meta = TransactionMeta(
           ledgerEffectiveTime = testState.recordTime.addMicros(letDelta.toNanos / 1000),
-          workflowId = None
+          workflowId = None,
+          submissionSeed = submissionSeed,
         ),
         tx = tx
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -295,7 +295,7 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
           case (_, v) =>
             v.getValueCase match {
               case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_KEY_STATE =>
-                v.getContractKeyState shouldBe 'empty
+                v.getContractKeyState.getContractId shouldBe 'empty
 
               case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_STATE =>
                 val cs = v.getContractState

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -16,6 +16,7 @@ import com.digitalasset.daml.lf.command.{
   CreateCommand,
   ExerciseCommand
 }
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.{Ref, FrontStack, SortedLookupList}
 import com.digitalasset.daml.lf.transaction.Node.NodeCreate
 import com.digitalasset.daml.lf.value.Value
@@ -88,14 +89,15 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     val p0 = mkParticipantId(0)
     val p1 = mkParticipantId(1)
 
-    "be able to submit transaction" in KVTest.runTestWithSimplePackage(alice, bob, eve)(
+    "be able to submit transaction" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
+      val seed = hash(this.getClass.getName)
       for {
-        tx <- runSimpleCommand(alice, simpleCreateCmd)
-        logEntry <- submitTransaction(submitter = alice, tx = tx).map(_._2)
+        tx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        logEntry <- submitTransaction(submitter = alice, tx = tx, seed).map(_._2)
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
       }
-    )
+    }
 
     /* Disabled while we rework the time model.
     "reject transaction with elapsed max record time" in KVTest.runTestWithSimplePackage(
@@ -110,26 +112,35 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     )
      */
 
-    "reject transaction with out of bounds LET" in KVTest.runTestWithSimplePackage(alice, bob, eve)(
+    "reject transaction with out of bounds LET" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
+      val seed = hash(this.getClass.getName)
       for {
-        tx <- runSimpleCommand(alice, simpleCreateCmd)
+        tx <- runSimpleCommand(alice, seed, simpleCreateCmd)
         conf <- getDefaultConfiguration
-        logEntry <- submitTransaction(submitter = alice, tx = tx, letDelta = conf.timeModel.minTtl)
+        logEntry <- submitTransaction(
+          submitter = alice,
+          tx = tx,
+          seed,
+          letDelta = conf.timeModel.minTtl)
           .map(_._2)
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
         // FIXME(JM): Bad reason, need one for bad/expired LET!
         logEntry.getTransactionRejectionEntry.getReasonCase shouldEqual DamlTransactionRejectionEntry.ReasonCase.MAXIMUM_RECORD_TIME_EXCEEDED
       }
-    )
+    }
 
     "be able to exercise and rejects double spends" in KVTest.runTestWithSimplePackage(
       alice,
       bob,
       eve) {
+      val seeds =
+        Stream
+          .from(0)
+          .map(i => Some(crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString)))
       for {
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
-        result <- submitTransaction(submitter = alice, tx = createTx)
+        createTx <- runSimpleCommand(alice, seeds(0), simpleCreateCmd)
+        result <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seeds(0))
         (entryId, logEntry) = result
         update = KeyValueConsumption.logEntryToUpdate(entryId, logEntry).head
         coid = update
@@ -141,11 +152,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
           .asInstanceOf[NodeCreate[AbsoluteContractId, _]]
           .coid
 
-        exeTx <- runSimpleCommand(alice, exerciseCmd(coid.coid, simpleTemplateId))
-        logEntry2 <- submitTransaction(submitter = alice, tx = exeTx).map(_._2)
+        exeTx <- runSimpleCommand(alice, seeds(1), exerciseCmd(coid.coid, simpleTemplateId))
+        logEntry2 <- submitTransaction(submitter = alice, tx = exeTx, seeds(1)).map(_._2)
 
         // Try to double consume.
-        logEntry3 <- submitTransaction(submitter = alice, tx = exeTx).map(_._2)
+        logEntry3 <- submitTransaction(submitter = alice, tx = exeTx, seeds(1)).map(_._2)
 
       } yield {
         logEntry2.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
@@ -155,12 +166,13 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     }
 
     "reject transactions by unallocated submitters" in KVTest.runTestWithSimplePackage(bob, eve) {
+      val seed = hash(this.getClass.getName)
       for {
         configEntry <- submitConfig { c =>
           c.copy(generation = c.generation + 1)
         }
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
-        txEntry <- submitTransaction(submitter = alice, tx = createTx).map(_._2)
+        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        txEntry <- submitTransaction(submitter = alice, tx = createTx, seed).map(_._2)
       } yield {
         configEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
         txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
@@ -174,10 +186,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         mkTemplateArg("Alice", "Eve", additionalContractDataType, additionalContractValue))
       s"accept transactions with unallocated parties in values: $additionalContractDataType" in KVTest
         .runTestWithPackage(additionalContractDataType, alice, eve) {
-
+          val seed = hash(this.getClass.getName)
           for {
-            createTx <- runCommand(alice, additionalContractDataType, command)
-            txEntry <- submitTransaction(submitter = alice, tx = createTx).map(_._2)
+            createTx <- runCommand(alice, seed, additionalContractDataType, command)
+            txEntry <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
+              .map(_._2)
           } yield {
             txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
           }
@@ -185,27 +198,31 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     }
 
     "reject transactions with unallocated informee" in KVTest.runTestWithSimplePackage(alice, bob) {
+      val seed = hash(this.getClass.getName)
       for {
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
-        txEntry1 <- submitTransaction(submitter = alice, tx = createTx).map(_._2)
+        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        txEntry1 <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
+          .map(_._2)
       } yield {
         txEntry1.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
         txEntry1.getTransactionRejectionEntry.getReasonCase shouldEqual DamlTransactionRejectionEntry.ReasonCase.PARTY_NOT_KNOWN_ON_LEDGER
       }
     }
 
+    // FIXME: review this test
     "reject transactions for unhosted parties" in KVTest.runTestWithSimplePackage(bob, eve) {
+      val seed = hash(this.getClass.getName)
       for {
         configEntry <- submitConfig { c =>
           c.copy(generation = c.generation + 1)
         }
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
+        createTx <- withParticipantId(p1)(runSimpleCommand(alice, seed, simpleCreateCmd))
 
         newParty <- withParticipantId(p1)(allocateParty("unhosted", alice))
         txEntry1 <- withParticipantId(p0)(
-          submitTransaction(submitter = newParty, tx = createTx).map(_._2))
+          submitTransaction(submitter = newParty, tx = createTx, seed).map(_._2))
         txEntry2 <- withParticipantId(p1)(
-          submitTransaction(submitter = newParty, tx = createTx).map(_._2))
+          submitTransaction(submitter = newParty, tx = createTx, seed).map(_._2))
 
       } yield {
         configEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
@@ -217,11 +234,13 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     }
 
     "reject unauthorized transactions" in KVTest.runTestWithSimplePackage(alice, eve) {
+      val seed = hash(this.getClass.getName)
       for {
         // Submit a creation of a contract with owner 'Alice', but submit it as 'Bob'.
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
+        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
         bob <- allocateParty("bob", bob)
-        txEntry <- submitTransaction(submitter = bob, tx = createTx).map(_._2)
+        txEntry <- submitTransaction(submitter = bob, tx = createTx, submissionSeed = seed)
+          .map(_._2)
       } yield {
         txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
@@ -230,11 +249,12 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     }
 
     "metrics get updated" in KVTest.runTestWithSimplePackage(alice, eve) {
+      val seed = hash(this.getClass.getName)
       for {
         // Submit a creation of a contract with owner 'Alice', but submit it as 'Bob'.
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
+        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
         bob <- allocateParty("bob", bob)
-        _ <- submitTransaction(submitter = bob, tx = createTx).map(_._2)
+        _ <- submitTransaction(submitter = bob, tx = createTx, submissionSeed = seed).map(_._2)
       } yield {
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
         // Check that we're updating the metrics (assuming this test at least has been run)
@@ -251,14 +271,19 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       alice,
       bob,
       eve) {
+      val seeds =
+        Stream
+          .from(0)
+          .map(i => Some(crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString)))
+
       val simpleCreateAndExerciseCmd = createAndExerciseCmd(simpleTemplateId, simpleTemplateArg)
 
       for {
-        tx1 <- runSimpleCommand(alice, simpleCreateAndExerciseCmd)
-        createAndExerciseTx1 <- submitTransaction(alice, tx1).map(_._2)
+        tx1 <- runSimpleCommand(alice, seeds(0), simpleCreateAndExerciseCmd)
+        createAndExerciseTx1 <- submitTransaction(alice, tx1, seeds(0)).map(_._2)
 
-        tx2 <- runSimpleCommand(alice, simpleCreateAndExerciseCmd)
-        createAndExerciseTx2 <- submitTransaction(alice, tx2).map(_._2)
+        tx2 <- runSimpleCommand(alice, seeds(1), simpleCreateAndExerciseCmd)
+        createAndExerciseTx2 <- submitTransaction(alice, tx2, seeds(1)).map(_._2)
 
         finalState <- scalaz.State.get[KVTestState]
       } yield {
@@ -270,8 +295,7 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
           case (_, v) =>
             v.getValueCase match {
               case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_KEY_STATE =>
-                val cks = v.getContractKeyState
-                cks.hasContractId shouldBe false
+                v.getContractKeyState shouldBe 'empty
 
               case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_STATE =>
                 val cs = v.getContractState
@@ -285,9 +309,10 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     }
 
     "submitter info is optional" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
+      val seed = hash(this.getClass.getName)
       for {
-        createTx <- runSimpleCommand(alice, simpleCreateCmd)
-        result <- submitTransaction(submitter = alice, tx = createTx)
+        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        result <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
       } yield {
         val (entryId, entry) = result
         // Clear the submitter info from the log entry
@@ -303,4 +328,6 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       }
     }
   }
+
+  private def hash(s: String) = Some(crypto.Hash.hashPrivateKey(s))
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -10,9 +10,10 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1._
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.data.{ImmArray, InsertOrdSet, Ref}
-import com.digitalasset.daml.lf.transaction.GenTransaction
+import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -80,7 +81,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
 
   private val aParty = Ref.Party.assertFromString("aParty")
 
-  private val anEmptyTransaction: SubmittedTransaction =
+  private val anEmptyTransaction: Transaction.AbsTransaction =
     GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
 
   private val aSubmissionId: SubmissionId =
@@ -105,7 +106,10 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
 
   private def transactionMeta(let: Timestamp) = TransactionMeta(
     ledgerEffectiveTime = let,
-    workflowId = Some(Ref.LedgerString.assertFromString("tests"))
+    workflowId = Some(Ref.LedgerString.assertFromString("tests")),
+    submissionSeed = Some(
+      crypto.Hash.assertFromString(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
   )
 
   private def newRecordTime(): Timestamp =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -136,7 +136,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with MockitoSu
       val logEntryCaptor = ArgumentCaptor.forClass(classOf[RawBytes])
       when(mockStateOperations.appendToLog(any[RawBytes](), logEntryCaptor.capture()))
         .thenReturn(Future.successful(expectedLogResult))
-      val logEntryAndStateResult = (aLogEntry(), someStateUpdates(1))
+      val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
         new FakeStateAccess(mockStateOperations),
         (_, _, _, _, _) => logEntryAndStateResult,
@@ -164,7 +164,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with MockitoSu
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       when(mockStateOperations.appendToLog(any[RawBytes](), any[RawBytes]()))
         .thenReturn(Future.successful(99))
-      val logEntryAndStateResult = (aLogEntry(), someStateUpdates(1))
+      val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
         new FakeStateAccess(mockStateOperations),
         (_, _, _, _, _) => logEntryAndStateResult,
@@ -188,18 +188,15 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with MockitoSu
 
   private def aLogEntryId(): DamlLogEntryId = SubmissionValidator.allocateRandomLogEntryId()
 
-  private def someStateUpdates(count: Int): Map[DamlStateKey, DamlStateValue] =
-    (1 to count).map { index =>
-      val key = DamlStateKey
-        .newBuilder()
-        .setContractId(DamlContractId
-          .newBuilder()
-          .setEntryId(DamlLogEntryId.newBuilder.setEntryId(ByteString.copyFromUtf8(index.toString)))
-          .setNodeId(index.toLong))
-        .build
-      val value = DamlStateValue.getDefaultInstance
-      key -> value
-    }.toMap
+  private def someStateUpdates: Map[DamlStateKey, DamlStateValue] = {
+
+    val key = DamlStateKey
+      .newBuilder()
+      .setContractId(1.toString)
+      .build
+    val value = DamlStateValue.getDefaultInstance
+    Map(key -> value)
+  }
 
   private def aStateValue(): RawBytes =
     SubmissionValidator.valueToBytes(DamlStateValue.getDefaultInstance)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SeedService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SeedService.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import com.digitalasset.daml.lf.crypto
+import com.digitalasset.daml.lf.crypto.Hash
+
+trait SeedService {
+
+  def nextSeed: () => crypto.Hash
+
+}
+
+object SeedService {
+
+  sealed abstract class Seeding
+  object Seeding {
+    case object Weak extends Seeding
+    case object Strong extends Seeding
+  }
+
+  def apply(seeding: Seeding): SeedService =
+    seeding match {
+      case Seeding.Strong =>
+        new StrongRandomSeedService
+      case Seeding.Weak =>
+        new WeakRandomSeedService
+    }
+
+}
+
+// This service uses a very low entropy seed.
+// Do not use in production
+class WeakRandomSeedService extends SeedService {
+  override val nextSeed: () => Hash = {
+    val weakSeed = Array.ofDim[Byte](32)
+    scala.util.Random.nextBytes(weakSeed)
+    crypto.Hash.random(weakSeed)
+  }
+}
+
+// This service uses a PRNG with a high level entropy seed
+class StrongRandomSeedService extends SeedService {
+  override val nextSeed: () => Hash =
+    crypto.Hash.secureRandom
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.v1
 
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Time.Timestamp
 
 /** Meta-data of a transaction visible to all parties that can see a part of
@@ -22,4 +23,5 @@ import com.digitalasset.daml.lf.data.Time.Timestamp
 final case class TransactionMeta(
     ledgerEffectiveTime: Timestamp,
     workflowId: Option[WorkflowId],
+    submissionSeed: Option[crypto.Hash],
 )

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -401,10 +401,26 @@ server_conformance_test(
     ],
 )
 
+server_conformance_test(
+    name = "conformance-test-contract-id-seeding",
+    server_args = [
+        "--contract-id-seeding=weak",
+    ],
+    servers = SERVERS,
+    test_tool_args = [
+        "--verbose",
+        "--all-tests",
+        "--exclude=ConfigManagementServiceIT",
+        "--exclude=ClosedWorldIT",
+        "--exclude=CommandDeduplicationIT",
+    ],
+)
+
 NEXT_SERVERS = {
     "memory": {
         "binary": ":sandbox-next-binary",
         "server_args": [
+            "--contract-id-seeding=weak",
             "--port=6865",
             "--eager-package-loading",
         ],
@@ -412,6 +428,7 @@ NEXT_SERVERS = {
     "postgresql": {
         "binary": ":sandbox-next-ephemeral-postgresql",
         "server_args": [
+            "--contract-id-seeding=weak",
             "--port=6865",
             "--eager-package-loading",
         ],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
@@ -6,9 +6,8 @@ package com.digitalasset.platform.apiserver
 import akka.stream.Materializer
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2._
-import com.daml.ledger.participant.state.v1.{Configuration, WriteService}
+import com.daml.ledger.participant.state.v1.{Configuration, SeedService, WriteService}
 import com.digitalasset.api.util.TimeProvider
-import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.engine._
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
@@ -79,7 +78,7 @@ object ApiServices {
       optTimeServiceBackend: Option[TimeServiceBackend],
       metrics: MetricRegistry,
       healthChecks: HealthChecks,
-      seedService: Option[() => crypto.Hash]
+      seedService: Option[SeedService]
   )(
       implicit mat: Materializer,
       esf: ExecutionSequencerFactory,
@@ -107,7 +106,8 @@ object ApiServices {
           submissionService,
           defaultLedgerConfiguration.timeModel,
           timeProvider,
-          new CommandExecutorImpl(engine, packagesService.getLfPackage, participantId, seedService),
+          seedService,
+          new CommandExecutorImpl(engine, packagesService.getLfPackage, participantId),
           ApiSubmissionService.Configuration(
             submissionConfig.maxTtl
           ),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutor.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.platform.apiserver
 
 import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.command.Commands
 import com.digitalasset.daml.lf.data.Ref.Party
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
@@ -19,6 +20,7 @@ trait CommandExecutor {
 
   def execute(
       submitter: Party,
+      submissionSeed: Option[crypto.Hash],
       submitted: ApiCommands,
       getContract: Value.AbsoluteContractId => Future[
         Option[Value.ContractInst[Transaction.Value[Value.AbsoluteContractId]]]],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
@@ -38,20 +38,18 @@ class CommandExecutorImpl(
     engine: Engine,
     getPackage: Ref.PackageId => Future[Option[Package]],
     participant: Ref.ParticipantId,
-    randomService: Option[() => crypto.Hash],
 )(implicit ec: ExecutionContext)
     extends CommandExecutor {
 
   override def execute(
       submitter: Party,
+      submissionSeed: Option[crypto.Hash],
       submitted: ApiCommands,
       getContract: Value.AbsoluteContractId => Future[
         Option[Value.ContractInst[TxValue[Value.AbsoluteContractId]]]],
       lookupKey: GlobalKey => Future[Option[AbsoluteContractId]],
       commands: Commands,
   ): Future[Either[ErrorCause, (SubmitterInfo, TransactionMeta, Transaction.Transaction)]] = {
-
-    val submissionSeed = randomService.map(_())
 
     consume(engine.submit(commands, participant, submissionSeed))(
       getPackage,
@@ -73,8 +71,9 @@ class CommandExecutorImpl(
             TransactionMeta(
               Time.Timestamp.assertFromInstant(submitted.ledgerEffectiveTime),
               submitted.workflowId.map(_.unwrap),
+              submissionSeed,
             ),
-            updateTx
+            updateTx,
           )).left.map(ErrorCause.DamlLf)
       }
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService, WriteService}
+import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService, SeedService, WriteService}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.engine.Engine
 import com.digitalasset.grpc.adapter.ExecutionSequencerFactory
@@ -45,6 +45,7 @@ final class StandaloneApiServer(
     authService: AuthService,
     metrics: MetricRegistry,
     timeServiceBackend: Option[TimeServiceBackend] = None,
+    seedService: Option[SeedService],
     engine: Engine = sharedEngine // allows sharing DAML engine with DAML-on-X participant
 )(implicit logCtx: LoggingContext)
     extends ResourceOwner[Int] {
@@ -136,7 +137,7 @@ final class StandaloneApiServer(
               optTimeServiceBackend = timeServiceBackend,
               metrics = metrics,
               healthChecks = healthChecks,
-              seedService = None,
+              seedService = seedService,
             )(mat, esf, logCtx)
         },
         config.port,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -22,6 +22,7 @@ import com.daml.ledger.participant.state.v1.SubmissionResult.{
   Overloaded
 }
 import com.daml.ledger.participant.state.v1.{
+  SeedService,
   SubmissionResult,
   SubmitterInfo,
   TimeModel,
@@ -29,6 +30,7 @@ import com.daml.ledger.participant.state.v1.{
   WriteService
 }
 import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.engine.{Error => LfError}
 import com.digitalasset.daml.lf.transaction.Transaction.Transaction
 import com.digitalasset.daml.lf.transaction.{BlindingInfo, Transaction}
@@ -65,6 +67,7 @@ object ApiSubmissionService {
       submissionService: IndexSubmissionService,
       timeModel: TimeModel,
       timeProvider: TimeProvider,
+      seedService: Option[SeedService],
       commandExecutor: CommandExecutor,
       configuration: ApiSubmissionService.Configuration,
       metrics: MetricRegistry)(
@@ -78,6 +81,7 @@ object ApiSubmissionService {
         submissionService,
         timeModel,
         timeProvider,
+        seedService,
         commandExecutor,
         configuration,
         metrics),
@@ -97,6 +101,7 @@ final class ApiSubmissionService private (
     submissionService: IndexSubmissionService,
     timeModel: TimeModel,
     timeProvider: TimeProvider,
+    seedService: Option[SeedService],
     commandExecutor: CommandExecutor,
     configuration: ApiSubmissionService.Configuration,
     metrics: MetricRegistry)(
@@ -124,7 +129,7 @@ final class ApiSubmissionService private (
       metrics.timer("daml.lapi.command_submission_service.submitted_transactions")
   }
 
-  private def deduplicateAndRecordOnLedger(commands: ApiCommands)(
+  private def deduplicateAndRecordOnLedger(seed: Option[crypto.Hash], commands: ApiCommands)(
       implicit logCtx: LoggingContext): Future[Unit] = {
     val deduplicationKey = commands.submitter + "%" + commands.commandId.unwrap
     val submittedAt = Instant.now
@@ -132,7 +137,7 @@ final class ApiSubmissionService private (
 
     submissionService.deduplicateCommand(deduplicationKey, submittedAt, ttl).flatMap {
       case CommandDeduplicationNew =>
-        recordOnLedger(commands)
+        recordOnLedger(seed, commands)
           .transform(mapSubmissionResult)
           .andThen {
             case Success(_) =>
@@ -192,7 +197,7 @@ final class ApiSubmissionService private (
           _ => {
             logger.trace(s"Received composite commands: $commands")
             logger.debug(s"Received composite command let ${commands.ledgerEffectiveTime}.")
-            deduplicateAndRecordOnLedger(commands)
+            deduplicateAndRecordOnLedger(seedService.map(_.nextSeed()), commands)
           }
         )
         .andThen(logger.logErrorsOnCall[Unit])(DirectExecutionContext)
@@ -221,12 +226,15 @@ final class ApiSubmissionService private (
       Failure(error)
   }
 
-  private def recordOnLedger(commands: ApiCommands)(
-      implicit logCtx: LoggingContext): Future[SubmissionResult] =
+  private def recordOnLedger(
+      submissionSeed: Option[crypto.Hash],
+      commands: ApiCommands,
+  )(implicit logCtx: LoggingContext): Future[SubmissionResult] =
     for {
       res <- commandExecutor
         .execute(
           commands.submitter,
+          submissionSeed,
           commands,
           contractStore.lookupActiveContract(commands.submitter, _),
           contractStore.lookupContractKey(commands.submitter, _),
@@ -236,7 +244,7 @@ final class ApiSubmissionService private (
     } yield submissionResult
 
   private def handleResult(
-      res: scala.Either[ErrorCause, (SubmitterInfo, TransactionMeta, Transaction.Transaction)]
+      res: scala.Either[ErrorCause, (SubmitterInfo, TransactionMeta, Transaction.Transaction)],
   ) =
     res match {
       case Right((submitterInfo, transactionMeta, transaction)) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -5,16 +5,14 @@ package com.digitalasset.platform.sandbox
 
 import java.io.File
 import java.nio.file.Files
-import java.security.SecureRandom
 import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.participant.state.v1.{ParticipantId, SeedService}
 import com.daml.ledger.participant.state.{v1 => ParticipantState}
 import com.digitalasset.api.util.TimeProvider
-import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.engine.Engine
 import com.digitalasset.dec.DirectExecutionContext
@@ -267,12 +265,6 @@ final class SandboxServer(
           )
       }
 
-      val seedService =
-        if (config.useSortableCid)
-          Some(crypto.Hash.secureRandom(SecureRandom.getInstanceStrong.generateSeed(32)))
-        else
-          None
-
       for {
         indexAndWriteService <- indexAndWriteServiceResourceOwner.acquire()
         ledgerId <- Resource.fromFuture(indexAndWriteService.indexService.getLedgerId())
@@ -302,7 +294,7 @@ final class SandboxServer(
                   .map(TimeServiceBackend.withObserver(_, indexAndWriteService.publishHeartbeat)),
                 metrics = metrics,
                 healthChecks = healthChecks,
-                seedService = seedService,
+                seedService = config.seeding.map(SeedService(_)),
               )(mat, esf, logCtx)
               .map(_.withServices(List(resetService(ledgerId, authorizer, executionContext)))),
           currentPort.getOrElse(config.port),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -320,6 +320,8 @@ final class SandboxServer(
           ledgerType,
           authService.getClass.getSimpleName
         )
+        if (config.seeding.contains(SeedService.Seeding.Weak))
+          logger.warn("Contract id seeding uses a weak seed. DO NOT USE IN PRODUCTION.")
         apiServer
       }
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -311,17 +311,16 @@ final class SandboxServer(
       } yield {
         Banner.show(Console.out)
         logger.withoutContext.info(
-          "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}",
+          "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}",
           BuildInfo.Version,
           ledgerId,
           apiServer.port.toString,
           config.damlPackages,
           timeProviderType.description,
           ledgerType,
-          authService.getClass.getSimpleName
+          authService.getClass.getSimpleName,
+          config.seeding.fold("no")(_.toString.toLowerCase),
         )
-        if (config.seeding.contains(SeedService.Seeding.Weak))
-          logger.warn("Contract id seeding uses a weak seed. DO NOT USE IN PRODUCTION.")
         apiServer
       }
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -8,6 +8,7 @@ import java.time.Duration
 
 import ch.qos.logback.classic.Level
 import com.auth0.jwt.algorithms.Algorithm
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.jwt.{ECDSAVerifier, HMAC256Verifier, JwksVerifier, RSA256Verifier}
 import com.digitalasset.ledger.api.auth.AuthServiceJWT
@@ -191,11 +192,14 @@ object Cli {
       .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given JWKS URL")
       .action( (url, config) => config.copy(authService = Some(AuthServiceJWT(JwksVerifier(url)))))
 
-    opt[Unit]("sortable-contract-ids")
-      .hidden()
+    private val seedingMap = Map[String, Option[Seeding]]("no" ->None, "weak" -> Some(Seeding.Weak), "strong" -> Some(Seeding.Strong))
+
+    opt[String]("contract-id-seeding")
       .optional()
-      .text("(Experimental) use new sortable contract ids")
-      .action( (_, config) => config.copy(useSortableCid = true))
+      .text(s"""Set the seeding of contract ids. Possible values are ${seedingMap.keys.mkString(",")}. Default is "no".""")
+      .validate(v => Either.cond(seedingMap.contains(v.toLowerCase), (), s"seeding must be ${seedingMap.keys.mkString(",")}"))
+      .action((text, config) => config.copy(seeding = seedingMap(text)))
+      .hidden()
 
     help("help").text("Print the usage text")
 
@@ -229,6 +233,8 @@ object Cli {
     }.getOrElse(false)
   }
 
-  def parse(args: Array[String]): Option[SandboxConfig] =
-    cmdArgParser.parse(args, SandboxConfig.default)
+  def parse(
+      args: Array[String],
+      default: SandboxConfig = SandboxConfig.default): Option[SandboxConfig] =
+    cmdArgParser.parse(args, default)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.nio.file.Path
 
 import ch.qos.logback.classic.Level
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.ledger.participant.state.v1.TimeModel
 import com.digitalasset.ledger.api.auth.AuthService
 import com.digitalasset.ledger.api.tls.TlsConfiguration
@@ -34,7 +35,7 @@ final case class SandboxConfig(
     eagerPackageLoading: Boolean,
     logLevel: Option[Level],
     authService: Option[AuthService],
-    useSortableCid: Boolean
+    seeding: Option[Seeding],
 )
 
 object SandboxConfig {
@@ -42,7 +43,7 @@ object SandboxConfig {
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
-  lazy val default: SandboxConfig =
+  lazy val nextDefault: SandboxConfig =
     SandboxConfig(
       address = None,
       port = DefaultPort,
@@ -60,6 +61,9 @@ object SandboxConfig {
       eagerPackageLoading = false,
       logLevel = None, // the default is in logback.xml
       authService = None,
-      useSortableCid = false
+      seeding = Some(Seeding.Strong),
     )
+
+  lazy val default: SandboxConfig =
+    nextDefault.copy(seeding = None)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Main.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Main.scala
@@ -5,11 +5,12 @@ package com.digitalasset.platform.sandboxnext
 
 import com.digitalasset.platform.sandbox.GlobalLogLevel
 import com.digitalasset.platform.sandbox.cli.Cli
+import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.resources.ProgramResource
 
 object Main {
   def main(args: Array[String]): Unit = {
-    val config = Cli.parse(args).getOrElse(sys.exit(1))
+    val config = Cli.parse(args, SandboxConfig.nextDefault).getOrElse(sys.exit(1))
     config.logLevel.foreach(GlobalLogLevel.set)
     new ProgramResource(new Runner().owner(config)).run()
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -118,7 +118,7 @@ class Runner {
       } yield {
         Banner.show(Console.out)
         logger.withoutContext.info(
-          "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}",
+          "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}",
           BuildInfo.Version,
           ledgerId,
           port.toString,
@@ -126,9 +126,8 @@ class Runner {
           timeProviderType.description,
           ledgerType,
           authService.getClass.getSimpleName,
+          config.seeding.fold("no")(_.toString.toLowerCase),
         )
-        if (config.seeding.contains(SeedService.Seeding.Weak))
-          logger.warn("Contract id seeding uses a weak seed. DO NOT USE IN PRODUCTION.")
       }
     }
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -35,6 +35,7 @@ import com.digitalasset.platform.indexer.{
   IndexerStartupMode,
   StandaloneIndexerServer
 }
+import com.digitalasset.platform.sandbox.SandboxServer.logger
 import com.digitalasset.platform.sandbox.banner.Banner
 import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.platform.sandboxnext.Runner._
@@ -126,6 +127,8 @@ class Runner {
           ledgerType,
           authService.getClass.getSimpleName,
         )
+        if (config.seeding.contains(SeedService.Seeding.Weak))
+          logger.warn("Contract id seeding uses a weak seed. DO NOT USE IN PRODUCTION.")
       }
     }
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.on.sql.Database.InvalidDatabaseException
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1
-import com.daml.ledger.participant.state.v1.{ReadService, WriteService}
+import com.daml.ledger.participant.state.v1.{ReadService, SeedService, WriteService}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.data.Ref
@@ -106,7 +106,14 @@ class Runner {
         authService = config.authService.getOrElse(AuthServiceWildcard)
         _ <- ResourceOwner.forFuture(() =>
           Future.sequence(config.damlPackages.map(uploadDar(_, ledger))))
-        port <- startParticipant(config, indexJdbcUrl, ledger, authService, timeServiceBackend)
+        port <- startParticipant(
+          config,
+          indexJdbcUrl,
+          ledger,
+          authService,
+          timeServiceBackend,
+          config.seeding.map(SeedService(_)),
+        )
       } yield {
         Banner.show(Console.out)
         logger.withoutContext.info(
@@ -140,6 +147,7 @@ class Runner {
       ledger: KeyValueParticipantState,
       authService: AuthService,
       timeServiceBackend: Option[TimeServiceBackend],
+      seedService: Option[SeedService],
   )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Int] =
     for {
       _ <- startIndexerServer(
@@ -154,6 +162,7 @@ class Runner {
         writeService = ledger,
         authService = authService,
         timeServiceBackend = timeServiceBackend,
+        seedService = seedService
       )
     } yield port
 
@@ -180,6 +189,7 @@ class Runner {
       writeService: WriteService,
       authService: AuthService,
       timeServiceBackend: Option[TimeServiceBackend],
+      seedService: Option[SeedService],
   )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Int] =
     new StandaloneApiServer(
       ApiServerConfig(
@@ -199,6 +209,7 @@ class Runner {
       authService = authService,
       metrics = SharedMetricRegistries.getOrCreate(s"ledger-api-server-$ParticipantId"),
       timeServiceBackend = timeServiceBackend,
+      seedService = seedService
     )
 }
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
@@ -160,7 +160,7 @@ abstract class ScenarioLoadingITBase
             val contractIds = events.map(_.contractId).toSet
 
             // note how we skip #0, #2 and #5 because of the `pass`es in the scenario.
-            contractIds shouldBe Set("#4:0", "#7:2", "#3:0", "#7:1", "#1:0", "#7:0", "#6:0")
+            contractIds.size shouldBe 7 // Set("#4:0", "#7:2", "#3:0", "#7:1", "#1:0", "#7:0", "#6:0")
           }
         }
       }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
@@ -159,8 +159,7 @@ abstract class ScenarioLoadingITBase
             val events = responses.flatMap(extractEvents)
             val contractIds = events.map(_.contractId).toSet
 
-            // note how we skip #0, #2 and #5 because of the `pass`es in the scenario.
-            contractIds.size shouldBe 7 // Set("#4:0", "#7:2", "#3:0", "#7:1", "#1:0", "#7:0", "#6:0")
+            contractIds.size shouldBe 7
           }
         }
       }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -16,7 +16,7 @@ import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Node._
-import com.digitalasset.daml.lf.transaction.Transaction.{NodeId, TContractId, Value}
+import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.value.Value.{
   AbsoluteContractId,
   ContractInst,
@@ -100,10 +100,13 @@ class ImplicitPartyAdditionIT
       ledger: Ledger,
       submitter: String,
       commandId: String,
-      node: GenNode[NodeId, TContractId, Value[TContractId]]): Future[SubmissionResult] = {
-    val event1: NodeId = NodeId(0)
+      node: Transaction.AbsNode,
+  ): Future[SubmissionResult] = {
+    val event1: Transaction.NodeId = Transaction.NodeId(0)
 
-    val transaction = GenTransaction[NodeId, TContractId, Value[TContractId]](
+    val let = Time.Timestamp.assertFromInstant(LET)
+
+    val transaction: Transaction.AbsTransaction = GenTransaction(
       HashMap(event1 -> node),
       ImmArray(event1),
       None
@@ -117,8 +120,9 @@ class ImplicitPartyAdditionIT
     )
 
     val transactionMeta = TransactionMeta(
-      Time.Timestamp.assertFromInstant(LET),
-      Some(Ref.LedgerString.assertFromString("wfid"))
+      let,
+      Some(Ref.LedgerString.assertFromString("wfid")),
+      None,
     )
 
     ledger.publishTransaction(submitterInfo, transactionMeta, transaction)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -14,8 +14,9 @@ import com.daml.ledger.participant.state.v1.{
 }
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
+import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.transaction.GenTransaction
-import com.digitalasset.daml.lf.transaction.Transaction.{NodeId, TContractId, Value}
+import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.ledger.api.domain.{LedgerId, RejectionReason}
 import com.digitalasset.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
@@ -83,8 +84,10 @@ class TransactionMRTComplianceIT
 
   "A Ledger" should {
     "reject transactions with a record time after the MRT" in allFixtures { ledger =>
-      val dummyTransaction =
-        GenTransaction[NodeId, TContractId, Value[TContractId]](HashMap.empty, ImmArray.empty, None)
+      val seed = Some(crypto.Hash.hashPrivateKey(this.getClass.getName))
+
+      val dummyTransaction: Transaction.AbsTransaction =
+        GenTransaction(HashMap.empty, ImmArray.empty, None)
 
       val submitterInfo = SubmitterInfo(
         Ref.Party.assertFromString("submitter"),
@@ -94,7 +97,8 @@ class TransactionMRTComplianceIT
       )
       val transactionMeta = TransactionMeta(
         Time.Timestamp.assertFromInstant(LET),
-        Some(Ref.LedgerString.assertFromString("wfid"))
+        Some(Ref.LedgerString.assertFromString("wfid")),
+        seed
       )
 
       ledger


### PR DESCRIPTION
In this PR we make kvutils work with the new random contract id scheme. 

In particular, we drop all relative contract of kvutils. 

This advances the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
