### PR TITLE
fix passing is_release through

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         parameters:
           release_tag: $(release_tag)
           name: 'linux'
-          is_release: $(is_release)
+          is_release: variables.is_release
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
@@ -133,7 +133,7 @@ jobs:
         parameters:
           release_tag: $(release_tag)
           name: macos
-          is_release: $(is_release)
+          is_release: variables.is_release
       - bash: mkdir -p $(bazel-repo-cache-path)
         displayName: ensure bazel repo cache exists
       - template: ci/tell-slack-failed.yml
@@ -162,7 +162,7 @@ jobs:
       - template: ci/build-windows.yml
         parameters:
           release_tag: $(release_tag)
-          is_release: $(is_release)
+          is_release: variables.is_release
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -66,7 +66,7 @@ steps:
       NPM_TOKEN: $(NPM_TOKEN)
     name: publish_npm_mvn
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'),
                    eq('${{parameters.name}}', 'linux'))
   - bash: |
@@ -77,12 +77,12 @@ steps:
       echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
     name: publish
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)
       artifactName: $(publish.tarball)
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -49,18 +49,18 @@ steps:
     env:
       SIGNING_KEY: $(microsoft-code-signing)
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.installer)
       artifactName: $(publish.installer)
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
-                   eq('${{parameters.is_release}}', 'true'),
+                   eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)


### PR DESCRIPTION
Somehow, in the current setup, the publish steps do not get executed on master. This is what Azure reports:

```
Evaluating: and(succeeded(), eq('$(is_release)', 'true'),
eq(variables['Build.SourceBranchName'], 'master'), eq('linux', 'linux'))
Expanded: and(True, eq('$(is_release)', 'true'),
eq(variables['Build.SourceBranchName'], 'master'), eq('linux', 'linux'))
Result: False
```

So it looks like, in the condition, `${{parameters.is_release}}` evaluates to the literal string `$(is_release)`. If we look at the point of invocation of the ~function~ template, we can see:

```
      - template: ci/build-unix.yml
        parameters:
          release_tag: $(release_tag)
          name: 'linux'
          is_release: $(is_release)
```

so it does not seem completely crazy. However, according to the documentation, we should expect that to be replaced by the value of the corresponding variable, as per:

```
    variables:
      release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
      release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
      trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
      is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
```

What's interesting here is that, within `build-unix.yml`, we are also using `release_tag` in the exact same way:

```
  - bash: ./build.sh "_$(uname)"
    displayName: 'Build'
    env:
      DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
```

and this time output from the build seems to show the value being correctly substituted:

```
damlc - Compiler and IDE backend for the Digital Asset Modelling
Language
SDK Version: 0.13.55-snapshot.20200226.3266.d58bb459

Usage: <interactive> COMMAND
  Invoke the DAML compiler. Use -h for help.
```

My current guess is that the (undocumented, as far as I can tell) evaluation order is as follows:

1. In the template, syntactically replace all the parameters.
2. In the job definition, replace the call to the template with the code of the template. So it is as if we had written the template directly in the `azure-pipelines.yml` file, with `$(release_tag)` and `$(is_release)`.
3. Run the build. When we reach the time to run this specific job, we can evaluate the expressions for the variables and replace them in the rest of the job.

So what is going wrong? I believe the issue is with the quotes, preventing the substitution of `is_release`. They came directly from the [documented syntax](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#use-a-template-parameter-as-part-of-a-condition), but if the above evaluation order is correct, they should not be there.

There are actually two things going wrong here. The first one is that the syntax `$()` is used to substitute a value in what Azure considers a string. This is the case for `env` keys. However, the `condition` key is not a string, it is an Azure "expression". Expressions have their own evaluation rules and syntax, and in particular, `$()` is not a substitution rule there, so when it sees `$()` in a string in an expression (due to the quotes), it leaves it alone.

Removing the quotes does not directly help, though, as we then end with

```
condition: eq($(is_release), 'true')
```

and `$()` is not valid syntax in an expression. The way to use variables in an expression is `variables.name` (or `variables["name"]`, because why have only one?).

So that means we have to pass variables to the template in different ways depending on how they will be used. So much fun.

CHANGELOG_BEGIN
CHANGELOG_END