### PR TITLE
fix Windows signing (maybe)

### DIFF
--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -29,10 +29,10 @@ steps:
       artifactName: 'Test logs'
 
   - bash: |
-      export DAML_SDK_RELEASE_VERSION=${{parameters.release_tag}}
+      set -euo pipefail
       INSTALLER=daml-sdk-${{parameters.release_tag}}-windows.exe
       mv "bazel-bin/release/windows-installer/daml-sdk-installer.exe" "$(Build.StagingDirectory)/$INSTALLER"
-      chmod +x "$(Build.StagingDirectory)/$INSTALLER"
+      chmod +wx "$(Build.StagingDirectory)/$INSTALLER"
       cleanup () {
           rm -f signing_key.pfx
       }
@@ -40,14 +40,15 @@ steps:
       echo "$SIGNING_KEY" | base64 -d > signing_key.pfx
       MSYS_NO_PATHCONV=1 signtool.exe sign '/f' signing_key.pfx '/fd' sha256 '/tr' "http://timestamp.digicert.com" '/v' "$(Build.StagingDirectory)/$INSTALLER"
       rm signing_key.pfx
+      trap - EXIT
       echo "##vso[task.setvariable variable=installer;isOutput=true]$INSTALLER"
-      bazel build //release:sdk-release-tarball
       TARBALL=daml-sdk-${{parameters.release_tag}}-windows.tar.gz
       cp bazel-bin/release/sdk-release-tarball.tar.gz '$(Build.StagingDirectory)'/$TARBALL
       echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
     name: publish
     env:
       SIGNING_KEY: $(microsoft-code-signing)
+      DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'master'))


### PR DESCRIPTION
During the latest attempt at making a snapshot release (#4749), everything seemingly went well except for the step of signing the Windows installer.

Based on a very obscure error message (Access Denied) and a bit of Google search, my current hypothesis is that the signing fails because the artifact produced by Bazel is read-only. This was not an issue in the previous setup because we were getting the installer from an Azure internal download between different jobs. We are now getting the binary directly from Bazel.

This also adds a `set -e` to the relevant Bash snippet, because ideally they should always have one.

CHANGELOG_BEGIN
CHANGELOG_END