### PR TITLE
Add create-and-exercise JSON API endpoint

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -546,6 +546,111 @@ HTTP Response
 
 Formatted similar to :ref:`Exercise by Contract ID response <exercise-response>`.
 
+Create and Exercise in the Same Transaction
+*******************************************
+
+This command allows creating a contract and exercising a choice on the newly created contract in the same transaction.
+
+HTTP Request
+============
+
+- URL: ``/v1/create-and-exercise``
+- Method: ``POST``
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "templateId": "Iou:Iou",
+      "payload": {
+        "observers": [],
+        "issuer": "Alice",
+        "amount": "999.99",
+        "currency": "USD",
+        "owner": "Alice"
+      },
+      "choice": "Iou_Transfer",
+      "argument": {
+        "newOwner": "Bob"
+      }
+    }
+
+Where:
+
+- ``templateId`` -- the initial contract template identifier, in the same format as in same as in the :ref:`create request <create-request>`,
+- ``payload`` -- the initial contract fields as defined in the DAML template and formatted according to :doc:`lf-value-specification`,
+- ``choice`` -- DAML contract choice, that is being exercised,
+- ``argument`` -- contract choice argument(s).
+
+HTTP Response
+=============
+
+Please note that the response below is for a consuming choice, so it contains:
+
+- ``created`` and ``archived`` events for the initial contract (``"contractId": "#1:0"``), which was created and archived right away when a consuming choice was exercised on it,
+- a ``created`` event for the contract that is the result of the choice exercise (``"contractId": "#1:2"``).
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "result": {
+        "exerciseResult": "#1:2",
+        "events": [
+          {
+            "created": {
+              "observers": [],
+              "agreementText": "",
+              "payload": {
+                "observers": [],
+                "issuer": "Alice",
+                "amount": "999.99",
+                "currency": "USD",
+                "owner": "Alice"
+              },
+              "signatories": [
+                "Alice"
+              ],
+              "contractId": "#1:0",
+              "templateId": "a3b788b4dc18dc060bfb82366ae6dc055b1e361d646d5cfdb1b729607e344336:Iou:Iou"
+            }
+          },
+          {
+            "archived": {
+              "contractId": "#1:0",
+              "templateId": "a3b788b4dc18dc060bfb82366ae6dc055b1e361d646d5cfdb1b729607e344336:Iou:Iou"
+            }
+          },
+          {
+            "created": {
+              "observers": [
+                "Bob"
+              ],
+              "agreementText": "",
+              "payload": {
+                "iou": {
+                  "observers": [],
+                  "issuer": "Alice",
+                  "amount": "999.99",
+                  "currency": "USD",
+                  "owner": "Alice"
+                },
+                "newOwner": "Bob"
+              },
+              "signatories": [
+                "Alice"
+              ],
+              "contractId": "#1:2",
+              "templateId": "a3b788b4dc18dc060bfb82366ae6dc055b1e361d646d5cfdb1b729607e344336:Iou:IouTransfer"
+            }
+          }
+        ]
+      },
+      "status": 200
+    }
 
 Fetch Contract by Contract ID
 *****************************

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -7,10 +7,11 @@ import java.time.Instant
 
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
-import com.digitalasset.http.CommandService.{ExerciseCommandRef, Error}
+import com.digitalasset.http.CommandService.{Error, ExerciseCommandRef}
 import com.digitalasset.http.domain.{
   ActiveContract,
   Contract,
+  CreateAndExerciseCommand,
   CreateCommand,
   ExerciseCommand,
   ExerciseResponse,
@@ -74,6 +75,14 @@ class CommandService(
     } yield ExerciseResponse(exerciseResult, contracts)
 
     et.run
+  }
+
+  def createAndExercise(
+      jwt: Jwt,
+      jwtPayload: JwtPayload,
+      input: CreateAndExerciseCommand[lav1.value.Record, lav1.value.Value])
+    : Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
+    ???
   }
 
   private def logResult[A](op: Symbol, fa: Future[A]): Future[A] = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -111,6 +111,26 @@ class Endpoints(
 
     } yield domain.OkResponse(jsVal)
 
+  def createAndExercise(req: HttpRequest): ET[domain.OkResponse[JsValue, Unit]] =
+    for {
+      t3 <- FutureUtil.eitherT(input(req)): ET[(Jwt, JwtPayload, String)]
+
+      (jwt, jwtPayload, reqBody) = t3
+
+      cmd <- either(
+        decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
+      ): ET[domain.CreateAndExerciseCommand[ApiValue, ApiValue]]
+//
+//      ac <- eitherT(
+//        handleFutureFailure(commandService.createAndExercise(jwt, jwtPayload, cmd))
+//      ): ET[domain.ActiveContract[lav1.value.Value]]
+//
+//      jsVal <- either(encoder.encodeV(ac).liftErr(ServerError)): ET[JsValue]
+
+      jsVal = JsString("")
+
+    } yield domain.OkResponse(jsVal)
+
   def fetch(req: HttpRequest): ET[domain.OkResponse[JsValue, Unit]] =
     for {
       input <- FutureUtil.eitherT(input(req)): ET[(Jwt, JwtPayload, String)]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
@@ -3,10 +3,18 @@
 
 package com.digitalasset.http
 
+import scalaz.syntax.tag._
+
 object ErrorMessages {
   def cannotResolveTemplateId(t: domain.TemplateId[_]): String =
     s"Cannot resolve template ID, given: ${t.toString}"
 
   def cannotResolveTemplateId(a: domain.ContractLocator[_]): String =
     s"Cannot resolve templateId, given: $a"
+
+  def cannotResolvePayloadType(t: domain.TemplateId[_]): String =
+    s"Cannot resolve payload type, given: ${t.toString}"
+
+  def cannotResolveChoiceArgType(t: domain.TemplateId[_], c: domain.Choice): String =
+    s"Cannot resolve choice argument type, given: ${t.toString}, ${c.unwrap}"
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -231,7 +231,6 @@ object HttpService extends StrictLogging {
       packageService.resolveTemplateRecordType,
       packageService.resolveChoiceRecordType,
       packageService.resolveKeyType,
-      jsValueToApiValueConverter.jsObjectToApiRecord,
       jsValueToApiValueConverter.jsValueToApiValue,
       jsValueToApiValueConverter.jsValueToLfValue,
     )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -229,7 +229,7 @@ object HttpService extends StrictLogging {
     val decoder = new DomainJsonDecoder(
       packageService.resolveTemplateId,
       packageService.resolveTemplateRecordType,
-      packageService.resolveChoiceRecordType,
+      packageService.resolveChoiceArgType,
       packageService.resolveKeyType,
       jsValueToApiValueConverter.jsValueToApiValue,
       jsValueToApiValueConverter.jsValueToLfValue,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -76,8 +76,8 @@ private class PackageService(reloadPackageStoreIfChanged: PackageService.ReloadP
     () => state.templateIdMap.all
 
   // See the above comment
-  def resolveChoiceRecordType: ResolveChoiceRecordType =
-    (x, y) => PackageService.resolveChoiceRecordType(state.choiceTypeMap)(x, y)
+  def resolveChoiceArgType: ResolveChoiceArgType =
+    (x, y) => PackageService.resolveChoiceArgType(state.choiceTypeMap)(x, y)
 
   // See the above comment
   def resolveKeyType: ResolveKeyType =
@@ -108,7 +108,7 @@ object PackageService {
   type AllTemplateIds =
     () => Set[TemplateId.RequiredPkg]
 
-  type ResolveChoiceRecordType =
+  type ResolveChoiceArgType =
     (TemplateId.RequiredPkg, Choice) => Error \/ iface.Type
 
   type ResolveKeyType =
@@ -162,13 +162,13 @@ object PackageService {
   private def findTemplateIdByK2(m: Map[TemplateId.NoPkg, TemplateId.RequiredPkg])(
       k: TemplateId.NoPkg): Option[TemplateId.RequiredPkg] = m.get(k)
 
-  def resolveChoiceRecordType(choiceIdMap: ChoiceTypeMap)(
+  def resolveChoiceArgType(choiceIdMap: ChoiceTypeMap)(
       templateId: TemplateId.RequiredPkg,
       choice: Choice): Error \/ iface.Type = {
     val k = (templateId, choice)
     choiceIdMap
       .get(k)
-      .toRightDisjunction(InputError(s"Cannot resolve Choice Record type, given: ${k.toString}"))
+      .toRightDisjunction(InputError(s"Cannot resolve Choice Argument type, given: ${k.toString}"))
   }
 
   def resolveKey(keyTypeMap: KeyTypeMap)(templateId: TemplateId.RequiredPkg): Error \/ iface.Type =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -302,7 +302,7 @@ object domain {
           fa: ActiveContract[_],
           templateId: TemplateId.RequiredPkg,
           f: PackageService.ResolveTemplateRecordType,
-          g: PackageService.ResolveChoiceRecordType,
+          g: PackageService.ResolveChoiceArgType,
           h: PackageService.ResolveKeyType,
       ): Error \/ LfType =
         f(templateId)
@@ -387,7 +387,7 @@ object domain {
             fa: EnrichedContractKey[_],
             templateId: TemplateId.RequiredPkg,
             f: PackageService.ResolveTemplateRecordType,
-            g: PackageService.ResolveChoiceRecordType,
+            g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType =
           h(templateId)
@@ -409,7 +409,7 @@ object domain {
         fa: F[_],
         templateId: TemplateId.RequiredPkg,
         f: PackageService.ResolveTemplateRecordType,
-        g: PackageService.ResolveChoiceRecordType,
+        g: PackageService.ResolveChoiceArgType,
         h: PackageService.ResolveKeyType,
     ): Error \/ LfType
   }
@@ -456,7 +456,7 @@ object domain {
             fa: ExerciseCommand[_, domain.ContractLocator[_]],
             templateId: TemplateId.RequiredPkg,
             f: PackageService.ResolveTemplateRecordType,
-            g: PackageService.ResolveChoiceRecordType,
+            g: PackageService.ResolveChoiceArgType,
             h: PackageService.ResolveKeyType,
         ): Error \/ LfType =
           g(templateId, fa.choice)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -421,20 +421,6 @@ object domain {
       )(f: A => G[B]): G[CreateCommand[B]] =
         f(fa.payload).map(a => fa.copy(payload = a))
     }
-
-    implicit val hasTemplateId: HasTemplateId[CreateCommand] = new HasTemplateId[CreateCommand] {
-      override def templateId(fa: CreateCommand[_]): TemplateId.OptionalPkg = fa.templateId
-
-      override def lfType(
-          fa: CreateCommand[_],
-          templateId: TemplateId.RequiredPkg,
-          f: PackageService.ResolveTemplateRecordType,
-          g: PackageService.ResolveChoiceRecordType,
-          h: PackageService.ResolveKeyType,
-      ): Error \/ LfType =
-        f(templateId)
-          .leftMap(e => Error('CreateCommand_hasTemplateId_lfType, e.shows))
-    }
   }
 
   object ExerciseCommand {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -5,46 +5,18 @@ package com.digitalasset.http.json
 
 import com.digitalasset.http.domain
 import com.digitalasset.ledger.api.{v1 => lav1}
+import scalaz.\/
 import scalaz.syntax.bitraverse._
 import scalaz.syntax.show._
 import scalaz.syntax.traverse._
-import scalaz.{Traverse, \/}
 import spray.json.{JsObject, JsValue, JsonWriter}
-
-import scala.language.higherKinds
 
 class DomainJsonEncoder(
     val apiRecordToJsObject: lav1.value.Record => JsonError \/ JsObject,
-    val apiValueToJsValue: lav1.value.Value => JsonError \/ JsValue) {
+    val apiValueToJsValue: lav1.value.Value => JsonError \/ JsValue
+) {
 
   import com.digitalasset.http.util.ErrorOps._
-
-  def encodeR[F[_]](fa: F[lav1.value.Record])(
-      implicit ev1: Traverse[F],
-      ev2: JsonWriter[F[JsObject]]): JsonError \/ JsObject =
-    for {
-      a <- encodeUnderlyingRecord(fa)
-      b <- SprayJson.encode[F[JsObject]](a)(ev2).liftErr(JsonError)
-      c <- SprayJson.mustBeJsObject(b)
-    } yield c
-
-  // encode underlying values
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def encodeUnderlyingRecord[F[_]: Traverse](fa: F[lav1.value.Record]): JsonError \/ F[JsObject] =
-    fa.traverse(a => apiRecordToJsObject(a))
-
-  def encodeV[F[_]](fa: F[lav1.value.Value])(
-      implicit ev1: Traverse[F],
-      ev2: JsonWriter[F[JsValue]]): JsonError \/ JsValue =
-    for {
-      a <- encodeUnderlyingValue(fa)
-      b <- SprayJson.encode[F[JsValue]](a)(ev2).liftErr(JsonError)
-    } yield b
-
-  // encode underlying values
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def encodeUnderlyingValue[F[_]: Traverse](fa: F[lav1.value.Value]): JsonError \/ F[JsValue] =
-    fa.traverse(a => apiValueToJsValue(a))
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   def encodeExerciseCommand(
@@ -54,19 +26,13 @@ class DomainJsonEncoder(
     for {
       x <- cmd.bitraverse(
         arg => apiValueToJsValue(arg),
-        ref => encodeContractLocatorUnderlyingValue(ref)
-      )
+        ref => ref.traverse(a => apiValueToJsValue(a))
+      ): JsonError \/ domain.ExerciseCommand[JsValue, domain.ContractLocator[JsValue]]
 
       y <- SprayJson.encode(x).liftErr(JsonError)
 
     } yield y
 
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  private def encodeContractLocatorUnderlyingValue(
-      fa: domain.ContractLocator[lav1.value.Value]): JsonError \/ domain.ContractLocator[JsValue] =
-    fa.traverse(a => apiValueToJsValue(a))
-
-  // TODO(Leo) see if you can get get rid of the above boilerplate and rely on the JsonWriters defined below
   object implicits {
     implicit val ApiValueJsonWriter: JsonWriter[lav1.value.Value] = (obj: lav1.value.Value) =>
       apiValueToJsValue(obj).valueOr(e => spray.json.serializationError(e.shows))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
@@ -12,7 +12,7 @@ import com.digitalasset.ledger.api.{v1 => lav1}
 import com.digitalasset.platform.participant.util.LfEngineToApi
 import scalaz.std.string._
 import scalaz.{-\/, \/, \/-}
-import spray.json.{JsObject, JsValue}
+import spray.json.JsValue
 
 class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
   import com.digitalasset.http.util.ErrorOps._
@@ -36,19 +36,6 @@ class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
       lfValue <- jsValueToLfValue(lfType, jsValue)
       apiValue <- JsValueToApiValueConverter.lfValueToApiValue(lfValue)
     } yield apiValue
-
-  def jsObjectToApiRecord(
-      lfType: domain.LfType,
-      jsObject: JsObject): JsonError \/ lav1.value.Record =
-    for {
-      a <- jsValueToApiValue(lfType, jsObject)
-      b <- mustBeApiRecord(a)
-    } yield b
-
-  private def mustBeApiRecord(a: lav1.value.Value): JsonError \/ lav1.value.Record = a.sum match {
-    case lav1.value.Value.Sum.Record(b) => \/-(b)
-    case _ => -\/(JsonError(s"Expected ${classOf[lav1.value.Value.Sum.Record]}, got: $a"))
-  }
 }
 
 object JsValueToApiValueConverter {
@@ -58,4 +45,9 @@ object JsValueToApiValueConverter {
 
   def lfValueToApiValue(lfValue: domain.LfValue): JsonError \/ lav1.value.Value =
     \/.fromEither(LfEngineToApi.lfValueToApiValue(verbose = true, lfValue)).liftErr(JsonError)
+
+  def mustBeApiRecord(a: lav1.value.Value): JsonError \/ lav1.value.Record = a.sum match {
+    case lav1.value.Value.Sum.Record(b) => \/-(b)
+    case _ => -\/(JsonError(s"Expected ${classOf[lav1.value.Value.Sum.Record]}, got: $a"))
+  }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -267,6 +267,10 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
     }
 
+  implicit val CreateAndExerciseCommandFormat
+    : RootJsonFormat[domain.CreateAndExerciseCommand[JsValue, JsValue]] =
+    jsonFormat5(domain.CreateAndExerciseCommand[JsValue, JsValue])
+
   implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
     jsonFormat2(domain.ExerciseResponse[JsValue])
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -12,8 +12,8 @@ import com.digitalasset.daml.lf.value.json.ApiCodecCompressed
 import com.digitalasset.http.domain
 import com.digitalasset.http.json.TaggedJsonFormat._
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
-import scalaz.{-\/, NonEmptyList, \/-}
 import scalaz.syntax.std.option._
+import scalaz.{-\/, NonEmptyList, \/-}
 import spray.json._
 
 object JsonProtocol extends DefaultJsonProtocol {
@@ -268,8 +268,8 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
 
   implicit val CreateAndExerciseCommandFormat
-    : RootJsonFormat[domain.CreateAndExerciseCommand[JsValue, JsValue]] =
-    jsonFormat5(domain.CreateAndExerciseCommand[JsValue, JsValue])
+    : RootJsonFormat[domain.CreateAndExerciseCommand[JsObject, JsValue]] =
+    jsonFormat5(domain.CreateAndExerciseCommand[JsObject, JsValue])
 
   implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
     jsonFormat2(domain.ExerciseResponse[JsValue])

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -232,8 +232,8 @@ object JsonProtocol extends DefaultJsonProtocol {
   implicit val CommandMetaFormat: RootJsonFormat[domain.CommandMeta] = jsonFormat3(
     domain.CommandMeta)
 
-  implicit val CreateCommandFormat: RootJsonFormat[domain.CreateCommand[JsObject]] = jsonFormat3(
-    domain.CreateCommand[JsObject])
+  implicit val CreateCommandFormat: RootJsonFormat[domain.CreateCommand[JsValue]] = jsonFormat3(
+    domain.CreateCommand[JsValue])
 
   implicit val ExerciseCommandFormat
     : RootJsonFormat[domain.ExerciseCommand[JsValue, domain.ContractLocator[JsValue]]] =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -268,8 +268,8 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
 
   implicit val CreateAndExerciseCommandFormat
-    : RootJsonFormat[domain.CreateAndExerciseCommand[JsObject, JsValue]] =
-    jsonFormat5(domain.CreateAndExerciseCommand[JsObject, JsValue])
+    : RootJsonFormat[domain.CreateAndExerciseCommand[JsValue, JsValue]] =
+    jsonFormat5(domain.CreateAndExerciseCommand[JsValue, JsValue])
 
   implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
     jsonFormat2(domain.ExerciseResponse[JsValue])

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
@@ -6,57 +6,63 @@ package com.digitalasset.http.util
 import java.time.Instant
 
 import com.digitalasset.api.util.TimestampConversion.fromInstant
-import com.digitalasset.http.CommandService.Error
-import com.digitalasset.http.domain.Contract
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => lav1}
-import com.typesafe.scalalogging.StrictLogging
-import scalaz.\/
-import scalaz.syntax.show._
+import scalaz.syntax.tag._
 
-object Commands extends StrictLogging {
+object Commands {
   def create(
       templateId: lar.TemplateId,
-      payload: lav1.value.Record): lav1.commands.Command.Command.Create = {
-
+      payload: lav1.value.Record
+  ): lav1.commands.Command.Command.Create =
     lav1.commands.Command.Command.Create(
-      lav1.commands.CreateCommand(
-        templateId = Some(lar.TemplateId.unwrap(templateId)),
-        createArguments = Some(payload)))
-  }
+      lav1.commands
+        .CreateCommand(templateId = Some(templateId.unwrap), createArguments = Some(payload)))
 
   def exercise(
       templateId: lar.TemplateId,
       contractId: lar.ContractId,
       choice: lar.Choice,
-      argument: lav1.value.Value): lav1.commands.Command.Command.Exercise = {
-
+      argument: lav1.value.Value
+  ): lav1.commands.Command.Command.Exercise =
     lav1.commands.Command.Command.Exercise(
       lav1.commands.ExerciseCommand(
-        templateId = Some(lar.TemplateId.unwrap(templateId)),
-        contractId = lar.ContractId.unwrap(contractId),
-        choice = lar.Choice.unwrap(choice),
+        templateId = Some(templateId.unwrap),
+        contractId = contractId.unwrap,
+        choice = choice.unwrap,
         choiceArgument = Some(argument)
       )
     )
-  }
 
   def exerciseByKey(
       templateId: lar.TemplateId,
       contractKey: lav1.value.Value,
       choice: lar.Choice,
       argument: lav1.value.Value
-  ): lav1.commands.Command.Command.ExerciseByKey = {
-
+  ): lav1.commands.Command.Command.ExerciseByKey =
     lav1.commands.Command.Command.ExerciseByKey(
       lav1.commands.ExerciseByKeyCommand(
-        templateId = Some(lar.TemplateId.unwrap(templateId)),
+        templateId = Some(templateId.unwrap),
         contractKey = Some(contractKey),
-        choice = lar.Choice.unwrap(choice),
+        choice = choice.unwrap,
         choiceArgument = Some(argument)
       )
     )
-  }
+
+  def createAndExercise(
+      templateId: lar.TemplateId,
+      payload: lav1.value.Record,
+      choice: lar.Choice,
+      argument: lav1.value.Value
+  ): lav1.commands.Command.Command.CreateAndExercise =
+    lav1.commands.Command.Command.CreateAndExercise(
+      lav1.commands.CreateAndExerciseCommand(
+        templateId = Some(templateId.unwrap),
+        createArguments = Some(payload),
+        choice = choice.unwrap,
+        choiceArgument = Some(argument)
+      )
+    )
 
   def submitAndWaitRequest(
       ledgerId: lar.LedgerId,
@@ -65,22 +71,17 @@ object Commands extends StrictLogging {
       ledgerEffectiveTime: Instant,
       maximumRecordTime: Instant,
       party: lar.Party,
-      command: lav1.commands.Command.Command): lav1.command_service.SubmitAndWaitRequest = {
-
+      command: lav1.commands.Command.Command
+  ): lav1.command_service.SubmitAndWaitRequest = {
     val commands = lav1.commands.Commands(
-      ledgerId = lar.LedgerId.unwrap(ledgerId),
-      applicationId = lar.ApplicationId.unwrap(applicationId),
-      commandId = lar.CommandId.unwrap(commandId),
-      party = lar.Party.unwrap(party),
+      ledgerId = ledgerId.unwrap,
+      applicationId = applicationId.unwrap,
+      commandId = commandId.unwrap,
+      party = party.unwrap,
       ledgerEffectiveTime = Some(fromInstant(ledgerEffectiveTime)),
       maximumRecordTime = Some(fromInstant(maximumRecordTime)),
       commands = Seq(lav1.commands.Command(command))
     )
-
     lav1.command_service.SubmitAndWaitRequest(Some(commands))
   }
-
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  def contracts(tx: lav1.transaction.Transaction): Error \/ List[Contract[lav1.value.Value]] =
-    Contract.fromTransaction(tx).leftMap(e => Error('contracts, e.shows))
 }


### PR DESCRIPTION
Closes: #4507

- `/v1/create-and-exercise` JSON API endpoint
- some refactoring around JSON encoding/decoding

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
