### PR TITLE
GSG: Attempt to add copy to clipboard button

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -404,7 +404,7 @@ nixpkgs_package(
 #sphinx
 nixpkgs_package(
     name = "sphinx_nix",
-    attribute_path = "sphinx183",
+    attribute_path = "sphinxBundle",
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
     repositories = dev_env_nix_repos,

--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -34,6 +34,7 @@ sys.path.insert(0, os.path.abspath('../static'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_copybutton"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/configs/pdf/conf.py
+++ b/docs/configs/pdf/conf.py
@@ -36,7 +36,8 @@ sys.path.extend(map(os.path.abspath, glob.glob('packages/*')))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-  'sphinx.ext.autodoc'
+  'sphinx.ext.autodoc',
+  'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -63,6 +63,16 @@ let shared = rec {
   sass = pkgs.sass;
 
   # sphinx 2.2.2 causes build failures of //docs:pdf-docs.
+  sphinx-copybutton = pkgs.python3Packages.buildPythonPackage rec {
+    pname = "sphinx-copybutton";
+    version = "0.2.8";
+    src = pkgs.python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "022k191039z8frbmsmfj2cmrkp897r4n5agvb557w1dg8hfckbj8";
+    };
+    doCheck = false;
+    propagatedBuildInputs = [ pkgs.python3Packages.flit sphinx183 ];
+  };
   sphinx183 = pkgs.python3Packages.sphinx.overridePythonAttrs (attrs: rec {
     version = "1.8.3";
     src = attrs.src.override {
@@ -70,6 +80,7 @@ let shared = rec {
       sha256 = "c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8";
     };
   });
+  sphinxBundle = pkgs.python3.withPackages (_: [sphinx-copybutton sphinx183]);
 
   # Custom combination of latex packages for our latex needs
   texlive = pkgs.texlive.combine {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -144,7 +144,7 @@ in rec {
       python37Packages = pkgs.python37Packages;
     };
 
-    sphinx183 = bazel_dependencies.sphinx183;
+    sphinxBundle = bazel_dependencies.sphinxBundle;
 
     convert = bazel_dependencies.imagemagick;
 


### PR DESCRIPTION
Trying out the 'sphinx-copybutton' package. It "works", but renders way too big. According to the docs (https://sphinx-copybutton.readthedocs.io/en/latest/#customization) it is possible to overwrite the CSS rules, so this may be fixable that way.

CC @hurryabit if you want to use this. Thanks @aherrmann for the help adding the dependency.

Note also this doesn't work with the live-preview.sh script at the moment.

<img width="1440" alt="Screen Shot 2020-02-28 at 4 34 54 pm" src="https://user-images.githubusercontent.com/10836630/75565216-daea6f00-5a4d-11ea-8410-cc7842e3ccdc.png">


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
