### PR TITLE
Remove -j 200

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,14 +22,9 @@ fi
 # so do a full build first.
 (
   cd compiler
-  # Bazel also limits cache downloads by -j so increasing this to a ridiculous value
-  # helps. Bazel separately controls the number of jobs using CPUs so this should not
-  # overload machines.
-  # This also appears to be what Google uses internally, see
-  # https://github.com/bazelbuild/bazel/issues/6394#issuecomment-436234594.
-  bazel build -j 200 //... --build_tag_filters "$tag_filter"
+  bazel build //... --build_tag_filters "$tag_filter"
 )
-bazel test -j 200 //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
+bazel test //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null
 # Check that we can load damlc in ghci


### PR DESCRIPTION
Originally, we introduced this since it made fully cached builds slightly faster. However, that was a long time ago. Looking at the numbers now, things actually seem to be significantly faster without this (possibly due to changes in how Bazel handles this). In particular on MacOS where I’ve seen a couple of builds with < 20 minutes on CI which I did not see in quite some time without this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
