### PR TITLE
Lower Ledger api server rejected submissions to info

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -217,7 +217,7 @@ final class ApiSubmissionService private (
       Failure(Status.INTERNAL.augmentDescription(reason).asRuntimeException)
 
     case Failure(error) =>
-      logger.error("Submission of command has failed.", error)
+      logger.info(s"Submission of command rejected: ${error.getMessage}")
       Failure(error)
   }
 


### PR DESCRIPTION
Rejected submissions are a user-error and don't indicate a problem with the server not functioning properly. Such user errors make it hard to spot "real" server-side warnings and errors.

Closes #4772

CHANGELOG_BEGIN
- The Ledger API Server now logs rejected submissions at a lower "INFO" level to remove a source of warnings/errors without relation to server health.

CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
