### PR TITLE
[DAML-LF] add submission time for contract ids seeding

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -52,7 +52,7 @@ final class Engine(nextRandomInt: () => Int) {
   private[this] val _commandTranslation: CommandPreprocessor = new CommandPreprocessor(
     _compiledPackages)
 
-  // We want to make the submissionTime different from the ledgerTime,
+  // We want that people do not rely on submissionTime=ledgerTime,
   // then we pick a random time +/- 10 micro seconds around ledger time
   private def deriveSubmissionTime(ledgerTime: Time.Timestamp) =
     ledgerTime.addMicros((nextRandomInt() % 11).toLong)
@@ -88,7 +88,7 @@ final class Engine(nextRandomInt: () => Int) {
       cmds: Commands,
       participantId: ParticipantId,
       submissionSeed: Option[crypto.Hash],
-  ): Result[(Transaction.Transaction, Transaction.MetaData)] = {
+  ): Result[(Transaction.Transaction, Transaction.Metadata)] = {
     val submissionTime = deriveSubmissionTime(cmds.ledgerEffectiveTime)
     _commandTranslation
       .preprocessCommands(cmds)
@@ -120,7 +120,7 @@ final class Engine(nextRandomInt: () => Int) {
                           sys.error(s"INTERNAL ERROR: Missing dependencies of package $pkgId"))
                     (pkgIds + pkgId) union transitiveDeps
                 }
-                tx -> Transaction.MetaData(
+                tx -> Transaction.Metadata(
                   submissionTime = submissionTime,
                   usedPackages = deps,
                   dependsOnTime = dependsOnTime,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -276,13 +276,13 @@ object Speedy {
         checkSubmitterInMaintainers: Boolean,
         sexpr: SExpr,
         compiledPackages: CompiledPackages,
-        seedWithTime: Option[(crypto.Hash, Time.Timestamp)] = None,
+        transactionSeedAndSubmissionTime: Option[(crypto.Hash, Time.Timestamp)] = None,
     ): Machine =
       fromSExpr(
         SEApp(sexpr, Array(SEValue.Token)),
         checkSubmitterInMaintainers,
         compiledPackages,
-        seedWithTime,
+        transactionSeedAndSubmissionTime,
       )
 
     // Used from repl.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -375,7 +375,7 @@ object Transaction {
    * @dependsOnTime: indicate the transaction computation depends on ledger
    *        time.
    */
-  final case class MetaData(
+  final case class Metadata(
       submissionTime: Time.Timestamp,
       usedPackages: Set[PackageId],
       dependsOnTime: Boolean

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -376,6 +376,7 @@ object Transaction {
    *        time.
    */
   final case class MetaData(
+      submissionTime: Time.Timestamp,
       usedPackages: Set[PackageId],
       dependsOnTime: Boolean
   )

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -154,6 +154,8 @@ message DamlTransactionEntry {
 
   // The nonce used to generate contract ids
   bytes submission_seed = 5;
+
+  google.protobuf.Timestamp submission_time = 6;
 }
 
 // A transaction rejection entry.

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -155,6 +155,7 @@ message DamlTransactionEntry {
   // The nonce used to generate contract ids
   bytes submission_seed = 5;
 
+  // The time used to derive contract ids
   google.protobuf.Timestamp submission_time = 6;
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -229,6 +229,7 @@ object KeyValueConsumption {
         workflowId = Some(txEntry.getWorkflowId)
           .filter(_.nonEmpty)
           .map(parseLedgerString("WorkflowId")),
+        submissionTime = parseTimestamp(txEntry.getSubmissionTime),
         submissionSeed = parseOptHash(txEntry.getSubmissionSeed),
         optUsedPackages = None,
       ),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -65,6 +65,7 @@ object KeyValueSubmission {
           .setWorkflowId(meta.workflowId.getOrElse(""))
           .setSubmissionSeed(meta.submissionSeed.fold(ByteString.EMPTY)(x =>
             ByteString.copyFrom(x.toByteArray)))
+          .setSubmissionTime(buildTimestamp(meta.submissionTime))
       )
       .build
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -59,17 +59,19 @@ object Version {
     * Handling of older versions is handled by [[Envelope.open]] which performs the migration to latest version.
     *
     * Version history:
-    *   0: Initial version
+    *   0: * Initial version
     *
-    *   1: Use hashing to serialize contract keys. Backwards incompatible to avoid having to do two lookups
-    *      of a single contract key.
+    *   1: * Use hashing to serialize contract keys. Backwards incompatible to avoid having to do two lookups
+    *        of a single contract key.
     *
-    *   2: Deprecate use of relative contract identifiers. The transaction is submitted with absolute contract
-    *      identifiers. Backwards incompatible to remove unnecessary traversal of the transaction when consuming
-    *      it and to make it possible to remove DamlLogEntryId.
+    *   2: * Deprecate use of relative contract identifiers. The transaction is submitted with absolute contract
+    *        identifiers. Backwards incompatible to remove unnecessary traversal of the transaction when consuming
+    *        it and to make it possible to remove DamlLogEntryId.
     *
-    *   3: Add an explicit deduplication time window to each submission. Backwards incompatible because
-    *      it is unclear how to set a sensible default value while the submission time us unknown.
+    *   3: * Add an explicit deduplication time window to each submission. Backwards incompatible because
+    *        it is unclear how to set a sensible default value while the submission time us unknown.
+    *      * Add submissionTime in DamlTransactionEntry and used this time instead ledgerTime to derive
+    *        contract ids.
     */
   val version: Long = 3
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -758,6 +758,7 @@ object ParticipantStateIntegrationSpecBase {
     TransactionMeta(
       ledgerEffectiveTime = let,
       workflowId = Some(Ref.LedgerString.assertFromString("tests")),
+      submissionTime = let.addMicros(-1000),
       submissionSeed = Some(
         crypto.Hash.assertFromString(
           "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -163,7 +163,7 @@ object KVTest {
       submissionSeed: Option[crypto.Hash],
       additionalContractDataTy: String,
       cmds: Command*,
-  ): KVTest[(Transaction.AbsTransaction, Transaction.MetaData)] =
+  ): KVTest[(Transaction.AbsTransaction, Transaction.Metadata)] =
     for {
       s <- get[KVTestState]
       (tx, meta) = s.engine
@@ -197,12 +197,12 @@ object KVTest {
       submitter: Party,
       submissionSeed: Option[crypto.Hash],
       cmds: Command*,
-  ): KVTest[(Transaction.AbsTransaction, Transaction.MetaData)] =
+  ): KVTest[(Transaction.AbsTransaction, Transaction.Metadata)] =
     runCommand(submitter, submissionSeed, defaultAdditionalContractDataTy, cmds: _*)
 
   def submitTransaction(
       submitter: Party,
-      transaction: (Transaction.AbsTransaction, Transaction.MetaData),
+      transaction: (Transaction.AbsTransaction, Transaction.Metadata),
       submissionSeed: Option[crypto.Hash],
       mrtDelta: Duration = minMRTDelta,
       letDelta: Duration = Duration.ZERO,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -224,6 +224,7 @@ object KVTest {
         meta = TransactionMeta(
           ledgerEffectiveTime = testState.recordTime.addMicros(letDelta.toNanos / 1000),
           workflowId = None,
+          submissionTime = txMetaData.submissionTime,
           submissionSeed = submissionSeed,
           optUsedPackages = Some(txMetaData.usedPackages)
         ),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -112,6 +112,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
   private def transactionMeta(let: Timestamp) = TransactionMeta(
     ledgerEffectiveTime = let,
     workflowId = Some(Ref.LedgerString.assertFromString("tests")),
+    submissionTime = let.addMicros(1000),
     submissionSeed = Some(
       crypto.Hash.assertFromString(
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -23,6 +23,7 @@ import com.digitalasset.daml.lf.data.{Ref, Time}
 final case class TransactionMeta(
     ledgerEffectiveTime: Time.Timestamp,
     workflowId: Option[WorkflowId],
+    submissionTime: Time.Timestamp,
     submissionSeed: Option[crypto.Hash],
     optUsedPackages: Option[Set[Ref.PackageId]],
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
@@ -73,6 +73,7 @@ class CommandExecutorImpl(
             TransactionMeta(
               Time.Timestamp.assertFromInstant(submitted.ledgerEffectiveTime),
               submitted.workflowId.map(_.unwrap),
+              meta.submissionTime,
               submissionSeed,
               Some(meta.usedPackages)
             ),

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -121,6 +121,7 @@ class ImplicitPartyAdditionIT
     val transactionMeta = TransactionMeta(
       ledgerEffectiveTime = let,
       workflowId = Some(Ref.LedgerString.assertFromString("wfid")),
+      submissionTime = let.addMicros(1000),
       submissionSeed = None,
       optUsedPackages = None,
     )

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -100,6 +100,7 @@ class TransactionMRTComplianceIT
       val transactionMeta = TransactionMeta(
         ledgerEffectiveTime = Time.Timestamp.assertFromInstant(LET),
         workflowId = Some(Ref.LedgerString.assertFromString("wfid")),
+        submissionTime = Time.Timestamp.assertFromInstant(ST),
         submissionSeed = seed,
         optUsedPackages = None,
       )


### PR DESCRIPTION
This PR add concept of submission time. This time is generated by the engine and it used (instead of ledger time) to seed the contract id scheme.

This PR also add support for this new concept to kvutils. 

This PR advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
