### PR TITLE
Sandbox: Standardize logging when initializing the ledger.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -21,7 +21,6 @@ import com.digitalasset.platform.store.dao.{
 import com.digitalasset.platform.store.{BaseLedger, DbType, ReadOnlyLedger}
 import com.digitalasset.resources.ProgramResource.StartupException
 import com.digitalasset.resources.ResourceOwner
-import scalaz.syntax.tag._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -72,7 +71,7 @@ object ReadOnlySqlLedger {
         .lookupLedgerId()
         .flatMap {
           case Some(foundLedgerId @ `initialLedgerId`) =>
-            logger.info(s"Found existing ledger with ID: ${foundLedgerId.unwrap}")
+            logger.info(s"Found existing ledger with ID: $foundLedgerId")
             Future.successful(foundLedgerId)
           case Some(foundLedgerId) =>
             Future.failed(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -38,7 +38,6 @@ import com.digitalasset.platform.store.entries.{LedgerEntry, PackageLedgerEntry,
 import com.digitalasset.platform.store.{BaseLedger, DbType, FlywayMigrations, PersistenceEntry}
 import com.digitalasset.resources.ProgramResource.StartupException
 import com.digitalasset.resources.ResourceOwner
-import scalaz.syntax.tag._
 
 import scala.collection.immutable.Queue
 import scala.concurrent.{ExecutionContext, Future}
@@ -475,7 +474,7 @@ private final class SqlLedgerFactory(ledgerDao: LedgerDao)(implicit logCtx: Logg
       initialLedgerEntries: ImmArray[LedgerEntryOrBump],
       packages: InMemoryPackageStore,
   ): Future[LedgerId] = {
-    logger.info(s"Found existing ledger with ID: ${foundLedgerId.unwrap}")
+    logger.info(s"Found existing ledger with ID: $foundLedgerId")
     if (initialLedgerEntries.nonEmpty) {
       logger.warn(
         s"Initial ledger entries provided, presumably from scenario, but there is an existing database, and thus they will not be used.")


### PR DESCRIPTION
Seemed inconsistent between Sandbox and other ledgers using the Ledger API Server. I've changed them so they match.

I changed `JdbcIndexer#initializeIndexer` to simply throw a `LedgerIdMismatchException` rather than logging, as the exception is caught and logged by the `RecoveringIndexer` anyway.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
