### PR TITLE
Command client remove deduplication

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -149,75 +149,61 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
 
   test(
     "CSduplicateSubmitAndWait",
-    "SubmitAndWait should be idempotent when reusing the same command identifier",
+    "SubmitAndWait should fail on duplicate requests",
     allocate(SingleParty),
   ) {
     case Participants(Participant(ledger, party)) =>
       for {
         request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
         _ <- ledger.submitAndWait(request)
-        _ <- ledger.submitAndWait(request)
-        transactions <- ledger.flatTransactions(party)
+        failure <- ledger.submitAndWait(request).failed
       } yield {
-        assert(
-          transactions.size == 1,
-          s"Expected only 1 transaction, but received ${transactions.size}",
-        )
-
+        assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
   }
 
   test(
     "CSduplicateSubmitAndWaitForTransactionId",
-    "SubmitAndWaitForTransactionId should be idempotent when reusing the same command identifier",
+    "SubmitAndWaitForTransactionId should fail on duplicate requests",
     allocate(SingleParty),
   ) {
     case Participants(Participant(ledger, party)) =>
       for {
         request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
-        transactionId1 <- ledger.submitAndWaitForTransactionId(request)
-        transactionId2 <- ledger.submitAndWaitForTransactionId(request)
+        _ <- ledger.submitAndWaitForTransactionId(request)
+        failure <- ledger.submitAndWaitForTransactionId(request).failed
       } yield {
-        assert(
-          transactionId1 == transactionId2,
-          s"The transaction identifiers did not match: transactionId1=$transactionId1, transactionId2=$transactionId2",
-        )
+        assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
   }
 
   test(
     "CSduplicateSubmitAndWaitForTransaction",
-    "SubmitAndWaitForTransaction should be idempotent when reusing the same command identifier",
+    "SubmitAndWaitForTransaction should fail on duplicate requests",
     allocate(SingleParty),
   ) {
     case Participants(Participant(ledger, party)) =>
       for {
         request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
-        transaction1 <- ledger.submitAndWaitForTransaction(request)
-        transaction2 <- ledger.submitAndWaitForTransaction(request)
+        _ <- ledger.submitAndWaitForTransaction(request)
+        failure <- ledger.submitAndWaitForTransaction(request).failed
       } yield {
-        assert(
-          transaction1 == transaction2,
-          s"The transactions did not match: transaction1=$transaction1, transaction2=$transaction2",
-        )
+        assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
   }
 
   test(
     "CSduplicateSubmitAndWaitForTransactionTree",
-    "SubmitAndWaitForTransactionTree should be idempotent when reusing the same command identifier",
+    "SubmitAndWaitForTransactionTree should fail on duplicate requests",
     allocate(SingleParty),
   ) {
     case Participants(Participant(ledger, party)) =>
       for {
         request <- ledger.submitAndWaitRequest(party, Dummy(party).create.command)
-        transactionTree1 <- ledger.submitAndWaitForTransactionTree(request)
-        transactionTree2 <- ledger.submitAndWaitForTransactionTree(request)
+        _ <- ledger.submitAndWaitForTransactionTree(request)
+        failure <- ledger.submitAndWaitForTransactionTree(request).failed
       } yield {
-        assert(
-          transactionTree1 == transactionTree2,
-          s"The transaction trees did not match: transactionTree1=$transactionTree1, transactionTree2=$transactionTree2",
-        )
+        assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
   }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -234,38 +234,6 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
   }
 
   test(
-    "TXDeduplicateCommands",
-    "Commands with identical submitter, command identifier, and application identifier should be accepted and deduplicated",
-    allocate(TwoParties),
-  ) {
-    case Participants(Participant(ledger, alice, bob)) =>
-      for {
-        aliceRequest <- ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
-        _ <- ledger.submitAndWait(aliceRequest)
-        _ <- ledger.submitAndWait(aliceRequest)
-        aliceTransactions <- ledger.flatTransactions(alice)
-
-        // now let's create another command that uses same applicationId and commandId, but submitted by Bob
-        bobRequestTemplate <- ledger.submitAndWaitRequest(bob, Dummy(bob).create.command)
-        bobRequest = bobRequestTemplate
-          .update(_.commands.commandId := aliceRequest.getCommands.commandId)
-          .update(_.commands.applicationId := aliceRequest.getCommands.applicationId)
-        _ <- ledger.submitAndWait(bobRequest)
-        bobTransactions <- ledger.flatTransactions(bob)
-      } yield {
-        assert(
-          aliceTransactions.length == 1,
-          s"Only one transaction was expected to be seen by $alice but ${aliceTransactions.length} appeared",
-        )
-
-        assert(
-          bobTransactions.length == 1,
-          s"Expected a transaction to be seen by $bob but ${bobTransactions.length} appeared",
-        )
-      }
-  }
-
-  test(
     "TXRejectEmptyFilter",
     "A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status",
     allocate(SingleParty),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
@@ -145,7 +145,6 @@ object ApiServices {
           commandConfig.maxParallelSubmissions,
           commandConfig.maxCommandsInFlight,
           commandConfig.limitMaxCommandsInFlight,
-          commandConfig.historySize,
           commandConfig.retentionPeriod,
           submissionConfig.maxDeduplicationTime
         ),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiCommandService.scala
@@ -120,7 +120,7 @@ final class ApiCommandService private (
                 }
               }
             } yield {
-              TrackerImpl(trackingFlow, configuration.inputBufferSize, configuration.historySize)
+              TrackerImpl(trackingFlow, configuration.inputBufferSize)
             }
           }
       } else {
@@ -197,7 +197,6 @@ object ApiCommandService {
       maxParallelSubmissions: Int,
       maxCommandsInFlight: Int,
       limitMaxCommandsInFlight: Boolean,
-      historySize: Int,
       retentionPeriod: FiniteDuration,
       // TODO(RA): this should be updated dynamically from the ledger configuration
       maxDeduplicationTime: java.time.Duration)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/CommandConfiguration.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/CommandConfiguration.scala
@@ -10,7 +10,6 @@ final case class CommandConfiguration(
     maxParallelSubmissions: Int,
     maxCommandsInFlight: Int,
     limitMaxCommandsInFlight: Boolean,
-    historySize: Int,
     retentionPeriod: FiniteDuration
 )
 
@@ -21,7 +20,6 @@ object CommandConfiguration {
       maxParallelSubmissions = 128,
       maxCommandsInFlight = 256,
       limitMaxCommandsInFlight = true,
-      historySize = 5000,
       retentionPeriod = 24.hours
     )
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -47,7 +47,7 @@ class TrackerImplTest
       .toMat(TestSink.probe[NotUsed])(Keep.both)
       .run()
     queue = q
-    sut = new TrackerImpl(q, 10)
+    sut = new TrackerImpl(q)
     consumer = sink
   }
 


### PR DESCRIPTION
This PR removes the deduplication from the command client. The command client deduplication:
- uses a fixed size cache, and is therefore not reliable
- no longer works now that the submission service returns an ALREADY_EXISTS error on duplicate submissions

Fixes https://github.com/digital-asset/daml/issues/4623
