### PR TITLE
[Engine] track if time is used during evaluation

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -452,7 +452,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "reinterpret to the same result" in {
       val Right((tx, _)) = interpretResult
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
-      val Right(rtx) =
+      val Right((rtx, _)) =
         engine
           .reinterpret(Some(submissionSeed), participant, Set(party), txRoots, let)
           .consume(lookupContract, lookupPackage, lookupKey)
@@ -492,36 +492,34 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       .consume(lookupContract, lookupPackage, lookupKey)
     res shouldBe 'right
     val interpretResult =
-      res.flatMap(
-        r =>
-          engine
-            .interpretCommands(
-              validating = false,
-              checkSubmitterInMaintainers = true,
-              submitters = Set(party),
-              commands = r,
-              time = let,
-              transactionSeed = Some(transactionSeed)
-            )
-            .consume(lookupContract, lookupPackage, lookupKey))
-    val Right(tx) = interpretResult
+      res
+        .flatMap(
+          r =>
+            engine
+              .interpretCommands(
+                validating = false,
+                checkSubmitterInMaintainers = true,
+                submitters = Set(party),
+                commands = r,
+                ledgerTime = let,
+                transactionSeed = Some(transactionSeed)
+              )
+              .consume(lookupContract, lookupPackage, lookupKey))
+    val Right((tx, _)) = interpretResult
 
     "be translated" in {
-      val submitResult = engine
+      val Right((rtx, _)) = engine
         .submit(Commands(party, ImmArray(command), let, "test"), participant, Some(submissionSeed))
         .consume(lookupContract, lookupPackage, lookupKey)
-        .map(_._1)
-      interpretResult shouldBe 'right
-      (interpretResult |@| submitResult)(_ isReplayedBy _) shouldBe Right(true)
+      (tx isReplayedBy rtx) shouldBe true
     }
 
     "reinterpret to the same result" in {
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
-      val reinterpretResult =
-        engine
-          .reinterpret(Some(submissionSeed), participant, Set(party), txRoots, let)
-          .consume(lookupContract, lookupPackage, lookupKey)
-      (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
+      val Right((rtx, _)) = engine
+        .reinterpret(Some(submissionSeed), participant, Set(party), txRoots, let)
+        .consume(lookupContract, lookupPackage, lookupKey)
+      (tx isReplayedBy rtx) shouldBe true
     }
 
     "be validated" in {
@@ -589,18 +587,20 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       .consume(lookupContractWithKey, lookupPackage, lookupKey)
     res shouldBe 'right
     val result =
-      res.flatMap(
-        r =>
-          engine
-            .interpretCommands(
-              validating = false,
-              checkSubmitterInMaintainers = true,
-              submitters = Set(alice),
-              commands = r,
-              time = let,
-              transactionSeed = Some(transactionSeed)
-            )
-            .consume(lookupContractWithKey, lookupPackage, lookupKey))
+      res
+        .flatMap(
+          r =>
+            engine
+              .interpretCommands(
+                validating = false,
+                checkSubmitterInMaintainers = true,
+                submitters = Set(alice),
+                commands = r,
+                ledgerTime = let,
+                transactionSeed = Some(transactionSeed)
+              )
+              .consume(lookupContractWithKey, lookupPackage, lookupKey))
+        .map(_._1)
     val tx = result.right.value
 
     "be translated" in {
@@ -617,6 +617,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         engine
           .reinterpret(Some(submissionSeed), participant, Set(alice), txRoots, let)
           .consume(lookupContractWithKey, lookupPackage, lookupKey)
+          .map(_._1)
       (result |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
 
@@ -663,18 +664,20 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       .consume(lookupContract, lookupPackage, lookupKey)
     res shouldBe 'right
     val interpretResult =
-      res.flatMap(
-        r =>
-          engine
-            .interpretCommands(
-              validating = false,
-              checkSubmitterInMaintainers = true,
-              submitters = Set(party),
-              commands = r,
-              time = let,
-              transactionSeed = Some(transactionSeed)
-            )
-            .consume(lookupContract, lookupPackage, lookupKey))
+      res
+        .flatMap(
+          r =>
+            engine
+              .interpretCommands(
+                validating = false,
+                checkSubmitterInMaintainers = true,
+                submitters = Set(party),
+                commands = r,
+                ledgerTime = let,
+                transactionSeed = Some(transactionSeed)
+              )
+              .consume(lookupContract, lookupPackage, lookupKey))
+        .map(_._1)
     val Right(tx) = interpretResult
 
     "be translated" in {
@@ -691,6 +694,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         engine
           .reinterpret(Some(submissionSeed), participant, Set(party), txRoots, let)
           .consume(lookupContract, lookupPackage, lookupKey)
+          .map(_._1)
       (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
     }
 
@@ -886,41 +890,41 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       .consume(lookupContractForPayout, lookupPackage, lookupKey)
     res shouldBe 'right
     val interpretResult =
-      res.flatMap(
-        r =>
-          engine
-            .interpretCommands(
-              validating = false,
-              checkSubmitterInMaintainers = true,
-              submitters = Set(bob),
-              commands = r,
-              time = let,
-              transactionSeed = Some(transactionSeed)
-            )
-            .consume(lookupContractForPayout, lookupPackage, lookupKey))
+      res
+        .flatMap(
+          r =>
+            engine
+              .interpretCommands(
+                validating = false,
+                checkSubmitterInMaintainers = true,
+                submitters = Set(bob),
+                commands = r,
+                ledgerTime = let,
+                transactionSeed = Some(transactionSeed)
+              )
+              .consume(lookupContractForPayout, lookupPackage, lookupKey))
     interpretResult shouldBe 'right
+    val Right((tx, _)) = interpretResult
 
     "be translated" in {
       val submitResult = engine
         .submit(Commands(bob, ImmArray(command), let, "test"), participant, Some(submissionSeed))
         .consume(lookupContractForPayout, lookupPackage, lookupKey)
-        .map(_._1)
       submitResult shouldBe 'right
-
-      (interpretResult |@| submitResult)(_ isReplayedBy _) shouldBe Right(true)
+      val Right((rtx, _)) = interpretResult
+      (rtx isReplayedBy tx) shouldBe true
     }
 
-    val Right(tx) = interpretResult
     val Right(blindingInfo) =
       Blinding.checkAuthorizationAndBlind(tx, Set(bob))
 
     "reinterpret to the same result" in {
       val txRoots = tx.roots.map(id => tx.nodes(id)).toSeq
-      val reinterpretResult =
+      val Right((rtx, _)) =
         engine
           .reinterpret(Some(submissionSeed), participant, Set(bob), txRoots, let)
           .consume(lookupContractForPayout, lookupPackage, lookupKey)
-      (interpretResult |@| reinterpretResult)(_ isReplayedBy _) shouldBe Right(true)
+      (rtx isReplayedBy tx) shouldBe true
     }
 
     "blinded correctly" in {
@@ -972,7 +976,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "events generated correctly" in {
-      val Right(tx) = interpretResult
+      val Right((tx, _)) = interpretResult
       val Seq(_, noid1) = tx.nodes.keys.toSeq.sortBy(_.index)
       val Right(blindingInfo) =
         Blinding.checkAuthorizationAndBlind(tx, Set(bob))
@@ -1099,18 +1103,20 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         .preprocessCommands(Commands(exerciseActor, ImmArray(command), let, "test"))
         .consume(lookupContract, lookupPackage, lookupKey)
 
-      res.flatMap(
-        r =>
-          engine
-            .interpretCommands(
-              validating = false,
-              checkSubmitterInMaintainers = true,
-              submitters = Set(exerciseActor),
-              commands = r,
-              time = let,
-              transactionSeed = Some(transactionSeed)
-            )
-            .consume(lookupContract, lookupPackage, lookupKey))
+      res
+        .flatMap(
+          r =>
+            engine
+              .interpretCommands(
+                validating = false,
+                checkSubmitterInMaintainers = true,
+                submitters = Set(exerciseActor),
+                commands = r,
+                ledgerTime = let,
+                transactionSeed = Some(transactionSeed)
+              )
+              .consume(lookupContract, lookupPackage, lookupKey))
+        .map(_._1)
 
     }
 
@@ -1136,7 +1142,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       fetchNodes.foreach {
         case (nid, n) =>
           val fetchTx = GenTx(HashMap(nid -> n), ImmArray(nid))
-          val Right(reinterpreted) = engine
+          val Right((reinterpreted, _)) = engine
             .reinterpret(None, participant, n.requiredAuthorizers, Seq(n), let)
             .consume(lookupContract, lookupPackage, lookupKey)
           (fetchTx isReplayedBy reinterpreted) shouldBe true
@@ -1194,6 +1200,31 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
       reinterpreted shouldBe 'right
     }
+
+  }
+
+  "getTime set dependsOnTime flag" in {
+    val templateId = Identifier(basicTestsPkgId, "BasicTests:TimeGetter")
+    def run(choiceName: ChoiceName) = {
+      val submissionSeed = hash(s"getTime set dependsOnTime flag: ($choiceName)")
+      val command =
+        CreateAndExerciseCommand(
+          templateId = templateId,
+          createArgument = ValueRecord(None, ImmArray(None -> ValueParty(party))),
+          choiceId = choiceName,
+          choiceArgument = ValueRecord(None, ImmArray.empty),
+        )
+      engine
+        .submit(
+          Commands(party, ImmArray(command), Time.Timestamp.now(), "test"),
+          participant,
+          Some(submissionSeed))
+        .consume(lookupContract, lookupPackage, lookupKey)
+    }
+
+    run("FactorialOfThree").map(_._2.dependsOnTime) shouldBe Right(false)
+    run("GetTime").map(_._2.dependsOnTime) shouldBe Right(true)
+    run("FactorialOfThree").map(_._2.dependsOnTime) shouldBe Right(false)
 
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -61,6 +61,8 @@ object Speedy {
       traceLog: TraceLog,
       /* Compiled packages (DAML-LF ast + compiled speedy expressions). */
       var compiledPackages: CompiledPackages,
+      /* Flag to trace usage of get_time builtins */
+      var dependsOnTime: Boolean,
   ) {
 
     def kontPop(): Kont = kont.remove(kont.size - 1)
@@ -254,6 +256,7 @@ object Speedy {
         compiledPackages = compiledPackages,
         checkSubmitterInMaintainers = checkSubmitterInMaintainers,
         validating = false,
+        dependsOnTime = false,
       )
 
     def newBuilder(

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -507,3 +507,18 @@ data Nesting146 = Nesting146 {x: Nesting147}
 data Nesting147 = Nesting147 {x: Nesting148}
 data Nesting148 = Nesting148 {x: Nesting149}
 data Nesting149 = Nesting149 {x: Int}
+
+template TimeGetter with
+    p : Party
+  where
+    signatory p
+    controller p can
+      GetTime : Time
+        do
+         t <- getTime
+         pure t
+      FactorialOfThree: Int
+        do
+          pure $ product [1, 2, 3]
+
+

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -380,9 +380,12 @@ object Transaction {
    *        This is a hint for what packages are required to validate
    *        the transaction using the current interpreter.
    *        The used packages are not serialized using [[TransactionCoder]].
+   * @dependsOnTime: indicate the transaction computation depends on ledger
+   *        time.
    */
   final case class MetaData(
       usedPackages: Set[PackageId],
+      dependsOnTime: Boolean
   )
 
   type AbsTransaction = GenTransaction.WithTxValue[NodeId, Value.AbsoluteContractId]


### PR DESCRIPTION
This PR, add a flag in the `GenTransaction` `MetaData` to marks if the engine used the getTime builtin during evalution.   

This PR advances the state of #4556.


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
