### PR TITLE
Don't return witnessed contracts in ActiveContractsService

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
@@ -221,7 +221,6 @@ object Event extends value.CidContainer3WithDefaultCidResolver[Event] {
               // purge fetch children -- we do not have fetch events
               val relevantChildren =
                 ne.children.filter(!isIrrelevantNode(_))
-              val stakeholders = ne.stakeholders
               val evt = ExerciseEvent(
                 ne.targetCoid,
                 templateId,
@@ -230,7 +229,7 @@ object Event extends value.CidContainer3WithDefaultCidResolver[Event] {
                 ne.actingParties,
                 ne.consuming,
                 relevantChildren,
-                stakeholders intersect disclosure(nodeId),
+                ne.stakeholders,
                 disclosure(nodeId),
                 ne.exerciseResult
               )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/EventFilter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/EventFilter.scala
@@ -34,8 +34,9 @@ object EventFilter {
       .filter(_.witnessParties.nonEmpty)
 
   def apply(event: ActiveContract)(txf: TransactionFilter): Option[ActiveContract] =
-    Some(event.copy(witnesses = event.witnesses.filter(included(_, event.contract.template, txf))))
+    Some(event)
       .filter(ac =>
         (ac.signatories union ac.observers).exists(included(_, event.contract.template, txf)))
+      .map(_.copy(witnesses = event.witnesses.filter(included(_, event.contract.template, txf))))
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/EventFilter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/EventFilter.scala
@@ -35,6 +35,7 @@ object EventFilter {
 
   def apply(event: ActiveContract)(txf: TransactionFilter): Option[ActiveContract] =
     Some(event.copy(witnesses = event.witnesses.filter(included(_, event.contract.template, txf))))
-      .filter(_.witnesses.nonEmpty)
+      .filter(ac =>
+        (ac.signatories union ac.observers).exists(included(_, event.contract.template, txf)))
 
 }

--- a/ledger/test-common/src/main/daml/Test.daml
+++ b/ledger/test-common/src/main/daml/Test.daml
@@ -526,6 +526,11 @@ template Witnesses
      do
       return ()
 
+    nonconsuming choice WitnessesCreateNewWitnesses: ContractId Witnesses
+     controller p_actor
+     do
+      create this with p_signatory = p_actor
+
 -- Contract used to divulge instances of Witnesses to the actor
 -- of witnesses. Otherwise we cannot exercise!
 template DivulgeWitnesses


### PR DESCRIPTION
The change to `EventFilter` and to the query in `JdbcLedgerDao` are
"duplicate work", but we need the change in `EventFilter` for the
`InMemoryLedger`, and the change in `JdbcLedgerDao` so that we avoid
fetching a contract that anyway would be discarded later.

```
CHANGELOG_BEGIN
[Sandbox]: Witnessed contracts for which a party is not a stakeholder
are no longer returned in the active contract stream.
CHANGELOG_END
```

Fixes #3254.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
