### PR TITLE
[engine] refactor transaction's usedPackages

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -139,8 +139,7 @@ object Blinding {
 
     GenTransaction(
       roots = go(BackStack.empty, FrontStack(tx.roots)),
-      nodes = filteredNodes,
-      optUsedPackages = tx.optUsedPackages
+      nodes = filteredNodes
     )
   }
 }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -79,7 +79,7 @@ final class Engine {
       cmds: Commands,
       participantId: ParticipantId,
       submissionSeed: Option[crypto.Hash],
-  ): Result[Transaction.Transaction] = {
+  ): Result[(Transaction.Transaction, Transaction.MetaData)] = {
     _commandTranslation
       .preprocessCommands(cmds)
       .flatMap { processedCmds =>
@@ -109,7 +109,7 @@ final class Engine {
                         sys.error(s"INTERNAL ERROR: Missing dependencies of package $pkgId"))
                   (pkgIds + pkgId) union transitiveDeps
               }
-              tx.copy(optUsedPackages = Some(deps))
+              tx -> Transaction.MetaData(usedPackages = deps)
             }
         }
       }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -217,7 +217,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
       }) match {
       case Left(err) =>
         fail(s"Unexpected error: $err")
-      case Right(tx) =>
+      case Right((tx, _)) =>
         pcs.update(tx)
         tx
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -170,7 +170,7 @@ case class PartialTransaction(
 
         nodes.keySet diff allChildNodeIds
       }
-      val tx = GenTransaction(nodes, ImmArray(rootNodes), None)
+      val tx = GenTransaction(nodes, ImmArray(rootNodes))
 
       tx.foreach { (nid, node) =>
         val rootPrefix = if (rootNodes.contains(nid)) "root " else ""
@@ -189,13 +189,7 @@ case class PartialTransaction(
   def finish: Either[PartialTransaction, Tx.Transaction] =
     context match {
       case ContextRoot(_, children) if aborted.isEmpty =>
-        Right(
-          GenTransaction(
-            nodes = nodes,
-            roots = children.toImmArray,
-            optUsedPackages = None,
-          ),
-        )
+        Right(GenTransaction(nodes = nodes, roots = children.toImmArray))
       case _ =>
         Left(this)
     }

--- a/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
+++ b/daml-lf/transaction-scalacheck/src/main/scala/com/digitalasset/daml/lf/value/ValueGenerators.scala
@@ -337,7 +337,7 @@ object ValueGenerators {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(Tx.NodeId(_)))
-    } yield GenTransaction(HashMap(nodes: _*), ImmArray(roots), None)
+    } yield GenTransaction(HashMap(nodes: _*), ImmArray(roots))
   }
 
   /*
@@ -399,11 +399,7 @@ object ValueGenerators {
 
     nonDanglingRefNodeGen(3, Tx.NodeId(0)).map {
       case (nodeIds, nodes) =>
-        GenTransaction(
-          nodes,
-          nodeIds,
-          None
-        )
+        GenTransaction(nodes, nodeIds)
     }
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -65,11 +65,6 @@ case class VersionedTransaction[Nid, Cid](
   *
   * @param nodes The nodes of this transaction.
   * @param roots References to the root nodes of the transaction.
-  * @param optUsedPackages The set of packages used during command processing.
-  *                     This is a hint for what packages are required to validate
-  *                     the transaction using the current interpreter.
-  *                     The used packages are not serialized using [[TransactionCoder]].
-  *
   * Users of this class may assume that all instances are well-formed, i.e., `isWellFormed.isEmpty`.
   * For performance reasons, users are not required to call `isWellFormed`.
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
@@ -77,7 +72,6 @@ case class VersionedTransaction[Nid, Cid](
 final case class GenTransaction[Nid, +Cid, +Val](
     nodes: HashMap[Nid, GenNode[Nid, Cid, Val]],
     roots: ImmArray[Nid],
-    optUsedPackages: Option[Set[PackageId]],
 ) extends value.CidContainer[GenTransaction[Nid, Cid, Val]] {
 
   import GenTransaction._
@@ -332,6 +326,7 @@ final case class GenTransaction[Nid, +Cid, +Val](
 }
 
 object GenTransaction extends value.CidContainer3WithDefaultCidResolver[GenTransaction] {
+
   type WithTxValue[Nid, +Cid] = GenTransaction[Nid, Cid, Transaction.Value[Cid]]
 
   case class NotWellFormedError[Nid](nid: Nid, reason: NotWellFormedErrorReason)
@@ -345,14 +340,13 @@ object GenTransaction extends value.CidContainer3WithDefaultCidResolver[GenTrans
       f2: A2 => B2,
       f3: A3 => B3,
   ): GenTransaction[A1, A2, A3] => GenTransaction[B1, B2, B3] = {
-    case GenTransaction(nodes, roots, optUsedPackages) =>
+    case GenTransaction(nodes, roots) =>
       GenTransaction(
         nodes = nodes.map {
           case (nodeId, node) =>
             f1(nodeId) -> GenNode.map3(f1, f2, f3)(node)
         },
-        roots = roots.map(f1),
-        optUsedPackages
+        roots = roots.map(f1)
       )
   }
 }
@@ -379,6 +373,17 @@ object Transaction {
     *
     */
   type Transaction = GenTransaction.WithTxValue[NodeId, TContractId]
+
+  /* Transaction meta data
+   * @param submissionTime: submission time
+   * @param usedPackages The set of packages used during command processing.
+   *        This is a hint for what packages are required to validate
+   *        the transaction using the current interpreter.
+   *        The used packages are not serialized using [[TransactionCoder]].
+   */
+  final case class MetaData(
+      usedPackages: Set[PackageId],
+  )
 
   type AbsTransaction = GenTransaction.WithTxValue[NodeId, Value.AbsoluteContractId]
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -590,7 +590,7 @@ object TransactionCoder {
     for {
       rs <- roots
       ns <- nodes
-    } yield GenTransaction(ns, rs, None)
+    } yield GenTransaction(ns, rs)
   }
 
   def toPartySet(strList: ProtocolStringList): Either[DecodeError, Set[Party]] = {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -325,11 +325,7 @@ class TransactionCoderSpec
       val nodes = ImmArray((1 to 10000).map { nid =>
         Value.NodeId(nid) -> node
       })
-      val tx = GenTransaction(
-        nodes = HashMap(nodes.toSeq: _*),
-        roots = nodes.map(_._1),
-        optUsedPackages = None,
-      )
+      val tx = GenTransaction(nodes = HashMap(nodes.toSeq: _*), roots = nodes.map(_._1))
 
       tx shouldEqual TransactionCoder
         .decodeVersionedTransaction(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -119,7 +119,7 @@ object TransactionSpec {
   def StringTransaction(
       nodes: HashMap[String, GenNode[String, V.AbsoluteContractId, Value]],
       roots: ImmArray[String],
-  ): StringTransaction = GenTransaction(nodes, roots, None)
+  ): StringTransaction = GenTransaction(nodes, roots)
 
   def dummyExerciseNode(
       children: ImmArray[String],

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.kvutils
 import scala.collection.mutable
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.v1.TransactionMeta
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.transaction.Node._
 import com.digitalasset.daml.lf.transaction.Transaction
@@ -43,13 +44,16 @@ private[kvutils] object InputsAndEffects {
   /** Compute the inputs to a DAML transaction, that is, the referenced contracts, keys
     * and packages.
     */
-  def computeInputs(tx: Transaction.AbsTransaction): List[DamlStateKey] = {
+  def computeInputs(
+      tx: Transaction.AbsTransaction,
+      meta: TransactionMeta,
+  ): List[DamlStateKey] = {
     val inputs = mutable.LinkedHashSet[DamlStateKey]()
 
     {
       import PackageId.ordering
       inputs ++=
-        tx.optUsedPackages
+        meta.optUsedPackages
           .getOrElse(
             throw new InternalError("Transaction was not annotated with used packages")
           )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -229,7 +229,8 @@ object KeyValueConsumption {
         workflowId = Some(txEntry.getWorkflowId)
           .filter(_.nonEmpty)
           .map(parseLedgerString("WorkflowId")),
-        submissionSeed = parseOptHash(txEntry.getSubmissionSeed)
+        submissionSeed = parseOptHash(txEntry.getSubmissionSeed),
+        optUsedPackages = None,
       ),
       transaction = transaction,
       transactionId = hexTxId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -49,7 +49,7 @@ object KeyValueSubmission {
       tx: Transaction.AbsTransaction,
   ): DamlSubmission = {
 
-    val inputDamlStateFromTx = InputsAndEffects.computeInputs(tx)
+    val inputDamlStateFromTx = InputsAndEffects.computeInputs(tx, meta)
     val encodedSubInfo = buildSubmitterInfo(submitterInfo)
 
     DamlSubmission.newBuilder

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -16,7 +16,7 @@ import com.digitalasset.daml.bazeltools.BazelRunfiles._
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.data.{ImmArray, InsertOrdSet, Ref}
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
@@ -736,7 +736,7 @@ object ParticipantStateIntegrationSpecBase {
   private val IdleTimeout: FiniteDuration = 5.seconds
 
   private val emptyTransaction: Transaction.AbsTransaction =
-    GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
+    GenTransaction(HashMap.empty, ImmArray.empty)
 
   private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("test-participant")
   private val sourceDescription = Some("provided by test")
@@ -759,7 +759,8 @@ object ParticipantStateIntegrationSpecBase {
       workflowId = Some(Ref.LedgerString.assertFromString("tests")),
       submissionSeed = Some(
         crypto.Hash.assertFromString(
-          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
+      optUsedPackages = Some(Set.empty),
     )
 
   private def matchPackageUpload(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -92,8 +92,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     "be able to submit transaction" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
       val seed = hash(this.getClass.getName)
       for {
-        tx <- runSimpleCommand(alice, seed, simpleCreateCmd)
-        logEntry <- submitTransaction(submitter = alice, tx = tx, seed).map(_._2)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        logEntry <- submitTransaction(
+          submitter = alice,
+          transaction = transaction,
+          submissionSeed = seed).map(_._2)
       } yield {
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
       }
@@ -115,12 +118,12 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     "reject transaction with out of bounds LET" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
       val seed = hash(this.getClass.getName)
       for {
-        tx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
         conf <- getDefaultConfiguration
         logEntry <- submitTransaction(
           submitter = alice,
-          tx = tx,
-          seed,
+          transaction = transaction,
+          submissionSeed = seed,
           letDelta = conf.timeModel.minTtl)
           .map(_._2)
       } yield {
@@ -139,8 +142,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
           .from(0)
           .map(i => Some(crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString)))
       for {
-        createTx <- runSimpleCommand(alice, seeds(0), simpleCreateCmd)
-        result <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seeds(0))
+        transaction1 <- runSimpleCommand(alice, seeds(0), simpleCreateCmd)
+        result <- submitTransaction(
+          submitter = alice,
+          transaction = transaction1,
+          submissionSeed = seeds(0))
         (entryId, logEntry) = result
         update = KeyValueConsumption.logEntryToUpdate(entryId, logEntry).head
         coid = update
@@ -152,11 +158,17 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
           .asInstanceOf[NodeCreate[AbsoluteContractId, _]]
           .coid
 
-        exeTx <- runSimpleCommand(alice, seeds(1), exerciseCmd(coid.coid, simpleTemplateId))
-        logEntry2 <- submitTransaction(submitter = alice, tx = exeTx, seeds(1)).map(_._2)
+        transaction2 <- runSimpleCommand(alice, seeds(1), exerciseCmd(coid.coid, simpleTemplateId))
+        logEntry2 <- submitTransaction(
+          submitter = alice,
+          transaction = transaction2,
+          submissionSeed = seeds(1)).map(_._2)
 
         // Try to double consume.
-        logEntry3 <- submitTransaction(submitter = alice, tx = exeTx, seeds(1)).map(_._2)
+        logEntry3 <- submitTransaction(
+          submitter = alice,
+          transaction = transaction2,
+          submissionSeed = seeds(1)).map(_._2)
 
       } yield {
         logEntry2.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
@@ -171,8 +183,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         configEntry <- submitConfig { c =>
           c.copy(generation = c.generation + 1)
         }
-        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
-        txEntry <- submitTransaction(submitter = alice, tx = createTx, seed).map(_._2)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        txEntry <- submitTransaction(
+          submitter = alice,
+          transaction = transaction,
+          submissionSeed = seed).map(_._2)
       } yield {
         configEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
         txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
@@ -188,8 +203,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
         .runTestWithPackage(additionalContractDataType, alice, eve) {
           val seed = hash(this.getClass.getName)
           for {
-            createTx <- runCommand(alice, seed, additionalContractDataType, command)
-            txEntry <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
+            transaction <- runCommand(alice, seed, additionalContractDataType, command)
+            txEntry <- submitTransaction(
+              submitter = alice,
+              transaction = transaction,
+              submissionSeed = seed)
               .map(_._2)
           } yield {
             txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_ENTRY
@@ -200,8 +218,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     "reject transactions with unallocated informee" in KVTest.runTestWithSimplePackage(alice, bob) {
       val seed = hash(this.getClass.getName)
       for {
-        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
-        txEntry1 <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        txEntry1 <- submitTransaction(
+          submitter = alice,
+          transaction = transaction,
+          submissionSeed = seed)
           .map(_._2)
       } yield {
         txEntry1.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
@@ -220,9 +241,10 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
 
         newParty <- withParticipantId(p1)(allocateParty("unhosted", alice))
         txEntry1 <- withParticipantId(p0)(
-          submitTransaction(submitter = newParty, tx = createTx, seed).map(_._2))
+          submitTransaction(submitter = newParty, createTx, seed).map(_._2))
         txEntry2 <- withParticipantId(p1)(
-          submitTransaction(submitter = newParty, tx = createTx, seed).map(_._2))
+          submitTransaction(submitter = newParty, transaction = createTx, submissionSeed = seed)
+            .map(_._2))
 
       } yield {
         configEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
@@ -237,9 +259,12 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       val seed = hash(this.getClass.getName)
       for {
         // Submit a creation of a contract with owner 'Alice', but submit it as 'Bob'.
-        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
         bob <- allocateParty("bob", bob)
-        txEntry <- submitTransaction(submitter = bob, tx = createTx, submissionSeed = seed)
+        txEntry <- submitTransaction(
+          submitter = bob,
+          transaction = transaction,
+          submissionSeed = seed)
           .map(_._2)
       } yield {
         txEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
@@ -252,9 +277,10 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       val seed = hash(this.getClass.getName)
       for {
         // Submit a creation of a contract with owner 'Alice', but submit it as 'Bob'.
-        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
         bob <- allocateParty("bob", bob)
-        _ <- submitTransaction(submitter = bob, tx = createTx, submissionSeed = seed).map(_._2)
+        _ <- submitTransaction(submitter = bob, transaction = transaction, submissionSeed = seed)
+          .map(_._2)
       } yield {
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
         // Check that we're updating the metrics (assuming this test at least has been run)
@@ -311,8 +337,12 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     "submitter info is optional" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
       val seed = hash(this.getClass.getName)
       for {
-        createTx <- runSimpleCommand(alice, seed, simpleCreateCmd)
-        result <- submitTransaction(submitter = alice, tx = createTx, submissionSeed = seed)
+        transaction <- runSimpleCommand(alice, seed, simpleCreateCmd)
+        result <- submitTransaction(
+          submitter = alice,
+          transaction = transaction,
+          submissionSeed = seed,
+        )
       } yield {
         val (entryId, entry) = result
         // Clear the submitter info from the log entry

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -72,7 +72,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
   "computePerPartyProjectionRoots" should {
 
     "yield no roots with empty transaction" in {
-      val emptyTransaction: Transaction = GenTransaction(HashMap.empty, ImmArray.empty, None)
+      val emptyTransaction: Transaction = GenTransaction(HashMap.empty, ImmArray.empty)
       project(emptyTransaction) shouldBe List.empty
     }
 
@@ -83,7 +83,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
         Set(Party.assertFromString("Alice")),
         Set(Party.assertFromString("Alice"), Party.assertFromString("Bob")))
       val tx =
-        GenTransaction(nodes = HashMap(nid -> root), roots = ImmArray(nid), optUsedPackages = None)
+        GenTransaction(nodes = HashMap(nid -> root), roots = ImmArray(nid))
 
       project(tx) shouldBe List(
         ProjectionRoots(Party.assertFromString("Alice"), BackStack(nid)),
@@ -125,7 +125,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
         GenTransaction(
           nodes = HashMap(nid1 -> exe, nid2 -> create, nid3 -> bobCreate, nid4 -> charlieCreate),
           roots = ImmArray(nid1, nid3, nid4),
-          optUsedPackages = None)
+        )
 
       project(tx) shouldBe List(
         // Alice should see the exercise as the root.

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Time.Timestamp
-import com.digitalasset.daml.lf.data.{ImmArray, InsertOrdSet, Ref}
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
@@ -82,7 +82,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
   private val aParty = Ref.Party.assertFromString("aParty")
 
   private val anEmptyTransaction: Transaction.AbsTransaction =
-    GenTransaction(HashMap.empty, ImmArray.empty, Some(InsertOrdSet.empty))
+    GenTransaction(HashMap.empty, ImmArray.empty)
 
   private val aSubmissionId: SubmissionId =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)
@@ -109,7 +109,8 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
     workflowId = Some(Ref.LedgerString.assertFromString("tests")),
     submissionSeed = Some(
       crypto.Hash.assertFromString(
-        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
+    optUsedPackages = Some(Set.empty)
   )
 
   private def newRecordTime(): Timestamp =

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.v1
 
 import com.digitalasset.daml.lf.crypto
-import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.data.{Ref, Time}
 
 /** Meta-data of a transaction visible to all parties that can see a part of
   * the transaction.
@@ -21,7 +21,8 @@ import com.digitalasset.daml.lf.data.Time.Timestamp
   *
   */
 final case class TransactionMeta(
-    ledgerEffectiveTime: Timestamp,
+    ledgerEffectiveTime: Time.Timestamp,
     workflowId: Option[WorkflowId],
     submissionSeed: Option[crypto.Hash],
+    optUsedPackages: Option[Set[Ref.PackageId]],
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
@@ -87,14 +87,7 @@ trait WriteService
     *                        associated [[ReadService]].
     * @param transactionMeta : the meta-data accessible to all consumers of the
     *                        transaction. See [[TransactionMeta]] for more information.
-    * @param transaction     : the submitted transaction. This transaction can
-    *                        contain contract-ids that are relative to this transaction itself.
-    *                        These are used to refer to contracts created in the transaction
-    *                        itself. The participant state implementation is expected to convert
-    *                        these into absolute contract-ids that are guaranteed to be unique.
-    *                        This typically happens after a transaction has been assigned a
-    *                        globally unique id, as then the contract-ids can be derived from that
-    *                        transaction id.
+    * @param transaction     : the submitted transaction.
     *
     * @return an async result of a SubmissionResult
     */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
@@ -87,8 +87,14 @@ trait WriteService
     *                        associated [[ReadService]].
     * @param transactionMeta : the meta-data accessible to all consumers of the
     *                        transaction. See [[TransactionMeta]] for more information.
-    * @param transaction     : the submitted transaction.
-    *
+    * @param transaction     : the submitted transaction. This transaction can
+    *                        contain contract-ids that are relative to this transaction itself.
+    *                        These are used to refer to contracts created in the transaction
+    *                        itself. The participant state implementation is expected to convert
+    *                        these into absolute contract-ids that are guaranteed to be unique.
+    *                        This typically happens after a transaction has been assigned a
+    *                        globally unique id, as then the contract-ids can be derived from that
+    *                        transaction id.
     * @return an async result of a SubmissionResult
     */
   def submitTransaction(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutorImpl.scala
@@ -57,7 +57,8 @@ class CommandExecutorImpl(
       lookupKey)
       .map { submission =>
         (for {
-          updateTx <- submission
+          result <- submission
+          (updateTx, meta) = result
           _ <- Blinding
             .checkAuthorizationAndBlind(updateTx, Set(submitter))
         } yield
@@ -72,6 +73,7 @@ class CommandExecutorImpl(
               Time.Timestamp.assertFromInstant(submitted.ledgerEffectiveTime),
               submitted.workflowId.map(_.unwrap),
               submissionSeed,
+              Some(meta.usedPackages)
             ),
             updateTx,
           )).left.map(ErrorCause.DamlLf)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -233,7 +233,7 @@ object ScenarioLoader {
         val transactionId = txId.id
         val workflowId =
           Some(Ref.LedgerString.assertConcat(workflowIdPrefix, Ref.LedgerString.fromInt(stepId)))
-        val tx = GenTransaction(richTransaction.nodes, richTransaction.roots, None)
+        val tx = GenTransaction(richTransaction.nodes, richTransaction.roots)
         val mappedExplicitDisclosure = richTransaction.explicitDisclosure
         val mappedLocalImplicitDisclosure = richTransaction.localImplicitDisclosure
         val mappedGlobalImplicitDisclosure = richTransaction.globalImplicitDisclosure

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -109,7 +109,6 @@ class ImplicitPartyAdditionIT
     val transaction: Transaction.AbsTransaction = GenTransaction(
       HashMap(event1 -> node),
       ImmArray(event1),
-      None
     )
 
     val submitterInfo = SubmitterInfo(
@@ -120,9 +119,10 @@ class ImplicitPartyAdditionIT
     )
 
     val transactionMeta = TransactionMeta(
-      let,
-      Some(Ref.LedgerString.assertFromString("wfid")),
-      None,
+      ledgerEffectiveTime = let,
+      workflowId = Some(Ref.LedgerString.assertFromString("wfid")),
+      submissionSeed = None,
+      optUsedPackages = None,
     )
 
     ledger.publishTransaction(submitterInfo, transactionMeta, transaction)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionMRTComplianceIT.scala
@@ -80,6 +80,7 @@ class TransactionMRTComplianceIT
   }
 
   val LET = Instant.EPOCH.plusSeconds(2)
+  val ST = LET.plusNanos(3)
   val MRT = Instant.EPOCH.plusSeconds(5)
 
   "A Ledger" should {
@@ -87,18 +88,19 @@ class TransactionMRTComplianceIT
       val seed = Some(crypto.Hash.hashPrivateKey(this.getClass.getName))
 
       val dummyTransaction: Transaction.AbsTransaction =
-        GenTransaction(HashMap.empty, ImmArray.empty, None)
+        GenTransaction(HashMap.empty, ImmArray.empty)
 
       val submitterInfo = SubmitterInfo(
-        Ref.Party.assertFromString("submitter"),
-        Ref.LedgerString.assertFromString("appId"),
-        Ref.LedgerString.assertFromString("cmdId"),
-        Time.Timestamp.assertFromInstant(MRT)
+        submitter = Ref.Party.assertFromString("submitter"),
+        applicationId = Ref.LedgerString.assertFromString("appId"),
+        commandId = Ref.LedgerString.assertFromString("cmdId"),
+        maxRecordTime = Time.Timestamp.assertFromInstant(MRT)
       )
       val transactionMeta = TransactionMeta(
-        Time.Timestamp.assertFromInstant(LET),
-        Some(Ref.LedgerString.assertFromString("wfid")),
-        seed
+        ledgerEffectiveTime = Time.Timestamp.assertFromInstant(LET),
+        workflowId = Some(Ref.LedgerString.assertFromString("wfid")),
+        submissionSeed = seed,
+        optUsedPackages = None,
       )
 
       ledger

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -164,7 +164,6 @@ class JdbcLedgerDaoSpec
               key = Some(keyWithMaintainers)
             )),
           ImmArray(event1),
-          None
         ),
         Map(event1 -> Set[Party]("Alice", "Bob"), event2 -> Set[Party]("Alice", "In", "Chains"))
       )
@@ -471,7 +470,6 @@ class JdbcLedgerDaoSpec
               key = Some(keyWithMaintainers)
             )),
           ImmArray(event1),
-          None
         ),
         Map(event1 -> Set("Alice", "Bob"), event2 -> Set("Alice", "In", "Chains"))
       )
@@ -528,7 +526,6 @@ class JdbcLedgerDaoSpec
             )
           ),
           ImmArray(event1, event2),
-          None
         ),
         Map(event1 -> Set("Alice", "Bob"), event2 -> Set("Alice", "In", "Chains"))
       )
@@ -574,7 +571,6 @@ class JdbcLedgerDaoSpec
                 key = None
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set("Alice", "Bob"))
         )
@@ -614,7 +610,6 @@ class JdbcLedgerDaoSpec
                 key = None
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set("Alice", "Bob"))
         )
@@ -784,7 +779,6 @@ class JdbcLedgerDaoSpec
                     Set(party)))
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set(party))
         ),
@@ -826,7 +820,6 @@ class JdbcLedgerDaoSpec
                     Set(party)))
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set(party))
         ),
@@ -856,7 +849,6 @@ class JdbcLedgerDaoSpec
                 result.map(id => AbsoluteContractId(s"contractId$id")),
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set(party))
         ),
@@ -886,7 +878,6 @@ class JdbcLedgerDaoSpec
                 stakeholders = Set(party),
               )),
             ImmArray[EventId](s"event$id"),
-            None
           ),
           Map((s"event$id": EventId) -> Set(party))
         ),
@@ -1098,7 +1089,7 @@ class JdbcLedgerDaoSpec
           Some("workflowId"),
           let,
           let,
-          GenTransaction(HashMap.empty, ImmArray.empty, None),
+          GenTransaction(HashMap.empty, ImmArray.empty),
           Map.empty
         ),
         Map(AbsoluteContractId(s"contractId$id") -> Set(bob)),


### PR DESCRIPTION
In this PR, we refactor `optUsedPackage` field from `GenTransaction`. 

We move out this information from `GenTransaction` to a new case class call `MetaData`. This new class will be used in upcoming PR to store a flag to track usage of time in the submission (required by #3830) and submission time (required by ##3830).

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
