### PR TITLE
Bump allocation area

### DIFF
--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -56,8 +56,10 @@ common_haskell_flags = [
     "-threaded",
     "-rtsopts",
 
-    # run on two cores, disable idle & parallel GC
-    "-with-rtsopts=-N2 -qg -I0",
+    # run on two cores, disable idle & parallel GC, increase allocation area
+    # The allocation area was determined experimentally on //compiler/damlc/tests:packaging.
+    # Feel free to change it if measurements show a different value to be better.
+    "-with-rtsopts=-N2 -qg -I0 -A20M",
 ]
 
 def _wrap_rule(rule, name = "", deps = [], hackage_deps = [], compiler_flags = [], **kwargs):

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -343,7 +343,7 @@ damlc_compile_test(
 damlc_compile_test(
     name = "memory-bond-trading",
     srcs = [":bond-trading"],
-    heap_limit = "200M" if is_windows else "100M",
+    heap_limit = "210M" if is_windows else "110M",
     main = "bond-trading/Test.daml",
     stack_limit = "100K" if is_windows else "70K",
 )


### PR DESCRIPTION
On the packaging tests this seems to speed things up from about 210s
to 165s on my local machine which seems like a nice improvement for a
6 character addition. I’ve played around with a few different
allocation areas and 20M seems like a decent default.

EDIT: I originally used 128M but that seems to cause issues on Windows. 20M doesn’t change things significantly compared to 128M.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
