### PR TITLE
Sandbox: Refactoring and cleanup around `FlywayMigrations` and `JdbcIndexerFactory`.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -48,15 +48,21 @@ final class JdbcIndexerFactory[Status <: InitStatus] private (metrics: MetricReg
   private[indexer] val asyncTolerance = 30.seconds
 
   def validateSchema(jdbcUrl: String)(
-      implicit x: Status =:= Uninitialized): JdbcIndexerFactory[Initialized] = {
-    new FlywayMigrations(jdbcUrl).validate()
-    this.asInstanceOf[JdbcIndexerFactory[Initialized]]
+      implicit x: Status =:= Uninitialized,
+      executionContext: ExecutionContext,
+  ): Future[JdbcIndexerFactory[Initialized]] = {
+    new FlywayMigrations(jdbcUrl)
+      .validate()
+      .map(_ => this.asInstanceOf[JdbcIndexerFactory[Initialized]])
   }
 
   def migrateSchema(jdbcUrl: String, allowExistingSchema: Boolean)(
-      implicit x: Status =:= Uninitialized): JdbcIndexerFactory[Initialized] = {
-    new FlywayMigrations(jdbcUrl).migrate(allowExistingSchema)
-    this.asInstanceOf[JdbcIndexerFactory[Initialized]]
+      implicit x: Status =:= Uninitialized,
+      executionContext: ExecutionContext,
+  ): Future[JdbcIndexerFactory[Initialized]] = {
+    new FlywayMigrations(jdbcUrl)
+      .migrate(allowExistingSchema)
+      .map(_ => this.asInstanceOf[JdbcIndexerFactory[Initialized]])
   }
 
   def owner(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -27,7 +27,6 @@ import com.digitalasset.platform.store.entries.{LedgerEntry, PackageLedgerEntry,
 import com.digitalasset.platform.store.{FlywayMigrations, PersistenceEntry}
 import com.digitalasset.resources.{Resource, ResourceOwner}
 
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -35,8 +34,6 @@ final class JdbcIndexerFactory(
     jdbcUrl: String,
     metrics: MetricRegistry,
 )(implicit logCtx: LoggingContext) {
-  private[indexer] val asyncTolerance = 30.seconds
-
   def validateSchema()(
       implicit executionContext: ExecutionContext
   ): Future[InitializedJdbcIndexerFactory] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/RecoveringIndexer.scala
@@ -20,13 +20,12 @@ import scala.util.{Failure, Success}
 /**
   * A helper that restarts an indexer whenever an error occurs.
   *
+  * @param scheduler    Used to schedule the restart operation.
   * @param restartDelay Time to wait before restarting the indexer after a failure
-  * @param asyncTolerance Time to wait for asynchronous operations to complete
   */
 final class RecoveringIndexer(
     scheduler: Scheduler,
     restartDelay: FiniteDuration,
-    asyncTolerance: FiniteDuration,
 )(implicit logCtx: LoggingContext) {
   private implicit val executionContext: ExecutionContext = DirectExecutionContext
   private val logger = ContextualizedLogger.get(this.getClass)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -30,7 +30,7 @@ final class StandaloneIndexerServer(
         .forActorSystem(() =>
           ActorSystem("StandaloneIndexerServer-" + config.participantId.filterNot(".:#/ ".toSet)))
         .acquire()
-      indexerFactory = JdbcIndexerFactory(config.jdbcUrl, metrics)
+      indexerFactory = new JdbcIndexerFactory(config.jdbcUrl, metrics)
       indexer = new RecoveringIndexer(
         actorSystem.scheduler,
         config.restartDelay,
@@ -54,7 +54,7 @@ final class StandaloneIndexerServer(
 
   private def startIndexer(
       indexer: RecoveringIndexer,
-      initializedIndexerFactory: JdbcIndexerFactory[Initialized],
+      initializedIndexerFactory: InitializedJdbcIndexerFactory,
       actorSystem: ActorSystem,
   )(implicit executionContext: ExecutionContext): Resource[Future[Unit]] =
     indexer

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -30,7 +30,7 @@ final class StandaloneIndexerServer(
         .forActorSystem(() =>
           ActorSystem("StandaloneIndexerServer-" + config.participantId.filterNot(".:#/ ".toSet)))
         .acquire()
-      indexerFactory = JdbcIndexerFactory(metrics)
+      indexerFactory = JdbcIndexerFactory(config.jdbcUrl, metrics)
       indexer = new RecoveringIndexer(
         actorSystem.scheduler,
         config.restartDelay,
@@ -41,11 +41,11 @@ final class StandaloneIndexerServer(
           Resource.successful(Future.unit)
         case IndexerStartupMode.MigrateAndStart =>
           Resource
-            .fromFuture(indexerFactory.migrateSchema(config.jdbcUrl, config.allowExistingSchema))
+            .fromFuture(indexerFactory.migrateSchema(config.allowExistingSchema))
             .flatMap(startIndexer(indexer, _, actorSystem))
         case IndexerStartupMode.ValidateAndStart =>
           Resource
-            .fromFuture(indexerFactory.validateSchema(config.jdbcUrl))
+            .fromFuture(indexerFactory.validateSchema())
             .flatMap(startIndexer(indexer, _, actorSystem))
       }
     } yield {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -34,7 +34,6 @@ final class StandaloneIndexerServer(
       indexer = new RecoveringIndexer(
         actorSystem.scheduler,
         config.restartDelay,
-        indexerFactory.asyncTolerance
       )
       _ <- config.startupMode match {
         case IndexerStartupMode.MigrateOnly =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/FlywayMigrations.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/FlywayMigrations.scala
@@ -3,70 +3,51 @@
 
 package com.digitalasset.platform.store
 
-import com.digitalasset.dec.DirectExecutionContext
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.digitalasset.platform.store.FlywayMigrations._
 import com.digitalasset.platform.store.dao.HikariConnection
-import com.digitalasset.resources.Resource
+import com.digitalasset.resources.ResourceOwner
 import com.zaxxer.hikari.HikariDataSource
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.MigrationVersion
 import org.flywaydb.core.api.configuration.FluentConfiguration
 
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext}
-import scala.util.control.NonFatal
+import scala.concurrent.{ExecutionContext, Future}
 
 class FlywayMigrations(jdbcUrl: String)(implicit logCtx: LoggingContext) {
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private val dbType = DbType.jdbcType(jdbcUrl)
 
-  private def newDataSource()(
+  def validate()(implicit executionContext: ExecutionContext): Future[Unit] =
+    dataSource.use { ds =>
+      Future {
+        val flyway = configurationBase(dbType).dataSource(ds).load()
+        logger.info("Running Flyway validation...")
+        flyway.validate()
+        logger.info("Flyway schema validation finished successfully.")
+      }
+    }
+
+  def migrate(allowExistingSchema: Boolean = false)(
       implicit executionContext: ExecutionContext
-  ): Resource[HikariDataSource] =
-    HikariConnection.owner(jdbcUrl, "daml.index.db.migration", 2, 2, 250.millis, None).acquire()
-
-  def validate(): Unit = {
-    val dataSourceResource = newDataSource()(DirectExecutionContext)
-    val ds = Await.result(dataSourceResource.asFuture, 1.second)
-    try {
-      val flyway = configurationBase(dbType).dataSource(ds).load()
-      logger.info(s"running Flyway validation..")
-      flyway.validate()
-      logger.info(s"Flyway schema validation finished successfully")
-    } catch {
-      case NonFatal(e) =>
-        logger.error("an error occurred while running schema migration", e)
-        //there is little point in communicating this error in a typed manner, we should rather blow up
-        throw e
-    } finally {
-      val _ = Await.result(dataSourceResource.release(), 1.second)
+  ): Future[Unit] =
+    dataSource.use { ds =>
+      Future {
+        val flyway = configurationBase(dbType)
+          .dataSource(ds)
+          .baselineOnMigrate(allowExistingSchema)
+          .baselineVersion(MigrationVersion.fromVersion("0"))
+          .load()
+        logger.info("Running Flyway migration...")
+        val stepsTaken = flyway.migrate()
+        logger.info(s"Flyway schema migration finished successfully, applying $stepsTaken steps.")
+      }
     }
-  }
 
-  def migrate(allowExistingSchema: Boolean = false): Unit = {
-    val dataSourceResource = newDataSource()(DirectExecutionContext)
-    val ds = Await.result(dataSourceResource.asFuture, 1.second)
-    try {
-      val flyway = configurationBase(dbType)
-        .dataSource(ds)
-        .baselineOnMigrate(allowExistingSchema)
-        .baselineVersion(MigrationVersion.fromVersion("0"))
-        .load()
-      logger.info(s"running Flyway migration..")
-      val stepsTaken = flyway.migrate()
-      logger.info(s"Flyway schema migration finished successfully, applying $stepsTaken steps.")
-    } catch {
-      case NonFatal(e) =>
-        logger.error("an error occurred while running schema migration", e)
-        //TODO: shall we quit gracefully if something goes off track?
-        //there is little point in communicating this error in a typed manner, we should rather blow up
-        throw e
-    } finally {
-      val _ = Await.result(dataSourceResource.release(), 1.second)
-    }
-  }
+  private def dataSource: ResourceOwner[HikariDataSource] =
+    HikariConnection.owner(jdbcUrl, "daml.index.db.migration", 2, 2, 250.millis, None)
 }
 
 object FlywayMigrations {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerSpec.scala
@@ -45,8 +45,7 @@ class RecoveringIndexerSpec
 
   "RecoveringIndexer" should {
     "work when the stream completes" in newLoggingContext { implicit logCtx =>
-      val recoveringIndexer =
-        new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.millis),
       )
@@ -73,8 +72,7 @@ class RecoveringIndexerSpec
     }
 
     "work when the stream is stopped" in newLoggingContext { implicit logCtx =>
-      val recoveringIndexer =
-        new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Stream completes after 10s, but is released before that happens
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.seconds),
@@ -105,8 +103,7 @@ class RecoveringIndexerSpec
     }
 
     "wait until the subscription completes" in newLoggingContext { implicit logCtx =>
-      val recoveringIndexer =
-        new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 100.millis, 10.millis),
       )
@@ -135,8 +132,7 @@ class RecoveringIndexerSpec
     }
 
     "recover from failure" in newLoggingContext { implicit logCtx =>
-      val recoveringIndexer =
-        new RecoveringIndexer(actorSystem.scheduler, 10.millis, 1.second)
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SubscriptionFails, 10.millis, 10.millis),
@@ -178,9 +174,8 @@ class RecoveringIndexerSpec
     }
 
     "respect restart delay" in newLoggingContext { implicit logCtx =>
-      val delay = 500.millis
-      val recoveringIndexer =
-        new RecoveringIndexer(actorSystem.scheduler, delay, 1.second)
+      val restartDelay = 500.millis
+      val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, restartDelay)
       // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SubscriptionFails, 0.millis, 0.millis),
@@ -193,7 +188,7 @@ class RecoveringIndexerSpec
         .transformWith(finallyRelease(resource))
         .map { _ =>
           val t1 = System.nanoTime()
-          (t1 - t0).nanos should be >= delay
+          (t1 - t0).nanos should be >= restartDelay
           testIndexer.actions shouldBe Seq[IndexerEvent](
             EventSubscribeCalled("A"),
             EventSubscribeFail("A"),


### PR DESCRIPTION
This makes a few changes around migrations for terseness and readability improvements. It's probably easiest just to look at each commit in turn.

Changes:

* return `Future[Unit]` from migrations rather than awaiting
* remove explicit error-handling from migrations, because this will be propagated and handled at the top level
* pass the JDBC URL into the `JdbcIndexerFactory` constructor, not its methods
* replace the JdbcIndexerFactory's `InitStatus` with two classes
* stop passing around the ledger ID in `JdbcIndexerFactory`
* remove the indexer `asyncTolerance`; it's no longer used

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
