### PR TITLE
Only log message about duplicate package uploads in debug level

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/packages/InMemoryPackageStore.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/packages/InMemoryPackageStore.scala
@@ -83,7 +83,7 @@ case class InMemoryPackageStore(
         )
       case Some(oldDetails) =>
         // Note: we are discarding the new metadata (size, known since, source description)
-        logger.warn(
+        logger.debug(
           s"Ignoring duplicate upload of package $pkgId. Existing package: $oldDetails, new package: $details")
         this
     }


### PR DESCRIPTION
It is basically impossible to not hit this all the time if you upload
more than one package so issuing a warning is a bit confusing.

changelog_begin

- [Sandbox] The warning about duplicate package uploads is no longer
  emitted by default.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
