### PR TITLE
change standard change report time

### DIFF
--- a/ci/cron/monthly.yaml
+++ b/ci/cron/monthly.yaml
@@ -11,7 +11,7 @@ trigger: none
 
 # Run on schedule: first Monday of each month at 4AM UTC
 schedules:
-  - cron: '0 4 1-7 * Mon'
+  - cron: '0 6 1-7 * Mon'
     displayName: monthly
     branches:
       include:


### PR DESCRIPTION
In the current setup, the report generation starts at 4. However, the daily killing of all machines also starts at 4, giving the report little chance of ever finishing.

CHANGELOG_BEGIN
CHANGELOG_END