### PR TITLE
test that ContractStreamStep#append preserves data sensibly

### DIFF
--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
@@ -1,0 +1,72 @@
+package com.digitalasset.http
+package util
+
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.syntax.apply._
+import scalaz.syntax.semigroup._
+import scalaz.{@@, Semigroup, Tag}
+
+class ContractStreamStepTest
+    extends FlatSpec
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with TableDrivenPropertyChecks {
+  import ContractStreamStepTest._, ContractStreamStep._
+  import InsertDeleteStepTest._
+
+  behavior of "append"
+
+  it should "be associative for valid streams" in forAll(validStreamGen) { csses =>
+    whenever(csses.size >= 3) {
+      forEvery(
+        Table(("a", "b", "c"), csses.sliding(3).map { case Seq(a, b, c) => (a, b, c) }.toSeq: _*)) {
+        case (a, b, c) =>
+          (a |+| (b |+| c)) should ===((a |+| b) |+| c)
+      }
+    }
+  }
+
+  it should "report the last offset" in forAll(anyCssGen, anyCssGen) { (a, b) =>
+    def off(css: ContractStreamStep[_, _]) = css match {
+      case Acs(_) => None
+      case LiveBegin(off) => off.toOption
+      case Txn(_, off) => Some(off)
+    }
+    off(a |+| b) should ===(off(b) orElse off(a))
+  }
+
+  it should "preserve append across toInsertDelete" in forAll(anyCssGen, anyCssGen) { (a, b) =>
+    (a |+| b).toInsertDelete should ===(a.toInsertDelete |+| b.toInsertDelete)
+  }
+}
+
+object ContractStreamStepTest {
+  import InsertDeleteStepTest._, InsertDeleteStep.Inserts, ContractStreamStep._
+  import org.scalacheck.Arbitrary.arbitrary
+  import org.scalacheck.Gen
+
+  type CSS = ContractStreamStep[Unit, Cid]
+
+  implicit val `CSS semigroup`: Semigroup[CSS] =
+    Semigroup instance (_.append(_)(Cid.unwrap))
+
+  private val offGen: Gen[domain.Offset] = Tag subst Tag.unsubst(arbitrary[String @@ Alpha])
+  private val acsGen = arbitrary[Inserts[Cid]] map (Acs(_))
+  private val noAcsLBGen = Gen const LiveBegin(LedgerBegin)
+  private val postAcsGen = offGen map (o => LiveBegin(AbsoluteBookmark(o)))
+  private val txnGen = ^(arbitrary[IDS], offGen)(Txn(_, _))
+
+  private val validStreamGen: Gen[Seq[CSS]] = for {
+    beforeAfter <- Gen.zip(
+      Gen.containerOf[Vector, CSS](acsGen),
+      Gen.containerOf[Vector, CSS](txnGen))
+    (acsSeq, txnSeq) = beforeAfter
+    liveBegin <- if (acsSeq.isEmpty) noAcsLBGen else postAcsGen
+  } yield (acsSeq :+ liveBegin) ++ txnSeq
+
+  private val anyCssGen: Gen[CSS] =
+    Gen.frequency((4, acsGen), (1, noAcsLBGen), (1, postAcsGen), (4, txnGen))
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.digitalasset.http
 package util
 

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
@@ -59,7 +59,7 @@ object InsertDeleteStepTest {
   implicit val `Alpha arb`: Arbitrary[Cid] = Cid subst Arbitrary(
     Gen.alphaUpperChar map (_.toString))
 
-  private implicit val `IDS monoid`
+  private[util] implicit val `IDS monoid`
     : Monoid[IDS] = Monoid instance (_.append(_)(Cid.unwrap), InsertDeleteStep(
     Vector.empty,
     Map.empty,


### PR DESCRIPTION
`ContractStreamStep#append` is kind of tricky, so let's test some sensible data preservation properties it should have.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
