### PR TITLE
Only unmangle once in decodeValueName

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -113,13 +113,9 @@ decodeValueName ident mangledV dnId = do
     mangled <- decodeInternableStrings mangledV dnId
     case mangled of
         [] -> throwError $ MissingField ident
-        [unmangled] -> do
-            mangled <- decodeNameString id unmangled
-            case unmangleIdentifier mangled of
-                Right unmangled -> pure $ ExprValName unmangled
-                -- NOTE(MH): This is an ugly hack to keep backwards compatibility.
-                -- We need to fix this in DAML-LF 2.
-                Left _ -> pure $ ExprValName mangled
+        [mangled] -> do
+            unmangled <- decodeNameString id mangled
+            pure $ ExprValName unmangled
         _ -> throwError $ ParseError $ "Unexpected multi-segment def name: " ++ show mangledV ++ "//" ++ show mangled
 
 -- | Decode a reference to a top-level value. The name is mangled and will be


### PR DESCRIPTION
The `decodeValueName` code is rather confusing. It calls things
unmangled that are mangled and the other way around.

Furthermore, it unmangles twice, once in `decodeNameString` and once
directly in `decodeValueName`. The code claims that this is a
compatiblity hack but unless someone can explain to me what exactly is
failing here or CI fails, I would prefer to just kill this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
