### PR TITLE
report-std-change: handle GitHub errors

### DIFF
--- a/ci/cron/monthly.yaml
+++ b/ci/cron/monthly.yaml
@@ -9,7 +9,7 @@ pr: none
 # Do not run on merge to master
 trigger: none
 
-# Run on schedule: first Monday of each month at 4AM UTC
+# Run on schedule: first Monday of each month at 6AM UTC
 schedules:
   - cron: '0 6 1-7 * Mon'
     displayName: monthly
@@ -40,5 +40,12 @@ jobs:
                -XPOST \
                $(Slack.team-daml-ci) \
                --data "{\"text\": \"<@U6XMLDZEX> Here is the list of \\\"Standard Changes\\\" for the daml repo, month of ${REPORT_MONTH}. Please forward to security@digitalasset.com.\", \"attachments\": [{\"text\": \"\`\`\`$(cat std-change-report-daml-${REPORT_MONTH}.csv | jq -sR | sed 's/^"//' | sed 's/"$//')\`\`\`\"}]}"
+          if [ -f "std-change-report-daml-${REPORT_MONTH}.csv.err" ]; then
+              curl -H 'Content-Type: application/json' \
+                   -i \
+                   -XPOST \
+                   $(Slack.team-daml-ci) \
+                   --data "{\"text\": \"<@U6XMLDZEX> The following commits could not be processed. Please manually check them before sending the report.\", \"attachments\": [{\"text\": \"\`\`\`$(cat std-change-report-daml-${REPORT_MONTH}.csv.err | jq -sR | sed 's/^"//' | sed 's/"$//')\`\`\`\"}]}"
+          fi
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)


### PR DESCRIPTION
There have been a few GitHub glitches last week that resulted in a few commits on master not being associated with a PR (though they really were created from merging a PR, and the correct PR number is in their title).

This makes the report script crash on not finding the PR, so this PR fixes that. And a comment.

CHANGELOG_BEGIN
CHANGELOG_END