### PR TITLE
handle dual LiveBegin case

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ContractStreamStep.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ContractStreamStep.scala
@@ -7,7 +7,7 @@ package util
 import Collections._
 import InsertDeleteStep.{Cid, Inserts}
 
-import scalaz.\/
+import scalaz.{Semigroup, \/}
 import scalaz.std.tuple._
 import scalaz.syntax.functor._
 
@@ -84,4 +84,7 @@ private[http] object ContractStreamStep extends WithLAV1[ContractStreamStep] {
   final case class Txn[+D, +C](step: InsertDeleteStep[D, C], offsetAfter: domain.Offset)
       extends ContractStreamStep[D, C]
   object Txn extends WithLAV1[Txn]
+
+  implicit def `CSS semigroup`[D, C: Cid]: Semigroup[ContractStreamStep[D, C]] =
+    Semigroup instance (_ append _)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ContractStreamStep.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ContractStreamStep.scala
@@ -18,7 +18,7 @@ private[http] sealed abstract class ContractStreamStep[+D, +C] extends Product w
 
   def toInsertDelete: InsertDeleteStep[D, C] = this match {
     case Acs(inserts) => InsertDeleteStep(inserts, Map.empty)
-    case LiveBegin(_) => InsertDeleteStep(Vector.empty, Map.empty)
+    case LiveBegin(_) => InsertDeleteStep.Empty
     case Txn(step, _) => step
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/InsertDeleteStep.scala
@@ -7,7 +7,7 @@ package util
 import com.digitalasset.http.dbbackend.Queries.DBContract
 import com.digitalasset.ledger.api.v1.{event => evv1}
 
-import scalaz.{\/, \/-}
+import scalaz.{Monoid, \/, \/-}
 import scalaz.syntax.tag._
 
 import scala.collection.generic.CanBuildFrom
@@ -57,6 +57,8 @@ private[http] object InsertDeleteStep extends WithLAV1[InsertDeleteStep] {
   type Inserts[+C] = Vector[C]
   val Inserts: Vector.type = Vector
 
+  val Empty: InsertDeleteStep[Nothing, Nothing] = apply(Vector.empty, Map.empty)
+
   abstract class Cid[-C] extends (C AbstractFunction1 String)
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -66,6 +68,10 @@ private[http] object InsertDeleteStep extends WithLAV1[InsertDeleteStep] {
     implicit def ofFst[L](implicit L: Cid[L]): Cid[(L, Any)] = la => L(la._1)
     // ofFst and ofSnd should *not* both be defined, being incoherent together
   }
+
+  // we always use the Last semigroup for D
+  implicit def `IDS monoid`[D, C: Cid]: Monoid[InsertDeleteStep[D, C]] =
+    Monoid instance (_ append _, Empty)
 
   def appendForgettingDeletes[D, C](leftInserts: Inserts[C], right: InsertDeleteStep[Any, C])(
       implicit cid: Cid[C],

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
@@ -13,7 +13,7 @@ import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz.scalacheck.ScalazProperties
 import scalaz.syntax.apply._
 import scalaz.syntax.semigroup._
-import scalaz.{@@, Equal, Semigroup, Tag}
+import scalaz.{@@, Equal, Tag}
 
 class ContractStreamStepTest
     extends FlatSpec
@@ -21,6 +21,7 @@ class ContractStreamStepTest
     with Matchers
     with GeneratorDrivenPropertyChecks
     with TableDrivenPropertyChecks {
+
   import ContractStreamStepTest._, ContractStreamStep._
   import InsertDeleteStepTest._
 
@@ -45,6 +46,7 @@ class ContractStreamStepTest
       case LiveBegin(off) => off.toOption
       case Txn(_, off) => Some(off)
     }
+
     off(a |+| b) should ===(off(b) orElse off(a))
   }
 
@@ -63,9 +65,6 @@ object ContractStreamStepTest {
   import Arbitrary.arbitrary
 
   type CSS = ContractStreamStep[Unit, Cid]
-
-  implicit val `CSS semigroup`: Semigroup[CSS] =
-    Semigroup instance (_.append(_)(Cid.unwrap))
 
   private val offGen: Gen[domain.Offset] = Tag subst Tag.unsubst(arbitrary[String @@ Alpha])
   private val acsGen = arbitrary[Inserts[Cid]] map (Acs(_))

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ContractStreamStepTest.scala
@@ -24,6 +24,9 @@ class ContractStreamStepTest
   import ContractStreamStepTest._, ContractStreamStep._
   import InsertDeleteStepTest._
 
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
   behavior of "append"
 
   it should "be associative for valid streams" in forAll(validStreamGen) { csses =>

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/InsertDeleteStepTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.scalacheck.ScalazProperties
 import scalaz.syntax.semigroup._
-import scalaz.{@@, Equal, Monoid, Tag}
+import scalaz.{@@, Equal, Tag}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 class InsertDeleteStepTest
@@ -18,6 +18,9 @@ class InsertDeleteStepTest
     with FlatSpecCheckLaws
     with GeneratorDrivenPropertyChecks {
   import InsertDeleteStepTest._
+
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   behavior of "InsertDeleteStep append monoid"
 
@@ -59,11 +62,7 @@ object InsertDeleteStepTest {
   implicit val `Alpha arb`: Arbitrary[Cid] = Cid subst Arbitrary(
     Gen.alphaUpperChar map (_.toString))
 
-  private[util] implicit val `IDS monoid`
-    : Monoid[IDS] = Monoid instance (_.append(_)(Cid.unwrap), InsertDeleteStep(
-    Vector.empty,
-    Map.empty,
-  ))
+  private[util] implicit val `test Cid`: InsertDeleteStep.Cid[Cid] = Cid.unwrap
 
   implicit val `IDS arb`: Arbitrary[IDS] =
     Arbitrary(arbitrary[(Vector[Cid], Map[Cid, Unit])] map {


### PR DESCRIPTION
Two LiveBegins can't happen in a real websocket stream, but we test it anyway and it failed in master, so we just fix it.

Also moves the Monoid and Semigroup instances suggested by @leo-da in #4809 to main code.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
