### PR TITLE
daml2ts: Keep workspace package.json intact

### DIFF
--- a/language-support/ts/codegen/BUILD.bazel
+++ b/language-support/ts/codegen/BUILD.bazel
@@ -19,6 +19,7 @@ da_haskell_binary(
         "lens",
         "optparse-applicative",
         "text",
+        "unordered-containers",
         "zip-archive",
     ],
     main_function = "TsCodeGenMain.main",

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -49,11 +49,6 @@ cd $TMP_DIR
 
 $DAML2TS -o daml2ts $DAR -p $TMP_DIR/package.json
 $YARN install --frozen-lockfile
-# Remove the daml-types and daml-ledger workspaces. They were here for
-# the purposes of dependency resolution and can't participate in a
-# 'daml workspaces run build'.
-sed -i '/\"daml-types\",/d' $TMP_DIR/package.json
-sed -i '/\"daml-ledger\",/d' $TMP_DIR/package.json
 $YARN workspaces run build
 $YARN workspaces run lint
 cd build-and-lint

--- a/language-support/ts/codegen/tests/ts/package.json
+++ b/language-support/ts/codegen/tests/ts/package.json
@@ -1,8 +1,10 @@
 {
   "private": true,
   "workspaces": [
-    "daml-types",
-    "daml-ledger",
     "build-and-lint"
-  ]
+  ],
+  "resolutions": {
+    "@daml/types": "file:daml-types",
+    "@daml/ledger": "file:daml-ledger"
+  }
 }


### PR DESCRIPTION
Keep all fields in the workspace `package.json` given to `daml2ts`
instead of only `private` and `workspaces`.

This also allows for removing the `sed` hack in the `build-and-lint`
test and use the `resolution` field of the workspace `package.json`
to point to our local versions of `@daml/types` and `@daml/ledger`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/4820)
<!-- Reviewable:end -->
