### PR TITLE
Cache unmangleIdentifier

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -11,7 +11,7 @@ module DA.Daml.LF.Mangling
 import Data.Bits
 import Data.Char
 import Data.Coerce
-import Data.Either (fromRight)
+import Data.Either.Combinators
 import qualified Data.Text as T
 import qualified Data.Text.Array as TA
 import qualified Data.Text.Internal as T (text)
@@ -116,7 +116,7 @@ mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
 newtype UnmangledIdentifier = UnmangledIdentifier T.Text
 
 unmangleIdentifier :: T.Text -> Either String UnmangledIdentifier
-unmangleIdentifier txt = coerce $ do
+unmangleIdentifier txt = mapLeft (\err -> "Could not unmangle name " ++ show txt ++ ": " ++ err) $ coerce $ do
   case T.uncons txt of
       Nothing -> Left "Empty identifier"
       Just (c, _)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -2,10 +2,15 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE MultiWayIf #-}
-module DA.Daml.LF.Mangling (mangleIdentifier, unmangleIdentifier) where
+module DA.Daml.LF.Mangling
+    ( UnmangledIdentifier(..)
+    , mangleIdentifier
+    , unmangleIdentifier
+    ) where
 
 import Data.Bits
 import Data.Char
+import Data.Coerce
 import Data.Either (fromRight)
 import qualified Data.Text as T
 import qualified Data.Text.Array as TA
@@ -107,8 +112,11 @@ mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
             | ord c > 0xFFFF = MangledSize 1 (word16s + 10)
             | otherwise = MangledSize 1 (word16s + 6)
 
-unmangleIdentifier :: T.Text -> Either String T.Text
-unmangleIdentifier txt = do
+-- | Newtype to make it explicit when we have already unmangled a string.
+newtype UnmangledIdentifier = UnmangledIdentifier T.Text
+
+unmangleIdentifier :: T.Text -> Either String UnmangledIdentifier
+unmangleIdentifier txt = coerce $ do
   case T.uncons txt of
       Nothing -> Left "Empty identifier"
       Just (c, _)


### PR DESCRIPTION
Previously we unmangled once per reference to an identifier rather
than doing the unmangling once per entry in the string interning
table. This PR fixes this which brings a pretty decent performance
improvement. On my testcase the time for converting for converting
from the low-level proto AST to the high-level Haskell AST goes down
from 13.5 to 7.5s on a certain DALF that we know very well. Max
residency also goes down from 2GB to 1.5GB (although that number is
somewhat unreliable ime) and allocations drop by 8%.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
