### PR TITLE
change msys2 mirror

### DIFF
--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -2,12 +2,12 @@
     "homepage": "http://msys2.github.io",
     "version": "20180531",
     "url": [
-        "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz",
-        "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-jq-1.6-2-any.pkg.tar.xz#/jq.msys2",
-        "http://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
-        "http://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
-        "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-openssl-1.1.1.c-1-any.pkg.tar.xz#/openssl.msys2",
-        "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-postgresql-11.3-1-any.pkg.tar.xz#/pgsql.msys2"
+        "https://mirror.yandex.ru/mirrors/msys2/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz",
+        "https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/mingw-w64-x86_64-jq-1.6-2-any.pkg.tar.xz#/jq.msys2",
+        "https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
+        "https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
+        "https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/mingw-w64-x86_64-openssl-1.1.1.c-1-any.pkg.tar.xz#/openssl.msys2",
+        "https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/mingw-w64-x86_64-postgresql-11.3-1-any.pkg.tar.xz#/pgsql.msys2"
     ],
     "hash": [
         "4e799b5c3efcf9efcb84923656b7bcff16f75a666911abd6620ea8e5e1e9870c",


### PR DESCRIPTION
The `repo.msys2.org` server is currently broken and has been for about 7 hours at least from what I can find out online. This PR changes to the next mirror in the list that seems to work for me locally; list taken from [the GitHub repo](https://github.com/msys2/MSYS2-packages/blob/master/pacman-mirrors/mirrorlist.msys).

CHANGELOG_BEGIN
CHANGELOG_END