### PR TITLE
Sandbox: Re-use actor systems between the StandaloneApiServer and StandaloneIndexerServer.

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -8,16 +8,14 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import com.daml.ledger.participant.state.v1.{ReadService, SubmissionId, WriteService}
+import com.daml.ledger.participant.state.v1.SubmissionId
 import com.digitalasset.daml.lf.archive.DarReader
 import com.digitalasset.daml_lf_dev.DamlLf.Archive
-import com.digitalasset.ledger.api.auth.AuthService
-import com.digitalasset.logging.LoggingContext
 import com.digitalasset.logging.LoggingContext.newLoggingContext
 import com.digitalasset.platform.apiserver.StandaloneApiServer
 import com.digitalasset.platform.indexer.StandaloneIndexerServer
-import com.digitalasset.resources.ResourceOwner
 import com.digitalasset.resources.akka.AkkaResourceOwner
+import com.digitalasset.resources.{Resource, ResourceOwner}
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,32 +29,48 @@ class Runner[T <: ReadWriteService, Extra](
       .owner(name, factory.extraConfigParser, factory.defaultExtraConfig, args)
       .flatMap(owner)
 
-  def owner(originalConfig: Config[Extra]): ResourceOwner[Unit] = {
-    val config = factory.manipulateConfig(originalConfig)
+  def owner(originalConfig: Config[Extra]): ResourceOwner[Unit] = new ResourceOwner[Unit] {
+    override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] = {
+      val config = factory.manipulateConfig(originalConfig)
 
-    implicit val system: ActorSystem = ActorSystem(
-      "[^A-Za-z0-9_\\-]".r.replaceAllIn(name.toLowerCase, "-"))
-    implicit val materializer: Materializer = Materializer(system)
-    implicit val executionContext: ExecutionContext = system.dispatcher
+      implicit val system: ActorSystem = ActorSystem(
+        "[^A-Za-z0-9_\\-]".r.replaceAllIn(name.toLowerCase, "-"))
+      implicit val materializer: Materializer = Materializer(system)
 
-    newLoggingContext { implicit logCtx =>
-      for {
-        // Take ownership of the actor system and materializer so they're cleaned up properly.
-        // This is necessary because we can't declare them as implicits within a `for` comprehension.
-        _ <- AkkaResourceOwner.forActorSystem(() => system)
-        _ <- AkkaResourceOwner.forMaterializer(() => materializer)
+      newLoggingContext { implicit logCtx =>
+        for {
+          // Take ownership of the actor system and materializer so they're cleaned up properly.
+          // This is necessary because we can't declare them as implicits in a `for` comprehension.
+          _ <- AkkaResourceOwner.forActorSystem(() => system).acquire()
+          _ <- AkkaResourceOwner.forMaterializer(() => materializer).acquire()
 
-        // initialize all configured participants
-        _ <- ResourceOwner.sequence(config.participants.map { participantConfig =>
-          for {
-            ledger <- factory
-              .readWriteServiceOwner(config, participantConfig)
-            _ <- ResourceOwner.forFuture(() =>
-              Future.sequence(config.archiveFiles.map(uploadDar(_, ledger))))
-            _ <- startParticipant(config, participantConfig, system, ledger)
-          } yield ()
-        })
-      } yield ()
+          // initialize all configured participants
+          _ <- Resource.sequence(config.participants.map { participantConfig =>
+            for {
+              ledger <- factory.readWriteServiceOwner(config, participantConfig).acquire()
+              _ <- Resource.fromFuture(
+                Future.sequence(config.archiveFiles.map(uploadDar(_, ledger))))
+              _ <- new StandaloneIndexerServer(
+                system,
+                readService = ledger,
+                factory.indexerConfig(participantConfig),
+                factory.indexerMetricRegistry(participantConfig),
+              ).acquire()
+              _ <- new StandaloneApiServer(
+                factory.apiServerConfig(participantConfig, config),
+                factory.commandConfig(config),
+                factory.submissionConfig(config),
+                readService = ledger,
+                writeService = ledger,
+                authService = factory.authService(config),
+                factory.apiServerMetricRegistry(participantConfig),
+                factory.timeServiceBackend(config),
+                config.seeding,
+              ).acquire()
+            } yield ()
+          })
+        } yield ()
+      }
     }
   }
 
@@ -70,56 +84,4 @@ class Runner[T <: ReadWriteService, Extra](
       _ <- to.uploadPackages(submissionId, dar.all, None).toScala
     } yield ()
   }
-
-  private def startParticipant(
-      config: Config[Extra],
-      participantConfig: ParticipantConfig,
-      actorSystem: ActorSystem,
-      ledger: ReadWriteService,
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Unit] =
-    for {
-      _ <- startIndexerServer(
-        participantConfig,
-        actorSystem,
-        readService = ledger,
-      )
-      _ <- startApiServer(
-        config,
-        participantConfig,
-        readService = ledger,
-        writeService = ledger,
-        authService = factory.authService(config),
-      )
-    } yield ()
-
-  private def startIndexerServer(
-      config: ParticipantConfig,
-      actorSystem: ActorSystem,
-      readService: ReadService,
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Unit] =
-    new StandaloneIndexerServer(
-      actorSystem,
-      readService,
-      factory.indexerConfig(config),
-      factory.indexerMetricRegistry(config),
-    )
-
-  private def startApiServer(
-      config: Config[Extra],
-      participantConfig: ParticipantConfig,
-      readService: ReadService,
-      writeService: WriteService,
-      authService: AuthService,
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): ResourceOwner[Unit] =
-    new StandaloneApiServer(
-      factory.apiServerConfig(participantConfig, config),
-      factory.commandConfig(config),
-      factory.submissionConfig(config),
-      readService,
-      writeService,
-      authService,
-      factory.apiServerMetricRegistry(participantConfig),
-      factory.timeServiceBackend(config),
-      config.seeding,
-    ).map(_ => ())
 }

--- a/ledger/recovering-indexer-integration-tests/BUILD.bazel
+++ b/ledger/recovering-indexer-integration-tests/BUILD.bazel
@@ -29,6 +29,7 @@ da_scala_test_suite(
         "//ledger/test-common",
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",
+        "//libs-scala/resources-akka",
         "//libs-scala/timer-utils",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -24,6 +24,7 @@ import com.digitalasset.platform.indexer.RecoveringIndexerIntegrationSpec._
 import com.digitalasset.platform.store.dao.{JdbcLedgerDao, LedgerDao}
 import com.digitalasset.platform.testing.LogCollector
 import com.digitalasset.resources.ResourceOwner
+import com.digitalasset.resources.akka.AkkaResourceOwner
 import com.digitalasset.timer.RetryStrategy
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -201,7 +202,9 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase()}-$testId;db_close_delay=-1;db_close_on_exit=false"
     for {
       participantState <- newParticipantState(Some(ledgerId), participantId)
+      actorSystem <- AkkaResourceOwner.forActorSystem(() => ActorSystem())
       _ <- new StandaloneIndexerServer(
+        actorSystem,
         participantState,
         IndexerConfig(
           participantId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -7,12 +7,12 @@ import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.ReadService
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
-import com.digitalasset.resources.akka.AkkaResourceOwner
 import com.digitalasset.resources.{Resource, ResourceOwner}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 final class StandaloneIndexerServer(
+    actorSystem: ActorSystem,
     readService: ReadService,
     config: IndexerConfig,
     metrics: MetricRegistry,
@@ -21,39 +21,34 @@ final class StandaloneIndexerServer(
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
-  override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] =
-    for {
-      // ActorSystem name not allowed to contain daml-lf LedgerString characters ".:#/ "
-      actorSystem <- AkkaResourceOwner
-        .forActorSystem(() =>
-          ActorSystem("StandaloneIndexerServer-" + config.participantId.filterNot(".:#/ ".toSet)))
-        .acquire()
-      indexerFactory = new JdbcIndexerFactory(config.jdbcUrl, metrics)
-      indexer = new RecoveringIndexer(
-        actorSystem.scheduler,
-        config.restartDelay,
-      )
-      _ <- config.startupMode match {
-        case IndexerStartupMode.MigrateOnly =>
-          Resource.successful(Future.unit)
-        case IndexerStartupMode.MigrateAndStart =>
-          Resource
-            .fromFuture(indexerFactory.migrateSchema(config.allowExistingSchema))
-            .flatMap(startIndexer(indexer, _, actorSystem))
-        case IndexerStartupMode.ValidateAndStart =>
-          Resource
-            .fromFuture(indexerFactory.validateSchema())
-            .flatMap(startIndexer(indexer, _, actorSystem))
-      }
-    } yield {
-      logger.debug("Waiting for indexer to initialize the database")
+  override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] = {
+    val indexerFactory = new JdbcIndexerFactory(config.jdbcUrl, metrics)
+    val indexer = new RecoveringIndexer(actorSystem.scheduler, config.restartDelay)
+    config.startupMode match {
+      case IndexerStartupMode.MigrateOnly =>
+        Resource.successful(())
+      case IndexerStartupMode.MigrateAndStart =>
+        Resource
+          .fromFuture(indexerFactory.migrateSchema(config.allowExistingSchema))
+          .flatMap(startIndexer(indexer, _, actorSystem))
+          .map { _ =>
+            logger.debug("Waiting for the indexer to initialize the database.")
+          }
+      case IndexerStartupMode.ValidateAndStart =>
+        Resource
+          .fromFuture(indexerFactory.validateSchema())
+          .flatMap(startIndexer(indexer, _, actorSystem))
+          .map { _ =>
+            logger.debug("Waiting for the indexer to initialize the database.")
+          }
     }
+  }
 
   private def startIndexer(
       indexer: RecoveringIndexer,
       initializedIndexerFactory: InitializedJdbcIndexerFactory,
       actorSystem: ActorSystem,
-  )(implicit executionContext: ExecutionContext): Resource[Future[Unit]] =
+  )(implicit executionContext: ExecutionContext): Resource[Unit] =
     indexer
       .start(
         () =>
@@ -61,4 +56,5 @@ final class StandaloneIndexerServer(
             .owner(config.participantId, actorSystem, readService, config.jdbcUrl)
             .flatMap(_.subscription(readService))
             .acquire())
+      .map(_ => ())
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -141,6 +141,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 _ <- ResourceOwner.forFuture(() =>
                   Future.sequence(config.damlPackages.map(uploadDar(_, ledger))))
                 _ <- new StandaloneIndexerServer(
+                  actorSystem = system,
                   readService = ledger,
                   config = IndexerConfig(
                     ParticipantId,

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwner.scala
@@ -6,10 +6,8 @@ package com.digitalasset.resources
 import java.util.Timer
 import java.util.concurrent.{CompletionStage, ExecutorService}
 
-import scala.collection.generic.CanBuildFrom
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -104,32 +102,4 @@ object ResourceOwner {
 
   def forTimer(acquire: () => Timer): ResourceOwner[Timer] =
     new TimerResourceOwner(acquire)
-
-  /**
-    * @see [[Resource.sequence()]]
-    */
-  def sequence[T, C[X] <: TraversableOnce[X]](seq: C[ResourceOwner[T]])(
-      implicit bf: CanBuildFrom[C[ResourceOwner[T]], T, C[T]],
-      executionContext: ExecutionContext,
-  ): ResourceOwner[C[T]] =
-    seq
-      .foldLeft(ResourceOwner.successful(bf()))((builderResource, elementResource) =>
-        for {
-          builder <- builderResource
-          element <- elementResource
-        } yield builder += element)
-      .map(_.result())
-
-  /**
-    * @see [[Resource.sequenceIgnoringValues()]]
-    */
-  def sequenceIgnoringValues[T, C[X] <: TraversableOnce[X]](seq: C[ResourceOwner[T]])(
-      implicit executionContext: ExecutionContext,
-  ): ResourceOwner[Unit] =
-    seq
-      .foldLeft(ResourceOwner.unit)((builderResource, elementResource) =>
-        for {
-          _ <- builderResource
-          _ <- elementResource
-        } yield ())
 }


### PR DESCRIPTION
On a Sandbox reset, shutting down the actor systems and recreating them slows things down a little, and is unnecessary when they can simply be shared.

This required some refactoring of the _kvutils/app_ `Runner` to accommodate this concept, along the same lines as Sandbox Next's Runner.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
