### PR TITLE
kvutils: Improve submission performance.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.on.memory.InMemoryLedgerReaderWriter._
 import com.daml.ledger.on.memory.InMemoryState.MutableLog
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.api.{LedgerEntry, LedgerReader, LedgerWriter}
 import com.daml.ledger.participant.state.kvutils.{KeyValueCommitting, SequentialLogEntryId}
 import com.daml.ledger.participant.state.v1._
@@ -54,8 +55,8 @@ final class InMemoryLedgerReaderWriter(
   override def currentHealth(): HealthStatus =
     Healthy
 
-  override def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult] =
-    committer.commit(correlationId, envelope)
+  override def commit(correlationId: String, submission: DamlSubmission): Future[SubmissionResult] =
+    committer.commit(correlationId, submission)
 
   override def events(offset: Option[Offset]): Source[LedgerEntry, NotUsed] =
     dispatcher

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter._
 import com.daml.ledger.on.sql.queries.Queries
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.api.{LedgerEntry, LedgerReader, LedgerWriter}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
@@ -82,8 +83,8 @@ final class SqlLedgerReaderWriter(
       )
       .map { case (_, entry) => entry }
 
-  override def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult] =
-    committer.commit(correlationId, envelope)
+  override def commit(correlationId: String, submission: DamlSubmission): Future[SubmissionResult] =
+    committer.commit(correlationId, submission)
 
   object SqlLedgerStateAccess extends LedgerStateAccess[Index] {
     override def inTransaction[T](body: LedgerStateOperations[Index] => Future[T]): Future[T] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 import java.util.concurrent.CompletionStage
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueSubmission}
+import com.daml.ledger.participant.state.kvutils.KeyValueSubmission
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.{Ref, Time}
 import com.digitalasset.daml_lf_dev.DamlLf
@@ -81,6 +81,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter)(
 
   private def commit(
       correlationId: String,
-      submission: DamlSubmission): CompletionStage[SubmissionResult] =
-    FutureConverters.toJava(writer.commit(correlationId, Envelope.enclose(submission).toByteArray))
+      submission: DamlSubmission,
+  ): CompletionStage[SubmissionResult] =
+    FutureConverters.toJava(writer.commit(correlationId, submission))
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -3,13 +3,14 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.digitalasset.ledger.api.health.ReportsHealth
 
 import scala.concurrent.Future
 
 trait LedgerWriter extends ReportsHealth {
-  def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult]
+  def commit(correlationId: String, submission: DamlSubmission): Future[SubmissionResult]
 
   def participantId: ParticipantId
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -18,6 +18,7 @@ import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.google.protobuf.ByteString
 
 import scala.collection.JavaConverters._
+import scala.collection.breakOut
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -217,12 +218,10 @@ object SubmissionValidator {
   private[validator] def serializeProcessedSubmission(
       logEntryAndState: LogEntryAndState): (RawBytes, RawKeyValuePairs) = {
     val (logEntry, damlStateUpdates) = logEntryAndState
-    val rawStateUpdates = damlStateUpdates
-      .map {
+    val rawStateUpdates: Vector[(RawBytes, RawBytes)] =
+      damlStateUpdates.map {
         case (key, value) => keyToBytes(key) -> valueToBytes(value)
-      }
-      .toSeq
-      .sortBy(_._1.toIterable)
+      }(breakOut)
     (Envelope.enclose(logEntry).toByteArray, rawStateUpdates)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.validator
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.digitalasset.daml.lf.data.Time.Timestamp
@@ -20,12 +21,12 @@ class ValidatingCommitter[LogResult](
 ) {
   def commit(
       correlationId: String,
-      envelope: Array[Byte],
+      submission: DamlSubmission,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
       validator
         .validateAndCommitWithLoggingContext(
-          envelope,
+          submission,
           correlationId,
           Timestamp.assertFromInstant(now()),
           participantId,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -7,7 +7,7 @@ import java.time.{Clock, Duration}
 import java.util.UUID
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateWriterSpec._
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.crypto
@@ -16,19 +16,21 @@ import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.Matchers._
+import org.scalatest.mockito.MockitoSugar._
 import org.scalatest.{Assertion, WordSpec}
 
 import scala.collection.immutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 
-class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
+class KeyValueParticipantStateWriterSpec extends WordSpec {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "participant state writer" should {
     "submit a transaction" in {
-      val transactionCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val transactionCaptor = captor[DamlSubmission]
       val writer = createWriter(Some(transactionCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
       val recordTime = newRecordTime()
@@ -37,49 +39,46 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
         submitterInfo(recordTime, aParty),
         transactionMeta(recordTime),
         anEmptyTransaction)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
-      verifyEnvelope(transactionCaptor.getValue)(_.hasTransactionEntry)
+      verify(writer, times(1)).commit(anyString(), any[DamlSubmission]())
+      verifySubmission(transactionCaptor.getValue)(_.hasTransactionEntry)
     }
 
     "upload a package" in {
-      val packageUploadCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val packageUploadCaptor = captor[DamlSubmission]
       val writer = createWriter(Some(packageUploadCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.uploadPackages(aSubmissionId, List.empty, sourceDescription = None)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
-      verifyEnvelope(packageUploadCaptor.getValue)(_.hasPackageUploadEntry)
+      verify(writer, times(1)).commit(anyString(), any[DamlSubmission]())
+      verifySubmission(packageUploadCaptor.getValue)(_.hasPackageUploadEntry)
     }
 
     "submit a configuration" in {
-      val configurationCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val configurationCaptor = captor[DamlSubmission]
       val writer = createWriter(Some(configurationCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.submitConfiguration(newRecordTime().addMicros(10000), aSubmissionId, aConfiguration)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
-      verifyEnvelope(configurationCaptor.getValue)(_.hasConfigurationSubmission)
+      verify(writer, times(1)).commit(anyString(), any[DamlSubmission]())
+      verifySubmission(configurationCaptor.getValue)(_.hasConfigurationSubmission)
     }
 
     "allocate a party without hint" in {
-      val partyAllocationCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val partyAllocationCaptor = captor[DamlSubmission]
       val writer = createWriter(Some(partyAllocationCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.allocateParty(hint = None, displayName = None, aSubmissionId)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
-      verifyEnvelope(partyAllocationCaptor.getValue)(_.hasPartyAllocationEntry)
+      verify(writer, times(1)).commit(anyString(), any[DamlSubmission]())
+      verifySubmission(partyAllocationCaptor.getValue)(_.hasPartyAllocationEntry)
     }
   }
+}
 
-  private def verifyEnvelope(written: Array[Byte])(
-      assertion: DamlSubmission => Boolean): Assertion =
-    Envelope.openSubmission(written) match {
-      case Right(value) => assert(assertion(value) === true)
-      case _ => fail()
-    }
+object KeyValueParticipantStateWriterSpec {
 
-  private val aParty = Ref.Party.assertFromString("aParty")
+  private val aParty =
+    Ref.Party.assertFromString("aParty")
 
   private val anEmptyTransaction: Transaction.AbsTransaction =
     GenTransaction(HashMap.empty, ImmArray.empty)
@@ -87,11 +86,15 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
   private val aSubmissionId: SubmissionId =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)
 
-  private val aConfiguration: Configuration = Configuration(1, TimeModel.reasonableDefault)
+  private val aConfiguration: Configuration =
+    Configuration(1, TimeModel.reasonableDefault)
 
-  private def createWriter(captor: Option[ArgumentCaptor[Array[Byte]]] = None): LedgerWriter = {
+  private def captor[T](implicit classTag: ClassTag[T]): ArgumentCaptor[T] =
+    ArgumentCaptor.forClass(classTag.runtimeClass.asInstanceOf[Class[T]])
+
+  private def createWriter(captor: Option[ArgumentCaptor[DamlSubmission]] = None): LedgerWriter = {
     val writer = mock[LedgerWriter]
-    when(writer.commit(anyString(), captor.map(_.capture()).getOrElse(any[Array[Byte]]())))
+    when(writer.commit(anyString(), captor.map(_.capture()).getOrElse(any[DamlSubmission]())))
       .thenReturn(Future.successful(SubmissionResult.Acknowledged))
     when(writer.participantId).thenReturn(v1.ParticipantId.assertFromString("test-participant"))
     writer
@@ -115,4 +118,10 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
 
   private def newRecordTime(): Timestamp =
     Timestamp.assertFromInstant(Clock.systemUTC().instant())
+
+  private def verifySubmission(written: DamlSubmission)(
+      assertion: DamlSubmission => Boolean
+  ): Assertion =
+    assert(assertion(written) === true)
+
 }


### PR DESCRIPTION
We currently go through the following conversion process before submitting:

`DamlSubmission` → `Envelope` → `ByteString` → `Array[Byte]` → `Envelope` → `DamlSubmission`.

This is unnecessary, obviously, but is also expensive: parsing an envelope from a byte array is not cheap, especially when it involves decompression. (The compression, on the other hand, seems to be fine.)

This makes some changes to avoid all these hops, and passes the `DamlSubmission` directly to the `commit` function of a `LedgerWriter`.

I have changed `SubmissionValidator`’s method signatures to accept `submission: DamlSubmission` instead of `envelope: RawBytes` (where `type RawBytes = Array[Byte]`). If necessary, we can re-introduce the old method signatures, which would wrap the new methods, deserializing the submission and passing it through.

This will probably be easier to review if you inform GitHub that it should ignore whitespace changes.

### Changelog

- **[Ledger Integration Kit]** Performance improvements during submission.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
