### PR TITLE
Overload submit so that it doesn’t collide with DAML script

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -164,7 +164,6 @@ renderModule dflags imports line binds expr = unlines $
      , "{-# LANGUAGE PartialTypeSignatures #-}"
      , "daml 1.2"
      , "module " <> lineModuleName line <> " where"
-     , "import Prelude hiding (submit)"
      , "import Daml.Script"
      ] <>
      map (\moduleName -> T.unpack $ "import " <> LF.moduleNameString moduleName) imports <>

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -28,9 +28,9 @@ module DA.Internal.LF
   , Update
 
   , Scenario
-  , submit
-  , submitMustFail
   , scenario
+
+  , HasSubmit(..)
 
   , HasTime
   , getTime
@@ -200,20 +200,25 @@ instance Action Scenario where
 instance ActionFail Scenario where
     fail = primitive @"SAbort"
 
-infixr 0 `submit`
--- | `submit p u` describes the scenario in which party `p` attempts to update the
--- ledger with update action `u`, and returns the value returned by the underlying
--- update action. This scenario is considered a failure if the underlying update
--- action fails.
-submit : Party -> Update a -> Scenario a
-submit = primitive @"SCommit"
+class HasSubmit m cmds | m -> cmds, cmds -> m where
+  -- | `submit p cmds` submits the commands `cmds` as a single transaction
+  -- from party `p` and returns the value returned by `cmds`.
+  --
+  -- If the transaction fails, `submit` also fails.
+  submit : Party -> cmds a -> m a
 
+  -- | `submitMustFail p cmds` submits the commands `cmds` as a single transaction
+  -- from party `p`.
+  --
+  -- It only succeeds if the submitting the transaction fails.
+  submitMustFail : Party -> cmds a -> m ()
+
+instance HasSubmit Scenario Update where
+  submit = primitive @"SCommit"
+  submitMustFail = primitive @"SMustFailAt"
+
+infixr 0 `submit`
 infixr 0 `submitMustFail`
--- | `submitMustFail` describes the scenario in which party `p` attempts to update the
--- ledger with update action `u`, and the update is *expected to fail*. Therefore, this
--- scenario fails if the underlying update action *succeeds*.
-submitMustFail : Party -> Update a -> Scenario ()
-submitMustFail = primitive @"SMustFailAt"
 
 -- | Declare you are building a scenario.
 scenario : Scenario a -> Scenario a

--- a/compiler/damlc/tests/daml-test-files/SubmitFail.daml
+++ b/compiler/damlc/tests/daml-test-files/SubmitFail.daml
@@ -10,7 +10,7 @@ main = scenario do
   alice <- getParty "Alice"
 
   let _ = submit alice (error "submit-error" : Update ())
-  let _ = submit alice (pure (error "submit-pure-error" : ()))
+  let _ = submit alice (pure (error "submit-pure-error") : Update ())
 
   submitMustFail alice (error "fail-error" : Update ())
   submitMustFail alice (pure (error "fail-pure-error": ()))

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -206,7 +206,6 @@ packagingTests = testGroup "packaging"
         writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
           [ "daml 1.2"
           , "module Main where"
-          , "import Prelude hiding (submit)"
           , "import Daml.Script"
           , "template T with p : Party where signatory p"
           , "init : Script ()"

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -22,7 +22,6 @@ module Daml.Script
   , sleep
   ) where
 
-import Prelude hiding (submit, submitMustFail)
 import DA.Optional
 import DA.Time
 
@@ -176,16 +175,13 @@ data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailu
 -- | Submit the commands as a single transaction.
 
 -- This will error if the submission fails.
-submit : Party -> Commands a -> Script a
-submit p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
-  where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
 
--- | Submit the commands as a single transaction
--- but error if it succeeds. This is only
--- useful for testing.
-submitMustFail : Party -> Commands a -> Script ()
-submitMustFail p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
-  where fail _ = error "Expected submit to fail but it succeeded"
+instance HasSubmit Script Commands where
+  submit p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
+    where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
+
+  submitMustFail p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
+    where fail _ = error "Expected submit to fail but it succeeded"
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -5,8 +5,6 @@
 
 module MultiTest where
 
-import Prelude hiding (getParty, submit, submitMustFail)
-
 import Daml.Script
 
 template T

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -5,7 +5,6 @@
 
 module ScriptTest where
 
-import Prelude hiding (getParty, submit, submitMustFail)
 import DA.Time
 
 import Daml.Script

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -64,10 +64,7 @@ library to the ``dependencies`` field in ``daml.yaml``.
    :start-after: # script-dependencies-begin
    :end-before: # script-dependencies-end
 
-In addition to that you also need to import the ``Daml.Script`` module
-and since DAML script provides ``submit`` and ``submitMustFail``
-functions that collide with the ones used in scenarios, we need to
-hide those. We also enable the ``ApplicativeDo`` extension. We will
+We also enable the ``ApplicativeDo`` extension. We will
 see below why this is useful.
 
 .. literalinclude:: ./template-root/src/ScriptExample.daml

--- a/docs/source/daml-script/template-root/src/ScriptExample.daml
+++ b/docs/source/daml-script/template-root/src/ScriptExample.daml
@@ -5,7 +5,7 @@
 {-# LANGUAGE ApplicativeDo #-}
 
 module ScriptExample where
-import Prelude hiding (submit, submitMustFail)
+
 import Daml.Script
 -- DAML_SCRIPT_HEADER_END
 


### PR DESCRIPTION
This introduces a `HasSubmit` typeclass (following the naming scheme
of `HasCreate`, …) and instances for `Scenario` and `Script`. This
avoids the need to hide `submit` in every single DAML script.

changelog_begin

- [DAML Standard Library] ``submit`` and ``submitMustFail`` are now
  overloaded so that they can be used in both scenarios and DAML script.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
