### PR TITLE
ld -s --> ld -unexported_symbols_list=* on macOS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ build_environment(name = "build_environment")
 
 dadew(name = "dadew")
 
-load("@os_info//:os_info.bzl", "is_linux", "is_windows")
+load("@os_info//:os_info.bzl", "is_darwin", "is_linux", "is_windows")
 load("//bazel_tools:ghc_dwarf.bzl", "ghc_dwarf")
 
 ghc_dwarf(name = "ghc_dwarf")
@@ -318,7 +318,9 @@ haskell_register_ghc_nixpkgs(
     # with the GHCi linker to the point where :main takes several minutes rather than several seconds.
     compiler_flags = common_ghc_flags + [
         "-fexternal-dynamic-refs",
-    ] + (["-g3"] if enable_ghc_dwarf else ["-optl-s"]),
+    ] + (["-g3"] if enable_ghc_dwarf else ([
+        "-optl-unexported_symbols_list=*",
+    ] if is_darwin else ["-optl-s"])),
     compiler_flags_select = {
         "@com_github_digital_asset_daml//:profiling_build": ["-fprof-auto"],
         "//conditions:default": [],


### PR DESCRIPTION
On MacOS the `-s` linker flag (`--strip-all`) is obsolete. Instead, one should pass `-unexported_symbols_list=*` to strip all symbols.

This is to avoid "unknown linker flags" warnings on MacOS.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
