### PR TITLE
Added --damlc option to daml-sdk-head

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -20,6 +20,7 @@ fi
 NUKE=0
 PROFILING=0
 SKIP_JARS=0
+JUST_DAMLC=0
 for opt in "$@" ; do
   case $opt in
     "--nuke")
@@ -31,12 +32,16 @@ for opt in "$@" ; do
     "--skip-jars")
       SKIP_JARS=1;
       ;;
+    "--damlc")
+      JUST_DAMLC=1;
+      ;;
     *)
       echo "Unknown option: $opt"
       echo "Available options:"
       echo "  --nuke  Remove existing daml installation before installing daml-head."
       echo "  --profiling  Build Haskell executables with profiling enabled."
       echo "  --skip-jars  Skip building and installing the JARs."
+      echo "  --damlc  Update damlc only, if daml-head is already installed."
       exit 1
   esac
 done
@@ -55,13 +60,37 @@ if [ -d $DAML_HOME ] && [ "$NUKE" -ne "0" ] ; then
 fi
 
 readonly DAML_HEAD_SDK="$DAML_HOME/sdk/0.0.0"
-if [ -d $DAML_HEAD_SDK ] ; then
+if [ -d $DAML_HEAD_SDK ] && [ "$JUST_DAMLC" -eq "0" ] ; then
   echo "$(tput setaf 3)Removing existing daml-head installation.$(tput sgr 0)"
   rm -f $DAML_HOME/bin/daml-head
   chmod -R u+w $DAML_HEAD_SDK
   rm -rf $DAML_HEAD_SDK
 fi
 
+if [ -d $DAML_HEAD_SDK ] && [ "$JUST_DAMLC" -ne "0" ] ; then
+  # daml-head is installed, so just replace damlc
+  echo "$(tput setaf 3)Existing daml-head installation found."
+  echo "Building damlc version 0.0.0, this may take a while ...$(tput sgr 0)"
+  echo ""
+
+  function cleanup() {
+    echo "damlc 0.0.0 failed to build/install - if you need help ask on #product-daml"
+    echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
+  }
+  trap cleanup EXIT
+
+  bazel build $BAZEL_MODE_FLAG //compiler/damlc:damlc-dist.tar.gz
+
+  readonly TARBALL=$(bazel info bazel-bin $BAZEL_MODE_FLAG)/compiler/damlc/damlc-dist.tar.gz
+  chmod -R u+w $DAML_HEAD_SDK
+  rm -rf $DAML_HEAD_SDK/damlc
+  mkdir -p $DAML_HEAD_SDK/damlc
+  tar xzf $TARBALL -C $DAML_HEAD_SDK/damlc --strip-components 1
+
+  trap - EXIT
+  echo "$(tput setaf 3)Done installing damlc 0.0.0$(tput sgr 0)"
+  exit 0
+fi
 
 echo "$(tput setaf 3)Building version 0.0.0 - this may take a while ...$(tput sgr 0)"
 echo ""


### PR DESCRIPTION
An option to just update the `damlc` distribution, if `daml-head` is already installed. This is technically unnecessary but it cuts half a minute out of my iteration time when working on damlc, so it's just a minor convenience.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
