### PR TITLE
Unexperimentalize DAML script

### DIFF
--- a/docs/configs/pdf/index.rst
+++ b/docs/configs/pdf/index.rst
@@ -36,6 +36,7 @@ Building applications
    :maxdepth: 2
 
    app-dev/index
+   daml-script/index
    app-dev/bindings-java/index
    app-dev/bindings-scala/index
    app-dev/bindings-js
@@ -95,7 +96,6 @@ Experimental features
    upgrade/index
    json-api/index
    triggers/index
-   daml-script/index
    daml-repl/index
    tools/visual
    daml2ts/index

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -9,12 +9,6 @@ DAML Script
 
    daml-script-docs
 
-**WARNING:** DAML Script is an experimental feature that is actively
-being designed and is *subject to breaking changes*.
-We welcome feedback about DAML script on
-`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=DAML+Script>`_
-or `on Slack <https://hub.daml.com/slack/>`_.
-
 DAML scenarios provide a simple API for experimenting with DAML models
 and getting quick feedback in DAML studio. However, scenarios are run
 in a special process and do not interact with an actual ledger. This
@@ -25,7 +19,8 @@ DAML script addresses this problem by providing you with an API with
 the simplicity of DAML scenarios and all the benefits such as being
 able to reuse your DAML types and logic while running against an
 actual ledger. This means that you can use it to test automation
-logic, your UI but also for ledger initialization where scenarios
+logic, your UI but also for
+:ref:`ledger initialization <script-ledger-initialization>` where scenarios
 cannot be used (with the exception of :doc:`/tools/sandbox`).
 
 You can also use DAML Script interactively using :doc:`/daml-repl/index`.
@@ -195,6 +190,8 @@ We can then initialize our ledger passing in the json file via ``--input-file``.
 ``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json --static-time``
 
 If you open Navigator, you can now see the contracts that have been created.
+
+.. _script-ledger-initialization:
 
 Using DAML Script for Ledger Initialization
 ===========================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ DAML SDK documentation
    :caption: Building applications
 
    app-dev/index
+   DAML Script <daml-script/index>
    app-dev/bindings-java/index
    app-dev/bindings-scala/index
    app-dev/bindings-js
@@ -99,7 +100,6 @@ DAML SDK documentation
    upgrade/index
    json-api/index
    DAML Triggers <triggers/index>
-   DAML Script <daml-script/index>
    DAML Repl <daml-repl/index>
    tools/visual
    daml2ts/index


### PR DESCRIPTION
The only remaining thing that I wanted to get in before doing that was
overloading ``submit`` which has now happened. I’m sure we can come up
with tons of improvements but I don’t expect breaking changes to the
current state.

changelog_begin

- [DAML Script] DAML Script is no longer experimental.

changelog_end

fixes #4615

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
