### PR TITLE
Fix git tag of releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,7 @@ jobs:
         persistCredentials: true
       - bash: |
           set -euxo pipefail
-          if git tag v$(release_tag); then
+          if git tag v$(release_tag) $(release_sha); then
             git push origin v$(release_tag)
             mkdir $(Build.StagingDirectory)/release
           else


### PR DESCRIPTION
Previously, we tagged the commit that made the release instead of the
commit we are building the release off.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
