### PR TITLE
bind repl to localhost

### DIFF
--- a/compiler/repl-service/server/BUILD.bazel
+++ b/compiler/repl-service/server/BUILD.bazel
@@ -21,7 +21,6 @@ da_scala_binary(
     resources = glob(["src/main/resources/*"]),
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
-        "@maven//:io_grpc_grpc_netty",
     ],
     deps = [
         "//compiler/repl-service/protos:repl_service_java_proto",
@@ -34,6 +33,8 @@ da_scala_binary(
         "//ledger-api/rs-grpc-bridge",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -23,8 +23,9 @@ import com.digitalasset.ledger.client.configuration.{
 }
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.services.commands.CommandUpdater
-import io.grpc.ServerBuilder
+import io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
+import java.net.{InetAddress, InetSocketAddress}
 import java.nio.file.{Files, Paths}
 import java.util.logging.{Level, Logger}
 import scala.collection.JavaConverters._
@@ -58,8 +59,8 @@ object ReplServiceMain extends App {
   val clients = Await.result(Runner.connect(participantParams, clientConfig), 30.seconds)
 
   val server =
-    ServerBuilder
-      .forPort(0)
+    NettyServerBuilder
+      .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
       .addService(new ReplService(clients, ec, materializer))
       .maxInboundMessageSize(maxMessageSize)
       .build


### PR DESCRIPTION
Currently the repl server is bound to 0.0.0.0, which is not great for security and makes running the tests a bit disruptive on macOS.

This binds it to 127.0.0.1 instead.

CHANGELOG_BEGIN
- [DAML Repl - Experimental] The REPL server will now bind to 127.0.0.1
  instead of 0.0.0.0.
CHANGELOG_END