### PR TITLE
Wrap Script in StateT to make evaluation order a bit less important

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -91,7 +91,7 @@ data QueryACS a = QueryACS
 -- | Query the set of active contracts of the template
 -- that are visible to the given party.
 query : forall t. Template t => Party -> Script [(ContractId t, t)]
-query p = Script $ lift $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(cid, tpl) -> (coerceContractId cid, fromSome $ fromAnyTemplate tpl))))
+query p = lift $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(cid, tpl) -> (coerceContractId cid, fromSome $ fromAnyTemplate tpl))))
 
 data AllocateParty a = AllocateParty
   { displayName : Text
@@ -114,7 +114,7 @@ newtype ParticipantName = ParticipantName { participantName : Text }
 -- | Allocate a party with the given display name
 -- using the party management service.
 allocateParty : Text -> Script Party
-allocateParty displayName = Script $ lift $ Free $ AllocParty $ AllocateParty
+allocateParty displayName = lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = ""
   , participant = None
@@ -124,7 +124,7 @@ allocateParty displayName = Script $ lift $ Free $ AllocParty $ AllocateParty
 -- | Allocate a party with the given display name and id hint
 -- using the party management service.
 allocatePartyWithHint : Text -> PartyIdHint -> Script Party
-allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ lift $ Free $ AllocParty $ AllocateParty
+allocatePartyWithHint displayName (PartyIdHint idHint) = lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = idHint
   , participant = None
@@ -134,7 +134,7 @@ allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ lift $ Free $ 
 -- | Allocate a party with the given display name
 -- on the specified participant using the party management service.
 allocatePartyOn : Text -> ParticipantName -> Script Party
-allocatePartyOn displayName (ParticipantName participant) = Script $ lift $ Free $ AllocParty $ AllocateParty
+allocatePartyOn displayName (ParticipantName participant) = lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = ""
   , participant = Some participant
@@ -144,7 +144,7 @@ allocatePartyOn displayName (ParticipantName participant) = Script $ lift $ Free
 -- | Allocate a party with the given display name and id hint
 -- on the specified participant using the party management service.
 allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
-allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ lift $ Free $ AllocParty $ AllocateParty
+allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = idHint
   , participant = Some participant
@@ -153,7 +153,7 @@ allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName partic
 
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where
-  getTime = Script $ lift $ Free (GetTime pure)
+  getTime = lift $ Free (GetTime pure)
 
 -- | Sleep for the given duration.
 --
@@ -162,7 +162,7 @@ instance HasTime Script where
 --
 -- Note that this will sleep for the same duration in both wallcock and static time mode.
 sleep : RelTime -> Script ()
-sleep duration = Script $ lift $ Free (Sleep $ SleepRec duration pure)
+sleep duration = lift $ Free (Sleep $ SleepRec duration pure)
 
 data SubmitFailure = SubmitFailure
   { status : Int
@@ -177,22 +177,22 @@ data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailu
 -- This will error if the submission fails.
 
 instance HasSubmit Script Commands where
-  submit p cmds = Script $ lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
+  submit p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
     where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
 
-  submitMustFail p cmds = Script $ lift $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
+  submitMustFail p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
     where fail _ = error "Expected submit to fail but it succeeded"
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.
-newtype Script a = Script { runScript : StateT () (Free ScriptF) a }
--- We use StateT to separate evaluation of something of type Script from execution and to ensure
+newtype Script a = Script { runScript : () -> (Free ScriptF (a, ())) }
+-- We use an inlined StateT () to separate evaluation of something of type Script from execution and to ensure
 -- proper sequencing of evaluation. This is mainly so that `debug` does something
 -- slightly more sensible.
-  deriving (Functor, Applicative, Action)
+  deriving Functor
 
 instance CanAbort Script where
-  abort s = Script (StateT $ \_ -> error s)
+  abort s = Script (\_ -> error s)
 
 data LedgerValue = LedgerValue {}
 
@@ -215,25 +215,20 @@ exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRe
 createAndExerciseCmd : forall t c r. Choice t c r => t -> c -> Commands r
 createAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) identity) (pure fromLedgerValue))
 
--- We implement our own StateT since it is not in daml-stdlib atm
+instance Applicative Script where
+    pure a = Script $ \ s -> return (a, s)
 
-newtype StateT s m a = StateT { runStateT : s -> m (a,s) }
-  deriving Functor
-
-instance Action m => Applicative (StateT s m) where
-    pure a = StateT $ \ s -> return (a, s)
-
-    StateT mf <*> StateT mx = StateT $ \ s -> do
+    Script mf <*> Script mx = Script $ \ s -> do
         (f, s') <- mf s
         (x, s'') <- mx s'
         return (f x, s'')
 
-instance Action m => Action (StateT s m) where
-    m >>= k  = StateT $ \ s -> do
-        (a, s') <- runStateT m s
-        runStateT (k a) s'
+instance Action Script where
+    m >>= k  = Script $ \ s -> do
+        (a, s') <- runScript m s
+        runScript (k a) s'
 
-lift : Action m => m a -> StateT s m a
-lift m = StateT $ \s -> do
+lift : Free ScriptF a -> Script a
+lift m = Script $ \s -> do
   a <- m
   pure (a, s)

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -91,7 +91,7 @@ data QueryACS a = QueryACS
 -- | Query the set of active contracts of the template
 -- that are visible to the given party.
 query : forall t. Template t => Party -> Script [(ContractId t, t)]
-query p = Script $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(cid, tpl) -> (coerceContractId cid, fromSome $ fromAnyTemplate tpl))))
+query p = Script $ lift $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(cid, tpl) -> (coerceContractId cid, fromSome $ fromAnyTemplate tpl))))
 
 data AllocateParty a = AllocateParty
   { displayName : Text
@@ -114,7 +114,7 @@ newtype ParticipantName = ParticipantName { participantName : Text }
 -- | Allocate a party with the given display name
 -- using the party management service.
 allocateParty : Text -> Script Party
-allocateParty displayName = Script $ Free $ AllocParty $ AllocateParty
+allocateParty displayName = Script $ lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = ""
   , participant = None
@@ -124,7 +124,7 @@ allocateParty displayName = Script $ Free $ AllocParty $ AllocateParty
 -- | Allocate a party with the given display name and id hint
 -- using the party management service.
 allocatePartyWithHint : Text -> PartyIdHint -> Script Party
-allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free $ AllocParty $ AllocateParty
+allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = idHint
   , participant = None
@@ -134,7 +134,7 @@ allocatePartyWithHint displayName (PartyIdHint idHint) = Script $ Free $ AllocPa
 -- | Allocate a party with the given display name
 -- on the specified participant using the party management service.
 allocatePartyOn : Text -> ParticipantName -> Script Party
-allocatePartyOn displayName (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
+allocatePartyOn displayName (ParticipantName participant) = Script $ lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = ""
   , participant = Some participant
@@ -144,7 +144,7 @@ allocatePartyOn displayName (ParticipantName participant) = Script $ Free $ Allo
 -- | Allocate a party with the given display name and id hint
 -- on the specified participant using the party management service.
 allocatePartyWithHintOn : Text -> PartyIdHint -> ParticipantName -> Script Party
-allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ Free $ AllocParty $ AllocateParty
+allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName participant) = Script $ lift $ Free $ AllocParty $ AllocateParty
   { displayName
   , idHint = idHint
   , participant = Some participant
@@ -153,7 +153,7 @@ allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName partic
 
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where
-  getTime = Script $ Free (GetTime pure)
+  getTime = Script $ lift $ Free (GetTime pure)
 
 -- | Sleep for the given duration.
 --
@@ -162,7 +162,7 @@ instance HasTime Script where
 --
 -- Note that this will sleep for the same duration in both wallcock and static time mode.
 sleep : RelTime -> Script ()
-sleep duration = Script $ Free (Sleep $ SleepRec duration pure)
+sleep duration = Script $ lift $ Free (Sleep $ SleepRec duration pure)
 
 data SubmitFailure = SubmitFailure
   { status : Int
@@ -177,19 +177,22 @@ data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailu
 -- This will error if the submission fails.
 
 instance HasSubmit Script Commands where
-  submit p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
+  submit p cmds = Script $ lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
     where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
 
-  submitMustFail p cmds = Script $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
+  submitMustFail p cmds = Script $ lift $ Free (fmap pure $ Submit $ SubmitCmd p (fail <$> cmds) (const ()))
     where fail _ = error "Expected submit to fail but it succeeded"
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.
-newtype Script a = Script (Free ScriptF a)
+newtype Script a = Script { runScript : StateT () (Free ScriptF) a }
+-- We use StateT to separate evaluation of something of type Script from execution and to ensure
+-- proper sequencing of evaluation. This is mainly so that `debug` does something
+-- slightly more sensible.
   deriving (Functor, Applicative, Action)
 
 instance CanAbort Script where
-  abort = error
+  abort s = Script (StateT $ \_ -> error s)
 
 data LedgerValue = LedgerValue {}
 
@@ -211,3 +214,26 @@ exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRe
 -- | Create a contract and exercise a choice on it in the same transacton.
 createAndExerciseCmd : forall t c r. Choice t c r => t -> c -> Commands r
 createAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) identity) (pure fromLedgerValue))
+
+-- We implement our own StateT since it is not in daml-stdlib atm
+
+newtype StateT s m a = StateT { runStateT : s -> m (a,s) }
+  deriving Functor
+
+instance Action m => Applicative (StateT s m) where
+    pure a = StateT $ \ s -> return (a, s)
+
+    StateT mf <*> StateT mx = StateT $ \ s -> do
+        (f, s') <- mf s
+        (x, s'') <- mx s'
+        return (f x, s'')
+
+instance Action m => Action (StateT s m) where
+    m >>= k  = StateT $ \ s -> do
+        (a, s') <- runStateT m s
+        runStateT (k a) s'
+
+lift : Action m => m a -> StateT s m a
+lift m = StateT $ \s -> do
+  a <- m
+  pure (a, s)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -298,13 +298,16 @@ class Runner(
 
     stepToValue()
     machine.toSValue match {
-      // Unwrap Script newtype, StateT and apply to ()
+      // Unwrap Script newtype and apply to ()
       case SRecord(_, _, vals) if vals.size == 1 => {
         vals.get(0) match {
-          case SRecord(_, _, vals) if vals.size == 1 => {
+          case SPAP(_, _, _) =>
             machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))
-          }
-          case v => throw new ConverterException(s"Expected record with 1 field but got $v")
+          case v =>
+            throw new ConverterException(
+              "Mismatch in structure of Script type. " +
+                "This probably means that you tried to run a script built against an " +
+                "SDK <= 0.13.55-snapshot.20200304.3329.6a1c75cf with a script runner from a newer SDK.")
         }
       }
       case v => throw new ConverterException(s"Expected record with 1 field but got $v")
@@ -475,7 +478,7 @@ class Runner(
         case SVariant(_, "Pure", v) =>
           v match {
             case SRecord(_, _, vals) if vals.size == 2 => {
-              // Unwrap the Tuple2 we get from StateT.
+              // Unwrap the Tuple2 we get from the inlined StateT.
               Future { vals.get(0) }
             }
             case _ => throw new RuntimeException(s"Expected Tuple2 but got $v")

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -48,6 +48,7 @@ EOF
 da_scala_library(
     name = "test-lib",
     srcs = glob(["src/**/*.scala"]),
+    resources = glob(["src/main/resources/**/*"]),
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -48,6 +48,7 @@ ScriptTest:test4 SUCCESS
 ScriptTest:testCreateAndExercise SUCCESS
 ScriptTest:testKey SUCCESS
 ScriptTest:time SUCCESS
+ScriptTest:traceOrder SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
 ScriptExample:initializeFixed SUCCESS

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -5,8 +5,8 @@
 
 module ScriptTest where
 
+import DA.Foldable
 import DA.Time
-
 import Daml.Script
 
 template T
@@ -167,3 +167,11 @@ auth (alice, bob) = do
   proposal <- submit alice $ createCmd (TProposal alice bob)
   _ <- submit bob $ exerciseCmd proposal Accept
   pure ()
+
+traceOrder : Script ()
+traceOrder = do
+  let y: Script () = abort "foobar"
+  forA_ [0,1] $ \i -> do
+    debug "abc"
+    x <- getTime
+    debug "def"

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -270,6 +270,22 @@ case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
+case class TraceOrder(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:traceOrder"))
+  def traceMsg(msg: String) = s"""[DA.Internal.Prelude:540]: "$msg""""
+  def runTests(): Unit = {
+    runner.genericTest(
+      "traceOrder",
+      scriptId,
+      None, {
+        case SUnit => Right(())
+        case v => Left(s"Expected SUnit but got $v")
+      },
+      Some(Seq(traceMsg("abc"), traceMsg("def"), traceMsg("abc"), traceMsg("def")))
+    )
+  }
+}
+
 case class TestAuth(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:auth"))
   def runTests(): Unit = {
@@ -330,6 +346,7 @@ object SingleParticipant {
           new TestRunner(participantParams, dar, config.wallclockTime, tokenHolder.flatMap(_.token))
         config.accessTokenFile match {
           case None =>
+            TraceOrder(dar, runner).runTests()
             Test0(dar, runner).runTests()
             Test1(dar, runner).runTests()
             Test2(dar, runner).runTests()

--- a/daml-script/test/src/main/resources/logback-test.xml
+++ b/daml-script/test/src/main/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="TEST-LOGGER" class="com.digitalasset.daml.lf.engine.script.test.LogCollector" />
+
+    <logger name="io.netty" level="WARN" />
+    <logger name="io.grpc.netty" level="WARN" />
+    <logger name="daml.tracelog" level="DEBUG">
+      <appender-ref ref="TEST-LOGGER" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This PR wraps the Script newtype in `StateT` which means that
evaluation won’t do much so `debug` behaves a bit more sensibly and
you don’t end up evaluating a script that only consists of `pure` and
`>>=` if you do not execute it.

fixes #4821

changelog_begin

- [DAML Script] Fix an issue where ``debug`` messages were output
  before the script was executed.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
