### PR TITLE
Support specifying sandbox/navigator/json-api options in daml.yaml

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -255,6 +255,62 @@ packagingTests = testGroup "packaging"
                 _ -> assertFailure "Expected JSON object in response body"
               -- waitForProcess' will block on Windows so we explicitly kill the process.
               terminateProcess startPh
+     , testCase "sandbox-options is picked up" $ withTempDir $ \tmpDir -> do
+        let projDir = tmpDir </> "sandbox-options"
+        createDirectoryIfMissing True (projDir </> "daml")
+        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+          [ "sdk-version: " <> sdkVersion
+          , "name: sandbox-options"
+          , "version: \"1.0\""
+          , "source: daml"
+          , "sandbox-options:"
+          , "  - --wall-clock-time"
+          , "  - --ledgerid=MyLedger"
+          , "dependencies:"
+          , "  - daml-prim"
+          , "  - daml-stdlib"
+          ]
+        writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
+          [ "daml 1.2"
+          , "module Main where"
+          , "template T with p : Party where signatory p"
+          ]
+        sandboxPort :: Int <- fromIntegral <$> getFreePort
+        jsonApiPort :: Int <- fromIntegral <$> getFreePort
+        let startProc = shell $ unwords
+              [ "daml"
+              , "start"
+              , "--start-navigator=no"
+              , "--sandbox-port=" <> show sandboxPort
+              , "--json-api-port=" <> show jsonApiPort
+              ]
+        withCurrentDirectory projDir $
+          withCreateProcess startProc $ \_ _ _ startPh ->
+            race_ (waitForProcess' startProc startPh) $ do
+              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
+                    { JWT.unregisteredClaims = JWT.ClaimsMap $
+                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
+                    }
+              let headers =
+                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
+                    ] :: RequestHeaders
+              waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
+
+              manager <- newManager defaultManagerSettings
+              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
+              let createRequest = initialRequest
+                    { method = "POST"
+                    , requestHeaders = headers
+                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
+                        ["templateId" Aeson..= Aeson.String "Main:T"
+                        ,"payload" Aeson..= [Aeson.String "Alice"]
+                        ]
+                    }
+              createResponse <- httpLbs createRequest manager
+              -- If the ledger id or wall clock time is not picked up this would fail.
+              statusCode (responseStatus createResponse) @?= 200
+              -- waitForProcess' will block on Windows so we explicitly kill the process.
+              terminateProcess startPh
     ]
 
 quickstartTests :: FilePath -> FilePath -> TestTree

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -133,6 +133,11 @@ Here is what each field means:
     errors, there should be no reason to modify this.
 
 - ``build-options``: a list of tokens that will be appended to some invocations of ``damlc`` (currently `build` and `ide`). Note that there is no further shell parsing applied.
+- ``sandbox-options``: a list of options that will be passed to Sandbox in ``daml start``.
+- ``navigator-options``: a list of options that will be passed to Navigator in ``daml start``.
+- ``json-api-options``: a list of options that will be passed to the HTTP JSON API in ``daml start``.
+- ``script-options``: a list of options that will be passed to the DAML script
+  runner when running the ``init-script`` as part of ``daml start``.
 
 ..  TODO (@robin-da) document the dependency syntax
 


### PR DESCRIPTION


- [DAML Assistant] You can now specify options for
  Sandbox/Navigator/the HTTP JSON API in ``daml.yaml`` via
  ``sandbox-options``/``navigator-options``/``json-api-options``. These
  options will be picked up by running ``daml start``. This is
  particularly useful for specifying ``--wall-clock-time`` and for
  specifying a fixed ledger ID during development.

changelog_end

fixes #2993

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
