### PR TITLE
Improve error messages when we cannot find packages in the script runner

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -359,12 +359,14 @@ object Converter {
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
   def fromCreated(
       translator: ValueTranslator,
-      primPackageId: PackageId,
-      stdlibPackageId: PackageId,
+      daTypesPackageId: PackageId,
+      daInternalAnyPackageId: PackageId,
       created: CreatedEvent): Either[String, SValue] = {
     val anyTemplateTyCon =
-      Identifier(stdlibPackageId, QualifiedName.assertFromString("DA.Internal.LF:AnyTemplate"))
-    val pairTyCon = Identifier(primPackageId, QualifiedName.assertFromString("DA.Types:Tuple2"))
+      Identifier(
+        daInternalAnyPackageId,
+        QualifiedName.assertFromString("DA.Internal.LF:AnyTemplate"))
+    val pairTyCon = Identifier(daTypesPackageId, QualifiedName.assertFromString("DA.Types:Tuple2"))
     for {
       templateId <- created.templateId match {
         case None => Left(s"Missing field templateId in $created")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -84,7 +84,13 @@ object RunnerMain {
           fileContent.parseJson
         })
 
-        val runner = new Runner(dar, applicationId, commandUpdater, timeProvider)
+        val runner = try {
+          new Runner(dar, applicationId, commandUpdater, timeProvider)
+        } catch {
+          case e: Throwable =>
+            system.terminate
+            sys.exit(1)
+        }
         val participantParams = config.participantConfig match {
           case Some(file) => {
             val source = Source.fromFile(file)


### PR DESCRIPTION
The logic for detecting these needs to be improved but for now this at
least gives a useful error message instead of some internal stacktrace.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
