### PR TITLE
Fix calculation of transaction tree projections

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
@@ -87,6 +87,11 @@ object EventOps {
   implicit final class TreeEventOps(val event: TreeEvent) extends AnyVal {
     def eventId: String = event.kind.fold(_.eventId, _.eventId)
     def childEventIds: Seq[String] = event.kind.fold(_.childEventIds, _ => Nil)
+    def filterChildEventIds(f: String => Boolean): TreeEvent =
+      event.kind.fold(
+        exercise =>
+          TreeEvent(TreeExercised(exercise.copy(childEventIds = exercise.childEventIds.filter(f)))),
+        create => TreeEvent(TreeCreated(create)))
     def witnessParties: Seq[String] = event.kind.fold(_.witnessParties, _.witnessParties)
     def templateId: Option[Identifier] = event.kind.fold(_.templateId, _.templateId)
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.testtool.tests.TransactionService.{
   comparableTransactionTrees,
   comparableTransactions
 }
-import com.digitalasset.ledger.api.v1.transaction.TreeEvent.Kind.{Created, Exercised}
+import com.digitalasset.ledger.api.v1.transaction.TreeEvent.Kind.Exercised
 import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree, TreeEvent}
 import com.digitalasset.ledger.client.binding.Primitive
 import com.digitalasset.ledger.client.binding.Value.encode
@@ -192,7 +192,7 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
             eventsToObserve.remove(eventId) match {
               case Some(TreeEvent(Exercised(exercisedEvent))) =>
                 exercisedEvent.childEventIds.foreach(go)
-              case Some(TreeEvent(Created(_))) =>
+              case Some(TreeEvent(_)) =>
                 ()
               case None =>
                 throw new AssertionError(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionService.scala
@@ -11,11 +11,16 @@ import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.testtool.tests.TransactionService.{
   comparableTransactionTrees,
-  comparableTransactions,
+  comparableTransactions
 }
-import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree}
+import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree, TreeEvent}
 import com.digitalasset.ledger.client.binding.Primitive
 import com.digitalasset.ledger.client.binding.Value.encode
+import com.digitalasset.ledger.test_stable.Iou.Iou
+import com.digitalasset.ledger.test_stable.Iou.Iou._
+import com.digitalasset.ledger.test_stable.Iou.IouTransfer._
+import com.digitalasset.ledger.test_stable.IouTrade.IouTrade
+import com.digitalasset.ledger.test_stable.IouTrade.IouTrade._
 import com.digitalasset.ledger.test_stable.Test.Agreement._
 import com.digitalasset.ledger.test_stable.Test.AgreementFactory._
 import com.digitalasset.ledger.test_stable.Test.Choice1._
@@ -28,6 +33,7 @@ import com.digitalasset.ledger.test_stable.Test._
 import io.grpc.Status
 import scalaz.Tag
 
+import scala.collection.mutable
 import scala.concurrent.Future
 
 class TransactionService(session: LedgerSession) extends LedgerTestSuite(session) {
@@ -133,6 +139,94 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
           trees.size == treesToRead,
           s"$treesToRead should have been received but ${trees.size} were instead",
         )
+      }
+  }
+
+  test(
+    "TXTreeBlinding",
+    "Trees should be served according to the blinding/projection rules",
+    allocate(TwoParties, SingleParty, SingleParty)
+  ) {
+    case Participants(
+        Participant(alpha, alice, gbp_bank),
+        Participant(beta, bob),
+        Participant(delta, dkk_bank)) =>
+      for {
+        gbpIouIssue <- alpha.create(gbp_bank, Iou(gbp_bank, gbp_bank, "GBP", 100, Nil))
+        gbpTransfer <- alpha.exerciseAndGetContract(
+          gbp_bank,
+          gbpIouIssue.exerciseIou_Transfer(_, alice))
+        dkkIouIssue <- delta.create(dkk_bank, Iou(dkk_bank, dkk_bank, "DKK", 110, Nil))
+        dkkTransfer <- delta.exerciseAndGetContract(
+          dkk_bank,
+          dkkIouIssue.exerciseIou_Transfer(_, bob))
+
+        aliceIou1 <- eventually {
+          alpha.exerciseAndGetContract[Iou](alice, gbpTransfer.exerciseIouTransfer_Accept(_))
+        }
+        aliceIou <- eventually {
+          alpha.exerciseAndGetContract[Iou](alice, aliceIou1.exerciseIou_AddObserver(_, bob))
+        }
+        bobIou <- eventually {
+          beta.exerciseAndGetContract[Iou](bob, dkkTransfer.exerciseIouTransfer_Accept(_))
+        }
+
+        trade <- eventually {
+          alpha.create(
+            alice,
+            IouTrade(alice, bob, aliceIou, gbp_bank, "GBP", 100, dkk_bank, "DKK", 110))
+        }
+        tree <- eventually { beta.exercise(bob, trade.exerciseIouTrade_Accept(_, bobIou)) }
+
+        aliceTree <- alpha.transactionTreeById(tree.transactionId, alice)
+        bobTree <- beta.transactionTreeById(tree.transactionId, bob)
+        gbpTree <- alpha.transactionTreeById(tree.transactionId, gbp_bank)
+        dkkTree <- delta.transactionTreeById(tree.transactionId, dkk_bank)
+
+      } yield {
+        def treeIsWellformed(tree: TransactionTree): Unit = {
+          val eventsToObserve = mutable.Map.empty[String, TreeEvent] ++= tree.eventsById
+
+          def go(eventId: String): Unit = {
+            assert(
+              eventsToObserve.contains(eventId),
+              s"Referenced eventId $eventId is not available as node in the transaction.")
+            val Some(event) = eventsToObserve.remove(eventId)
+            event.kind.exercised.toList.flatMap(_.childEventIds).foreach { childEventId =>
+              go(childEventId)
+            }
+          }
+          tree.rootEventIds.foreach(go)
+          assert(
+            eventsToObserve.isEmpty,
+            s"After traversing the transaction, there are still unvisted nodes: $eventsToObserve")
+        }
+
+        treeIsWellformed(aliceTree)
+        treeIsWellformed(bobTree)
+        treeIsWellformed(gbpTree)
+        treeIsWellformed(dkkTree)
+
+        // both bob and alice see the entire transaction:
+        // 1x Exercise IouTrade.IouTrade_Accept
+        // 2 x Iou transfer with 4 nodes each (see below)
+        //
+        assert(aliceTree.eventsById.size == 9)
+        assert(bobTree.eventsById.size == 9)
+
+        assert(aliceTree.rootEventIds.size == 1)
+        assert(bobTree.rootEventIds.size == 1)
+
+        // banks only see the transfer of their issued Iou:
+        // Exercise Iou.Iou_Transfer -> Create IouTransfer
+        // Exercise IouTransfer.IouTransfer_Accept -> Create Iou
+        assert(gbpTree.eventsById.size == 4)
+        assert(dkkTree.eventsById.size == 4)
+
+        // the exercises are the root nodes
+        assert(gbpTree.rootEventIds.size == 2)
+        assert(dkkTree.rootEventIds.size == 2)
+
       }
   }
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -349,6 +349,7 @@ server_conformance_test(
     servers = SERVERS,
     test_tool_args = [
         "--verbose",
+        "--all-tests",
         "--exclude=LotsOfPartiesIT",
         "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -349,7 +349,6 @@ server_conformance_test(
     servers = SERVERS,
     test_tool_args = [
         "--verbose",
-        "--all-tests",
         "--exclude=LotsOfPartiesIT",
         "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/TransactionConversion.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/TransactionConversion.scala
@@ -154,9 +154,9 @@ object TransactionConversion {
     val (replaced, roots) =
       tx.roots.foldLeft((false, IndexedSeq.empty[EventId])) {
         case ((replaced, roots), eventId) =>
-          if (isCreateOrExercise(tx.nodes(eventId)) && disclosure.contains(eventId))
+          if (isCreateOrExercise(tx.nodes(eventId)) && disclosure.contains(eventId)) {
             (replaced, roots :+ eventId)
-          else
+          } else
             tx.nodes(eventId) match {
               case e: Exercise => (true, roots ++ e.children.toIndexedSeq)
               case _ => (true, roots)

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -73,6 +73,10 @@ lf_test_versions = [
     [
         daml_compile(
             name = "Test-%s" % target_name,
+            srcs = [
+                "src/main/daml/Iou.daml",
+                "src/main/daml/IouTrade.daml",
+            ],
             main_src = "src/main/daml/Test.daml",
             target = target,
             visibility = ["//visibility:public"],

--- a/ledger/test-common/src/main/daml/Iou.daml
+++ b/ledger/test-common/src/main/daml/Iou.daml
@@ -1,0 +1,86 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module Iou where
+
+type IouCid = ContractId Iou
+
+template Iou
+  with
+    issuer : Party
+    owner : Party
+    currency : Text
+    amount : Decimal
+    observers : [Party]
+  where
+    ensure amount > 0.0
+
+    signatory issuer, owner
+
+    observer observers
+
+    controller owner can
+
+      -- Split the IOU by dividing the amount.
+      Iou_Split : (IouCid, IouCid)
+         with
+          splitAmount: Decimal
+        do
+          let restAmount = amount - splitAmount
+          splitCid <- create this with amount = splitAmount
+          restCid <- create this with amount = restAmount
+          return (splitCid, restCid)
+
+      -- Merge two IOUs by aggregating their amounts.
+      Iou_Merge : IouCid
+        with
+          otherCid: IouCid
+        do
+          otherIou <- fetch otherCid
+          -- Check the two IOU's are compatible
+          assert (
+            currency == otherIou.currency &&
+            owner == otherIou.owner &&
+            issuer == otherIou.issuer
+            )
+          -- Retire the old Iou
+          archive otherCid
+          -- Return the merged Iou
+          create this with amount = amount + otherIou.amount
+
+      Iou_Transfer : ContractId IouTransfer
+        with
+          newOwner : Party
+        do create IouTransfer with iou = this; newOwner
+
+      Iou_AddObserver : IouCid
+        with
+          newObserver : Party
+        do create this with observers = newObserver :: observers
+
+      Iou_RemoveObserver : IouCid
+        with
+          oldObserver : Party
+        do create this with observers = filter (/= oldObserver) observers
+
+template IouTransfer
+  with
+    iou : Iou
+    newOwner : Party
+  where
+    signatory iou.issuer, iou.owner
+
+    controller iou.owner can
+      IouTransfer_Cancel : IouCid
+        do create iou
+
+    controller newOwner can
+      IouTransfer_Reject : IouCid
+        do create iou
+
+      IouTransfer_Accept : IouCid
+        do
+          create iou with
+            owner = newOwner
+            observers = []

--- a/ledger/test-common/src/main/daml/IouTrade.daml
+++ b/ledger/test-common/src/main/daml/IouTrade.daml
@@ -1,0 +1,49 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module IouTrade where
+
+import DA.Assert
+
+import Iou
+
+template IouTrade
+  with
+    buyer : Party
+    seller : Party
+    baseIouCid : IouCid
+    baseIssuer : Party
+    baseCurrency : Text
+    baseAmount : Decimal
+    quoteIssuer : Party
+    quoteCurrency : Text
+    quoteAmount : Decimal
+  where
+    signatory buyer
+
+    controller seller can
+      IouTrade_Accept : (IouCid, IouCid)
+        with
+          quoteIouCid : IouCid
+        do
+          baseIou <- fetch baseIouCid
+          baseIssuer === baseIou.issuer
+          baseCurrency === baseIou.currency
+          baseAmount === baseIou.amount
+          buyer === baseIou.owner
+          quoteIou <- fetch quoteIouCid
+          quoteIssuer === quoteIou.issuer
+          quoteCurrency === quoteIou.currency
+          quoteAmount === quoteIou.amount
+          seller === quoteIou.owner
+          quoteIouTransferCid <- exercise quoteIouCid Iou_Transfer with
+            newOwner = buyer
+          transferredQuoteIouCid <- exercise quoteIouTransferCid IouTransfer_Accept
+          baseIouTransferCid <- exercise baseIouCid Iou_Transfer with
+            newOwner = seller
+          transferredBaseIouCid <- exercise baseIouTransferCid IouTransfer_Accept
+          return (transferredQuoteIouCid, transferredBaseIouCid)
+
+      TradeProposal_Reject : ()
+        do return ()

--- a/ledger/test-common/src/main/daml/Test.daml
+++ b/ledger/test-common/src/main/daml/Test.daml
@@ -7,6 +7,9 @@ module Test where
 
 import DA.Time
 
+import Iou()
+import IouTrade()
+
 template Dummy
   with
     operator : Party


### PR DESCRIPTION
Events in transaction trees should only reference other events
that:
1) are either create or exercise events
2) the requesting parties are a witness of

This applies to recalculated root nodes as well as
the child event ids referenced in exercise nodes.

CHANGELOG_BEGIN
[Sandbox]: fixed projection of transaction trees.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
