### PR TITLE
Ledger API Server: Add the `GetParties` endpoint.

### DIFF
--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
@@ -31,15 +31,17 @@ service PartyManagementService {
   // daml-on-sql: returns an identifier supplied on command line at launch time
   // daml-on-kv-ledger: as above
   // canton: returns globally unique identifier of the backing participant
-  rpc GetParticipantId (GetParticipantIdRequest) returns
-    (GetParticipantIdResponse);
+  rpc GetParticipantId (GetParticipantIdRequest) returns (GetParticipantIdResponse);
+
+  // Get the party details of the given party, or a ``NOT_FOUND`` error if the
+  // requested party is unknown.
+  rpc GetParty (GetPartyRequest) returns (GetPartyResponse);
 
   // List the parties known by the backing participant.
   // The list returned contains parties whose ledger access is facilitated by
   // backing participant and the ones maintained elsewhere.
   // This request will always succeed.
-  rpc ListKnownParties (ListKnownPartiesRequest) returns
-    (ListKnownPartiesResponse);
+  rpc ListKnownParties (ListKnownPartiesRequest) returns (ListKnownPartiesResponse);
 
   // Adds a new party to the set managed by the backing participant.
   // Caller specifies a party identifier suggestion, the actual identifier
@@ -71,6 +73,21 @@ message GetParticipantIdResponse {
   string participant_id = 1;
 }
 
+message GetPartyRequest {
+
+  // The stable unique identifier of a DAML party.
+  // Must be a valid PartyIdString (as described in ``value.proto``).
+  // Required
+  string party = 1;
+}
+
+message GetPartyResponse {
+
+  // The details of the requested DAML party hosted by the participant, if available.
+  // Required
+  PartyDetails party_details = 1;
+}
+
 message ListKnownPartiesRequest {
 }
 
@@ -79,6 +96,25 @@ message ListKnownPartiesResponse {
   // The details of all DAML parties hosted by the participant.
   // Required
   repeated PartyDetails party_details = 1;
+}
+
+message AllocatePartyRequest {
+
+  // A hint to the backing participant which party ID to allocate. It can be
+  // ignored.
+  // Must be a valid PartyIdString (as described in ``value.proto``).
+  // Optional
+  string party_id_hint = 1;
+
+  // Human-readable name of the party to be added to the participant. It doesn't
+  // have to be unique.
+  // Optional
+  string display_name = 2;
+}
+
+message AllocatePartyResponse {
+
+  PartyDetails party_details = 1;
 }
 
 message PartyDetails {
@@ -96,23 +132,4 @@ message PartyDetails {
   // true if party is hosted by the backing participant.
   // Required
   bool is_local = 3;
-}
-
-message AllocatePartyRequest {
-
-  // A hint to the backing participant what party id to allocate. It can be
-  // ignored.
-  // Must be a valid PartyIdString (as describe in ``value.proto``).
-  // Optional
-  string party_id_hint = 1;
-
-  // Human readable name of the party to be added to the participant. It doesn't
-  // have to be unique.
-  // Optional
-  string display_name = 2;
-}
-
-message AllocatePartyResponse {
-
-  PartyDetails party_details = 1;
 }

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
@@ -33,10 +33,6 @@ service PartyManagementService {
   // canton: returns globally unique identifier of the backing participant
   rpc GetParticipantId (GetParticipantIdRequest) returns (GetParticipantIdResponse);
 
-  // Get the party details of the given party, or a ``NOT_FOUND`` error if the
-  // requested party is unknown.
-  rpc GetParty (GetPartyRequest) returns (GetPartyResponse);
-
   // Get the party details of the given parties. Only known parties will be
   // returned in the list.
   // This request will always succeed.
@@ -76,21 +72,6 @@ message GetParticipantIdResponse {
   // Identifier of the participant, which SHOULD be globally unique.
   // Must be a valid LedgerString (as describe in ``value.proto``).
   string participant_id = 1;
-}
-
-message GetPartyRequest {
-
-  // The stable, unique identifier of a DAML party.
-  // Must be a valid PartyIdString (as described in ``value.proto``).
-  // Required
-  string party = 1;
-}
-
-message GetPartyResponse {
-
-  // The details of the requested DAML party hosted by the participant, if available.
-  // Required
-  PartyDetails party_details = 1;
 }
 
 message GetPartiesRequest {

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
@@ -37,6 +37,11 @@ service PartyManagementService {
   // requested party is unknown.
   rpc GetParty (GetPartyRequest) returns (GetPartyResponse);
 
+  // Get the party details of the given parties. Only known parties will be
+  // returned in the list.
+  // This request will always succeed.
+  rpc GetParties (GetPartiesRequest) returns (GetPartiesResponse);
+
   // List the parties known by the backing participant.
   // The list returned contains parties whose ledger access is facilitated by
   // backing participant and the ones maintained elsewhere.
@@ -75,7 +80,7 @@ message GetParticipantIdResponse {
 
 message GetPartyRequest {
 
-  // The stable unique identifier of a DAML party.
+  // The stable, unique identifier of a DAML party.
   // Must be a valid PartyIdString (as described in ``value.proto``).
   // Required
   string party = 1;
@@ -86,6 +91,22 @@ message GetPartyResponse {
   // The details of the requested DAML party hosted by the participant, if available.
   // Required
   PartyDetails party_details = 1;
+}
+
+message GetPartiesRequest {
+
+  // The stable, unique identifier of the DAML parties.
+  // Must be valid PartyIdStrings (as described in ``value.proto``).
+  // Required
+  repeated string parties = 1;
+}
+
+message GetPartiesResponse {
+
+  // The details of the requested DAML parties by the participant, if known.
+  // The party details may not be in the same order as requested.
+  // Required
+  repeated PartyDetails party_details = 1;
 }
 
 message ListKnownPartiesRequest {

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
@@ -25,9 +25,6 @@ final class PartyManagementServiceAuthorization(
   ): Future[GetParticipantIdResponse] =
     authorizer.requireAdminClaims(service.getParticipantId)(request)
 
-  override def getParty(request: GetPartyRequest): Future[GetPartyResponse] =
-    authorizer.requireAdminClaims(service.getParty)(request)
-
   override def getParties(request: GetPartiesRequest): Future[GetPartiesResponse] =
     authorizer.requireAdminClaims(service.getParties)(request)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
@@ -21,15 +21,20 @@ final class PartyManagementServiceAuthorization(
     with GrpcApiService {
 
   override def getParticipantId(
-      request: GetParticipantIdRequest): Future[GetParticipantIdResponse] =
+      request: GetParticipantIdRequest
+  ): Future[GetParticipantIdResponse] =
     authorizer.requireAdminClaims(service.getParticipantId)(request)
+
+  override def getParty(request: GetPartyRequest): Future[GetPartyResponse] =
+    authorizer.requireAdminClaims(service.getParty)(request)
+
+  override def listKnownParties(
+      request: ListKnownPartiesRequest
+  ): Future[ListKnownPartiesResponse] =
+    authorizer.requireAdminClaims(service.listKnownParties)(request)
 
   override def allocateParty(request: AllocatePartyRequest): Future[AllocatePartyResponse] =
     authorizer.requireAdminClaims(service.allocateParty)(request)
-
-  override def listKnownParties(
-      request: ListKnownPartiesRequest): Future[ListKnownPartiesResponse] =
-    authorizer.requireAdminClaims(service.listKnownParties)(request)
 
   override def bindService(): ServerServiceDefinition =
     PartyManagementServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
@@ -28,6 +28,9 @@ final class PartyManagementServiceAuthorization(
   override def getParty(request: GetPartyRequest): Future[GetPartyResponse] =
     authorizer.requireAdminClaims(service.getParty)(request)
 
+  override def getParties(request: GetPartiesRequest): Future[GetPartiesResponse] =
+    authorizer.requireAdminClaims(service.getParties)(request)
+
   override def listKnownParties(
       request: ListKnownPartiesRequest
   ): Future[ListKnownPartiesResponse] =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -29,7 +29,6 @@ import com.digitalasset.ledger.api.v1.admin.party_management_service.{
   AllocatePartyRequest,
   GetParticipantIdRequest,
   GetPartiesRequest,
-  GetPartyRequest,
   ListKnownPartiesRequest,
   PartyDetails
 }
@@ -191,9 +190,6 @@ private[testtool] final class ParticipantTestContext private[participant] (
 
   def allocateParties(n: Int): Future[Vector[Party]] =
     Future.sequence(Vector.fill(n)(allocateParty()))
-
-  def getParty(party: Party): Future[Option[PartyDetails]] =
-    services.partyManagement.getParty(GetPartyRequest(party.unwrap)).map(_.partyDetails)
 
   def getParties(parties: Seq[Party]): Future[Seq[PartyDetails]] =
     services.partyManagement

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -11,29 +11,31 @@ import com.daml.ledger.api.testtool.infrastructure.{Identification, LedgerServic
 import com.digitalasset.ledger.api.refinements.ApiTypes.TemplateId
 import com.digitalasset.ledger.api.v1.active_contracts_service.{
   GetActiveContractsRequest,
-  GetActiveContractsResponse,
+  GetActiveContractsResponse
 }
 import com.digitalasset.ledger.api.v1.admin.config_management_service.{
   GetTimeModelRequest,
   GetTimeModelResponse,
   SetTimeModelRequest,
   SetTimeModelResponse,
-  TimeModel,
+  TimeModel
 }
 import com.digitalasset.ledger.api.v1.admin.package_management_service.{
   ListKnownPackagesRequest,
   PackageDetails,
-  UploadDarFileRequest,
+  UploadDarFileRequest
 }
 import com.digitalasset.ledger.api.v1.admin.party_management_service.{
   AllocatePartyRequest,
   GetParticipantIdRequest,
+  GetPartyRequest,
   ListKnownPartiesRequest,
+  PartyDetails
 }
 import com.digitalasset.ledger.api.v1.command_completion_service.{
   Checkpoint,
   CompletionStreamRequest,
-  CompletionStreamResponse,
+  CompletionStreamResponse
 }
 import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
@@ -44,7 +46,7 @@ import com.digitalasset.ledger.api.v1.event.{CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.ledger_configuration_service.{
   GetLedgerConfigurationRequest,
   GetLedgerConfigurationResponse,
-  LedgerConfiguration,
+  LedgerConfiguration
 }
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
 import com.digitalasset.ledger.api.v1.package_service._
@@ -53,13 +55,13 @@ import com.digitalasset.ledger.api.v1.transaction.{Transaction, TransactionTree}
 import com.digitalasset.ledger.api.v1.transaction_filter.{
   Filters,
   InclusiveFilters,
-  TransactionFilter,
+  TransactionFilter
 }
 import com.digitalasset.ledger.api.v1.transaction_service.{
   GetLedgerEndRequest,
   GetTransactionByEventIdRequest,
   GetTransactionByIdRequest,
-  GetTransactionsRequest,
+  GetTransactionsRequest
 }
 import com.digitalasset.ledger.api.v1.value.{Identifier, Value}
 import com.digitalasset.ledger.client.binding.Primitive.Party
@@ -188,6 +190,9 @@ private[testtool] final class ParticipantTestContext private[participant] (
 
   def allocateParties(n: Int): Future[Vector[Party]] =
     Future.sequence(Vector.fill(n)(allocateParty()))
+
+  def getParty(party: Party): Future[Option[PartyDetails]] =
+    services.partyManagement.getParty(GetPartyRequest(party.unwrap)).map(_.partyDetails)
 
   def listKnownParties(): Future[Set[Party]] =
     services.partyManagement

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -28,6 +28,7 @@ import com.digitalasset.ledger.api.v1.admin.package_management_service.{
 import com.digitalasset.ledger.api.v1.admin.party_management_service.{
   AllocatePartyRequest,
   GetParticipantIdRequest,
+  GetPartiesRequest,
   GetPartyRequest,
   ListKnownPartiesRequest,
   PartyDetails
@@ -193,6 +194,11 @@ private[testtool] final class ParticipantTestContext private[participant] (
 
   def getParty(party: Party): Future[Option[PartyDetails]] =
     services.partyManagement.getParty(GetPartyRequest(party.unwrap)).map(_.partyDetails)
+
+  def getParties(parties: Seq[Party]): Future[Seq[PartyDetails]] =
+    services.partyManagement
+      .getParties(GetPartiesRequest(parties.map(_.unwrap)))
+      .map(_.partyDetails)
 
   def listKnownParties(): Future[Set[Party]] =
     services.partyManagement

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -176,11 +176,11 @@ private[testtool] final class ParticipantTestContext private[participant] (
   /**
     * Non managed version of party allocation. Use exclusively when testing the party management service.
     */
-  def allocateParty(partyHintId: Option[String], displayName: Option[String]): Future[Party] =
+  def allocateParty(partyIdHint: Option[String], displayName: Option[String]): Future[Party] =
     services.partyManagement
       .allocateParty(
         new AllocatePartyRequest(
-          partyIdHint = partyHintId.getOrElse(""),
+          partyIdHint = partyIdHint.getOrElse(""),
           displayName = displayName.getOrElse(""),
         ),
       )
@@ -189,7 +189,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
   def allocateParties(n: Int): Future[Vector[Party]] =
     Future.sequence(Vector.fill(n)(allocateParty()))
 
-  def listParties(): Future[Set[Party]] =
+  def listKnownParties(): Future[Set[Party]] =
     services.partyManagement
       .listKnownParties(new ListKnownPartiesRequest())
       .map(_.partyDetails.map(partyDetails => Party(partyDetails.party)).toSet)
@@ -204,7 +204,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
         Future
           .sequence(participants.map(otherParticipant => {
             otherParticipant
-              .listParties()
+              .listKnownParties()
               .map { actualParties =>
                 assert(
                   expectedParties.subsetOf(actualParties),

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.index.v2
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.participant.state.v1.{ParticipantId, Party}
 import com.digitalasset.ledger.api.domain.{LedgerOffset, PartyDetails, PartyEntry}
 
 import scala.concurrent.Future
@@ -16,6 +16,8 @@ import scala.concurrent.Future
   */
 trait IndexPartyManagementService {
   def getParticipantId(): Future[ParticipantId]
+
+  def getParty(party: Party): Future[Option[PartyDetails]]
 
   def listParties(): Future[List[PartyDetails]]
 

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -19,6 +19,8 @@ trait IndexPartyManagementService {
 
   def getParty(party: Party): Future[Option[PartyDetails]]
 
+  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+
   def listParties(): Future[List[PartyDetails]]
 
   def partyEntries(beginOffset: LedgerOffset.Absolute): Source[PartyEntry, NotUsed]

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -17,8 +17,6 @@ import scala.concurrent.Future
 trait IndexPartyManagementService {
   def getParticipantId(): Future[ParticipantId]
 
-  def getParty(party: Party): Future[Option[PartyDetails]]
-
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 
   def listParties(): Future[List[PartyDetails]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -25,7 +25,7 @@ import com.digitalasset.ledger.api.v1.admin.party_management_service._
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.digitalasset.platform.api.grpc.GrpcApiService
 import com.digitalasset.platform.server.api.validation.ErrorFactories
-import io.grpc.{ServerServiceDefinition, Status}
+import io.grpc.ServerServiceDefinition
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.duration.DurationInt
@@ -60,13 +60,6 @@ final class ApiPartyManagementService private (
       details: com.digitalasset.ledger.api.domain.PartyDetails
   ): PartyDetails =
     PartyDetails(details.party, details.displayName.getOrElse(""), details.isLocal)
-
-  override def getParty(request: GetPartyRequest): Future[GetPartyResponse] =
-    partyManagementService
-      .getParty(Ref.Party.assertFromString(request.party))
-      .flatMap(_.fold(Future.failed[GetPartyResponse](Status.NOT_FOUND.asRuntimeException()))(p =>
-        Future.successful(GetPartyResponse(Some(mapPartyDetails(p))))))(DE)
-      .andThen(logger.logErrorsOnCall[GetPartyResponse])(DE)
 
   override def getParties(request: GetPartiesRequest): Future[GetPartiesResponse] =
     partyManagementService

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -68,6 +68,12 @@ final class ApiPartyManagementService private (
         Future.successful(GetPartyResponse(Some(mapPartyDetails(p))))))(DE)
       .andThen(logger.logErrorsOnCall[GetPartyResponse])(DE)
 
+  override def getParties(request: GetPartiesRequest): Future[GetPartiesResponse] =
+    partyManagementService
+      .getParties(request.parties.map(Ref.Party.assertFromString))
+      .map(ps => GetPartiesResponse(ps.map(mapPartyDetails)))(DE)
+      .andThen(logger.logErrorsOnCall[GetPartiesResponse])(DE)
+
   override def listKnownParties(
       request: ListKnownPartiesRequest
   ): Future[ListKnownPartiesResponse] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -272,6 +272,9 @@ abstract class LedgerBackedIndexService(
   override def getParticipantId(): Future[ParticipantId] =
     Future.successful(participantId)
 
+  override def getParty(party: Party): Future[Option[PartyDetails]] =
+    ledger.getParty(party)
+
   override def listParties(): Future[List[PartyDetails]] =
     ledger.parties
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -272,9 +272,6 @@ abstract class LedgerBackedIndexService(
   override def getParticipantId(): Future[ParticipantId] =
     Future.successful(participantId)
 
-  override def getParty(party: Party): Future[Option[PartyDetails]] =
-    ledger.getParties(Seq(party)).map(_.headOption)(DEC)
-
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     ledger.getParties(parties)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -273,7 +273,7 @@ abstract class LedgerBackedIndexService(
     Future.successful(participantId)
 
   override def getParty(party: Party): Future[Option[PartyDetails]] =
-    ledger.getParty(party)
+    ledger.getParties(Seq(party)).map(_.headOption)(DEC)
 
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     ledger.getParties(parties)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -275,6 +275,9 @@ abstract class LedgerBackedIndexService(
   override def getParty(party: Party): Future[Option[PartyDetails]] =
     ledger.getParty(party)
 
+  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+    ledger.getParties(parties)
+
   override def listParties(): Future[List[PartyDetails]] =
     ledger.parties
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -44,7 +44,6 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val lookupKey: Timer = metrics.timer("daml.index.lookup_key")
     val lookupTransaction: Timer = metrics.timer("daml.index.lookup_transaction")
     val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
-    val getParty: Timer = metrics.timer("daml.index.get_party")
     val getParties: Timer = metrics.timer("daml.index.get_parties")
     val parties: Timer = metrics.timer("daml.index.parties")
     val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
@@ -87,9 +86,6 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
       transactionId: TransactionId
   ): Future[Option[(Long, LedgerEntry.Transaction)]] =
     timedFuture(Metrics.lookupTransaction, ledger.lookupTransaction(transactionId))
-
-  override def getParty(party: Party): Future[Option[PartyDetails]] =
-    timedFuture(Metrics.getParty, ledger.getParty(party))
 
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     timedFuture(Metrics.getParties, ledger.getParties(parties))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -45,6 +45,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val lookupTransaction: Timer = metrics.timer("daml.index.lookup_transaction")
     val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
     val getParty: Timer = metrics.timer("daml.index.get_party")
+    val getParties: Timer = metrics.timer("daml.index.get_parties")
     val parties: Timer = metrics.timer("daml.index.parties")
     val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
@@ -89,6 +90,9 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
 
   override def getParty(party: Party): Future[Option[PartyDetails]] =
     timedFuture(Metrics.getParty, ledger.getParty(party))
+
+  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+    timedFuture(Metrics.getParties, ledger.getParties(parties))
 
   override def parties: Future[List[PartyDetails]] =
     timedFuture(Metrics.parties, ledger.parties)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -44,6 +44,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val lookupKey: Timer = metrics.timer("daml.index.lookup_key")
     val lookupTransaction: Timer = metrics.timer("daml.index.lookup_transaction")
     val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
+    val getParty: Timer = metrics.timer("daml.index.get_party")
     val parties: Timer = metrics.timer("daml.index.parties")
     val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
@@ -74,15 +75,20 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
 
   override def lookupContract(
       contractId: Value.AbsoluteContractId,
-      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
+      forParty: Party
+  ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]] =
     timedFuture(Metrics.lookupContract, ledger.lookupContract(contractId, forParty))
 
   override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]] =
     timedFuture(Metrics.lookupKey, ledger.lookupKey(key, forParty))
 
   override def lookupTransaction(
-      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
+      transactionId: TransactionId
+  ): Future[Option[(Long, LedgerEntry.Transaction)]] =
     timedFuture(Metrics.lookupTransaction, ledger.lookupTransaction(transactionId))
+
+  override def getParty(party: Party): Future[Option[PartyDetails]] =
+    timedFuture(Metrics.getParty, ledger.getParty(party))
 
   override def parties: Future[List[PartyDetails]] =
     timedFuture(Metrics.parties, ledger.parties)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -257,11 +257,6 @@ class InMemoryLedger(
     }
   }
 
-  override def getParty(party: Party): Future[Option[PartyDetails]] =
-    Future.successful(this.synchronized {
-      acs.parties.get(party)
-    })
-
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       parties.flatMap(party => acs.parties.get(party).toList).toList

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -257,6 +257,11 @@ class InMemoryLedger(
     }
   }
 
+  override def getParty(party: Party): Future[Option[PartyDetails]] =
+    Future.successful(this.synchronized {
+      acs.parties.get(party)
+    })
+
   override def parties: Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       acs.parties.values.toList
@@ -265,7 +270,8 @@ class InMemoryLedger(
   override def publishPartyAllocation(
       submissionId: SubmissionId,
       party: Party,
-      displayName: Option[String]): Future[SubmissionResult] =
+      displayName: Option[String]
+  ): Future[SubmissionResult] =
     Future.successful(this.synchronized[SubmissionResult] {
       val ids = acs.parties.keySet
       if (ids.contains(party)) {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -262,6 +262,11 @@ class InMemoryLedger(
       acs.parties.get(party)
     })
 
+  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+    Future.successful(this.synchronized {
+      parties.flatMap(party => acs.parties.get(party).toList).toList
+    })
+
   override def parties: Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       acs.parties.values.toList

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -22,6 +22,7 @@ import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
   LedgerId,
+  PartyDetails,
   TransactionFilter,
   TransactionId
 }
@@ -107,6 +108,9 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
 
   override def getParty(party: Party): Future[Option[domain.PartyDetails]] =
     ledgerDao.getParty(party)
+
+  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+    ledgerDao.getParties(parties)
 
   override def parties: Future[List[domain.PartyDetails]] =
     ledgerDao.getParties

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -106,9 +106,6 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
     ledgerDao
       .lookupTransaction(TransactionId.unwrap(transactionId))
 
-  override def getParty(party: Party): Future[Option[domain.PartyDetails]] =
-    ledgerDao.getParty(party)
-
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     ledgerDao.getParties(parties)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -36,10 +36,10 @@ import com.digitalasset.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry
 }
+import scalaz.syntax.tag.ToTagOps
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scalaz.syntax.tag.ToTagOps
 
 class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: LedgerReadDao)
     extends ReadOnlyLedger {
@@ -100,9 +100,13 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
     ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty)
 
   override def lookupTransaction(
-      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]] =
+      transactionId: TransactionId
+  ): Future[Option[(Long, LedgerEntry.Transaction)]] =
     ledgerDao
       .lookupTransaction(TransactionId.unwrap(transactionId))
+
+  override def getParty(party: Party): Future[Option[domain.PartyDetails]] =
+    ledgerDao.getParty(party)
 
   override def parties: Future[List[domain.PartyDetails]] =
     ledgerDao.getParties

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -55,14 +55,18 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
 
   def lookupContract(
       contractId: Value.AbsoluteContractId,
-      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]]
+      forParty: Party
+  ): Future[Option[ContractInst[Value.VersionedValue[AbsoluteContractId]]]]
 
   def lookupKey(key: GlobalKey, forParty: Party): Future[Option[AbsoluteContractId]]
 
   def lookupTransaction(
-      transactionId: TransactionId): Future[Option[(Long, LedgerEntry.Transaction)]]
+      transactionId: TransactionId
+  ): Future[Option[(Long, LedgerEntry.Transaction)]]
 
   // Party management
+  def getParty(party: Party): Future[Option[PartyDetails]]
+
   def parties: Future[List[PartyDetails]]
 
   def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -65,8 +65,6 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
   ): Future[Option[(Long, LedgerEntry.Transaction)]]
 
   // Party management
-  def getParty(party: Party): Future[Option[PartyDetails]]
-
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 
   def parties: Future[List[PartyDetails]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -67,6 +67,8 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
   // Party management
   def getParty(party: Party): Future[Option[PartyDetails]]
 
+  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+
   def parties: Future[List[PartyDetails]]
 
   def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1452,9 +1452,6 @@ private class JdbcLedgerDao(
     Future.successful(LedgerSnapshot(endExclusive, contractStream))
   }
 
-  private val SQL_SELECT_PARTY =
-    SQL("select party, display_name, ledger_offset, explicit from parties where party = {party}")
-
   private val SQL_SELECT_SOME_PARTIES =
     SQL(
       "select party, display_name, ledger_offset, explicit from parties where party in ({parties})")
@@ -1469,15 +1466,6 @@ private class JdbcLedgerDao(
       "ledger_offset",
       "explicit"
     )
-
-  override def getParty(party: Party): Future[Option[PartyDetails]] =
-    dbDispatcher
-      .executeSql("load_party") { implicit conn =>
-        SQL_SELECT_PARTY
-          .on("party" -> party)
-          .as(PartyDataParser.singleOpt)
-      }
-      .map(_.map(constructPartyDetails))(executionContext)
 
   override def getParties: Future[List[PartyDetails]] =
     dbDispatcher

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -118,11 +118,11 @@ trait LedgerReadDao extends ReportsHealth {
   /** Returns a single party, if they exist. */
   def getParty(party: Party): Future[Option[PartyDetails]]
 
-  /** Returns a list of all known parties. */
-  def getParties: Future[List[PartyDetails]]
-
   /** Returns a list of party details for the parties specified. */
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+
+  /** Returns a list of all known parties. */
+  def getParties: Future[List[PartyDetails]]
 
   def getPartyEntries(
       startInclusive: LedgerOffset,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -115,12 +115,19 @@ trait LedgerReadDao extends ReportsHealth {
       filter: TransactionFilter
   ): Future[LedgerSnapshot]
 
+  /** Returns a single party, if they exist. */
+  def getParty(party: Party): Future[Option[PartyDetails]]
+
   /** Returns a list of all known parties. */
   def getParties: Future[List[PartyDetails]]
 
+  /** Returns a list of party details for the parties specified. */
+  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+
   def getPartyEntries(
       startInclusive: LedgerOffset,
-      endExclusive: LedgerOffset): Source[(LedgerOffset, PartyLedgerEntry), NotUsed]
+      endExclusive: LedgerOffset
+  ): Source[(LedgerOffset, PartyLedgerEntry), NotUsed]
 
   /** Returns a list of all known DAML-LF packages */
   def listLfPackages: Future[Map[PackageId, PackageDetails]]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -115,9 +115,6 @@ trait LedgerReadDao extends ReportsHealth {
       filter: TransactionFilter
   ): Future[LedgerSnapshot]
 
-  /** Returns a single party, if they exist. */
-  def getParty(party: Party): Future[Option[PartyDetails]]
-
   /** Returns a list of party details for the parties specified. */
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -43,6 +43,7 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
       metrics.timer("daml.index.db.lookup_ledger_configuration")
     val lookupKey: Timer = metrics.timer("daml.index.db.lookup_key")
     val lookupActiveContract: Timer = metrics.timer("daml.index.db.lookup_active_contract")
+    val getParty: Timer = metrics.timer("daml.index.db.get_party")
     val getParties: Timer = metrics.timer("daml.index.db.get_parties")
     val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
@@ -81,20 +82,29 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
 
   override def getActiveContractSnapshot(
       untilExclusive: LedgerOffset,
-      filter: TransactionFilter): Future[LedgerSnapshot] =
+      filter: TransactionFilter
+  ): Future[LedgerSnapshot] =
     ledgerDao.getActiveContractSnapshot(untilExclusive, filter)
 
   override def getLedgerEntries(
       startInclusive: LedgerOffset,
-      endExclusive: LedgerOffset): Source[(LedgerOffset, LedgerEntry), NotUsed] =
+      endExclusive: LedgerOffset
+  ): Source[(LedgerOffset, LedgerEntry), NotUsed] =
     ledgerDao.getLedgerEntries(startInclusive, endExclusive)
+
+  override def getParty(party: Party): Future[Option[PartyDetails]] =
+    timedFuture(Metrics.getParty, ledgerDao.getParty(party))
 
   override def getParties: Future[List[PartyDetails]] =
     timedFuture(Metrics.getParties, ledgerDao.getParties)
 
+  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+    timedFuture(Metrics.getParties, ledgerDao.getParties(parties))
+
   override def getPartyEntries(
       startInclusive: LedgerOffset,
-      endExclusive: LedgerOffset): Source[(LedgerOffset, PartyLedgerEntry), NotUsed] =
+      endExclusive: LedgerOffset
+  ): Source[(LedgerOffset, PartyLedgerEntry), NotUsed] =
     ledgerDao.getPartyEntries(startInclusive, endExclusive)
 
   override def listLfPackages: Future[Map[PackageId, PackageDetails]] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -43,7 +43,6 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
       metrics.timer("daml.index.db.lookup_ledger_configuration")
     val lookupKey: Timer = metrics.timer("daml.index.db.lookup_key")
     val lookupActiveContract: Timer = metrics.timer("daml.index.db.lookup_active_contract")
-    val getParty: Timer = metrics.timer("daml.index.db.get_party")
     val getParties: Timer = metrics.timer("daml.index.db.get_parties")
     val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
@@ -91,9 +90,6 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
       endExclusive: LedgerOffset
   ): Source[(LedgerOffset, LedgerEntry), NotUsed] =
     ledgerDao.getLedgerEntries(startInclusive, endExclusive)
-
-  override def getParty(party: Party): Future[Option[PartyDetails]] =
-    timedFuture(Metrics.getParty, ledgerDao.getParty(party))
 
   override def getParties: Future[List[PartyDetails]] =
     timedFuture(Metrics.getParties, ledgerDao.getParties)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -5,6 +5,7 @@ package com.digitalasset.platform.store.dao
 
 import java.io.File
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.stream.scaladsl.{Sink, Source}
@@ -38,12 +39,13 @@ import com.digitalasset.ledger.api.domain.{
   Filters,
   InclusiveFilters,
   LedgerId,
+  PartyDetails,
   RejectionReason,
   TransactionFilter
 }
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.digitalasset.logging.LoggingContext.newLoggingContext
-import com.digitalasset.platform.store.entries.{ConfigurationEntry, LedgerEntry}
+import com.digitalasset.platform.store.entries.{ConfigurationEntry, LedgerEntry, PartyLedgerEntry}
 import com.digitalasset.platform.store.{DbType, FlywayMigrations, PersistenceEntry}
 import com.digitalasset.resources.Resource
 import com.digitalasset.testing.postgresql.PostgresAroundAll
@@ -404,6 +406,51 @@ class JdbcLedgerDaoSpec
           offset3 -> ConfigurationEntry
             .Accepted(s"refuse-config-$offset3", participantId, lastConfig)
         )
+      }
+    }
+
+    "store and retrieve all parties" in {
+      val alice = PartyDetails(
+        party = Ref.Party.assertFromString(s"Alice-${UUID.randomUUID()}"),
+        displayName = Some("Alice Arkwright"),
+        isLocal = true,
+      )
+      val bob = PartyDetails(
+        party = Ref.Party.assertFromString(s"Bob-${UUID.randomUUID()}"),
+        displayName = Some("Bob Bobertson"),
+        isLocal = true,
+      )
+      val participantId = Ref.ParticipantId.assertFromString("participant-0")
+      val offset1 = nextOffset()
+      for {
+        response <- ledgerDao.storePartyEntry(
+          offset1,
+          offset1 + 1,
+          None,
+          PartyLedgerEntry.AllocationAccepted(
+            submissionIdOpt = Some(UUID.randomUUID().toString),
+            participantId = participantId,
+            recordTime = Instant.now,
+            partyDetails = alice,
+          ),
+        )
+        _ = response should be(PersistenceResponse.Ok)
+        offset2 = nextOffset()
+        response <- ledgerDao.storePartyEntry(
+          offset2,
+          offset2 + 1,
+          None,
+          PartyLedgerEntry.AllocationAccepted(
+            submissionIdOpt = Some(UUID.randomUUID().toString),
+            participantId = participantId,
+            recordTime = Instant.now,
+            partyDetails = bob,
+          ),
+        )
+        _ = response should be(PersistenceResponse.Ok)
+        parties <- ledgerDao.getParties
+      } yield {
+        parties should contain allOf (alice, bob)
       }
     }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -477,11 +477,11 @@ class JdbcLedgerDaoSpec
           ),
         )
         _ = response should be(PersistenceResponse.Ok)
-        carolPartyDetails <- ledgerDao.getParty(party)
-        noPartyDetails <- ledgerDao.getParty(nonExistentParty)
+        carolPartyDetails <- ledgerDao.getParties(Seq(party))
+        noPartyDetails <- ledgerDao.getParties(Seq(nonExistentParty))
       } yield {
-        carolPartyDetails should be(Some(carol))
-        noPartyDetails should be(None)
+        carolPartyDetails should be(Seq(carol))
+        noPartyDetails should be(Seq.empty)
       }
     }
 


### PR DESCRIPTION
90% of this was required to add implicit party allocation to Sandbox Next™ (#4500), so I thought I'd just get the extra 10% done.

### Changelog

- [Ledger API] Added an endpoint to retrieve a single party's details at `com.digitalasset.ledger.api.v1.admin.PartyManagementService.GetParty`. Please consult the ledger API reference documentation for more information.
- [Ledger API] Added an endpoint to retrieve multiple parties's details at `com.digitalasset.ledger.api.v1.admin.PartyManagementService.GetParties`. Please consult the ledger API reference documentation for more information.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
