### PR TITLE
Add a warning for data X = Y {...}.

### DIFF
--- a/compiler/damlc/tests/daml-test-files/DataTypes.daml
+++ b/compiler/damlc/tests/daml-test-files/DataTypes.daml
@@ -7,13 +7,11 @@
 
 module DataTypes where
 
-data Rec = MkRec with x: Int
+data Rec = Rec with x: Int
 
-newtype RecNT = MkRecNT with x: Int
+newtype RecNT = RecNT with x: Int
 
--- NOTE(MH): This is translted to a variant with one constructor and _not_
--- to a record.
-data Unit = MkUnit{}
+data Unit = Unit{}
 
 data Tag = MkTag Int
 
@@ -40,11 +38,11 @@ eval = \case
 
 
 main = scenario do
-  assert $ (MkRec with x = 5).x == 5
+  assert $ (Rec with x = 5).x == 5
 
-  assert $ (MkRecNT with x = 7).x == 7
+  assert $ (RecNT with x = 7).x == 7
 
-  assert $ case MkUnit of {MkUnit -> True}
+  assert $ case Unit of {Unit -> True}
 
   assert $ untag (MkTag 3) == 3
 

--- a/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
@@ -3,6 +3,6 @@
 
 -- @WARN Record type X has constructor Y with different name. This may cause problems with cross-SDK upgrades. Possible solution: Change the constructor name to X
 
-module RecordCtorCheck where
+module RecordConstructorCheck where
 
 data X = Y {}

--- a/compiler/damlc/tests/daml-test-files/RecordCtorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordCtorCheck.daml
@@ -1,0 +1,8 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @WARN Record type X has constructor Y with different name. This may cause problems with cross-SDK upgrades. Possible solution: Change the constructor name to X
+
+module RecordCtorCheck where
+
+data X = Y {}


### PR DESCRIPTION
Part of #4718.

changelog_begin

- [DAML Compiler] The DAML compiler now emits a warning when you declare a single-constructor record type where the constructor name does not match the type name, such as ``data X = Y {...}``. This kind of type declaration can cause problems with cross-SDK upgrades because the record constructor name cannot be recorded in the DAML-LF representation. In the future, this warning will be upgraded to an error.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
