### PR TITLE
sandbox: Normalize language around listing all known parties.

### DIFF
--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -19,7 +19,7 @@ trait IndexPartyManagementService {
 
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 
-  def listParties(): Future[List[PartyDetails]]
+  def listKnownParties(): Future[List[PartyDetails]]
 
   def partyEntries(beginOffset: LedgerOffset.Absolute): Source[PartyEntry, NotUsed]
 }

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -71,7 +71,8 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
               .toScala
             _ <- index.use { ledgerDao =>
               eventually { (_, _) =>
-                ledgerDao.getParties
+                ledgerDao
+                  .listKnownParties()
                   .map(parties => parties.map(_.displayName))
                   .map(_ shouldBe Seq(Some("Alice")))
               }
@@ -118,7 +119,8 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
                 .toScala
               _ <- index.use { ledgerDao =>
                 eventually { (_, _) =>
-                  ledgerDao.getParties
+                  ledgerDao
+                    .listKnownParties()
                     .map(parties => parties.map(_.displayName))
                     .map(_ shouldBe Seq(Some("Alice"), Some("Bob"), Some("Carol")))
                 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -71,7 +71,7 @@ final class ApiPartyManagementService private (
       request: ListKnownPartiesRequest
   ): Future[ListKnownPartiesResponse] =
     partyManagementService
-      .listParties()
+      .listKnownParties()
       .map(ps => ListKnownPartiesResponse(ps.map(mapPartyDetails)))(DE)
       .andThen(logger.logErrorsOnCall[ListKnownPartiesResponse])(DE)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -275,8 +275,8 @@ abstract class LedgerBackedIndexService(
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     ledger.getParties(parties)
 
-  override def listParties(): Future[List[PartyDetails]] =
-    ledger.parties
+  override def listKnownParties(): Future[List[PartyDetails]] =
+    ledger.listKnownParties()
 
   override def partyEntries(beginOffset: LedgerOffset.Absolute): Source[PartyEntry, NotUsed] = {
     ledger.partyEntries(beginOffset.value.toLong).map {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -45,7 +45,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val lookupTransaction: Timer = metrics.timer("daml.index.lookup_transaction")
     val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
     val getParties: Timer = metrics.timer("daml.index.get_parties")
-    val parties: Timer = metrics.timer("daml.index.parties")
+    val listKnownParties: Timer = metrics.timer("daml.index.list_known_parties")
     val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
     val getLfPackage: Timer = metrics.timer("daml.index.get_lf_package")
@@ -90,8 +90,8 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     timedFuture(Metrics.getParties, ledger.getParties(parties))
 
-  override def parties: Future[List[PartyDetails]] =
-    timedFuture(Metrics.parties, ledger.parties)
+  override def listKnownParties(): Future[List[PartyDetails]] =
+    timedFuture(Metrics.listKnownParties, ledger.listKnownParties())
 
   override def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed] =
     ledger.partyEntries(beginOffset)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -262,7 +262,7 @@ class InMemoryLedger(
       parties.flatMap(party => acs.parties.get(party).toList).toList
     })
 
-  override def parties: Future[List[PartyDetails]] =
+  override def listKnownParties(): Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       acs.parties.values.toList
     })

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -22,7 +22,6 @@ import com.digitalasset.ledger.api.domain
 import com.digitalasset.ledger.api.domain.{
   ApplicationId,
   LedgerId,
-  PartyDetails,
   TransactionFilter,
   TransactionId
 }
@@ -106,11 +105,11 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
     ledgerDao
       .lookupTransaction(TransactionId.unwrap(transactionId))
 
-  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+  override def getParties(parties: Seq[Party]): Future[List[domain.PartyDetails]] =
     ledgerDao.getParties(parties)
 
-  override def parties: Future[List[domain.PartyDetails]] =
-    ledgerDao.getParties
+  override def listKnownParties(): Future[List[domain.PartyDetails]] =
+    ledgerDao.listKnownParties()
 
   override def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed] =
     dispatcher.startingAt(beginOffset, RangeSource(ledgerDao.getPartyEntries))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -67,7 +67,7 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
   // Party management
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 
-  def parties: Future[List[PartyDetails]]
+  def listKnownParties(): Future[List[PartyDetails]]
 
   def partyEntries(beginOffset: Long): Source[(Long, PartyLedgerEntry), NotUsed]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -119,7 +119,7 @@ trait LedgerReadDao extends ReportsHealth {
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
 
   /** Returns a list of all known parties. */
-  def getParties: Future[List[PartyDetails]]
+  def listKnownParties(): Future[List[PartyDetails]]
 
   def getPartyEntries(
       startInclusive: LedgerOffset,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -44,6 +44,7 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
     val lookupKey: Timer = metrics.timer("daml.index.db.lookup_key")
     val lookupActiveContract: Timer = metrics.timer("daml.index.db.lookup_active_contract")
     val getParties: Timer = metrics.timer("daml.index.db.get_parties")
+    val listKnownParties: Timer = metrics.timer("daml.index.db.list_known_parties")
     val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
     val deduplicateCommand: Timer = metrics.timer("daml.index.db.deduplicate_command")
@@ -91,11 +92,11 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
   ): Source[(LedgerOffset, LedgerEntry), NotUsed] =
     ledgerDao.getLedgerEntries(startInclusive, endExclusive)
 
-  override def getParties: Future[List[PartyDetails]] =
-    timedFuture(Metrics.getParties, ledgerDao.getParties)
-
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
     timedFuture(Metrics.getParties, ledgerDao.getParties(parties))
+
+  override def listKnownParties(): Future[List[PartyDetails]] =
+    timedFuture(Metrics.listKnownParties, ledgerDao.listKnownParties())
 
   override def getPartyEntries(
       startInclusive: LedgerOffset,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -14,9 +14,8 @@ import com.daml.ledger.participant.state.v1.{
 }
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
-import com.digitalasset.daml.lf.transaction.GenTransaction
 import com.digitalasset.daml.lf.transaction.Node._
-import com.digitalasset.daml.lf.transaction.Transaction
+import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import com.digitalasset.daml.lf.value.Value.{
   AbsoluteContractId,
   ContractInst,
@@ -191,7 +190,7 @@ class ImplicitPartyAdditionIT
           .ledgerEntries(None, None)
           .take(2)
           .runWith(Sink.seq)
-        parties <- ledger.parties
+        parties <- ledger.listKnownParties()
       } yield {
         createResult shouldBe SubmissionResult.Acknowledged
         exerciseResult shouldBe SubmissionResult.Acknowledged

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -448,7 +448,7 @@ class JdbcLedgerDaoSpec
           ),
         )
         _ = response should be(PersistenceResponse.Ok)
-        parties <- ledgerDao.getParties
+        parties <- ledgerDao.listKnownParties()
       } yield {
         parties should contain allOf (alice, bob)
       }


### PR DESCRIPTION
This renames methods backing the `ListKnownParties` request to from `parties`, `getParties` or `listParties` to `listKnownParties`.

### Changelog

- **[Ledger API Server]** Renamed two metrics:
  - `daml.index.parties` was renamed to `daml.index.list_known_parties`
  - `daml.index.db.get_parties` was renamed to `daml.index.db.list_known_parties`

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
