### PR TITLE
add commands to extract relevant changelogs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -17,13 +17,21 @@ CURRENT=$(cat LATEST | awk '{print $2}')
 STABLE_REGEX="\d+\.\d+\.\d+"
 VERSION_REGEX="^${STABLE_REGEX}(-snapshot\.\d{8}\.\d+(\.\d+)?\.[0-9a-f]{8})?$"
 
+release_sha() {
+    git show $1:LATEST | gawk '{print $1}'
+}
+
+release_version() {
+    git show $1:LATEST | gawk '{print $2}'
+}
+
 check() {
-    if ! echo $CURRENT | grep -q -P $VERSION_REGEX; then
+    if ! echo $(release_version HEAD) | grep -q -P $VERSION_REGEX; then
         echo "Invalid version number in LATEST file, needs manual correction."
         exit 1
     else
         echo -n "Valid version number ("
-        if is_stable $CURRENT; then
+        if is_stable $(release_version HEAD); then
             echo -n "stable"
         else
             echo -n "snapshot"
@@ -31,7 +39,6 @@ check() {
         echo ")."
     fi
 }
-
 
 is_stable() {
     local version="$1"
@@ -44,18 +51,44 @@ make_snapshot() {
     local number_of_commits=$(git rev-list --count $sha)
     local commit_sha_8=$(git log -n1 --format=%h --abbrev=8 $sha)
     local prerelease="snapshot.$commit_date.$number_of_commits.0.$commit_sha_8"
-    if is_stable "$CURRENT"; then
-        local stable="$CURRENT"
+    if is_stable "$(release_version HEAD)"; then
+        local stable="$(release_version HEAD)"
     else
-        local stable=$(echo "$CURRENT" | grep -o -P "^$STABLE_REGEX")
+        local stable=$(echo "$(release_version HEAD)" | grep -o -P "^$STABLE_REGEX")
     fi
     echo "$sha $stable-$prerelease" > LATEST
     echo "Updated LATEST file."
 }
 
+parse_range() {
+    case $1 in
+        head)
+            git rev-parse HEAD
+        ;;
+        latest)
+            release_sha HEAD
+        ;;
+        previous)
+            release_sha $(git log -n2 --format=%H LATEST | sed 1d)
+        ;;
+        stable)
+            for sha in $(git log --format=%H LATEST | sed 1d); do
+                if is_stable $(release_version $sha); then
+                    release_sha $sha
+                    break
+                fi
+            done
+        ;;
+        *)
+            display_help
+            exit 1
+        ;;
+    esac
+}
+
 display_help() {
     cat <<EOF
-This script is meant to help with managing the LATEST file. Usage:
+This script is meant to help with managing releases. Usage:
 
 $0 snapshot SHA
         Updates the LATEST file to point to the given SHA (which must be a
@@ -63,12 +96,35 @@ $0 snapshot SHA
         version defined in LATEST is already a snapshot, keeps the stable part
         of the version unchanged; otherwise, increments the patch number.
 
+$0 check
+        Checks that the LATEST file is well-formed and prints a message saying
+        whether the latest release is considered stable or snapshot.
+
+$0 changes <start> <end>
+        Prints the changes between start and end. In this context, possible
+        values are, in order:
+          head
+              The current commit.
+          latest
+              The commit pointed at by the LATEST file in the current commit.
+          previous
+              The most recent release (stable or snapshot) before the current
+              one.
+          stable
+              The most recent stable release before the current one.
+        Specifying them out of order is not supported.
+
 Any other invocation will display this help message.
 
 Note: at the moment, changing the version string for a stable release is left
 as a manual exercice, but that may change in the future.
 EOF
 }
+
+if [ -z "${1+x}" ]; then
+    display_help
+    exit 1
+fi
 
 case $1 in
     snapshot)
@@ -79,13 +135,21 @@ case $1 in
         else
             display_help
         fi
-        ;;
+    ;;
     check)
         check
-        ;;
+    ;;
+    changes)
+        if [ -z "${2+x}" ] || [ -z "${3+x}" ]; then
+            display_help
+            exit 1
+        else
+            ./unreleased.sh $(parse_range $2)..$(parse_range $3)
+        fi
+    ;;
     *)
         display_help
-        ;;
+    ;;
 esac
 
 trap - EXIT

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -17,7 +17,13 @@ latest commit on master.
 
 1. **[STABLE]** Coordinate with the product and marketing teams to define
    release highlights, tweets, blog posts, as well as timeline for publishing
-   the release. Define a version number, `$VERSION`.
+   the release. Define a version number, `$VERSION`. The following command may
+   be useful as a starting point; it will list all changes between the previous
+   stable release and the latest snapshot release:
+
+   ```
+   ./release.sh changes stable latest
+   ```
 
 1. Pull the latest master branch of the `daml` repository and create a new,
    clean branch off it. For a snapshot, run `./release.sh snapshot HEAD`; for
@@ -170,6 +176,16 @@ latest commit on master.
    both the changes in this release (i.e. since the last snapshot) and the
    complete list of changes since the last stable release. Use the raw output
    of `unreleased.sh`.
+
+   You can produce the changes since the previous (snapshot or stable) release
+   by running:
+   ```
+   ./release.sh changes previous latest
+   ```
+   and the changes between the latest stable and the previous release with:
+   ```
+   ./release.sh changes stable previous
+   ```
 
 1. **[STABLE]** Coordinate with product (& marketing) for the relevant public
    announcements (public Slack, Twitter, etc.).


### PR DESCRIPTION
In the current state of the release instructions, the person in charge of the release has to figure out how to produce the changelog. This PR adds more specific (and hopefully simpler) instructions for producing relevant changelogs.

CHANGELOG_BEGIN
CHANGELOG_END