### PR TITLE
skip testing release script after making a release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,7 @@ jobs:
           eval "$(./dev-env/bin/dade-assist)"
           bazel build //release:release
           ./bazel-bin/release/release --release-dir "$(mktemp -d)"
+        condition: and(succeeded(), ne(variables['is_release'], 'true'))
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 


### PR DESCRIPTION
Currently, on Linux, after the normal build, we try running the release script (in "dry run" mode). This is to check that the release script not only compiles, but actually runs. To be honest I'm not entirely sure why we do that as a separate step (i.e. why does `bazel test //...` not give us confidence about this script?), but the point of this PR is that, while there may be some benefit in running this script on normal PRs to check that we have not broken the release step, there is absolutely no point in running it _on a release build_, i.e. right after we've used the same script in "real" ("wet run"? :thinking:) mode.

CHANGELOG_BEGIN
CHANGELOG_END