### PR TITLE
hopefully fix Azure pipelines github tag release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,10 +266,12 @@ jobs:
           gitHubConnection: 'garyverhaegen-da'
           repositoryName: '$(Build.Repository.Name)'
           action: 'create'
-          target: '$(Build.SourceVersion)'
-          tagSource: 'auto'
+          target: '$(release_sha)'
+          tagSource: 'manual'
+          tag: 'v$(release_tag)'
           assets: $(Build.StagingDirectory)/release/*
           assetUploadMode: 'replace'
+          title: 'v$(release_tag)'
           addChangeLog: false
           isPrerelease: true
         condition: not(eq(variables['skip-github'], 'TRUE'))


### PR DESCRIPTION
Maybe. If I'm reading [that](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops) right.

CHANGELOG_BEGIN
CHANGELOG_END