### PR TITLE
retry releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -15,7 +15,7 @@ trap uhoh EXIT
 
 CURRENT=$(cat LATEST | awk '{print $2}')
 STABLE_REGEX="\d+\.\d+\.\d+"
-VERSION_REGEX="^${STABLE_REGEX}(-snapshot\.\d{8}\.\d+\.[0-9a-f]{8})?$"
+VERSION_REGEX="^${STABLE_REGEX}(-snapshot\.\d{8}\.\d+(\.\d+)?\.[0-9a-f]{8})?$"
 
 check() {
     if ! echo $CURRENT | grep -q -P $VERSION_REGEX; then
@@ -43,7 +43,7 @@ make_snapshot() {
     local commit_date=$(git log -n1 --format=%cd --date=format:%Y%m%d $sha)
     local number_of_commits=$(git rev-list --count $sha)
     local commit_sha_8=$(git log -n1 --format=%h --abbrev=8 $sha)
-    local prerelease="snapshot.$commit_date.$number_of_commits.$commit_sha_8"
+    local prerelease="snapshot.$commit_date.$number_of_commits.0.$commit_sha_8"
     if is_stable "$CURRENT"; then
         local stable="$CURRENT"
     else


### PR DESCRIPTION
This PR changes the release version format for snapshot releases to allow for an optional "build number", i.e. "how many times have we screwed up this release before this attempt?".

Adding this to the version string should be fine because:

- It is a number, so GHC will be happy.
- It is dot-separated and (manually) incrementing, so all three formats will sort it correctly.
- The SemVer->GHC conversion only looks at the beginning and ending of the snapshot string, and this changes the middle.

This is necessary because sometimes we screw up releases (e.g. #4902), but also because sometimes releases screw themselves up by somehow corrupting the Windows cache, and so far changing the version number ahs been the only way out of that. So far that has meant changing the target commit, but that's a very poor reason to choose a target commit.

We should not ahve to include additional code in a release just because our release process is flaky.

CHANGELOG_BEGIN
CHANGELOG_END