### PR TITLE
Fix CreatedEvent Protobuf documentation

### DIFF
--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/event.proto
@@ -57,11 +57,12 @@ message CreatedEvent {
   // Required
   Record create_arguments = 4;
 
-  // The parties that are notified of this event. For `CreatedEvent`s,
-  // these are the intersection of the stakeholders of the contract in
-  // question and the parties specified in the `TransactionFilter`. The
-  // stakeholders are the union of the signatories and the observers of
-  // the contract.
+  // The parties that are notified of this event. When a `CreatedEvent`
+  // is returned as part of a transaction tree, this will include all
+  // the parties specified in the `TransactionFilter` that are informees
+  // of the event. If served as part of a flat transaction those will
+  // be limited to all parties specified in the `TransactionFilter` that
+  // are stakeholders of the contract (i.e. either signatories or observers).
   // Required
   repeated string witness_parties = 5;
 


### PR DESCRIPTION
CHANGELOG_BEGIN
[Documentation] Ledger API documentation clarifies how witness_parties
are determined depending on whether CreatedEvents are served as part of
the flat or full transaction stream.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
