### PR TITLE
Include Bazel patch to mark tests as exclusive

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -65,6 +65,9 @@ conformance_test(
     ],
     runner = "@//bazel_tools/client_server/runner:runner",
     server = ":canton-test-runner-with-dependencies",
+    # NOTE (MK): Canton tries to access ~/.ammonite/cache for the coursier cache which fails with sandboxing
+    # and caching. This might be fixable by overriding COURSIER_CACHE.
+    tags = ["local"],
     test_tool_args = [
         "--verbose",
         "--include=SemanticTests",

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -28,6 +28,21 @@ let
         wrapProgram $out/bin/pg_tmp --prefix PATH : ${pkgs.postgresql_9_6}/bin:$out/bin
       '';
     });
+    bazel = pkgs.bazel.overrideAttrs(oldAttrs: {
+      patches = oldAttrs.patches ++ [
+        # Note (MK)
+        # This patch enables caching of tests marked as `exclusive`. It got apparently
+        # rolled back because it caused problems internally at Google but it’s unclear
+        # what is actually failing and it seems to work fine for us.
+        # See https://github.com/bazelbuild/bazel/pull/8983/files#diff-107db037d4a55f2421fed9ed5c6cc31b
+        # for the only change that actually affects the code in this patch. The rest is tests
+        # and/or documentation.
+        (pkgs.fetchurl {
+          url = "https://patch-diff.githubusercontent.com/raw/bazelbuild/bazel/pull/8983.patch";
+          sha256 = "1j25bycn9q7536ab3ln6yi6zpzv2b25fwdyxbgnalkpl2dz9idb7";
+        })
+      ];
+    });
   };
 
   nixpkgs = import src {


### PR DESCRIPTION
This should hopefully avoid rerunning the conformance tests as often
as we do now. While this patch is not applied on Windows (since we get
it from nix), this is not really an issue since most of the exclusive
tests (in particular, all conformance tests) are disabled on Windows
anyway.

I’ve tested this locally accross a couple of runs and I get the
caching I want and looking at the code in the patch, the change looks
very reasonable. I somewhat wonder if it just broke internally at
google because they marked tests as exclusive that should have gotten
no-cache.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
