### PR TITLE
Add lazy flattening function to Relation

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
@@ -38,9 +38,9 @@ object Relation {
 
     def flatten[A, B](relation: Relation[A, B]): Iterator[(A, B)] =
       for {
-        key <- relation.keysIterator
-        value <- relation(key)
-      } yield (key, value)
+        kvs <- relation.iterator
+        value <- kvs._2
+      } yield (kvs._1, value)
   }
 
 }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Relation.scala
@@ -35,6 +35,12 @@ object Relation {
 
       mutMap.toMap
     }
+
+    def flatten[A, B](relation: Relation[A, B]): Iterator[(A, B)] =
+      for {
+        key <- relation.keysIterator
+        value <- relation(key)
+      } yield (key, value)
   }
 
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RelationTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RelationTest.scala
@@ -44,4 +44,10 @@ class RelationTest extends PropSpec with Matchers with PropertyChecks {
       }
     }
   }
+
+  property("flattening is the inverse of grouping") {
+    forAll { m: Map[Int, Set[Char]] =>
+      flatten(m).toSeq.groupBy(_._1).mapValues(_.map(_._2).toSet) shouldEqual m
+    }
+  }
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RelationTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RelationTest.scala
@@ -45,9 +45,13 @@ class RelationTest extends PropSpec with Matchers with PropertyChecks {
     }
   }
 
-  property("flattening is the inverse of grouping") {
+  property("flattening is the inverse of grouping for non empty relations") {
     forAll { m: Map[Int, Set[Char]] =>
-      flatten(m).toSeq.groupBy(_._1).mapValues(_.map(_._2).toSet) shouldEqual m
+      // an empty map and a map with exclusively empty values represent
+      // the same relationship but the underlying structure is different
+      whenever(m.values.forall(_.nonEmpty)) {
+        flatten(m).toSeq.groupBy(_._1).mapValues(_.map(_._2).toSet) shouldEqual m
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a `flatten` function to produce and iterator from a `Relation` (i.e. a `Map[A, Set[B]]`) that is each element in the set value paired with the corresponding key. Inverse of grouping.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
