### PR TITLE
Enable caching and sandboxing for canton ledger API test tool

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -65,9 +65,6 @@ conformance_test(
     ],
     runner = "@//bazel_tools/client_server/runner:runner",
     server = ":canton-test-runner-with-dependencies",
-    # NOTE (MK): Canton tries to access ~/.ammonite/cache for the coursier cache which fails with sandboxing
-    # and caching. This might be fixable by overriding COURSIER_CACHE.
-    tags = ["local"],
     test_tool_args = [
         "--verbose",
         "--include=SemanticTests",

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -68,6 +68,14 @@ if [[ -z "$port_file" ]]; then
   exit 2
 fi
 
+# Change HOME since Canton uses ammonite in the default configuration
+# which tries to write to ~/.ammonite/cache which is read-only
+# when sandboxing is enabled.
+export HOME=$(mktemp -d)
+# ammonite calls System.getProperty('user.home') which does not
+# read $HOME.
+command+=("--wrapper_script_flag=--jvm_flag=-Duser.home=$HOME")
+
 # Redirect the Canton logs to a file for now, because they're really, really noisy.
 echo >&2 'Starting Canton...'
 "${command[@]}" &
@@ -84,6 +92,7 @@ function stop() {
   status=$?
   kill -INT "$pid" || :
   rm -f "$port_file" || :
+  rm -rf "$HOME" || :
   exit "$status"
 }
 


### PR DESCRIPTION
After some investigation, canton does not currently expose a nice way
to tell ammonite where it should write its files or even better use
the in-memory mode. However, ammonite respects $HOME so we can just
set that to a temp directory which fixes the issue.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
