### PR TITLE
kvutils: Switch from `Array[Byte]` to `ByteString`.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.on.memory.InMemoryLedgerReaderWriter._
 import com.daml.ledger.on.memory.InMemoryState.MutableLog
 import com.daml.ledger.participant.state.kvutils.api.{LedgerEntry, LedgerReader, LedgerWriter}
-import com.daml.ledger.participant.state.kvutils.{KeyValueCommitting, SequentialLogEntryId}
+import com.daml.ledger.participant.state.kvutils.{Bytes, KeyValueCommitting, SequentialLogEntryId}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.{
@@ -28,7 +28,6 @@ import com.digitalasset.ledger.api.health.{HealthStatus, Healthy}
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.OneAfterAnother
 import com.digitalasset.resources.ResourceOwner
-import com.google.protobuf.ByteString
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -54,7 +53,7 @@ final class InMemoryLedgerReaderWriter(
   override def currentHealth(): HealthStatus =
     Healthy
 
-  override def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult] =
+  override def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult] =
     committer.commit(correlationId, envelope)
 
   override def events(offset: Option[Offset]): Source[LedgerEntry, NotUsed] =
@@ -91,14 +90,12 @@ private class InMemoryLedgerStateOperations(
     extends BatchingLedgerStateOperations[Index] {
   override def readState(keys: Seq[Key]): Future[Seq[Option[Value]]] =
     Future.successful {
-      keys.map(keyBytes => state.get(ByteString.copyFrom(keyBytes)))
+      keys.map(keyBytes => state.get(keyBytes))
     }
 
   override def writeState(keyValuePairs: Seq[(Key, Value)]): Future[Unit] =
     Future.successful {
-      state ++= keyValuePairs.map {
-        case (keyBytes, valueBytes) => ByteString.copyFrom(keyBytes) -> valueBytes
-      }
+      state ++= keyValuePairs
     }
 
   override def appendToLog(key: Key, value: Value): Future[Index] =

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
@@ -50,5 +50,5 @@ object InMemoryState {
   type MutableState = mutable.Map[StateKey, StateValue] with ImmutableState
 
   type StateKey = ByteString
-  type StateValue = Array[Byte]
+  type StateValue = ByteString
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter._
 import com.daml.ledger.on.sql.queries.Queries
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.api.{LedgerEntry, LedgerReader, LedgerWriter}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
@@ -82,7 +83,7 @@ final class SqlLedgerReaderWriter(
       )
       .map { case (_, entry) => entry }
 
-  override def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult] =
+  override def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult] =
     committer.commit(correlationId, envelope)
 
   object SqlLedgerStateAccess extends LedgerStateAccess[Index] {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -27,7 +27,7 @@ final class H2Queries(override protected implicit val connection: Connection)
 
   override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
     Try {
-      SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
+      SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES (${key.toByteArray}, ${value.toByteArray})"
         .executeInsert()
       ()
     }.flatMap(_ => lastInsertId())

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -26,7 +26,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
   }
 
   override def insertRecordIntoLog(key: Key, value: Value): Try[Index] = Try {
-    SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value) RETURNING sequence_no"
+    SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES (${key.toByteArray}, ${value.toByteArray}) RETURNING sequence_no"
       .as(long("sequence_no").single)
   }
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -27,7 +27,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
 
   override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
     Try {
-      SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
+      SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES (${key.toByteArray}, ${value.toByteArray})"
         .executeInsert()
       ()
     }.flatMap(_ => lastInsertId())
@@ -39,13 +39,13 @@ final class SqliteQueries(override protected implicit val connection: Connection
       ()
     }.flatMap(_ => lastInsertId())
 
-  override protected val updateStateQuery: String =
-    s"INSERT INTO $StateTable VALUES ({key}, {value}) ON CONFLICT(key) DO UPDATE SET value = {value}"
-
   private def lastInsertId(): Try[Index] = Try {
     SQL"SELECT LAST_INSERT_ROWID() AS row_id"
       .as(long("row_id").single)
   }
+
+  override protected val updateStateQuery: String =
+    s"INSERT INTO $StateTable VALUES ({key}, {value}) ON CONFLICT(key) DO UPDATE SET value = {value}"
 }
 
 object SqliteQueries {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -81,6 +81,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter)(
 
   private def commit(
       correlationId: String,
-      submission: DamlSubmission): CompletionStage[SubmissionResult] =
-    FutureConverters.toJava(writer.commit(correlationId, Envelope.enclose(submission).toByteArray))
+      submission: DamlSubmission,
+  ): CompletionStage[SubmissionResult] =
+    FutureConverters.toJava(writer.commit(correlationId, Envelope.enclose(submission)))
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerEntry.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state.kvutils.api
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
 import com.daml.ledger.participant.state.v1.Offset
 
@@ -15,16 +16,16 @@ object LedgerEntry {
   final class LedgerRecord(
       val offset: Offset,
       val entryId: DamlLogEntryId,
-      val envelope: Array[Byte]
+      val envelope: Bytes,
   ) extends LedgerEntry
 
   final case class Heartbeat(offset: Offset, instant: Instant) extends LedgerEntry
 
   object LedgerRecord {
-    def apply(offset: Offset, entryId: DamlLogEntryId, envelope: Array[Byte]): LedgerRecord =
+    def apply(offset: Offset, entryId: DamlLogEntryId, envelope: Bytes): LedgerRecord =
       new LedgerRecord(offset, entryId, envelope)
 
-    def unapply(record: LedgerRecord): Option[(Offset, DamlLogEntryId, Array[Byte])] =
+    def unapply(record: LedgerRecord): Option[(Offset, DamlLogEntryId, Bytes)] =
       Some((record.offset, record.entryId, record.envelope))
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -3,13 +3,14 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.digitalasset.ledger.api.health.ReportsHealth
 
 import scala.concurrent.Future
 
 trait LedgerWriter extends ReportsHealth {
-  def commit(correlationId: String, envelope: Array[Byte]): Future[SubmissionResult]
+  def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult]
 
   def participantId: ParticipantId
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -3,6 +3,9 @@
 
 package com.daml.ledger.participant.state
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.google.protobuf.ByteString
+
 /** The participant-state key-value utilities provide methods to succintly implement
   * [[com.daml.ledger.participant.state.v1.ReadService]] and
   * [[com.daml.ledger.participant.state.v1.WriteService]] on top of ledger's that provide a key-value state storage.
@@ -24,8 +27,7 @@ package com.daml.ledger.participant.state
   * with them separately, even though both log entries and DAML state values may live in the same storage.
   */
 package object kvutils {
-  import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+  type Bytes = ByteString
 
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.validator
 
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.validator.LedgerStateOperations._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -81,6 +82,6 @@ abstract class NonBatchingLedgerStateOperations[LogResult](
 }
 
 object LedgerStateOperations {
-  type Key = Array[Byte]
-  type Value = Array[Byte]
+  type Key = Bytes
+  type Value = Bytes
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -18,6 +18,7 @@ import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.google.protobuf.ByteString
 
 import scala.collection.JavaConverters._
+import scala.collection.breakOut
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -215,12 +216,10 @@ object SubmissionValidator {
   private[validator] def serializeProcessedSubmission(
       logEntryAndState: LogEntryAndState): (RawBytes, RawKeyValuePairs) = {
     val (logEntry, damlStateUpdates) = logEntryAndState
-    val rawStateUpdates = damlStateUpdates
-      .map {
+    val rawStateUpdates: Vector[(RawBytes, RawBytes)] =
+      damlStateUpdates.map {
         case (key, value) => keyToBytes(key) -> valueToBytes(value)
-      }
-      .toSeq
-      .sortBy(_._1.toIterable)
+      }(breakOut)
     (Envelope.enclose(logEntry).toByteArray, rawStateUpdates)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -5,11 +5,13 @@ package com.daml.ledger.validator
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.logging.LoggingContext.newLoggingContext
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 class ValidatingCommitter[LogResult](
@@ -20,7 +22,7 @@ class ValidatingCommitter[LogResult](
 ) {
   def commit(
       correlationId: String,
-      envelope: Array[Byte],
+      envelope: Bytes,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
       validator
@@ -36,7 +38,7 @@ class ValidatingCommitter[LogResult](
             SubmissionResult.Acknowledged
           case Left(MissingInputState(keys)) =>
             SubmissionResult.InternalError(
-              s"Missing input state: ${keys.map(_.map("%02x".format(_)).mkString).mkString(", ")}")
+              s"Missing input state: ${keys.map(_.asScala.map("%02x".format(_)).mkString).mkString(", ")}")
           case Left(ValidationError(reason)) =>
             SubmissionResult.InternalError(reason)
         }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
@@ -3,13 +3,15 @@
 
 package com.daml.ledger.validator
 
+import com.daml.ledger.participant.state.kvutils.Bytes
+
 import scala.util.control.NoStackTrace
 
 sealed trait ValidationFailed extends RuntimeException with NoStackTrace
 
 object ValidationFailed {
 
-  final case class MissingInputState(keys: Seq[Array[Byte]]) extends ValidationFailed
+  final case class MissingInputState(keys: Seq[Bytes]) extends ValidationFailed
 
   final case class ValidationError(reason: String) extends ValidationFailed
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -7,7 +7,8 @@ import java.time.{Clock, Duration}
 import java.util.UUID
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateWriterSpec._
+import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope}
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.crypto
@@ -16,19 +17,20 @@ import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Transaction}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.mockito.MockitoSugar._
 import org.scalatest.{Assertion, WordSpec}
 
 import scala.collection.immutable.HashMap
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 
-class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
+class KeyValueParticipantStateWriterSpec extends WordSpec {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "participant state writer" should {
     "submit a transaction" in {
-      val transactionCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val transactionCaptor = captor[Bytes]
       val writer = createWriter(Some(transactionCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
       val recordTime = newRecordTime()
@@ -37,47 +39,49 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
         submitterInfo(recordTime, aParty),
         transactionMeta(recordTime),
         anEmptyTransaction)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
+      verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(transactionCaptor.getValue)(_.hasTransactionEntry)
     }
 
     "upload a package" in {
-      val packageUploadCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val packageUploadCaptor = captor[Bytes]
       val writer = createWriter(Some(packageUploadCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.uploadPackages(aSubmissionId, List.empty, sourceDescription = None)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
+      verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(packageUploadCaptor.getValue)(_.hasPackageUploadEntry)
     }
 
     "submit a configuration" in {
-      val configurationCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val configurationCaptor = captor[Bytes]
       val writer = createWriter(Some(configurationCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.submitConfiguration(newRecordTime().addMicros(10000), aSubmissionId, aConfiguration)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
+      verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(configurationCaptor.getValue)(_.hasConfigurationSubmission)
     }
 
     "allocate a party without hint" in {
-      val partyAllocationCaptor = ArgumentCaptor.forClass(classOf[Array[Byte]])
+      val partyAllocationCaptor = captor[Bytes]
       val writer = createWriter(Some(partyAllocationCaptor))
       val instance = new KeyValueParticipantStateWriter(writer)
 
       instance.allocateParty(hint = None, displayName = None, aSubmissionId)
-      verify(writer, times(1)).commit(anyString(), any[Array[Byte]]())
+      verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(partyAllocationCaptor.getValue)(_.hasPartyAllocationEntry)
     }
   }
 
-  private def verifyEnvelope(written: Array[Byte])(
-      assertion: DamlSubmission => Boolean): Assertion =
+  private def verifyEnvelope(written: Bytes)(assertion: DamlSubmission => Boolean): Assertion =
     Envelope.openSubmission(written) match {
       case Right(value) => assert(assertion(value) === true)
       case _ => fail()
     }
+}
+
+object KeyValueParticipantStateWriterSpec {
 
   private val aParty = Ref.Party.assertFromString("aParty")
 
@@ -89,9 +93,12 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with MockitoSugar {
 
   private val aConfiguration: Configuration = Configuration(1, TimeModel.reasonableDefault)
 
-  private def createWriter(captor: Option[ArgumentCaptor[Array[Byte]]] = None): LedgerWriter = {
+  private def captor[T](implicit classTag: ClassTag[T]): ArgumentCaptor[T] =
+    ArgumentCaptor.forClass(classTag.runtimeClass.asInstanceOf[Class[T]])
+
+  private def createWriter(captor: Option[ArgumentCaptor[Bytes]] = None): LedgerWriter = {
     val writer = mock[LedgerWriter]
-    when(writer.commit(anyString(), captor.map(_.capture()).getOrElse(any[Array[Byte]]())))
+    when(writer.commit(anyString(), captor.map(_.capture()).getOrElse(any[Bytes]())))
       .thenReturn(Future.successful(SubmissionResult.Acknowledged))
     when(writer.participantId).thenReturn(v1.ParticipantId.assertFromString("test-participant"))
     writer


### PR DESCRIPTION
Improves performance a little by reducing the number of conversions back and forth.

_ledger-on-sql_ still needs to convert things to byte arrays, unfortunately, but at least not all the time.

Also stops sorting the state updates, because… why?

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
