### PR TITLE
Rename EC auth cmdline options in line with the standard and document them.

### DIFF
--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -70,7 +70,7 @@ To start Sandbox with authentication based on `JWT <https://jwt.io/>`__ tokens,
 use one of the following command line options:
 
 - ``--auth-jwt-rs256-crt=<filename>``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA DSA with SHA-256) with the public key loaded from the given X.509 certificate file.
+  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
@@ -85,7 +85,7 @@ use one of the following command line options:
   and DER-encoded certificates (binary files) are supported.
 
 - ``--auth-jwt-rs256-jwks=<url>``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA DSA with SHA-256) with the public key loaded from the given `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
+  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
 
 .. warning::
 

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -70,17 +70,22 @@ To start Sandbox with authentication based on `JWT <https://jwt.io/>`__ tokens,
 use one of the following command line options:
 
 - ``--auth-jwt-rs256-crt=<filename>``.
-  The sandbox will expect all tokens to be signed with RSA256 with the public key loaded from the given X.509 certificate file.
+  The sandbox will expect all tokens to be signed with RS256 (RSA DSA with SHA-256) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+- ``--auth-jwt-es256-crt=<filename>``.
+  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certicates (binary files) are supported.
 
-- ``--auth-jwt-ec-crt=<filename>``.
-  The sandbox will expect all tokens to be signed with ECDSA512 with the public key loaded from the given X.509 certificate file.
+- ``--auth-jwt-es512-crt=<filename>``.
+  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512)     with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certicates (binary files) are supported.
+  and DER-encoded certificates (binary files) are supported.
 
 - ``--auth-jwt-rs256-jwks=<url>``.
-  The sandbox will expect all tokens to be signed with RSA256 with the public key loaded from the given `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
+  The sandbox will expect all tokens to be signed with RS256 (RSA DSA with SHA-256) with the public key loaded from the given `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
 
 .. warning::
 
@@ -142,17 +147,22 @@ which generates the following files:
 Generating EC keys
 ==================
 
-To generate EC (elliptic curve) keys for testing purposes, use the following command
+To generate EC (elliptic curve) 256-bit keys for testing purposes, use the following command
 
 .. code-block:: none
 
-  openssl req -x509 -nodes -days 3650 -newkey ec:<(openssl ecparam -name prime256v1) -keyout ecdsa.key -out ecdsa.crt
+  openssl req -x509 -nodes -days 3650 -newkey ec:<(openssl ecparam -name prime256v1) -keyout ecdsa256.key -out ecdsa256.crt
 
 which generates the following files:
 
-- ``ecdsa.key``: the private key in PEM/DER/PKCS#1 format
-- ``ecdsa.crt``: a self-signed certificate containing the public key, in PEM/DER/X.509 Certificate format
+- ``ecdsa256.key``: the private key in PEM/DER/PKCS#1 format
+- ``ecdsa256.crt``: a self-signed certificate containing the public key, in PEM/DER/X.509 Certificate format
 
+Similarly, you can use the following command for EC 512-bit keys:
+
+.. code-block:: none
+
+  openssl req -x509 -nodes -days 3650 -newkey ec:<(openssl ecparam -name secp521r1) -keyout ecdsa512.key -out ecdsa512.crt
 
 Command-line reference
 **********************

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -147,7 +147,7 @@ which generates the following files:
 Generating EC keys
 ==================
 
-To generate EC (elliptic curve) 256-bit keys for testing purposes, use the following command
+To generate keys to be used with ES256 for testing purposes, use the following command
 
 .. code-block:: none
 
@@ -158,7 +158,7 @@ which generates the following files:
 - ``ecdsa256.key``: the private key in PEM/DER/PKCS#1 format
 - ``ecdsa256.crt``: a self-signed certificate containing the public key, in PEM/DER/X.509 Certificate format
 
-Similarly, you can use the following command for EC 512-bit keys:
+Similarly, you can use the following command for ES512 keys:
 
 .. code-block:: none
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -183,7 +183,7 @@ object Cli {
                 .fromCrtFile(path)
                 .valueOr(err => sys.error(s"Failed to create RSA256 verifier: $err"))))))
 
-      opt[String]("auth-jwt-ec256-crt")
+      opt[String]("auth-jwt-es256-crt")
         .optional()
         .validate(v =>
           Either.cond(v.length > 0, (), "Certificate file path must be a non-empty string"))
@@ -195,7 +195,7 @@ object Cli {
                 .fromCrtFile(path, Algorithm.ECDSA256(_, null))
                 .valueOr(err => sys.error(s"Failed to create ECDSA256 verifier: $err"))))))
 
-      opt[String]("auth-jwt-ec512-crt")
+      opt[String]("auth-jwt-es512-crt")
         .optional()
         .validate(v =>
           Either.cond(v.length > 0, (), "Certificate file path must be a non-empty string"))


### PR DESCRIPTION
CHANGELOG_BEGIN
[Sandbox] Rename the `--auth-jwt-ec256-crt` command line option to `--auth-jwt-es256-crt`, `--auth-jwt-ec512-crt` to `--auth-jwt-es512-crt` and fix their docs
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
