### PR TITLE
Fix lf versions in the tests for buliding against newer LF versions

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -600,11 +600,12 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
               , "name: a"
               , "source: ."
               , "dependencies: [daml-prim, daml-stdlib]"
+              , "build-options: [--target=1.8]"
               ]
           writeFileUTF8 (tmpDir </> "a" </> "A.daml") $ unlines
               [ "daml 1.2 module A where"
               ]
-          withCurrentDirectory (tmpDir </> "a") $ callProcessSilent damlc ["build", "-o", tmpDir </> "a" </> "a.dar", "--target=1.8"]
+          withCurrentDirectory (tmpDir </> "a") $ callProcessSilent damlc ["build", "-o", tmpDir </> "a" </> "a.dar"]
 
           step "Building b"
           createDirectoryIfMissing True (tmpDir </> "b")
@@ -618,6 +619,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
               , "  - daml-stdlib"
               , "data-dependencies:"
               , "  - " <> show (tmpDir </> "a" </> "a.dar")
+              , "build-options: [--target=1.7]"
               ]
           writeFileUTF8 (tmpDir </> "b" </> "B.daml") $ unlines
               [ "daml 1.2 module B where"
@@ -634,11 +636,12 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
               , "name: a"
               , "source: ."
               , "dependencies: [daml-prim, daml-stdlib]"
+              , "build-options: [--target=1.8]"
               ]
           writeFileUTF8 (tmpDir </> "a" </> "A.daml") $ unlines
               [ "daml 1.2 module A where"
               ]
-          withCurrentDirectory (tmpDir </> "a") $ callProcessSilent damlc ["build", "-o", tmpDir </> "a" </> "a.dar", "--target=1.8"]
+          withCurrentDirectory (tmpDir </> "a") $ callProcessSilent damlc ["build", "-o", tmpDir </> "a" </> "a.dar"]
 
           step "Building b"
           createDirectoryIfMissing True (tmpDir </> "b")
@@ -651,6 +654,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
               , "  - daml-prim"
               , "  - daml-stdlib"
               , "  - " <> show (tmpDir </> "a" </> "a.dar")
+              , "build-options: [--target=1.7]"
               ]
           writeFileUTF8 (tmpDir </> "b" </> "B.daml") $ unlines
               [ "daml 1.2 module B where"


### PR DESCRIPTION
This makes sure that they won’t break once we switch defaults. For
consistency they are specified via `build-options` everywhere.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
