### PR TITLE
bump nix

### DIFF
--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -23,7 +23,7 @@ if [[ ! -e /nix ]]; then
   sudo mkdir -m 0755 /nix
   sudo chown "$(id -u):$(id -g)" /nix
 
-  curl -sfL https://nixos.org/releases/nix/nix-2.3.2/install | bash
+  curl -sfL https://nixos.org/releases/nix/nix-2.3.3/install | bash
 fi
 
 # shellcheck source=../dev-env/lib/ensure-nix


### PR DESCRIPTION
Today it looks like the nix servers refuse to serve the 2.3.2 installer.

```
$ curl -sL https://nixos.org/releases/nix/nix-2.3.2/install -i
HTTP/2 301
cache-control: public, max-age=0, must-revalidate
content-length: 64
content-type: text/plain; charset=utf-8
date: Wed, 11 Mar 2020 11:54:06 GMT
location: https://releases.nixos.org/nix/nix-2.3.2/install
age: 201
server: Netlify
x-nf-request-id: c5822544-1835-40bb-8576-a380a584fafb-38946782

HTTP/2 403
content-type: application/xml
date: Wed, 11 Mar 2020 11:57:27 GMT
server: AmazonS3
x-cache: Error from cloudfront
via: 1.1 f291c7a8655cbe888970e5f435898d0b.cloudfront.net (CloudFront)
x-amz-cf-pop: BRU50-C1
x-amz-cf-id: c3txvuz_uux9Xbw6QY14aQYDwZD-DsVBvpnYkCsRWQWnhcAqL7sRYQ==

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>349006793D9C5DBE</RequestId><HostId>lvm3fi9TydI5V/t70+jZIta28AmtzzJrbk3rBuZOFvQfThAqIo8v39ya41/21Or6/ztHZcrDfq4=</HostId></Error>
```

This breaks all of our macOS builds. This PR aims at working around that
by bumping the nix version, as at least locally that new URL works.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
