### PR TITLE
Fix tests not running with bazel test

### DIFF
--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
@@ -62,6 +62,8 @@ class ScalaCodeGenIT
   override implicit lazy val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = Span(20, Seconds), interval = Span(250, Millis))
 
+  // Needs a non-serial execution context because beforeAll() is blocking
+  // Does not have issues with Bazel, as test are not actually asynchronous due to the use of whenReady()
   override implicit def executionContext: ExecutionContext = ExecutionContext.global
 
   override protected def packageFiles: List[File] = List(

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallAuthTests.scala
@@ -16,7 +16,7 @@ import io.grpc.Status
 import io.grpc.stub.AbstractStub
 import org.scalatest.{Assertion, AsyncFlatSpec, Matchers}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 trait ServiceCallAuthTests
@@ -24,8 +24,6 @@ trait ServiceCallAuthTests
     with SandboxFixtureWithAuth
     with SuiteResourceManagementAroundAll
     with Matchers {
-
-  override implicit def executionContext: ExecutionContext = ExecutionContext.global
 
   def serviceCallName: String
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
@@ -24,7 +24,7 @@ import io.grpc.Status
 import org.scalatest.{Assertion, AsyncWordSpec, Inspectors, Matchers}
 import scalaz.syntax.tag._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -35,8 +35,6 @@ class CommandServiceBackPressureIT
     with SandboxFixture
     with TestCommands
     with SuiteResourceManagementAroundAll {
-
-  override implicit def executionContext: ExecutionContext = ExecutionContext.global
 
   private val commands = 50
 


### PR DESCRIPTION
Asynchronous scalatest tests that override `executionContext` silently do nothing when run through `bazel test`. This can only be seen by reading the test log:

```
Discovery starting.
Discovery completed in 2 seconds, 37 milliseconds.
Run starting. Expected test count is: 2

[...some log output of the test...]

Run completed in 28 seconds, 728 milliseconds.
Total number of tests run: 0
Suites: completed 2, aborted 0
Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
No tests were executed.
```

This change increases the run time of the affected tests. `CommandServiceBackPressureIT.scala` now takes 60sec instead of 30sec on my machine, but at least it now does something.