### PR TITLE
daml-assistant tests: fix flaky test on Windows

### DIFF
--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -340,7 +340,7 @@ testGetDispatchEnv = Tasty.testGroup "DA.Daml.Assistant.Env.getDispatchEnv"
     ]
 
 testAscendants :: Tasty.TestTree
-testAscendants = Tasty.testGroup "DA.Daml.Assistant.ascendants"
+testAscendants = Tasty.testGroup "DA.Daml.Project.Util.ascendants"
     [ Tasty.testCase "unit tests" $ do
         Tasty.assertEqual "empty path" ["."] (ascendants "")
         Tasty.assertEqual "curdir path" ["."] (ascendants ".")

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -362,7 +362,10 @@ testAscendants = Tasty.testGroup "DA.Daml.Assistant.ascendants"
                    head (ascendants p) == p)
     , Tasty.testProperty "tail . ascendants == ascendants . takeDirectory"
         (\p1 p2 -> let p = dropTrailingPathSeparator (p1 </> p2)
-                   in notNull p1 && notNull p2 && isRelative p2 ==>
+                   in notNull p1 && notNull p2 && p1 </> p2 /= p2 ==>
+                      -- We use `p1 </> p2 /= p2` instead of `isRelative p2`
+                      -- because, on Windows, `isRelative "\\foo" == True`,
+                      -- while `x </> "\\foo" = "\\foo"`.
                       tail (ascendants p) == ascendants (takeDirectory p))
     ]
 


### PR DESCRIPTION
```
bazel test //daml-assistant:test --test_arg=--quickcheck-replay=425714
```
failed on Windows in the test-case:
```
tail . ascendents == ascendents . takeDirectory
```
In that case the two path components given to the test case shrink to `p1 = "a"` and `p2 = "\\"`. Confusingly, on Windows
```
isRelative "\\" == True
```
while
```
"a" </> "\\" = "\\"
```
This is documented behaviour on Windows, see [1] and [2].

Using `p1 </> p2 /= p2` instead of `isRelative p2` works around this.

[1]: https://hackage.haskell.org/package/filepath-1.4.2.1/docs/System-FilePath-Posix.html#v:-60--47--62-
[2]: https://hackage.haskell.org/package/filepath-1.4.2.1/docs/System-FilePath-Posix.html#v:isRelative

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
