### PR TITLE
Client module import ideal syntax

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint/src/__tests__/test.ts
@@ -7,7 +7,7 @@ import { encode } from 'jwt-simple';
 import Ledger, { CreateEvent, ArchiveEvent, Event, Stream } from  '@daml/ledger';
 import pEvent from 'p-event';
 
-import * as buildAndLint from '@daml.js/build-and-lint-1.0.0'
+import buildAndLint from '@daml.js/build-and-lint-1.0.0'
 
 const LEDGER_ID = 'build-and-lint-test';
 const APPLICATION_ID = 'build-and-lint-test';


### PR DESCRIPTION
A follow up on https://github.com/digital-asset/daml/pull/4926. This realizes the "ideal syntax" of https://github.com/digital-asset/daml/issues/4832:
```typescript
import foo from "@daml.js/foo"
```

- Also takes the opportunity to reformat some lists in `writeEsLintConfig` to be conformant to the agreed convention