### PR TITLE
DAML-LF: introduce HexString to represents base16 array encoding

### DIFF
--- a/daml-lf/data/BUILD.bazel
+++ b/daml-lf/data/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//visibility:public",
     ],
     deps = [
+        "@maven//:com_google_guava_guava",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.digitalasset.daml.lf.data
 
+import com.google.common.io.BaseEncoding
 import scalaz.Equal
 
 sealed trait StringModule[T] {
@@ -25,6 +26,14 @@ sealed trait StringModule[T] {
   def toStringMap[V](map: Map[T, V]): Map[String, V]
 }
 
+sealed trait HexaStringModule[T <: String] extends StringModule[T] {
+
+  def encode(a: Array[Byte]): T
+
+  def decode(a: T): Array[Byte]
+
+}
+
 /** ConcatenableMatchingString are non empty US-ASCII strings built with letters, digits,
   * and some other (parameterizable) extra characters.
   * We use them to represent identifiers. In this way, we avoid
@@ -35,9 +44,7 @@ sealed trait StringModule[T] {
   * Those properties are heavily use to generate some ids by combining other existing
   * ids.
   */
-sealed trait ConcatenableStringModule[T <: String] extends StringModule[T] {
-
-  def encode(a: Array[Byte]): T
+sealed trait ConcatenableStringModule[T <: String, HS <: String] extends StringModule[T] {
 
   def fromLong(i: Long): T
 
@@ -46,24 +53,8 @@ sealed trait ConcatenableStringModule[T <: String] extends StringModule[T] {
   def concat(s: T, ss: T*): Either[String, T]
 
   def assertConcat(s: T, ss: T*): T
-}
 
-sealed trait UnionStringModule[T <: String, TA <: T, TB <: T] extends StringModule[T] {
-
-  def toEither(s: T): Either[TA, TB]
-
-  def isA(s: T): Boolean
-
-  def toA(s: T): Option[TA]
-
-  def assertToVA(s: T): TA
-
-  def isB(s: T): Boolean
-
-  def toB(s: T): Option[TB]
-
-  def assertToVB(s: T): TB
-
+  def fromHexaString(s: HS): T
 }
 
 sealed abstract class IdString {
@@ -74,6 +65,8 @@ sealed abstract class IdString {
   //
   // In a language like C# you'll need to use some other unicode char for `$`.
   type Name <: String
+
+  type HexaString <: String
 
   // Human-readable package names and versions.
   type PackageName <: String
@@ -101,14 +94,15 @@ sealed abstract class IdString {
   /** Identifiers for contracts */
   type ContractIdString <: String
 
+  val HexaString: HexaStringModule[HexaString]
   val Name: StringModule[Name]
-  val PackageName: ConcatenableStringModule[PackageName]
+  val PackageName: ConcatenableStringModule[PackageName, HexaString]
   val PackageVersion: StringModule[PackageVersion]
-  val Party: ConcatenableStringModule[Party]
-  val PackageId: ConcatenableStringModule[PackageId]
+  val Party: ConcatenableStringModule[Party, HexaString]
+  val PackageId: ConcatenableStringModule[PackageId, HexaString]
   val ParticipantId: StringModule[ParticipantId]
-  val LedgerString: ConcatenableStringModule[LedgerString]
-  val ContractIdString: ConcatenableStringModule[ContractIdString]
+  val LedgerString: ConcatenableStringModule[LedgerString, HexaString]
+  val ContractIdString: ConcatenableStringModule[ContractIdString, HexaString]
 }
 
 private sealed abstract class StringModuleImpl extends StringModule[String] {
@@ -129,6 +123,24 @@ private sealed abstract class StringModuleImpl extends StringModule[String] {
 
   final def toStringMap[V](map: Map[String, V]): Map[String, V] =
     map
+}
+
+private object HexaStringModuleImpl extends StringModuleImpl with HexaStringModule[String] {
+
+  private val baseEncode = BaseEncoding.base16().lowerCase()
+
+  override def fromString(str: String): Either[String, String] =
+    Either.cond(
+      HexaStringModuleImpl.baseEncode.canDecode(str),
+      str,
+      s"cannot parse HexaString $str"
+    )
+
+  override def encode(a: Array[Byte]): T =
+    HexaStringModuleImpl.baseEncode.encode(a)
+
+  override def decode(a: T): Array[Byte] =
+    HexaStringModuleImpl.baseEncode.decode(a)
 }
 
 private final class MatchingStringModule(string_regex: String) extends StringModuleImpl {
@@ -155,7 +167,7 @@ private final class ConcatenableMatchingStringModule(
     extraAllowedChars: Char => Boolean,
     maxLength: Int = Int.MaxValue
 ) extends StringModuleImpl
-    with ConcatenableStringModule[String] {
+    with ConcatenableStringModule[String, String] {
 
   override def fromString(s: String): Either[String, T] =
     if (s.isEmpty)
@@ -166,8 +178,6 @@ private final class ConcatenableMatchingStringModule(
       s.find(c => c > 0x7f || !(c.isLetterOrDigit || extraAllowedChars(c)))
         .fold[Either[String, T]](Right(s))(c =>
           Left(s"""non expected character 0x${c.toInt.toHexString} in "$s""""))
-
-  override def encode(a: Array[Byte]): String = a.map("%02x" format _).mkString
 
   override def fromLong(i: Long): T = i.toString
 
@@ -183,9 +193,13 @@ private final class ConcatenableMatchingStringModule(
   override def assertConcat(s: T, ss: T*): T =
     assertRight(concat(s, ss: _*))
 
+  override def fromHexaString(s: String): String = s
 }
 
 private[data] final class IdStringImpl extends IdString {
+
+  override type HexaString = String
+  override val HexaString: HexaStringModule[HexaString] = HexaStringModuleImpl
 
   // We are very restrictive with regards to identifiers, taking inspiration
   // from the lexical structure of Java:
@@ -199,7 +213,7 @@ private[data] final class IdStringImpl extends IdString {
   /** Package names are non-empty US-ASCII strings built from letters, digits, minus and underscore.
     */
   override type PackageName = String
-  override val PackageName: ConcatenableStringModule[PackageName] =
+  override val PackageName: ConcatenableStringModule[PackageName, HexaString] =
     new ConcatenableMatchingStringModule("-_".contains(_))
 
   /** Package versions are non-empty strings consisting of segments of digits (without leading zeros)
@@ -214,13 +228,13 @@ private[data] final class IdStringImpl extends IdString {
     * empty identifiers, escaping problems, and other similar pitfalls.
     */
   override type Party = String
-  override val Party: ConcatenableStringModule[Party] =
+  override val Party: ConcatenableStringModule[Party, HexaString] =
     new ConcatenableMatchingStringModule(":-_ ".contains(_))
 
   /** Reference to a package via a package identifier. The identifier is the ascii7
     * lowercase hex-encoded hash of the package contents found in the DAML LF Archive. */
   override type PackageId = String
-  override val PackageId: ConcatenableStringModule[PackageId] =
+  override val PackageId: ConcatenableStringModule[PackageId, HexaString] =
     new ConcatenableMatchingStringModule("-_ ".contains(_))
 
   /**
@@ -230,7 +244,7 @@ private[data] final class IdStringImpl extends IdString {
     */
   // We allow space because the navigator's applicationId used it.
   override type LedgerString = String
-  override val LedgerString: ConcatenableStringModule[LedgerString] =
+  override val LedgerString: ConcatenableStringModule[LedgerString, HexaString] =
     new ConcatenableMatchingStringModule("._:-#/ ".contains(_), 255)
 
   override type ParticipantId = String
@@ -240,6 +254,6 @@ private[data] final class IdStringImpl extends IdString {
     * Legacy contractIds.
     */
   override type ContractIdString = LedgerString
-  override val ContractIdString: ConcatenableStringModule[LedgerString] = LedgerString
+  override val ContractIdString: ConcatenableStringModule[LedgerString, HexaString] = LedgerString
 
 }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -15,8 +15,8 @@ object Ref {
   implicit def `Name equal instance`: Equal[Name] = Name.equalInstance
 
   /* Encoding of byte array */
-  type HexaString = IdString.HexaString
-  val HexaString = IdString.HexaString
+  type HexString = IdString.HexString
+  val HexString = IdString.HexString
 
   type PackageName = IdString.PackageName
   val PackageName: IdString.PackageName.type = IdString.PackageName

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -14,6 +14,10 @@ object Ref {
   val Name: IdString.Name.type = IdString.Name
   implicit def `Name equal instance`: Equal[Name] = Name.equalInstance
 
+  /* Encoding of byte array */
+  type HexaString = IdString.HexaString
+  val HexaString = IdString.HexaString
+
   type PackageName = IdString.PackageName
   val PackageName: IdString.PackageName.type = IdString.PackageName
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -240,7 +240,7 @@ case class PartialTransaction(
         Value.RelativeContractId(Value.NodeId(nextNodeIdx))
       )(
         hash =>
-          Value.AbsoluteContractId(Ref.ContractIdString.assertFromString("0" + hash.toHexaString))
+          Value.AbsoluteContractId(Ref.ContractIdString.assertFromString("0" + hash.toHexString))
       )
       val createNode = Node.NodeCreate(
         nodeSeed,

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -73,7 +73,6 @@ da_scala_library(
         ":value_java_proto",
         "//daml-lf/data",
         "//daml-lf/language",
-        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -20,9 +20,9 @@ final class Hash private (private val bytes: Array[Byte]) {
 
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexaString: Ref.HexaString = Ref.HexaString.encode(bytes)
+  def toHexString: Ref.HexString = Ref.HexString.encode(bytes)
 
-  override def toString: String = s"Hash($toHexaString)"
+  override def toString: String = s"Hash($toHexString)"
 
   override def equals(other: Any): Boolean =
     other match {
@@ -271,8 +271,8 @@ object Hash {
 
   }
 
-  def fromHexaString(s: Ref.HexaString): Either[String, Hash] = {
-    val bytes = Ref.HexaString.decode(s)
+  def fromHexString(s: Ref.HexString): Either[String, Hash] = {
+    val bytes = Ref.HexString.decode(s)
     Either.cond(
       bytes.length == underlyingHashLength,
       new Hash(bytes),
@@ -282,8 +282,8 @@ object Hash {
 
   def fromString(s: String): Either[String, Hash] =
     for {
-      hexaString <- Ref.HexaString.fromString(s)
-      hash <- fromHexaString(hexaString)
+      hexaString <- Ref.HexString.fromString(s)
+      hash <- fromHexString(hexaString)
     } yield hash
 
   def assertFromString(s: String): Hash =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -11,17 +11,16 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time, Utf8}
 import com.digitalasset.daml.lf.value.Value
-import com.google.common.io.BaseEncoding
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.control.NoStackTrace
 
 final class Hash private (private val bytes: Array[Byte]) {
 
   def toByteArray: Array[Byte] = bytes.clone()
 
-  def toHexaString: String = Hash.hexEncoding.encode(bytes)
+  def toHexaString: Ref.HexaString = Ref.HexaString.encode(bytes)
 
   override def toString: String = s"Hash($toHexaString)"
 
@@ -47,8 +46,6 @@ object Hash {
 
   private val version = 0.toByte
   private val underlyingHashLength = 32
-
-  private val hexEncoding = BaseEncoding.base16().lowerCase()
 
   private case class HashingError(msg: String) extends Exception with NoStackTrace
 
@@ -274,19 +271,20 @@ object Hash {
 
   }
 
-  def fromString(s: String): Either[String, Hash] = {
-    def error = s"Cannot parse hash $s"
-    try {
-      val bytes = hexEncoding.decode(s)
-      Either.cond(
-        bytes.length == underlyingHashLength,
-        new Hash(bytes),
-        error,
-      )
-    } catch {
-      case NonFatal(_) => Left(error)
-    }
+  def fromHexaString(s: Ref.HexaString): Either[String, Hash] = {
+    val bytes = Ref.HexaString.decode(s)
+    Either.cond(
+      bytes.length == underlyingHashLength,
+      new Hash(bytes),
+      s"Cannot parse hash $s",
+    )
   }
+
+  def fromString(s: String): Either[String, Hash] =
+    for {
+      hexaString <- Ref.HexaString.fromString(s)
+      hash <- fromHexaString(hexaString)
+    } yield hash
 
   def assertFromString(s: String): Hash =
     data.assertRight(fromString(s))

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -89,7 +89,7 @@ class HashSpec extends WordSpec with Matchers {
       val hash = "ea24627f5b014af67dbedb13d950e60be7f96a1a5bd9fb1a3b9a85b7fa9db4bc"
       val value = complexRecordT.inj(complexRecordV)
       val name = defRef("module", "name")
-      Hash.assertHashContractKey(name, value).toHexaString shouldBe hash
+      Hash.assertHashContractKey(name, value).toHexString shouldBe hash
     }
 
     "be deterministic and thread safe" in {
@@ -541,7 +541,7 @@ class HashSpec extends WordSpec with Matchers {
             .builder(Hash.Purpose.Testing, Hash.aCid2String)
             .addTypedValue(value)
             .build
-            .toHexaString
+            .toHexString
           s"${value.toString}$sep $hash"
         }
         .mkString("", sep, sep)
@@ -553,7 +553,7 @@ class HashSpec extends WordSpec with Matchers {
   "Hash.fromString" should {
     "convert properly string" in {
       val s = "01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086"
-      Hash.assertFromString(s).toHexaString shouldBe s
+      Hash.assertFromString(s).toHexString shouldBe s
     }
   }
 


### PR DESCRIPTION
In this PR we introduce a new `IdString` to type hexa decimal encoding of byte array.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
