### PR TITLE
do not send release notes to hubspot

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -40,7 +40,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
           AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-          HUBSPOT_TOKEN: $(HUBSPOT_TOKEN)
       - bash: |
           set -euo pipefail
           MESSAGE=$(git log --pretty=format:%s -n1)


### PR DESCRIPTION
@bame-da wants a more manual process where he can control exactly when release notes are posted, possibly in advance.

CHANGELOG_BEGIN
CHANGELOG_END