### PR TITLE
Make extractor and navigator work without client auth

### DIFF
--- a/extractor/src/main/scala/com/digitalasset/extractor/config/ConfigParser.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/config/ConfigParser.scala
@@ -48,6 +48,12 @@ object ConfigParser {
       tlsPem: Option[String] = None,
       tlsCrt: Option[String] = None,
       tlsCaCrt: Option[String] = None,
+      // tlsExplicit is used to handle the --tls flag
+      // which allows you to enable tls without any special certs,
+      // i.e., tls without client auth with the default root certs.
+      // If any certificates are set tls is enabled implicitly and
+      // tlsExplicit is redundant.
+      tlsExplicit: Boolean = false,
       accessTokenFile: Option[Path] = None,
   )
 
@@ -231,7 +237,7 @@ object ConfigParser {
         .optional()
         .text(
           s"TLS: The crt file to be used as the cert chain.\n${colSpacer}" +
-            s"Required if any other TLS parameters are set."
+            s"Required for client authentication."
         )
         .validate(validatePath(_, "The file specified via --crt does not exist"))
         .action { (path, c) =>
@@ -243,6 +249,13 @@ object ConfigParser {
         .validate(validatePath(_, "The file specified via --cacrt does not exist"))
         .action { (path, c) =>
           c.copy(tlsCaCrt = Some(path))
+        }
+
+      opt[Unit]("tls")
+        .optional()
+        .text("TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set")
+        .action { (_, c) =>
+          c.copy(tlsExplicit = true)
         }
 
       note("\nAuthentication:")
@@ -298,7 +311,7 @@ object ConfigParser {
       }
 
       val tlsConfig = TlsConfiguration(
-        enabled = cliParams.tlsPem.isDefined || cliParams.tlsCrt.isDefined || cliParams.tlsCaCrt.isDefined,
+        enabled = cliParams.tlsPem.isDefined || cliParams.tlsCrt.isDefined || cliParams.tlsCaCrt.isDefined || cliParams.tlsExplicit,
         keyCertChainFile = cliParams.tlsCrt.map(new File(_)),
         keyFile = cliParams.tlsPem.map(new File(_)),
         trustCertCollectionFile = cliParams.tlsCaCrt.map(new File(_))

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/TlsNoClientAuthSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/TlsNoClientAuthSpec.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.extractor
+
+import java.io.File
+import java.nio.file.Files
+
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.extractor.config.SnapshotEndSetting
+import com.digitalasset.extractor.services.ExtractorFixture
+import com.digitalasset.extractor.targets.TextPrintTarget
+import com.digitalasset.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.digitalasset.ledger.api.tls.TlsConfiguration
+import com.digitalasset.platform.sandbox.config.SandboxConfig
+import io.netty.handler.ssl.ClientAuth
+import org.scalatest._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+class TlsNoClientAuthSpec
+    extends FlatSpec
+    with Suite
+    with SuiteResourceManagementAroundAll
+    with ExtractorFixture
+    with Matchers {
+
+  override protected def darFile = new File(rlocation("extractor/VeryLargeArchive.dar"))
+
+  val List(serverCrt, serverPem, caCrt) = {
+    val dir = Files.createTempDirectory("TlsIT")
+    dir.toFile.deleteOnExit()
+    List("server.crt", "server.pem", "ca.crt").map { src =>
+      val target = dir.resolve(src)
+      target.toFile.deleteOnExit()
+      val stream = getClass.getClassLoader.getResourceAsStream("certificates/" + src)
+      Files.copy(stream, target)
+      Some(target.toFile)
+    }
+  }
+
+  override protected def config: SandboxConfig =
+    super.config
+      .copy(
+        tlsConfig = Some(
+          TlsConfiguration(
+            enabled = true,
+            serverCrt,
+            serverPem,
+            caCrt,
+            clientAuth = ClientAuth.NONE)))
+
+  "Extractor" should "be able to connect with TLS enabled but no client cert" in {
+    val config = baseConfig.copy(
+      ledgerPort = serverPort,
+      tlsConfig = TlsConfiguration(enabled = true, None, None, caCrt),
+      to = SnapshotEndSetting.Head,
+    )
+    val extractor =
+      new Extractor(config, TextPrintTarget)()
+
+    Await.result(extractor.run(), Duration.Inf) // as with ExtractorFixture#run
+    Await.result(extractor.shutdown(), Duration.Inf) // as with ExtractorFixture#kill
+    succeed
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -30,7 +30,7 @@ final case class TlsConfiguration(
       Some(
         GrpcSslContexts
           .forClient()
-          .keyManager(keyCertChainFile.orNull, keyFileOrFail)
+          .keyManager(keyCertChainFile.orNull, keyFile.orNull)
           .trustManager(trustCertCollectionFile.orNull)
           .build()
       )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -110,7 +110,7 @@ object Arguments {
 
       opt[String]("crt")
         .optional()
-        .text("TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set.")
+        .text("TLS: The crt file to be used as the cert chain. Required for client authentication.")
         .validate(path => validatePath(path, "The file specified via --crt does not exist"))
         .action(crtConfig)
 
@@ -122,6 +122,13 @@ object Arguments {
           arguments.copy(tlsConfig = arguments.tlsConfig.fold(
             Some(TlsConfiguration(true, None, None, Some(new File(path)))))(c =>
             Some(c.copy(trustCertCollectionFile = Some(new File(path)))))))
+
+      opt[Unit]("tls")
+        .optional()
+        .text("TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set")
+        .action((path, arguments) =>
+          arguments.copy(tlsConfig =
+            arguments.tlsConfig.fold(Some(TlsConfiguration(true, None, None, None)))(Some(_))))
 
       opt[Unit]("database")
         .hidden()


### PR DESCRIPTION
This depends on #4965, I’ll rebase as soon as that is merged.

This PR fixes the tls configuration to work if client auth is not
enabled and adds a `--tls` flag to extractor and navigator which
allows you to enable tls without overriding any certificates.

There is a test for extractor but none for navigator since there are
no tls tests at all afaict atm. I did however test it manually.

changelog_begin

- [Navigator] Navigator can now run a TLS enabled ledger without
  client authentication. You can enable TLS without any special
  certificates by passing ``--tls``.

- [Extractor] Extractor can now run a TLS enabled ledger without
  client authentication. You can enable TLS without any special
  certificates by passing ``--tls``.

changelog_end


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
