### PR TITLE
Remove expired deduplication entries

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -50,6 +50,8 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
     val getLfPackage: Timer = metrics.timer("daml.index.get_lf_package")
     val deduplicateCommand: Timer = metrics.timer("daml.index.deduplicate_command")
+    val removeExpiredDeduplicationData: Timer =
+      metrics.timer("daml.index.remove_expired_deduplication_data")
   }
 
   override def ledgerId: LedgerId = ledger.ledgerId
@@ -126,6 +128,11 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     timedFuture(
       Metrics.deduplicateCommand,
       ledger.deduplicateCommand(deduplicationKey, submittedAt, deduplicateUntil))
+
+  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+    timedFuture(
+      Metrics.removeExpiredDeduplicationData,
+      ledger.removeExpiredDeduplicationData(currentTime))
 }
 
 object MeteredReadOnlyLedger {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -115,7 +115,7 @@ private class ReadOnlySqlLedger(
   // of the deduplication time window.
   private val (deduplicationCleanupKillSwitch, deduplicationCleanupDone) =
     Source
-      .tick[Unit](0.millis, 100.millis, ())
+      .tick[Unit](0.millis, 10.minutes, ())
       .mapAsync[Unit](1)(_ => ledgerDao.removeExpiredDeduplicationData(Instant.now()))
       .viaMat(KillSwitches.single)(Keep.right[Cancellable, UniqueKillSwitch])
       .toMat(Sink.ignore)(Keep.both[UniqueKillSwitch, Future[Done]])

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -3,6 +3,9 @@
 
 package com.digitalasset.platform.index
 
+import java.time.Instant
+
+import akka.actor.Cancellable
 import akka.stream._
 import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
 import akka.{Done, NotUsed}
@@ -101,12 +104,31 @@ private class ReadOnlySqlLedger(
       .toMat(Sink.foreach(dispatcher.signalNewHead))(Keep.both[UniqueKillSwitch, Future[Done]])
       .run()
 
+  // Periodically remove all expired deduplication cache entries.
+  // The current approach is not ideal for multiple ReadOnlySqlLedgers sharing
+  // the same database (as is the case for a horizontally scaled ledger API server).
+  // In that case, an external process periodically clearing expired entries would be better.
+  //
+  // Deduplication entries are added by the submission service, which might use
+  // a different clock than the current clock (e.g., horizontally scaled ledger API server).
+  // This is not an issue, because applications are not expected to submit towards the end
+  // of the deduplication time window.
+  private val (deduplicationCleanupKillSwitch, deduplicationCleanupDone) =
+    Source
+      .tick[Unit](0.millis, 100.millis, ())
+      .mapAsync[Unit](1)(_ => ledgerDao.removeExpiredDeduplicationData(Instant.now()))
+      .viaMat(KillSwitches.single)(Keep.right[Cancellable, UniqueKillSwitch])
+      .toMat(Sink.ignore)(Keep.both[UniqueKillSwitch, Future[Done]])
+      .run()
+
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
   override def close(): Unit = {
     // Terminate the dispatcher first so that it doesn't trigger new queries.
     super.close()
+    deduplicationCleanupKillSwitch.shutdown()
     ledgerEndUpdateKillSwitch.shutdown()
+    Await.result(deduplicationCleanupDone, 10.seconds)
     Await.result(ledgerEndUpdateDone, 10.seconds)
     ()
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -423,7 +423,7 @@ class InMemoryLedger(
   override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
     Future.successful {
       this.synchronized {
-        commands.filter(p => p._2.deduplicateUntil.isAfter(currentTime))
+        commands.retain((_, v) => v.deduplicateUntil.isAfter(currentTime))
         ()
       }
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -419,4 +419,12 @@ class InMemoryLedger(
         }
       }
     }
+
+  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+    Future.successful {
+      this.synchronized {
+        commands.filter(p => p._2.deduplicateUntil.isAfter(currentTime))
+        ()
+      }
+    }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -142,6 +142,9 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Long, ledgerDao: 
       deduplicateUntil: Instant): Future[CommandDeduplicationResult] =
     ledgerDao.deduplicateCommand(deduplicationKey, submittedAt, deduplicateUntil)
 
+  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+    ledgerDao.removeExpiredDeduplicationData(currentTime)
+
   override def close(): Unit = {
     dispatcher.close()
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1685,6 +1685,19 @@ private class JdbcLedgerDao(
       }
     }
 
+  private val SQL_DELETE_EXPIRED_COMMANDS = SQL("""
+      |delete from participant_command_submissions
+      |where deduplicate_until < {currentTime}
+    """.stripMargin)
+
+  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+    dbDispatcher.executeSql("remove_expired_deduplication_data") { implicit conn =>
+      SQL_DELETE_EXPIRED_COMMANDS
+        .on("currentTime" -> currentTime)
+        .execute()
+      ()
+    }
+
   private val SQL_TRUNCATE_ALL_TABLES =
     SQL("""
         |truncate ledger_entries cascade;

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -148,12 +148,27 @@ trait LedgerReadDao extends ReportsHealth {
     * @param deduplicationKey The key used to deduplicate commands
     * @param submittedAt The time when the command was submitted
     * @param deduplicateUntil The time until which the command should be deduplicated
-    * @return
+    * @return whether the command is a duplicate or not
     */
   def deduplicateCommand(
       deduplicationKey: String,
       submittedAt: Instant,
       deduplicateUntil: Instant): Future[CommandDeduplicationResult]
+
+  /**
+    * Remove all expired deduplication entries. This method has to be called
+    * periodically to ensure that the deduplication cache does not grow unboundedly.
+    *
+    * @param currentTime The current time. This should use the same source of time as
+    *                    the `deduplicateUntil` argument of [[deduplicateCommand]].
+    *
+    * @return when DAO has finished removing expired entries. Clients do not
+    *         need to wait for the operation to finish, it is safe to concurrently
+    *         call deduplicateCommand().
+    */
+  def removeExpiredDeduplicationData(
+      currentTime: Instant,
+  ): Future[Unit]
 }
 
 trait LedgerWriteDao extends ReportsHealth {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -48,6 +48,8 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
     val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
     val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
     val deduplicateCommand: Timer = metrics.timer("daml.index.db.deduplicate_command")
+    val removeExpiredDeduplicationData: Timer =
+      metrics.timer("daml.index.db.remove_expired_deduplication_data")
   }
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
@@ -134,6 +136,11 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
     timedFuture(
       Metrics.deduplicateCommand,
       ledgerDao.deduplicateCommand(deduplicationKey, submittedAt, deduplicateUntil))
+
+  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+    timedFuture(
+      Metrics.removeExpiredDeduplicationData,
+      ledgerDao.removeExpiredDeduplicationData(currentTime))
 }
 
 class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: MetricRegistry)


### PR DESCRIPTION
This PR adds a periodic task to the `ReadOnlySqlLedger` (the backing store of the index) that clears expired command deduplication entries.

Fixes #4959.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
