### PR TITLE
Support TLS in DAML script and DAML triggers

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -106,6 +106,7 @@ $(location @openssl_dev_env//:openssl) x509 -req -in $(location client.csr) -CA 
     tools = [
         "@openssl_dev_env//:openssl",
     ],
+    visibility = ["//visibility:public"],
 )
 
 da_haskell_test(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -53,7 +53,7 @@ object RunnerMain {
           applicationId = ApplicationId.unwrap(applicationId),
           ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
           commandClient = CommandClientConfiguration.default,
-          sslContext = None,
+          sslContext = config.tlsConfig.flatMap(_.client),
           token = tokenHolder.flatMap(_.token),
         )
         val timeProvider: TimeProvider =

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -148,6 +148,33 @@ client_server_test(
 )
 
 client_server_test(
+    name = "test_wallclock_time_tls",
+    client = ":test_client_single_participant",
+    client_args = [
+        "-w",
+        "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:ca.crt))",
+    ],
+    client_files = [
+        "$(rootpath :script-test.dar)",
+    ],
+    data = [
+        ":script-test.dar",
+        "//daml-assistant/daml-helper:ca.crt",
+        "//daml-assistant/daml-helper:server.crt",
+        "//daml-assistant/daml-helper:server.pem",
+    ],
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "-w",
+        "--port=0",
+        "--crt $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:server.crt))",
+        "--pem $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:server.pem))",
+        "--client-auth=none",
+    ],
+    server_files = ["$(rootpath :script-test.dar)"],
+)
+
+client_server_test(
     name = "test_multiparticipant",
     client = ":test_client_multi_participant",
     client_args = [

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
@@ -104,7 +104,7 @@ object MultiParticipant {
           Map.empty
         )
 
-        val runner = new TestRunner(participantParams, dar, config.wallclockTime, None)
+        val runner = new TestRunner(participantParams, dar, config.wallclockTime, None, None)
         MultiTest(dar, runner).runTests()
         MultiPartyIdHintTest(dar, runner).runTests()
     }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -27,7 +27,10 @@ case class Config(
     ledgerPort: Int,
     darPath: File,
     wallclockTime: Boolean,
-    accessTokenFile: Option[Path])
+    accessTokenFile: Option[Path],
+    // We use the presence of a root CA as a proxy for whether to enable TLS or not.
+    rootCa: Option[File],
+)
 
 case class Test0(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:test0"))
@@ -322,12 +325,16 @@ object SingleParticipant {
       .action { (f, c) =>
         c.copy(accessTokenFile = Some(Paths.get(f)))
       }
+
+    opt[File]("cacrt")
+      .optional()
+      .action((d, c) => c.copy(rootCa = Some(d)))
   }
 
   private val applicationId = ApplicationId("DAML Script Tests")
 
   def main(args: Array[String]): Unit = {
-    configParser.parse(args, Config(0, null, false, None)) match {
+    configParser.parse(args, Config(0, null, false, None, None)) match {
       case None =>
         sys.exit(1)
       case Some(config) =>
@@ -343,7 +350,12 @@ object SingleParticipant {
         val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
 
         val runner =
-          new TestRunner(participantParams, dar, config.wallclockTime, tokenHolder.flatMap(_.token))
+          new TestRunner(
+            participantParams,
+            dar,
+            config.wallclockTime,
+            tokenHolder.flatMap(_.token),
+            config.rootCa)
         config.accessTokenFile match {
           case None =>
             TraceOrder(dar, runner).runTests()

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -80,7 +80,7 @@ object RunnerMain {
           applicationId = ApplicationId.unwrap(applicationId),
           ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
           commandClient = CommandClientConfiguration.default.copy(ttl = config.commandTtl),
-          sslContext = None,
+          sslContext = config.tlsConfig.flatMap(_.client),
           token = tokenHolder.flatMap(_.token)
         )
 

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -101,6 +101,34 @@ client_server_test(
     server_files = ["$(rootpath :acs.dar)"],
 )
 
+client_server_test(
+    name = "test_wallclock_time_tls",
+    timeout = "long",
+    client = ":test_client",
+    client_args = [
+        "-w",
+        "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:ca.crt))",
+    ],
+    client_files = [
+        "$(rootpath :acs.dar)",
+    ],
+    data = [
+        ":acs.dar",
+        "//daml-assistant/daml-helper:ca.crt",
+        "//daml-assistant/daml-helper:server.crt",
+        "//daml-assistant/daml-helper:server.pem",
+    ],
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "-w",
+        "--port=0",
+        "--crt $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:server.crt))",
+        "--pem $(rlocation $TEST_WORKSPACE/$(rootpath //daml-assistant/daml-helper:server.pem))",
+        "--client-auth=none",
+    ],
+    server_files = ["$(rootpath :acs.dar)"],
+)
+
 AUTH_TOKEN = "I_CAN_HAZ_AUTH"
 
 # This is a genrule so we can replace it by something nicer that actually generates the token


### PR DESCRIPTION
~~Depends on #4966, I’ll rebase as soon as that is merged.~~

This adds CLI parametrs for connecting via TLS following the scheme
used by navigator, extractor and `daml ledger`.

changelog_begin

- [DAML Script] Support TLS. Enable it by passing ``--tls``. You can
  set certificates for client authentication via ``--pem`` and
  ``-crt`` and a custom root CA for validating the server certificate
  via ``--cacrt``.

- [DAML Triggers - Experimental] Support TLS. Enable it by passing ``--tls``. You can
  set certificates for client authentication via ``--pem`` and
  ``-crt`` and a custom root CA for validating the server certificate
  via ``--cacrt``.

changelog_end
nn
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
