### PR TITLE
Deprecate useExercise

### DIFF
--- a/language-support/ts/daml-react/README.md
+++ b/language-support/ts/daml-react/README.md
@@ -47,23 +47,16 @@ Now you can use the following React hooks to interact with a DAML ledger:
 const party = useParty()
 ```
 
-`useExercise`
+`useLedger`
 -------------
-`useExercise` returns a function to exercise a choice by contract id.
+`useLedger` returns an instance of the `Ledger` class of @daml/ledger to interact with the DAML
+ledger.
 
 ```typescript
-const [exerciseChoice] = useExercise(ContractTemplate.ChoiceName)
-const onClick = () => exerciseChoice(contractId, argument)
+const ledger = useLedger()
+const newContract = await ledger.create(ContractTemplate, arguments)
 ```
 
-`useExerciseByKey`
-------------------
-`useExerciseByKey` returns a function to exercise a choice by contract key.
-
-```typescript
-const [exerciseByKey] = useExerciseByKey(ContractTemplate.ChoiceName)
-const onClick = () => exerciseByKey(key, argument)
-```
 
 `useQuery`
 ----------

--- a/language-support/ts/daml-react/README.md
+++ b/language-support/ts/daml-react/README.md
@@ -34,7 +34,7 @@ const App: React.FC = () => {
     >
       <MainScreen />
     </DamlLedger>
-}
+};
 ```
 
 Now you can use the following React hooks to interact with a DAML ledger:
@@ -44,17 +44,19 @@ Now you can use the following React hooks to interact with a DAML ledger:
 `useParty` returns the party, for which commands are currently send to the ledger.
 
 ```typescript
-const party = useParty()
+const party = useParty();
 ```
 
 `useLedger`
 -------------
-`useLedger` returns an instance of the `Ledger` class of @daml/ledger to interact with the DAML
+`useLedger` returns an instance of the `Ledger` class of [@daml/ledger](https://docs.daml.com/app-dev/bindings-ts/daml-ledger/index.html) to interact with the DAML
 ledger.
 
 ```typescript
-const ledger = useLedger()
-const newContract = await ledger.create(ContractTemplate, arguments)
+const ledger = useLedger();
+const newContract = await ledger.create(ContractTemplate, arguments);
+const archiveEvent = await Ledger.archive(ContractTemplate, contractId);
+const [choiceReturnValue, events] = await ledger.exercise(ContractChoice, contractId, choiceArguments);
 ```
 
 
@@ -65,7 +67,7 @@ template and specified field values of the contracts of that template.
 
 ```typescript
 const {contracts, isLoading} = useQuery(ContractTemplate, () => {field: value}, [dependency1,
-dependency2, ...])
+dependency2, ...]);
 ```
 
 `useReload`
@@ -73,8 +75,8 @@ dependency2, ...])
 `useReload` returns a function to reload the results of queries.
 
 ```typescript
-const reload = useReload()
-const onClick = reload
+const reload = useReload();
+const onClick = reload;
 ```
 
 `useStreamQuery`
@@ -83,7 +85,7 @@ const onClick = reload
 
 ```typescript
 const {contracts, isLoading} = useStreamQuery(ContractTemplate, () => {field: value}, [dependency1,
-dependency2, ...])
+dependency2, ...]);
 ```
 
 `useFetchByKey`
@@ -91,7 +93,7 @@ dependency2, ...])
 `useFetchByKey` returns the unique contract of a given template and a given contract key.
 
 ```typescript
-const {contract, isLoading} = useFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...])
+const {contract, isLoading} = useFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
 ```
 
 `useStreamFetchByKey`
@@ -100,7 +102,7 @@ const {contract, isLoading} = useFetchByKey(ContractTemplate, () => key, [depend
 the result.
 
 ```typescript
-const {contract, isLoading} = useStreamFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...])
+const {contract, isLoading} = useStreamFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
 ```
 
 

--- a/language-support/ts/daml-react/hooks.test.ts
+++ b/language-support/ts/daml-react/hooks.test.ts
@@ -6,10 +6,9 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import React, { ComponentType, useState } from 'react';
 import { renderHook, RenderHookResult, act } from '@testing-library/react-hooks';
-import DamlLedger, { useParty, useQuery, useFetchByKey } from './index';
+import DamlLedger, { useParty, useQuery, useFetchByKey, useLedger } from './index';
 import Ledger from '@daml/ledger';
 import { Template } from '@daml/types';
-import {useLedger} from './hooks';
 
 const mockConstructor = jest.fn();
 const mockQuery = jest.fn();

--- a/language-support/ts/daml-react/hooks.test.ts
+++ b/language-support/ts/daml-react/hooks.test.ts
@@ -7,7 +7,9 @@
 import React, { ComponentType, useState } from 'react';
 import { renderHook, RenderHookResult, act } from '@testing-library/react-hooks';
 import DamlLedger, { useParty, useQuery, useFetchByKey } from './index';
+import Ledger from '@daml/ledger';
 import { Template } from '@daml/types';
+import {useLedger} from './hooks';
 
 const mockConstructor = jest.fn();
 const mockQuery = jest.fn();
@@ -50,6 +52,11 @@ test('DamlLedger', () => {
 test('useParty', () => {
   const {result} = renderDamlHook(() => useParty());
   expect(result.current).toBe(PARTY);
+});
+
+test('useLedger', () => {
+  const {result} = renderDamlHook(() => useLedger())
+  expect(result.current).toBeInstanceOf(Ledger);
 });
 
 describe('useQuery', () => {

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Choice, ContractId, Template } from "@daml/types";
-import { CreateEvent, Query } from '@daml/ledger';
+import Ledger, { CreateEvent, Query } from '@daml/ledger';
 import { useState, useContext, useEffect } from "react";
 import { DamlLedgerState, DamlLedgerContext } from './context'
 
@@ -31,6 +31,13 @@ const useDamlState = (): DamlLedgerState => {
 export const useParty = () => {
   const state = useDamlState();
   return state.party;
+}
+
+/**
+ * React Hook that returns the Ledger instance to interact with the connected DAML ledger.
+ */
+export const useLedger = (): Ledger => {
+  return useDamlState().ledger;
 }
 
 /**
@@ -131,6 +138,7 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
  * @ignore
  */
 export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (cid: ContractId<T>, argument: C) => Promise<R> => {
+  console.log('useExercise is deprecated. Please use "useLedger" instead.');
   const state = useDamlState();
   const exercise = async (cid: ContractId<T>, argument: C) => {
     const [result] = await state.ledger.exercise(choice, cid, argument);
@@ -147,6 +155,7 @@ export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (c
  * @ignore
  */
 export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): (key: K, argument: C) => Promise<R> => {
+  console.log('useExerciseByKey is deprecated. Please use "useLedger" instead.');
   const state = useDamlState();
   const exerciseByKey = async (key: K, argument: C) => {
     const [result] = await state.ledger.exerciseByKey(choice, key, argument);

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -133,9 +133,8 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
 /**
  * React Hook that returns a function to exercise a choice by contract id.
  *
- * DEPRECATED. Use [[useLedger]] instead.
+ * @deprecated Use [[useLedger]] instead.
  *
- * @ignore
  */
 export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (cid: ContractId<T>, argument: C) => Promise<R> => {
   console.log('useExercise is deprecated. Please use "useLedger" instead.');
@@ -150,9 +149,8 @@ export const useExercise = <T extends object, C, R>(choice: Choice<T, C, R>): (c
 /**
  * React Hook that returns a function to exercise a choice by key.
  *
- * DEPRECATED. Use [[useLedger]] instead.
+ * @deprecated Use [[useLedger]] instead.
  *
- * @ignore
  */
 export const useExerciseByKey = <T extends object, C, R, K>(choice: Choice<T, C, R, K>): (key: K, argument: C) => Promise<R> => {
   console.log('useExerciseByKey is deprecated. Please use "useLedger" instead.');


### PR DESCRIPTION
We deprecate the react hooks 'useExercise' and 'useExerciseByKey' and offer a 'useLedger' hook instead.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
