### PR TITLE
fix: include assets for generated docs

### DIFF
--- a/language-support/ts/typedoc.bzl
+++ b/language-support/ts/typedoc.bzl
@@ -15,7 +15,7 @@ def ts_docs(pkg_name):
           # NOTE: we need the --ignoreCompilerErrors flag because we get errors when tsc is trying to
           # resolve the imported packages.
           $(location @language_support_ts_deps//typedoc/bin:typedoc) --out docs --ignoreCompilerErrors --readme README.md $(SRCS)
-          tar czf $@ docs
+          tar -hczf $@ docs
         """,
         visibility = ["//visibility:public"],
     ) if not is_windows else None


### PR DESCRIPTION
The generated documentation pages where missing assets like images because they are pointed to by links during the bazel build. Now tar dereferences those links and includes the additional assets in the package.
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
