### PR TITLE
Change daml2ts code generation for DAML enums

### DIFF
--- a/docs/source/daml2ts/index.rst
+++ b/docs/source/daml2ts/index.rst
@@ -189,23 +189,25 @@ The thing to note is how the definition of the ``Add`` case has given rise to a 
 Enums
 ~~~~~
 
-DAML enumerations map naturally to TypeScript.
+Given a DAML enumeration like this,
 
 .. code-block:: daml
    :linenos:
 
    data Color = Red | Blue | Yellow
 
-The companion TypeScript type is the following.
+the generated TypeScript will consist of a type declaration and the definition of an associated companion object.
 
 .. code-block:: typescript
    :linenos:
 
-   enum Color {
-     Red = 'Red',
-     Blue = 'Blue',
-     Yellow = 'Yellow',
-   }
+   type Color = | 'Red' | 'Blue' | 'Yellow'
+
+   const Color : {readonly Red: Color; readonly Blue: Color; readonly Yellow: Color} = {
+     Red: 'Red',
+     Blue: 'Blue',
+     Yellow: 'Yellow',
+   } as const;
 
 Templates and choices
 ~~~~~~~~~~~~~~~~~~~~~

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -32,6 +32,10 @@ template AllTypes with
     tuple: (Int, Text)
     enum: Color
     enumList: [Color]
+    enumList2: [Color]
+    optcol1: OptColor1
+    optcol2: OptColor2
+    optcol3: OptColor2
     variant: Expr Int
     optionalVariant: Expr Int
     sumProd : Quux
@@ -81,6 +85,18 @@ data Foo a b = Foo {
   y: Foo b a;
   z: b
 }
+
+-- Non-polymorhpic variant
+data OptColor1 =
+    Color1 Color
+  | Transparent1
+  deriving (Show, Eq)
+
+-- Non-polymorphic sum of products
+data OptColor2 =
+    Color2 {color2 : Color}
+  | Transparent2
+  deriving (Show, Eq)
 
 data Expr a =
     Lit a

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -238,6 +238,10 @@ test('create + fetch & exercise', async () => {
     tuple: {_1: '12', _2: 'mmm'},
     enum: buildAndLint.Main.Color.Red,
     enumList: [buildAndLint.Main.Color.Red, buildAndLint.Main.Color.Blue, buildAndLint.Main.Color.Yellow],
+    enumList2: ['Red', 'Blue', 'Yellow'],
+    optcol1: {tag: 'Transparent1', value: {}},
+    optcol2: {tag: 'Color2', value: {color2: 'Red'}}, // 'Red' is of type Color
+    optcol3: {tag: 'Color2', value: {color2: buildAndLint.Main.Color.Blue}}, // Color.Blue is of type 'Color'
     variant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
     optionalVariant: {tag: 'Add', value: {_1:{tag: 'Lit', value: '1'}, _2:{tag: 'Lit', value: '2'}}},
     sumProd: {tag: 'Corge', value: {x:'1', y:'Garlpy'}},


### PR DESCRIPTION
The issue is that it seems that the `enum` declaration is something of a misfeature in TypeScript and that better facilities exists for capturing their intent ([1], [2]).

- [1] 'Programming TypeScript' - Cherny, pg. 43
- [2] 'Effective TypeScript' - Vanderkam, pg. 197

### Before this PR:

Given,
```haskell
data Color = Red | Blue | Yellow
```
we generated,
```typescript
export enum Color {
  Red = 'Red',
  Blue = 'Blue',
  Yellow = 'Yellow',
}
daml.STATIC_IMPLEMENTS_SERIALIZABLE_CHECK<Color>(Color)
// eslint-disable-next-line @typescript-eslint/no-namespace
export namespace Color {
  export const decoder = () => jtv.oneOf<Color>(
    jtv.constant(Color.Red),
    jtv.constant(Color.Blue),
    jtv.constant(Color.Yellow),
  );
}
```

### After this PR:
Given,
```haskell
data Color = Red | Blue | Yellow
```
we generate,
```typescript
  export type Color = | 'Red' | 'Blue' | 'Yellow'
  export const Color: Serializable<Color> & {
    readonly Red: Color; readonly Blue: Color; readonly Green: Color;
  } = {
    Red: 'Red',
    Blue: 'Blue',
    Green: 'Green',
    decoder: () => jtv.oneOf<Color>(
      jtv.constant(Color.Red),
      jtv.constant(Color.Blue),
      jtv.constant(Color.Yellow)
    ),
  } as const;
  daml.STATIC_IMPLEMENTS_SERIALIZABLE_CHECK<Color>(Color)
```
- If accepted, this PR closes https://github.com/digital-asset/daml/issues/4883;
- The change in representation is tested by the existing 'build-and-lint' tests and new tests have been added testing that we can use color literals;
- Incidentally, additional tests were added to 'build-and-lint' addressing a gap in testing non-polymorphic variant and sums-of-products.
