### PR TITLE
saner scalafmt target

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -305,15 +305,15 @@ object SExpr {
                 SEApp(
                   SEVar(5),
                   Array(
-                    SEVar(4) /* z */,
-                    SEVar(2), /* y */
-                  ),
+                    SEVar(4), /* z */
+                    SEVar(2) /* y */
+                  )
                 ),
-                SEVar(1), /* ys */
-              ),
-            ),
+                SEVar(1) /* ys */
+              )
+            )
           )
-        ),
+        )
       )
 
     private val foldRBody: SExpr =
@@ -339,12 +339,12 @@ object SExpr {
                   /* foldr f z ys */
                   SEVar(5), /* f */
                   SEVar(4), /* z */
-                  SEVar(1), /* ys */
-                ),
-              ),
-            ),
-          ),
-        )),
+                  SEVar(1) /* ys */
+                )
+              )
+            )
+          )
+        ))
       )
 
     private val equalListBody: SExpr =
@@ -361,7 +361,7 @@ object SExpr {
             //   nil -> True
             //   default -> False
             SECase(SEVar(1)) of (SCaseAlt(SCPNil, SEValue.True),
-            SCaseAlt(SCPDefault, SEValue.False)),
+            SCaseAlt(SCPDefault, SEValue.False))
           ),
           // cons x xss ->
           SCaseAlt(
@@ -382,11 +382,11 @@ object SExpr {
                     SEApp(EqualList, Array(SEVar(7), SEVar(1), SEVar(3))),
                   ),
                   SCaseAlt(SCPPrimCon(PCFalse), SEValue.False)
-                ),
+                )
               )
-            ),
+            )
           )
-        ),
+        )
       )
   }
 

--- a/fmt.sh
+++ b/fmt.sh
@@ -57,6 +57,10 @@ USAGE
       dade_copyright_arg=check
       buildifier_target=//:buildifier
       ;;
+    --scalafmt-diff)
+      shift
+      scalafmt_args+=(--mode=diff --diff-branch=origin/master)
+      ;;
     *)
       echo "fmt.sh: unknown argument $1" >&2
       exit 1
@@ -115,7 +119,7 @@ done
 trap - EXIT
 
 # check for scala code style
-run ./scalafmt.sh "${scalafmt_args[@]:-}"
+run scalafmt "${scalafmt_args[@]:-}"
 
 # check for Bazel build files code formatting
 run bazel run "$buildifier_target"

--- a/language-support/scala/examples/iou-no-codegen/build.sbt
+++ b/language-support/scala/examples/iou-no-codegen/build.sbt
@@ -21,7 +21,7 @@ lazy val application = project
   .settings(
     name := "application",
     commonSettings,
-    libraryDependencies ++= applicationDependencies,
+    libraryDependencies ++= applicationDependencies
   )
 
 lazy val commonSettings = Seq(
@@ -35,10 +35,10 @@ lazy val commonSettings = Seq(
     "-Xlint:_,-unused"
   ),
   resolvers ++= daResolvers,
-  classpathTypes += "maven-plugin",
+  classpathTypes += "maven-plugin"
 )
 
 lazy val applicationDependencies = Seq(
   "com.daml.scala" %% "bindings" % daSdkVersion,
-  "com.daml.scala" %% "bindings-akka" % daSdkVersion,
+  "com.daml.scala" %% "bindings-akka" % daSdkVersion
 )

--- a/language-support/scala/examples/quickstart-scala/build.sbt
+++ b/language-support/scala/examples/quickstart-scala/build.sbt
@@ -22,7 +22,7 @@ lazy val `scala-codegen` = project
   .settings(
     name := "scala-codegen",
     commonSettings,
-    libraryDependencies ++= codeGenDependencies,
+    libraryDependencies ++= codeGenDependencies
   )
 
 lazy val `application` = project
@@ -30,7 +30,7 @@ lazy val `application` = project
   .settings(
     name := "application",
     commonSettings,
-    libraryDependencies ++= codeGenDependencies ++ applicationDependencies,
+    libraryDependencies ++= codeGenDependencies ++ applicationDependencies
   )
   .dependsOn(`scala-codegen`)
 // </doc-ref:modules>
@@ -47,15 +47,15 @@ lazy val commonSettings = Seq(
     "-Xlint:_,-unused"
   ),
   resolvers ++= daResolvers,
-  classpathTypes += "maven-plugin",
+  classpathTypes += "maven-plugin"
 )
 
 // <doc-ref:dependencies>
 lazy val codeGenDependencies = Seq(
-  "com.daml.scala" %% "bindings" % daSdkVersion,
+  "com.daml.scala" %% "bindings" % daSdkVersion
 )
 
 lazy val applicationDependencies = Seq(
-  "com.daml.scala" %% "bindings-akka" % daSdkVersion,
+  "com.daml.scala" %% "bindings-akka" % daSdkVersion
 )
 // </doc-ref:dependencies>

--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Copyright (c) 2020 The DAML Authors. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-set -eu -o pipefail
-
-cd "${0%/*}"
-scalafmt --mode=diff --diff-branch=origin/master "$@"


### PR DESCRIPTION
The current behaviour of our scalafmt checks compares for changes with origin/master, which means it is dependent on the state of the local git repository. This makes it non-reproducible.

Added to the fact that the master branch is not currently green as per our scalafmt rules, this makes it impossible to rebuild older commits, which in turn could interfere with our release process.

This PR does two things:

1. Fix our codebase to agree with our formatting rules.
2. Add a flag to `fmt.sh` to enable scalafmt's diff behaviour, and change the default to a full scan.

CHANGELOG_BEGIN
CHANGELOG_END