### PR TITLE
Explaining the DAML code in GSG

### DIFF
--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -61,7 +61,7 @@ The last part of the DAML model is the operation to add friends, called a *choic
 DAML contracts are *immutable* (can not be changed in place), so the only way to "update" one is to archive it and create a new instance.
 That is what the ``AddFriend`` choice does: after checking some preconditions, it archives the current user contract and creates a new one with the extra friend added to the list. Here is a quick explanation of the code: 
 
-    - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name, which is in this case ``AddFriend``.
+    - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name ``AddFriend``.
     - The return type of a choice is defined next. In this case it is ``ContractId User``.
     - After that we pass arguments for the choice with ``with`` keyword and for ``AddFriend`` this is  ``friend: Party``.
     - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case it would be the logged in user with the defined ``username``.  

--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -67,7 +67,7 @@ That is what the ``AddFriend`` choice does: after checking some preconditions, i
     - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case, it is the ``username`` party associated with the ``User`` contract.
     - The ``do`` keyword marks the start of the choice's body where its functionality will be written.
     - After passing some checks current contract is archived with ``archive self`` 
-    - New contract containig the new friend added to the list is creted with ``create this with friends = friend :: friends``
+    - A new ``User`` contract with the added friend is created.
 
 This information should be enough for understanding how choices work in this guide. More detailed information on choices can be found in :doc:`our docs </daml/reference/choices>`).
 

--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -63,7 +63,7 @@ That is what the ``AddFriend`` choice does: after checking some preconditions, i
 
     - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name ``AddFriend``.
     - The return type of a choice is defined next. In this case it is ``ContractId User``.
-    - After that we pass arguments for the choice with ``with`` keyword and for ``AddFriend`` this is  ``friend: Party``.
+    - After that we pass arguments for the choice with ``with`` keyword. Here this is the friend we are trying to add.
     - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case it would be the logged in user with the defined ``username``.  
     - The ``do`` keyword marks the start of the choice's body where its functionality will be written.
     - After passing some checks current contract is archived with ``archive self`` 

--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -59,14 +59,17 @@ The last part of the DAML model is the operation to add friends, called a *choic
   :end-before: -- ADDFRIEND_END
 
 DAML contracts are *immutable* (can not be changed in place), so the only way to "update" one is to archive it and create a new instance.
-That is what the ``AddFriend`` choice does: after checking some preconditions, it archives the current user contract and creates a new one with the extra friend added to the list.
+That is what the ``AddFriend`` choice does: after checking some preconditions, it archives the current user contract and creates a new one with the extra friend added to the list. Here is a quick explanation of the code: 
 
-There is some boilerplate to set up the choice (full details in the :doc:`DAML reference </daml/reference/choices>`):
+    - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name, which is in this case ``AddFriend``.
+    - The return type of a choice is defined next. In this case it is ``ContractId User``.
+    - After that we pass arguments for the choice with ``with`` keyword and for ``AddFriend`` this is  ``friend: Party``.
+    - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case it would be the logged in user with the defined ``username``.  
+    - The ``do`` keyword marks the start of the choice's body where its functionality will be written.
+    - After passing some checks current contract is archived with ``archive self`` 
+    - New contract containig the new friend added to the list is creted with ``create this with friends = friend :: friends``
 
-    - We make contract archival explicit by marking the choice as ``nonconsuming`` and then calling ``archive self`` in the body (choices which aren't ``nonconsuming`` archive or *consume* the contract implicitly).
-    - The return type is ``ContractId User``, a reference to the new contract for the calling code.
-    - The new ``friend: Party`` is passed as an argument to the choice.
-    - The ``controller``, the party able to exercise the choice, is the one named on the ``User`` contract.
+This information should be enough for understanding how choices work in this guide. More detailed information on choices can be found in :doc:`our docs </daml/reference/choices>`).
 
 Let's move on to how our DAML model is reflected and used on the UI side.
 

--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -64,7 +64,7 @@ That is what the ``AddFriend`` choice does: after checking some preconditions, i
     - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name ``AddFriend``.
     - The return type of a choice is defined next. In this case it is ``ContractId User``.
     - After that we pass arguments for the choice with ``with`` keyword. Here this is the friend we are trying to add.
-    - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case it would be the logged in user with the defined ``username``.  
+    - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case, it is the ``username`` party associated with the ``User`` contract.
     - The ``do`` keyword marks the start of the choice's body where its functionality will be written.
     - After passing some checks current contract is archived with ``archive self`` 
     - New contract containig the new friend added to the list is creted with ``create this with friends = friend :: friends``


### PR DESCRIPTION
Added a bit more explanation for the DAML code in GSG. The rationale behind explaining that `nonconsuming choice` is a single keyword is that:

- they will soon become default
- the GSG has only nonconsuming choices and wanted to leave out the nonconcusming vs. consuming out of the GSG 
- discussed the approach with @hurryabit 

resolves #4879

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
