### PR TITLE
Have 'daml new' generate a "package.json" for daml2ts support

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -13,6 +13,7 @@ da_haskell_library(
     ),
     hackage_deps = [
         "aeson",
+        "aeson-pretty",
         "async",
         "base",
         "bytestring",

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -55,6 +55,7 @@ import Data.Maybe
 import qualified Data.Map.Strict as Map
 import Data.List.Extra
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
 import DA.PortFile
 import qualified Data.Text as T
@@ -81,6 +82,7 @@ import Web.Browser
 import qualified Web.JWT as JWT
 import Data.Aeson
 import Data.Aeson.Text
+import Data.Aeson.Encode.Pretty
 
 import DA.Directory
 import DA.Daml.Helper.Ledger as Ledger
@@ -638,6 +640,13 @@ runNew targetFolder templateNameM pkgDeps dataDeps = do
                    $ configTemplate
         writeFileUTF8 configPath config
         removeFile configTemplatePath
+
+    -- Write an empty 'package.json' for daml2ts support.
+    BSL.writeFile (targetFolder </> "package.json") $
+      encodePretty (object
+                    [ "private" .= True
+                    , "workspaces" .= ([] :: [T.Text])
+                    ])
 
     -- Done.
     putStrLn $

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -456,13 +456,13 @@ cleanTests baseDir = testGroup "daml clean"
 -- | Check we can generate language bindings.
 codegenTests :: FilePath -> TestTree
 codegenTests codegenDir = testGroup "daml codegen"
-    [ codegenTestFor "ts" Nothing
-    , codegenTestFor "java" Nothing
-    , codegenTestFor "scala" (Just "com.cookiemonster.nomnomnom")
+    [ codegenTestFor "ts" Nothing True
+    , codegenTestFor "java" Nothing False
+    , codegenTestFor "scala" (Just "com.cookiemonster.nomnomnom") False
     ]
     where
-        codegenTestFor :: String -> Maybe String -> TestTree
-        codegenTestFor lang namespace =
+        codegenTestFor :: String -> Maybe String -> Bool -> TestTree
+        codegenTestFor lang namespace withPackageJson =
             testCase lang $ do
                 createDirectoryIfMissing True codegenDir
                 withCurrentDirectory codegenDir $ do
@@ -473,9 +473,10 @@ codegenTests codegenDir = testGroup "daml codegen"
                         let darFile = projectDir</> ".daml/dist/proj-" ++ lang ++ "-0.0.1.dar"
                             outDir  = projectDir</> "generated" </> lang
                         callCommandQuiet $
-                          unwords [ "daml", "codegen", lang
+                          unwords ([ "daml", "codegen", lang
                                   , darFile ++ maybe "" ("=" ++) namespace
-                                  , "-o", outDir]
+                                  , "-o", outDir
+                                  ] ++ [ arg | withPackageJson, arg <- ["-p", "package.json" ]])
                         contents <- listDirectory outDir
                         assertBool "bindings were written" (not $ null contents)
 


### PR DESCRIPTION
The `daml new` command now writes a skeleton 'package.json' to the target project directory to support daml2ts. 