### PR TITLE
skip fmt check for release

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -22,7 +22,9 @@ steps:
 
   - bash: ./fmt.sh --test
     displayName: 'Platform-agnostic lints and checks'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    # Temporary hack for 0.13.55. Should be removed once published.
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'),
+                   ne(${{parameters.is_release}}, 'true'))
 
   - bash: ci/configure-bazel.sh
     displayName: 'Configure Bazel'


### PR DESCRIPTION
The formatting check used to be git-repo-dependent (see #4985), which is
preventing our candidate 0.13.55 from building.

This PR introduces a temporary hack to disable format checking on
release PRs & commits. It should be reverted once 0.13.55 is released.

CHANGELOG_BEGIN
CHANGELOG_END