### PR TITLE
`kvutils`: Sort updated states by their keys

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/Common.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/Common.scala
@@ -8,10 +8,10 @@ import java.util.concurrent.TimeUnit
 import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlStateMap
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlConfigurationEntry,
   DamlLogEntry,
   DamlStateKey,
-  DamlStateValue,
-  DamlConfigurationEntry
+  DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.ledger.participant.state.v1.Configuration
@@ -19,6 +19,7 @@ import com.digitalasset.daml.lf.data.InsertOrdMap
 import org.slf4j.Logger
 
 import scala.annotation.tailrec
+import scala.collection.immutable.SortedMap
 
 private[kvutils] object Common {
   type DamlOutputStateMap = Map[DamlStateKey, DamlStateValue]
@@ -171,7 +172,7 @@ private[kvutils] object Common {
       * state built thus far by the computation. */
     def done[A](logEntry: DamlLogEntry): Commit[A] =
       Commit { state =>
-        Left(CommitDone(logEntry, state.resultState))
+        Left(CommitDone(logEntry, SortedMap(state.resultState.toSeq: _*)))
       }
   }
 
@@ -197,4 +198,7 @@ private[kvutils] object Common {
           }, conf => Some(Some(entry) -> conf))
       }
       .getOrElse(None -> defaultConfig)
+
+  private[kvutils] implicit val damlStateKeyOrdering: Ordering[DamlStateKey] =
+    Ordering.by(key => key.hashCode())
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -215,12 +215,10 @@ object SubmissionValidator {
   private[validator] def serializeProcessedSubmission(
       logEntryAndState: LogEntryAndState): (RawBytes, RawKeyValuePairs) = {
     val (logEntry, damlStateUpdates) = logEntryAndState
-    val rawStateUpdates = damlStateUpdates
-      .map {
+    val rawStateUpdates =
+      damlStateUpdates.map {
         case (key, value) => keyToBytes(key) -> valueToBytes(value)
-      }
-      .toSeq
-      .sortBy(_._1.toIterable)
+      }.toSeq
     (Envelope.enclose(logEntry).toByteArray, rawStateUpdates)
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -11,7 +11,8 @@ import com.google.protobuf.ByteString
 import org.scalatest.{Matchers, WordSpec}
 
 class CommitterSpec extends WordSpec with Matchers {
-  private class TestCommitter(outputKeys: Seq[String]) extends Committer[ByteString, ByteString] {
+  type Bytes = ByteString
+  private class TestCommitter(outputKeys: Seq[String]) extends Committer[Bytes, Bytes] {
     private val addKeysStep: Step = (context: CommitContext, _) => {
       val damlStateValue = DamlStateValue.getDefaultInstance
       for (outputKey <- outputKeys) {
@@ -25,7 +26,7 @@ class CommitterSpec extends WordSpec with Matchers {
 
     override def steps: Iterable[(StepInfo, Step)] = Seq(("add keys", addKeysStep))
 
-    override def init(ctx: CommitContext, submission: ByteString): ByteString = submission
+    override def init(ctx: CommitContext, submission: Bytes): Bytes = submission
   }
 
   "Committer" should {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -1,0 +1,45 @@
+package com.daml.ledger.participant.state.kvutils.committer
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlLogEntry,
+  DamlLogEntryId,
+  DamlStateKey,
+  DamlStateValue
+}
+import com.digitalasset.daml.lf.data.{Ref, Time}
+import com.google.protobuf.ByteString
+import org.scalatest.{Matchers, WordSpec}
+
+class CommitterSpec extends WordSpec with Matchers {
+  private class TestCommitter(outputKeys: Seq[String]) extends Committer[ByteString, ByteString] {
+    private val addKeysStep: Step = (context: CommitContext, _) => {
+      val damlStateValue = DamlStateValue.getDefaultInstance
+      for (outputKey <- outputKeys) {
+        val outputDamlStateKey = DamlStateKey.newBuilder
+          .setContractId(outputKey)
+          .build
+        context.set(outputDamlStateKey, damlStateValue)
+      }
+      StepStop(DamlLogEntry.getDefaultInstance)
+    }
+
+    override def steps: Iterable[(StepInfo, Step)] = Seq(("add keys", addKeysStep))
+
+    override def init(ctx: CommitContext, submission: ByteString): ByteString = submission
+  }
+
+  "Committer" should {
+    "return output states in sorted order" in {
+      val instance = new TestCommitter(Seq("b", "c", "a"))
+      val (_, actualStateUpdates) = instance.run(
+        DamlLogEntryId.getDefaultInstance,
+        Time.Timestamp.MaxValue,
+        Time.Timestamp.MinValue,
+        ByteString.copyFromUtf8("aSubmission"),
+        Ref.ParticipantId.assertFromString("aParticipantId"),
+        Map.empty
+      )
+      actualStateUpdates.map(_._1.getContractId) shouldBe Seq("a", "b", "c")
+    }
+  }
+}


### PR DESCRIPTION
In order to ensure deterministic ordering of keys output for state updates this PR switches to using a `SortedMap` when collecting such keys during processing of a submission. Deterministic ordering of keys is required to guarantee that outputs from the same submission will generate the same hash.
Summary of changes:
* Changed common committing logic and `ProcessTransactionSubmission` to return updated states in a `SorrtedMap`.
* Added `Ordering` for `DamlStateKey`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
