### PR TITLE
Fix detection of package ids for triggers

### DIFF
--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -60,8 +60,7 @@ main = do
           let bazelQueryCommand = shell $
                   "bazel query 'kind(\"(scala|java)_library\", deps(" ++
                   (T.unpack . getBazelTarget . artTarget) a ++
-                  ")) intersect //... " ++
-                  "except (//compiler/scenario-service/protos:scenario_service_java_proto + //compiler/repl-service/protos:repl_service_java_proto + //daml-script/runner:script-runner-lib)'"
+                  ")) intersect //...'"
           internalDeps <- liftIO $ lines <$> readCreateProcess bazelQueryCommand ""
           -- check if a dependency is not already a maven target from artifacts.yaml
           let missingDeps = filter (`Set.notMember` allMavenTargets) internalDeps

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -9,8 +9,7 @@ load(
 
 da_scala_library(
     name = "trigger-runner-lib",
-    srcs = glob(["src/main/scala/**/*.scala"]) + [":src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
-    generated_srcs = [":src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
+    srcs = glob(["src/main/scala/**/*.scala"]),
     tags = ["maven_coordinates=com.digitalasset.daml.lf.engine.trigger:runner:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
@@ -31,29 +30,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_typelevel_paiges_core_2_12",
     ],
-)
-
-# This genrule generates a Scala file containing the package id of the trigger library
-# at build time. We use that to detect mismatches and warn the user about it.
-genrule(
-    name = "trigger-package-id",
-    srcs = [
-        "//triggers/daml:daml-trigger.dar",
-        "//compiler/damlc",
-    ],
-    outs = ["src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala"],
-    cmd = """
-      PACKAGE_ID=$$($(location //compiler/damlc) inspect-dar $(location //triggers/daml:daml-trigger.dar) | awk '/daml-trigger-[^-]*-([a..f]|[0..9])*/ {print $$2}')
-      cat << EOF > $(location src/main/com/digitalasset/daml/lf/engine/trigger/TriggerPackageIds.scala)
-package com.digitalasset.daml.lf.engine
-
-import com.digitalasset.daml.lf.data.Ref.PackageId
-
-package object trigger {
-  val EXPECTED_TRIGGER_PACKAGE_ID = PackageId.assertFromString($$PACKAGE_ID)
-}
-EOF
-    """,
 )
 
 da_scala_binary(

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -28,14 +28,14 @@ import com.digitalasset.auth.TokenHolder
 object RunnerMain {
 
   def listTriggers(darPath: File, dar: Dar[(PackageId, Package)]) = {
-    val triggerIds = TriggerIds.fromDar(dar)
     println(s"Listing triggers in $darPath:")
     for ((modName, mod) <- dar.main._2.modules) {
       for ((defName, defVal) <- mod.definitions) {
         defVal match {
           case DValue(TApp(TTyCon(tcon), _), _, _, _) => {
-            if (tcon == triggerIds.getHighlevelId("Trigger")
-              || tcon == triggerIds.getId("Trigger")) {
+            val triggerIds = TriggerIds(tcon.packageId)
+            if (tcon == triggerIds.damlTrigger("Trigger")
+              || tcon == triggerIds.damlTriggerLowLevel("Trigger")) {
               println(s"  $modName:$defName")
             }
           }


### PR DESCRIPTION
Previously we assumed that the module name was globally unique in the
DAR which is definitely not guaranteed. Now we instead detect the
package id of the trigger library based on the type of the trigger we
are running which doesn’t fall apart if there are multiple versions of
the trigger library.

I’ve also removed the check for the package id of the trigger library
since I’d like the trigger runner to be backwarts compatible from now on (we
didn’t break that in a while).

This is slightly ugly since the Runner class is currently not specific
to a single trigger but only the individual methods are aware of the
specific trigger identifier. I’ll refactor this in a separate PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
