### PR TITLE
Output whether command execution depends on time

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/CommandExecutor.scala
@@ -16,6 +16,25 @@ import com.digitalasset.platform.store.ErrorCause
 
 import scala.concurrent.Future
 
+/**
+  * The result of command execution.
+  *
+  * @param submitterInfo       The submitter info
+  * @param transactionMeta     The transaction meta-data
+  * @param dependsOnLedgerTime True if the output of command execution depends in any way
+  *                            on the ledger time, as specified through [[Commands.ledgerEffectiveTime]].
+  *                            If this value is false, then the ledger time of the resulting transaction
+  *                            ([[TransactionMeta.ledgerEffectiveTime]] can safely be changed after command
+  *                            interpretation.
+  * @param transaction         The transaction
+  */
+final case class CommandExecutionResult(
+    submitterInfo: SubmitterInfo,
+    transactionMeta: TransactionMeta,
+    transaction: Transaction.Transaction,
+    dependsOnLedgerTime: Boolean,
+)
+
 trait CommandExecutor {
 
   def execute(
@@ -26,5 +45,5 @@ trait CommandExecutor {
         Option[Value.ContractInst[Transaction.Value[Value.AbsoluteContractId]]]],
       lookupKey: GlobalKey => Future[Option[AbsoluteContractId]],
       commands: Commands
-  ): Future[Either[ErrorCause, (SubmitterInfo, TransactionMeta, Transaction.Transaction)]]
+  ): Future[Either[ErrorCause, CommandExecutionResult]]
 }


### PR DESCRIPTION
Small refactoring to have `CommandExecutor` output whether the execution depends on ledger time.

Fixes https://github.com/digital-asset/daml/issues/4556.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
