### PR TITLE
sandbox: Make sure we can get the details of an empty list of parties.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -130,6 +130,7 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
         partyDetails <- ledger.getParties(
           Seq(party1, party2, binding.Primitive.Party("non-existent")))
         noPartyDetails <- ledger.getParties(Seq(binding.Primitive.Party("non-existent")))
+        zeroPartyDetails <- ledger.getParties(Seq.empty)
       } yield {
         assert(
           partyDetails.sortBy(_.displayName) == Seq(
@@ -149,6 +150,9 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
         assert(
           noPartyDetails.isEmpty,
           s"Retrieved some parties when the party specified did not exist: $noPartyDetails")
+        assert(
+          zeroPartyDetails.isEmpty,
+          s"Retrieved some parties when no parties were requested: $zeroPartyDetails")
       }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1469,13 +1469,16 @@ private class JdbcLedgerDao(
     )
 
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
-    dbDispatcher
-      .executeSql("load_parties") { implicit conn =>
-        SQL_SELECT_MULTIPLE_PARTIES
-          .on("parties" -> parties)
-          .as(PartyDataParser.*)
-      }
-      .map(_.map(constructPartyDetails))(executionContext)
+    if (parties.isEmpty)
+      Future.successful(List.empty)
+    else
+      dbDispatcher
+        .executeSql("load_parties") { implicit conn =>
+          SQL_SELECT_MULTIPLE_PARTIES
+            .on("parties" -> parties)
+            .as(PartyDataParser.*)
+        }
+        .map(_.map(constructPartyDetails))(executionContext)
 
   override def listKnownParties(): Future[List[PartyDetails]] =
     dbDispatcher

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSpec.scala
@@ -455,6 +455,14 @@ class JdbcLedgerDaoSpec
       }
     }
 
+    "retrieve zero parties" in {
+      for {
+        noPartyDetails <- ledgerDao.getParties(Seq.empty)
+      } yield {
+        noPartyDetails should be(Seq.empty)
+      }
+    }
+
     "retrieve a single party, if they exist" in {
       val party = Ref.Party.assertFromString(s"Carol-${UUID.randomUUID()}")
       val nonExistentParty = UUID.randomUUID().toString


### PR DESCRIPTION
This would fail only on PostgreSQL because `IN ()` is invalid. H2 seems to be fine with it.

### Changelog

- **[Ledger API Server]** Support a call to `GetParties` with an empty list of parties.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
