### PR TITLE
 Engine: Replace SResultMissingDefinition by SResultMissingPackage

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -386,7 +386,7 @@ final class Engine(nextRandomInt: () => Int) {
               s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${machine.ptx.nodesToString}"
             ))
 
-        case SResultMissingPackage(pkgId, callback) =>
+        case SResultNeedPackage(pkgId, callback) =>
           return Result.needPackage(
             pkgId,
             pkg => {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -386,11 +386,11 @@ final class Engine(nextRandomInt: () => Int) {
               s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${machine.ptx.nodesToString}"
             ))
 
-        case SResultMissingDefinition(ref, callback) =>
+        case SResultMissingPackage(pkgId, callback) =>
           return Result.needPackage(
-            ref.packageId,
+            pkgId,
             pkg => {
-              _compiledPackages.addPackage(ref.packageId, pkg).flatMap {
+              _compiledPackages.addPackage(pkgId, pkg).flatMap {
                 case _ =>
                   callback(_compiledPackages)
                   interpretLoop(machine, time)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -39,7 +39,7 @@ object SResult {
     * initialized. The caller must retrieve the definition and fill it in
     * the packages cache it had provided to initialize the machine.
     */
-  final case class SResultMissingPackage(
+  final case class SResultNeedPackage(
       pkg: PackageId,
       callback: CompiledPackages => Unit,
   ) extends SResult

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -9,7 +9,6 @@ import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data.Time
 import com.digitalasset.daml.lf.transaction.Transaction._
 import com.digitalasset.daml.lf.speedy.SError._
-import com.digitalasset.daml.lf.speedy.SExpr.SDefinitionRef
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 
 /** The result from small-step evaluation.
@@ -40,8 +39,8 @@ object SResult {
     * initialized. The caller must retrieve the definition and fill it in
     * the packages cache it had provided to initialize the machine.
     */
-  final case class SResultMissingDefinition(
-      ref: SDefinitionRef,
+  final case class SResultMissingPackage(
+      pkg: PackageId,
       callback: CompiledPackages => Unit,
   ) extends SResult
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -160,9 +160,9 @@ object Speedy {
 
         case None =>
           val ref = eval.ref
-          kont.add(KCacheVal(eval, Nil))
           compiledPackages.getDefinition(ref) match {
             case Some(body) =>
+              kont.add(KCacheVal(eval, Nil))
               CtrlExpr(body)
             case None =>
               if (compiledPackages.getPackage(ref.packageId).isDefined)
@@ -173,9 +173,9 @@ object Speedy {
                 throw SpeedyHungry(
                   SResultNeedPackage(
                     ref.packageId, { packages =>
-                      // Just in case the packages are not updated properly by the caller
-                      assert(compiledPackages.getPackage(ref.packageId).isDefined)
                       this.compiledPackages = packages
+                      // To avoid infinite loop in case the packages are not updated properly by the caller
+                      assert(compiledPackages.getPackage(ref.packageId).isDefined)
                       this.ctrl = lookupVal(eval)
                     }
                   ),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -154,10 +154,10 @@ object Speedy {
 
     def lookupVal(eval: SEVal): Ctrl = {
       eval.cached match {
-        case Some((v, stack_trace)) => {
+        case Some((v, stack_trace)) =>
           pushStackTrace(stack_trace)
           CtrlValue(v)
-        }
+
         case None =>
           val ref = eval.ref
           kont.add(KCacheVal(eval, Nil))
@@ -165,24 +165,22 @@ object Speedy {
             case Some(body) =>
               CtrlExpr(body)
             case None =>
-              throw SpeedyHungry(
-                SResultNeedPackage(
-                  ref.packageId, { packages =>
-                    this.compiledPackages = packages
-                    compiledPackages.getDefinition(ref) match {
-                      case Some(body) =>
-                        this.ctrl = CtrlExpr(body)
-                      case None =>
-                        crash(
-                          s"definition $ref not found even after caller provided new set of packages",
-                        )
-                    }
-                  },
-                ),
-              )
-          }
+              if (compiledPackages.getPackage(ref.packageId).isDefined)
+                crash(
+                  s"definition $ref not found even after caller provided new set of packages",
+                )
+              else
+            throw SpeedyHungry(
+              SResultNeedPackage(
+                ref.packageId, { packages =>
+                  // Just in case the packages are not updated properly by the caller
+                  assert(compiledPackages.getPackage(ref.packageId).isDefined)
+                  this.compiledPackages = packages
+                  this.ctrl = lookupVal(eval)
+                }
+              ),
+            )
       }
-
     }
 
     /** Returns true when the machine has finished evaluation.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -170,16 +170,17 @@ object Speedy {
                   s"definition $ref not found even after caller provided new set of packages",
                 )
               else
-            throw SpeedyHungry(
-              SResultNeedPackage(
-                ref.packageId, { packages =>
-                  // Just in case the packages are not updated properly by the caller
-                  assert(compiledPackages.getPackage(ref.packageId).isDefined)
-                  this.compiledPackages = packages
-                  this.ctrl = lookupVal(eval)
-                }
-              ),
-            )
+                throw SpeedyHungry(
+                  SResultNeedPackage(
+                    ref.packageId, { packages =>
+                      // Just in case the packages are not updated properly by the caller
+                      assert(compiledPackages.getPackage(ref.packageId).isDefined)
+                      this.compiledPackages = packages
+                      this.ctrl = lookupVal(eval)
+                    }
+                  ),
+                )
+          }
       }
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -166,7 +166,7 @@ object Speedy {
               CtrlExpr(body)
             case None =>
               throw SpeedyHungry(
-                SResultMissingPackage(
+                SResultNeedPackage(
                   ref.packageId, { packages =>
                     this.compiledPackages = packages
                     compiledPackages.getDefinition(ref) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -166,8 +166,8 @@ object Speedy {
               CtrlExpr(body)
             case None =>
               throw SpeedyHungry(
-                SResultMissingDefinition(
-                  ref, { packages =>
+                SResultMissingPackage(
+                  ref.packageId, { packages =>
                     this.compiledPackages = packages
                     compiledPackages.getDefinition(ref) match {
                       case Some(body) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -225,8 +225,8 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
 
       run()
       result match {
-        case SResultMissingDefinition(ref2, cb) =>
-          LfDefRef(ref) shouldBe ref2
+        case SResultMissingPackage(pkgId, cb) =>
+          LfDefRef(ref) shouldBe pkgId
           cb(pkgs2)
           result = SResultContinue
           run()
@@ -250,8 +250,8 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       }
       run()
       result match {
-        case SResultMissingDefinition(ref2, cb) =>
-          LfDefRef(ref) shouldBe ref2
+        case SResultMissingPackage(pkgId, cb) =>
+          ref.packageId shouldBe pkgId
           result = SResultContinue
           try {
             cb(pkgs1)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -210,6 +210,24 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
             ),
         ),
       ).right.get
+    val pkgs3 = PureCompiledPackages(
+      Map(
+        dummyPkg ->
+          Package(
+            List(
+              Module(
+                modName,
+                Map.empty,
+                LanguageVersion.default,
+                FeatureFlags.default,
+              ),
+            ),
+            Set.empty[PackageId],
+            None,
+          ),
+      ),
+    ).right.get
+
     "succeeds" in {
       val machine = Speedy.Machine.fromExpr(
         EVal(ref),
@@ -253,7 +271,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
           ref.packageId shouldBe pkgId
           result = SResultContinue
           try {
-            cb(pkgs1)
+            cb(pkgs3)
             sys.error(s"expected crash when definition not provided")
           } catch {
             case _: SErrorCrash => ()

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -225,7 +225,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
 
       run()
       result match {
-        case SResultMissingPackage(pkgId, cb) =>
+        case SResultNeedPackage(pkgId, cb) =>
           LfDefRef(ref) shouldBe pkgId
           cb(pkgs2)
           result = SResultContinue
@@ -250,7 +250,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       }
       run()
       result match {
-        case SResultMissingPackage(pkgId, cb) =>
+        case SResultNeedPackage(pkgId, cb) =>
           ref.packageId shouldBe pkgId
           result = SResultContinue
           try {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -10,7 +10,6 @@ import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.language.LanguageVersion
 import com.digitalasset.daml.lf.language.Util._
 import com.digitalasset.daml.lf.speedy.SError._
-import com.digitalasset.daml.lf.speedy.SExpr.LfDefRef
 import com.digitalasset.daml.lf.speedy.SResult._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -226,7 +225,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       run()
       result match {
         case SResultNeedPackage(pkgId, cb) =>
-          LfDefRef(ref) shouldBe pkgId
+          ref.packageId shouldBe pkgId
           cb(pkgs2)
           result = SResultContinue
           run()

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -54,7 +54,7 @@ final case class ScenarioRunner(
         case SResultError(err) =>
           throw SRunnerException(err)
 
-        case SResultMissingPackage(pkgId, _) =>
+        case SResultNeedPackage(pkgId, _) =>
           crash(s"package $pkgId not found")
 
         case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -54,8 +54,8 @@ final case class ScenarioRunner(
         case SResultError(err) =>
           throw SRunnerException(err)
 
-        case SResultMissingDefinition(ref, _) =>
-          crash(s"definition $ref not found")
+        case SResultMissingPackage(pkgId, _) =>
+          crash(s"package $pkgId not found")
 
         case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
           lookupContract(coid, committers, cbMissing, cbPresent)


### PR DESCRIPTION
In this PR we replace the speedy exception `SResultMissingDefinition` by `SResultMissingPackage`

This is a preparatory work as we will need package also when translating `Variant` and `Enum` value to SValue in order to get the "rank" of the `Variant`/`Enum` constructor, that is the position of the constructor in the definition.

This advance the state of #2256 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
