### PR TITLE
Allow reusing same ValidatingCommitter for multiple participants

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -37,7 +37,6 @@ final class InMemoryLedgerReaderWriter(
     with LedgerReader {
 
   private val committer = new ValidatingCommitter(
-    participantId,
     () => timeProvider.getCurrentTime,
     SubmissionValidator
       .create(new InMemoryLedgerStateAccess(state), () => sequentialLogEntryId.next()),
@@ -48,7 +47,7 @@ final class InMemoryLedgerReaderWriter(
     Healthy
 
   override def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult] =
-    committer.commit(correlationId, envelope)
+    committer.commit(correlationId, envelope, participantId)
 
   override def events(offset: Option[Offset]): Source[LedgerEntry, NotUsed] =
     dispatcher

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -50,7 +50,6 @@ final class SqlLedgerReaderWriter(
     with LedgerReader {
 
   private val committer = new ValidatingCommitter[Index](
-    participantId,
     () => timeProvider.getCurrentTime,
     SubmissionValidator.create(SqlLedgerStateAccess),
     latestSequenceNo => dispatcher.signalNewHead(latestSequenceNo + 1),
@@ -83,7 +82,7 @@ final class SqlLedgerReaderWriter(
       .map { case (_, entry) => entry }
 
   override def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult] =
-    committer.commit(correlationId, envelope)
+    committer.commit(correlationId, envelope, participantId)
 
   object SqlLedgerStateAccess extends LedgerStateAccess[Index] {
     override def inTransaction[T](body: LedgerStateOperations[Index] => Future[T]): Future[T] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.v1.PackageId
 /** Errors thrown by kvutils.
   *
   * Validation and consistency errors are turned into command rejections.
-  * Note that processSubmission can also fail with a protobuf exception,
+  * Note that [[KeyValueCommitting.processSubmission]] can also fail with a protobuf exception,
   * e.g. https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/InvalidProtocolBufferException.
   */
 sealed abstract class Err extends RuntimeException with Product with Serializable

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -15,7 +15,6 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 class ValidatingCommitter[LogResult](
-    participantId: ParticipantId,
     now: () => Instant,
     validator: SubmissionValidator[LogResult],
     postCommit: LogResult => Unit,
@@ -23,6 +22,7 @@ class ValidatingCommitter[LogResult](
   def commit(
       correlationId: String,
       envelope: Bytes,
+      submittingParticipantId: ParticipantId,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
       validator
@@ -30,7 +30,7 @@ class ValidatingCommitter[LogResult](
           envelope,
           correlationId,
           Timestamp.assertFromInstant(now()),
-          participantId,
+          submittingParticipantId,
         )
         .map {
           case Right(value) =>


### PR DESCRIPTION
Summary of changes:
* Take `submittingParticipantId` as a parameter to `ValidatingCommitter.commit` instead of passing it as a constructor argument (a validator may receive requests from multiple participants).

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
