### PR TITLE
Move non-IO initialization out of trigger runner

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -53,14 +53,153 @@ final case class CompletionMsg(c: Completion) extends TriggerMsg
 final case class TransactionMsg(t: Transaction) extends TriggerMsg
 final case class HeartbeatMsg() extends TriggerMsg
 
-final case class Trigger(expr: Expr, ty: TypeConApp, triggerIds: TriggerIds)
+final case class TypedExpr(expr: Expr, ty: TypeConApp)
+
+final case class Trigger(
+    expr: TypedExpr,
+    triggerIds: TriggerIds,
+    filters: Filters, // We store Filters rather than TransactionFilter since
+    // the latter is party-specific.
+    heartbeat: Option[FiniteDuration]
+)
+
+// Utilities for interacting with the speedy machine.
+object Machine extends StrictLogging {
+  // Run speedy until we arrive at a value.
+  def stepToValue(machine: Speedy.Machine): Unit = {
+    while (!machine.isFinal) {
+      machine.step() match {
+        case SResultContinue => ()
+        case SResultError(err) => {
+          logger.error(Pretty.prettyError(err, machine.ptx).render(80))
+          throw err
+        }
+        case res => {
+          val errMsg = s"Unexpected speedy result: $res"
+          logger.error(errMsg)
+          throw new RuntimeException(errMsg)
+        }
+      }
+    }
+  }
+}
+
+object Trigger extends StrictLogging {
+  def fromIdentifier(
+      compiledPackages: CompiledPackages,
+      triggerId: Identifier): Either[String, Trigger] = {
+
+    // Given an identifier to a high- or lowlevel trigger,
+    // return an expression that will run the corresponding trigger
+    // as a low-level trigger (by applying runTrigger) and the type of that expression.
+    def detectTriggerType(tyCon: TypeConName, tyArg: Type): Either[String, TypedExpr] = {
+      val triggerIds = TriggerIds(tyCon.packageId)
+      if (tyCon == triggerIds.damlTriggerLowLevel("Trigger")) {
+        logger.debug("Running low-level trigger")
+        val expr = EVal(triggerId)
+        val ty = TypeConApp(tyCon, ImmArray(tyArg))
+        Right(TypedExpr(expr, ty))
+      } else if (tyCon == triggerIds.damlTrigger("Trigger")) {
+        logger.debug("Running high-level trigger")
+
+        val runTrigger = EVal(triggerIds.damlTrigger("runTrigger"))
+        val expr = EApp(runTrigger, EVal(triggerId))
+
+        val triggerState = TTyCon(triggerIds.damlTriggerInternal("TriggerState"))
+        val stateTy = TApp(triggerState, tyArg)
+        val lowLevelTriggerTy = triggerIds.damlTriggerLowLevel("Trigger")
+        val ty = TypeConApp(lowLevelTriggerTy, ImmArray(stateTy))
+
+        Right(TypedExpr(expr, ty))
+      } else {
+        Left(s"Unexpected trigger type constructor $tyCon")
+      }
+    }
+
+    val compiler = Compiler(compiledPackages.packages)
+    for {
+      pkg <- compiledPackages
+        .getPackage(triggerId.packageId)
+        .toRight(s"Could not find package: ${triggerId.packageId}")
+      definition <- pkg.lookupIdentifier(triggerId.qualifiedName)
+      expr <- definition match {
+        case DValue(TApp(TTyCon(tcon), stateTy), _, _, _) => detectTriggerType(tcon, stateTy)
+        case DValue(ty, _, _, _) => Left(s"$ty is not a valid type for a trigger")
+        case _ => Left(s"Trigger must points to a value but points to $definition")
+      }
+      triggerIds = TriggerIds(expr.ty.tycon.packageId)
+      converter: Converter = Converter(compiledPackages, triggerIds)
+      filter <- getTriggerFilter(compiledPackages, compiler, converter, expr)
+      heartbeat <- getTriggerHeartbeat(compiledPackages, compiler, converter, expr)
+    } yield Trigger(expr, triggerIds, filter, heartbeat)
+  }
+
+  // Return the heartbeat specified by the user.
+  private def getTriggerHeartbeat(
+      compiledPackages: CompiledPackages,
+      compiler: Compiler,
+      converter: Converter,
+      expr: TypedExpr): Either[String, Option[FiniteDuration]] = {
+    val heartbeat = compiler.compile(
+      ERecProj(expr.ty, Name.assertFromString("heartbeat"), expr.expr)
+    )
+    var machine = Speedy.Machine.fromSExpr(heartbeat, false, compiledPackages)
+    Machine.stepToValue(machine)
+    machine.toSValue match {
+      case SOptional(None) => Right(None)
+      case SOptional(Some(relTime)) => converter.toFiniteDuration(relTime).map(Some(_))
+      case value => Left(s"Expected Optional but got $value.")
+    }
+  }
+
+  // Return the trigger filter specified by the user.
+  def getTriggerFilter(
+      compiledPackages: CompiledPackages,
+      compiler: Compiler,
+      converter: Converter,
+      expr: TypedExpr): Either[String, Filters] = {
+    val registeredTemplates =
+      compiler.compile(ERecProj(expr.ty, Name.assertFromString("registeredTemplates"), expr.expr))
+    var machine =
+      Speedy.Machine.fromSExpr(registeredTemplates, false, compiledPackages)
+    Machine.stepToValue(machine)
+    machine.toSValue match {
+      case SVariant(_, "AllInDar", _) => {
+        val packages: Seq[(PackageId, Package)] = compiledPackages.packageIds
+          .map(pkgId => (pkgId, compiledPackages.getPackage(pkgId).get))
+          .toSeq
+        val templateIds = packages.flatMap({
+          case (pkgId, pkg) =>
+            pkg.modules.toList.flatMap({
+              case (modName, module) =>
+                module.definitions.toList.flatMap({
+                  case (entityName, definition) =>
+                    definition match {
+                      case DDataType(_, _, DataRecord(_, Some(tpl))) =>
+                        Seq(toApiIdentifier(Identifier(pkgId, QualifiedName(modName, entityName))))
+                      case _ => Seq()
+                    }
+                })
+            })
+        })
+        Right(Filters(Some(InclusiveFilters(templateIds))))
+      }
+      case SVariant(_, "RegisteredTemplates", v) =>
+        converter.toRegisteredTemplates(v) match {
+          case Right(tpls) => Right(Filters(Some(InclusiveFilters(tpls.map(toApiIdentifier(_))))))
+          case Left(err) => Left(err)
+        }
+      case v => Left(s"Expected AllInDar or RegisteredTemplates but got $v")
+    }
+  }
+}
 
 class Runner(
+    compiledPackages: CompiledPackages,
+    trigger: Trigger,
     client: LedgerClient,
     timeProviderType: TimeProviderType,
     applicationId: ApplicationId,
-    val compiledPackages: CompiledPackages,
-    trigger: Trigger,
     party: String,
 ) extends StrictLogging {
   private val compiler = Compiler(compiledPackages.packages)
@@ -71,14 +210,12 @@ class Runner(
   // This is the set of command ids emitted by the trigger.
   // We track this to detect collisions.
   private var usedCommandIds: Set[String] = Set.empty
+  private var transactionFilter = TransactionFilter(Seq((party, trigger.filters)).toMap)
 
   // Handles the result of initialState or update, i.e., (s, [Commands], Text)
   // by submitting the commands, printing the log message and returning
   // the new state
-  private def handleStepResult(
-      converter: Converter,
-      v: SValue,
-      submit: SubmitRequest => Unit): SValue =
+  private def handleStepResult(v: SValue, submit: SubmitRequest => Unit): SValue =
     v match {
       case SRecord(recordId, _, values)
           if recordId.qualifiedName ==
@@ -120,79 +257,6 @@ class Runner(
         throw new RuntimeException(s"Expected Tuple2 but got $v")
       }
     }
-
-  // Run speedy until we arrive at a value.
-  private def stepToValue(machine: Speedy.Machine): Unit = {
-    while (!machine.isFinal) {
-      machine.step() match {
-        case SResultContinue => ()
-        case SResultError(err) => {
-          logger.error(Pretty.prettyError(err, machine.ptx).render(80))
-          throw err
-        }
-        case res => {
-          val errMsg = s"Unexpected speedy result: $res"
-          logger.error(errMsg)
-          throw new RuntimeException(errMsg)
-        }
-      }
-    }
-  }
-
-  // Return the heartbeat specified by the user.
-  def getTriggerHeartbeat(): Option[FiniteDuration] = {
-    val heartbeat = compiler.compile(
-      ERecProj(trigger.ty, Name.assertFromString("heartbeat"), trigger.expr)
-    )
-    var machine = Speedy.Machine.fromSExpr(heartbeat, false, compiledPackages)
-    stepToValue(machine)
-    machine.toSValue match {
-      case SOptional(None) => None
-      case SOptional(Some(relTime)) =>
-        converter.toFiniteDuration(relTime) match {
-          case Left(err) => throw new ConverterException(err)
-          case Right(duration) => Some(duration)
-        }
-      case value => throw new ConverterException(s"Expected Optional but got $value.")
-    }
-  }
-
-  // Return the trigger filter specified by the user.
-  def getTriggerFilter(): TransactionFilter = {
-    val registeredTemplates = compiler.compile(
-      ERecProj(trigger.ty, Name.assertFromString("registeredTemplates"), trigger.expr))
-    var machine =
-      Speedy.Machine.fromSExpr(registeredTemplates, false, compiledPackages)
-    stepToValue(machine)
-    val templateIds = machine.toSValue match {
-      case SVariant(_, "AllInDar", _) => {
-        val packages: Seq[(PackageId, Package)] = compiledPackages.packageIds
-          .map(pkgId => (pkgId, compiledPackages.getPackage(pkgId).get))
-          .toSeq
-        packages.flatMap({
-          case (pkgId, pkg) =>
-            pkg.modules.toList.flatMap({
-              case (modName, module) =>
-                module.definitions.toList.flatMap({
-                  case (entityName, definition) =>
-                    definition match {
-                      case DDataType(_, _, DataRecord(_, Some(tpl))) =>
-                        Seq(toApiIdentifier(Identifier(pkgId, QualifiedName(modName, entityName))))
-                      case _ => Seq()
-                    }
-                })
-            })
-        })
-      }
-      case SVariant(_, "RegisteredTemplates", v) =>
-        converter.toRegisteredTemplates(v) match {
-          case Right(tpls) => tpls.map(toApiIdentifier(_))
-          case Left(err) => throw new ConverterException(err)
-        }
-      case v => throw new ConverterException(s"Expected AllInDar or RegisteredTemplates but got $v")
-    }
-    TransactionFilter(List((party, Filters(Some(InclusiveFilters(templateIds))))).toMap)
-  }
 
   private def msgSource(
       client: LedgerClient,
@@ -240,9 +304,11 @@ class Runner(
   ): Sink[TriggerMsg, Future[SExpr]] = {
     logger.info(s"Trigger is running as ${party}")
     val update =
-      compiler.compile(ERecProj(trigger.ty, Name.assertFromString("update"), trigger.expr))
+      compiler.compile(
+        ERecProj(trigger.expr.ty, Name.assertFromString("update"), trigger.expr.expr))
     val getInitialState =
-      compiler.compile(ERecProj(trigger.ty, Name.assertFromString("initialState"), trigger.expr))
+      compiler.compile(
+        ERecProj(trigger.expr.ty, Name.assertFromString("initialState"), trigger.expr.expr))
 
     var machine = Speedy.Machine.fromSExpr(null, false, compiledPackages)
     val createdExpr: SExpr = SEValue(converter.fromACS(acs) match {
@@ -259,8 +325,8 @@ class Runner(
           SEValue(STimestamp(clientTime)): SExpr,
           createdExpr))
     machine.ctrl = Speedy.CtrlExpr(initialState)
-    stepToValue(machine)
-    val evaluatedInitialState = handleStepResult(converter, machine.toSValue, submit)
+    Machine.stepToValue(machine)
+    val evaluatedInitialState = handleStepResult(machine.toSValue, submit)
     logger.debug(s"Initial state: $evaluatedInitialState")
     Flow[TriggerMsg]
       .mapConcat[TriggerMsg]({
@@ -312,20 +378,20 @@ class Runner(
           Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
         machine.ctrl = Speedy.CtrlExpr(
           SEApp(update, Array(SEValue(STimestamp(clientTime)): SExpr, SEValue(messageVal), state)))
-        stepToValue(machine)
-        val newState = handleStepResult(converter, machine.toSValue, submit)
+        Machine.stepToValue(machine)
+        val newState = handleStepResult(machine.toSValue, submit)
         SEValue(newState)
       }))(Keep.right[NotUsed, Future[SExpr]])
   }
 
   // Query the ACS. This allows you to separate the initialization of the initial state
   // from the first run. This is only intended for tests.
-  def queryACS(filter: TransactionFilter)(
+  def queryACS()(
       implicit materializer: Materializer,
       executionContext: ExecutionContext): Future[(Seq[CreatedEvent], LedgerOffset)] = {
     for {
       acsResponses <- client.activeContractSetClient
-        .getActiveContracts(filter, verbose = true)
+        .getActiveContracts(transactionFilter, verbose = true)
         .runWith(Sink.seq)
       offset = Array(acsResponses: _*).lastOption
         .fold(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))(resp =>
@@ -335,13 +401,12 @@ class Runner(
 
   // Run the trigger given the state of the ACS.
   def runWithACS[T](
-      heartbeat: Option[FiniteDuration],
       acs: Seq[CreatedEvent],
       offset: LedgerOffset,
-      filter: TransactionFilter,
       msgFlow: Graph[FlowShape[TriggerMsg, TriggerMsg], T] = Flow[TriggerMsg],
   )(implicit materializer: Materializer, executionContext: ExecutionContext): (T, Future[SExpr]) = {
-    val (source, postFailure) = msgSource(client, offset, heartbeat, party, filter)
+    val (source, postFailure) =
+      msgSource(client, offset, trigger.heartbeat, party, transactionFilter)
     def submit(req: SubmitRequest) = {
       val f = client.commandClient
         .withTimeProvider(Some(Runner.getTimeProvider(timeProviderType)))
@@ -369,65 +434,6 @@ object Runner extends StrictLogging {
     }
   }
 
-  // Given an identifier, search for the trigger and return the necessary metadata
-  // to run it.
-  // Throws an exception if the trigger is not found or not a valid trigger.
-  def getTrigger(compiledPackages: CompiledPackages, triggerId: Identifier): Trigger = {
-    val (tyCon: TypeConName, stateTy) =
-      compiledPackages
-        .getPackage(triggerId.packageId)
-        .flatMap(_.lookupIdentifier(triggerId.qualifiedName).toOption) match {
-        case Some(DValue(TApp(TTyCon(tcon), stateTy), _, _, _)) => (tcon, stateTy)
-        case _ => {
-          val errMsg = s"Identifier ${triggerId.qualifiedName} does not point to a trigger"
-          throw new RuntimeException(errMsg)
-        }
-      }
-    val triggerIds = TriggerIds(tyCon.packageId)
-    if (tyCon == triggerIds.damlTriggerLowLevel("Trigger")) {
-      logger.debug("Running low-level trigger")
-      val triggerVal = EVal(triggerId)
-      val triggerTy = TypeConApp(tyCon, ImmArray(stateTy))
-      Trigger(triggerVal, triggerTy, triggerIds)
-    } else if (tyCon == triggerIds.damlTrigger("Trigger")) {
-      logger.debug("Running high-level trigger")
-      val runTrigger = EVal(triggerIds.damlTrigger("runTrigger"))
-      val triggerState = TTyCon(triggerIds.damlTriggerInternal("TriggerState"))
-      val lowLevelTriggerTy = triggerIds.damlTriggerLowLevel("Trigger")
-      val lowTriggerVal = EApp(runTrigger, EVal(triggerId))
-      val lowStateTy = TApp(triggerState, stateTy)
-      val lowTriggerTy = TypeConApp(lowLevelTriggerTy, ImmArray(lowStateTy))
-      Trigger(lowTriggerVal, lowTriggerTy, triggerIds)
-    } else {
-      val errMsg =
-        s"Identifier ${triggerId.qualifiedName} does not point to a trigger. Its type must be Daml.Trigger.Trigger or Daml.Trigger.LowLevel.Trigger."
-      throw new RuntimeException(errMsg)
-    }
-  }
-
-  // Construct a trigger runner from the given DAR.
-  def fromDar(
-      dar: Dar[(PackageId, Package)],
-      triggerId: Identifier,
-      client: LedgerClient,
-      timeProviderType: TimeProviderType,
-      applicationId: ApplicationId,
-      party: String): Runner = {
-    val darMap = dar.all.toMap
-    val compiler = Compiler(darMap)
-    val compiledPackages =
-      PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
-    val trigger = Runner.getTrigger(compiledPackages, triggerId)
-    new Runner(
-      client,
-      timeProviderType,
-      applicationId,
-      compiledPackages,
-      trigger,
-      party
-    )
-  }
-
   // Convience wrapper that creates the runner and runs the trigger.
   def run(
       dar: Dar[(PackageId, Package)],
@@ -437,13 +443,20 @@ object Runner extends StrictLogging {
       applicationId: ApplicationId,
       party: String
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Future[SExpr] = {
-    val runner = Runner.fromDar(dar, triggerId, client, timeProviderType, applicationId, party)
-    val filter = runner.getTriggerFilter()
-    val heartbeat = runner.getTriggerHeartbeat()
+    val darMap = dar.all.toMap
+    val compiler = Compiler(darMap)
+    val compiledPackages =
+      PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
+    val trigger = Trigger.fromIdentifier(compiledPackages, triggerId) match {
+      case Left(err) => throw new RuntimeException(s"Invalid trigger: $err")
+      case Right(trigger) => trigger
+    }
+    val runner =
+      new Runner(compiledPackages, trigger, client, timeProviderType, applicationId, party)
     for {
-      (acs, offset) <- runner.queryACS(filter)
+      (acs, offset) <- runner.queryACS()
       finalState <- runner
-        .runWithACS(heartbeat, acs, offset, filter)
+        .runWithACS(acs, offset)
         ._2
     } yield finalState
   }


### PR DESCRIPTION
Previously parts of the initialization, in particular, the code for
finding the filter and the heartbeat were part of the Runner. This led
to an akward API and didn’t really make any sense.

Now all of this code is part of a pure `Trigger.fromIdentifier`
method and the runner only takes care of actually running the
ledger. This could also be useful for the trigger service where we
might want to synchronously call `getIdentifier` so users get some
indication if there request even points to a valid trigger
directly. However, this is not tackled by this PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
