### PR TITLE
daml2ts : Simplify docs, use mapped types for enums.

### DIFF
--- a/docs/source/daml2ts/index.rst
+++ b/docs/source/daml2ts/index.rst
@@ -203,7 +203,7 @@ the generated TypeScript will consist of a type declaration and the definition o
 
    type Color = | 'Red' | 'Blue' | 'Yellow'
 
-   const Color : {readonly Red: Color; readonly Blue: Color; readonly Yellow: Color} = {
+   const Color = {
      Red: 'Red',
      Blue: 'Blue',
      Yellow: 'Yellow',

--- a/docs/source/daml2ts/index.rst
+++ b/docs/source/daml2ts/index.rst
@@ -207,6 +207,7 @@ the generated TypeScript will consist of a type declaration and the definition o
      Red: 'Red',
      Blue: 'Blue',
      Yellow: 'Yellow',
+     keys: ['Red','Blue','Yellow'],
    } as const;
 
 Templates and choices

--- a/docs/source/daml2ts/index.rst
+++ b/docs/source/daml2ts/index.rst
@@ -201,7 +201,7 @@ the generated TypeScript will consist of a type declaration and the definition o
 .. code-block:: typescript
    :linenos:
 
-   type Color = | 'Red' | 'Blue' | 'Yellow'
+   type Color = 'Red' | 'Blue' | 'Yellow'
 
    const Color = {
      Red: 'Red',

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -351,8 +351,9 @@ genDefDataType curPkgId conName mod tpls def =
               -- The complete definition of the companion object.
               serDesc =
                 ["export const " <> conName <> ": daml.Serializable<" <> conName <> "> " <>
-                 "& { readonly [e in " <> conName <> "]: e } = {"] ++
+                 "& { readonly keys: " <> conName <> "[] } & { readonly [e in " <> conName <> "]: e } = {"] ++
                 ["  " <> cons <> ": '" <> cons <> "'," | cons <- cs] ++
+                ["  keys: [" <> T.concat ["'" <> cons <> "'," | cons <- cs] <> "],"] ++
                 ["  decoder: () => jtv.oneOf<" <> conName <> ">" <> "("] ++
                 ["      jtv.constant(" <> conName <> "." <> cons <> ")," | cons <- cs] ++
                 ["  ),"] ++

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -325,9 +325,6 @@ genDefDataType curPkgId conName mod tpls def =
                     concatMap (onHead (fromJust . T.stripPrefix (T.pack "export const ")) . onLast (<> ";")) assocSers
                   -- The complete definition of the companion function.
                   in function ++ props
-                     -- To-do: Can we formulate a static implements
-                     -- serializable check that works for companion
-                     -- functions?
               else -- Companion object.
                 let
                   assocNames = map fst assocDefDataTypes
@@ -346,23 +343,20 @@ genDefDataType curPkgId conName mod tpls def =
                     -- associated serializer above? This replaces them.
                     concatMap (\(n, ser) -> n <> ": ({" : onLast (<> ",") ser) assocSers
                   -- The complete definition of the companion object.
-                  in ["export const " <> conName <> ":\n  " <> typ' <> " = ({"] ++ body ++ ["});"] ++
-                     ["daml.STATIC_IMPLEMENTS_SERIALIZABLE_CHECK<" <> conName <> ">(" <> conName <> ")"]
+                  in ["export const " <> conName <> ":\n  " <> typ' <> " = ({"] ++ body ++ ["});"]
             in ((typeDesc, serDesc), Set.unions $ map (Set.setOf typeModuleRef . snd) bs)
         DataEnum enumCons ->
           let cs = map unVariantConName enumCons
               typeDesc = "" : ["  | '" <> cons <> "'" | cons <- cs]
               -- The complete definition of the companion object.
               serDesc =
-                [ "export const " <> conName <> ": daml.Serializable<" <> conName <> "> & {"] <>
-                [ "  readonly " <> cons <> ": " <> conName <> ";" | cons <- cs ] ++
-                ["} = {"] ++
+                ["export const " <> conName <> ": daml.Serializable<" <> conName <> "> " <>
+                 "& { readonly [e in " <> conName <> "]: e } = {"] ++
                 ["  " <> cons <> ": '" <> cons <> "'," | cons <- cs] ++
                 ["  decoder: () => jtv.oneOf<" <> conName <> ">" <> "("] ++
                 ["      jtv.constant(" <> conName <> "." <> cons <> ")," | cons <- cs] ++
                 ["  ),"] ++
-                ["} as const;"] ++
-                ["daml.STATIC_IMPLEMENTS_SERIALIZABLE_CHECK<" <> conName <> ">(" <> conName <> ")"]
+                ["};"]
           in
           ((makeType typeDesc, serDesc), Set.empty)
         DataRecord fields ->

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -18,16 +18,6 @@ export interface Serializable<T> {
 }
 
 /**
- * @internal
- *
- * This is a check to ensure that enum's are serializable. If the enum is named 'Color', the check
- * is done by adding a line 'STATIC_IMPLEMENTS_SERIALIZABLE_CHECK<Color>(Color)' after the
- * definition of 'Color'.
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-export const STATIC_IMPLEMENTS_SERIALIZABLE_CHECK = <T>(_: Serializable<T>) => {}
-
-/**
  * Interface for objects representing DAML templates. It is similar to the
  * `Template` type class in DAML.
  *


### PR DESCRIPTION
- Use mapped types in the definition of enum companion objects, remove implements serializable checks (https://github.com/digital-asset/daml/pull/4975#discussion_r392896248);
- Simplify docs (https://github.com/digital-asset/daml/pull/4975#discussion_r392887749).
- Removes implements serializable check definition from `daml-types` (https://github.com/digital-asset/daml/pull/4975#discussion_r392897237).