### PR TITLE
daml-assistant: Add `daml sandbox-next`.

### DIFF
--- a/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
+++ b/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.daml.sdk
-import com.digitalasset.daml.lf.engine.trigger.{RunnerMain => Trigger}
-import com.digitalasset.daml.lf.engine.script.{RunnerMain => Script}
-import com.digitalasset.daml.lf.engine.script.{TestMain => TestScript}
+
 import com.digitalasset.codegen.{CodegenMain => Codegen}
+import com.digitalasset.daml.lf.engine.script.{RunnerMain => Script, TestMain => TestScript}
+import com.digitalasset.daml.lf.engine.trigger.{RunnerMain => Trigger}
 import com.digitalasset.extractor.{Main => Extractor}
 import com.digitalasset.http.{Main => JsonApi}
 import com.digitalasset.navigator.{NavigatorBackend => Navigator}
 import com.digitalasset.platform.sandbox.{SandboxMain => Sandbox}
+import com.digitalasset.platform.sandboxnext.{Main => SandboxNext}
 
 object SdkMain {
   def main(args: Array[String]): Unit = {
@@ -24,6 +25,7 @@ object SdkMain {
       case "json-api" => JsonApi.main(rest)
       case "navigator" => Navigator.main(rest)
       case "sandbox" => Sandbox.main(rest)
+      case "sandbox-next" => SandboxNext.main(rest)
       case _ => sys.exit(1)
     }
   }

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -325,11 +325,29 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
           callCommandQuiet "daml damlc test --files daml/Main.daml"
     , testCase "daml damlc visual-web" $ withCurrentDirectory quickstartDir $
           callCommandQuiet $ unwords ["daml damlc visual-web .daml/dist/quickstart-0.0.1.dar -o visual.html -b"]
-    , testCase "sandbox startup" $
+    , testCase "Sandbox startup" $
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do
           p :: Int <- fromIntegral <$> getFreePort
           let sandboxProc = (shell $ unwords ["daml", "sandbox", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
+          withCreateProcess sandboxProc  $
+              \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
+              waitForConnectionOnPort (threadDelay 100000) p
+              addr : _ <- getAddrInfo
+                  (Just socketHints)
+                  (Just "127.0.0.1")
+                  (Just $ show p)
+              bracket
+                  (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+                  close
+                  (\s -> connect s (addrAddress addr))
+              -- waitForProcess' will block on Windows so we explicitly kill the process.
+              terminateProcess ph
+    , testCase "Sandbox Next startup" $
+      withCurrentDirectory quickstartDir $
+      withDevNull $ \devNull -> do
+          p :: Int <- fromIntegral <$> getFreePort
+          let sandboxProc = (shell $ unwords ["daml", "sandbox-next", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
           withCreateProcess sandboxProc  $
               \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
               waitForConnectionOnPort (threadDelay 100000) p

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -43,6 +43,10 @@ commands:
   path: daml-helper/daml-helper
   desc: "Launch the Sandbox"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
+- name: sandbox-next
+  path: daml-helper/daml-helper
+  desc: "Launch the Sandbox's upcoming implementation (for testing purposes)"
+  args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-next"]
 - name: navigator
   path: daml-helper/daml-helper
   desc: "Launch the Navigator"

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -45,7 +45,7 @@ commands:
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
 - name: sandbox-next
   path: daml-helper/daml-helper
-  desc: "Launch the Sandbox's upcoming implementation (for testing purposes)"
+  desc: "Launch the Sandbox's upcoming implementation (experimental, for testing purposes)"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-next"]
 - name: navigator
   path: daml-helper/daml-helper


### PR DESCRIPTION
### Changelog

- [DAML Assistant] You can now run a pre-release version of Sandbox with `daml sandbox-next` so you can test it out and verify everything is working as expected. Running this will launch Sandbox rebuilt on a more modern architecture. An upcoming release of DAML will switch over to the new implementation by default.

Resolves #4085.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
