### PR TITLE
Handle failures during trigger initialization synchronously

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -22,6 +22,7 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//language-support/scala/bindings",

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -95,6 +95,16 @@ class ServiceTest extends AsyncFlatSpec with Eventually {
     Http().singleRequest(req)
   }
 
+  it should "should fail for non-existent trigger" in withHttpService { (uri: Uri, client) =>
+    for {
+      resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:foobar", "Alice")
+      body <- {
+        assert(resp.status == StatusCodes.UnprocessableEntity)
+        resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+      }
+    } yield assert(body == "Could not find name foobar in module TestTrigger")
+  }
+
   it should "should enable a trigger on http request" in withHttpService { (uri: Uri, client) =>
     // start the trigger
     for {


### PR DESCRIPTION
Previously the http endpoint for starting a trigger would always
return immediately. Based on the recent refactorings, we now do the
non-IO trigger initialization synchronously and return a failed http
status code with an error message.

This also refactors the code to only have one (mutable) set of
compiled packages which is a prerequisite for dynamic package uploads.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
