### PR TITLE
[Engine] Add rank to Enum and Variant speedy value

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/SortedLookupList.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/SortedLookupList.scala
@@ -25,6 +25,8 @@ final class SortedLookupList[+X] private (entries: ImmArray[(String, X)]) extend
 
   def values: ImmArray[X] = entries.map(_._2)
 
+  def iterator: Iterator[(String, X)] = entries.iterator
+
   def toHashMap: HashMap[String, X] = HashMap(entries.toSeq: _*)
 
   override def canEqual(that: Any): Boolean = that.isInstanceOf[SortedLookupList[_]]

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -432,10 +432,14 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         )
 
       case EEnumCon(tyCon, constructor) =>
-        SEValue(SEnum(tyCon, constructor))
+        val enumDef =
+          lookupEnumDefinition(tyCon).getOrElse(throw CompileError(s"enum $tyCon not found"))
+        SEValue(SEnum(tyCon, constructor, enumDef.constructorRank(constructor)))
 
       case EVariantCon(tapp, variant, arg) =>
-        SBVariantCon(tapp.tycon, variant)(translate(arg))
+        val variantDef = lookupVariantDefinition(tapp.tycon)
+          .getOrElse(throw CompileError(s"variant ${tapp.tycon} not found"))
+        SBVariantCon(tapp.tycon, variant, variantDef.constructorRank(variant))(translate(arg))
 
       case let: ELet =>
         val (bindings, body) = collectLets(let)
@@ -868,6 +872,22 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
       }
       .getOrElse(throw CompileError(s"template $tycon not found"))
 
+  private def lookupVariantDefinition(tycon: TypeConName): Option[DataVariant] =
+    lookupDefinition(tycon).flatMap {
+      case DDataType(_, _, data: DataVariant) =>
+        Some(data)
+      case _ =>
+        None
+    }
+
+  private def lookupEnumDefinition(tycon: TypeConName): Option[DataEnum] =
+    lookupDefinition(tycon).flatMap {
+      case DDataType(_, _, data: DataEnum) =>
+        Some(data)
+      case _ =>
+        None
+    }
+
   private def lookupRecordIndex(tapp: TypeConApp, field: FieldName): Int =
     lookupDefinition(tapp.tycon)
       .flatMap {
@@ -1051,8 +1071,8 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
               goV(v)
           }
         case SRecord(_, _, args) => args.forEach(goV)
-        case SVariant(_, _, value) => goV(value)
-        case SEnum(_, _) => ()
+        case SVariant(_, _, _, value) => goV(value)
+        case SEnum(_, _, _) => ()
         case SAny(_, v) => goV(v)
         case _: SPAP | SToken | SStruct(_, _) =>
           throw CompileError("validate: unexpected SEValue")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -497,7 +497,7 @@ object Pretty {
               text("$project") + char('[') + text(id.qualifiedName.toString) + char(':') + str(
                 field,
               ) + char(']')
-            case SBVariantCon(id, v) =>
+            case SBVariantCon(id, v, _) =>
               text("$variant") + char('[') + text(id.qualifiedName.toString) + char(':') + text(v) + char(
                 ']',
               )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -9,7 +9,7 @@ import java.util
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.data.Numeric.Scale
-import com.digitalasset.daml.lf.language.Ast._
+import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.speedy.SError._
 import com.digitalasset.daml.lf.speedy.SExpr._
 import com.digitalasset.daml.lf.speedy.Speedy.{
@@ -719,7 +719,7 @@ object SBuiltin {
   }
 
   /** $tproj[field] :: Struct -> a */
-  final case class SBStructProj(field: FieldName) extends SBuiltin(1) {
+  final case class SBStructProj(field: Ast.FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
         case SStruct(fields, values) =>
@@ -731,7 +731,7 @@ object SBuiltin {
   }
 
   /** $tupd[field] :: Struct -> a -> Struct */
-  final case class SBStructUpd(field: FieldName) extends SBuiltin(2) {
+  final case class SBStructUpd(field: Ast.FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
         case SStruct(fields, values) =>
@@ -745,9 +745,10 @@ object SBuiltin {
   }
 
   /** $vcon[V, variant] :: a -> V */
-  final case class SBVariantCon(id: Identifier, variant: VariantConName) extends SBuiltin(1) {
+  final case class SBVariantCon(id: Identifier, variant: Ast.VariantConName, constructorRank: Int)
+      extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SVariant(id, variant, args.get(0)))
+      machine.ctrl = CtrlValue(SVariant(id, variant, constructorRank, args.get(0)))
     }
   }
 
@@ -902,6 +903,101 @@ object SBuiltin {
     }
   }
 
+  // This function translates well-typed values.
+  // Raises an exception if missing packages.
+  @throws[SpeedyHungry]
+  def translateValue(machine: Machine, value: V[V.ContractId]): CtrlValue = {
+    def go(value0: V[V.ContractId]): SValue =
+      value0 match {
+        case V.ValueList(vs) => SList(vs.map[SValue](go))
+        case V.ValueContractId(coid) => SContractId(coid)
+        case V.ValueInt64(x) => SInt64(x)
+        case V.ValueNumeric(x) => SNumeric(x)
+        case V.ValueText(t) => SText(t)
+        case V.ValueTimestamp(t) => STimestamp(t)
+        case V.ValueParty(p) => SParty(p)
+        case V.ValueBool(b) => SBool(b)
+        case V.ValueDate(x) => SDate(x)
+        case V.ValueUnit => SUnit
+        case V.ValueRecord(Some(id), fs) =>
+          val fields = Name.Array.ofDim(fs.length)
+          val values = new util.ArrayList[SValue](fields.length)
+          fs.foreach {
+            case (optk, v) =>
+              optk match {
+                case None =>
+                  throw crash("SValue.fromValue: record missing field name")
+                case Some(k) =>
+                  fields(values.size) = k
+                  val _ = values.add(go(v))
+              }
+          }
+          SRecord(id, fields, values)
+        case V.ValueRecord(None, _) =>
+          crash("SValue.fromValue: record missing identifier")
+        case V.ValueStruct(fs) =>
+          val fields = Name.Array.ofDim(fs.length)
+          val values = new util.ArrayList[SValue](fields.length)
+          fs.foreach {
+            case (k, v) =>
+              fields(values.size) = k
+              val _ = values.add(go(v))
+          }
+          SStruct(fields, values)
+        case V.ValueVariant(None, _variant @ _, _value @ _) =>
+          crash("SValue.fromValue: variant without identifier")
+        case V.ValueEnum(None, constructor @ _) =>
+          crash("SValue.fromValue: enum without identifier")
+        case V.ValueOptional(mbV) =>
+          SOptional(mbV.map(go))
+        case V.ValueTextMap(map) =>
+          STextMap(map.mapValue(go).toHashMap)
+        case V.ValueGenMap(entries) =>
+          SGenMap(
+            entries.iterator.map { case (k, v) => go(k) -> go(v) }
+          )
+        case V.ValueVariant(Some(id), variant, value) =>
+          machine.compiledPackages.getPackage(id.packageId) match {
+            case Some(pkg) =>
+              pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
+                case Ast.DDataType(_, _, data: Ast.DataVariant) =>
+                  SVariant(id, variant, data.constructorRank(variant), go(value))
+                case _ =>
+                  crash(s"definition for variant $id not found")
+              }
+            case None =>
+              throw SpeedyHungry(
+                SResultNeedPackage(
+                  id.packageId,
+                  pkg => {
+                    machine.compiledPackages = pkg
+                    machine.ctrl = translateValue(machine, value)
+                  }
+                ))
+          }
+        case V.ValueEnum(Some(id), constructor) =>
+          machine.compiledPackages.getPackage(id.packageId) match {
+            case Some(pkg) =>
+              pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
+                case Ast.DDataType(_, _, data: Ast.DataEnum) =>
+                  SEnum(id, constructor, data.constructorRank(constructor))
+                case _ =>
+                  crash(s"definition for variant $id not found")
+              }
+            case None =>
+              throw SpeedyHungry(
+                SResultNeedPackage(
+                  id.packageId,
+                  pkg => {
+                    machine.compiledPackages = pkg
+                    machine.ctrl = translateValue(machine, value)
+                  }
+                ))
+          }
+      }
+    CtrlValue(go(value))
+  }
+
   /** $fetch[T]
     *    :: ContractId a
     *    -> Token
@@ -935,7 +1031,7 @@ object SBuiltin {
                           machine.ctrl =
                             CtrlWronglyTypeContractId(acoid, templateId, coinst.template)
                         } else {
-                          machine.ctrl = CtrlValue(SValue.fromValue(coinst.arg.value))
+                          machine.ctrl = translateValue(machine, coinst.arg.value)
                         }
                     },
                   ),
@@ -956,7 +1052,7 @@ object SBuiltin {
         // (see below).
         crash(s"Relative contract $coid ($templateId) not found from partial transaction")
       } else {
-        machine.ctrl = CtrlValue(SValue.fromValue(coinst.arg.value))
+        machine.ctrl = translateValue(machine, coinst.arg.value)
       }
     }
   }
@@ -1258,7 +1354,7 @@ object SBuiltin {
     *    :: t
     *    -> Any (where t = ty)
     */
-  final case class SBToAny(ty: Type) extends SBuiltin(1) {
+  final case class SBToAny(ty: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(SAny(ty, args.get(0)))
     }
@@ -1268,7 +1364,7 @@ object SBuiltin {
     *    :: Any
     *    -> Optional t (where t = expectedType)
     */
-  final case class SBFromAny(expectedTy: Type) extends SBuiltin(1) {
+  final case class SBFromAny(expectedTy: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       machine.ctrl = CtrlValue(args.get(0) match {
         case SAny(actualTy, v) =>
@@ -1490,7 +1586,7 @@ object SBuiltin {
   private def extractKeyWithMaintainers(v: SValue): KeyWithMaintainers[Tx.Value[Nothing]] =
     v match {
       case SStruct(flds, vals)
-          if flds.length == 2 && flds(0) == keyFieldName && flds(1) == maintainersFieldName =>
+          if flds.length == 2 && flds(0) == Ast.keyFieldName && flds(1) == Ast.maintainersFieldName =>
         rightOrCrash(
           for {
             keyVal <- vals

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -477,7 +477,7 @@ object Speedy {
               case _ => false
             }
           }
-        case SVariant(_, con1, arg) =>
+        case SVariant(_, con1, _, arg) =>
           alts.find { alt =>
             alt.pattern match {
               case SCPVariant(_, con2) if con1 == con2 =>
@@ -488,7 +488,7 @@ object Speedy {
               case _ => false
             }
           }
-        case SEnum(_, con1) =>
+        case SEnum(_, con1, _) =>
           alts.find { alt =>
             alt.pattern match {
               case SCPEnum(_, con2) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -32,12 +32,12 @@ private[lf] object Equality {
         tuple match {
           case (x: SPrimLit, y: SPrimLit) =>
             x == y && equality(stack)
-          case (SEnum(tyCon1, con1), SEnum(tyCon2, con2)) =>
+          case (SEnum(tyCon1, con1, _), SEnum(tyCon2, con2, _)) =>
             tyCon1 == tyCon2 && con1 == con2 && equality(stack)
           case (SRecord(tyCon1, fields1, args1), SRecord(tyCon2, fields2, args2)) =>
             tyCon1 == tyCon2 && (fields1 sameElements fields2) &&
               equality(zipAndPush(args1.iterator().asScala, args2.iterator().asScala, stack))
-          case (SVariant(tyCon1, con1, arg1), SVariant(tyCon2, con2, arg2)) =>
+          case (SVariant(tyCon1, con1, _, arg1), SVariant(tyCon2, con2, _, arg2)) =>
             tyCon1 == tyCon2 && con1 == con2 && equality((arg1, arg2) +: stack)
           case (SList(lst1), SList(lst2)) =>
             lst1.length == lst2.length &&

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
@@ -64,11 +64,11 @@ private[speedy] object Hasher {
                 loop(cmdsRest, cid.hashCode :: stack)
               case STypeRep(t) =>
                 loop(cmdsRest, t.hashCode() :: stack)
-              case SEnum(_, constructor) =>
+              case SEnum(_, constructor, _) =>
                 loop(cmdsRest, constructor.hashCode :: stack)
               case SRecord(_, _, values) =>
                 loop(pushOrderedValues(values.size, values.iterator().asScala, cmdsRest), stack)
-              case SVariant(_, variant, value) =>
+              case SVariant(_, variant, _, value) =>
                 loop(Value(value) :: Mix(variant.hashCode) :: cmdsRest, stack)
               case SStruct(_, values) =>
                 loop(pushOrderedValues(values.size, values.iterator().asScala, cmdsRest), stack)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
@@ -189,8 +189,8 @@ object Ordering extends scala.math.Ordering[SValue] {
             case STypeRep(t2) =>
               compareType(t1, t2) -> ImmArray.empty
           }
-          case SEnum(_, con1) => {
-            case SEnum(_, con2) =>
+          case SEnum(_, con1, _) => {
+            case SEnum(_, con2, _) =>
               // FIXME https://github.com/digital-asset/daml/issues/2256
               // should not compare constructor syntactically
               (con1 compareTo con2) -> ImmArray.empty
@@ -199,8 +199,8 @@ object Ordering extends scala.math.Ordering[SValue] {
             case SRecord(_, _, args2) =>
               0 -> (args1.iterator().asScala zip args2.iterator().asScala).to[ImmArray]
           }
-          case SVariant(_, con1, arg1) => {
-            case SVariant(_, con2, arg2) =>
+          case SVariant(_, con1, _, arg1) => {
+            case SVariant(_, con2, _, arg2) =>
               // FIXME https://github.com/digital-asset/daml/issues/2256
               // should not compare constructor syntactically
               (con1 compareTo con2) -> ImmArray((arg1, arg2))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -13,7 +13,6 @@ import com.digitalasset.daml.lf.speedy.SError.{DamlEArithmeticError, SError, SEr
 import com.digitalasset.daml.lf.speedy.SResult.{SResultContinue, SResultError}
 import com.digitalasset.daml.lf.speedy.SValue._
 import com.digitalasset.daml.lf.testing.parser.Implicits._
-import com.digitalasset.daml.lf.value.Value.{ValueGenMap, ValueInt64, ValueText}
 import org.scalactic.Equality
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
@@ -939,28 +938,20 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       "inserts as expected" in {
         val e = e"$map"
         eval(e) shouldEqual Right(
-          SValue.fromValue(
-            ValueGenMap(
-              ImmArray(
-                ValueText("a") -> ValueInt64(1),
-                ValueText("b") -> ValueInt64(2),
-                ValueText("c") -> ValueInt64(3),
-              ),
-            ),
+          SGenMap(
+            SText("a") -> SInt64(1),
+            SText("b") -> SInt64(2),
+            SText("c") -> SInt64(3),
           ),
         )
       }
 
       "replaces already present key" in {
         eval(e"""$builtin @Text @Int64 "b" 4 $map""") shouldEqual Right(
-          SValue.fromValue(
-            ValueGenMap(
-              ImmArray(
-                ValueText("a") -> ValueInt64(1),
-                ValueText("b") -> ValueInt64(4),
-                ValueText("c") -> ValueInt64(3),
-              ),
-            ),
+          SGenMap(
+            SText("a") -> SInt64(1),
+            SText("b") -> SInt64(4),
+            SText("c") -> SInt64(3),
           ),
         )
       }
@@ -1003,27 +994,19 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
 
       "deletes existing key" in {
         eval(e"""$builtin @Text @Int64 "a" $map""") shouldEqual Right(
-          SValue.fromValue(
-            ValueGenMap(ImmArray(ValueText("b") -> ValueInt64(2), ValueText("c") -> ValueInt64(3))),
-          ),
+          SGenMap(SText("b") -> SInt64(2), SText("c") -> SInt64(3)),
         )
         eval(e"""$builtin @Text @Int64 "b" $map""") shouldEqual Right(
-          SValue.fromValue(
-            ValueGenMap(ImmArray(ValueText("a") -> ValueInt64(1), ValueText("c") -> ValueInt64(3))),
-          ),
+          SGenMap(SText("a") -> SInt64(1), SText("c") -> SInt64(3)),
         )
       }
 
       "does nothing with non-existing key" in {
         eval(e"""$builtin @Text @Int64 "d" $map""") shouldEqual Right(
-          SValue.fromValue(
-            ValueGenMap(
-              ImmArray(
-                ValueText("a") -> ValueInt64(1),
-                ValueText("b") -> ValueInt64(2),
-                ValueText("c") -> ValueInt64(3),
-              ),
-            ),
+          SGenMap(
+            SText("a") -> SInt64(1),
+            SText("b") -> SInt64(2),
+            SText("c") -> SInt64(3),
           ),
         )
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -69,7 +69,10 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     List(0, 1).map(x => SContractId(RelativeContractId(NodeId(x))))
   private val contractIds = absoluteContractId ++ relativeContractId
 
-  private val enums = List(EnumCon1, EnumCon2).map(SEnum(EnumTypeCon, _))
+  private val enums = List(
+    SEnum(EnumTypeCon, EnumCon1, 0),
+    SEnum(EnumTypeCon, EnumCon2, 1)
+  )
 
   private val struct0 = List(SStruct(Ref.Name.Array.empty, ArrayList()))
 
@@ -88,8 +91,8 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     } yield SRecord(Record2TypeCon, record2Fields, ArrayList(x, y))
 
   private def mkVariant(as: List[SValue], bs: List[SValue]) =
-    as.map(SVariant(VariantTypeCon, VariantCon1, _)) ++
-      bs.map(SVariant(VariantTypeCon, VariantCon2, _))
+    as.map(SVariant(VariantTypeCon, VariantCon1, 0, _)) ++
+      bs.map(SVariant(VariantTypeCon, VariantCon2, 1, _))
 
   private def mkStruct2(fst: List[SValue], snd: List[SValue]) =
     for {
@@ -223,8 +226,8 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
       STextMap(HashMap.empty) ->
         STextMap(HashMap("a" -> lfFunction)),
       SGenMap.Empty -> SGenMap(SInt64(0) -> lfFunction),
-      SVariant(VariantTypeCon, VariantCon1, SInt64(0)) ->
-        SVariant(VariantTypeCon, VariantCon2, lfFunction),
+      SVariant(VariantTypeCon, VariantCon1, 0, SInt64(0)) ->
+        SVariant(VariantTypeCon, VariantCon2, 1, lfFunction),
       SAny(AstUtil.TInt64, SInt64(1)) ->
         SAny(AstUtil.TFun(AstUtil.TInt64, AstUtil.TInt64), lfFunction),
     )

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -63,8 +63,8 @@ class OrderingSpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     List(
       "1969-07-21T02:56:15.000000Z",
       "1970-01-01T00:00:00.000000Z",
-      "2020-02-02T20:20:02.020000Z")
-      .map(STimestamp compose Time.Timestamp.assertFromString)
+      "2020-02-02T20:20:02.020000Z",
+    ).map(STimestamp compose Time.Timestamp.assertFromString)
   private val parties =
     List("alice", "bob", "carol").map(SParty compose Ref.Party.assertFromString)
   private val absoluteContractId =
@@ -74,7 +74,10 @@ class OrderingSpec extends WordSpec with Matchers with TableDrivenPropertyChecks
 //    List(0, 1).map(x => SContractId(Value.RelativeContractId(Value.NodeId(x))))
   private val contractIds = absoluteContractId //++ relativeContractId
 
-  private val enums = List(EnumCon1, EnumCon2, EnumCon3).map(SEnum(EnumTypeCon, _))
+  private val enums =
+    List(EnumCon1, EnumCon2, EnumCon3).zipWithIndex.map {
+      case (con, rank) => SEnum(EnumTypeCon, con, rank)
+    }
 
   private val struct0 = List(SStruct(Ref.Name.Array.empty, ArrayList()))
 
@@ -198,9 +201,9 @@ class OrderingSpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     } yield SRecord(Record2TypeCon, record2Fields, ArrayList(x, y))
 
   private def mkVariant(as: List[SValue], bs: List[SValue]) =
-    as.map(SVariant(VariantTypeCon, VariantCon1, _)) ++
-      as.map(SVariant(VariantTypeCon, VariantCon2, _)) ++
-      bs.map(SVariant(VariantTypeCon, VariantCon3, _))
+    as.map(SVariant(VariantTypeCon, VariantCon1, 0, _)) ++
+      as.map(SVariant(VariantTypeCon, VariantCon2, 1, _)) ++
+      bs.map(SVariant(VariantTypeCon, VariantCon3, 2, _))
 
   private def mkStruct2(fst: List[SValue], snd: List[SValue]) =
     for {
@@ -357,8 +360,8 @@ class OrderingSpec extends WordSpec with Matchers with TableDrivenPropertyChecks
       STextMap(HashMap.empty) ->
         STextMap(HashMap("a" -> lfFunction)),
       SGenMap.Empty -> SGenMap(SInt64(0) -> lfFunction),
-      SVariant(VariantTypeCon, VariantCon1, SInt64(0)) ->
-        SVariant(VariantTypeCon, VariantCon2, lfFunction),
+      SVariant(VariantTypeCon, VariantCon1, 0, SInt64(0)) ->
+        SVariant(VariantTypeCon, VariantCon2, 1, lfFunction),
       SAny(AstUtil.TInt64, SInt64(1)) ->
         SAny(AstUtil.TFun(AstUtil.TInt64, AstUtil.TInt64), lfFunction),
     )

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -512,8 +512,13 @@ object Ast {
   sealed abstract class DataCons extends Product with Serializable
   final case class DataRecord(fields: ImmArray[(FieldName, Type)], optTemplate: Option[Template])
       extends DataCons
-  final case class DataVariant(variants: ImmArray[(VariantConName, Type)]) extends DataCons
-  final case class DataEnum(constructors: ImmArray[EnumConName]) extends DataCons
+  final case class DataVariant(variants: ImmArray[(VariantConName, Type)]) extends DataCons {
+    lazy val constructorRank: Map[VariantConName, Int] =
+      variants.iterator.map(_._1).zipWithIndex.toMap
+  }
+  final case class DataEnum(constructors: ImmArray[EnumConName]) extends DataCons {
+    lazy val constructorRank: Map[EnumConName, Int] = constructors.iterator.zipWithIndex.toMap
+  }
 
   case class TemplateKey(
       typ: Type,

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -81,6 +81,8 @@ data Transaction = Transaction
  }
 
 -- | An event in a transaction.
+-- This definition should be kept consistent with the object `EventVariant` defined in
+-- triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
 data Event
   = CreatedEvent Created
   | ArchivedEvent Archived
@@ -116,6 +118,8 @@ fromArchived Archived {eventId, contractId}
   = None
 
 -- | Either a transaction or a completion.
+-- This definition should be kept consistent with the object `MessageVariant` defined in
+-- triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
 data Message
   = MTransaction Transaction
   | MCompletion Completion
@@ -125,11 +129,15 @@ data Message
 -- Note that you will only get completions for commands emitted from the trigger.
 -- Contrary to the ledger API completion stream, this also includes
 -- synchronous failures.
+
 data Completion = Completion
   { commandId : CommandId
   , status : CompletionStatus
   } deriving Show
 
+
+-- This definition should be kept consistent with the object `CompletionStatusVariant` defined in
+-- triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
 data CompletionStatus
   = Failed { status : Int, message : Text }
   | Succeeded { transactionId : TransactionId }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -164,7 +164,7 @@ object Trigger extends StrictLogging {
       Speedy.Machine.fromSExpr(registeredTemplates, false, compiledPackages)
     Machine.stepToValue(machine)
     machine.toSValue match {
-      case SVariant(_, "AllInDar", _) => {
+      case SVariant(_, "AllInDar", _, _) => {
         val packages: Seq[(PackageId, Package)] = compiledPackages.packageIds
           .map(pkgId => (pkgId, compiledPackages.getPackage(pkgId).get))
           .toSeq
@@ -184,7 +184,7 @@ object Trigger extends StrictLogging {
         })
         Right(Filters(Some(InclusiveFilters(templateIds))))
       }
-      case SVariant(_, "RegisteredTemplates", v) =>
+      case SVariant(_, "RegisteredTemplates", _, v) =>
         converter.toRegisteredTemplates(v) match {
           case Right(tpls) => Right(Filters(Some(InclusiveFilters(tpls.map(toApiIdentifier(_))))))
           case Left(err) => Left(err)


### PR DESCRIPTION
In this PR we add to the `Enum` and `Variant`  speedy value of the index of the constructor within the respective definition.

Once this is merged, we could adapt the value ordering to respect the DAML-LF spec.

This advances the state of #2256  

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
