### PR TITLE
KVutils: drop useless addContractInput

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -88,9 +88,7 @@ private[kvutils] object InputsAndEffects {
                 GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key.value)))
             }
 
-          case exe @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
-            addContractInput(exe.targetCoid)
-
+          case NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           case lookup @ NodeLookupByKey(_, _, _, _) =>
             // We need both the contract key state and the contract state. The latter is used to verify
             // that the submitter can access the contract.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -89,6 +89,8 @@ private[kvutils] object InputsAndEffects {
             }
 
           case NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+            ()
+
           case lookup @ NodeLookupByKey(_, _, _, _) =>
             // We need both the contract key state and the contract state. The latter is used to verify
             // that the submitter can access the contract.


### PR DESCRIPTION
In this PR we drop a useless `addContractInput` call in the `InputAndEffect` object

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
