### PR TITLE
Infer daml-script package id from script

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -197,8 +197,15 @@ class ReplService(val clients: Participants[LedgerClient], ec: ExecutionContext,
       ttl = java.time.Duration.ofSeconds(30),
       overrideTtl = true)
     // TODO[AH] Provide daml-script package id from REPL client.
-    val (scriptPackageId, _) = packages.find{case (pkgId, pkg) => pkg.modules.contains(DottedName.assertFromString("Daml.Script"))}.get
-    val runner = new Runner(dar, ScriptIds(scriptPackageId), ApplicationId("daml repl"), commandUpdater, TimeProvider.UTC)
+    val (scriptPackageId, _) = packages.find {
+      case (pkgId, pkg) => pkg.modules.contains(DottedName.assertFromString("Daml.Script"))
+    }.get
+    val runner = new Runner(
+      dar,
+      ScriptIds(scriptPackageId),
+      ApplicationId("daml repl"),
+      commandUpdater,
+      TimeProvider.UTC)
     var scriptExpr: SExpr = SEVal(
       LfDefRef(
         Identifier(homePackageId, QualifiedName(mod.name, DottedName.assertFromString("expr")))),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -196,7 +196,9 @@ class ReplService(val clients: Participants[LedgerClient], ec: ExecutionContext,
       timeProviderO = Some(TimeProvider.UTC),
       ttl = java.time.Duration.ofSeconds(30),
       overrideTtl = true)
-    val runner = new Runner(dar, ApplicationId("daml repl"), commandUpdater, TimeProvider.UTC)
+    // TODO[AH] Provide daml-script package id from REPL client.
+    val (scriptPackageId, _) = packages.find{case (pkgId, pkg) => pkg.modules.contains(DottedName.assertFromString("Daml.Script"))}.get
+    val runner = new Runner(dar, ScriptIds(scriptPackageId), ApplicationId("daml repl"), commandUpdater, TimeProvider.UTC)
     var scriptExpr: SExpr = SEVal(
       LfDefRef(
         Identifier(homePackageId, QualifiedName(mod.name, DottedName.assertFromString("expr")))),

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -395,9 +395,7 @@ object Converter {
     } yield Identifier(packageId, QualifiedName(moduleName, entityName))
 
   // Convert a Created event to a pair of (ContractId (), AnyTemplate)
-  def fromCreated(
-      translator: ValueTranslator,
-      created: CreatedEvent): Either[String, SValue] = {
+  def fromCreated(translator: ValueTranslator, created: CreatedEvent): Either[String, SValue] = {
     val anyTemplateTyCon = daInternalAny("AnyTemplate")
     val pairTyCon = daTypes("Tuple2")
     for {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -49,6 +49,23 @@ case class ScriptIds(val scriptPackageId: PackageId) {
       QualifiedName(ModuleName.assertFromString("Daml.Script"), DottedName.assertFromString(s)))
 }
 
+object ScriptIds {
+  // Constructs ScriptIds if the given type has the form Daml.Script.Script a.
+  def fromType(ty: Type): Option[ScriptIds] = {
+    ty match {
+      case TApp(TTyCon(tyCon), _) => {
+        val scriptIds = ScriptIds(tyCon.packageId)
+        if (tyCon == scriptIds.damlScript("Script")) {
+          Some(scriptIds)
+        } else {
+          None
+        }
+      }
+      case _ => None
+    }
+  }
+}
+
 class ConverterException(message: String) extends RuntimeException(message)
 
 case class AnyTemplate(ty: Identifier, arg: SValue)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -246,10 +246,7 @@ class Runner(
     SubmitAndWaitRequest(Some(commandUpdater.applyOverrides(commands)))
   }
 
-  def run(
-      initialClients: Participants[LedgerClient],
-      script: Script,
-      inputValue: Option[JsValue])(
+  def run(initialClients: Participants[LedgerClient], script: Script, inputValue: Option[JsValue])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[SValue] = {
     val scriptExpr = (script.param, inputValue) match {
@@ -264,11 +261,9 @@ class Runner(
         SEApp(script.expr, Array(SEValue(translateValue(param, inputLfVal))))
       }
       case (None, Some(_)) =>
-        throw new RuntimeException(
-          s"The script ${script.id} does not take arguments.")
+        throw new RuntimeException(s"The script ${script.id} does not take arguments.")
       case (Some(_), None) =>
-        throw new RuntimeException(
-          s"The script ${script.id} requires an argument.")
+        throw new RuntimeException(s"The script ${script.id} requires an argument.")
     }
     runExpr(initialClients, scriptExpr)
   }
@@ -390,11 +385,8 @@ class Runner(
                   acsResponses.flatMap(acsPages => {
                     val res =
                       FrontStack(acsPages.flatMap(page => page.activeContracts))
-                        .traverseU(
-                          Converter
-                            .fromCreated(
-                              valueTranslator,
-                              _))
+                        .traverseU(Converter
+                          .fromCreated(valueTranslator, _))
                         .fold(s => throw new ConverterException(s), identity)
                     machine.ctrl =
                       Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -111,15 +111,11 @@ object ParticipantsJsonProtocol extends DefaultJsonProtocol {
 final case class Script(id: Identifier, expr: SExpr, param: Option[Type], scriptIds: ScriptIds)
 
 object Script {
-  def fromDar(dar: Dar[(PackageId, Package)], scriptId: Identifier): Script = {
+  def fromDar(dar: Dar[(PackageId, Package)], scriptId: Identifier): Either[String, Script] = {
     val darMap = dar.all.toMap
     val compiler = Compiler(darMap)
-    val compiledPackages =
-      PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
-    fromIdentifier(compiledPackages, scriptId) match {
-      case Right(x) => x
-      case Left(e) => throw new RuntimeException(e)
-    }
+    PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys))
+      .flatMap(fromIdentifier(_, scriptId))
   }
   def fromIdentifier(
       compiledPackages: CompiledPackages,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -84,12 +84,11 @@ object RunnerMain {
           fileContent.parseJson
         })
 
-        val script = try {
-          Script.fromDar(dar, scriptId)
-        } catch {
-          case e: Throwable =>
+        val script = Script.fromDar(dar, scriptId) match {
+          case Left(err) =>
             system.terminate
             sys.exit(1)
+          case Right(x) => x
         }
         val runner = try {
           new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -84,8 +84,15 @@ object RunnerMain {
           fileContent.parseJson
         })
 
+        val script = try {
+          Script.fromDar(dar, scriptId)
+        } catch {
+          case e: Throwable =>
+            system.terminate
+            sys.exit(1)
+        }
         val runner = try {
-          new Runner(dar, applicationId, commandUpdater, timeProvider)
+          new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
         } catch {
           case e: Throwable =>
             system.terminate
@@ -112,7 +119,7 @@ object RunnerMain {
         }
         val flow: Future[Unit] = for {
           clients <- Runner.connect(participantParams, clientConfig)
-          _ <- runner.run(clients, scriptId, inputValue)
+          _ <- runner.run(clients, script, inputValue)
         } yield ()
 
         flow.onComplete(_ => system.terminate())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.archive.{Dar, DarReader, Decode}
-import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName, DottedName}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.language.Ast.Package
 import com.digitalasset.daml_lf_dev.DamlLf
@@ -111,6 +111,20 @@ object TestMain extends StrictLogging {
             )
         }
 
+        val testScripts = dar.main._2.modules.flatMap {
+          case (moduleName, module) => {
+            val valueDefinitions = module.definitions.collect {
+              case (name, Ast.DValue(ty, _, _, _)) => {
+                val id = Identifier(dar.main._1, QualifiedName(moduleName, name))
+                (id, ty)
+              }
+            }
+            valueDefinitions.collect(Function.unlift {
+              case (id, ty) => ScriptIds.fromType(ty).map((id, _))
+            })
+          }
+        }
+
         val flow: Future[Boolean] = for {
           clients <- Runner.connect(participantParams, clientConfig)
           _ <- clients.getParticipant(None) match {
@@ -121,45 +135,24 @@ object TestMain extends StrictLogging {
           }
           success = new AtomicBoolean(true)
           _ <- Future.sequence {
-            dar.main._2.modules.flatMap {
-              case (moduleName, module) => {
-                object ScriptDefinition {
-                  def unapply(nameAndDefn: (DottedName, Ast.Definition))
-                    : Option[(Identifier, ScriptIds)] = {
-                    nameAndDefn match {
-                      case (name, Ast.DValue(ty, _, _, _)) => {
-                        ScriptIds.fromType(ty) match {
-                          case Some(scriptIds) =>
-                            Some(
-                              (Identifier(dar.main._1, QualifiedName(moduleName, name)), scriptIds))
-                          case None => None
-                        }
-                      }
-                      case _ => None
-                    }
-                  }
+            testScripts.map {
+              case (scriptId, scriptIds) => {
+                val runner = new Runner(dar, scriptIds, applicationId, commandUpdater, timeProvider)
+                val script = Script.fromDar(dar, scriptId)
+                val testRun: Future[Unit] = for {
+                  _ <- runner.run(clients, script, None)
+                } yield ()
+                // Print test result and remember failure.
+                testRun.onComplete {
+                  case Failure(exception) =>
+                    success.set(false)
+                    println(s"${scriptId.qualifiedName} FAILURE ($exception)")
+                  case Success(_) =>
+                    println(s"${scriptId.qualifiedName} SUCCESS")
                 }
-                module.definitions.collect {
-                  case ScriptDefinition(scriptId, scriptIds) => {
-                    val runner =
-                      new Runner(dar, scriptIds, applicationId, commandUpdater, timeProvider)
-                    val script = Script.fromDar(dar, scriptId)
-                    val testRun: Future[Unit] = for {
-                      _ <- runner.run(clients, script, None)
-                    } yield ()
-                    // Print test result and remember failure.
-                    testRun.onComplete {
-                      case Failure(exception) =>
-                        success.set(false)
-                        println(s"${scriptId.qualifiedName} FAILURE ($exception)")
-                      case Success(_) =>
-                        println(s"${scriptId.qualifiedName} SUCCESS")
-                    }
-                    // Do not abort in case of failure, but complete all test runs.
-                    testRun.recover {
-                      case _ => ()
-                    }
-                  }
+                // Do not abort in case of failure, but complete all test runs.
+                testRun.recover {
+                  case _ => ()
                 }
               }
             }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -138,7 +138,10 @@ object TestMain extends StrictLogging {
             testScripts.map {
               case (scriptId, scriptIds) => {
                 val runner = new Runner(dar, scriptIds, applicationId, commandUpdater, timeProvider)
-                val script = Script.fromDar(dar, scriptId)
+                val script = Script.fromDar(dar, scriptId) match {
+                  case Left(err) => throw new RuntimeException(err)
+                  case Right(x) => x
+                }
                 val testRun: Future[Unit] = for {
                   _ <- runner.run(clients, script, None)
                 } yield ()

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -124,11 +124,14 @@ object TestMain extends StrictLogging {
             dar.main._2.modules.flatMap {
               case (moduleName, module) => {
                 object ScriptDefinition {
-                  def unapply(nameAndDefn: (DottedName, Ast.Definition)): Option[(Identifier, ScriptIds)] = {
+                  def unapply(nameAndDefn: (DottedName, Ast.Definition))
+                    : Option[(Identifier, ScriptIds)] = {
                     nameAndDefn match {
                       case (name, Ast.DValue(ty, _, _, _)) => {
                         ScriptIds.fromType(ty) match {
-                          case Some(scriptIds) => Some((Identifier(dar.main._1, QualifiedName(moduleName, name)), scriptIds))
+                          case Some(scriptIds) =>
+                            Some(
+                              (Identifier(dar.main._1, QualifiedName(moduleName, name)), scriptIds))
                           case None => None
                         }
                       }
@@ -138,7 +141,8 @@ object TestMain extends StrictLogging {
                 }
                 module.definitions.collect {
                   case ScriptDefinition(scriptId, scriptIds) => {
-                    val runner = new Runner(dar, scriptIds, applicationId, commandUpdater, timeProvider)
+                    val runner =
+                      new Runner(dar, scriptIds, applicationId, commandUpdater, timeProvider)
                     val script = Script.fromDar(dar, scriptId)
                     val testRun: Future[Unit] = for {
                       _ <- runner.run(clients, script, None)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -111,7 +111,10 @@ class TestRunner(
 
     val clientsF = Runner.connect(participantParams, clientConfig)
 
-    val script = Script.fromDar(dar, scriptId)
+    val script = Script.fromDar(dar, scriptId) match {
+      case Left(err) => throw new RuntimeException(err)
+      case Right(x) => x
+    }
     val runner = new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
 
     val testFlow: Future[Unit] = for {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -111,11 +111,12 @@ class TestRunner(
 
     val clientsF = Runner.connect(participantParams, clientConfig)
 
-    val runner = new Runner(dar, applicationId, commandUpdater, timeProvider)
+    val script = Script.fromDar(dar, scriptId)
+    val runner = new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- runner.run(clients, scriptId, inputValue)
+      result <- runner.run(clients, script, inputValue)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>


### PR DESCRIPTION
Similar to https://github.com/digital-asset/daml/pull/5016 but for daml-script this detects the package id of the daml-script library based on the type of the script we are running.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
