### PR TITLE
StandaloneApiServer facility for lf-seeding opt-out

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -66,7 +66,7 @@ class Runner[T <: ReadWriteService, Extra](
                 authService = factory.authService(config),
                 factory.apiServerMetricRegistry(participantConfig, config),
                 factory.timeServiceBackend(config),
-                config.seeding,
+                Some(config.seeding),
               ).acquire()
             } yield ()
           })

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -50,7 +50,7 @@ final class StandaloneApiServer(
     authService: AuthService,
     metrics: MetricRegistry,
     timeServiceBackend: Option[TimeServiceBackend] = None,
-    seeding: Seeding,
+    seeding: Option[Seeding],
     otherServices: immutable.Seq[BindableService] = immutable.Seq.empty,
     otherInterceptors: List[ServerInterceptor] = List.empty,
     engine: Engine = sharedEngine // allows sharing DAML engine with DAML-on-X participant
@@ -102,7 +102,7 @@ final class StandaloneApiServer(
               optTimeServiceBackend = timeServiceBackend,
               metrics = metrics,
               healthChecks = healthChecks,
-              seedService = Some(SeedService(seeding)),
+              seedService = seeding.map(SeedService(_)),
             )(mat, esf, logCtx)
             .map(_.withServices(otherServices))
         },

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -203,7 +203,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   authService = authService,
                   metrics = SharedMetricRegistries.getOrCreate(s"ledger-api-server-$ParticipantId"),
                   timeServiceBackend = timeServiceBackend,
-                  seeding = seeding,
+                  seeding = Some(seeding),
                   otherServices = List(resetService),
                   otherInterceptors = List(resetService),
                 )


### PR DESCRIPTION
Until all DAML-on-X implementations have a chance to implement
seeding support for daml-lf contract-ids.

Closes #5077

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ X Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
