### PR TITLE
2nd part of stabilizing flaky websocket integration test

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -115,7 +115,6 @@ da_scala_test(
         ":Account.dar",
         "//docs:quickstart-model.dar",
     ],
-    flaky = True,
     plugins = [
         "@maven//:org_spire_math_kind_projector_2_12",
     ],

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -10,6 +10,7 @@ import com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.iface
 import com.digitalasset.http.util.ClientUtil.boxedRecord
+import com.digitalasset.http.util.LedgerOffsetUtil
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => lav1}
 import scalaz.Isomorphism.{<~>, IsoFunctorTemplate}
@@ -19,7 +20,19 @@ import scalaz.std.vector._
 import scalaz.syntax.show._
 import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
-import scalaz.{-\/, @@, Applicative, Bitraverse, NonEmptyList, Show, Tag, Traverse, \/, \/-}
+import scalaz.{
+  -\/,
+  @@,
+  Applicative,
+  Bitraverse,
+  NonEmptyList,
+  Semigroup,
+  Show,
+  Tag,
+  Traverse,
+  \/,
+  \/-
+}
 import spray.json.JsValue
 
 import scala.annotation.tailrec
@@ -144,6 +157,14 @@ object domain {
 
     def toLedgerApi(o: Offset): lav1.ledger_offset.LedgerOffset =
       lav1.ledger_offset.LedgerOffset(lav1.ledger_offset.LedgerOffset.Value.Absolute(unwrap(o)))
+
+    implicit val ordering: Ordering[Offset] =
+      Ordering.by(LedgerOffsetUtil.parseOffsetString _ compose unwrap)(
+        LedgerOffsetUtil.LongEitherLongLongOrdering)
+
+    implicit val semigroup: Semigroup[Offset] = new Semigroup[Offset] {
+      override def append(f1: Offset, f2: => Offset): Offset = ordering.max(f1, f2)
+    }
   }
 
   final case class StartingOffset(offset: Offset)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -29,6 +29,7 @@ import scalaz.{
   Semigroup,
   Show,
   Tag,
+  Tags,
   Traverse,
   \/,
   \/-
@@ -162,9 +163,7 @@ object domain {
       Ordering.by(LedgerOffsetUtil.parseOffsetString _ compose unwrap)(
         LedgerOffsetUtil.LongEitherLongLongOrdering)
 
-    implicit val semigroup: Semigroup[Offset] = new Semigroup[Offset] {
-      override def append(f1: Offset, f2: => Offset): Offset = ordering.max(f1, f2)
-    }
+    implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
   }
 
   final case class StartingOffset(offset: Offset)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/LedgerOffsetUtil.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/LedgerOffsetUtil.scala
@@ -8,7 +8,7 @@ import scalaz.{-\/, \/, \/-}
 
 object LedgerOffsetUtil {
 
-  private val LongEitherLongLongOrdering: Ordering[Long \/ (Long, Long)] = {
+  private[http] val LongEitherLongLongOrdering: Ordering[Long \/ (Long, Long)] = {
     import scalaz.std.tuple._
     import scalaz.std.anyVal._
     scalaz.Order[Long \/ (Long, Long)].toScalaOrdering
@@ -17,8 +17,11 @@ object LedgerOffsetUtil {
   implicit val AbsoluteOffsetOrdering: Ordering[LedgerOffset.Value.Absolute] =
     Ordering.by(parseOffset)(LongEitherLongLongOrdering)
 
-  private def parseOffset(a: LedgerOffset.Value.Absolute): Long \/ (Long, Long) = {
-    val offset: String = a.value
+  private def parseOffset(offset: LedgerOffset.Value.Absolute): Long \/ (Long, Long) = {
+    parseOffsetString(offset.value)
+  }
+
+  private[http] def parseOffsetString(offset: String): Long \/ (Long, Long) = {
     offset.split('-') match {
       case Array(_, a2, a3) =>
         \/-((a2.toLong, a3.toLong))


### PR DESCRIPTION
handling empty events, which we may receive a bunch in the end of the run when there is no activity

Closes: #4979

` flaky = True` does not always help, there were windows builds that failed all 3 flaky attempts.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
