### PR TITLE
Use type application for 'decode'

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -743,7 +743,7 @@ setupWorkspace optInputPackageJson optOutputDir dependencies = do
     (Just <$> BSL.readFile optInputPackageJson) (const $ pure Nothing)
   packageJson <- case mbBytes of
     Nothing -> pure mempty
-    Just bytes -> case decode bytes :: Maybe PackageJson of
+    Just bytes -> case decode @PackageJson bytes of
       Nothing -> fail $ "Error decoding JSON from '" <> optInputPackageJson <> "'"
       Just packageJson -> pure packageJson
   transformAndWrite ourWorkspaces outBaseDir packageJson


### PR DESCRIPTION
TsCodeGen - replace a type annotation by use of a type application.