### PR TITLE
java-binding: fix protobuf testing generator 

### DIFF
--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -94,10 +94,15 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "bindings-java-tests",
-    srcs = glob([
-        "src/test/**/*Spec.scala",
-        "src/test/**/*Test.scala",
-    ]),
+    srcs = glob(
+        [
+            "src/test/**/*Spec.scala",
+            "src/test/**/*Test.scala",
+        ],
+        exclude = [
+            "src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala",
+        ],
+    ),
     deps = [
         ":bindings-java",
         ":bindings-java-tests-lib",

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -94,15 +94,10 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "bindings-java-tests",
-    srcs = glob(
-        [
-            "src/test/**/*Spec.scala",
-            "src/test/**/*Test.scala",
-        ],
-        exclude = [
-            "src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala",
-        ],
-    ),
+    srcs = glob([
+        "src/test/**/*Spec.scala",
+        "src/test/**/*Test.scala",
+    ]),
     deps = [
         ":bindings-java",
         ":bindings-java-tests-lib",

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -1,8 +1,7 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.javaapi
-package data
+package com.daml.ledger.javaapi.data
 
 import java.time.{Instant, LocalDate}
 

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 The DAML Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.javaapi.data
+package com.daml.ledger.javaapi
+package data
 
 import java.time.{Instant, LocalDate}
 
@@ -144,7 +145,6 @@ object Generators {
               if (maxSize >= 1) Gen.chooseNum(1, maxSize) else Gen.const(1))
             newHeight = height / size
             keys <- Gen.listOfN(size, Arbitrary.arbString.arbitrary)
-            if keys.distinct == keys
             values <- Gen.listOfN(size, Gen.resize(newHeight, valueGen))
           } yield
             (keys zip values).map {


### PR DESCRIPTION
This PR fixes the `com.daml.ledger.javaapi.data.Generators` that made the java-bindings test flaky.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
